### PR TITLE
Run IO in the test background

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -80,6 +80,13 @@ def pytest_addoption(parser):
         default=False,
         help="Collect OCS logs when test case failed",
     )
+    parser.addoption(
+        '--io_in_bg',
+        dest='io_in_bg',
+        action="store_true",
+        default=False,
+        help="Run IO in the background",
+    )
 
 
 def pytest_configure(config):
@@ -176,6 +183,7 @@ def process_cluster_cli_params(config):
         cluster_name = f"ocs-ci-{getuser()[:8]}"
     ocsci_config.RUN['cli_params']['teardown'] = get_cli_param(config, "teardown", default=False)
     ocsci_config.RUN['cli_params']['deploy'] = get_cli_param(config, "deploy", default=False)
+    ocsci_config.RUN['cli_params']['io_in_bg'] = get_cli_param(config, "io_in_bg", default=False)
     ocsci_config.ENV_DATA['cluster_name'] = cluster_name
     ocsci_config.ENV_DATA['cluster_path'] = cluster_path
     get_cli_param(config, 'collect-logs')

--- a/ocs_ci/framework/testlib.py
+++ b/ocs_ci/framework/testlib.py
@@ -2,7 +2,7 @@ from ocs_ci.framework.pytest_customization.marks import *  # noqa: F403
 
 
 @pytest.mark.usefixtures(  # noqa: F405
-    'environment_checker',
+    'run_io_in_background', 'environment_checker'
 )
 class BaseTest:
     """

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -24,7 +24,6 @@ API_VERSION = "v1"
 CEPHFILESYSTEM_NAME = 'ocsci-cephfs'
 RBD_PROVISIONER = 'rbd.csi.ceph.com'
 CEPHFS_PROVISIONER = 'cephfs.csi.ceph.com'
-DEFAULT_STORAGECLASS_NAME = 'rook-ceph-block'
 
 TEMP_YAML = os.path.join(constants.TEMPLATE_DIR, "temp.yaml")
 

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -24,6 +24,7 @@ API_VERSION = "v1"
 CEPHFILESYSTEM_NAME = 'ocsci-cephfs'
 RBD_PROVISIONER = 'rbd.csi.ceph.com'
 CEPHFS_PROVISIONER = 'cephfs.csi.ceph.com'
+DEFAULT_STORAGECLASS_NAME = 'rook-ceph-block'
 
 TEMP_YAML = os.path.join(constants.TEMPLATE_DIR, "temp.yaml")
 

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -184,6 +184,8 @@ class Pod(OCS):
         Returns:
             str: The mount path of the volume on the pod (e.g. /var/lib/www/html/)
         """
+        # TODO: Allow returning a path of a specified volume of a specified
+        #  container
         return (
             self.pod_data.get(
                 'spec'

--- a/ocs_ci/utility/spreadsheet/spreadsheet_api.py
+++ b/ocs_ci/utility/spreadsheet/spreadsheet_api.py
@@ -26,7 +26,6 @@ class GoogleSpreadSheetAPI(object):
             google_api, scope
         )
         client = gspread.authorize(creds)
-
         self.sheet = client.open(sheet_name).get_worksheet(sheet_index)
 
     def update_sheet(self, row, col, value):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,14 +459,10 @@ def run_io_in_background(request):
 
             if pod_obj:
                 pod_obj.delete()
-                pod_obj.ocp.wait_for_delete(
-                    resource_name=pod_obj.name
-                )
+                pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
             if pvc_obj:
                 pvc_obj.delete()
-                pvc_obj.ocp.wait_for_delete(
-                    resource_name=pvc_obj.name
-                )
+                pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
             if sc_obj:
                 sc_obj.delete()
             if cbp_obj:
@@ -485,12 +481,9 @@ def run_io_in_background(request):
             interface_name=cbp_obj.name,
             secret_name=secret_obj.name
         )
-        pvc_obj = helpers.create_pvc(
-            sc_name=sc_obj.name, size='2Gi',
-        )
+        pvc_obj = helpers.create_pvc(sc_name=sc_obj.name, size='2Gi')
         pod_obj = helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL,
-            pvc_name=pvc_obj.name
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_obj.name
         )
 
         def run_io_in_bg():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -428,6 +428,34 @@ def run_io_in_background(request):
         set_test_status('running')
         request.g_sheet = GoogleSpreadSheetAPI("IO BG results", 0)
 
+        def run_io_in_bg():
+            """
+            Run IO by executing FIO and deleting the file created for FIO on
+            the pod, in a while true loop. Will be running as long as
+            the test is running.
+            """
+            while get_test_status() == 'running':
+                request.pod_obj.run_io('fs', '1G')
+                result = request.pod_obj.get_fio_results()
+
+                now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                reads = result.get('jobs')[0].get('read').get('iops')
+                writes = result.get('jobs')[0].get('write').get('iops')
+                request.g_sheet.insert_row([now, reads, writes])
+
+                request.results.append((reads, writes))
+
+                file_path = os.path.join(
+                    request.pod_obj.get_mount_path(),
+                    request.pod_obj.io_params['filename']
+                )
+                request.pod_obj.exec_cmd_on_pod(f'rm -rf {file_path}')
+            set_test_status('terminated')
+
+        log.info(f"Start running IO in the test background")
+
+        request.thread = threading.Thread(target=run_io_in_bg)
+
         def finalizer():
             """
             Delete the resources created during setup, used for
@@ -487,32 +515,4 @@ def run_io_in_background(request):
             pvc_name=request.pvc_obj.name
         )
 
-        def run_io_in_bg():
-            """
-            Run IO by executing FIO and deleting the file created for FIO on
-            the pod, in a while true loop. Will be running as long as
-            the test is running.
-            """
-            while get_test_status() == 'running':
-                request.pod_obj.run_io('fs', '1G')
-                result = request.pod_obj.get_fio_results()
-
-                now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                reads = result.get('jobs')[0].get('read').get('iops')
-                writes = result.get('jobs')[0].get('write').get('iops')
-                request.g_sheet.insert_row(
-                    [f"{now}", f"Reads: {reads}", f"Writes: {writes}"]
-                )
-
-                request.results.append((reads, writes))
-
-                file_path = os.path.join(
-                    request.pod_obj.get_mount_path(),
-                    request.pod_obj.io_params['filename']
-                )
-                request.pod_obj.exec_cmd_on_pod(f'rm -rf {file_path}')
-            set_test_status('terminated')
-
-        log.info(f"Start running IO in the test background")
-        request.thread = threading.Thread(target=run_io_in_bg)
         request.thread.start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -411,6 +411,8 @@ def run_io_in_background(request):
     """
     if config.RUN['cli_params'].get('io_in_bg'):
         log.info(f"Tests will be running while IO is in the background")
+
+        g_sheet = None
         if config.RUN['google_api_secret']:
             g_sheet = GoogleSpreadSheetAPI("IO BG results", 0)
         else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -131,7 +131,8 @@ def create_pod(
     if node_name:
         pod_data['spec']['nodeName'] = node_name
     else:
-        del pod_data['spec']['nodeName']
+        if 'nodeName' in pod_data.get('spec'):
+            del pod_data['spec']['nodeName']
 
     pod_obj = pod.Pod(**pod_data)
     pod_name = pod_data.get('metadata').get('name')


### PR DESCRIPTION
Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>

- Session scope fixture that is being called before environment_checker fixture. This fixture creates a PVC and a pod and runs FIO on that pod and deletes the file in a while true loop. This is being done as long as the test is running. The IO is being stopped when the test is done
- Added a new cli param: --io_in_bg
