### PR TITLE
Fix storageclass path

### DIFF
--- a/resources/storage_class.py
+++ b/resources/storage_class.py
@@ -6,7 +6,7 @@ import logging
 import yaml
 import tempfile
 
-from ocs import constants, defaults
+from ocs import constants
 from resources.ocs import OCS
 
 log = logging.getLogger(__name__)

--- a/resources/storage_class.py
+++ b/resources/storage_class.py
@@ -30,13 +30,13 @@ class StorageClass(OCS):
         self.interface = interface
         if self.interface == 'cephfs':
             self.yaml_path = os.path.join(
-                constants.TEMPLATE_CSI_RBD_DIR, "rbd_storageclass.yaml"
+                constants.TEMPLATE_CSI_FS_DIR, "storageclass.yaml"
             )
             # TODO: Implement
             pass
         if self.interface == 'rbd':
             self.yaml_path = os.path.join(
-                constants.TEMPLATE_CSI_FS_DIR, "cephfs_storageclass.yaml"
+                constants.TEMPLATE_CSI_RBD_DIR, "storageclass.yaml"
             )
             # TODO: Implement
             pass

--- a/resources/storage_class.py
+++ b/resources/storage_class.py
@@ -43,6 +43,8 @@ class StorageClass(OCS):
 
         self.sc_data = yaml.safe_load(open(self.yaml_path, 'r'))
         self.sc_data.update(kwargs)
+
+        # TODO(HACK): Fix properly inheritance to OCS, storage classes don't use namespace
         self.sc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
         super(StorageClass, self).__init__(
             api_version=self.sc_data['apiVersion'],

--- a/resources/storage_class.py
+++ b/resources/storage_class.py
@@ -44,12 +44,9 @@ class StorageClass(OCS):
         self.sc_data = yaml.safe_load(open(self.yaml_path, 'r'))
         self.sc_data.update(kwargs)
 
-        # TODO(HACK): Fix properly inheritance to OCS, storage classes don't use namespace
-        self.sc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
         super(StorageClass, self).__init__(
             api_version=self.sc_data['apiVersion'],
-            kind=self.sc_data['kind'],
-            metadata=self.sc_data['metadata']
+            kind=self.sc_data['kind']
         )
         self._name = self.sc_data['metadata']['name']
         self.temp_yaml = tempfile.NamedTemporaryFile(

--- a/resources/storage_class.py
+++ b/resources/storage_class.py
@@ -6,7 +6,7 @@ import logging
 import yaml
 import tempfile
 
-from ocs import constants
+from ocs import constants, defaults
 from resources.ocs import OCS
 
 log = logging.getLogger(__name__)
@@ -43,9 +43,11 @@ class StorageClass(OCS):
 
         self.sc_data = yaml.safe_load(open(self.yaml_path, 'r'))
         self.sc_data.update(kwargs)
+        self.sc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
         super(StorageClass, self).__init__(
-            self.sc_data['apiVersion'], self.sc_data['kind'],
-            self.sc_data['metadata']['namespace']
+            api_version=self.sc_data['apiVersion'],
+            kind=self.sc_data['kind'],
+            metadata=self.sc_data['metadata']
         )
         self._name = self.sc_data['metadata']['name']
         self.temp_yaml = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
- Fixes https://github.com/red-hat-storage/ocs-ci/issues/193
- Storage class doesn't use `namespace`. Added default namespace so that the class can inherit from `OCS` class.