### PR TITLE
add travis and update tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial  # required for Python >= 3.7
 language: python
 # we care only about python 3.7
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+# we care only about python 3.7
+python:
+  - "3.7"
+# installation of dependencies, the rest is handled by tox
+install:
+  - pip install tox
+# command to run unit tests
+script:
+  - tox
+# list of tox enviroments to run
+# this way, result for each env will be reported separately
+env:
+  - TOXENV=py37
+  - TOXENV=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ deps = flake8
 commands = flake8
 
 [flake8]
-max-line-length = 120
+max-line-length = 79
 ignore = E402, E741, W503

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = py37
+envlist = py37,flake8
 
 [testenv]
 deps =
     -rrequirements.txt
-    flake8
     pytest
+commands = {envpython} -m pytest
 
-commands =
-    pytest
-    flake8
+[testenv:flake8]
+deps = flake8
+commands = flake8
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,7 @@ deps = flake8
 commands = flake8
 
 [flake8]
-max-line-length = 79
 ignore = E402, E741, W503
+max-line-length = 120
+# We will change this to 79 in new PR with all the fixes of:
+# https://travis-ci.org/red-hat-storage/ocs-ci/jobs/523393041


### PR DESCRIPTION
All checks (unit test run and flake8 check) are executed via tox.

Tox config now contains multiple environments, so that it's possible
to run flake8 check without running unit tests::

    $ tox -e flake8

Running tox still runs all the checks.

This split is useful for the travis job, which will contain two separate
items, one for each tox environment, so that it's immediately visible if
the failure is in flake8 or unit test rerun.