### PR TITLE
Improve logging on failures

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -82,7 +82,9 @@ def wait_for_resource_state(resource, state, timeout=60):
             condition=state, resource_name=resource.name, timeout=timeout
         )
     except TimeoutExpiredError:
-        logger.info(f"{resource.kind} {resource.name} failed to reach {state}")
+        logger.error(f"{resource.kind} {resource.name} failed to reach {state}")
+        resource.reload()
+        logging.error(f"\n{resource.describe()}")
         return False
     logger.info(f"{resource.kind} {resource.name} reached state {state}")
     return True


### PR DESCRIPTION
 Saw Rook testing logs and it is very helpful to see
 describe of object when it fails reaching some state

Signed-off-by: ratamir <ratamir@redhat.com>