### PR TITLE
parallel() -- to do ops in parallel

### DIFF
--- a/tests/test_ocs_basic_install.py
+++ b/tests/test_ocs_basic_install.py
@@ -13,6 +13,7 @@ from utility import templating
 from utility.aws import AWS
 from utility.retry import retry
 from utility.utils import run_cmd, download_openshift_installer
+from ocs.parallel import parallel
 
 log = logging.getLogger(__name__)
 
@@ -177,17 +178,17 @@ def create_ebs_volumes(
     """
     aws = AWS(region_name)
     worker_instances = aws.get_instances_by_name_pattern(worker_pattern)
-    for worker in worker_instances:
-        log.info(
-            f"Creating and attaching {size} GB volume to {worker['name']}"
-        )
-        aws.create_volume_and_attach(
-            availability_zone=worker['avz'],
-            instance_id=worker['id'],
-            name=f"{worker['name']}_extra_volume",
-            size=size,
-        )
-
+    with parallel() as p:
+        for worker in worker_instances:
+            log.info(
+                f"Creating and attaching {size} GB volume to {worker['name']}"
+            )
+            p.spawn(aws.create_volume_and_attach,
+                availability_zone=worker['avz'],
+                instance_id=worker['id'],
+                name=f"{worker['name']}_extra_volume",
+                size=size,
+                    )
 
 @retry((CephHealthException, CommandFailed), tries=20, delay=30, backoff=1)
 def ceph_health_check():
@@ -221,4 +222,3 @@ def ceph_health_check():
     else:
         raise CephHealthException(
             f"Ceph cluster health is not OK. Health: {health}"
-        )


### PR DESCRIPTION
tests/test_ocs_basic_install.py:
- Added func parallel() to create_ebs_volumes() to create and attach volumes to the worker node in parallel
