### PR TITLE
Resource name enhancement

### DIFF
--- a/ocs/constants.py
+++ b/ocs/constants.py
@@ -43,3 +43,7 @@ IGNORE_SC = "gp2"
 # encoded value of 'admin'
 ADMIN_BASE64 = 'YWRtaW4='
 GB = 1024 ** 3
+
+# component
+RBD_COMPONENT = 'rbd'
+CEPHFS_COMPONENT = 'cephfs'


### PR DESCRIPTION
ocs/constants.py

Added component names for rbd and cephfs
tests/helpers.py

Added a variable 'component' in functions create_pvc(),create_storage_class() and create_secret() which passed to create_unique_resource_name() which creates resources.
Resources can be identified easily with this component name in the resource name
Signed-off-by: Shreekar sshreeka@redhat.com