### PR TITLE
Updating the yamls based on upstream rook changes

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -44,5 +44,5 @@ ENV_DATA:
   # Do not change to specific version like v14.2.1-20190430 if not needed
   # cause we don't need to update it each time new 14.x version is released
   # but only once when move to new version like v15.
-  ceph_image: 'ceph/ceph:v14'
+  ceph_image: 'ceph/daemon-base:latest-nautilus-devel'
   rook_image: 'rook/ceph:master'

--- a/ocs_ci/templates/ocs-deployment/cluster.yaml
+++ b/ocs_ci/templates/ocs-deployment/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: {{ ceph_image | default('ceph/ceph:v14.2.0-20190410') }}
+    image: {{ ceph_image | default('ceph/daemon-base:latest-nautilus-devel') }}
     # Whether to allow unsupported versions of Ceph. Currently luminous, mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Do not set to true in production.
     allowUnsupported: {{ allow_unsupported_ceph | default('true') }}

--- a/ocs_ci/templates/ocs-deployment/common.yaml
+++ b/ocs_ci/templates/ocs-deployment/common.yaml
@@ -6,14 +6,17 @@
 # If the operator needs to manage multiple clusters (in different namespaces), see the section below
 # for "cluster-specific resources". The resources below that section will need to be created for each namespace
 # where the operator needs to manage the cluster. The resources above that section do not be created again.
+#
+# Most of the sections are prefixed with a 'OLM' keyword which is used to build our CSV for an OLM (Operator Life Cycle manager)
 ###################################################################################################################
----
+
 # Namespace where the operator and other rook resources are created
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ cluster_namespace | default('openshift-storage') }}
 ---
+# OLM: BEGIN CEPH CRD
 # The CRD declarations
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -101,7 +104,9 @@ spec:
       type: string
       description: Ceph Health
       JSONPath: .status.ceph.health
+# OLM: END CEPH CRD
 ---
+# OLM: BEGIN CEPH FS CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -123,7 +128,9 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+# OLM: END CEPH FS CRD
 ---
+# OLM: BEGIN CEPH NFS CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -139,7 +146,9 @@ spec:
     - nfs
   scope: Namespaced
   version: v1
+# OLM: END CEPH NFS CRD
 ---
+# OLM: BEGIN CEPH OBJECT STORE CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -153,7 +162,9 @@ spec:
     singular: cephobjectstore
   scope: Namespaced
   version: v1
+# OLM: END CEPH OBJECT STORE CRD
 ---
+# OLM: BEGIN CEPH OBJECT STORE USERS CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -167,7 +178,9 @@ spec:
     singular: cephobjectstoreuser
   scope: Namespaced
   version: v1
+# OLM: END CEPH OBJECT STORE USERS CRD
 ---
+# OLM: BEGIN CEPH BLOCK POOL CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -181,7 +194,9 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+# OLM: END CEPH BLOCK POOL CRD
 ---
+# OLM: BEGIN CEPH VOLUME POOL CRD
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -197,7 +212,9 @@ spec:
     - rv
   scope: Namespaced
   version: v1alpha2
+# OLM: END CEPH VOLUME POOL CRD
 ---
+# OLM: BEGIN OPERATOR ROLE
 # The cluster role for managing all the cluster-specific resources in a namespace
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -404,6 +421,8 @@ rules:
   - list
   - watch
 ---
+# OLM: END OPERATOR ROLE
+# OLM: BEGIN SERVICE ACCOUNT SYSTEM
 # The rook system service account used by the operator, agent, and discovery pods
 apiVersion: v1
 kind: ServiceAccount
@@ -414,6 +433,8 @@ metadata:
     operator: rook
     storage-backend: ceph
 ---
+# OLM: END SERVICE ACCOUNT SYSTEM
+# OLM: BEGIN OPERATOR ROLEBINDING
 # Grant the operator, agent, and discovery agents access to resources in the namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -450,17 +471,21 @@ subjects:
   name: rook-ceph-system
   namespace: {{ cluster_namespace | default('openshift-storage') }}
 ---
+# OLM: END OPERATOR ROLEBINDING
 #################################################################################################################
 # Beginning of cluster-specific resources. The example will assume the cluster will be created in the "rook-ceph"
 # namespace. If you want to create the cluster in a different namespace, you will need to modify these roles
 # and bindings accordingly.
 #################################################################################################################
 # Service account for the Ceph OSDs. Must exist and cannot be renamed.
+# OLM: BEGIN SERVICE ACCOUNT OSD
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
   namespace: {{ cluster_namespace | default('openshift-storage') }}
+# OLM: END SERVICE ACCOUNT OSD
+# OLM: BEGIN SERVICE ACCOUNT MGR
 ---
 # Service account for the Ceph Mgr. Must exist and cannot be renamed.
 apiVersion: v1
@@ -468,7 +493,17 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
   namespace: {{ cluster_namespace | default('openshift-storage') }}
+# OLM: END SERVICE ACCOUNT MGR
 ---
+# OLM: BEGIN CMD REPORTER SERVICE ACCOUNT
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
+# OLM: END CMD REPORTER SERVICE ACCOUNT
+---
+# OLM: BEGIN CLUSTER ROLE
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -541,8 +576,31 @@ rules:
   - "*"
   verbs:
   - "*"
+# OLM: END CLUSTER ROLE
 ---
-  # Allow the operator to create resources in this cluster's namespace
+# OLM: BEGIN CMD REPORTER ROLE
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+# OLM: END CMD REPORTER ROLE
+---
+# OLM: BEGIN CLUSTER ROLEBINDING
+# Allow the operator to create resources in this cluster's namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -615,4 +673,21 @@ subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
   namespace: {{ cluster_namespace | default('openshift-storage') }}
-
+# OLM: END CLUSTER ROLEBINDING
+---
+# OLM: BEGIN CMD REPORTER ROLEBINDING
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
+# OLM: END CMD REPORTER ROLEBINDING
+---


### PR DESCRIPTION
Fix for the issue #397

Changed the image name in default_config.yml to **ceph/daemon-base:latest-nautilus-devel**  since this new image is needed for cephfs pvcs to get bound. 
```
  image: ceph/daemon-base:latest-nautilus-devel
```
CephFS pvcs were in Pending state if we used the current ceph image mentioned below. : 

**-  ceph_image: 'ceph/ceph:v14'**


Confirmed following:
1. rook ceph cluster install works
2. rbd and cephfs pvc are getting BOUND

