### PR TITLE
OCS-580: Respin ceph pod(osd, mon, mgr) and check the interaction with monitoring pods

### DIFF
--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -19,6 +19,7 @@ def create_configmap_cluster_monitoring_pod(sc_name):
     """
     Create a configmap named cluster-monitoring-config
     and configure pvc on monitoring pod
+
     Args:
         sc_name (str): Name of the storage class
 
@@ -58,6 +59,7 @@ def validate_pvc_created_and_bound_on_monitoring_pods():
 def validate_pvc_are_mounted_on_monitoring_pods(pod_list):
     """
     Validate created pvc are mounted on monitoring pods
+
     Args:
         pod_list (list): List of the pods where pvc are mounted
 
@@ -73,7 +75,10 @@ def validate_pvc_are_mounted_on_monitoring_pods(pod_list):
 
 def get_list_pvc_objs_created_on_monitoring_pods():
     """
-    Returns list of pvc objects
+    Returns list of pvc objects created on monitoring pods
+
+    Returns:
+        list: List of pvc objs
 
     """
     pvc_list = get_all_pvcs(namespace=defaults.OCS_MONITORING_NAMESPACE)
@@ -88,9 +93,12 @@ def get_list_pvc_objs_created_on_monitoring_pods():
     return pvc_obj_list
 
 
-def get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric():
+def get_metrics_persistentvolumeclaims_info():
     """
-    Returns the created pvc information
+    Returns the created pvc information on prometheus pod
+
+    Returns:
+        response.content (dict): The pvc metrics collected on prometheus pod
 
     """
     prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
@@ -101,18 +109,21 @@ def get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric():
 
 
 @retry(UnexpectedBehaviour, tries=10, delay=3, backoff=1)
-def collected_metrics_for_created_pvc(pvc_name):
+def check_pvcdata_collected_on_prometheus(pvc_name):
     """
     Checks whether initially pvc related data is collected on pod
 
     Args:
         pvc_name (str): Name of the pvc
 
+    Returns:
+        True on success, raise exception on failures
+
     """
     logger.info(
         f"Verify for created pvc {pvc_name} related data is collected on prometheus pod"
     )
-    pvcs_data = get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric()
+    pvcs_data = get_metrics_persistentvolumeclaims_info()
     list_pvcs_data = pvcs_data.get('data').get('result')
     pvc_list = [pvc for pvc in list_pvcs_data if pvc_name == pvc.get('metric').get('persistentvolumeclaim')]
     if not pvc_list:

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -1,12 +1,16 @@
 import logging
 import yaml
+import json
 
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
-from ocs_ci.ocs import constants
+from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, PVC
 from ocs_ci.ocs.resources.pod import get_pod_obj
 from tests import helpers
