### PR TITLE
Update TC OCS-324: Fix #525 and use factory fixtures

### DIFF
--- a/tests/manage/pv_services/test_delete_create_pvc_same_name.py
+++ b/tests/manage/pv_services/test_delete_create_pvc_same_name.py
@@ -4,111 +4,91 @@ A test for deleting an existing PVC and create a new PVC with the same name
 import logging
 import pytest
 
-from ocs_ci.ocs import constants, exceptions, ocp
-from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import ManageTest, tier2
 from tests import helpers
 
 logger = logging.getLogger(__name__)
 
-PVC_OBJ = None
 
-
-@pytest.fixture(params=[constants.CEPHBLOCKPOOL, constants.CEPHFILESYSTEM])
-def test_fixture(request):
+@pytest.fixture()
+def resources(request):
     """
-    Parametrized fixture which allows test to be run for different CEPH
-    interface.
-    The test will run for each interface provided in params.
+    Delete the pvc resources and validate pv deletion created during the test
+
+    Returns:
+        list: empty list of pvcs
     """
-    self = request.node.cls
-    self.interface_type = request.param
+    pvcs = []
 
-    setup(self)
-    yield
-    teardown(self)
+    def finalizer():
+        for instance in pvcs:
+            if not instance.is_deleted:
+                instance.delete()
+                instance.ocp.wait_for_delete(
+                    instance.name
+                )
+            assert helpers.validate_pv_delete(instance.backed_pv)
 
-
-def setup(self):
-    """
-    Creates the resources needed for the type of interface to be used.
-
-    For CephBlockPool interface: Creates CephBlockPool, Secret and StorageClass
-    For CephFilesystem interface: Creates Secret and StorageClass
-    """
-    logger.info(f"Creating resources for {self.interface_type} interface")
-
-    self.interface_name = None
-    if self.interface_type == constants.CEPHBLOCKPOOL:
-        self.cbp_obj = helpers.create_ceph_block_pool()
-        assert self.cbp_obj, f"Failed to create block pool"
-        self.interface_name = self.cbp_obj.name
-
-    elif self.interface_type == constants.CEPHFILESYSTEM:
-        self.interface_name = helpers.get_cephfs_data_pool_name()
-
-    self.secret_obj = helpers.create_secret(interface_type=self.interface_type)
-    assert self.secret_obj, f"Failed to create secret"
-
-    self.sc_obj = helpers.create_storage_class(
-        interface_type=self.interface_type,
-        interface_name=self.interface_name,
-        secret_name=self.secret_obj.name
-    )
-    assert self.sc_obj, f"Failed to create storage class"
-
-
-def teardown(self):
-    """
-    Deletes the resources for the type of interface used.
-    """
-    logger.info(f"Deleting resources for {self.interface_type} interface")
-
-    resources_list = [PVC_OBJ, self.sc_obj, self.secret_obj]
-    if self.interface_type == constants.CEPHBLOCKPOOL:
-        resources_list.append(self.cbp_obj)
-
-    for resource in resources_list:
-        try:
-            logger.info(f"Deleting {resource.kind} {resource.name}")
-            resource.delete()
-        except AttributeError:
-            continue
-        except exceptions.CommandFailed:
-            logger.error(f"Deletion of {resource.kind} {resource.name} failed")
+    request.addfinalizer(finalizer)
+    return pvcs
 
 
 @tier2
 @pytest.mark.polarion_id("OCS-324")
 class TestDeleteCreatePVCSameName(ManageTest):
     """
-    Delete PVC and create a new PVC with same name
+    Automates the testcase OCS-324
+    OCS-324 - FT-OCP-PVCDeleteAndCreate-SameName: Delete PVC and create a new
+    PVC with same name
     """
-    def test_pvc_delete_create_same_name(self, test_fixture):
+    @pytest.mark.parametrize(
+        argnames="interface",
+        argvalues=[
+            pytest.param(*[constants.CEPHBLOCKPOOL]),
+            pytest.param(*[constants.CEPHFILESYSTEM])
+        ]
+    )
+    def test_delete_create_pvc_same_name(
+        self, interface, pvc_factory, resources
+    ):
         """
-        TC OCS 324
+        Delete PVC and create a new PVC with same name
         """
