### PR TITLE
conftest: Fix teardown finalizer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,9 @@ def cluster(request, log_cli_level):
     teardown = config.RUN['cli_params']['teardown']
     # Add a finalizer to teardown the cluster after test execution is finished
     if teardown:
-        request.addfinalizer(cluster_teardown(log_cli_level))
+        def cluster_teardown_finalizer():
+            cluster_teardown(log_cli_level)
+        request.addfinalizer(cluster_teardown_finalizer)
         log.info("Will teardown cluster because --teardown was provided")
     # Test cluster access and if exist just skip the deployment.
     if is_cluster_running(cluster_path):


### PR DESCRIPTION
We broke the teardown finalizer recently, by calling the function
immediately and causing None to be passed to addfinalizer(), resulting
in `TypeError: 'NoneType' object is not callable`
Caused by: https://github.com/red-hat-storage/ocs-ci/commit/b21121bf0103a813a582f24196fe21fcc1a6e623#diff-484462fced51d1a06b1d93b4a44dd535R93

Signed-off-by: Zack Cerza <zack@redhat.com>