### PR TITLE
add flake8-broken-line checks into our flake8 run

### DIFF
--- a/ocs/ceph.py
+++ b/ocs/ceph.py
@@ -328,8 +328,10 @@ class Ceph(object):
         collocated = self.ansible_config.get('osd_scenario') == 'collocated'
         lvm = self.ansible_config.get('osd_scenario') == 'lvm'
         if not collocated and not lvm:
-            reserved_devs = \
-                [raw_journal_device for raw_journal_device in set(self.ansible_config.get('dedicated_devices'))]
+            reserved_devs = [
+                raw_journal_device
+                for raw_journal_device
+                in set(self.ansible_config.get('dedicated_devices'))]
         if len(node.get_free_volumes()) >= len(reserved_devs):
             for _ in reserved_devs:
                 node.get_free_volumes()[0].status = NodeVolume.ALLOCATED
@@ -611,9 +613,9 @@ class Ceph(object):
                     logger.info("Using the cdn repo for the test")
                     node.setup_rhel_cdn_repos(build)
             else:
-                if self.ansible_config.get('ceph_repository_type') != 'iso' or \
-                        self.ansible_config.get('ceph_repository_type') == 'iso' and \
-                        (node.role == 'installer'):
+                if (self.ansible_config.get('ceph_repository_type') != 'iso'
+                        or self.ansible_config.get('ceph_repository_type') == 'iso'
+                        and (node.role == 'installer')):
                     if node.pkg_type == 'deb':
                         node.setup_deb_repos(ubuntu_repo)
                         sleep(15)
@@ -1033,8 +1035,7 @@ class CephNode(object):
 
         stdin, stdout, stderr = self.rssh().exec_command("dmesg")
         self.rssh_transport().set_keepalive(15)
-        changepwd = 'echo ' + "'" + self.username + ":" + self.password + "'" \
-                    + "|" + "chpasswd"
+        changepwd = 'echo ' + "'" + self.username + ":" + self.password + "'" + "|" + "chpasswd"
         logger.info("Running command %s", changepwd)
         stdin, stdout, stderr = self.rssh().exec_command(changepwd)
         logger.info(stdout.readlines())
@@ -1313,9 +1314,9 @@ class CephNode(object):
         user = 'redhat'
         passwd = 'OgYZNpkj6jZAIF20XFZW0gnnwYBjYcmt7PeY76bLHec9'
         num = str(build).split('.')[0]
-        cmd = 'umask 0077; echo deb https://{user}:{passwd}@rhcs.download.redhat.com/{num}-updates/Tools ' \
-              '$(lsb_release -sc) main | tee /etc/apt/sources.list.d/Tools.list'.format(user=user, passwd=passwd,
-                                                                                        num=num)
+        cmd = ('umask 0077; echo deb https://{user}:{passwd}@rhcs.download.redhat.com/{num}-updates/Tools '
+               '$(lsb_release -sc) main | tee /etc/apt/sources.list.d/Tools.list').format(user=user, passwd=passwd,
+                                                                                          num=num)
         self.exec_command(sudo=True, cmd=cmd)
         self.exec_command(sudo=True, cmd='wget -O - https://www.redhat.com/security/fd431d51.txt | apt-key add -')
         self.exec_command(sudo=True, cmd='apt-get update')
@@ -1364,8 +1365,7 @@ class CephNode(object):
         self.exec_command(cmd='sudo rm -f /etc/apt/sources.list.d/*')
         repos = ['MON', 'OSD', 'Tools']
         for repo in repos:
-            cmd = 'sudo echo deb ' + deb_repo + '/{0}'.format(repo) + \
-                  ' $(lsb_release -sc) main'
+            cmd = 'sudo echo deb ' + deb_repo + '/{0}'.format(repo) + ' $(lsb_release -sc) main'
             self.exec_command(cmd=cmd + ' > ' + "/tmp/{0}.list".format(repo))
             self.exec_command(cmd='sudo cp /tmp/{0}.list'.format(repo)
                                   + ' /etc/apt/sources.list.d/')

--- a/ocs/clients.py
+++ b/ocs/clients.py
@@ -62,14 +62,16 @@ class WinNode(object):
         pass
 
     def connect_to_target(self, ip, username, password):
