### PR TITLE
pass --logger-logsdir parameter to pytest

### DIFF
--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -46,15 +46,14 @@ def init_ocsci_conf(arguments=None):
         with open(os.path.expanduser(cluster_config)) as file_stream:
             cluster_config_data = yaml.safe_load(file_stream)
             framework.config.update(cluster_config_data)
+    framework.config.RUN['run_id'] = int(time.time())
 
 
 def main(arguments):
     init_ocsci_conf(arguments)
-    run_id = int(time.time())
-    framework.config.RUN['run_id'] = run_id
     pytest_logs_dir = os.path.join(os.path.expanduser(
         framework.config.RUN['log_dir']
-    ), f'pytest-logs-{run_id}')
+    ), f"pytest-logs-{framework.config.RUN['run_id']}")
     utils.create_directory_path(pytest_logs_dir)
     arguments.extend([
         '-p', 'ocs_ci.framework.pytest_customization.ocscilib',

--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pytest
 import yaml
@@ -49,10 +50,17 @@ def init_ocsci_conf(arguments=None):
 
 def main(arguments):
     init_ocsci_conf(arguments)
+    run_id = int(time.time())
+    framework.config.RUN['run_id'] = run_id
+    pytest_logs_dir = os.path.join(os.path.expanduser(
+        framework.config.RUN['log_dir']
+    ), f'pytest-logs-{run_id}')
+    utils.create_directory_path(pytest_logs_dir)
     arguments.extend([
         '-p', 'ocs_ci.framework.pytest_customization.ocscilib',
         '-p', 'ocs_ci.framework.pytest_customization.marks',
         '-p', 'ocs_ci.framework.pytest_customization.reports',
+        '--logger-logsdir', pytest_logs_dir,
     ])
     utils.add_path_to_env_path(os.path.expanduser(
         framework.config.RUN['bin_dir']))

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -638,7 +638,7 @@ def collect_ocs_logs(dir_name):
 
     """
     log_dir_path = os.path.join(
-        ocsci_config.RUN['log_dir'],
+        os.path.expanduser(ocsci_config.RUN['log_dir']),
         f"failed_testcase_ocs_logs_{ocsci_config.RUN['run_id']}"
     )
     create_directory_path(log_dir_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,7 @@ def pytest_logger_config(logger_config):
     logger_config.set_formatter_class(OCSLogFormatter)
 
 
-ep_time = config.RUN['run_id']
-log_dir = f"logs_{ep_time}"
+log_dir = f"logs_{config.RUN['run_id']}"
 log_path = os.path.expanduser(
     os.path.join(config.RUN['log_dir'], log_dir)
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,7 @@ def pytest_logger_config(logger_config):
     logger_config.set_formatter_class(OCSLogFormatter)
 
 
-ep_time = int(time.time())
-config.RUN['run_id'] = ep_time
+ep_time = config.RUN['run_id']
 log_dir = f"logs_{ep_time}"
 log_path = os.path.expanduser(
     os.path.join(config.RUN['log_dir'], log_dir)


### PR DESCRIPTION
- place pytest logs to `RUN[`log_dir`]` to `pytest-logs-{run_id}` subdirectory
- generate `RUN['run_id']` directly in `run-ci` wrapper, so we can use the
  value for the `--logger-logsdir` parameter
- fixes https://github.com/red-hat-storage/ocs-ci/issues/415