### PR TITLE
Fix issue with error while testing version of oc

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -529,8 +529,13 @@ def get_openshift_client(
         delete_file(tarball)
         # return to the previous working directory
         os.chdir(previous_dir)
-
-    client_version = run_cmd(f"{client_binary_path} version")
+    try:
+        client_version = run_cmd(f"{client_binary_path} version")
+    except CommandFailed as ex:
+        if "Unable to connect to the server" in str(ex):
+            pass
+        else:
+            raise
     log.info(f"OpenShift Client version: {client_version}")
 
     return client_binary_path


### PR DESCRIPTION
Sometime there is an issue while installing new cluster:
./bin/oc version
Client Version: version.Info{Major:"4", Minor:"1+",
GitVersion:"v4.1.2-201906121056+3569a06-dirty", GitCommit:"3569a06",
GitTreeState:"dirty", BuildDate:"2019-06-12T15:47:26Z", GoVersion:"go1.11.5",
 Compiler:"gc", Platform:"linux/amd64"}
Unable to connect to the server: dial tcp:
lookup api.ksandha-85879.qe.rh-ocs.com on 10.75.5.25:53: no such host

It somehow remember the old cluster which is not available yet.