### PR TITLE
function to get base64 encoded ceph keyring

### DIFF
--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -4,6 +4,7 @@ General OCP object
 import os
 import logging
 import yaml
+import base64
 from ocs import defaults
 from munch import munchify
 
@@ -283,3 +284,19 @@ def exec_ceph_cmd(ceph_cmd):
     if isinstance(out, list):
         return [item.toDict() for item in out if item]
     return out.toDict()
+
+
+def getbase64_ceph_secret(keyring_name):
+    """
+    Get ceph keyring in base64 encoded format.
+
+    Args:
+        keyring_name (str): Keyring name i.e. client.admin, client.kubernetes
+
+    Returns:
+        base64 encoded value.
+    """
+    cmd_out = exec_ceph_cmd(ceph_cmd=f"ceph auth get-key {keyring_name}")
+    key = cmd_out.get('key')
+    out = base64.b64encode(key.encode("utf-8"))
+    return str(out, "utf-8")

--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -288,13 +288,13 @@ def exec_ceph_cmd(ceph_cmd):
 
 def getbase64_ceph_secret(keyring_name):
     """
-    Get ceph keyring in base64 encoded format
+    Get a ceph keyring in base64 encoded format
 
     Args:
         keyring_name (str): Keyring name i.e. client.admin, client.kubernete
         Ceph client keyring created with "client.<client_type|client_name>"
         Ceph supports client keys without "client" in prefix too
-        This param expects full name of key 
+        This param expects full name of key
         eg: "client.admin", "client.test", "kubernetes"
 
     Returns:

--- a/ocs/ocp.py
+++ b/ocs/ocp.py
@@ -288,13 +288,17 @@ def exec_ceph_cmd(ceph_cmd):
 
 def getbase64_ceph_secret(keyring_name):
     """
-    Get ceph keyring in base64 encoded format.
+    Get ceph keyring in base64 encoded format
 
     Args:
-        keyring_name (str): Keyring name i.e. client.admin, client.kubernetes
+        keyring_name (str): Keyring name i.e. client.admin, client.kubernete
+        Ceph client keyring created with "client.<client_type|client_name>"
+        Ceph supports client keys without "client" in prefix too
+        This param expects full name of key 
+        eg: "client.admin", "client.test", "kubernetes"
 
     Returns:
-        base64 encoded value.
+        base64 encoded value
     """
     cmd_out = exec_ceph_cmd(ceph_cmd=f"ceph auth get-key {keyring_name}")
     key = cmd_out.get('key')


### PR DESCRIPTION
  - Added a function getbase65_ceph_secret() which takes keyring name and returns base64 encoded key for any ceph keyrings.
Signed-off-by: ramkiperiy <rperiyas@redhat.com>