### PR TITLE
load utility module after configuration init

### DIFF
--- a/run_ocsci.py
+++ b/run_ocsci.py
@@ -8,7 +8,6 @@ import yaml
 
 from ocs import defaults
 from ocsci import config as ocsci_config
-from utility.utils import add_path_to_env_path
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -116,6 +115,7 @@ def main():
         '-p', 'ocsci.pytest_customization.marks',
         '-p', 'ocsci.pytest_customization.ocsci_logging',
     ])
+    from utility.utils import add_path_to_env_path
     add_path_to_env_path(os.path.join(HERE, 'bin'))
     exit(pytest.main(arguments))
 


### PR DESCRIPTION
- `utility` module have to be loaded after `init_ocsci_conf(arguments)`
- fixes https://github.com/red-hat-storage/ocs-ci/issues/233