### PR TITLE
In some cases command with stderr is perfectly OK

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -650,7 +650,10 @@ def run_cmd(cmd, **kwargs):
     )
     log.debug(f"CMD output: {r.stdout.decode()}")
     if r.stderr:
-        log.error(f"CMD error:: {r.stderr.decode()}")
+        if r.returncode == 0:
+            log.debug(f"CMD error: {r.stderr.decode()}")
+        else:
+            log.error(f"CMD error: {r.stderr.decode()}")
     if r.returncode:
         raise CommandFailed(
             f"Error during execution of command: {cmd}."


### PR DESCRIPTION
I have spent some time investigating error in `tests/test_pv_creation.py` output:

```
08:55:27 - MainThread - tests.test_pv_creation - INFO - Deleting the Persistent Volume my-pv1
08:55:27 - MainThread - utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig ../dev-scripts/ocp/auth/kubeconfig delete -f test.yaml
08:55:27 - MainThread - utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig ../dev-scripts/ocp/auth/kubeconfig get PersistentVolume my-pv1 -o yaml
08:55:27 - MainThread - utility.utils - ERROR - CMD error:: Error from server (NotFound): persistentvolumes "my-pv1" not found
08:55:27 - MainThread - tests.test_pv_creation - INFO - PV my-pv1 doesn't exist
```

where test is asserting that PV was deleted, but `run_cmd` emits error. I think that is confusing and that it is up to test to assert and log error only if it is error.