### PR TITLE
Testcase and helpers.py enhancement

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -115,3 +115,7 @@ FIO_IO_PARAMS_YAML = os.path.join(
 FIO_IO_RW_PARAMS_YAML = os.path.join(
     TEMPLATE_FIO_DIR, "workload_io_rw.yaml"
 )
+
+# constants
+RBD_INTERFACE = 'rbd'
+CEPHFS_INTERFACE = 'cephfs'

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -91,7 +91,6 @@ CSI_RBD_POD_YAML = os.path.join(
 CSI_CEPHFS_POD_YAML = os.path.join(
     TEMPLATE_CSI_FS_DIR, "pod.yaml"
 )
-
 CSI_RBD_SECRET_YAML = os.path.join(
     TEMPLATE_CSI_RBD_DIR, "secret.yaml"
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -140,7 +140,7 @@ def create_rbd_pod(request):
     Create a pod
     """
     class_instance = request.node.cls
-
     class_instance.pod_obj = helpers.create_pod(
-        interface_type=constants.CEPHBLOCKPOOL, pvc=class_instance.pvc_obj.name
+        interface_type=constants.CEPHBLOCKPOOL,
+        pvc=class_instance.pvc_obj.name
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -142,5 +142,5 @@ def create_rbd_pod(request):
     class_instance = request.node.cls
     class_instance.pod_obj = helpers.create_pod(
         interface_type=constants.CEPHBLOCKPOOL,
-        pvc=class_instance.pvc_obj.name
+        pvc_name=class_instance.pvc_obj.name
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -270,7 +270,6 @@ def create_pvc(sc_name, pvc_name=None, size=None, wait=True):
         pvc_name (str): The name of the PVC to create
         size(str): Size of pvc to create
         wait (bool): True for wait for the VPC operation to complete, False otherwise
-        size(str): Size of pvc to create
 
     Returns:
         PVC: PVC instance
@@ -289,8 +288,8 @@ def create_pvc(sc_name, pvc_name=None, size=None, wait=True):
     created_pvc = ocs_obj.create(do_reload=wait)
     assert created_pvc, f"Failed to create resource {pvc_name}"
     if wait:
-        ocs_obj.reload()
         assert wait_for_resource_state(ocs_obj, constants.STATUS_BOUND)
+        ocs_obj.reload()
 
     return ocs_obj
 
@@ -587,7 +586,8 @@ def get_all_pvs():
          dict: Dict of all pv in openshift-storage namespace
     """
     ocp_pv_obj = ocp.OCP(
-        kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+        kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE
+    )
     return ocp_pv_obj.get()
 
 
@@ -602,7 +602,7 @@ def validate_pv_delete(pv_name):
         bool: True if deletion is successful
 
     Raises:
-        CommandFailed: If pv is not deleted
+        AssertionError: If pv is not deleted
     """
     ocp_pv_obj = ocp.OCP(
         kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,12 +4,15 @@ Helper functions file for OCS QE
 import datetime
 import logging
 
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.utility import templating
 from ocs_ci.framework import config
-from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources import pod, pvc
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.exceptions import CommandFailed
+
+from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -33,16 +36,11 @@ def create_unique_resource_name(resource_description, resource_type):
     return f"{resource_type}-{resource_description[:23]}-{current_date_time[:10]}"
 
 
-def create_resource(
-    desired_status=constants.STATUS_AVAILABLE, wait=True, **kwargs
-):
+def create_resource(**kwargs):
     """
     Create a resource
 
     Args:
-        desired_status (str): The status of the resource to wait for
-        wait (bool): True for waiting for the resource to reach the desired
-            status, False otherwise
         kwargs (dict): Dictionary of the OCS resource
 
     Returns:
@@ -57,24 +55,37 @@ def create_resource(
     assert created_resource, (
         f"Failed to create resource {resource_name}"
     )
-    if wait:
-        assert ocs_obj.ocp.wait_for_resource(
-            condition=desired_status, resource_name=resource_name
-        ), f"{ocs_obj.kind} {resource_name} failed to reach"
-        f"status {desired_status}"
     return ocs_obj
 
 
-def create_pod(interface_type=None, pvc=None, desired_status=constants.STATUS_RUNNING, wait=True):
+def wait_for_resource_state(resource, state):
+    """
+    Wait for a resource to get to a given status
+
+    Args:
+        resource (OCS obj): The resource object
+        state (str): The status to wait for
+
+    Returns:
+        bool: True if resource reached the desired state, False otherwise
+    """
+    try:
+        resource.ocp.wait_for_resource(
+            condition=state, resource_name=resource.name
+        )
+    except TimeoutExpiredError:
+        return False
+    logger.info(f"{resource.kind} {resource.name} reached state {state}")
+    return True
+
+
+def create_pod(interface_type=None, pvc=None):
     """
     Create a pod
 
     Args:
-        interface_type (str): The interface type (CephFS, RBD, etc.)
-        pvc (str): The PVC that should be attached to the newly created pod
-        desired_status (str): The status of the pod to wait for
-        wait (bool): True for waiting for the pod to reach the desired
-            status, False otherwise
+        interface_type (str): The type of the Ceph interface
+        pvc (str): The name of the PVC to attach to the pod
 
     Returns:
         Pod: A Pod instance
@@ -96,15 +107,10 @@ def create_pod(interface_type=None, pvc=None, desired_status=constants.STATUS_RU
         pod_data['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] = pvc
     pod_obj = pod.Pod(**pod_data)
     pod_name = pod_data.get('metadata').get('name')
-    created_resource = pod_obj.create(do_reload=wait)
+    created_resource = pod_obj.create()
     assert created_resource, (
         f"Failed to create resource {pod_name}"
     )
-    if wait:
-        assert pod_obj.ocp.wait_for_resource(
-            condition=desired_status, resource_name=pod_name
-        ), f"{pod_obj.kind} {pod_name} failed to reach"
-        f"status {desired_status}"
     return pod_obj
 
 
@@ -126,6 +132,7 @@ def create_secret(interface_type):
         )
         secret_data['stringData']['userID'] = constants.ADMIN_USER
         secret_data['stringData']['userKey'] = get_admin_key()
+        interface = constants.RBD_INTERFACE
     elif interface_type == constants.CEPHFILESYSTEM:
         secret_data = templating.load_yaml_to_dict(
             constants.CSI_CEPHFS_SECRET_YAML
@@ -134,12 +141,13 @@ def create_secret(interface_type):
         del secret_data['stringData']['userKey']
         secret_data['stringData']['adminID'] = constants.ADMIN_USER
         secret_data['stringData']['adminKey'] = get_admin_key()
+        interface = constants.CEPHFS_INTERFACE
     secret_data['metadata']['name'] = create_unique_resource_name(
-        'test', 'secret'
+        f'test-{interface}', 'secret'
     )
     secret_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
 
-    return create_resource(**secret_data, wait=False)
+    return create_resource(**secret_data)
 
 
 def create_ceph_block_pool(pool_name=None):
@@ -159,7 +167,7 @@ def create_ceph_block_pool(pool_name=None):
         )
     )
     cbp_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
-    cbp_obj = create_resource(**cbp_data, wait=False)
+    cbp_obj = create_resource(**cbp_data)
 
     assert verify_block_pool_exists(cbp_obj.name), (
         f"Block pool {cbp_obj.name} does not exist"
@@ -197,6 +205,7 @@ def create_storage_class(
         sc_data['parameters'][
             'csi.storage.k8s.io/node-publish-secret-namespace'
         ] = defaults.ROOK_CLUSTER_NAMESPACE
+        interface = constants.RBD_INTERFACE
     elif interface_type == constants.CEPHFILESYSTEM:
         sc_data = templating.load_yaml_to_dict(
             constants.CSI_CEPHFS_STORAGECLASS_YAML
@@ -207,12 +216,13 @@ def create_storage_class(
         sc_data['parameters'][
             'csi.storage.k8s.io/node-stage-secret-namespace'
         ] = defaults.ROOK_CLUSTER_NAMESPACE
+        interface = constants.CEPHFS_INTERFACE
         sc_data['parameters']['fsName'] = get_cephfs_name()
     sc_data['parameters']['pool'] = interface_name
 
     sc_data['metadata']['name'] = (
         sc_name if sc_name else create_unique_resource_name(
-            'test', 'storageclass'
+            f'test-{interface}', 'storageclass'
         )
     )
     sc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
@@ -230,7 +240,7 @@ def create_storage_class(
         del sc_data['parameters']['userid']
     except KeyError:
         pass
-    return create_resource(**sc_data, wait=False)
+    return create_resource(**sc_data)
 
 
 def create_pvc(sc_name, pvc_name=None, wait=True):
@@ -255,9 +265,11 @@ def create_pvc(sc_name, pvc_name=None, wait=True):
     )
     pvc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
     pvc_data['spec']['storageClassName'] = sc_name
-    return create_resource(
-        desired_status=constants.STATUS_BOUND, **pvc_data, wait=wait
-    )
+    ocs_obj = pvc.PVC(**pvc_data)
+    pvc_name = pvc_data.get('metadata').get('name')
+    created_pvc = ocs_obj.create()
+    assert created_pvc, f"Failed to create resource {pvc_name}"
+    return ocs_obj
 
 
 def verify_block_pool_exists(pool_name):
@@ -273,7 +285,6 @@ def verify_block_pool_exists(pool_name):
     logger.info(f"Verifying that block pool {pool_name} exists")
     ct_pod = pod.get_ceph_tools_pod()
     pools = ct_pod.exec_ceph_cmd('ceph osd lspools')
-    logger.info(f'POOLS are {pools}')
     for pool in pools:
         if pool_name in pool.get('poolname'):
             return True
@@ -542,3 +553,38 @@ def run_io_with_rados_bench(**kw):
     logger.info(ret)
     logger.info("Finished radosbench")
     return ret
+
+
+def get_all_pvs():
+    """
+    Gets all pv in given namespace
+    Returns:
+         dict: Dict of all pvc in namespaces
+    """
+    ocp_pv_obj = ocp.OCP(
+        kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    output = ocp_pv_obj.get()
+    return output
+
+
+@retry(AssertionError, tries=10, delay=5, backoff=1)
+def validate_pv_delete(sc_name):
+    """
+    validates if pv is deleted after pvc deletion
+    Returns:
+        bool: True if deletion is successful
+    """
+    ocp_pv_list = get_all_pvs()
+    pv_list = ocp_pv_list['items']
+    logging.info(pv_list)
+    if pv_list:
+        for item in pv_list:
+            if sc_name == item['spec']['storageClassName']:
+                if item['spec']['persistentVolumeReclaimPolicy'] == 'Delete':
+                    raise AssertionError
+                elif item['spec']['persistentVolumeReclaimPolicy'] == 'Retain':
+                    return True
+            else:
+                return True
+    else:
+        return True

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,6 +58,9 @@ def create_resource(**kwargs):
     return ocs_obj
 
 
+<<<<<<< HEAD
+def create_pod(interface_type=None, pvc=None, desired_status=constants.STATUS_RUNNING, wait=True):
+=======
 def wait_for_resource_state(resource, state):
     """
     Wait for a resource to get to a given status

--- a/tests/manage/test_create_storage_class_pvc.py
+++ b/tests/manage/test_create_storage_class_pvc.py
@@ -122,8 +122,6 @@ class TestOSCBasics(ManageTest):
         CEPHFS_PVC_OBJ = helpers.create_pvc(
             sc_name=CEPHFS_SC_OBJ.name, pvc_name=pvc_name
         )
-        if CEPHFS_PVC_OBJ.backed_pv is None:
-            CEPHFS_PVC_OBJ.reload()
         log.info('creating cephfs pod')
         CEPHFS_POD_OBJ = helpers.create_pod(
             interface_type=constants.CEPHFILESYSTEM, pvc_name=CEPHFS_PVC_OBJ.name

--- a/tests/manage/test_create_storage_class_pvc.py
+++ b/tests/manage/test_create_storage_class_pvc.py
@@ -104,7 +104,7 @@ class TestOSCBasics(ManageTest):
         if RBD_PVC_OBJ.backed_pv is None:
             RBD_PVC_OBJ.reload()
         RBD_POD_OBJ = helpers.create_pod(
-            constants.CEPHBLOCKPOOL, RBD_PVC_OBJ.name
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=RBD_PVC_OBJ.name
         )
 
     @pytest.mark.polarion_id("OCS-346")
@@ -125,5 +125,5 @@ class TestOSCBasics(ManageTest):
             CEPHFS_PVC_OBJ.reload()
         log.info('creating cephfs pod')
         CEPHFS_POD_OBJ = helpers.create_pod(
-            constants.CEPHFILESYSTEM, CEPHFS_PVC_OBJ.name
+            interface_type=constants.CEPHFILESYSTEM, pvc_name=CEPHFS_PVC_OBJ.name
         )

--- a/tests/manage/test_create_storage_class_pvc.py
+++ b/tests/manage/test_create_storage_class_pvc.py
@@ -1,135 +1,127 @@
 import logging
-
 import pytest
 
-from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import tier1, ManageTest
-from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import get_admin_key_from_ceph_tools
-from ocs_ci.ocs.resources.pvc import PVC
 from tests import helpers
-from ocs_ci.utility import templating
 
 log = logging.getLogger(__name__)
 
 
-POD = ocp.OCP(kind='Pod', namespace=config.ENV_DATA['cluster_namespace'])
-CEPH_OBJ = None
+@pytest.fixture(scope='function')
+def test_fixture_rbd(request):
+    def finalizer():
+        teardown_rbd()
+
+    request.addfinalizer(finalizer)
+    setup_rbd()
 
 
-@pytest.fixture()
-def test_fixture(request):
+def setup_rbd():
     """
-    Create disks
+    Setting up the environment
+    Creating replicated pool,secret,storageclass for rbd
     """
-    self = request.node.cls
-    setup_fs(self)
-    yield
-    teardown_fs()
-
-
-def setup_fs(self):
-    """
-    Setting up the environment for the test
-    """
-    global CEPH_OBJ
-    self.fs_data = templating.load_yaml_to_dict(constants.CEPHFILESYSTEM_YAML)
-    self.fs_data['metadata']['name'] = helpers.create_unique_resource_name(
-        'test', 'cephfs'
+    log.info("Creating CephBlockPool")
+    global RBD_POOL
+    RBD_POOL = helpers.create_ceph_block_pool()
+    global RBD_SECRET_OBJ
+    RBD_SECRET_OBJ = helpers.create_secret(constants.CEPHBLOCKPOOL)
+    global RBD_SC_OBJ
+    log.info("Creating RBD Storage class ")
+    RBD_SC_OBJ = helpers.create_storage_class(
+        interface_type=constants.CEPHBLOCKPOOL,
+        interface_name=RBD_POOL.name,
+        secret_name=RBD_SECRET_OBJ.name
     )
-    self.fs_data['metadata']['namespace'] = config.ENV_DATA['cluster_namespace']
-    CEPH_OBJ = OCS(**self.fs_data)
-    CEPH_OBJ.create()
-    assert POD.wait_for_resource(
-        condition='Running', selector='app=rook-ceph-mds'
+
+
+def teardown_rbd():
+    """
+    Tearing down the environment
+    Deleting pod,replicated pool,pvc,storageclass,secret of rbd
+    """
+    global RBD_PVC_OBJ, RBD_POD_OBJ
+    log.info('deleting rbd pod')
+    RBD_POD_OBJ.delete()
+    log.info("Deleting RBD PVC")
+    RBD_PVC_OBJ.delete()
+    assert helpers.validate_pv_delete(RBD_SC_OBJ.name)
+    log.info("Deleting CEPH BLOCK POOL")
+    RBD_POOL.delete()
+    log.info("Deleting RBD Secret")
+    RBD_SECRET_OBJ.delete()
+    log.info("Deleting RBD Storageclass")
+    RBD_SC_OBJ.delete()
+    log.info("Deleting CephFS PVC")
+
+
+@pytest.fixture(scope='function')
+def test_fixture_cephfs(request):
+    def finalizer():
+        teardown_fs()
+
+    request.addfinalizer(finalizer)
+    setup_fs()
+
+
+def setup_fs():
+    log.info("Creating CEPHFS Secret")
+    global CEPHFS_SECRET_OBJ
+    CEPHFS_SECRET_OBJ = helpers.create_secret(constants.CEPHFILESYSTEM)
+
+    global CEPHFS_SC_OBJ
+    log.info("Creating CephFS Storage class ")
+    CEPHFS_SC_OBJ = helpers.create_storage_class(
+        constants.CEPHFILESYSTEM,
+        helpers.get_cephfs_data_pool_name(),
+        CEPHFS_SECRET_OBJ.name
     )
-    pods = POD.get(selector='app=rook-ceph-mds')['items']
-    assert len(pods) == 2
 
 
 def teardown_fs():
-    """
-    Tearing down the environment
-    """
-    global CEPH_OBJ
-    CEPH_OBJ.delete()
+    global CEPHFS_PVC_OBJ, CEPHFS_POD_OBJ
+    log.info('deleting cephfs pod')
+    CEPHFS_POD_OBJ.delete()
+    log.info('deleting cephfs pvc')
+    CEPHFS_PVC_OBJ.delete()
+    assert helpers.validate_pv_delete(CEPHFS_SC_OBJ.name)
+    log.info("Deleting CEPHFS Secret")
+    CEPHFS_SECRET_OBJ.delete()
+    log.info("Deleting CephFS Storageclass")
+    CEPHFS_SC_OBJ.delete()
 
 
 @tier1
 class TestOSCBasics(ManageTest):
-    mons = (
-        f'rook-ceph-mon-a.{config.ENV_DATA["cluster_namespace"]}'
-        f'.svc.cluster.local:6789,'
-        f'rook-ceph-mon-b.{config.ENV_DATA["cluster_namespace"]}.'
-        f'svc.cluster.local:6789,'
-        f'rook-ceph-mon-c.{config.ENV_DATA["cluster_namespace"]}'
-        f'.svc.cluster.local:6789'
-    )
-
     @pytest.mark.polarion_id("OCS-336")
-    def test_basics_rbd(self, test_fixture):
+    def test_basics_rbd(self, test_fixture_rbd):
         """
         Testing basics: secret creation,
-        storage class creation and pvc with cephfs
+        storage class creation,pvc and pod with rbd
         """
-        self.cephfs_secret = templating.load_yaml_to_dict(
-            constants.CSI_CEPHFS_SECRET_YAML
+        global RBD_PVC_OBJ, RBD_POD_OBJ
+        log.info('creating pvc for RBD ')
+        pvc_name = helpers.create_unique_resource_name(
+            'test-rbd', 'pvc'
         )
-        del self.cephfs_secret['data']['userID']
-        del self.cephfs_secret['data']['userKey']
-        self.cephfs_secret['data']['adminKey'] = (
-            get_admin_key_from_ceph_tools()
-        )
-        self.cephfs_secret['data']['adminID'] = constants.ADMIN_BASE64
-        logging.info(self.cephfs_secret)
-        secret = OCS(**self.cephfs_secret)
-        secret.create()
-        self.cephfs_sc = templating.load_yaml_to_dict(
-            constants.CSI_CEPHFS_STORAGECLASS_YAML
-        )
-        self.cephfs_sc['parameters']['monitors'] = self.mons
-        self.cephfs_sc['parameters']['pool'] = (
-            f"{self.fs_data['metadata']['name']}-data0"
-        )
-        storage_class = OCS(**self.cephfs_sc)
-        storage_class.create()
-        self.cephfs_pvc = templating.load_yaml_to_dict(
-            constants.CSI_CEPHFS_PVC_YAML
-        )
-        pvc = PVC(**self.cephfs_pvc)
-        pvc.create()
-        log.info(pvc.status)
-        assert 'Bound' in pvc.status
-        pvc.delete()
-        storage_class.delete()
-        secret.delete()
+        RBD_PVC_OBJ = helpers.create_pvc(RBD_SC_OBJ.name, pvc_name)
+        RBD_POD_OBJ = helpers.create_pod(
+            constants.CEPHBLOCKPOOL, RBD_PVC_OBJ.name)
 
     @pytest.mark.polarion_id("OCS-346")
-    def test_basics_cephfs(self):
+    def test_basics_cephfs(self, test_fixture_cephfs):
         """
         Testing basics: secret creation,
-         storage class creation  and pvc with rbd
+         storage class creation, pvc and pod with cephfs
         """
-        self.rbd_secret = templating.load_yaml_to_dict(
-            constants.CSI_RBD_SECRET_YAML
+        global CEPHFS_PVC_OBJ, CEPHFS_POD_OBJ
+        log.info('creating pvc for CephFS ')
+        pvc_name = helpers.create_unique_resource_name(
+            'test-cephfs', 'pvc'
         )
-        del self.rbd_secret['data']['kubernetes']
-        self.rbd_secret['data']['admin'] = get_admin_key_from_ceph_tools()
-        logging.info(self.rbd_secret)
-        secret = OCS(**self.rbd_secret)
-        secret.create()
-        self.rbd_sc = templating.load_yaml_to_dict(
-            constants.CSI_RBD_STORAGECLASS_YAML
-        )
-        self.rbd_sc['parameters']['monitors'] = self.mons
-        del self.rbd_sc['parameters']['userid']
-        storage_class = OCS(**self.rbd_sc)
-        storage_class.create()
-        self.rbd_pvc = templating.load_yaml_to_dict(constants.CSI_RBD_PVC_YAML)
-        pvc = PVC(**self.rbd_pvc)
-        pvc.create()
-        assert 'Bound' in pvc.status
-        pvc.delete()
-        storage_class.delete()
-        secret.delete()
+        CEPHFS_PVC_OBJ = helpers.create_pvc(
+            CEPHFS_SC_OBJ.name, pvc_name=pvc_name)
+        log.info('creating cephfs pod')
+        CEPHFS_POD_OBJ = helpers.create_pod(
+            constants.CEPHFILESYSTEM, CEPHFS_PVC_OBJ.name)

--- a/tests/manage/test_create_storage_class_pvc.py
+++ b/tests/manage/test_create_storage_class_pvc.py
@@ -100,7 +100,8 @@ class TestOSCBasics(ManageTest):
             'test-rbd', 'pvc'
         )
         RBD_PVC_OBJ = helpers.create_pvc(
-            sc_name=RBD_SC_OBJ.name, pvc_name=pvc_name)
+            sc_name=RBD_SC_OBJ.name, pvc_name=pvc_name
+        )
         if RBD_PVC_OBJ.backed_pv is None:
             RBD_PVC_OBJ.reload()
         RBD_POD_OBJ = helpers.create_pod(

--- a/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -95,6 +95,7 @@ def create_pvc_and_verify_pvc_exists(
     )
     pvc_data['spec']['storageClassName'] = sc_name
     pvc_data['spec']['resources']['requests']['storage'] = "10Gi"
+    pvc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
     pvc_obj = pvc.PVC(**pvc_data)
     pvc_obj.create()
     if wait:
@@ -104,7 +105,7 @@ def create_pvc_and_verify_pvc_exists(
         f"status {desired_status}"
     pvc_obj.reload()
 
-    # ToDo: Add validation to check pv exists on bcaekend
+    # ToDo: Add validation to check pv exists on backend
     # Commenting the below code: https://bugzilla.redhat.com/show_bug.cgi?id=1723656
     # Validate pv is created on ceph
     # logger.info(f"Verifying pv exists on backend")
@@ -138,11 +139,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         pvc_obj = create_pvc_and_verify_pvc_exists(
             self.sc_obj.name, self.cbp_obj.name
         )
-        pod_data = templating.load_yaml_to_dict(constants.CSI_RBD_POD_YAML)
-        pod_data['spec']['volumes'][0]['persistentVolumeClaim'][
-            'claimName'
-        ] = pvc_obj.name
-        pod_obj = helpers.create_pod(**pod_data)
+        pod_obj = helpers.create_pod(interface_type=constants.CEPHBLOCKPOOL, pvc=pvc_obj.name)
         used_percentage = pod.run_io_and_verify_mount_point(pod_obj)
         assert used_percentage > '90%', "I/O's didn't run completely"
         used_after_creating_pvc = check_ceph_used_space()

--- a/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -139,7 +139,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         pvc_obj = create_pvc_and_verify_pvc_exists(
             self.sc_obj.name, self.cbp_obj.name
         )
-        pod_obj = helpers.create_pod(interface_type=constants.CEPHBLOCKPOOL, pvc=pvc_obj.name)
+        pod_obj = helpers.create_pod(interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_obj.name)
         used_percentage = pod.run_io_and_verify_mount_point(pod_obj)
         assert used_percentage > '90%', "I/O's didn't run completely"
         used_after_creating_pvc = check_ceph_used_space()

--- a/tests/manage/test_pvc_disruptive.py
+++ b/tests/manage/test_pvc_disruptive.py
@@ -37,7 +37,7 @@ class BaseDisruption(ManageTest):
         )
 
         self.pod_obj = helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc=self.pvc_obj.name, wait=False
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=self.pvc_obj.name, wait=False
         )
         if operation_to_disrupt == 'create_pod':
             DISRUPTION_OPS.delete_resource()


### PR DESCRIPTION
tests/helpers.py
  - Changed create_pvc() to instanciate PVC
  - Modifications in create_pod()
  - Added 'interface' to resource name while creating resource
  - Added new functions
     -- get_all_pvs() --> Returns all pvc in given namespace
     -- validate_pv_delete() --> Validates if pv is deleted after pvc deletion with retry()

tests/manage/test_create_storage_class_pvc.py
 - Updated fixtures for cephfs and rbd
 - Added validate_pv_delete() for validating pv after pvc delete
 - Added pod creation for cephfs and rbd with default values

ocs_ci/ocs/constants.py
 - Added rbd and cephfs interfaces

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/343