### PR TITLE
Testcase: (RBD & Cephfs) Create StorageClass with wrong provisioner

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -43,6 +43,8 @@ PVC = "PersistentVolumeClaim"
 POD = "Pod"
 ROUTE = "Route"
 
+# Provisioners
+AWS_EFS_PROVISIONER = "openshift.org/aws-efs"
 
 # Other
 SECRET = "Secret"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -22,6 +22,8 @@ OCS_MONITORING_NAMESPACE = 'openshift-monitoring'
 KUBECONFIG_LOCATION = 'auth/kubeconfig'  # relative from cluster_dir
 API_VERSION = "v1"
 CEPHFILESYSTEM_NAME = 'ocsci-cephfs'
+RBD_PROVISIONER = 'rbd.csi.ceph.com'
+CEPHFS_PROVISIONER = 'cephfs.csi.ceph.com'
 
 TEMP_YAML = os.path.join(constants.TEMPLATE_DIR, "temp.yaml")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -198,7 +198,8 @@ def create_ceph_block_pool(pool_name=None):
 
 def create_storage_class(
     interface_type, interface_name, secret_name,
-    reclaim_policy=constants.RECLAIM_POLICY_DELETE, sc_name=None
+    reclaim_policy=constants.RECLAIM_POLICY_DELETE, sc_name=None,
+    provisioner=None
 ):
     """
     Create a storage class
@@ -227,6 +228,9 @@ def create_storage_class(
             'csi.storage.k8s.io/node-publish-secret-namespace'
         ] = defaults.ROOK_CLUSTER_NAMESPACE
         interface = constants.RBD_INTERFACE
+        sc_data['provisioner'] = (
+            provisioner if provisioner else defaults.RBD_PROVISIONER
+        )
     elif interface_type == constants.CEPHFILESYSTEM:
         sc_data = templating.load_yaml_to_dict(
             constants.CSI_CEPHFS_STORAGECLASS_YAML
@@ -239,6 +243,9 @@ def create_storage_class(
         ] = defaults.ROOK_CLUSTER_NAMESPACE
         interface = constants.CEPHFS_INTERFACE
         sc_data['parameters']['fsName'] = get_cephfs_name()
+        sc_data['provisioner'] = (
+            provisioner if provisioner else defaults.CEPHFS_PROVISIONER
+        )
     sc_data['parameters']['pool'] = interface_name
 
     sc_data['metadata']['name'] = (

--- a/tests/manage/test_create_storageclass_with_wrong_provisioner.py
+++ b/tests/manage/test_create_storageclass_with_wrong_provisioner.py
@@ -1,0 +1,97 @@
+import pytest
+import logging
+from tests import helpers
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import ManageTest, tier3
+from tests.fixtures import (
+    create_ceph_block_pool,
+    create_rbd_secret, create_cephfs_secret,
+)
+
+log = logging.getLogger(__name__)
+
+
+@tier3
+@pytest.mark.usefixtures(
+    create_rbd_secret.__name__,
+    create_cephfs_secret.__name__,
+    create_ceph_block_pool.__name__,
+)
+class TestCreateStorageClassWithWrongProvisioner(ManageTest):
+    """
+    Create Storage Class with wrong provisioner
+    """
+    @pytest.mark.parametrize(
+        argnames="interface",
+        argvalues=[
+            pytest.param(
+                *["RBD"], marks=pytest.mark.polarion_id("OCS-620")
+            ),
+            pytest.param(
+                *["CEPHFS"], marks=pytest.mark.polarion_id("OCS-621")
+            )
+        ]
+    )
+    def test_create_storage_class_with_wrong_provisioner(self, interface):
+        """
+        Test function which creates Storage Class with
+        wrong provisioner and verifies PVC status
+        """
+        log.info(f"Creating a {interface} storage class")
+        if interface == "RBD":
+            interface_type = constants.CEPHBLOCKPOOL
+            secret = self.rbd_secret_obj.name
+            interface_name = self.cbp_obj.name
+        else:
+            interface_type = constants.CEPHFILESYSTEM
+            secret = self.cephfs_secret_obj.name
+            interface_name = helpers.get_cephfs_data_pool_name()
+        sc_obj = helpers.create_storage_class(
+            interface_type=interface_type,
+            interface_name=interface_name,
+            secret_name=secret,
+            provisioner=constants.AWS_EFS_PROVISIONER
+        )
+        log.info(
+            f"{interface}Storage class: {sc_obj.name} created successfully"
+        )
+
+        # Create PVC
+        pvc_obj = helpers.create_pvc(sc_name=sc_obj.name, wait=False)
+
+        # Check PVC status
+        pvc_output = pvc_obj.get()
+        pvc_status = pvc_output['status']['phase']
+        log.info(
+            f"Status of PVC {pvc_obj.name} after creation: {pvc_status}"
+        )
+        log.info(
+            f"Waiting for status '{constants.STATUS_PENDING}' "
+            f"for 20 seconds (it shouldn't change)"
+        )
+
+        pvc_obj.ocp.wait_for_resource(
+            resource_name=pvc_obj.name,
+            condition=constants.STATUS_PENDING,
+            timeout=20,
+            sleep=5
+        )
+        # Check PVC status again after 20 seconds
+        pvc_output = pvc_obj.get()
+        pvc_status = pvc_output['status']['phase']
+        assert_msg = (
+            f"PVC {pvc_obj.name} is not in {constants.STATUS_PENDING} "
+            f"status"
+        )
+        assert pvc_status == constants.STATUS_PENDING, assert_msg
+        log.info(f"Status of {pvc_obj.name} after 20 seconds: {pvc_status}")
+
+        # Delete PVC
+        log.info(f"Deleting PVC: {pvc_obj.name}")
+        assert pvc_obj.delete()
+        log.info(f"PVC {pvc_obj.name} delete successfully")
+
+        # Delete Storage Class
+        log.info(f"Deleting Storageclass: {sc_obj.name}")
+        assert sc_obj.delete()
+        log.info(f"Storage Class: {sc_obj.name} deleted successfully")


### PR DESCRIPTION
Create StorageClass with wrong provisioner and create PVC using it and verify its status.
This PR covers both RBD and CephFS test cases

Signed-off-by: Prasad Desala <tdesala@redhat.com>