### PR TITLE
fixing accidental changes in mutable default structures

### DIFF
--- a/ocs/utils.py
+++ b/ocs/utils.py
@@ -579,7 +579,7 @@ def create_oc_resource(
     template_name,
     cluster_path,
     _templating,
-    template_data={},
+    template_data=None,
     template_dir="ocs-deployment",
 ):
     """
@@ -596,6 +596,8 @@ def create_oc_resource(
         template_dir (str): Directory under templates dir where template
             exists (default: ocs-deployment)
     """
+    if template_data is None:
+        template_data = {}
     template_path = os.path.join(template_dir, template_name)
     template = _templating.render_template(template_path, template_data)
     cfg_file = os.path.join(cluster_path, template_name)
@@ -610,7 +612,7 @@ def apply_oc_resource(
     template_name,
     cluster_path,
     _templating,
-    template_data={},
+    template_data=None,
     template_dir="ocs-deployment",
 ):
     """
@@ -627,6 +629,8 @@ def apply_oc_resource(
         template_dir (str): Directory under templates dir where template
             exists (default: ocs-deployment)
     """
+    if template_data is None:
+        template_data = {}
     template_path = os.path.join(template_dir, template_name)
     template = _templating.render_template(template_path, template_data)
     cfg_file = os.path.join(cluster_path, template_name)

--- a/ocsci/main.py
+++ b/ocsci/main.py
@@ -34,7 +34,7 @@ def get_param(param, arguments, default=None):
     return default
 
 
-def init_ocsci_conf(arguments=[], default_config=OCSCI_DEFAULT_CONFIG):
+def init_ocsci_conf(arguments=None, default_config=OCSCI_DEFAULT_CONFIG):
     """
     Function to init the default config for OCS CI
 
@@ -43,6 +43,8 @@ def init_ocsci_conf(arguments=[], default_config=OCSCI_DEFAULT_CONFIG):
         default_config (str): Default config data
 
     """
+    if arguments is None:
+        arguments = []
     custom_config = get_param('--ocsci-conf', arguments)
     cluster_config = get_param('--cluster-conf', arguments)
     config_data = ocsci.config.to_dict()

--- a/resources/pvc.py
+++ b/resources/pvc.py
@@ -1,6 +1,7 @@
 """
 General PVC object
 """
+import copy
 import logging
 
 from ocs import constants
@@ -102,7 +103,7 @@ def get_all_pvcs():
     return out
 
 
-def create_multiple_pvc(number_of_pvc=1, pvc_data=CSI_PVC_DICT.copy()):
+def create_multiple_pvc(number_of_pvc=1, pvc_data=copy.deepcopy(CSI_PVC_DICT)):
     """
     Create one or more PVC
 

--- a/resources/pvc.py
+++ b/resources/pvc.py
@@ -103,7 +103,7 @@ def get_all_pvcs():
     return out
 
 
-def create_multiple_pvc(number_of_pvc=1, pvc_data=copy.deepcopy(CSI_PVC_DICT)):
+def create_multiple_pvc(number_of_pvc=1, pvc_data=None):
     """
     Create one or more PVC
 
@@ -114,6 +114,8 @@ def create_multiple_pvc(number_of_pvc=1, pvc_data=copy.deepcopy(CSI_PVC_DICT)):
     Returns:
          list: List of PVC objects
     """
+    if pvc_data is None:
+        pvc_data = copy.deepcopy(CSI_PVC_DICT)
     pvc_objs = []
     pvc_base_name = pvc_data['metadata']['name']
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 from tests import helpers
 from ocs import defaults, constants
@@ -88,7 +90,7 @@ def create_pod(request):
     """
     class_instance = request.node.cls
 
