### PR TITLE
Add nodes operations

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -193,9 +193,14 @@ FIO_IO_RW_PARAMS_YAML = os.path.join(
 RBD_INTERFACE = 'rbd'
 CEPHFS_INTERFACE = 'cephfs'
 
-# Instance statuses
+# EC2 instance statuses
 INSTANCE_PENDING = 0
 INSTANCE_STOPPING = 64
 INSTANCE_STOPPED = 80
 INSTANCE_RUNNING = 16
 INSTANCE_SHUTTING_DOWN = 32
+
+# Node statuses
+NODE_READY = 'Ready'
+NODE_NOT_READY = 'NotReady'
+NODE_SCHEDULING_DISABLED = 'SchedulingDisabled'

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1,0 +1,117 @@
+from __future__ import print_function
+
+import logging
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import TimeoutSampler
+
+
+log = logging.getLogger(__name__)
+
+
+def get_node_objs(node_names=None):
+    """
+    Get node objects by node names
+
+    Args:
+        node_names (list): The node names to get their objects for.
+            If None, will return all cluster nodes
+
+    Returns:
+        list: Cluster node OCP objects
+
+    """
+    nodes_obj = OCP(kind='node')
+    node_objs = nodes_obj.get()['items']
+    if not node_names:
+        return node_objs
+    else:
+        return [
+            node_obj for node_obj in node_objs if (
+                node_obj.get('metadata').get('name') in node_names
+            )
+        ]
+
+
+def wait_for_nodes_status(node_names, status=constants.NODE_READY):
+    """
+    Wait until all nodes are in Ready status
+
+    Args:
+        node_names (list): The node names to wait for to reached the desire state
+        status (str): The node status to wait for
+            (e.g. 'Ready', 'NotReady', 'SchedulingDisabled')
+
+    Returns:
+        bool: True if all nodes reached the status, False otherwise
+
+    """
+    try:
+        for sample in TimeoutSampler(120, 3, get_node_objs, node_names):
+            for node in sample:
+                if not node_names:
+                    return True
+                for status_condition in node.get('status').get('conditions'):
+                    if 'True' in status_condition.get('status'):
+                        log.info(
+                            f"The following nodes are still not "
+                            f"in Ready status: {node_names}"
+                        )
+                        if status_condition.get('type') == status:
+                            node_names.remove(node.get('metadata').get('name'))
+    except TimeoutExpiredError:
+        log.error(f"The following nodes haven't reached status Ready: {node_names}")
+        return False
+
+
+def unschedule_nodes(nodes):
+    """
+    Change nodes to be unscheduled
+
+    Args:
+        nodes (list): The OCP objects of the nodes
+
+    """
+    for node in nodes:
+        node.exec_oc_cmd(f"adm cordon {node.get('metadata').get('name')}")
+    wait_for_nodes_status(nodes, status='SchedulingDisabled')
+
+
+def schedule_nodes(nodes):
+    """
+    Change nodes to be scheduled
+
+    Args:
+        nodes (list): The OCP objects of the nodes
+
+    """
+    for node in nodes:
+        node.exec_oc_cmd(f"adm uncordon {node.get('metadata').get('name')}")
+    wait_for_nodes_status(nodes)
+
+
+def drain_nodes(node_names):
+    """
+    Drain nodes
+
+    Args:
+        node_names (list): The names of the nodes
+
+    """
+    ocp = OCP(kind='node')
+    node_names = print(*node_names, sep=' ')
+    ocp.exec_oc_cmd(f"adm drain {node_names}")
+
+
+def maintenance_nodes(nodes):
+    """
+    Move nodes to maintenance
+
+    Args:
+        nodes (list): The OCP objects of the nodes to move to maintenance
+
+    """
+    unschedule_nodes(nodes)
+    node_names = [node.get('metadata').get('name') for node in nodes]
+    drain_nodes(node_names)

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -34,12 +34,13 @@ def get_node_objs(node_names=None):
         ]
 
 
