### PR TITLE
wip: depend on stable release of pip to prevent very recent minimal version of pip in tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,5 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-    - python: 3.6
-      env: TOXENV=flake8
     - python: 3.7
       env: TOXENV=flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+-e git+https://github.com/reportportal/client-Python.git@master#egg=reportportal-client
 -e .

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'apache-libcloud',
         'docopt==0.6.2',
         'gevent==1.4.0',
-        'reportportal-client @ git+https://github.com/reportportal/client-Python.git@master',
+        'reportportal-client',
         'requests==2.21.0',
         'paramiko==2.4.2',
         'pyyaml>=4.2b1',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-# Use a new pip so we can use PEP 508 URL requirements
-requires = pip >= 19.1.1
+# Use a new pip so we can use PEP 508 URL requirements, which is available
+# since pip 18.1 (2018-10-05)
+requires = pip >= 18.1
 envlist = py36,py37,flake8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,4 @@
 [tox]
-# Use a new pip so we can use PEP 508 URL requirements, which is available
-# since pip 18.1 (2018-10-05)
-requires = pip >= 18.1
 envlist = py36,py37,flake8
 
 [testenv]


### PR DESCRIPTION
Work in progress, based on https://github.com/red-hat-storage/ocs-ci/pull/210/files#r293921745

- [X] tox unit test run on recent distributions such as Fedora 30
- [ ] tox unit test run on RHEL 8
- [X] TravisCI run
- [ ] installation and usage of ocs-ci on Fedora 30 (there is no change in installation steps, as we already suggest to install ocs-ci vis `pip install -r requirements.txt`)