### PR TITLE
Fixing import error delete_all_pvcs func

### DIFF
--- a/tests/manage/test_create_pvc_random_storage_class.py
+++ b/tests/manage/test_create_pvc_random_storage_class.py
@@ -50,7 +50,7 @@ def teardown():
     """
     global RBD_SECRET_OBJ, CEPHFS_SECRET_OBJ
     log.info("Deleting PVC")
-    assert pvc.delete_all_pvcs()
+    assert pvc.delete_pvcs(PVC_OBJS)
     log.info("Deleting CEPH BLOCK POOL")
     assert helpers.delete_cephblockpool()
     log.info("Deleting RBD Secret")
@@ -93,10 +93,12 @@ def create_pvc(storageclass_list, count=1):
         storageclass_list (list): This will contain storageclass list
         count (int): count specify no of pvc want's to create
     """
+    global PVC_OBJS
+    PVC_OBJS = [0] * count
     for i in range(count):
         sc_name = random.choice(storageclass_list)
-        pvc_obj = helpers.create_pvc(sc_name)
-        log.info(f"{pvc_obj.name} got Created and got Bounded")
+        PVC_OBJS[i] = helpers.create_pvc(sc_name)
+        log.info(f"{PVC_OBJS[i].name} got created and got Bounded")
     return True
 
 

--- a/tests/manage/test_create_pvc_random_storage_class.py
+++ b/tests/manage/test_create_pvc_random_storage_class.py
@@ -94,7 +94,7 @@ def create_pvc(storageclass_list, count=1):
         count (int): count specify no of pvc want's to create
     """
     global PVC_OBJS
-    PVC_OBJS = [0] * count
+    PVC_OBJS = []
     for i in range(count):
         sc_name = random.choice(storageclass_list)
         PVC_OBJS[i] = helpers.create_pvc(sc_name)

--- a/tests/manage/test_create_pvc_random_storage_class.py
+++ b/tests/manage/test_create_pvc_random_storage_class.py
@@ -97,8 +97,9 @@ def create_pvc(storageclass_list, count=1):
     PVC_OBJS = []
     for i in range(count):
         sc_name = random.choice(storageclass_list)
-        PVC_OBJS[i] = helpers.create_pvc(sc_name)
-        log.info(f"{PVC_OBJS[i].name} got created and got Bounded")
+        pvc_objs = helpers.create_pvc(sc_name)
+        PVC_OBJS.append(pvc_objs)
+        log.info(f"{pvc_objs.name} got created and got Bounded")
     return True
 
 

--- a/tests/manage/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/test_pvc_concurrent_deletion_creation.py
@@ -70,7 +70,7 @@ def teardown(self):
     Delete project
     """
     # Delete newly created PVCs
-    assert delete_pvcs(pvc_objs_new), 'Failed to delete PVCs'
+    assert delete_pvcs(self.pvc_objs_new), 'Failed to delete PVCs'
     log.info(f'Newly created {self.number_of_pvc} PVCs are now deleted.')
 
     # Switch to default project
@@ -97,6 +97,7 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
     pvc_base_name_new = 'test-pvc-re'
     initial_pvs = []
     pvc_objs_initial = []
+    pvc_objs_new = []
 
     def test_multiple_pvc_concurrent_creation_deletion(self):
         """
@@ -123,11 +124,11 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
         pvc_objs = create_multiple_pvc(self.number_of_pvc, pvc_data)
 
         log.info(f'Created {self.number_of_pvc} new PVCs.')
-        global pvc_objs_new
-        pvc_objs_new = pvc_objs[:]
+        # global pvc_objs_new
+        self.pvc_objs_new = pvc_objs[:]
 
         # Verify PVCs are Bound
-        for pvc in pvc_objs_new:
+        for pvc in self.pvc_objs_new:
             pvc.reload()
             assert pvc.status == constants.STATUS_BOUND, (
                 f'PVC {pvc.name} is not Bound'

--- a/tests/manage/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/test_pvc_concurrent_deletion_creation.py
@@ -124,7 +124,6 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
         pvc_objs = create_multiple_pvc(self.number_of_pvc, pvc_data)
 
         log.info(f'Created {self.number_of_pvc} new PVCs.')
-        # global pvc_objs_new
         self.pvc_objs_new = pvc_objs[:]
 
         # Verify PVCs are Bound

--- a/tests/manage/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/test_pvc_concurrent_deletion_creation.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs import constants, ocp, exceptions
 from ocs_ci.utility.utils import run_async
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
-from ocs_ci.ocs.resources.pvc import create_multiple_pvc, delete_all_pvcs
+from ocs_ci.ocs.resources.pvc import create_multiple_pvc, delete_pvcs
 from tests.fixtures import (
     create_rbd_storageclass, create_ceph_block_pool, create_rbd_secret
 )
@@ -70,7 +70,7 @@ def teardown(self):
     Delete project
     """
     # Delete newly created PVCs
-    assert delete_all_pvcs(namespace=self.namespace), 'Failed to delete PVCs'
+    assert delete_pvcs(pvc_objs_new), 'Failed to delete PVCs'
     log.info(f'Newly created {self.number_of_pvc} PVCs are now deleted.')
 
     # Switch to default project
@@ -97,7 +97,6 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
     pvc_base_name_new = 'test-pvc-re'
     initial_pvs = []
     pvc_objs_initial = []
-    pvc_objs_new = []
 
     def test_multiple_pvc_concurrent_creation_deletion(self):
         """
@@ -124,7 +123,9 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
         pvc_objs = create_multiple_pvc(self.number_of_pvc, pvc_data)
 
         log.info(f'Created {self.number_of_pvc} new PVCs.')
-        self.pvc_objs_new = pvc_objs[:]
+        global pvc_objs_new
+        pvc_objs_new = [0] * self.number_of_pvc
+        pvc_objs_new = pvc_objs[:]
 
         # Verify PVCs are Bound
         for pvc in self.pvc_objs_new:

--- a/tests/manage/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/test_pvc_concurrent_deletion_creation.py
@@ -124,11 +124,10 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
 
         log.info(f'Created {self.number_of_pvc} new PVCs.')
         global pvc_objs_new
-        pvc_objs_new = [0] * self.number_of_pvc
         pvc_objs_new = pvc_objs[:]
 
         # Verify PVCs are Bound
-        for pvc in self.pvc_objs_new:
+        for pvc in pvc_objs_new:
             pvc.reload()
             assert pvc.status == constants.STATUS_BOUND, (
                 f'PVC {pvc.name} is not Bound'


### PR DESCRIPTION
Fixing the import error delete_all_pvc function
```
tests/manage/test_pvc_concurrent_deletion_creation.py:11: in <module>
    from ocs_ci.ocs.resources.pvc import create_multiple_pvc, delete_all_pvcs
E   ImportError: cannot import name 'delete_all_pvcs'
```