### PR TITLE
Updating OCS-347 with fixtures, removing global variable and handling the leftover PV

### DIFF
--- a/tests/manage/storageclass/test_rbd_csi_default_sc.py
+++ b/tests/manage/storageclass/test_rbd_csi_default_sc.py
@@ -8,11 +8,46 @@ import pytest
 from ocs_ci.framework.testlib import tier1, ManageTest
 from tests import helpers
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import ResourceLeftoversException
 from tests.fixtures import (
     create_ceph_block_pool, create_rbd_secret,
 )
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def resources(request):
+    """
+       Delete the resources created during the test
+       Returns:
+           tuple: empty lists of resources
+    """
+    pod, pvc, storageclass = ([] for _ in range(3))
+
+    def finalizer():
+        """
+            Delete the resources created during the test
+            """
+        failed_to_delete = []
+        for resource_type in pod, pvc, storageclass:
+            for resource in resource_type:
+                resource.delete()
+                try:
+                    resource.ocp.wait_for_delete(resource.name)
+                except TimeoutError:
+                    failed_to_delete.append(resource)
+                if resource.kind == constants.PVC:
+                    log.info("Checking whether PV is deleted")
+                    assert helpers.validate_pv_delete(resource.backed_pv)
+        if failed_to_delete:
+            raise ResourceLeftoversException(
+                f"Failed to delete resources: {failed_to_delete}"
+            )
+
+    request.addfinalizer(finalizer)
+
+    return pod, pvc, storageclass
 
 
 @tier1
@@ -27,36 +62,30 @@ class TestBasicPVCOperations(ManageTest):
     with rbd pool
     """
 
-    def test_ocs_347(self):
+    def test_ocs_347(self, resources):
+        pod, pvc, storageclass = resources
+
         log.info("Creating RBD StorageClass")
-        sc_obj = helpers.create_storage_class(
-            interface_type=constants.CEPHBLOCKPOOL,
-            interface_name=self.cbp_obj.name,
-            secret_name=self.rbd_secret_obj.name,
+        storageclass.append(
+            helpers.create_storage_class(
+                interface_type=constants.CEPHBLOCKPOOL,
+                interface_name=self.cbp_obj.name,
+                secret_name=self.rbd_secret_obj.name,
+            )
         )
-
         log.info("Creating a PVC")
-        pvc_obj = helpers.create_pvc(
-            sc_name=sc_obj.name, wait=True,
+        pvc.append(
+            helpers.create_pvc(
+                sc_name=storageclass[0].name, wait=True,
+            )
         )
-
         log.info(
-            f"Creating a pod on with pvc {pvc_obj.name}"
+            f"Creating a pod on with pvc {pvc[0].name}"
         )
-        pod_obj = helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_obj.name,
-            desired_status=constants.STATUS_RUNNING, wait=True,
-            pod_dict_path=constants.NGINX_POD_YAML
+        pod.append(
+            helpers.create_pod(
+                interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc[0].name,
+                desired_status=constants.STATUS_RUNNING, wait=True,
+                pod_dict_path=constants.NGINX_POD_YAML
+            )
         )
-
-        log.info("Deleting Pod")
-        pod_obj.delete()
-
-        log.info("Deleting PVC")
-        pvc_obj.delete()
-
-        log.info("Checking whether PV is deleted")
-        assert helpers.validate_pv_delete(pvc_obj.backed_pv)
-
-        log.info(f"Deleting RBD StorageClass {sc_obj.name}")
-        sc_obj.delete()


### PR DESCRIPTION
Improved my initial script by removing global variables, adding fixtures and handling the leftover PV(if any).
