### PR TITLE
Drop debug-level logging for openshift-install

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -413,8 +413,7 @@ def destroy_cluster(cluster_path):
 
     destroy_cmd = (
         f"{installer} destroy cluster "
-        f"--dir {cluster_path} "
-        f"--log-level debug"
+        f"--dir {cluster_path}"
     )
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,8 +150,7 @@ def cluster(request):
     log.info("Deploying cluster")
     run_cmd(
         f"{installer} create cluster "
-        f"--dir {cluster_path} "
-        f"--log-level debug"
+        f"--dir {cluster_path}"
     )
 
     # Test cluster access


### PR DESCRIPTION
I expect that some people will rather make this configurable than to simply drop `--log-level debug` entirely. I'll be willing to do that work *if* we want it. I also wouldn't be surprised if nobody would actually miss that output, though, so I'm starting with this.