-def wait_for_nodes_status(node_names, status=constants.NODE_READY):
+def wait_for_nodes_status(node_names=None, status=constants.NODE_READY):
     """
     Wait until all nodes are in Ready status
 
     Args:
-        node_names (list): The node names to wait for to reached the desire state
+        node_names (list): The node names to wait for to reached the desired state
+            If None, will return all cluster nodes
         status (str): The node status to wait for
             (e.g. 'Ready', 'NotReady', 'SchedulingDisabled')
 
@@ -47,6 +48,8 @@ def wait_for_nodes_status(node_names, status=constants.NODE_READY):
         bool: True if all nodes reached the status, False otherwise
 
     """
+    if not node_names:
+        node_names = [node.get('metadata').get('name') for node in get_node_objs()]
     try:
         for sample in TimeoutSampler(120, 3, get_node_objs, node_names):
             for node in sample:

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -40,7 +40,7 @@ def wait_for_nodes_status(node_names=None, status=constants.NODE_READY):
 
     Args:
         node_names (list): The node names to wait for to reached the desired state
-            If None, will return all cluster nodes
+            If None, will wait for all cluster nodes
         status (str): The node status to wait for
             (e.g. 'Ready', 'NotReady', 'SchedulingDisabled')
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -6,7 +6,7 @@ import logging
 import time
 import yaml
 
-from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs import defaults
@@ -376,56 +376,3 @@ def switch_to_default_rook_cluster_project():
         bool: True on success, False otherwise
     """
     return switch_to_project(defaults.ROOK_CLUSTER_NAMESPACE)
-
-
-def get_node_objs(node_names=None):
-    """
-    Get node objects by node names
-
-    Args:
-        node_names (list): The node names to get their objects for.
-            If None, will return all cluster nodes
-
-    Returns:
-        list: Cluster node OCP objects
-
-    """
-    nodes_obj = OCP(kind='node')
-    node_objs = nodes_obj.get()['items']
-    if not node_names:
-        return node_objs
-    else:
-        return [
-            node_obj for node_obj in node_objs if (
-                node_obj.get('metadata').get('name') in node_names
-            )
-        ]
-
-
-def wait_for_nodes_ready(node_names):
-    """
-    Wait until all nodes are in Ready status
-
-    Args:
-        node_names (list): The node names to wait for to be in Ready state
-
-    Returns:
-        bool: True if all nodes reached status Ready, False otherwise
-
-    """
-    try:
-        for sample in TimeoutSampler(120, 3, get_node_objs, node_names):
-            for node in sample:
-                if not node_names:
-                    return True
-                for status_condition in node.get('status').get('conditions'):
-                    if 'True' in status_condition.get('status'):
-                        log.info(
-                            f"The following nodes are still not "
-                            f"in Ready status: {node_names}"
-                        )
-                        if status_condition.get('type') == 'Ready':
-                            node_names.remove(node.get('metadata').get('name'))
-    except TimeoutExpiredError:
-        log.error(f"The following nodes haven't reached status Ready: {node_names}")
-        return False

--- a/tests/manage/cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/cluster/nodes/test_nodes_restart.py
@@ -3,7 +3,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.ocs import ocp, constants
+from ocs_ci.ocs import constants, node
 from ocs_ci.framework.testlib import tier4, ignore_leftovers, ManageTest
 from ocs_ci.utility import aws
 from ocs_ci.ocs.cluster import CephCluster
@@ -35,7 +35,7 @@ def instances(request, aws_obj):
         dict: The ID keys and the name values of the instances
 
     """
-    nodes = ocp.get_node_objs()
+    nodes = node.get_node_objs()
     ec2_instances = aws.get_instances_ids_and_names(nodes)
 
     def finalizer():
@@ -106,7 +106,7 @@ class BaseNodesRestart(ManageTest):
         check and functional resources tests
         """
         instances_names = list(instances.values())
-        assert ocp.wait_for_nodes_ready(instances_names), (
+        assert node.wait_for_nodes_status(instances_names), (
             "Not all nodes reached status Ready"
         )
 


### PR DESCRIPTION
Add node operations

  - Nodes maintenance related functions: 
    Scheduling, unscheduling, drain and full maintenance
  - Currently, due to the fact that pods are still using local storage, these operations won't work
    with OCS. See BZ 1734162

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>