-        global PVC_OBJ
-
-        PVC_OBJ = helpers.create_pvc(sc_name=self.sc_obj.name)
-        pv_obj = ocp.OCP(
-            kind=constants.PV, namespace=config.ENV_DATA['cluster_namespace']
+        # Create a PVC
+        pvcs = resources
+        pvc_obj1 = pvc_factory(
+            interface=interface, status=constants.STATUS_BOUND
         )
-        backed_pv = PVC_OBJ.get().get('spec').get('volumeName')
-        pv_status = pv_obj.get(backed_pv).get('status').get('phase')
-        assert constants.STATUS_BOUND in pv_status, (
-            f"{pv_obj.kind} {backed_pv} failed to reach {constants.STATUS_BOUND}"
+        pvcs.append(pvc_obj1)
+
+        # Check PV is Bound
+        pv_obj1 = pvc_obj1.backed_pv_obj
+        assert helpers.wait_for_resource_state(
+            resource=pv_obj1, state=constants.STATUS_BOUND
         )
 
-        logger.info(f"Deleting {PVC_OBJ.kind} {PVC_OBJ.name}")
-        assert PVC_OBJ.delete(), f"Failed to delete PVC"
+        # Delete the PVC
+        logger.info(f"Deleting PVC {pvc_obj1.name}")
+        pvc_obj1.delete()
+        pvc_obj1.ocp.wait_for_delete(pvc_obj1.name)
 
-        logger.info(f"Creating {PVC_OBJ.kind} with same name {PVC_OBJ.name}")
-        PVC_OBJ = helpers.create_pvc(
-            sc_name=self.sc_obj.name, pvc_name=PVC_OBJ.name
+        # Create a new PVC with same name
+        logger.info(f"Creating new PVC with same name {pvc_obj1.name}")
+        pvc_obj2 = helpers.create_pvc(
+            sc_name=pvc_obj1.storageclass.name,
+            pvc_name=pvc_obj1.name,
+            namespace=pvc_obj1.project.namespace,
+            wait=False
         )
-        backed_pv = PVC_OBJ.get().get('spec').get('volumeName')
-        pv_status = pv_obj.get(backed_pv).get('status').get('phase')
-        assert constants.STATUS_BOUND in pv_status, (
-            f"{pv_obj.kind} {backed_pv} failed to reach {constants.STATUS_BOUND}"
+        assert pvc_obj2, "Failed to create PVC"
+        pvcs.append(pvc_obj2)
+
+        # Check the new PVC and PV are Bound
+        helpers.wait_for_resource_state(
+            resource=pvc_obj2, state=constants.STATUS_BOUND
+        )
+        pv_obj2 = pvc_obj2.backed_pv_obj
+        assert helpers.wait_for_resource_state(
+            resource=pv_obj2, state=constants.STATUS_BOUND
         )

--- a/tests/manage/pv_services/test_delete_create_pvc_same_name.py
+++ b/tests/manage/pv_services/test_delete_create_pvc_same_name.py
@@ -35,18 +35,25 @@ def resources(request):
 
 
 @tier2
-@pytest.mark.polarion_id("OCS-324")
 class TestDeleteCreatePVCSameName(ManageTest):
     """
-    Automates the testcase OCS-324
-    OCS-324 - FT-OCP-PVCDeleteAndCreate-SameName: Delete PVC and create a new
-    PVC with same name
+    Automates the following test cases:
+    OCS-324 - RBD: FT-OCP-PVCDeleteAndCreate-SameName: Delete PVC and create a
+        new PVC with same name
+    OCS-1137 - CEPHFS: FT-OCP-PVCDeleteAndCreate-SameName: Delete PVC and
+        create a new PVC with same name
     """
     @pytest.mark.parametrize(
         argnames="interface",
         argvalues=[
-            pytest.param(*[constants.CEPHBLOCKPOOL]),
-            pytest.param(*[constants.CEPHFILESYSTEM])
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                marks=pytest.mark.polarion_id("OCS-324")
+            ),
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                marks=pytest.mark.polarion_id("OCS-1137")
+            )
         ]
     )
     def test_delete_create_pvc_same_name(


### PR DESCRIPTION
Update tests/manage/pv_services/test_delete_create_pvc_same_name.py 
 - Fix Issue #525
 - Updated the script to follow new coding guidelines for fixture usage

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>