+import ocs_ci.utility.prometheus
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +19,9 @@ def create_configmap_cluster_monitoring_pod(sc_name):
     """
     Create a configmap named cluster-monitoring-config
     and configure pvc on monitoring pod
-
     Args:
         sc_name (str): Name of the storage class
+
     """
     logger.info("Creating configmap cluster-monitoring-config")
     config_map = templating.load_yaml_to_dict(
@@ -29,7 +33,7 @@ def create_configmap_cluster_monitoring_pod(sc_name):
     config = yaml.dump(config)
     config_map['data']['config.yaml'] = config
     assert helpers.create_resource(**config_map)
-    ocp = OCP('v1', 'ConfigMap', 'openshift-monitoring')
+    ocp = OCP('v1', 'ConfigMap', defaults.OCS_MONITORING_NAMESPACE)
     assert ocp.get(resource_name='cluster-monitoring-config')
     logger.info("Successfully created configmap cluster-monitoring-config")
 
@@ -38,9 +42,10 @@ def validate_pvc_created_and_bound_on_monitoring_pods():
     """
     Validate pvc's created and bound in state
     on monitoring pods
+
     """
     logger.info("Verify pvc are created")
-    pvc_list = get_all_pvcs(namespace='openshift-monitoring')
+    pvc_list = get_all_pvcs(namespace=defaults.OCS_MONITORING_NAMESPACE)
     logger.info(f"PVC list {pvc_list}")
     # Check all pvc's are in bound state
     for pvc in pvc_list['items']:
@@ -53,45 +58,27 @@ def validate_pvc_created_and_bound_on_monitoring_pods():
 def validate_pvc_are_mounted_on_monitoring_pods(pod_list):
     """
     Validate created pvc are mounted on monitoring pods
-
     Args:
         pod_list (list): List of the pods where pvc are mounted
+
     """
     for pod in pod_list:
         pod_obj = get_pod_obj(
-            name=pod, namespace='openshift-monitoring'
+            name=pod.name, namespace=defaults.OCS_MONITORING_NAMESPACE
         )
         mount_point = pod_obj.exec_cmd_on_pod(command="df -kh")
-        assert "/dev/rbd" in mount_point, f"pvc is not mounted on pod {pod}"
+        assert "/dev/rbd" in mount_point, f"pvc is not mounted on pod {pod.name}"
     logger.info("Verified all pvc are mounted on monitoring pods")
-
-
-def validate_monitoring_pods_are_respinned_and_running_state(pods_list):
-    """
-    Validate monitoring pods are respinned and running state
-
-    Args:
-        pod_list (list): List of the pods where pvc are mounted
-    """
-    ocp = OCP(api_version='v1', kind='Pod', namespace='openshift-monitoring')
-    assert ocp.wait_for_resource(
-        condition=constants.STATUS_PENDING, resource_name=pods_list[0]
-    ), f"failed to reach pod {pods_list[0]} "
-    f"desired status {constants.STATUS_PENDING}"
-    for pod in pods_list:
-        assert ocp.wait_for_resource(
-            condition=constants.STATUS_RUNNING, resource_name=pod
-        ), f"failed to reach pod {pod} "
-        f"desired status {constants.STATUS_RUNNING}"
 
 
 def get_list_pvc_objs_created_on_monitoring_pods():
     """
     Returns list of pvc objects
+
     """
-    pvc_list = get_all_pvcs(namespace='openshift-monitoring')
+    pvc_list = get_all_pvcs(namespace=defaults.OCS_MONITORING_NAMESPACE)
     ocp_pvc_obj = OCP(
-        kind=constants.PVC, namespace='openshift-monitoring'
+        kind=constants.PVC, namespace=defaults.OCS_MONITORING_NAMESPACE
     )
     pvc_obj_list = []
     for pvc in pvc_list['items']:
@@ -99,3 +86,38 @@ def get_list_pvc_objs_created_on_monitoring_pods():
         pvc_obj = PVC(**pvc_dict)
         pvc_obj_list.append(pvc_obj)
     return pvc_obj_list
+
+
+def get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric():
+    """
+    Returns the created pvc information
+
+    """
+    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+    response = prometheus.get(
+        'query?query=kube_pod_spec_volumes_persistentvolumeclaims_info'
+    )
+    return json.loads(response.content.decode('utf-8'))
+
+
+@retry(UnexpectedBehaviour, tries=10, delay=3, backoff=1)
+def collected_metrics_for_created_pvc(pvc_name):
+    """
+    Checks whether initially pvc related data is collected on pod
+
+    Args:
+        pvc_name (str): Name of the pvc
+
+    """
+    logger.info(
+        f"Verify for created pvc {pvc_name} related data is collected on prometheus pod"
+    )
+    pvcs_data = get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric()
+    list_pvcs_data = pvcs_data['data']['result']
+    pvc_list = [pvc for pvc in list_pvcs_data if pvc_name == pvc['metric']['persistentvolumeclaim']]
+    if not pvc_list:
+        raise UnexpectedBehaviour(
+            f"On prometheus pod for created pvc {pvc_name} related data is not found"
+        )
+    logger.info(f"Created pvc {pvc_name} data {pvc_list} is collected on prometheus pod")
+    return True

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -117,7 +117,7 @@ def check_pvcdata_collected_on_prometheus(pvc_name):
         pvc_name (str): Name of the pvc
 
     Returns:
-        True on success, raise exception on failures
+        True on success, raises UnexpectedBehaviour on failures
 
     """
     logger.info(

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -113,8 +113,8 @@ def collected_metrics_for_created_pvc(pvc_name):
         f"Verify for created pvc {pvc_name} related data is collected on prometheus pod"
     )
     pvcs_data = get_kube_pod_spec_volumes_persistentvolumeclaims_info_metric()
-    list_pvcs_data = pvcs_data['data']['result']
-    pvc_list = [pvc for pvc in list_pvcs_data if pvc_name == pvc['metric']['persistentvolumeclaim']]
+    list_pvcs_data = pvcs_data.get('data').get('result')
+    pvc_list = [pvc for pvc in list_pvcs_data if pvc_name == pvc.get('metric').get('persistentvolumeclaim')]
     if not pvc_list:
         raise UnexpectedBehaviour(
             f"On prometheus pod for created pvc {pvc_name} related data is not found"

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -729,3 +729,19 @@ def get_pod_node(pod_obj):
     """
     node_name = pod_obj.get().get('spec').get('nodeName')
     return node.get_node_objs(node_names=node_name)[0]
+
+
+def delete_pods(pod_objs):
+    """
+    Deletes list of the pod objects
+
+    Args:
+        pod_objs (list): List of the pod objects to be deleted
+
+    Returns:
+        bool: True if deletion is successful
+
+    """
+    for pod in pod_objs:
+        pod.delete()
+    return True

--- a/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
+++ b/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
@@ -66,10 +66,10 @@ class TestRespinCephPodsAndInteractionWithPrometheus(E2ETest):
     """
 
     @tier4
-    def test_respinning_ceph_pods_and_interaction_with_prometheus_pod(self, test_fixture):
+    def test_monitoring_after_respinning_ceph_pods(self, test_fixture):
         """
         Test case to validate respinning the ceph pods and
-        the interaction with prometheus pod
+        its interaction with prometheus pod
         """
         namespace_list, pvc_objs, pod_objs, sc = test_fixture
 

--- a/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
+++ b/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
@@ -1,0 +1,126 @@
+import logging
+
+import pytest
+
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.framework.testlib import tier4, E2ETest
+from tests.fixtures import (
+    create_rbd_storageclass, create_ceph_block_pool,
+    create_rbd_secret
+)
+from tests.helpers import create_pvc, create_pod, create_unique_resource_name
+from ocs_ci.ocs.monitoring import collected_metrics_for_created_pvc
+from ocs_ci.ocs.resources import pvc, pod
+from tests import disruption_helpers
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def test_fixture(request):
+    """
+    Setup and teardown
+    """
+    self = request.node.cls
+
+    def finalizer():
+        teardown(self)
+    request.addfinalizer(finalizer)
+    setup(self)
+
+
+def setup(self):
+    """
+    Create multiple projects, pvcs and app pods
+    """
+
+    # Initializing
+    self.namespace_list = []
+    self.pvc_objs = []
+    self.pod_objs = []
+
+    assert create_multiple_project_and_pvc_and_check_metrics_are_collected(self)
+
+
+def teardown(self):
+    """
+    Delete app pods and PVCs
+    Delete project
+    """
+    # Delete created app pods and PVCs
+    assert pod.delete_pods(self.pod_objs)
+    assert pvc.delete_pvcs(self.pvc_objs)
+
+    # Switch to default project
+    ret = ocp.switch_to_default_rook_cluster_project()
+    assert ret, 'Failed to switch to default rook cluster project'
+
+    # Delete projects created
+    for prj in self.namespace_list:
+        prj_obj = ocp.OCP(kind='Project', namespace=prj)
+        prj_obj.delete(resource_name=prj)
+
+
+def create_multiple_project_and_pvc_and_check_metrics_are_collected(self):
+    """
+    Creates projects, pvcs and app pods
+    """
+    for i in range(5):
+        # Create new project
+        self.namespace = create_unique_resource_name('test', 'namespace')
+        self.project_obj = ocp.OCP(kind='Project', namespace=self.namespace)
+        assert self.project_obj.new_project(self.namespace), (
+            f'Failed to create new project {self.namespace}'
+        )
+        # Create PVCs
+        self.pvc_obj = create_pvc(
+            sc_name=self.sc_obj.name, namespace=self.namespace
+        )
+
+        # Create pod
+        self.pod_obj = create_pod(
+            interface_type=constants.CEPHBLOCKPOOL,
+            pvc_name=self.pvc_obj.name, namespace=self.namespace
+        )
+
+        self.namespace_list.append(self.namespace)
+        self.pvc_objs.append(self.pvc_obj)
+        self.pod_objs.append(self.pod_obj)
+
+    # Check for the created pvc metrics is collected
+    for pvc_obj in self.pvc_objs:
+        assert collected_metrics_for_created_pvc(pvc_obj.name), (
+            f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
+        )
+    return True
+
+
+@pytest.mark.usefixtures(
+    create_rbd_secret.__name__,
+    create_ceph_block_pool.__name__,
+    create_rbd_storageclass.__name__,
+    test_fixture.__name__
+)
+@pytest.mark.polarion_id("OCS-580")
+class TestRespinCephPodsAndInteractionWithPrometheus(E2ETest):
+    """
+    Respinning the ceph pods (i.e mon, osd, mgr) shouldn't have functional
+    impact to prometheus pods, all data/metrics should be collected correctly.
+    """
+
+    @tier4
+    def test_respinning_ceph_pods_and_interaction_with_prometheus_pod(self):
+        """
+        Test case to validate respinning the ceph pods and
+        the interaction with prometheus pod
+        """
+
+        # Re-spin the ceph pods(i.e mgr, mon, osd, mds) one by one
+        resource_to_delete = ['mgr', 'mon', 'osd']
+        disruption = disruption_helpers.Disruptions()
+        for res_to_del in resource_to_delete:
+            disruption.set_resource(resource=res_to_del)
+            disruption.delete_resource()
+
+        # Check for the created pvc metrics after respinning ceph pods
+        assert create_multiple_project_and_pvc_and_check_metrics_are_collected(self)

--- a/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
+++ b/tests/e2e/monitoring/test_when_respin_ceph_pods_interaction_with_prometheus.py
@@ -42,12 +42,18 @@ def test_fixture(request, storageclass_factory):
     pvc_objs = [helpers.create_pvc(
         sc_name=sc.name, namespace=each_namespace.namespace
     ) for each_namespace in namespace_list]
+    for pvc_obj in pvc_objs:
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
 
     # Create app pods
     pod_objs = [helpers.create_pod(
         interface_type=constants.CEPHBLOCKPOOL,
         pvc_name=each_pvc.name, namespace=each_pvc.namespace
     ) for each_pvc in pvc_objs]
+    for pod_obj in pod_objs:
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+        pod_obj.reload()
 
     # Check for the created pvc metrics on prometheus pod
     for pvc_obj in pvc_objs:
@@ -94,13 +100,20 @@ class TestRespinCephPodsAndInteractionWithPrometheus(E2ETest):
         pvcs = [helpers.create_pvc(
             sc_name=sc.name, namespace=each_namespace.namespace
         ) for each_namespace in namespaces]
+        for pvc_obj in pvcs:
+            helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+            pvc_obj.reload()
         pvc_objs.extend(pvcs)
 
         # Create app pods after the respinning ceph pods
-        pod_objs.extend(helpers.create_pod(
+        pods = [helpers.create_pod(
             interface_type=constants.CEPHBLOCKPOOL,
             pvc_name=each_pvc.name, namespace=each_pvc.namespace
-        ) for each_pvc in pvcs)
+        ) for each_pvc in pvcs]
+        for pod_obj in pods:
+            helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+            pod_obj.reload()
+        pod_objs.extend(pods)
 
         # Check for the created pvc metrics on prometheus pod
         for pvc_obj in pvcs:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -150,6 +150,21 @@ def create_project():
     return project_obj
 
 
+def create_multilpe_projects(number_of_project):
+    """
+    Create one or more projects
+
+    Args:
+        number_of_project (int): Number of projects to be created
+
+    Returns:
+         list: List of project objects
+
+    """
+    project_objs = [create_project() for _ in range(number_of_project)]
+    return project_objs
+
+
 def create_secret(interface_type):
     """
     Create a secret
@@ -258,6 +273,7 @@ def create_storage_class(
     Returns:
         OCS: An OCS instance for the storage class
     """
+
     sc_data = dict()
     if interface_type == constants.CEPHBLOCKPOOL:
         sc_data = templating.load_yaml_to_dict(


### PR DESCRIPTION
A testcase to validate respinning ceph pods(osd, mon, mgr) shouldn't have functional impact to prometheus pods, all data/metrics should be collected correctly.

Signed-off-by: Akarsha <akrai@redhat.com>