### PR TITLE
Deployment logger names

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -17,7 +17,7 @@ from ocs_ci.utility.aws import AWS as AWSUtil
 from ocs_ci.utility import utils
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 # As of now only IPI

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.resources.ocs import OCS
 from tests import helpers
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class Deployment(object):

--- a/ocs_ci/deployment/factory.py
+++ b/ocs_ci/deployment/factory.py
@@ -4,7 +4,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import exceptions
 from .aws import AWSIPI
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class DeploymentFactory(object):


### PR DESCRIPTION
Changed name of loggers in deployment module to use __name__ instead of __file__. This keeps the deployment module consistent with other loggers in ocs_ci.

Signed-off-by: Coady LaCroix <clacroix@redhat.com>