### PR TITLE
Suppress captured logs at end of session

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,5 +27,5 @@ log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message
 log_cli=true
 log_cli_level = INFO
 log_level = DEBUG
-addopts = --ignore=ocs_ci
+addopts = --ignore=ocs_ci --no-print-logs
 testpaths = tests


### PR DESCRIPTION
Automatically add --no-print-logs option to suppress dumping logs at the end of a session and to reduce html report file size.

This change solves two issues:
- Captured logs being dumped at the end of a session makes viewing the overall results in the console practically impossible.
- Enormous file size of html reports caused giant load times and reduces the value of these _summary_ reports

Before:
- tier1-report.html - 431M
- 55 sec. load time in browser

After:
- tier1-report.html - 906K
- < 1 sec. load time in browser

I don't think this 100% fixes the issue described in #323 but it is a significant start.