### PR TITLE
WIP: Update deployment to use a 4.2 nightly build

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -56,6 +56,10 @@ and place in the `data` directory at the root level of the project.
 If there is no `data` directory, create one.
 The name of the file should be `pull-secret`.
 
+In addition you will need to add a registry auth to your pull-secret to
+support deploying CI / Nightly builds. Please follow the instructions
+[here](https://mojo.redhat.com/docs/DOC-1204026) to do so.
+
 ## Tests
 
 ### AWS and CentralCI Authentication files

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -67,7 +67,8 @@ class AWSBase(Deployment):
         Args:
             size (int): Size of volume in GB (default: 100)
         """
-        with open(os.path.join(self.cluster_path, "terraform.tfvars")) as f:
+        tfvars_file = "terraform.tfvars.json"
+        with open(os.path.join(self.cluster_path, tfvars_file)) as f:
             tfvars = json.load(f)
 
         cluster_id = tfvars['cluster_id']

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -19,14 +19,14 @@ RUN:
   run_id: null  # this will be redefined in the execution
   kubeconfig_location: 'auth/kubeconfig' # relative from cluster_dir
   cli_params: {}  # this will be filled with CLI parameters data
-  client_version: '4.1.4'
+  client_version: '4.2.0-0.nightly-2019-07-30-073644'
   bin_dir: './bin'
   google_api_secret: '~/.ocs-ci/google_api_secret.json'
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.
 DEPLOYMENT:
-  installer_version: "4.1.4"
+  installer_version: "4.2.0-0.nightly-2019-07-30-073644"
   force_download_installer: True
   force_download_client: True
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -563,7 +563,7 @@ def get_openshift_mirror_url(file_name, version):
     else:
         raise UnsupportedOSType
     url = (
-        f"https://mirror.openshift.com/pub/openshift-v4/clients/ocp/"
+        f"https://openshift-release-artifacts.svc.ci.openshift.org/"
         f"{version}/{file_name}-{os_type}-{version}.tar.gz"
     )
     return url


### PR DESCRIPTION
- Updated the OCP client/installer versions to a 4.2 nightly build
- Added .json extension to the terraform.tfvars file
- Changed location of where we pull deployment artifacts from

Signed-off-by: Coady LaCroix <clacroix@redhat.com>