### PR TITLE
Polarion support

### DIFF
--- a/conf/ocsci/default_config.yaml
+++ b/conf/ocsci/default_config.yaml
@@ -47,7 +47,7 @@ REPORTING:
   email:
     address: "ocs-ci@redhat.com"
   polarion:
-    project_id: "OCS"
+    project_id: "OpenShiftContainerStorage"
 
 # This is the default information about environment. Will be overwritten with
 # --cluster-conf file.yaml data you will pass to the pytest.

--- a/conf/ocsci/default_config.yaml
+++ b/conf/ocsci/default_config.yaml
@@ -46,6 +46,8 @@ DEPLOYMENT:
 REPORTING:
   email:
     address: "ocs-ci@redhat.com"
+  polarion:
+    project_id: "OCS"
 
 # This is the default information about environment. Will be overwritten with
 # --cluster-conf file.yaml data you will pass to the pytest.

--- a/ocs/defaults.py
+++ b/ocs/defaults.py
@@ -55,6 +55,9 @@ REPORTING = {
     'email': {
         'address': 'ocs-ci@redhat.com',
     },
+    'polarion': {
+        'project_id': 'OCS',
+    }
 }
 
 RUN = {

--- a/ocs/defaults.py
+++ b/ocs/defaults.py
@@ -56,7 +56,7 @@ REPORTING = {
         'address': 'ocs-ci@redhat.com',
     },
     'polarion': {
-        'project_id': 'OCS',
+        'project_id': 'OpenShiftContainerStorage',
     }
 }
 

--- a/ocsci/pytest_customization/marks.py
+++ b/ocsci/pytest_customization/marks.py
@@ -34,6 +34,7 @@ scale = pytest.mark.scale
 deployment = pytest.mark.deployment
 destroy = pytest.mark.destroy
 upgrade = pytest.mark.upgrade
+polarion_id = pytest.mark.polarion_id
 
 # mark the test class with marker below to ignore leftover check
 ignore_leftovers = pytest.mark.ignore_leftovers

--- a/ocsci/pytest_customization/ocscilib.py
+++ b/ocsci/pytest_customization/ocscilib.py
@@ -103,3 +103,13 @@ def process_cluster_cli_params(config):
         cluster_path = os.path.join(cluster_dir_parent, cluster_name)
     ocsci_config.ENV_DATA['cluster_name'] = cluster_name
     ocsci_config.ENV_DATA['cluster_path'] = cluster_path
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """
+    Add Polarion ID property to test cases that are marked with one.
+    """
+    for item in items:
+        for marker in item.iter_markers(name="polarion_id"):
+            polarion_id = marker.args[0]
+            item.user_properties.append(("polarion-testcase-id", polarion_id))

--- a/ocsci/pytest_customization/ocscilib.py
+++ b/ocsci/pytest_customization/ocscilib.py
@@ -6,8 +6,8 @@ The basic configuration is done in run_ocsci.py module casue we need to load
 all the config before pytest run. This run_ocsci.py is just a wrapper for
 pytest which proccess config and passes all params to pytest.
 """
+import logging
 import os
-
 import random
 
 import ocs
@@ -16,6 +16,8 @@ from ocsci import config as ocsci_config
 __all__ = [
     "pytest_addoption",
 ]
+
+log = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser):
@@ -110,6 +112,16 @@ def pytest_collection_modifyitems(session, config, items):
     Add Polarion ID property to test cases that are marked with one.
     """
     for item in items:
-        for marker in item.iter_markers(name="polarion_id"):
-            polarion_id = marker.args[0]
-            item.user_properties.append(("polarion-testcase-id", polarion_id))
+        try:
+            marker = item.get_closest_marker(name="polarion_id")
+            if marker:
+                polarion_id = marker.args[0]
+                item.user_properties.append(
+                    ("polarion-testcase-id", polarion_id)
+                )
+        except IndexError:
+            log.warning(
+                f"polarion_id marker found with no value for "
+                f"{item.name} in {item.fspath}",
+                exc_info=True
+            )

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ markers =
     scale: scale related tests
     deployment: deplyment related tests
     upgrade: upgrade related tests
+    polarion_id: ID of test case used for reporting to Polarion
 
 
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from ocs import constants
+from ocsci.config import REPORTING
 from resources.ocs import OCS
 from utility.environment_check import environment_checker  # noqa: F401
 
