### PR TITLE
run_cmd() should return even decoded stderr and return code of the command

### DIFF
--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -64,7 +64,7 @@ class OCP(object):
             oc_cmd += f"--kubeconfig {kubeconfig} "
 
         oc_cmd += command
-        out = run_cmd(cmd=oc_cmd)
+        out, err, ret = run_cmd(cmd=oc_cmd)
         return munchify(yaml.safe_load(out))
 
     def get(self, resource_name='', out_yaml_format=True, selector=None):

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -635,6 +635,8 @@ def run_cmd(cmd, **kwargs):
 
     Returns:
         (str) Decoded stdout of command
+        (str) Decoded stderr of command
+        (str) return code of command
 
     """
     log.info(f"Executing command: {cmd}")
@@ -655,7 +657,7 @@ def run_cmd(cmd, **kwargs):
             f"Error during execution of command: {cmd}."
             f"\nError is {r.stderr.decode()}"
         )
-    return r.stdout.decode()
+    return r.stdout.decode(), r.stderr.decode(), r.returncode
 
 
 def download_file(url, filename):

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -634,7 +634,7 @@ def run_cmd(cmd, **kwargs):
         CommandFailed: In case the command execution fails
 
     Returns:
-        (str, str, str) Decoded stdout, decoded stderr, and return code of command
+        tuple (str, str, int): Decoded stdout, decoded stderr, and return code of command
 
     """
     log.info(f"Executing command: {cmd}")

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -634,7 +634,8 @@ def run_cmd(cmd, **kwargs):
         CommandFailed: In case the command execution fails
 
     Returns:
-        tuple (str, str, int): Decoded stdout, decoded stderr, and return code of command
+        tuple (str, str, int): Decoded stdout, decoded stderr, and 
+                               return code of command
 
     """
     log.info(f"Executing command: {cmd}")

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -634,9 +634,7 @@ def run_cmd(cmd, **kwargs):
         CommandFailed: In case the command execution fails
 
     Returns:
-        (str) Decoded stdout of command
-        (str) Decoded stderr of command
-        (str) return code of command
+        (str, str, str) Decoded stdout, decoded stderr, and return code of command
 
     """
     log.info(f"Executing command: {cmd}")
@@ -657,7 +655,7 @@ def run_cmd(cmd, **kwargs):
             f"Error during execution of command: {cmd}."
             f"\nError is {r.stderr.decode()}"
         )
-    return r.stdout.decode(), r.stderr.decode(), r.returncode
+    return (r.stdout.decode(), r.stderr.decode(), r.returncode)
 
 
 def download_file(url, filename):

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -634,7 +634,7 @@ def run_cmd(cmd, **kwargs):
         CommandFailed: In case the command execution fails
 
     Returns:
-        tuple (str, str, int): Decoded stdout, decoded stderr, and 
+        tuple (str, str, int): Decoded stdout, decoded stderr, and
                                return code of command
 
     """


### PR DESCRIPTION
Currently run_cmd is only returning the decoded stdout of command.

We use this function for running most of the oc commands. It will
be good if return even the decoded stderr and return code
of the command as these will help to do negative scenarios
validations

With this PR, run_cmd will return below,
1) decoded stdout of the command
2) decoded stderr of the command
3) return code of the command

Signed-off-by: Prasad Desala <tdesala@redhat.com>