### PR TITLE
FIO: ioengine=libaio and direct=1 for async IO while using depth > 1

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -242,6 +242,9 @@ class Pod(OCS):
         if fio_filename:
             self.io_params['filename'] = fio_filename
         self.io_params['iodepth'] = depth
+        if depth > 1:
+            self.io_params['ioengine'] = 'libaio'
+            self.io_params['direct'] = 1
         self.fio_thread = wl.run(**self.io_params)
 
 


### PR DESCRIPTION
Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>

iodepth > 1 requires async ioengines and direct=1

From https://fio.readthedocs.io/en/latest/fio_doc.html:
iodepth=int
Number of I/O units to keep in flight against the file. Note that increasing iodepth beyond 1 will not affect synchronous ioengines (except for small degrees when verify_async is in use). Even async engines may impose OS restrictions causing the desired depth not to be achieved. This may happen on Linux when using libaio and not setting direct=1, since buffered I/O is not async on that OS. Keep an eye on the I/O depth distribution in the fio output to verify that the achieved depth is as expected. Default: 1.