### PR TITLE
set default value of force_download_client to False

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -27,7 +27,7 @@ RUN:
 # the environment related data as those are defined in ENV_DATA section.
 DEPLOYMENT:
   installer_version: "4.2.0-0.nightly-2019-07-30-073644"
-  force_download_installer: True
+  force_download_installer: False
   force_download_client: False
 
 # Section for reporting configuration

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -28,7 +28,7 @@ RUN:
 DEPLOYMENT:
   installer_version: "4.2.0-0.nightly-2019-07-30-073644"
   force_download_installer: True
-  force_download_client: True
+  force_download_client: False
 
 # Section for reporting configuration
 REPORTING:


### PR DESCRIPTION
set default value of force_download_client to False to revert back to old
behavior i,e not download oc client during tier runs with existing cluster.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/509

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>