### PR TITLE
OCS-336 and OCS-346 - Test ocs basics

### DIFF
--- a/ocs/constants.py
+++ b/ocs/constants.py
@@ -36,3 +36,6 @@ POD = "Pod"
 
 # Other
 SECRET = "Secret"
+
+# encoded value of 'admin'
+ADMIN_BASE64 = 'YWRtaW4='

--- a/ocs/defaults.py
+++ b/ocs/defaults.py
@@ -1,14 +1,10 @@
 """
 Defaults module.
-
 This module is automatically loaded with variables defined in
 conf/ocsci/default_config.yaml in its DEFAULTS section.
-
 If the variable can be used in some config file sections from ocsci/config.py
 module, plese put your defaults rather to mentioned default_config.yaml file!
-
 See the documentation in conf/README.md file to understand this config file.
-
 PYTEST_DONT_REWRITE - avoid pytest to rewrite, keep this msg here please!
 """
 import os
@@ -110,5 +106,23 @@ CSI_RBD_SECRET = load_yaml_to_dict(
 CSI_CEPHFS_SECRET = load_yaml_to_dict(
     os.path.join(
         constants.TEMPLATE_CSI_FS_DIR, "secret.yaml"
+    )
+)
+
+CSI_CEPHFS_STORAGECLASS_DICT = load_yaml_to_dict(
+    os.path.join(
+        constants.TEMPLATE_CSI_FS_DIR, "storageclass.yaml"
+    )
+)
+
+CSI_CEPHFS_PVC = load_yaml_to_dict(
+    os.path.join(
+        constants.TEMPLATE_CSI_FS_DIR, "pvc.yaml"
+    )
+)
+
+CSI_RBD_PVC = load_yaml_to_dict(
+    os.path.join(
+        constants.TEMPLATE_CSI_RBD_DIR, "pvc.yaml"
     )
 )

--- a/resources/pod.py
+++ b/resources/pod.py
@@ -9,6 +9,7 @@ import tempfile
 import yaml
 from time import sleep
 from threading import Thread
+import base64
 
 from ocs.ocp import OCP
 from ocs import defaults, constants, exceptions
@@ -239,3 +240,15 @@ def run_io_in_bg(pod_obj, expect_to_fail=False):
     )
 
     return thread
+
+
+def get_admin_key_from_ceph_tools():
+    """
+    Fetches admin key secret from ceph
+    Returns:
+            admin keyring encoded with base64 as a string
+    """
+    tools_pod = get_ceph_tools_pod()
+    out = tools_pod.exec_ceph_cmd(ceph_cmd='ceph auth get-key client.admin')
+    base64_output = base64.b64encode(out['key'].encode()).decode()
+    return base64_output

