### PR TITLE
Rook mon crashloop and pod disappearance workaround

### DIFF
--- a/conf/ocs_basic_install.yml
+++ b/conf/ocs_basic_install.yml
@@ -7,4 +7,4 @@ ENV_DATA:
   platform: 'aws'
   worker_replicas: 3  # here you can define diff number of workers
   master_replicas: 3
-  rook_image: "rook/ceph:v1.0.4" # you can overwrite default rook image
+  rook_image: "rook/ceph:v1.0.0-256.g01ba50e" # you can overwrite default rook image

--- a/conf/ocs_basic_install.yml
+++ b/conf/ocs_basic_install.yml
@@ -7,4 +7,4 @@ ENV_DATA:
   platform: 'aws'
   worker_replicas: 3  # here you can define diff number of workers
   master_replicas: 3
-  rook_image: "rook/ceph:master" # you can overwrite default rook image
+  rook_image: "rook/ceph:v1.0.4" # you can overwrite default rook image

--- a/conf/ocsci/downstream_config.yaml
+++ b/conf/ocsci/downstream_config.yaml
@@ -2,3 +2,4 @@
 ENV_DATA:
   ceph_image: 'quay.io/rhceph-dev/rhceph-4.0-rhel-8:latest'
   rook_image: 'quay.io/rhceph-dev/rook:latest'
+  cluster_namespace: 'rook-ceph'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -47,4 +47,4 @@ ENV_DATA:
   # cause we don't need to update it each time new 14.x version is released
   # but only once when move to new version like v15.
   ceph_image: 'ceph/daemon-base:latest-nautilus-devel'
-  rook_image: 'rook/ceph:master'
+  rook_image: 'rook/ceph:v1.0.4'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -47,4 +47,4 @@ ENV_DATA:
   # cause we don't need to update it each time new 14.x version is released
   # but only once when move to new version like v15.
   ceph_image: 'ceph/daemon-base:latest-nautilus-devel'
-  rook_image: 'rook/ceph:v1.0.4'
+  rook_image: 'rook/ceph:v1.0.0-256.g01ba50e'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -40,7 +40,7 @@ REPORTING:
 # --cluster-conf file.yaml data you will pass to the pytest.
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
-  cluster_namespace: 'openshift-storage'
+  cluster_namespace: 'rook-ceph'
   platform: 'AWS'
   region: 'us-east-2'
   # Do not change to specific version like v14.2.1-20190430 if not needed

--- a/ocs_ci/framework/tests/test_config.py
+++ b/ocs_ci/framework/tests/test_config.py
@@ -16,7 +16,7 @@ class TestConfig(object):
             assert section == framework.config.get_defaults()[section_name]
 
     def test_defaults_specific(self):
-        assert framework.config.ENV_DATA['rook_image'] == 'rook/ceph:master'
+        assert framework.config.ENV_DATA['rook_image'] == 'rook/ceph:v1.0.4'
         assert framework.config.REPORTING['email']['address'] == 'ocs-ci@redhat.com'
         assert framework.config.RUN['bin_dir'] == './bin'
 

--- a/ocs_ci/framework/tests/test_config.py
+++ b/ocs_ci/framework/tests/test_config.py
@@ -16,7 +16,7 @@ class TestConfig(object):
             assert section == framework.config.get_defaults()[section_name]
 
     def test_defaults_specific(self):
-        assert framework.config.ENV_DATA['rook_image'] == 'rook/ceph:v1.0.4'
+        assert framework.config.ENV_DATA['rook_image'] == 'rook/ceph:v1.0.0-256.g01ba50e'
         assert framework.config.REPORTING['email']['address'] == 'ocs-ci@redhat.com'
         assert framework.config.RUN['bin_dir'] == './bin'
 

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -17,7 +17,7 @@ OPENSHIFT_REST_CLIENT_API_VERSION = 'v1'
 
 INSTALLER_VERSION = '4.1.4'
 CLIENT_VERSION = INSTALLER_VERSION
-ROOK_CLUSTER_NAMESPACE = 'openshift-storage'
+ROOK_CLUSTER_NAMESPACE = 'rook-ceph'
 OCS_MONITORING_NAMESPACE = 'openshift-monitoring'
 KUBECONFIG_LOCATION = 'auth/kubeconfig'  # relative from cluster_dir
 API_VERSION = "v1"

--- a/ocs_ci/templates/ocs-deployment/operator-openshift-with-csi.yaml
+++ b/ocs_ci/templates/ocs-deployment/operator-openshift-with-csi.yaml
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: {{ rook_image | default('rook/ceph:v1.0.4') }}
+        image: {{ rook_image | default('rook/ceph:v1.0.0-256.g01ba50e') }}
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/ocs_ci/templates/ocs-deployment/operator-openshift-with-csi.yaml
+++ b/ocs_ci/templates/ocs-deployment/operator-openshift-with-csi.yaml
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: {{ rook_image | default('rook/ceph:master') }}
+        image: {{ rook_image | default('rook/ceph:v1.0.4') }}
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:master
+        image: rook/ceph:v1.0.4
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.0.4
+        image: rook/ceph:v1.0.0-256.g01ba50e
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Replaced the latest Rook image with a hardcoded 1.0.4 until the image is fixed,
Also hardcoded 'rook-ceph' as the namespace for all of our deployments until we understand why the pods disappear under 'openshift-storage'