### PR TITLE
OCS-322 Create Duplicate Storageclass with latest changes

### DIFF
--- a/tests/manage/test_create_storageclass_with_same_name.py
+++ b/tests/manage/test_create_storageclass_with_same_name.py
@@ -26,9 +26,13 @@ def teardown():
     Tearing down the environment
 
     """
-    log.info(f"Deleting created storage class: {SC_OBJ.name}")
+    log.info(
+        f"Deleting created storage class: {SC_OBJ.name}"
+    )
     SC_OBJ.delete()
-    log.info(f"Storage class: {SC_OBJ.name} deleted successfully")
+    log.info(
+        f"Storage class: {SC_OBJ.name} deleted successfully"
+    )
 
 
 def create_storageclass(sc_name, expect_fail=False):
@@ -69,14 +73,17 @@ def create_storageclass(sc_name, expect_fail=False):
         assert not expect_fail, (
             "SC creation with same name passed. Expected to fail !!"
         )
-        log.info(f"Storage class: {SC_OBJ.name} created successfully")
+        log.info(
+            f"Storage class: {SC_OBJ.name} created successfully !!"
+        )
         log.debug(sc_data)
 
     except CommandFailed as ecf:
         assert "AlreadyExists" in str(ecf)
-        log.error(f"Cannot create two StorageClasses with same name !! \n"
-                  f"{ecf}"
-                  )
+        log.error(
+            f"Cannot create two StorageClasses with same name !! \n"
+            f"{ecf}"
+        )
 
 
 @tier1
@@ -94,6 +101,8 @@ class TestCaseOCS322(ManageTest):
 
         sc_name = "ocs-322-sc"
         create_storageclass(sc_name)
-        log.info(f"Attempting to create a storageclass "
-                 f"with duplicate name {sc_name}")
+        log.info(
+            f"Attempting to create a storageclass "
+            f"with duplicate name {sc_name}"
+        )
         create_storageclass(sc_name, expect_fail=True)

--- a/tests/manage/test_create_storageclass_with_same_name.py
+++ b/tests/manage/test_create_storageclass_with_same_name.py
@@ -1,0 +1,99 @@
+import logging
+import pytest
+
+from ocs import defaults
+from ocsci.testlib import tier1, ManageTest
+from resources.ocs import OCS
+from ocs.exceptions import CommandFailed
+from ocsci.config import ENV_DATA
+
+log = logging.getLogger(__name__)
+
+SC_OBJ = None
+
+
+@pytest.fixture(scope='class')
+def test_fixture(request):
+    """
+    This fixture defines the teardown function.
+    """
+
+    def finalizer():
+        teardown()
+
+    request.addfinalizer(finalizer)
+
+
+def teardown():
+    """
+    Tearing down the environment
+
+    """
+    log.info(f"Deleting created storage class: {SC_OBJ.name}")
+    SC_OBJ.delete()
+    log.info(f"Storage class: {SC_OBJ.name} deleted successfully")
+
+
+def create_storageclass(sc_name, expect_fail=False):
+    """
+    Function to create a storage class and check for
+    duplicate storage class name
+
+    Args:
+       sc_name (str): name of the storageclass
+        expect_fail (bool): To catch the incorrect scenario in OC - in case
+            two SCs are indeed created with same name
+
+    """
+
+    # Create a storage class
+    mons = (
+        f'rook-ceph-mon-a.{ENV_DATA["cluster_namespace"]}'
+        f'.svc.cluster.local:6789,'
+        f'rook-ceph-mon-b.{ENV_DATA["cluster_namespace"]}.'
+        f'svc.cluster.local:6789,'
+        f'rook-ceph-mon-c.{ENV_DATA["cluster_namespace"]}'
+        f'.svc.cluster.local:6789'
+    )
+    log.info("Creating a Storage Class")
+    sc_data = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+    sc_data['metadata']['name'] = sc_name
+    sc_data['parameters']['monitors'] = mons
+
+    global SC_OBJ
+    SC_OBJ = OCS(**sc_data)
+
+    # Check for expected failure with duplicate SC name
+    try:
+        SC_OBJ.create()
+        assert not expect_fail, (
+            "SC creation with same name passed. Expected to fail !!"
+        )
+        log.info(f"Storage class: {SC_OBJ.name} created successfully")
+        log.debug(sc_data)
+
+    except CommandFailed as ecf:
+        assert "AlreadyExists" in str(ecf)
+        log.error(f"Cannot create two StorageClasses with same name !! \n"
+                  f"{ecf}"
+                  )
+
+
+@tier1
+@pytest.mark.usefixtures(
+    test_fixture.__name__,
+)
+class TestCaseOCS322(ManageTest):
+    def test_create_storageclass_with_same_name(self):
+        """
+        To test that Storageclass creation with duplicate names is not allowed
+
+        TC Name = https://polarion.engineering.redhat.com/polarion/#/project/
+        OpenShiftContainerStorage/workitem?id=OCS-322
+        """
+
+        sc_name = "ocs-322-sc"
+        create_storageclass(sc_name)
+        log.info(f"Attempting to create a storageclass "
+                 f"with duplicate name {sc_name}")
+        create_storageclass(sc_name, expect_fail=True)

--- a/tests/manage/test_create_storageclass_with_same_name.py
+++ b/tests/manage/test_create_storageclass_with_same_name.py
@@ -18,10 +18,7 @@ def test_fixture(request):
     This fixture defines the teardown function.
     """
 