@@ -57,3 +58,12 @@ def invalid_cephfs_storageclass(request):
         f"{request.param['storageclass_name']}"
     )
     storageclass.delete()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def polarion_testsuite_properties(record_testsuite_property):
+    """
+    Configures polarion testsuite properties for junit xml
+    """
+    polarion_project_id = REPORTING['polarion']['project_id']
+    record_testsuite_property('polarion-projct-id', polarion_project_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from ocs import constants
-from ocsci.config import REPORTING
+from ocsci import config
 from resources.ocs import OCS
 from utility.environment_check import environment_checker  # noqa: F401
 
@@ -65,5 +65,5 @@ def polarion_testsuite_properties(record_testsuite_property):
     """
     Configures polarion testsuite properties for junit xml
     """
-    polarion_project_id = REPORTING['polarion']['project_id']
+    polarion_project_id = config.REPORTING['polarion']['project_id']
     record_testsuite_property('polarion-projct-id', polarion_project_id)

--- a/tests/manage/ocs_288.py
+++ b/tests/manage/ocs_288.py
@@ -117,6 +117,7 @@ def create_storageclass_cephfs():
 @pytest.mark.usefixtures(
     ocs288_fixture.__name__,
 )
+@pytest.mark.polarion_id("OCS-288")
 class TestCaseOCS288(ManageTest):
     """
     Creating PVC with random SC

--- a/tests/manage/test_create_storageclass_with_same_name.py
+++ b/tests/manage/test_create_storageclass_with_same_name.py
@@ -91,6 +91,7 @@ def create_storageclass(sc_name, expect_fail=False):
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )
+@pytest.mark.polarion_id("OCS-322")
 class TestCaseOCS322(ManageTest):
     def test_create_storageclass_with_same_name(self):
         """

--- a/tests/manage/test_ocs_324.py
+++ b/tests/manage/test_ocs_324.py
@@ -77,6 +77,7 @@ def teardown(self):
 
 
 @tier1
+@pytest.mark.polarion_id("OCS-324")
 class TestCaseOCS324(ManageTest):
     """
     Delete PVC and create a new PVC with same name

--- a/tests/manage/test_ocs_336_346.py
+++ b/tests/manage/test_ocs_336_346.py
@@ -65,6 +65,7 @@ class TestOSCBasics(ManageTest):
         f'.svc.cluster.local:6789'
     )
 
+    @pytest.mark.polarion_id("OCS-336")
     def test_ocs_336(self, test_fixture):
         """
         Testing basics: secret creation,
@@ -96,6 +97,7 @@ class TestOSCBasics(ManageTest):
         storage_class.delete()
         secret.delete()
 
+    @pytest.mark.polarion_id("OCS-346")
     def test_ocs_346(self):
         """
         Testing basics: secret creation,

--- a/tests/manage/test_pvc_deletion_during_io.py
+++ b/tests/manage/test_pvc_deletion_during_io.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
     create_pvc.__name__,
     create_pod.__name__
 )
+@pytest.mark.polarion_id("OCS-371")
 class TestCaseOCS371(ManageTest):
     """
     Delete PVC while IO is in progress

--- a/tests/manage/test_pvc_invalid_inputs.py
+++ b/tests/manage/test_pvc_invalid_inputs.py
@@ -59,6 +59,7 @@ def teardown():
 
 @tier1
 @pytest.mark.usefixtures(test_fixture.__name__)
+@pytest.mark.polarion_id("OCS-284")
 class TestPvcCreationInvalidInputs(ManageTest):
     """
     PVC creation with invaid inputs in pvc yaml

--- a/tests/manage/test_rbd_csi_default_sc.py
+++ b/tests/manage/test_rbd_csi_default_sc.py
@@ -50,6 +50,7 @@ def teardown():
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )
+@pytest.mark.polarion_id("OCS-347")
 class TestCaseOCS347(ManageTest):
     """
     Testing default storage class creation and pvc creation


### PR DESCRIPTION
Added the ability to mark tests with their respective `polarion_id`s in order to support posting our test results to Polarion. When we export our test results to a junit xml file (`--junit-xml report.xml`) any test cases that are marked with polarion_ids will have a custom property set that reflects the value. 

Ex.
```
<properties><property name="polarion-testcase-id" value="OCS-foo"/></properties>
```

Note that these changes do not add the ability to post the results to Polarion, only to support the tool we will use to take our xml test results and post the results. 