### PR TITLE
Deployment logging fix

### DIFF
--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -52,6 +52,7 @@ def init_ocsci_conf(arguments=None):
 def main(arguments):
     init_ocsci_conf(arguments)
     pytest_logs_dir = utils.ocsci_log_path()
+    utils.create_directory_path(framework.config.RUN['log_dir'])
     arguments.extend([
         '-p', 'ocs_ci.framework.pytest_customization.ocscilib',
         '-p', 'ocs_ci.framework.pytest_customization.marks',

--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -51,10 +51,7 @@ def init_ocsci_conf(arguments=None):
 
 def main(arguments):
     init_ocsci_conf(arguments)
-    pytest_logs_dir = os.path.join(os.path.expanduser(
-        framework.config.RUN['log_dir']
-    ), f"pytest-logs-{framework.config.RUN['run_id']}")
-    utils.create_directory_path(pytest_logs_dir)
+    pytest_logs_dir = utils.ocsci_log_path()
     arguments.extend([
         '-p', 'ocs_ci.framework.pytest_customization.ocscilib',
         '-p', 'ocs_ci.framework.pytest_customization.marks',

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -929,6 +929,7 @@ def create_directory_path(path):
     """
     Creates directory if path doesn't exists
     """
+    path = os.path.expanduser(path)
     if not os.path.exists(path):
         os.makedirs(path)
     else:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -933,3 +933,19 @@ def create_directory_path(path):
         os.makedirs(path)
     else:
         log.debug(f"{path} already exists")
+
+
+def ocsci_log_path():
+    """
+    Construct the full path for the log directory.
+
+    Returns:
+        str: full path for ocs-ci log directory
+
+    """
+    return os.path.expanduser(
+        os.path.join(
+            config.RUN['log_dir'],
+            f"ocs-ci-logs-{config.RUN['run_id']}"
+        )
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from ocs_ci.utility.environment_check import (
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
     destroy_cluster, run_cmd, get_openshift_installer, get_openshift_client,
-    is_cluster_running
+    is_cluster_running, ocsci_log_path
 )
 from tests import helpers
 
@@ -46,16 +46,6 @@ def pytest_logger_config(logger_config):
     logger_config.set_log_option_default('')
     logger_config.split_by_outcome()
     logger_config.set_formatter_class(OCSLogFormatter)
-
-
-log_dir = f"logs_{config.RUN['run_id']}"
-log_path = os.path.expanduser(
-    os.path.join(config.RUN['log_dir'], log_dir)
-)
-
-
-def pytest_logger_logdirlink():
-    return log_path
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -80,7 +70,7 @@ def cluster_teardown(log_level="DEBUG"):
 
 @pytest.fixture(scope="session", autouse=True)
 def cluster(request, log_cli_level):
-    log.info(f"All logs located at {log_path}")
+    log.info(f"All logs located at {ocsci_log_path()}")
     log.info("Running OCS basic installation")
     log.info(f"Openshift Installer will use log level: {log_cli_level}")
     cluster_path = config.ENV_DATA['cluster_path']


### PR DESCRIPTION
This PR addresses the issues documented in #436. I still wasn't able to determine with 100% certainty what the cause of the issues was, although I highly suspect it was some combination of setting the log_dir through `--logging-logsdir` as well as defining `pytest_logger_logdirlink` in our `conftest.py` which enables symlinking our logs. 

- Removed sym linking of pytest logs
- Moved log directory path construction to utility method
- Removed explicit call to create the log directory as pytest handles this for us

Fixes: #436 

Signed-off-by: Coady LaCroix <clacroix@redhat.com>