### PR TITLE
Addressing Tier1 test failures for test_cluster_utils

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,6 +20,9 @@ from ocs_ci.ocs import exceptions
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_TIMEOUT = 1200
+
+
 class CephCluster(object):
     """
     Handles all cluster related operations from ceph perspective
@@ -72,6 +75,8 @@ class CephCluster(object):
         self.cluster = ocs.OCS(**self.cluster_resource_config)
         if self.cephfs_config:
             self.cephfs = ocs.OCS(**self.cephfs_config)
+        else:
+            self.cephfs = None
 
         self.mon_selector = constant.MON_APP_LABEL
         self.mds_selector = constant.MDS_APP_LABEL
@@ -119,8 +124,16 @@ class CephCluster(object):
         # set port attrib on mon pods
         self.mons = list(map(self.set_port, self.mons))
         self.cluster.reload()
-        if self.cephfs_config:
+        if self.cephfs:
             self.cephfs.reload()
+        else:
+            try:
+                self.cephfs_config = self.CEPHFS.get().get('items')[0]
+                self.cephfs = ocs.OCS(**self.cephfs_config)
+                self.cephfs.reload()
+            except IndexError as e:
+                logging.warning(e)
+                logging.warning("No CephFS found")
 
         self.mon_count = len(self.mons)
         self.mds_count = len(self.mdss)
@@ -155,7 +168,7 @@ class CephCluster(object):
         self.cluster.reload()
         return self.cluster.data['status']['ceph']['health'] == "HEALTH_OK"
 
-    def cluster_health_check(self, timeout=0):
+    def cluster_health_check(self, timeout=DEFAULT_TIMEOUT):
         """
         Check overall cluster health.
         Relying on health reported by CephCluster.get()
@@ -172,7 +185,9 @@ class CephCluster(object):
         Raises:
             CephHealthException: if cluster is not healthy
         """
-        timeout = 10 * len(self.pods)
+        if timeout == DEFAULT_TIMEOUT:
+            # Scale timeout only if user hasn't passed any value
+            timeout = 10 * len(self.pods)
         sample = TimeoutSampler(
             timeout=timeout, sleep=3, func=self.is_health_ok
         )
@@ -243,6 +258,8 @@ class CephCluster(object):
                 condition='Running', selector=self.mon_selector,
                 resource_count=count, timeout=timeout, sleep=3,
             )
+            actual = len(pod.get_mon_pods())
+            assert count == actual, f"Expected {count},  Got{actual}"
         except exceptions.TimeoutExpiredError as e:
             logger.error(e)
             raise exceptions.MonCountException(

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,7 +20,9 @@ from ocs_ci.ocs import exceptions
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TIMEOUT = 1200
+# This value will not be consumed as is , instead it will be scaled based on
+# number of pods in the cluster
+DEFAULT_TIMEOUT = 300
 
 
 class CephCluster(object):
@@ -259,7 +261,7 @@ class CephCluster(object):
                 resource_count=count, timeout=timeout, sleep=3,
             )
             actual = len(pod.get_mon_pods())
-            assert count == actual, f"Expected {count},  Got{actual}"
+            assert count == actual, f"Expected {count},  Got {actual}"
         except exceptions.TimeoutExpiredError as e:
             logger.error(e)
             raise exceptions.MonCountException(

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,11 +20,6 @@ from ocs_ci.ocs import exceptions
 logger = logging.getLogger(__name__)
 
 
-# This value will not be consumed as is , instead it will be scaled based on
-# number of pods in the cluster
-DEFAULT_TIMEOUT = 300
-
-
 class CephCluster(object):
     """
     Handles all cluster related operations from ceph perspective
@@ -170,7 +165,7 @@ class CephCluster(object):
         self.cluster.reload()
         return self.cluster.data['status']['ceph']['health'] == "HEALTH_OK"
 
-    def cluster_health_check(self, timeout=DEFAULT_TIMEOUT):
+    def cluster_health_check(self, timeout=None):
         """
         Check overall cluster health.
         Relying on health reported by CephCluster.get()
@@ -187,9 +182,8 @@ class CephCluster(object):
         Raises:
             CephHealthException: if cluster is not healthy
         """
-        if timeout == DEFAULT_TIMEOUT:
-            # Scale timeout only if user hasn't passed any value
-            timeout = 10 * len(self.pods)
+        # Scale timeout only if user hasn't passed any value
+        timeout = timeout or (10 * len(self.pods))
         sample = TimeoutSampler(
             timeout=timeout, sleep=3, func=self.is_health_ok
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -421,7 +421,7 @@ def create_cephfilesystem():
     )
     assert POD[0].ocp.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector='app=rook-ceph-mds',
