### PR TITLE
Initial support for unit tests of pytest plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.yaml
 *.bak
 openshift-install*
 data/pull-secret
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft conf
+global-exclude *.py[cod] __pycache__ .gitignore *.html

--- a/pytest_customization/ocscilib.py
+++ b/pytest_customization/ocscilib.py
@@ -53,7 +53,11 @@ def pytest_configure(config):
         config (pytest.config): Pytest config object
 
     """
-    init_ocsci_conf(config)
+    here = os.path.abspath(os.path.dirname(__file__))
+    init_ocsci_conf(
+        config,
+        default_config=os.path.join(here, "..", "conf/ocsci/default_config.yaml"),
+        )
 
 
 def get_cli_param(config, name_of_param, default=None):
@@ -105,17 +109,13 @@ def process_cluster_cli_params(config):
     ocsci_config.ENV_DATA['cluster_path'] = cluster_path
 
 
-def init_ocsci_conf(
-    config,
-    default_config="conf/ocsci/default_config.yaml",
-):
+def init_ocsci_conf(config, default_config):
     """
     Function to init the default config for OCS CI
 
     Args:
         config (pytest.config): Pytest config object
-        default_config (str): Default config data (default:
-            conf/ocsci/default_config.yaml)
+        default_config (str): Default config data
 
     """
     custom_config = config.getoption('ocsci_conf')

--- a/pytest_customization/ocscilib.py
+++ b/pytest_customization/ocscilib.py
@@ -57,7 +57,7 @@ def pytest_configure(config):
     init_ocsci_conf(
         config,
         default_config=os.path.join(here, "..", "conf/ocsci/default_config.yaml"),
-        )
+    )
 
 
 def get_cli_param(config, name_of_param, default=None):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py37,flake8
 [testenv]
 deps =
     -rrequirements.txt
-commands = {envpython} -m pytest --ignore=tests -c unittests/pytest.ini unittests
+commands = {envpython} -m pytest --ignore=tests -c unittests/pytest.ini {posargs:unittests}
+
 [testenv:flake8]
 deps = flake8
 commands = flake8

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+pytest_plugins = 'pytester'

--- a/unittests/test_pytest.py
+++ b/unittests/test_pytest.py
@@ -43,3 +43,36 @@ def test_simple(testdir):
     result.stdout.fnmatch_lines(['*::test_foo PASSED*'])
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
+
+
+def test_config_parametrize(testdir):
+    """
+    Parametrization via config values, use case described in
+    https://github.com/red-hat-storage/ocs-ci/pull/61#issuecomment-494866745
+    """
+    # create a temporary pytest test module
+    testdir.makepyfile(textwrap.dedent("""\
+        import pytest
+
+        from ocsci import config as ocsci_config
+
+        @pytest.mark.parametrize("item", ocsci_config.DEMO)
+        def test_demo_parametrized_config(item):
+            assert item is not None
+        """))
+    # create config file
+    conf_file = testdir.makefile(".yaml", textwrap.dedent("""\
+        DEMO:
+         - 1
+         - 2
+        """))
+    # run pytest with the following cmd args
+    result = testdir.runpytest('-v', f'--ocsci-conf={conf_file}')
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        'collecting*collected 2 items',
+        '*test_demo_parametrized_config?1? PASSED*',
+        '*test_demo_parametrized_config?2? PASSED*',
+        ])
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0

--- a/unittests/test_pytest.py
+++ b/unittests/test_pytest.py
@@ -25,7 +25,7 @@ def test_help_message(testdir):
         '*--cluster-conf*',
         '*--cluster-path*',
         '*--cluster-name*',
-        ])
+    ])
 
 
 def test_simple(testdir):
@@ -73,6 +73,6 @@ def test_config_parametrize(testdir):
         'collecting*collected 2 items',
         '*test_demo_parametrized_config?1? PASSED*',
         '*test_demo_parametrized_config?2? PASSED*',
-        ])
+    ])
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0

--- a/unittests/test_pytest.py
+++ b/unittests/test_pytest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import textwrap
 
 import pytest
 
@@ -25,3 +26,20 @@ def test_help_message(testdir):
         '*--cluster-path*',
         '*--cluster-name*',
         ])
+
+
+def test_simple(testdir):
+    """
+    Make sure that  pytest itself is not broken by running very simple test.
+    """
+    # create a temporary pytest test module
+    testdir.makepyfile(textwrap.dedent("""\
+        def test_foo():
+            assert 1 == 1
+        """))
+    # run pytest with the following cmd args
+    result = testdir.runpytest('-v')
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(['*::test_foo PASSED*'])
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0

--- a/unittests/test_pytest.py
+++ b/unittests/test_pytest.py
@@ -1,7 +1,27 @@
+# -*- coding: utf-8 -*-
+
 import logging
+
+import pytest
+
 
 logger = logging.getLogger(__name__)
 
 
 def test_pytest_works():
     logger.info("This is prove that pytest works")
+
+
+def test_help_message(testdir):
+    """
+    Check that ``py.test --help`` output lists custom options of
+    ocscilib pytest plugin.
+    """
+    result = testdir.runpytest('--help')
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines([
+        '*--ocsci-conf*',
+        '*--cluster-conf*',
+        '*--cluster-path*',
+        '*--cluster-name*',
+        ])

--- a/unittests/test_pytest.py
+++ b/unittests/test_pytest.py
@@ -3,8 +3,6 @@
 import logging
 import textwrap
 
-import pytest
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull requests introduces unit tests of our pytest plugins, tested via pytest via [pytester](https://docs.pytest.org/en/latest/_modules/_pytest/pytester.html), which is official pytest module for testing pytest plugins via pytest.

It contains few simple test cases only, so that it's possible to add unit tests for config and cli option processing later.

Don't squash this pull request into single commit when merging, each commit message is meaningful.