### PR TITLE
Change installer and client to version 4.1.0

### DIFF
--- a/conf/ocsci/default_config.yaml
+++ b/conf/ocsci/default_config.yaml
@@ -42,7 +42,7 @@ RUN:
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.
 DEPLOYMENT:
-  installer_version: "4.1.0-rc.5"
+  installer_version: "4.1.0"
 
 # Section for reporting configuration
 REPORTING:


### PR DESCRIPTION
Currently the lastest version is pointing to 4.1.0 so we won't need
need to change this version each time when there is new RC like:
4.1.0-rc.9, but need to change just once there will be new version like
4.1.1 or 4.2.0.