### PR TITLE
PR for CSI templates - rbd and cephfs

### DIFF
--- a/templates/CSI/cephfs/pod.yaml
+++ b/templates/CSI/cephfs/pod.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csicephfs-demo-pod
+spec:
+  containers:
+   - name: web-server
+     image: nginx
+     volumeMounts:
+       - name: mypvc
+         mountPath: /var/lib/www/html
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: cephfs-pvc
+       readOnly: false

--- a/templates/CSI/cephfs/pvc.yaml
+++ b/templates/CSI/cephfs/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cephfs-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-cephfs

--- a/templates/CSI/cephfs/secret.yaml
+++ b/templates/CSI/cephfs/secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-cephfs-secret
+  namespace: default
+data:
+  # Required if provisionVolume is set to false
+  userID: BASE64-ENCODED-USER
+  userKey: BASE64-ENCODED-PASSWORD
+
+  # Required if provisionVolume is set to true
+  adminID: BASE64-ENCODED-USER
+  adminKey: BASE64-ENCODED-PASSWORD

--- a/templates/CSI/cephfs/storageclass.yaml
+++ b/templates/CSI/cephfs/storageclass.yaml
@@ -1,0 +1,37 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-cephfs
+provisioner: cephfs.csi.ceph.com
+parameters:
+  # Comma separated list of Ceph monitors
+  # if using FQDN, make sure csi plugin's dns policy is appropriate.  
+  monitors: mon1:port,mon2:port,...
+
+  # For provisionVolume: "true":
+  #   A new volume will be created along with a new Ceph user.
+  #   Requires admin credentials (adminID, adminKey).
+  # For provisionVolume: "false":
+  #   It is assumed the volume already exists and the user is expected
+  #   to provide path to that volume (rootPath) and user credentials (userID, userKey).
+  provisionVolume: "true"
+
+  # Ceph pool into which the volume shall be created
+  # Required for provisionVolume: "true"
+  pool: cephfs_data
+
+  # Root path of an existing CephFS volume
+  # Required for provisionVolume: "false"
+  # rootPath: /absolute/path
+
+  # The secrets have to contain user and/or Ceph admin credentials.
+  csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: default
+
+  # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
+  # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse
+  # or by setting the default mounter explicitly via --volumemounter command-line argument.
+  # mounter: kernel
+reclaimPolicy: Delete

--- a/templates/CSI/rbd/pod.yaml
+++ b/templates/CSI/rbd/pod.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csirbd-demo-pod
+spec:
+  containers:
+   - name: web-server
+     image: nginx
+     volumeMounts:
+       - name: mypvc
+         mountPath: /var/lib/www/html
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: rbd-pvc
+       readOnly: false

--- a/templates/CSI/rbd/pvc-restore.yaml
+++ b/templates/CSI/rbd/pvc-restore.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-pvc-restore
+spec:
+  storageClassName: csi-rbd
+  dataSource:
+    name: rbd-pvc-snapshot
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/templates/CSI/rbd/pvc.yaml
+++ b/templates/CSI/rbd/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-rbd

--- a/templates/CSI/rbd/secret.yaml
+++ b/templates/CSI/rbd/secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-rbd-secret
+  namespace: default
+data:
+  # Key value corresponds to a user name defined in Ceph cluster
+  admin: BASE64-ENCODED-PASSWORD
+  # Key value corresponds to a user name defined in Ceph cluster
+  kubernetes: BASE64-ENCODED-PASSWORD
+  # if monValueFromSecret is set to "monitors", uncomment the
+  # following and set the mon there
+  #monitors: BASE64-ENCODED-Comma-Delimited-Mons

--- a/templates/CSI/rbd/snapshot.yaml
+++ b/templates/CSI/rbd/snapshot.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshot
+metadata:
+  name: rbd-pvc-snapshot
+spec:
+  snapshotClassName: csi-rbdplugin-snapclass
+  source:
+    name: rbd-pvc
+    kind: PersistentVolumeClaim

--- a/templates/CSI/rbd/snapshotclass.yaml
+++ b/templates/CSI/rbd/snapshotclass.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-rbdplugin-snapclass
+snapshotter: rbd.csi.ceph.com
+parameters:
+  pool: rbd
+  monitors: mon1:port,mon2:port,...
+  csi.storage.k8s.io/snapshotter-secret-name: csi-rbd-secret
+  csi.storage.k8s.io/snapshotter-secret-namespace: default

--- a/templates/CSI/rbd/storageclass.yaml
+++ b/templates/CSI/rbd/storageclass.yaml
@@ -1,0 +1,36 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: csi-rbd
+provisioner: rbd.csi.ceph.com
+parameters:
+    # Comma separated list of Ceph monitors
+    # if using FQDN, make sure csi plugin's dns policy is appropriate.
+    monitors: mon1:port,mon2:port,...
+
+    # if "monitors" parameter is not set, driver to get monitors from same
+    # secret as admin/user credentials. "monValueFromSecret" provides the
+    # key in the secret whose value is the mons
+    #monValueFromSecret: "monitors"
+    
+    # Ceph pool into which the RBD image shall be created
+    pool: rbd
+
+    # RBD image format. Defaults to "2".
+    imageFormat: "2"
+
+    # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
+    imageFeatures: layering
+    
+    # The secrets have to contain Ceph admin credentials.
+    csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
+    csi.storage.k8s.io/provisioner-secret-namespace: default
+    csi.storage.k8s.io/node-publish-secret-name: csi-rbd-secret
+    csi.storage.k8s.io/node-publish-secret-namespace: default
+
+    # Ceph users for operating RBD
+    adminid: admin
+    userid: kubernetes
+    # uncomment the following to use rbd-nbd as mounter on supported nodes
+    #mounter: rbd-nbd
+reclaimPolicy: Delete


### PR DESCRIPTION
This PR addresses #106 .

For now, following jinja2 templates have been added under templates/csi-templates:

- csi-cephfs-secret.yaml  
- csi-cephfs-storageclass.yaml  
- csi-rbd-secret.yaml
- csi-rbd-storageclass.yaml
- cephblockpool.yaml
- pvc.yaml
- pod.yaml

Git hub links for the yamls:

https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/csi/example/rbd/
https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/csi/example/cephfs


Some points to add:
a) In storageclass.yaml, for "monitors" , I have used default FQDN name , assuming we have mon-a, mon-b and mon-c.
b) secret.yaml is expecting userid as kubernetes. If the userid is not kubernetes, we may have to add a different username here:

 ceph auth get-key kubernetes | base64
  **kubernetes**: {{ base64_encoded_user_password }}