### PR TITLE
ensure that the given --cluster-path if empty if --deploy is also provided

### DIFF
--- a/ocsci/exceptions.py
+++ b/ocsci/exceptions.py
@@ -1,0 +1,5 @@
+
+class ClusterPathNotProvidedError(Exception):
+
+    def __str__(self):
+        return "Please provide a --cluster-path that is empty or non-existant."

--- a/ocsci/pytest_customization/ocscilib.py
+++ b/ocsci/pytest_customization/ocscilib.py
@@ -12,6 +12,7 @@ import random
 
 import ocs
 from ocsci import config as ocsci_config
+from ocsci.exceptions import ClusterPathNotProvidedError
 
 __all__ = [
     "pytest_addoption",
@@ -99,6 +100,10 @@ def process_cluster_cli_params(config):
 
     """
     cluster_path = get_cli_param(config, 'cluster_path')
+    if not cluster_path:
+        raise ClusterPathNotProvidedError()
+    if not os.path.exists(cluster_path):
+        os.makedirs(cluster_path)
     # Importing here cause once the function is invoked we have already config
     # loaded, so this is OK to import once you sure that config is loaded.
     from oc.openshift_ops import OCP

--- a/ocsci/pytest_customization/ocscilib.py
+++ b/ocsci/pytest_customization/ocscilib.py
@@ -69,7 +69,8 @@ def pytest_configure(config):
         config (pytest.config): Pytest config object
 
     """
-    process_cluster_cli_params(config)
+    if not config.getoption("--help"):
+        process_cluster_cli_params(config)
 
 
 def get_cli_param(config, name_of_param, default=None):

--- a/ocsci/pytest_customization/tests/test_pytest.py
+++ b/ocsci/pytest_customization/tests/test_pytest.py
@@ -60,7 +60,7 @@ def test_simple(testdir):
     assert result.ret == 0
 
 
-def test_config_parametrize(testdir):
+def test_config_parametrize(testdir, tmpdir):
     """
     Parametrization via config values, use case described in
     https://github.com/red-hat-storage/ocs-ci/pull/61#issuecomment-494866745
@@ -85,7 +85,7 @@ def test_config_parametrize(testdir):
             - 1
             - 2
         """))
-    pytest_arguments = ['-v', f'--ocsci-conf={conf_file}']
+    pytest_arguments = ['-v', f'--ocsci-conf={conf_file}', f'--cluster-path={tmpdir}']
     # this is a bit hack which allow us init all the config which we do in
     # runner run_ocsci.py. Without this we won't be able to access config
     init_ocsci_conf(pytest_arguments)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from oc.openshift_ops import OCP
 from ocs import constants, ocp, defaults
 from ocs.exceptions import CommandFailed, CephHealthException
 from ocs.utils import create_oc_resource, apply_oc_resource
-from utility import templating
+from utility import templating, system
 from utility.aws import AWS
 from utility.retry import retry
 from utility.utils import destroy_cluster, run_cmd, get_openshift_installer, get_openshift_client, is_cluster_running
@@ -57,6 +57,10 @@ def cluster(request):
     elif not deploy and not teardown:
         msg = "The given cluster can not be connected to: {}. ".format(cluster_path)
         msg += "Provide a valid --cluster-path or use --deploy to deploy a new cluster"
+        pytest.fail(msg)
+    elif not system.is_path_empty(cluster_path) and deploy:
+        msg = "The given cluster path is not empty: {}. ".format(cluster_path)
+        msg += "Provide an empty --cluster-path and --deploy to deploy a new cluster"
         pytest.fail(msg)
     else:
         log.info("A testing cluster will be deployed and cluster information stored at: %s", cluster_path)

--- a/utility/system.py
+++ b/utility/system.py
@@ -1,0 +1,8 @@
+import os
+
+
+def is_path_empty(path):
+    for root, dirs, files in os.walk(path):
+        if files:
+            return False
+        return True

--- a/utility/system.py
+++ b/utility/system.py
@@ -2,6 +2,12 @@ import os
 
 
 def is_path_empty(path):
+    """
+    Returns True if the given path does not contain any files, False otherwise.
+
+    Args:
+        path (str): Path to be checked
+    """
     for root, dirs, files in os.walk(path):
         if files:
             return False


### PR DESCRIPTION
This is to guard against accidentally writing over an existing clusters information if for whatever reason it could not be accessed temporarily.

Also, I'm adding an ``ocsci.exceptions`` module and ``utility.system`` module. The ``ocsci.exceptions`` module we can use to store custom exceptions which can provide more meaningful exception messages back to the user. I was thinking the ``utility.system`` could contain system-level utility methods, for example file system modifications. Eventually we can port stuff from ``utility.utils`` that make sense to do so. 

This is a followup from #173 
