### PR TITLE
Monitoring testing

### DIFF
--- a/conf/examples/monitoring.yaml
+++ b/conf/examples/monitoring.yaml
@@ -1,0 +1,6 @@
+---
+ENV_DATA:
+  # for testing of OCS monitoring based on OCP Prometheus
+  # use via `--cluster-conf conf/ocsci/monitoring.yaml`
+  monitoring_enabled: true
+  cluster_namespace: 'openshift-storage'

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -173,19 +173,23 @@ class Deployment(object):
         )
         logger.info(f"Waiting {wait_time} seconds...")
         time.sleep(wait_time)
-        # HACK: skip creation of rook-ceph-mgr service monitor when monitoring
-        # is enabled (if this were not skipped, the step would fail because
-        # rook would create the service monitor at this point already)
-        # HACK: This should be dropped when OCS is managed by OLM
+        # HACK: This should be dropped (including service-monitor.yaml and
+        # prometheus-rules.yaml files) when OCS is managed by OLM
         if config.ENV_DATA.get('monitoring_enabled') not in ("true", "True", True):
+            # HACK: skip creation of rook-ceph-mgr service monitor when monitoring
+            # is enabled (if this were not skipped, the step would fail because
+            # rook would create the service monitor at this point already)
             create_oc_resource(
                 "service-monitor.yaml", self.cluster_path, _templating,
                 config.ENV_DATA
             )
-        create_oc_resource(
-            "prometheus-rules.yaml", self.cluster_path, _templating,
-            config.ENV_DATA
-        )
+            # HACK: skip creation of prometheus-rules, rook-ceph is concerned
+            # with it's setup now, based on clarification from Umanga
+            # Chapagain
+            create_oc_resource(
+                "prometheus-rules.yaml", self.cluster_path, _templating,
+                config.ENV_DATA
+            )
         logger.info(f"Waiting {wait_time} seconds...")
         time.sleep(wait_time)
 

--- a/ocs_ci/templates/monitoring/README.md
+++ b/ocs_ci/templates/monitoring/README.md
@@ -1,0 +1,18 @@
+# OCS Monitoring
+
+This directory contains yaml files necessary to deploy OCS cluster with
+monitoring enabled.
+
+The yaml files come from [Rook project](https://github.com/rook/rook/), and as
+such were originally created by Rook community under Apache 2.0 license.
+
+If you want to have your cluster deployed with monitoring, set
+`monitoring_enabled` to `true`, and use `openshift-storage` as namespace for
+OCS components, as shown in `conf/examples/monitoring.yaml` example config
+file.
+
+Based on:
+
+- [comment #10 of BZ 1731551](https://bugzilla.redhat.com/show_bug.cgi?id=1731551#c10)
+- [comment #18 of BZ 1731551](https://bugzilla.redhat.com/show_bug.cgi?id=1731551#c18)
+- [rook commit 1b6fe840f6ae7](https://github.com/rook/rook/commit/1b6fe840f6ae7372a9675ba727ecc65326708aa8)

--- a/ocs_ci/templates/monitoring/rbac.yaml
+++ b/ocs_ci/templates/monitoring/rbac.yaml
@@ -1,0 +1,72 @@
+---
+# OLM: BEGIN ROLE
+# Aspects for creation of monitoring resources
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# OLM: END ROLE
+---
+# OLM: BEGIN ROLE BINDING
+# Allow creation of monitoring resources
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitor
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph
+# OLM: END ROLE BINDING
+---
+# OLM: BEGIN ROLE
+# Aspects for metrics collection
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: rook-ceph
+rules:
+ - apiGroups:
+   - ""
+   resources:
+    - services
+    - endpoints
+    - pods
+   verbs:
+    - get
+    - list
+    - watch
+# OLM: END ROLE
+---
+# OLM: BEGIN ROLE BINDING
+# Allow collection of metrics
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-metrics
+subjects:
+- kind: ServiceAccount
+  # change to the serviceaccount and namespace to use for monitoring
+  name: prometheus-k8s
+  namespace: rook-ceph
+# OLM: END ROLE BINDING
+---

--- a/ocs_ci/templates/monitoring/rbac.yaml
+++ b/ocs_ci/templates/monitoring/rbac.yaml
@@ -1,11 +1,13 @@
 ---
+# based on https://github.com/rook/rook/commit/1b6fe840f6ae7372a9675ba727ecc65326708aa8
+# changed by ocs-ci project (see git log for details)
 # OLM: BEGIN ROLE
 # Aspects for creation of monitoring resources
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-monitor
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 rules:
 - apiGroups:
   - monitoring.coreos.com
@@ -21,7 +23,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-monitor
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -29,7 +31,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 # OLM: END ROLE BINDING
 ---
 # OLM: BEGIN ROLE
@@ -38,7 +40,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-metrics
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 rules:
  - apiGroups:
    - ""
@@ -58,7 +60,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-metrics
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -67,6 +69,6 @@ subjects:
 - kind: ServiceAccount
   # change to the serviceaccount and namespace to use for monitoring
   name: prometheus-k8s
-  namespace: rook-ceph
+  namespace: {{ cluster_namespace | default('openshift-storage') }}
 # OLM: END ROLE BINDING
 ---


### PR DESCRIPTION
This is a minimal change to allow qe team to enable Prometheus based monitoring, required for OCS Monitoring, Telemeter and Alerting features.

Right now, it works only with upstream rook images, so it still remains disabled by default.

Note that when OCS OLM arrives, this (and most of bundled yaml files from rook) won't be necessary.

Quickstart: use ` --cluster-conf conf/examples/monitoring.yaml` to enable monitoring (checking content of the example config file and README introduced in this commit is suggested though).

Please *don't use squash and merge* github feature when merging this, it would violate DCO and make me revert such commit.