### PR TITLE
WIP: switch back to openshift-storage namespace

### DIFF
--- a/conf/ocsci/downstream_config.yaml
+++ b/conf/ocsci/downstream_config.yaml
@@ -10,4 +10,4 @@ ENV_DATA:
   # rook_csi_provisioner_image:
   # rook_csi_snapshotter_image:
   # rook_csi_attacher_image:
-  cluster_namespace: 'rook-ceph'
+  cluster_namespace: 'openshift-storage'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -41,7 +41,7 @@ REPORTING:
 # --cluster-conf file.yaml data you will pass to the pytest.
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
-  cluster_namespace: 'rook-ceph'
+  cluster_namespace: 'openshift-storage'
   platform: 'AWS'
   region: 'us-east-2'
   # Do not change to specific version like v14.2.1-20190430 if not needed

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -17,7 +17,7 @@ OPENSHIFT_REST_CLIENT_API_VERSION = 'v1'
 
 INSTALLER_VERSION = '4.1.4'
 CLIENT_VERSION = INSTALLER_VERSION
-ROOK_CLUSTER_NAMESPACE = 'rook-ceph'
+ROOK_CLUSTER_NAMESPACE = 'openshift-storage'
 OCS_MONITORING_NAMESPACE = 'openshift-monitoring'
 KUBECONFIG_LOCATION = 'auth/kubeconfig'  # relative from cluster_dir
 API_VERSION = "v1"

--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-tools
-  namespace: rook-ceph
+  namespace: openshift-storage
   labels:
     app: rook-ceph-tools
 spec:


### PR DESCRIPTION
Resolves one part of qe hack/workaround as tracked in:
https://github.com/red-hat-storage/ocs-ci/issues/438

This is prefixed with WIP because it should not be merged at this point, but only when original product bug (see #438) is fixed. The pull request is here so for others (eg. @fbalak) to be setup monitoring properly, no matter if the product bug is resolved.

I'm using this for my setup (one of the things to do to unblock initial testing), and may rebase it  in the future without prior notice.