-        command = "Connect-IscsiTarget -NodeAddress iqn.2003-01.com.redhat.iscsi-gw:ceph-igw"\
-            r" -IsMultipathEnabled \$True -TargetPortalAddress {}  -AuthenticationType ONEWAYCHAP"\
-            " -ChapUsername {} -ChapSecret {}".format(ip, username, password)
+        command = (
+            "Connect-IscsiTarget -NodeAddress iqn.2003-01.com.redhat.iscsi-gw:ceph-igw"
+            r" -IsMultipathEnabled \$True -TargetPortalAddress {}  -AuthenticationType ONEWAYCHAP"
+            " -ChapUsername {} -ChapSecret {}").format(ip, username, password)
         self.win_exec(command)
 
     def disconnect_from_target(self,):
-        command = "Disconnect-IscsiTarget -NodeAddress "\
-            "iqn.2003-01.com.redhat.iscsi-gw:ceph-igw -Confirm:$false"
+        command = (
+            "Disconnect-IscsiTarget -NodeAddress "
+            "iqn.2003-01.com.redhat.iscsi-gw:ceph-igw -Confirm:$false")
         self.win_exec(command)
 
     def create_disk(self, number):

--- a/ocs/rados_utils.py
+++ b/ocs/rados_utils.py
@@ -244,8 +244,8 @@ class RadosHelper:
             mgr_object.containerized = True
             mgr_object.container_name = proxy_container
         else:
-            mgr_object = \
-                [mgr_object for mgr_object in node.get_ceph_objects('mgr') if
-                 mgr_object.containerized and mgr_object.container_name == proxy_container][0]
+            mgr_object = [
+                mgr_object for mgr_object in node.get_ceph_objects('mgr')
+                if mgr_object.containerized and mgr_object.container_name == proxy_container][0]
 
         return mgr_object

