### PR TITLE
Fixes Issue-371, added ioparam [fio_filename] to pod.run_io

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -177,7 +177,7 @@ class Pod(OCS):
 
     def run_io(
         self, storage_type, size, io_direction='rw', rw_ratio=75,
-        jobs=1, runtime=60,
+        jobs=1, runtime=60, fio_filename=None
     ):
         """
         Execute FIO on a pod
@@ -199,6 +199,7 @@ class Pod(OCS):
                 equivalent to 3 reads are performed for every 1 write)
             jobs (int): Number of jobs to execute FIO
             runtime (int): Number of seconds IO should run for
+            fio_filename(str): Name of fio file created on app pod's mount point
         """
         name = 'test_workload'
         spec = self.pod_data.get('spec')
@@ -225,6 +226,8 @@ class Pod(OCS):
             )
         io_params['runtime'] = runtime
         io_params['size'] = size
+        if fio_filename:
+            io_params['filename'] = fio_filename
 
         self.fio_thread = wl.run(**io_params)
 


### PR DESCRIPTION
Fixes Issue #371 

Added a variable "fio_filename" in ocs_ci/ocs/resources/pod.py **run_io** function

Please review.

**Verified the result:** 

e.g. added fio_filename = name of the app pod for simplicity in validating which pod the file belongs to: 

pod_obj.run_io('fs', '512M', fio_filename=pod_obj.name)

20:10:23 - MainThread - ocs_ci.ocs.workload - INFO - Done submitting..
20:10:23 - ThreadPoolExecutor-1_0 - ocs_ci.utility.utils - INFO - Executing command: oc -n namespace-test-0820075834 --kubeconfig /home/nberry/aws-install/jul8-1/auth/kubeconfig rsh pod-test-0820082948 fio --name=fio-rand-readwrite **--filename=/var/lib/www/html/pod-test-0820082948** --readwrite=randrw --bs=4K --direct=1 --numjobs=1 --time_based=1 --runtime=60 --size=1G --iodepth=4 --invalidate=1 --fsync_on_close=1 --rwmixread=75 --ioengine=libaio --output-format=json


Every 2.0s: oc rsh pod-test-0820082948 ls -l /var/lib/www/html        Mon Jul  8 20:10:36 2019

total 1048596
drwx------. 2 root root      16384 Jul  8 14:38 lost+found
**-rw-r--r--. 1 root root 1073741824 Jul  8 14:40 pod-test-0820082948**