-    pod_data = defaults.CSI_RBD_POD_DICT.copy()
+    pod_data = copy.deepcopy(defaults.CSI_RBD_POD_DICT)
     pod_data['metadata']['name'] = helpers.create_unique_resource_name(
         'test', 'pod'
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@
 Helper functions file for OCS QE
 """
 import base64
+import copy
 import datetime
 import logging
 
@@ -107,11 +108,11 @@ def create_secret(interface_type):
     """
     secret_data = dict()
     if interface_type == constants.CEPHBLOCKPOOL:
-        secret_data = defaults.CSI_RBD_SECRET.copy()
+        secret_data = copy.deepcopy(defaults.CSI_RBD_SECRET)
         del secret_data['data']['kubernetes']
         secret_data['data']['admin'] = get_admin_key()
     elif interface_type == constants.CEPHFILESYSTEM:
-        secret_data = defaults.CSI_CEPHFS_SECRET.copy()
+        secret_data = copy.deepcopy(defaults.CSI_CEPHFS_SECRET)
         del secret_data['data']['userID']
         del secret_data['data']['userKey']
         secret_data['data']['adminID'] = constants.ADMIN_BASE64
@@ -134,7 +135,7 @@ def create_ceph_block_pool(pool_name=None):
     Returns:
         OCS: An OCS instance for the Ceph block pool
     """
-    cbp_data = defaults.CEPHBLOCKPOOL_DICT.copy()
+    cbp_data = copy.deepcopy(defaults.CEPHBLOCKPOOL_DICT)
     cbp_data['metadata']['name'] = pool_name if pool_name else create_unique_resource_name(
         'test', 'cbp'
     )
@@ -165,11 +166,11 @@ def create_storage_class(
     """
     sc_data = dict()
     if interface_type == constants.CEPHBLOCKPOOL:
-        sc_data = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+        sc_data = copy.deepcopy(defaults.CSI_RBD_STORAGECLASS_DICT)
         sc_data['parameters']['csi.storage.k8s.io/node-publish-secret-name'] = secret_name
         sc_data['parameters']['csi.storage.k8s.io/node-publish-secret-namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
     elif interface_type == constants.CEPHFILESYSTEM:
-        sc_data = defaults.CSI_CEPHFS_STORAGECLASS_DICT.copy()
+        sc_data = copy.deepcopy(defaults.CSI_CEPHFS_STORAGECLASS_DICT)
         sc_data['parameters']['csi.storage.k8s.io/node-stage-secret-name'] = secret_name
         sc_data['parameters']['csi.storage.k8s.io/node-stage-secret-namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
     sc_data['parameters']['pool'] = interface_name
@@ -213,7 +214,7 @@ def create_pvc(sc_name, pvc_name=None):
     Returns:
         OCS: An OCS instance for the PVC
     """
-    pvc_data = defaults.CSI_PVC_DICT.copy()
+    pvc_data = copy.deepcopy(defaults.CSI_PVC_DICT)
     pvc_data['metadata']['name'] = pvc_name if pvc_name else create_unique_resource_name(
         'test', 'pvc'
     )
@@ -393,7 +394,7 @@ def create_cephfilesystem():
     Returns:
         bool: True if CephFileSystem creates successful
     """
-    fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
+    fs_data = copy.deepcopy(defaults.CEPHFILESYSTEM_DICT)
     fs_data['metadata']['name'] = create_unique_resource_name(
         'test', 'cephfs'
     )

--- a/tests/manage/test_create_storageclass_with_same_name.py
+++ b/tests/manage/test_create_storageclass_with_same_name.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+
 import pytest
 
 from ocs import defaults
@@ -61,7 +63,7 @@ def create_storageclass(sc_name, expect_fail=False):
         f'.svc.cluster.local:6789'
     )
     log.info("Creating a Storage Class")
-    sc_data = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+    sc_data = copy.deepcopy(defaults.CSI_RBD_STORAGECLASS_DICT)
     sc_data['metadata']['name'] = sc_name
     sc_data['parameters']['monitors'] = mons
 

--- a/tests/manage/test_ocs_336_346.py
+++ b/tests/manage/test_ocs_336_346.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+
 import pytest
 
 from ocs import ocp, defaults, constants
@@ -32,7 +34,7 @@ def setup_fs(self):
     Setting up the environment for the test
     """
     global CEPH_OBJ
-    self.fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
+    self.fs_data = copy.deepcopy(defaults.CEPHFILESYSTEM_DICT)
     self.fs_data['metadata']['name'] = helpers.create_unique_resource_name(
         'test', 'cephfs'
     )
@@ -71,7 +73,7 @@ class TestOSCBasics(ManageTest):
         Testing basics: secret creation,
         storage class creation and pvc with cephfs
         """
-        self.cephfs_secret = defaults.CSI_CEPHFS_SECRET.copy()
+        self.cephfs_secret = copy.deepcopy(defaults.CSI_CEPHFS_SECRET)
         del self.cephfs_secret['data']['userID']
         del self.cephfs_secret['data']['userKey']
         self.cephfs_secret['data']['adminKey'] = (
@@ -81,14 +83,14 @@ class TestOSCBasics(ManageTest):
         logging.info(self.cephfs_secret)
         secret = OCS(**self.cephfs_secret)
         secret.create()
-        self.cephfs_sc = defaults.CSI_CEPHFS_STORAGECLASS_DICT.copy()
+        self.cephfs_sc = copy.deepcopy(defaults.CSI_CEPHFS_STORAGECLASS_DICT)
         self.cephfs_sc['parameters']['monitors'] = self.mons
         self.cephfs_sc['parameters']['pool'] = (
             f"{self.fs_data['metadata']['name']}-data0"
         )
         storage_class = OCS(**self.cephfs_sc)
         storage_class.create()
-        self.cephfs_pvc = defaults.CSI_CEPHFS_PVC.copy()
+        self.cephfs_pvc = copy.deepcopy(defaults.CSI_CEPHFS_PVC)
         pvc = PVC(**self.cephfs_pvc)
         pvc.create()
         log.info(pvc.status)
@@ -103,18 +105,18 @@ class TestOSCBasics(ManageTest):
         Testing basics: secret creation,
          storage class creation  and pvc with rbd
         """
-        self.rbd_secret = defaults.CSI_RBD_SECRET.copy()
+        self.rbd_secret = copy.deepcopy(defaults.CSI_RBD_SECRET)
         del self.rbd_secret['data']['kubernetes']
         self.rbd_secret['data']['admin'] = get_admin_key_from_ceph_tools()
         logging.info(self.rbd_secret)
         secret = OCS(**self.rbd_secret)
         secret.create()
-        self.rbd_sc = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+        self.rbd_sc = copy.deepcopy(defaults.CSI_RBD_STORAGECLASS_DICT)
         self.rbd_sc['parameters']['monitors'] = self.mons
         del self.rbd_sc['parameters']['userid']
         storage_class = OCS(**self.rbd_sc)
         storage_class.create()
-        self.rbd_pvc = defaults.CSI_RBD_PVC.copy()
+        self.rbd_pvc = copy.deepcopy(defaults.CSI_RBD_PVC)
         pvc = PVC(**self.rbd_pvc)
         pvc.create()
         assert 'Bound' in pvc.status

--- a/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -2,7 +2,9 @@
 A test case to verify after deleting pvc whether
 size is returned to backend pool
 """
+import copy
 import logging
+
 import pytest
 
 from ocs import constants, defaults
@@ -88,7 +90,7 @@ def create_pvc_and_verify_pvc_exists(
     pvc exists on ceph side
     """
 
-    pvc_data = defaults.CSI_PVC_DICT.copy()
+    pvc_data = copy.deepcopy(defaults.CSI_PVC_DICT)
     pvc_data['metadata']['name'] = helpers.create_unique_resource_name(
         'test', 'pvc'
     )
@@ -135,7 +137,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         pvc_obj = create_pvc_and_verify_pvc_exists(
             self.sc_obj.name, self.cbp_obj.name
         )
-        pod_data = defaults.CSI_RBD_POD_DICT.copy()
+        pod_data = copy.deepcopy(defaults.CSI_RBD_POD_DICT)
         pod_data['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] = pvc_obj.name
         pod_obj = helpers.create_pod(**pod_data)
         used_percentage = pod.run_io_and_verify_mount_point(pod_obj)

--- a/tests/manage/test_pvc_invalid_inputs.py
+++ b/tests/manage/test_pvc_invalid_inputs.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+
 import pytest
 
 from ocs import defaults
@@ -36,7 +38,7 @@ def setup(self):
     """
     # Create a storage class
     log.info("Creating a Storage Class")
-    self.sc_data = defaults.CSI_RBD_STORAGECLASS_DICT.copy()
+    self.sc_data = copy.deepcopy(defaults.CSI_RBD_STORAGECLASS_DICT)
     self.sc_data['metadata']['name'] = helpers.create_unique_resource_name(
         'test', 'csi-rbd'
     )
@@ -85,7 +87,7 @@ def create_pvc_invalid_name(pvcname):
     Returns:
         None
     """
-    pvc_data = defaults.CSI_PVC_DICT.copy()
+    pvc_data = copy.deepcopy(defaults.CSI_PVC_DICT)
     pvc_data['metadata']['name'] = pvcname
     pvc_data['spec']['storageClassName'] = SC_OBJ.name
     pvc_obj = PVC(**pvc_data)
@@ -118,7 +120,7 @@ def create_pvc_invalid_size(pvcsize):
     Returns:
         None
     """
-    pvc_data = defaults.CSI_PVC_DICT.copy()
+    pvc_data = copy.deepcopy(defaults.CSI_PVC_DICT)
     pvc_data['metadata']['name'] = "auto"
     pvc_data['spec']['resources']['requests']['storage'] = pvcsize
     pvc_data['spec']['storageClassName'] = SC_OBJ.name

--- a/tests/test_add_mds_to_cluster.py
+++ b/tests/test_add_mds_to_cluster.py
@@ -1,7 +1,9 @@
 """
 A test for creating a CephFS
 """
+import copy
 import logging
+
 import pytest
 
 from ocs import ocp, defaults, constants
@@ -35,7 +37,7 @@ def setup(self):
     """
     Setting up the environment for the test
     """
-    self.fs_data = defaults.CEPHFILESYSTEM_DICT.copy()
+    self.fs_data = copy.deepcopy(defaults.CEPHFILESYSTEM_DICT)
     self.fs_data['metadata']['name'] = helpers.create_unique_resource_name(
         'test', 'cephfs'
     )

--- a/tests/test_storageclass_invalid.py
+++ b/tests/test_storageclass_invalid.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+
 import pytest
 
 from resources.pvc import PVC
@@ -18,7 +20,7 @@ class TestCaseOCS331(ManageTest):
         Test that Persistent Volume Claim can not be created from misconfigured
         CephFS Storage Class.
         """
-        pvc_data = defaults.CSI_PVC_DICT.copy()
+        pvc_data = copy.deepcopy(defaults.CSI_PVC_DICT)
         pvc_name = helpers.create_unique_resource_name('test', 'pvc')
         pvc_data['metadata']['name'] = pvc_name
         pvc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,14 @@ commands = py.test \
     {posargs}
 
 [testenv:flake8]
-deps = flake8
+deps =
+    flake8
+    flake8-mutable
 commands = flake8
 
 [flake8]
 ignore = E402, E741, W503
+enable-extensions = M511
 exclude =
     venv,
     .venv,

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -382,7 +382,7 @@ def create_run_dir(run_id):
     return run_dir
 
 
-def close_and_remove_filehandlers(logger=logging.getLogger()):
+def close_and_remove_filehandlers(logger=None):
     """
     Close FileHandlers and then remove them from the loggers handlers list.
 
@@ -392,6 +392,8 @@ def close_and_remove_filehandlers(logger=logging.getLogger()):
     Returns:
         None
     """
+    if logger is None:
+        logger = logging.getLogger()
     handlers = logger.handlers[:]
     for h in handlers:
         if isinstance(h, logging.FileHandler):


### PR DESCRIPTION
This is just *quick fix* (hack), proper fix requires us to use a different
API (eg. function or a fixture, which creates new object of given type).

This consists of 3 changes:

* replacing usage of `copy()` call with `copy.deepcopy()`
* removing [default mutable arguments](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)
* adding `M511` flake8 plugin to prevent this problem in the future (I will announce this on our list when merged so that all team members will know what this new flake8 error mean)

When merging, *don't use squash and merge* feature, I would like to be able to refer to commit 8ed5847d8024fd828821000cc8fad6a9dcbfeac9 as an example how to handle this problem.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/266