### PR TITLE
Improve wait_for_delete logging

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -335,8 +335,11 @@ class OCP(object):
             try:
                 self.get(resource_name=resource_name)
             except CommandFailed as ex:
-                logging.info(ex)
-                return True
+                if "NotFound" in str(ex):
+                    log.info(f"{self.kind} {resource_name} got deleted successfully")
+                    return True
+                else:
+                    raise ex
 
             if timeout < (time.time() - start_time):
                 raise TimeoutError(f"Timeout when waiting for {resource_name} to delete")


### PR DESCRIPTION
Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>

00:22:36 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /home/ebenahar/ebenahar-ocs-dir2/auth/kubeconfig get StorageClass storageclass-test-rbd-0300210683 -o yaml
00:22:37 - MainThread - ocs_ci.ocs.ocp - INFO - StorageClass storageclass-test-rbd-0300210683 got deleted successfully