### PR TITLE
skip empty configuration section

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -53,6 +53,8 @@ class Config:
                 raise ValueError(
                     f"{k} is not a valid config section. "
                     f"Valid sections: {field_names}")
+            if v is None:
+                continue
             section = getattr(self, k)
             merge_dict(section, v)
 


### PR DESCRIPTION
- do not process empty configuration section (which leads to
  `AttributeError: 'NoneType' object has no attribute 'items'`)
- fixes https://github.com/red-hat-storage/ocs-ci/issues/538