### PR TITLE
handle missing description for html reporting

### DIFF
--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -18,7 +18,10 @@ def pytest_html_results_table_row(report, cells):
     """
     Add content to the column Description
     """
-    cells.insert(2, html.td(report.description))
+    try:
+        cells.insert(2, html.td(report.description))
+    except AttributeError:
+        cells.insert(2, html.td('--- no description ---'))
 
 
 @pytest.mark.hookwrapper


### PR DESCRIPTION
- `report.description` is not properly configured, when the test
  execution fails. In such case, we should print the original error, not
  traceback related to missing description.
- fixes https://github.com/red-hat-storage/ocs-ci/issues/406