### PR TITLE
Fix pull-secret handling

### DIFF
--- a/templates/install-config.yaml.j2
+++ b/templates/install-config.yaml.j2
@@ -22,4 +22,4 @@ networking:
 platform:
   aws:
     region: {{ region | default('us-east-2') }}
-pullSecret: '{{ pull_secret }}' # Use double quotes inside pullSecret data!
+pullSecret: ''


### PR DESCRIPTION
openshift-install expects the pullSecret value to be a JSON string. Mine is
stored as a multiline object, and so the existing code to read it failed. I
really think a better approach is to use the existing parsers for both JSON and
YAML here, as they are extremely well-tested and supported.

Signed-off-by: Zack Cerza <zack@redhat.com>