### PR TITLE
Changing toc to table of contents in doc/Readme.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Hello and welcome in the official project documentation.
 
 Basic information about the project you can find in initial [README](../README.md) file.
 
-## TOC for documentation
+## Table of contents for documentation
 
 Rest of the information you can find in those sections
 


### PR DESCRIPTION
It's better not to use short forms like TOC in the documentation as the user might not always know what could be the abbreviations for them.