### PR TITLE
Fix Issue #449 - KeyError: 'nodeName' during pod creation

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -128,10 +128,12 @@ def create_pod(
     pod_data['metadata']['namespace'] = namespace
     if pvc_name:
         pod_data['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] = pvc_name
+
     if node_name:
         pod_data['spec']['nodeName'] = node_name
     else:
-        del pod_data['spec']['nodeName']
+        if 'nodeName' in pod_data.get('spec'):
+            del pod_data['spec']['nodeName']
 
     pod_obj = pod.Pod(**pod_data)
     pod_name = pod_data.get('metadata').get('name')


### PR DESCRIPTION
Handle the condition when 'nodeName' parameter is not present in pod YAML template.