-    def finalizer():
-        teardown()
-
-    request.addfinalizer(finalizer)
+    request.addfinalizer(teardown)
 
 
 def teardown():
@@ -40,9 +37,12 @@ def create_storageclass(sc_name, expect_fail=False):
     duplicate storage class name
 
     Args:
-       sc_name (str): name of the storageclass
-        expect_fail (bool): To catch the incorrect scenario in OC - in case
+        sc_name (str): name of the storageclass to be created
+        expect_fail (bool): To catch the incorrect scenario if
             two SCs are indeed created with same name
+
+    Returns:
+        None
 
     """
 


### PR DESCRIPTION
This is a new PR for TC - OCS-322 (Test that creation of Storageclass with duplicate name fails)
The old PR #91 has been closed.

Added the recent changes for kind classes. Please review and let me know if there's any error.

**The trial run of the Test case passed:** 

```
20:38:42 - MainThread - root - INFO - All logs are located under /tmp/logs
-------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------
20:38:42 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Creating a Storage Class
20:38:42 - MainThread - resources.ocs - INFO - Adding StorageClass with name ocs-322-sc
20:38:42 - MainThread - utility.utils - INFO - Executing command: oc -n default --kubeconfig /home/nberry/aws-install/jun15/auth/kubeconfig create -f /tmp/StorageClasst151d8ea -o yaml
20:38:43 - MainThread - utility.utils - INFO - Executing command: oc -n default --kubeconfig /home/nberry/aws-install/jun15/auth/kubeconfig get StorageClass ocs-322-sc -o yaml
20:38:44 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Storage class: ocs-322-sc created successfully
20:38:44 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Attempting to create a storageclass with duplicate name ocs-322-sc
20:38:44 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Creating a Storage Class
20:38:44 - MainThread - resources.ocs - INFO - Adding StorageClass with name ocs-322-sc
20:38:44 - MainThread - utility.utils - INFO - Executing command: oc -n default --kubeconfig /home/nberry/aws-install/jun15/auth/kubeconfig create -f /tmp/StorageClasstfwwoz86 -o yaml
20:38:45 - MainThread - utility.utils - ERROR - CMD error:: Error from server (AlreadyExists): error when creating "/tmp/StorageClasstfwwoz86": storageclasses.storage.k8s.io "ocs-322-sc" already exists

20:38:45 - MainThread - tests.manage.test_create_storageclass_with_same_name - ERROR - Cannot create two StorageClasses with same name !! 
Error during execution of command: ['oc', '-n', 'default', '--kubeconfig', '/home/nberry/aws-install/jun15/auth/kubeconfig', 'create', '-f', '/tmp/StorageClasstfwwoz86', '-o', 'yaml'].
Error is Error from server (AlreadyExists): error when creating "/tmp/StorageClasstfwwoz86": storageclasses.storage.k8s.io "ocs-322-sc" already exists

PASSED                                                                                                                                                                                                      [100%]
------------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------------
20:38:45 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Deleting created storage class: ocs-322-sc
20:38:45 - MainThread - utility.utils - INFO - Executing command: oc -n default --kubeconfig /home/nberry/aws-install/jun15/auth/kubeconfig delete StorageClass ocs-322-sc
20:38:47 - MainThread - tests.manage.test_create_storageclass_with_same_name - INFO - Storage class: ocs-322-sc deleted successfully


============================================================================================ 1 passed in 4.84 seconds =============================================================================================
(ocs-ci) [nberry@localhost ocs-ci]$ 
```
