### PR TITLE
Fix for exec_ceph_cmd

### DIFF
--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -286,7 +286,7 @@ def exec_ceph_cmd(ceph_cmd):
     out = ocp_pod_obj.exec_cmd_on_pod(ct_pod, ceph_cmd)
 
     # For some commands, like "ceph fs ls", the returned output is a list
-    if type(out) == type(list()):
+    if isinstance(out, list):
         new_out = list()
         [new_out.append(item.toDict()) for item in out if item is not None]
         return new_out

--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -65,13 +65,7 @@ class OCP(object):
 
         oc_cmd += command
         out = run_cmd(cmd=oc_cmd)
-
-        out = yaml.safe_load(out)
-        # In some cases, run_cmd() will return an empty string or in the case
-        # of executing ceph commands, it could return an empty list
-        if out != list():
-            return munchify(out)
-        return out
+        return munchify(yaml.safe_load(out))
 
     def get(self, resource_name='', out_yaml_format=True, selector=None):
         """

--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -281,7 +281,6 @@ def exec_ceph_cmd(ceph_cmd):
 
     # For some commands, like "ceph fs ls", the returned output is a list
     if isinstance(out, list):
-        new_out = list()
-        [new_out.append(item.toDict()) for item in out if item is not None]
+        new_out = [item.toDict() for item in out if item]
         return new_out
     return out.toDict()

--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -281,6 +281,5 @@ def exec_ceph_cmd(ceph_cmd):
 
     # For some commands, like "ceph fs ls", the returned output is a list
     if isinstance(out, list):
-        new_out = [item.toDict() for item in out if item]
-        return new_out
+        return [item.toDict() for item in out if item]
     return out.toDict()


### PR DESCRIPTION
For some commands, like "ceph fs ls", the returned output is a list