### PR TITLE
typo fix: templates/CSI/rbd/storageclass.yaml

### DIFF
--- a/templates/CSI/rbd/storageclass.yaml
+++ b/templates/CSI/rbd/storageclass.yaml
@@ -7,7 +7,7 @@ provisioner: rbd.csi.ceph.com
 parameters:
     # Comma separated list of Ceph monitors
     # if using FQDN, make sure csi plugin's dns policy is appropriate.
-    clustetID: rook-ceph
+    clusterID: rook-ceph
     # if "monitors" parameter is not set, driver to get monitors from same
     # secret as admin/user credentials. "monValueFromSecret" provides the
     # key in the secret whose value is the mons


### PR DESCRIPTION
 templates/CSI/rbd/storageclass.yaml
    - fixed typo 'clusterID'

Signed-off-by: Shreekar <sshreeka@redhat.com>