### PR TITLE
OCS-576: Prometheus pod restart should not have any functional impact

### DIFF
--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -19,10 +19,8 @@ def create_configmap_cluster_monitoring_pod(sc_name):
     """
     Create a configmap named cluster-monitoring-config
     and configure pvc on monitoring pod
-
     Args:
         sc_name (str): Name of the storage class
-
     """
     logger.info("Creating configmap cluster-monitoring-config")
     config_map = templating.load_yaml(
@@ -43,7 +41,6 @@ def validate_pvc_created_and_bound_on_monitoring_pods():
     """
     Validate pvc's created and bound in state
     on monitoring pods
-
     """
     logger.info("Verify pvc are created")
     pvc_list = get_all_pvcs(namespace=defaults.OCS_MONITORING_NAMESPACE)
@@ -60,10 +57,8 @@ def validate_pvc_created_and_bound_on_monitoring_pods():
 def validate_pvc_are_mounted_on_monitoring_pods(pod_list):
     """
     Validate created pvc are mounted on monitoring pods
-
     Args:
         pod_list (list): List of the pods where pvc are mounted
-
     """
     for pod in pod_list:
         pod_obj = get_pod_obj(
@@ -77,10 +72,8 @@ def validate_pvc_are_mounted_on_monitoring_pods(pod_list):
 def get_list_pvc_objs_created_on_monitoring_pods():
     """
     Returns list of pvc objects created on monitoring pods
-
     Returns:
         list: List of pvc objs
-
     """
     pvc_list = get_all_pvcs(namespace=defaults.OCS_MONITORING_NAMESPACE)
     ocp_pvc_obj = OCP(
@@ -97,10 +90,8 @@ def get_list_pvc_objs_created_on_monitoring_pods():
 def get_metrics_persistentvolumeclaims_info():
     """
     Returns the created pvc information on prometheus pod
-
     Returns:
         response.content (dict): The pvc metrics collected on prometheus pod
-
     """
     prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
     response = prometheus.get(
@@ -113,13 +104,10 @@ def get_metrics_persistentvolumeclaims_info():
 def check_pvcdata_collected_on_prometheus(pvc_name):
     """
     Checks whether initially pvc related data is collected on pod
-
     Args:
         pvc_name (str): Name of the pvc
-
     Returns:
         True on success, raises UnexpectedBehaviour on failures
-
     """
     logger.info(
         f"Verify for created pvc {pvc_name} related data is collected on prometheus pod"
@@ -138,13 +126,10 @@ def check_pvcdata_collected_on_prometheus(pvc_name):
 def check_ceph_health_status_metrics_on_prometheus(mgr_pod):
     """
     Check ceph health status metric is collected on prometheus pod
-
     Args:
         mgr_pod (str): Name of the mgr pod
-
     Returns:
         bool: True on success, false otherwise
-
     """
     prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
     response = prometheus.get(

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -739,6 +739,7 @@ def get_pod_obj(name, namespace=None):
 
     Returns:
         obj : A pod object
+
     """
     ocp_obj = OCP(api_version='v1', kind=constants.POD, namespace=namespace)
     ocp_dict = ocp_obj.get(resource_name=name)
@@ -791,6 +792,7 @@ def delete_pods(pod_objs):
         bool: True if deletion is successful
 
     """
+
     for pod in pod_objs:
         pod.delete()
 

--- a/tests/e2e/monitoring/test_prometheus_pod_restart.py
+++ b/tests/e2e/monitoring/test_prometheus_pod_restart.py
@@ -1,69 +1,34 @@
 import logging
-
 import pytest
 
 from ocs_ci.ocs import constants, ocp, defaults
 from ocs_ci.framework.testlib import tier4, E2ETest
-from tests import helpers
 from ocs_ci.ocs.monitoring import (
     check_pvcdata_collected_on_prometheus,)
-from ocs_ci.ocs.resources import pvc, pod
+from ocs_ci.ocs.resources import pod
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
-def test_fixture(request, storageclass_factory):
+def create_pods(pod_factory, num_of_pod=3):
     """
-    Setup and teardown
+    Create resources for the test
     """
-
-    def teardown():
-
-        # Delete created app pods and pvcs
-        assert pod.delete_pods(pod_objs)
-        assert pvc.delete_pvcs(pvc_objs)
-
-        # Switch to default project
-        ret = ocp.switch_to_default_rook_cluster_project()
-        assert ret, 'Failed to switch to default rook cluster project'
-
-        # Delete created projects
-        for prj in namespace_list:
-            prj.delete(resource_name=prj.namespace)
-
-    request.addfinalizer(teardown)
-
-    # Create a storage class
-    sc = storageclass_factory()
-
-    # Create projects
-    namespace_list = helpers.create_multilpe_projects(number_of_project=2)
-
-    # Create pvcs
-    pvc_objs = [helpers.create_pvc(
-        sc_name=sc.name, namespace=each_namespace.namespace
-    ) for each_namespace in namespace_list]
-    for pvc_obj in pvc_objs:
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
-        pvc_obj.reload()
-
-    # Create app pods
-    pod_objs = [helpers.create_pod(
-        interface_type=constants.CEPHBLOCKPOOL,
-        pvc_name=each_pvc.name, namespace=each_pvc.namespace
-    ) for each_pvc in pvc_objs]
-    for pod_obj in pod_objs:
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
-        pod_obj.reload()
+    pod_objs = [
+        pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            status=constants.STATUS_RUNNING
+        ) for _ in range(num_of_pod)
+    ]
 
     # Check for the created pvc metrics on prometheus pod
-    for pvc_obj in pvc_objs:
-        assert check_pvcdata_collected_on_prometheus(pvc_obj.name), (
-            f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
+    for pod_obj in pod_objs:
+        assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+            f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
         )
 
-    return namespace_list, pvc_objs, pod_objs, sc
+    return pod_objs
 
 
 @pytest.mark.polarion_id("OCS-576")
@@ -74,25 +39,25 @@ class TestPrometheusPodRestart(E2ETest):
     """
 
     @tier4
-    def test_monitoring_after_restarting_prometheus_pod(self, test_fixture):
+    def test_monitoring_after_restarting_prometheus_pod(self, create_pods):
         """
         Test case to validate prometheus pod restart
         should not have any functional impact
         """
-        namespace_list, pvc_objs, pod_objs, sc = test_fixture
+        pod_objs = create_pods
 
         # Get the prometheus pod
-        pod_obj = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
+        prometheus_pod_obj = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
 
-        for pod_object in pod_obj:
+        for pod_object in prometheus_pod_obj:
             # Get the pvc which mounted on prometheus pod
             pod_info = pod_object.get()
             pvc_name = pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
 
             # Restart the prometheus pod
             pod_object.delete(force=True)
-            POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
-            assert POD.wait_for_resource(
+            pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
+            assert pod_obj.wait_for_resource(
                 condition='Running', selector=f'app=prometheus', timeout=60
             )
 
@@ -102,8 +67,7 @@ class TestPrometheusPodRestart(E2ETest):
                 f"Old pvc not found after restarting the prometheus pod {pod_object.name}"
             )
 
-        # Check for the created pvc metrics are present after restarting prometheus pod
-        for pvc_obj in pvc_objs:
-            assert check_pvcdata_collected_on_prometheus(pvc_obj.name), (
-                f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
+        for pod_obj in pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
             )

--- a/tests/e2e/monitoring/test_prometheus_pod_restart.py
+++ b/tests/e2e/monitoring/test_prometheus_pod_restart.py
@@ -4,149 +4,106 @@ import pytest
 
 from ocs_ci.ocs import constants, ocp, defaults
 from ocs_ci.framework.testlib import tier4, E2ETest
-from tests.fixtures import (
-    create_rbd_storageclass, create_ceph_block_pool,
-    create_rbd_secret
-)
-from tests.helpers import create_pvc, create_pod, create_unique_resource_name
+from tests import helpers
 from ocs_ci.ocs.monitoring import (
-    collected_metrics_for_created_pvc,
-    check_used_size_of_prometheus_pod
-)
+    check_pvcdata_collected_on_prometheus,)
 from ocs_ci.ocs.resources import pvc, pod
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
-def test_fixture(request):
+def test_fixture(request, storageclass_factory):
     """
     Setup and teardown
-
-    """
-    self = request.node.cls
-
-    def finalizer():
-        teardown(self)
-    request.addfinalizer(finalizer)
-    setup(self)
-
-
-def setup(self):
-    """
-    Create projects, pvcs and app pods
-
     """
 
-    # Initializing
-    self.namespace_list = []
-    self.pvc_objs = []
-    self.pod_objs = []
+    def teardown():
 
-    assert create_project_and_pvc_and_check_metrics_are_collected(self)
+        # Delete created app pods and pvcs
+        assert pod.delete_pods(pod_objs)
+        assert pvc.delete_pvcs(pvc_objs)
 
+        # Switch to default project
+        ret = ocp.switch_to_default_rook_cluster_project()
+        assert ret, 'Failed to switch to default rook cluster project'
 
-def teardown(self):
-    """
-    Delete app pods and PVCs
-    Delete project
+        # Delete created projects
+        for prj in namespace_list:
+            prj.delete(resource_name=prj.namespace)
 
-    """
-    # Delete created app pods and PVCs
-    assert pod.delete_pods(self.pod_objs)
-    assert pvc.delete_pvcs(self.pvc_objs)
+    request.addfinalizer(teardown)
 
-    # Switch to default project
-    ret = ocp.switch_to_default_rook_cluster_project()
-    assert ret, 'Failed to switch to default rook cluster project'
+    # Create a storage class
+    sc = storageclass_factory()
 
-    # Delete projects created
-    for prj in self.namespace_list:
-        prj_obj = ocp.OCP(kind='Project', namespace=prj)
-        prj_obj.delete(resource_name=prj)
+    # Create projects
+    namespace_list = helpers.create_multilpe_projects(number_of_project=2)
 
+    # Create pvcs
+    pvc_objs = [helpers.create_pvc(
+        sc_name=sc.name, namespace=each_namespace.namespace
+    ) for each_namespace in namespace_list]
+    for pvc_obj in pvc_objs:
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
 
-def create_project_and_pvc_and_check_metrics_are_collected(self):
-    """
-    Creates projects, pvcs and app pods
-
-    """
-
-    # Create new project
-    self.namespace = create_unique_resource_name('test', 'namespace')
-    self.project_obj = ocp.OCP(kind='Project', namespace=self.namespace)
-    assert self.project_obj.new_project(self.namespace), (
-        f'Failed to create new project {self.namespace}'
-    )
-
-    # Create PVCs
-    self.pvc_obj = create_pvc(
-        sc_name=self.sc_obj.name, namespace=self.namespace
-    )
-
-    # Create pod
-    self.pod_obj = create_pod(
+    # Create app pods
+    pod_objs = [helpers.create_pod(
         interface_type=constants.CEPHBLOCKPOOL,
-        pvc_name=self.pvc_obj.name, namespace=self.namespace
-    )
+        pvc_name=each_pvc.name, namespace=each_pvc.namespace
+    ) for each_pvc in pvc_objs]
+    for pod_obj in pod_objs:
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+        pod_obj.reload()
 
-    self.namespace_list.append(self.namespace)
-    self.pvc_objs.append(self.pvc_obj)
-    self.pod_objs.append(self.pod_obj)
-
-    # Check for the created pvc metrics is collected
-    for pvc_obj in self.pvc_objs:
-        assert collected_metrics_for_created_pvc(pvc_obj.name), (
+    # Check for the created pvc metrics on prometheus pod
+    for pvc_obj in pvc_objs:
+        assert check_pvcdata_collected_on_prometheus(pvc_obj.name), (
             f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
         )
-    return True
+
+    return namespace_list, pvc_objs, pod_objs, sc
 
 
-@pytest.mark.usefixtures(
-    create_rbd_secret.__name__,
-    create_ceph_block_pool.__name__,
-    create_rbd_storageclass.__name__,
-    test_fixture.__name__
-)
 @pytest.mark.polarion_id("OCS-576")
-class TestRespinPrometheusPod(E2ETest):
+class TestPrometheusPodRestart(E2ETest):
     """
     Prometheus pod restart should not have any functional impact,
     i.e the data/metrics shouldn't be lost after the restart of prometheus pod.
     """
 
     @tier4
-    def test_respinning_ceph_pods_and_interaction_with_prometheus_pod(self):
+    def test_monitoring_after_restarting_prometheus_pod(self, test_fixture):
         """
         Test case to validate prometheus pod restart
         should not have any functional impact
         """
+        namespace_list, pvc_objs, pod_objs, sc = test_fixture
 
         # Get the prometheus pod
         pod_obj = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
 
-        # Get the pvc which mounted on prometheus[0] pod
-        pod_info = pod_obj[0].get()
-        pvc_name = pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
+        for pod_object in pod_obj:
+            # Get the pvc which mounted on prometheus pod
+            pod_info = pod_object.get()
+            pvc_name = pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
 
-        # Check the used space of prometheus[0] pod
-        initial_used_size = check_used_size_of_prometheus_pod(pod_obj[0])
+            # Restart the prometheus pod
+            pod_object.delete(force=True)
+            POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
+            assert POD.wait_for_resource(
+                condition='Running', selector=f'app=prometheus', timeout=60
+            )
 
-        # Respin one of the prometheus pod
-        pod_obj[0].delete(force=True)
-        POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
-        assert POD.wait_for_resource(
-            condition='Running', selector=f'app=prometheus', timeout=300
-        )
+            # Check the same pvc is mounted on new pod
+            pod_info = pod_object.get()
+            assert pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] in pvc_name, (
+                f"Old pvc not found after restarting the prometheus pod {pod_object.name}"
+            )
 
-        # Check the same pvc is mounted on new pod
-        pod_info = pod_obj[0].get()
-        assert pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] in pvc_name
-
-        # Check the used space of prometheus[0] pod should be equal or increased after respinning pod
-        # i.e, the data/metrics should not be deleted which was collected before
-        used_size_after_respin = check_used_size_of_prometheus_pod(pod_obj[0])
-        assert used_size_after_respin >= initial_used_size
-
-        # Check for the created pvc metrics after respinning ceph pods
-        assert create_project_and_pvc_and_check_metrics_are_collected(self)
+        # Check for the created pvc metrics are present after restarting prometheus pod
+        for pvc_obj in pvc_objs:
+            assert check_pvcdata_collected_on_prometheus(pvc_obj.name), (
+                f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
+            )

--- a/tests/e2e/monitoring/test_prometheus_pod_restart.py
+++ b/tests/e2e/monitoring/test_prometheus_pod_restart.py
@@ -1,0 +1,152 @@
+import logging
+
+import pytest
+
+from ocs_ci.ocs import constants, ocp, defaults
+from ocs_ci.framework.testlib import tier4, E2ETest
+from tests.fixtures import (
+    create_rbd_storageclass, create_ceph_block_pool,
+    create_rbd_secret
+)
+from tests.helpers import create_pvc, create_pod, create_unique_resource_name
+from ocs_ci.ocs.monitoring import (
+    collected_metrics_for_created_pvc,
+    check_used_size_of_prometheus_pod
+)
+from ocs_ci.ocs.resources import pvc, pod
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def test_fixture(request):
+    """
+    Setup and teardown
+
+    """
+    self = request.node.cls
+
+    def finalizer():
+        teardown(self)
+    request.addfinalizer(finalizer)
+    setup(self)
+
+
+def setup(self):
+    """
+    Create projects, pvcs and app pods
+
+    """
+
+    # Initializing
+    self.namespace_list = []
+    self.pvc_objs = []
+    self.pod_objs = []
+
+    assert create_project_and_pvc_and_check_metrics_are_collected(self)
+
+
+def teardown(self):
+    """
+    Delete app pods and PVCs
+    Delete project
+
+    """
+    # Delete created app pods and PVCs
+    assert pod.delete_pods(self.pod_objs)
+    assert pvc.delete_pvcs(self.pvc_objs)
+
+    # Switch to default project
+    ret = ocp.switch_to_default_rook_cluster_project()
+    assert ret, 'Failed to switch to default rook cluster project'
+
+    # Delete projects created
+    for prj in self.namespace_list:
+        prj_obj = ocp.OCP(kind='Project', namespace=prj)
+        prj_obj.delete(resource_name=prj)
+
+
+def create_project_and_pvc_and_check_metrics_are_collected(self):
+    """
+    Creates projects, pvcs and app pods
+
+    """
+
+    # Create new project
+    self.namespace = create_unique_resource_name('test', 'namespace')
+    self.project_obj = ocp.OCP(kind='Project', namespace=self.namespace)
+    assert self.project_obj.new_project(self.namespace), (
+        f'Failed to create new project {self.namespace}'
+    )
+
+    # Create PVCs
+    self.pvc_obj = create_pvc(
+        sc_name=self.sc_obj.name, namespace=self.namespace
+    )
+
+    # Create pod
+    self.pod_obj = create_pod(
+        interface_type=constants.CEPHBLOCKPOOL,
+        pvc_name=self.pvc_obj.name, namespace=self.namespace
+    )
+
+    self.namespace_list.append(self.namespace)
+    self.pvc_objs.append(self.pvc_obj)
+    self.pod_objs.append(self.pod_obj)
+
+    # Check for the created pvc metrics is collected
+    for pvc_obj in self.pvc_objs:
+        assert collected_metrics_for_created_pvc(pvc_obj.name), (
+            f"On prometheus pod for created pvc {pvc_obj.name} related data is not collected"
+        )
+    return True
+
+
+@pytest.mark.usefixtures(
+    create_rbd_secret.__name__,
+    create_ceph_block_pool.__name__,
+    create_rbd_storageclass.__name__,
+    test_fixture.__name__
+)
+@pytest.mark.polarion_id("OCS-576")
+class TestRespinPrometheusPod(E2ETest):
+    """
+    Prometheus pod restart should not have any functional impact,
+    i.e the data/metrics shouldn't be lost after the restart of prometheus pod.
+    """
+
+    @tier4
+    def test_respinning_ceph_pods_and_interaction_with_prometheus_pod(self):
+        """
+        Test case to validate prometheus pod restart
+        should not have any functional impact
+        """
+
+        # Get the prometheus pod
+        pod_obj = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
+
+        # Get the pvc which mounted on prometheus[0] pod
+        pod_info = pod_obj[0].get()
+        pvc_name = pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
+
+        # Check the used space of prometheus[0] pod
+        initial_used_size = check_used_size_of_prometheus_pod(pod_obj[0])
+
+        # Respin one of the prometheus pod
+        pod_obj[0].delete(force=True)
+        POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
+        assert POD.wait_for_resource(
+            condition='Running', selector=f'app=prometheus', timeout=300
+        )
+
+        # Check the same pvc is mounted on new pod
+        pod_info = pod_obj[0].get()
+        assert pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] in pvc_name
+
+        # Check the used space of prometheus[0] pod should be equal or increased after respinning pod
+        # i.e, the data/metrics should not be deleted which was collected before
+        used_size_after_respin = check_used_size_of_prometheus_pod(pod_obj[0])
+        assert used_size_after_respin >= initial_used_size
+
+        # Check for the created pvc metrics after respinning ceph pods
+        assert create_project_and_pvc_and_check_metrics_are_collected(self)


### PR DESCRIPTION
A testcase to validate prometheus pod restart should not have any functional impact, i.e the data/metrics shouldn't be lost after the restart of prometheus pod.

Signed-off-by: Akarsha <akrai@redhat.com>