+        selector=constants.MDS_APP_LABEL,
         timeout=120
     )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -304,8 +304,6 @@ def validate_cephfilesystem(fs_name):
     cmd = "ceph fs ls"
     logger.info(fs_name)
     out = ct_pod.exec_ceph_cmd(ceph_cmd=cmd)
-    # TO DELETE
-    logger.info(f"OUT={out}")
     if out:
         out = out[0]['name']
         logger.info(out)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -304,6 +304,8 @@ def validate_cephfilesystem(fs_name):
     cmd = "ceph fs ls"
     logger.info(fs_name)
     out = ct_pod.exec_ceph_cmd(ceph_cmd=cmd)
+    # TO DELETE
+    logger.info(f"OUT={out}")
     if out:
         out = out[0]['name']
         logger.info(out)
@@ -419,12 +421,12 @@ def create_cephfilesystem():
     POD = pod.get_all_pods(
         namespace=defaults.ROOK_CLUSTER_NAMESPACE
     )
-    for pod_names in POD:
-        if 'rook-ceph-mds' in pod_names.labels.values():
-            assert pod_names.ocp.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector='app=rook-ceph-mds'
-            )
+    assert POD[0].ocp.wait_for_resource(
+        condition=constants.STATUS_RUNNING,
+        selector='app=rook-ceph-mds',
+        timeout=120
+    )
+
     assert validate_cephfilesystem(fs_name=fs_data['metadata']['name'])
     return True
 

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.cluster import CephCluster
+from tests import helpers
 
 
 log = logging.getLogger(__name__)
@@ -21,26 +22,74 @@ def test_fixture(request):
     setup(self)
 
 
+@pytest.fixture(scope='function')
+def mon_resource(request):
+    self = request.node.cls
+    mon_count = self.cluster_obj.mon_count
+    log.info(f"Mon count before add = {mon_count}")
+    self.cluster_obj.scan_cluster()
+    self.cluster_obj.cluster.reload()
+    self.cluster_obj.cluster.data['spec']['mon']['allowMultiplePerNode'] = True
+    self.cluster_obj.cluster.apply(**self.cluster_obj.cluster.data)
+    yield
+    self.cluster_obj.mon_change_count(mon_count)
+    if mon_count != self.cluster_obj.mon_count:
+        log.error(f"Mon teardown failure")
+        log.error(
+            f"Expected: {mon_count}",
+            f"but found {self.cluster_obj.mon_count}"
+        )
+    log.info("Removed mon")
+    (self.cluster_obj.cluster.data
+        ['spec']['mon']['allowMultiplePerNode']) = False
+    self.cluster_obj.cluster.apply(**self.cluster_obj.cluster.data)
+
+
+@pytest.fixture(scope='function')
+def mds_resource(request):
+    self = request.node.cls
+    we_created_fs = False
+    if not self.cluster_obj.cephfs:
+        # cephfs doesn't exist , create one for this test
+        assert helpers.create_cephfilesystem()
+        self.cluster_obj.scan_cluster()
+        assert self.cluster_obj.cephfs
+        we_created_fs = True
+    mds_count = int(self.cluster_obj.mds_count / 2)
+    yield
+    self.cluster_obj.mds_change_count(mds_count)
+    current_count = int(self.cluster_obj.mds_count / 2)
+    if mds_count != current_count:
+        log.error(f"MDS teardown failure")
+        log.error(f"Expected: {mds_count} but found {current_count}")
+    if we_created_fs:
+        self.cluster_obj.cephfs.delete()
+        self.cluster_obj.cephfs = None
+
+
+@pytest.fixture(scope='function')
+def user_resource(request):
+    self = request.node.cls
+    log.info("Creating user")
+    assert self.cluster_obj.create_user(self.username, self.caps)
+    yield
+    del_cmd = f"ceph auth del {self.username}"
+    log.info("User deleted")
+    self.cluster_obj.toolbox.exec_ceph_cmd(del_cmd)
+
+
 def setup(self):
     """
     Setting up the environment for the test
     """
-    self.cluster = CephCluster()
-    assert self.cluster.create_user(self.username, self.caps)
+    self.cluster_obj = CephCluster()
 
 
 def teardown(self):
     """
     Tearing down the environment
     """
-    new_count = self.cluster.mon_count - 1
-    self.cluster.mon_change_count(new_count)
-    assert new_count == self.cluster.mon_count
-    new_mdscount = int(self.cluster.mds_count / 2) - 1
-    self.cluster.mds_change_count(new_mdscount)
-    assert new_mdscount * 2 == self.cluster.mds_count
-    del_cmd = f"ceph auth del {self.username}"
-    self.cluster.toolbox.exec_ceph_cmd(del_cmd)
+    assert self.cluster_obj.cluster_health_check()
 
 
 @tier1
