### PR TITLE
WIP: switch managage/test_add_mds_to_cluster.py to setup/teardown class methods

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -614,3 +614,18 @@ def validate_pv_delete(pv_name):
 
     except CommandFailed:
         return True
+
+
+def verify_fs_exist(pod_count):
+    """
+    Verifying if a ceph FS exist
+    """
+    POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace'])
+    assert POD.wait_for_resource(
+        condition='Running', selector='app=rook-ceph-mds',
+        resource_count=pod_count
+    )
+    pods = POD.get(selector='app=rook-ceph-mds')['items']
+    if len(pods) == pod_count:
+        return True
+    return False

--- a/tests/manage/test_add_mds_to_cluster.py
+++ b/tests/manage/test_add_mds_to_cluster.py
@@ -3,8 +3,6 @@ A test for creating a CephFS
 """
 import logging
 
-import pytest
-
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1, ManageTest
@@ -14,51 +12,12 @@ log = logging.getLogger(__name__)
 
 CEPHFS_DELETED = '"{cephfs_name}" deleted'
 
-POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace'])
-CEPHFS = ocp.OCP(kind=constants.CEPHFILESYSTEM)
-CEPH_OBJ = None
-
-
-@pytest.fixture(scope='class')
-def test_fixture(request):
-    """
-    Create disks
-    """
-    self = request.node.cls
-
-    def finalizer():
-        teardown(self)
-    request.addfinalizer(finalizer)
-    setup(self)
-
-
-def setup(self):
-    """
-    Setting up the environment for the test
-    """
-    global CEPHFS, CEPH_OBJ
-    CEPHFS = ocp.OCP(kind=constants.CEPHFILESYSTEM)
-    self.fs_data = CEPHFS.get(defaults.CEPHFILESYSTEM_NAME)
-    self.fs_name = self.fs_data['metadata']['name']
-    CEPH_OBJ = OCS(**self.fs_data)
-
-
-def teardown(self):
-    """
-    Tearing down the environment
-    """
-    self.fs_data = CEPHFS.get(defaults.CEPHFILESYSTEM_NAME)
-    self.fs_data['spec']['metadataServer']['activeCount'] = (
-        self.original_active_count
-    )
-    CEPH_OBJ.apply(**self.fs_data)
-    assert verify_fs_exist(self.original_active_count * 2)
-
 
 def verify_fs_exist(pod_count):
     """
     Verifying if a ceph FS exist
     """
+    POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace'])
     assert POD.wait_for_resource(
         condition='Running', selector='app=rook-ceph-mds',
         resource_count=pod_count
@@ -70,9 +29,6 @@ def verify_fs_exist(pod_count):
 
 
 @tier1
-@pytest.mark.usefixtures(
-    test_fixture.__name__,
-)
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem
@@ -80,6 +36,20 @@ class TestCephFilesystemCreation(ManageTest):
     new_active_count = 2
     original_active_count = 1
     fs_name = None
+
+    def setup_class(self):
+        self.CEPHFS = ocp.OCP(kind=constants.CEPHFILESYSTEM)
+        self.fs_data = self.CEPHFS.get(defaults.CEPHFILESYSTEM_NAME)
+        self.fs_name = self.fs_data['metadata']['name']
+        self.CEPH_OBJ = OCS(**self.fs_data)
+
+    def teardown_class(self):
+        self.fs_data = self.CEPHFS.get(defaults.CEPHFILESYSTEM_NAME)
+        self.fs_data['spec']['metadataServer']['activeCount'] = (
+            self.original_active_count
+        )
+        self.CEPH_OBJ.apply(**self.fs_data)
+        assert verify_fs_exist(self.original_active_count * 2)
 
     def test_cephfilesystem_creation(self):
         """
@@ -89,5 +59,5 @@ class TestCephFilesystemCreation(ManageTest):
         self.fs_data['spec']['metadataServer']['activeCount'] = (
             self.new_active_count
         )
-        CEPH_OBJ.apply(**self.fs_data)
+        self.CEPH_OBJ.apply(**self.fs_data)
         assert verify_fs_exist(self.new_active_count * 2)

--- a/tests/manage/test_add_mds_to_cluster.py
+++ b/tests/manage/test_add_mds_to_cluster.py
@@ -5,28 +5,14 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
+
+from tests import helpers
 
 log = logging.getLogger(__name__)
 
 CEPHFS_DELETED = '"{cephfs_name}" deleted'
-
-
-def verify_fs_exist(pod_count):
-    """
-    Verifying if a ceph FS exist
-    """
-    POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace'])
-    assert POD.wait_for_resource(
-        condition='Running', selector='app=rook-ceph-mds',
-        resource_count=pod_count
-    )
-    pods = POD.get(selector='app=rook-ceph-mds')['items']
-    if len(pods) == pod_count:
-        return True
-    return False
 
 
 @pytest.fixture(scope="class")
@@ -40,6 +26,7 @@ def fs_data(cephfs):
     fs_data = cephfs.get(defaults.CEPHFILESYSTEM_NAME)
     return fs_data
 
+
 @pytest.fixture(scope="class")
 def ceph_obj(request, fs_data):
     ceph_obj = OCS(**fs_data)
@@ -47,7 +34,7 @@ def ceph_obj(request, fs_data):
 
     def teardown():
         ceph_obj.apply(**fs_data)
-        assert verify_fs_exists(original_active_count * 2)
+        assert helpers.verify_fs_exists(original_active_count * 2)
 
     request.addfinalizer(teardown)
     return ceph_obj
@@ -60,7 +47,6 @@ class TestCephFilesystemCreation(ManageTest):
     """
     new_active_count = 2
 
-
     def test_cephfilesystem_creation(self, ceph_obj, fs_data):
         """
         Creating a Ceph Filesystem
@@ -70,4 +56,4 @@ class TestCephFilesystemCreation(ManageTest):
             self.new_active_count
         )
         ceph_obj.apply(**fs_data)
-        assert verify_fs_exist(self.new_active_count * 2)
+        assert helpers.verify_fs_exist(self.new_active_count * 2)


### PR DESCRIPTION
An example of what #285 is trying to address.

This allows us to avoid global variable usage while still leveraging pytest's setup and teardown capabilities.