--- a/ocs/utils.py
+++ b/ocs/utils.py
@@ -262,8 +262,8 @@ def create_ceph_conf(fsid, mon_hosts, pg_num='128', pgp_num='128', size='2',
     mon_init_memb = 'mon initial members = '
     mon_host = 'mon host = '
     public_network = 'public network = ' + pnetwork + '\n'
-    auth = 'auth cluster required = cephx\nauth service \
-            required = cephx\nauth client required = cephx\n'
+    auth = ('auth cluster required = cephx\nauth service '
+            'required = cephx\nauth client required = cephx\n')
     jsize = 'osd journal size = ' + jsize + '\n'
     size = 'osd pool default size = ' + size + '\n'
     pgnum = 'osd pool default pg num = ' + pg_num + '\n'
@@ -282,8 +282,7 @@ def setup_deb_repos(node, ubuntu_repo):
     node.exec_command(cmd='sudo rm -f /etc/apt/sources.list.d/*')
     repos = ['MON', 'OSD', 'Tools']
     for repo in repos:
-        cmd = 'sudo echo deb ' + ubuntu_repo + '/{0}'.format(repo) + \
-              ' $(lsb_release -sc) main'
+        cmd = 'sudo echo deb ' + ubuntu_repo + '/{0}'.format(repo) + ' $(lsb_release -sc) main'
         node.exec_command(cmd=cmd + ' > ' + "/tmp/{0}.list".format(repo))
         node.exec_command(cmd='sudo cp /tmp/{0}.list /etc/apt/sources.list.d/'.format(repo))
     ds_keys = ['https://www.redhat.com/security/897da07a.txt',
@@ -303,8 +302,8 @@ def setup_deb_cdn_repo(node, build=None):
     user = 'redhat'
     passwd = 'OgYZNpkj6jZAIF20XFZW0gnnwYBjYcmt7PeY76bLHec9'
     num = build.split('.')[0]
-    cmd = 'umask 0077; echo deb https://{user}:{passwd}@rhcs.download.redhat.com/{num}-updates/Tools ' \
-          '$(lsb_release -sc) main | tee /etc/apt/sources.list.d/Tools.list'.format(user=user, passwd=passwd, num=num)
+    cmd = ('umask 0077; echo deb https://{user}:{passwd}@rhcs.download.redhat.com/{num}-updates/Tools '
+           '$(lsb_release -sc) main | tee /etc/apt/sources.list.d/Tools.list').format(user=user, passwd=passwd, num=num)
     node.exec_command(sudo=True, cmd=cmd)
     node.exec_command(sudo=True, cmd='wget -O - https://www.redhat.com/security/fd431d51.txt | apt-key add -')
     node.exec_command(sudo=True, cmd='apt-get update')

--- a/ocsci/pytest_customization/tests/test_pytest.py
+++ b/ocsci/pytest_customization/tests/test_pytest.py
@@ -48,7 +48,7 @@ def test_simple(testdir):
     Make sure that  pytest itself is not broken by running very simple test.
     """
     # create a temporary pytest test module
-    testdir.makepyfile(textwrap.dedent("""\
+    testdir.makepyfile(textwrap.dedent("""
         def test_foo():
             assert 1 == 1
         """))
@@ -69,7 +69,7 @@ def test_config_parametrize(testdir):
         pytest_plugins = ['ocsci.pytest_customization.ocscilib']
     """))
     # create a temporary pytest test module
-    testdir.makepyfile(textwrap.dedent("""\
+    testdir.makepyfile(textwrap.dedent("""
         import pytest
 
         from ocsci import config as ocsci_config
@@ -79,7 +79,7 @@ def test_config_parametrize(testdir):
             assert item is not None
         """))
     # create config file
-    conf_file = testdir.makefile(".yaml", textwrap.dedent("""\
+    conf_file = testdir.makefile(".yaml", textwrap.dedent("""
         RUN:
           things:
             - 1

--- a/tests/manage/test_pvc_invalid_inputs.py
+++ b/tests/manage/test_pvc_invalid_inputs.py
@@ -95,9 +95,9 @@ def create_pvc_invalid_name(pvcname):
     try:
         pvc_obj.create()
     except CommandFailed as ex:
-        error = "subdomain must consist of lower case alphanumeric "\
-                "characters, '-' or '.', and must start and end with "\
-                "an alphanumeric character"
+        error = ("subdomain must consist of lower case alphanumeric "
+                 "characters, '-' or '.', and must start and end with "
+                 "an alphanumeric character")
         if error in str(ex):
             log.info(
                 f"PVC creation failed with error \n {ex} \n as "
@@ -129,8 +129,8 @@ def create_pvc_invalid_size(pvcsize):
     try:
         pvc_obj.create()
     except CommandFailed as ex:
-        error = "quantities must match the regular expression '^([+-]?[0-9.]"\
-                "+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
+        error = ("quantities must match the regular expression '^([+-]?[0-9.]"
+                 "+)([eEinumkKMGTP]*[-+]?[0-9]*)$'")
         if error in str(ex):
             log.info(
                 f"PVC creation failed with error \n {ex} \n as "

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,12 @@ commands = py.test \
 deps =
     flake8
     flake8-mutable
+    flake8-broken-line
 commands = flake8
 
 [flake8]
 ignore = E402, E741, W503
-enable-extensions = M511
+enable-extensions = M511, N400
 exclude =
     venv,
     .venv,

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -13,8 +13,10 @@ def lvcreate(osd, lv_name, vg_name, size):
 
 
 def make_partition(osd, device, start=None, end=None, gpt=False):
-    osd.exec_command(cmd='sudo parted --script %s mklabel gpt' % device) if gpt \
-        else osd.exec_command(cmd='sudo parted --script %s mkpart primary %s %s' % (device, start, end))
+    if gpt:
+        osd.exec_command(cmd='sudo parted --script %s mklabel gpt' % device)
+    else:
+        osd.exec_command(cmd='sudo parted --script %s mkpart primary %s %s' % (device, start, end))
 
 
 def osd_scenario1(osd, devices_dict, dmcrypt=False):
@@ -81,13 +83,15 @@ def osd_scenario1(osd, devices_dict, dmcrypt=False):
                        '1',
                        osd.LvmConfig.size.format(2))
 
-    scenario = "{{'data':'{datalv1}','data_vg':'{vg_name}'}},{{'data':'{datalv2}','data_vg':'{vg_name}'," \
-               "'db':'{dblv1}','db_vg':'{vg_name}'}}," \
-               "{{'data':'{datalv3}','data_vg':'{vg_name}','wal':'{wallv1}','wal_vg':'{vg_name}'}}," \
-               "{{'data':'{datalv4}','data_vg':'{vg_name}','db':'{dblv2}','db_vg':'{vg_name}','wal':'{wallv2}'," \
-               "'wal_vg':'{vg_name}'}}".format(vg_name=vgname, datalv1=data_lv1, datalv2=data_lv2, dblv1=db_lv1,
-                                               datalv3=data_lv3, wallv1=wal_lv1, datalv4=data_lv4,
-                                               dblv2=db_lv2, wallv2=wal_lv2)
+    # TODO: use fstrings, make it more readable
+    scenario = (
+        "{{'data':'{datalv1}','data_vg':'{vg_name}'}},{{'data':'{datalv2}','data_vg':'{vg_name}',"
+        "'db':'{dblv1}','db_vg':'{vg_name}'}},"
+        "{{'data':'{datalv3}','data_vg':'{vg_name}','wal':'{wallv1}','wal_vg':'{vg_name}'}},"
+        "{{'data':'{datalv4}','data_vg':'{vg_name}','db':'{dblv2}','db_vg':'{vg_name}','wal':'{wallv2}',"
+        "'wal_vg':'{vg_name}'}}").format(vg_name=vgname, datalv1=data_lv1, datalv2=data_lv2, dblv1=db_lv1,
+                                         datalv3=data_lv3, wallv1=wal_lv1, datalv4=data_lv4,
+                                         dblv2=db_lv2, wallv2=wal_lv2)
 
     return scenario, dmcrypt
 
@@ -124,12 +128,14 @@ def osd_scenario2(osd, devices_dict, dmcrypt=False):
     make_partition(osd, devices_dict.get('device1'), '90%', '95%')
     make_partition(osd, devices_dict.get('device1'), '95%', '100%')
 
-    scenario = "{{'data':'{vdb1}','db':'{vdb2}','wal':'{vdb3}'}},{{'data':'{vdc}','db':'{vdb4}','wal':'{vdb5}'}}," \
-               "{{'data':'{vdd}'}}".format(vdb1=devices_dict.get('device1') + '1',
-                                           vdb2=devices_dict.get('device1') + '2',
-                                           vdb3=devices_dict.get('device1') + '3', vdc=devices_dict.get('device2'),
-                                           vdb4=devices_dict.get('device1') + '4',
-                                           vdb5=devices_dict.get('device1') + '5', vdd=devices_dict.get('device3'))
+    # TODO: use fstrings, make it more readable
+    scenario = (
+        "{{'data':'{vdb1}','db':'{vdb2}','wal':'{vdb3}'}},{{'data':'{vdc}','db':'{vdb4}','wal':'{vdb5}'}},"
+        "{{'data':'{vdd}'}}").format(vdb1=devices_dict.get('device1') + '1',
+                                     vdb2=devices_dict.get('device1') + '2',
+                                     vdb3=devices_dict.get('device1') + '3', vdc=devices_dict.get('device2'),
+                                     vdb4=devices_dict.get('device1') + '4',
+                                     vdb5=devices_dict.get('device1') + '5', vdd=devices_dict.get('device3'))
 
     return scenario, dmcrypt
 
@@ -185,11 +191,14 @@ def osd_scenario3(osd, devices_dict, dmcrypt=False):
                        '1',
                        osd.LvmConfig.size.format(10))
 
-    scenario = "{{'data':'{vdb}','db':'{dblv1}','db_vg':'{vgname}','wal':'{wallv1}','wal_vg':'{vgname}'}}," \
-               "{{'data':'{datalv1}','data_vg':'{vgname}','db':'{vdd2}','wal':'{vdd3}'}},{{'data':'{vdd1}'}}" \
-        .format(vdb=devices_dict.get('device1'), dblv1=db_lv1, vgname=vgname, wallv1=wal_lv1, datalv1=data_lv1,
-                vdd1=devices_dict.get('device3') + '1', vdd2=devices_dict.get('device3') + '2',
-                vdd3=devices_dict.get('device3') + '3')
+    # TODO: use fstrings, make it more readable
+    scenario = (
+        "{{'data':'{vdb}','db':'{dblv1}','db_vg':'{vgname}','wal':'{wallv1}','wal_vg':'{vgname}'}},"
+        "{{'data':'{datalv1}','data_vg':'{vgname}','db':'{vdd2}','wal':'{vdd3}'}},"
+        "{{'data':'{vdd1}'}}").format(
+            vdb=devices_dict.get('device1'), dblv1=db_lv1, vgname=vgname, wallv1=wal_lv1, datalv1=data_lv1,
+            vdd1=devices_dict.get('device3') + '1', vdd2=devices_dict.get('device3') + '2',
+            vdd3=devices_dict.get('device3') + '3')
 
     return scenario, dmcrypt
 


### PR DESCRIPTION
In our cofing guidelines (ocs-ci/docs/coding_guidelines.md), we state
that:

> Do not use backslashes in the code for line breaker!

Since there is a flake8 plugin which can check this, I'm enabling it in
our flake8 run so that we simplify a review process.

The problem is reported like:

```
N400: Found backslash that is used for line braking
```