@@ -49,12 +98,11 @@ def teardown(self):
 )
 class TestClusterUtils(ManageTest):
     # Cluster will be populated in the fixture
-    cluster = None
     username = "client.test"
     caps = "mon 'allow r' osd 'allow rwx'"
 
-    def test_get_user_key(self):
-        key = self.cluster.get_user_key(self.username)
+    def test_get_user_key(self, user_resource):
+        key = self.cluster_obj.get_user_key(self.username)
         assert key
         logging.info(key)
 
@@ -62,24 +110,24 @@ class TestClusterUtils(ManageTest):
         """
         By default admin user will be created by rook
         """
-        key = self.cluster.get_admin_key()
+        key = self.cluster_obj.get_admin_key()
         assert key
 
     def test_get_mon_info(self):
-        for mon in self.cluster.mons:
+        for mon in self.cluster_obj.mons:
             logging.info(mon.name)
             logging.info(mon.port)
 
-    def test_add_mon(self):
-        cur_count = self.cluster.mon_count
+    def test_add_mon(self, mon_resource):
+        cur_count = self.cluster_obj.mon_count
         logging.info(f"current mon count = {cur_count}")
         new_count = cur_count + 1
-        self.cluster.mon_change_count(new_count)
-        assert new_count == self.cluster.mon_count
+        self.cluster_obj.mon_change_count(new_count)
+        assert new_count == self.cluster_obj.mon_count
 
-    def test_add_mds(self):
-        cur_count = int(self.cluster.mds_count / 2)
+    def test_add_mds(self, mds_resource):
+        cur_count = int(self.cluster_obj.mds_count / 2)
         logging.info(f"Current active count = {cur_count}")
         new_count = cur_count + 1
-        self.cluster.mds_change_count(new_count)
-        assert new_count * 2 == self.cluster.mds_count
+        self.cluster_obj.mds_change_count(new_count)
+        assert new_count * 2 == self.cluster_obj.mds_count

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -22,7 +22,7 @@ def test_fixture(request):
     setup(self)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def mon_resource(request):
     self = request.node.cls
     mon_count = self.cluster_obj.mon_count
@@ -40,12 +40,13 @@ def mon_resource(request):
             f"but found {self.cluster_obj.mon_count}"
         )
     log.info("Removed mon")
-    (self.cluster_obj.cluster.data
-        ['spec']['mon']['allowMultiplePerNode']) = False
+    self.cluster_obj.cluster.data['spec']['mon'][
+        'allowMultiplePerNode'
+    ] = False
     self.cluster_obj.cluster.apply(**self.cluster_obj.cluster.data)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def mds_resource(request):
     self = request.node.cls
     we_created_fs = False
@@ -67,7 +68,7 @@ def mds_resource(request):
         self.cluster_obj.cephfs = None
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def user_resource(request):
     self = request.node.cls
     log.info("Creating user")

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -24,6 +24,10 @@ def test_fixture(request):
 
 @pytest.fixture
 def mon_resource(request):
+    """
+    A fixture to handle mon resource cleanup,
+    this function brings the mon count to what it was before test started
+    """
     self = request.node.cls
     mon_count = self.cluster_obj.mon_count
     log.info(f"Mon count before add = {mon_count}")
@@ -48,6 +52,10 @@ def mon_resource(request):
 
 @pytest.fixture
 def mds_resource(request):
+    """
+    A fixture to handle mds resource cleanup
+    This function brings mds count to what it was before test started
+    """
     self = request.node.cls
     we_created_fs = False
     if not self.cluster_obj.cephfs:
@@ -70,6 +78,9 @@ def mds_resource(request):
 
 @pytest.fixture
 def user_resource(request):
+    """
+    A fixture for creating user for test and cleaning up after test is done
+    """
     self = request.node.cls
     log.info("Creating user")
     assert self.cluster_obj.create_user(self.username, self.caps)
@@ -81,16 +92,16 @@ def user_resource(request):
 
 def setup(self):
     """
-    Setting up the environment for the test
+    Create CephCluster object to be consumed by tests
     """
     self.cluster_obj = CephCluster()
 
 
 def teardown(self):
     """
-    Tearing down the environment
+    Make sure at the end cluster is in HEALTH_OK state
     """
-    assert self.cluster_obj.cluster_health_check()
+    assert self.cluster_obj.cluster_health_check(timeout=1200)
 
 
 @tier1


### PR DESCRIPTION
* Fix tier1 test_cluster_utils failures by introducing setup and teardown per test.
* Introduce mon_resource, mds_resource, user_resource as fixtures for tests

Signed-off-by: Shylesh Kumar <shmohan@redhat.com>