### PR TITLE
Update: tests/manage/test_ocs_336_346.py

### DIFF
--- a/tests/manage/test_ocs_336_346.py
+++ b/tests/manage/test_ocs_336_346.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 
 from ocs import ocp, defaults, constants
 from ocsci.config import ENV_DATA
@@ -7,51 +6,12 @@ from ocsci.testlib import tier1, ManageTest
 from resources.ocs import OCS
 from resources.pod import get_admin_key_from_ceph_tools
 from resources.pvc import PVC
-from tests import helpers
+from ocs.exceptions import CommandFailed
 
 log = logging.getLogger(__name__)
 
 
 POD = ocp.OCP(kind='Pod', namespace=ENV_DATA['cluster_namespace'])
-CEPH_OBJ = None
-
-
-@pytest.fixture()
-def test_fixture(request):
-    """
-    Create disks
-    """
-    self = request.node.cls
-    setup_fs(self)
-    yield
-    teardown_fs()
-
-
-def setup_fs(self):
-    """
-    Setting up the environment for the test
-    """
-    global CEPH_OBJ
-    self.fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
-    self.fs_data['metadata']['name'] = helpers.create_unique_resource_name(
-        'test', 'cephfs'
-    )
-    self.fs_data['metadata']['namespace'] = ENV_DATA['cluster_namespace']
-    CEPH_OBJ = OCS(**self.fs_data)
-    CEPH_OBJ.create()
-    assert POD.wait_for_resource(
-        condition='Running', selector='app=rook-ceph-mds'
-    )
-    pods = POD.get(selector='app=rook-ceph-mds')['items']
-    assert len(pods) == 2
-
-
-def teardown_fs():
-    """
-    Tearing down the environment
-    """
-    global CEPH_OBJ
-    CEPH_OBJ.delete()
 
 
 @tier1
@@ -65,11 +25,12 @@ class TestOSCBasics(ManageTest):
         f'.svc.cluster.local:6789'
     )
 
-    def test_ocs_336(self, test_fixture):
+    def test_ocs_336(self):
         """
         Testing basics: secret creation,
         storage class creation and pvc with cephfs
         """
+        self.fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
         self.cephfs_secret = defaults.CSI_CEPHFS_SECRET.copy()
         del self.cephfs_secret['data']['userID']
         del self.cephfs_secret['data']['userKey']
@@ -79,6 +40,7 @@ class TestOSCBasics(ManageTest):
         self.cephfs_secret['data']['adminID'] = constants.ADMIN_BASE64
         logging.info(self.cephfs_secret)
         secret = OCS(**self.cephfs_secret)
+        cleanup_resource(secret, self.cephfs_secret)
         secret.create()
         self.cephfs_sc = defaults.CSI_CEPHFS_STORAGECLASS_DICT.copy()
         self.cephfs_sc['parameters']['monitors'] = self.mons
@@ -86,11 +48,13 @@ class TestOSCBasics(ManageTest):
             f"{self.fs_data['metadata']['name']}-data0"
         )
         storage_class = OCS(**self.cephfs_sc)
+        cleanup_resource(storage_class, self.cephfs_sc)
         storage_class.create()
         self.cephfs_pvc = defaults.CSI_CEPHFS_PVC.copy()
         pvc = PVC(**self.cephfs_pvc)
+        cleanup_resource(pvc, self.cephfs_pvc)
         pvc.create()
-        log.info(pvc.status)
+        pvc.reload()
         assert 'Bound' in pvc.status
         pvc.delete()
         storage_class.delete()
@@ -101,21 +65,53 @@ class TestOSCBasics(ManageTest):
         Testing basics: secret creation,
          storage class creation  and pvc with rbd
         """
+        self.rbd_pool = defaults.CEPHBLOCKPOOL_DICT.copy()
+        pool = OCS(**self.rbd_pool)
+        cleanup_resource(pool, self.rbd_pool)
+        pool.create()
         self.rbd_secret = defaults.CSI_RBD_SECRET.copy()
         del self.rbd_secret['data']['kubernetes']
         self.rbd_secret['data']['admin'] = get_admin_key_from_ceph_tools()
         logging.info(self.rbd_secret)
         secret = OCS(**self.rbd_secret)
+        cleanup_resource(secret, self.rbd_secret)
         secret.create()
         self.rbd_sc = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
         self.rbd_sc['parameters']['monitors'] = self.mons
+        self.rbd_sc['parameters']['pool'] = self.rbd_pool['metadata']['name']
         del self.rbd_sc['parameters']['userid']
         storage_class = OCS(**self.rbd_sc)
+        cleanup_resource(storage_class, self.rbd_sc)
         storage_class.create()
         self.rbd_pvc = defaults.CSI_RBD_PVC.copy()
         pvc = PVC(**self.rbd_pvc)
+        cleanup_resource(pvc, self.rbd_pvc)
         pvc.create()
+        pvc.reload()
         assert 'Bound' in pvc.status
         pvc.delete()
         storage_class.delete()
         secret.delete()
+        pool.delete()
+
+
+def cleanup_resource(ocs_obj, resource_dict):
+    """
+    Cleans up resource if already created
+    Args:
+        ocs_obj: OCS object for ops
+        resource_dict: resource dict for deleting resource
+    Returns:
+        bool: True if resource exists
+    """
+    try:
+        output = str(ocs_obj.get())
+        if resource_dict['metadata']['name'] in output:
+            log.info(
+                f"cleaning up resource {resource_dict['metadata']['name']}"
+            )
+            ocs_obj.delete()
+            return True
+
+    except CommandFailed:
+        pass


### PR DESCRIPTION
 - Updated test func test_ocs_336() with removed fixtures which were creating and deleting cephfs (depends on PR https://github.com/red-hat-storage/ocs-ci/pull/226)
 - Added cleanup function cleanup_resource(), which checks resource if exists, else deletes
 - Added reload() for pvc object, which updates pvc status
 - Added pool creation for rbd --> test_ocs_346()

Signed-off-by: Shreekar <sshreeka@redhat.com>