### PR TITLE
Destroy cluster in bad shape

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -86,34 +86,42 @@ def pytest_configure(config):
         process_cluster_cli_params(config)
         # Add OCS related versions to the html report and remove extraneous metadata
         markers_arg = config.getoption('-m')
-        if not ("deployment" in markers_arg and ocsci_config.RUN['cli_params']['deploy']):
-            print("Collecting Cluster versions")
-            # remove extraneous metadata
-            del config._metadata['Python']
-            del config._metadata['Packages']
-            del config._metadata['Plugins']
-            del config._metadata['Platform']
+        if ocsci_config.RUN['cli_params'].get('teardown') or (
+            "deployment" in markers_arg
+            and ocsci_config.RUN['cli_params'].get('deploy')
+        ):
+            log.info(
+                "Skiping versions collecting because: Deploy or destroy of "
+                "cluster is performed."
+            )
+            return
+        print("Collecting Cluster versions")
+        # remove extraneous metadata
+        del config._metadata['Python']
+        del config._metadata['Packages']
+        del config._metadata['Plugins']
+        del config._metadata['Platform']
 
-            try:
-                # add cluster version
-                clusterversion = get_cluster_version()
-                config._metadata['Cluster Version'] = clusterversion
+        try:
+            # add cluster version
+            clusterversion = get_cluster_version()
+            config._metadata['Cluster Version'] = clusterversion
 
-                # add ceph version
-                ceph_version = get_ceph_version()
-                config._metadata['Ceph Version'] = ceph_version
+            # add ceph version
+            ceph_version = get_ceph_version()
+            config._metadata['Ceph Version'] = ceph_version
 
-                # add rook version
-                rook_version = get_rook_version()
-                config._metadata['Rook Version'] = rook_version
+            # add rook version
+            rook_version = get_rook_version()
+            config._metadata['Rook Version'] = rook_version
 
-                # add csi versions
-                csi_versions = get_csi_versions()
-                config._metadata['csi-provisioner'] = csi_versions.get('csi-provisioner')
-                config._metadata['cephfsplugin'] = csi_versions.get('cephfsplugin')
-                config._metadata['rbdplugin'] = csi_versions.get('rbdplugin')
-            except (FileNotFoundError, CommandFailed):
-                pass
+            # add csi versions
+            csi_versions = get_csi_versions()
+            config._metadata['csi-provisioner'] = csi_versions.get('csi-provisioner')
+            config._metadata['cephfsplugin'] = csi_versions.get('cephfsplugin')
+            config._metadata['rbdplugin'] = csi_versions.get('rbdplugin')
+        except (FileNotFoundError, CommandFailed):
+            pass
 
 
 def get_cli_param(config, name_of_param, default=None):


### PR DESCRIPTION
We cannot collect data like version info from the cluster when it's not
in good shape. So when destroy cluster, we just skip the version
collecting with change in this PR.

Should also fix the issue #335