--- a/tests/manage/OCS_336_346.py
+++ b/tests/manage/OCS_336_346.py
@@ -1,0 +1,121 @@
+import logging
+import pytest
+
+from ocs import ocp, defaults
+from ocsci.config import ENV_DATA
+from ocsci.testlib import tier1, ManageTest
+from resources.ocs import OCS
+from resources.pod import get_admin_key_from_ceph_tools
+from resources.pvc import PVC
+from tests import helpers
+
+log = logging.getLogger(__name__)
+
+
+POD = ocp.OCP(kind='Pod', namespace=ENV_DATA['cluster_namespace'])
+CEPH_OBJ = None
+
+
+@pytest.fixture()
+def test_fixture(request):
+    """
+    Create disks
+    """
+    self = request.node.cls
+    setup_fs(self)
+    yield
+    teardown_fs()
+
+
+def setup_fs(self):
+    """
+    Setting up the environment for the test
+    """
+    global CEPH_OBJ
+    self.fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
+    self.fs_data['metadata']['name'] = helpers.create_unique_resource_name(
+        'test', 'cephfs'
+    )
+    self.fs_data['metadata']['namespace'] = ENV_DATA['cluster_namespace']
+    CEPH_OBJ = OCS(**self.fs_data)
+    CEPH_OBJ.create()
+    assert POD.wait_for_resource(
+        condition='Running', selector='app=rook-ceph-mds'
+    )
+    pods = POD.get(selector='app=rook-ceph-mds')['items']
+    assert len(pods) == 2
+
+
+def teardown_fs():
+    """
+    Tearing down the environment
+    """
+    global CEPH_OBJ
+    CEPH_OBJ.delete()
+
+
+@tier1
+class TestOSCBasics(ManageTest):
+    mons = (
+        f'rook-ceph-mon-a.{ENV_DATA["cluster_namespace"]}'
+        f'.svc.cluster.local:6789,'
+        f'rook-ceph-mon-b.{ENV_DATA["cluster_namespace"]}.'
+        f'svc.cluster.local:6789,'
+        f'rook-ceph-mon-c.{ENV_DATA["cluster_namespace"]}'
+        f'.svc.cluster.local:6789'
+    )
+
+    def test_ocs_336(self, test_fixture):
+        """
+        Testing basics: secret creation,
+        storage class creation and pvc with cephfs
+        """
+        self.cephfs_secret = defaults.CSI_CEPHFS_SECRET.copy()
+        del self.cephfs_secret['data']['userID']
+        del self.cephfs_secret['data']['userKey']
+        self.cephfs_secret['data']['adminKey'] = (
+            get_admin_key_from_ceph_tools()
+        )
+        self.cephfs_secret['data']['adminID'] = defaults.constants.ADMIN_BASE64
+        logging.info(self.cephfs_secret)
+        secret = OCS(**self.cephfs_secret)
+        secret.create()
+        self.cephfs_sc = defaults.CSI_CEPHFS_STORAGECLASS_DICT.copy()
+        self.cephfs_sc['parameters']['monitors'] = self.mons
+        self.cephfs_sc['parameters']['pool'] = (
+            f"{self.fs_data['metadata']['name']}-data0"
+        )
+        storage_class = OCS(**self.cephfs_sc)
+        storage_class.create()
+        self.cephfs_pvc = defaults.CSI_CEPHFS_PVC.copy()
+        pvc = PVC(**self.cephfs_pvc)
+        pvc.create()
+        log.info(pvc.status)
+        assert 'Bound' in pvc.status
+        pvc.delete()
+        storage_class.delete()
+        secret.delete()
+
+    def test_ocs_346(self):
+        """
+        Testing basics: secret creation,
+         storage class creation  and pvc with rbd
+        """
+        self.rbd_secret = defaults.CSI_RBD_SECRET.copy()
+        del self.rbd_secret['data']['kubernetes']
+        self.rbd_secret['data']['admin'] = get_admin_key_from_ceph_tools()
+        logging.info(self.rbd_secret)
+        secret = OCS(**self.rbd_secret)
+        secret.create()
+        self.rbd_sc = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+        self.rbd_sc['parameters']['monitors'] = self.mons
+        del self.rbd_sc['parameters']['userid']
+        storage_class = OCS(**self.rbd_sc)
+        storage_class.create()
+        self.rbd_pvc = defaults.CSI_RBD_PVC.copy()
+        pvc = PVC(**self.rbd_pvc)
+        pvc.create()
+        assert 'Bound' in pvc.status
+        pvc.delete()
+        storage_class.delete()
+        secret.delete()

--- a/tests/manage/OCS_336_346.py
+++ b/tests/manage/OCS_336_346.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs import ocp, defaults
+from ocs import ocp, defaults, constants
 from ocsci.config import ENV_DATA
 from ocsci.testlib import tier1, ManageTest
 from resources.ocs import OCS
@@ -76,7 +76,7 @@ class TestOSCBasics(ManageTest):
         self.cephfs_secret['data']['adminKey'] = (
             get_admin_key_from_ceph_tools()
         )
-        self.cephfs_secret['data']['adminID'] = defaults.constants.ADMIN_BASE64
+        self.cephfs_secret['data']['adminID'] = constants.ADMIN_BASE64
         logging.info(self.cephfs_secret)
         secret = OCS(**self.cephfs_secret)
         secret.create()


### PR DESCRIPTION
resources/pod.py
 - Added function get_admin_key_from_ceph_tools(),which returns admin keyring in base64

ocs/defaults.py
 -  Added default path of csi templates of pvc and storage class for CEPHFS & RBD

ocs/constants.py
 - Added encode value for string 'admin'

tests/manage/OCS_336_346.py
- Added two cases OCS-336 and OCS-346, which covers basics such as secret creation, storage class creation with cephfs and rbd

resources/ocs.py
 - Added return statement to delete()