### PR TITLE
simplify our run name, lets just call it run-ci

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 `run.py` - (**deprecated**) is the main script for ocs-ci. You can view the
 full usage details by passing in the `--help` argument.
 
-For pytest run python -m run_ocsci --help
+For pytest usage run: run-ci --help
 
 ```bash
 python run.py --help
@@ -31,7 +31,7 @@ There are a few arguments that are required ocs test execution:
 ## Useful pytest arguments
 
 Some non-required arguments that we end up using a lot. You can use
-`python -m run_ocsci --help` to see all the parameters and description which you can pass
+`run-ci  --help` to see all the parameters and description which you can pass
 to the pytest.
 
 * `--capture=no` - when using pdb or ipdb you have to turn of capture mode
@@ -133,6 +133,6 @@ run-ci -m "tier1 and manage" \
 Destroy is moved already to pytest. If you would like to destroy existing
 cluster you can run following command:
 ```bash
-python -m run_ocsci -m destroy --cluster-name kerberos_ID-ocs-deployment \
+run-ci -m destroy --cluster-name kerberos_ID-ocs-deployment \
     --cluster-path /home/my_user/my-ocs-dir tests/
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,7 +111,7 @@ in third execution.
 Deployment is moved already to pytest. If you would like to deploy new cluster
 you can run following command:
 ```bash
-python -m run_ocsci -m deployment --ocsci-conf conf/ocsci/custom_config.yaml \
+run-ci -m deployment --ocsci-conf conf/ocsci/custom_config.yaml \
     --cluster-conf conf/ocs_basic_install.yml \
     --cluster-name kerberos_ID-ocs-deployment \
     --cluster-path /home/my_user/my-ocs-dir tests/
@@ -123,7 +123,7 @@ values.
 #### Runing tests on deployed environment
 
 ```bash
-python -m run_ocsci -m "tier1 and manage" \
+run-ci -m "tier1 and manage" \
     --cluster-name kerberos_ID-ocs-deployment \
     --cluster-path /home/my_user/my-ocs-dir tests/
  ```

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'run_ocsci=run_ocsci:main',
+            'run-ci=run_ocsci:main',
         ],
         'pytest11': [
             'ocscilib = ocsci.pytest_customization.ocscilib',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ envlist = py37,flake8
 [testenv]
 deps =
     -rrequirements.txt
-commands = {envpython} -m run_ocsci --ignore=tests -c unittests/pytest.ini {posargs:unittests}
+setenv =
+ PYTHONPATH=.
+commands = {envpython} {envbindir}/run-ci --ignore=tests -c unittests/pytest.ini {posargs:unittests}
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
simplify our run name, lets just call it run-ci (the repo name is ocs-ci, so it would imply
running ocs-ci)

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>