### PR TITLE
Add capability to use latest nightly OCP accepted builds

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -19,14 +19,19 @@ RUN:
   run_id: null  # this will be redefined in the execution
   kubeconfig_location: 'auth/kubeconfig' # relative from cluster_dir
   cli_params: {}  # this will be filled with CLI parameters data
-  client_version: '4.2.0-0.nightly-2019-08-06-195545'
+  # If the client version ends with .nightly, the version will be exposed
+  # to the latest accepted OCP nightly build version
+  client_version: '4.2.0-0.nightly'
   bin_dir: './bin'
   google_api_secret: '~/.ocs-ci/google_api_secret.json'
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.
 DEPLOYMENT:
-  installer_version: "4.2.0-0.nightly-2019-08-06-195545"
+  # if the installer version ends with .nightly, the version will be exposed
+  # to the latest accepted OCP nightly build version. You can also use the
+  # specific build version like: "4.2.0-0.nightly-2019-08-06-195545"
+  installer_version: "4.2.0-0.nightly"
   force_download_installer: True
   force_download_client: True
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -423,7 +423,7 @@ def get_url_content(url):
 
 def expose_nightly_ocp_version(version):
     """
-    This helper function exposing latest nightly version of OCP when the
+    This helper function exposes latest nightly version of OCP. When the
     version string ends with .nightly (e.g. 4.2.0-0.nightly) it will expose
     the version to latest accepted OCP build
     (e.g. 4.2.0-0.nightly-2019-08-08-103722)
@@ -433,6 +433,7 @@ def expose_nightly_ocp_version(version):
 
     Returns:
         str: Version of OCP exposed to full version if latest nighly passed
+
     """
     if not version.endswith(".nightly"):
         return version

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -402,6 +402,50 @@ def download_file(url, filename):
     assert r.ok
 
 
+def get_url_content(url):
+    """
+    Return URL content
+
+    Args:
+        url (str): URL address to return
+    Returns:
+        str: Content of URL
+
+    Raises:
+        AssertionError: When couldn't load URL
+
+    """
+    log.debug(f"Download '{url}' content.")
+    r = requests.get(url)
+    assert r.ok, f"Couldn't load URL: {url} content!"
+    return r.content
+
+
+def expose_nightly_ocp_version(version):
+    """
+    This helper function exposing latest nightly version of OCP when the
+    version string ends with .nightly (e.g. 4.2.0-0.nightly) it will expose
+    the version to latest accepted OCP build
+    (e.g. 4.2.0-0.nightly-2019-08-08-103722)
+
+    Args:
+        version (str): Verison of OCP
+
+    Returns:
+        str: Version of OCP exposed to full version if latest nighly passed
+    """
+    if not version.endswith(".nightly"):
+        return version
+    else:
+        latest_nightly_url = (
+            f"https://openshift-release.svc.ci.openshift.org/api/v1/"
+            f"releasestream/{version}/latest"
+        )
+        version_url_content = get_url_content(latest_nightly_url)
+        version_json = json.loads(version_url_content)
+        return version_json['name']
+
+
 def destroy_cluster(cluster_path, log_level="DEBUG"):
     """
     Destroy existing cluster resources in AWS.
@@ -469,6 +513,7 @@ def get_openshift_installer(
 
     """
     version = version or config.DEPLOYMENT['installer_version']
+    version = expose_nightly_ocp_version(version)
     bin_dir = os.path.expanduser(bin_dir or config.RUN['bin_dir'])
     installer_filename = "openshift-install"
     installer_binary_path = os.path.join(bin_dir, installer_filename)
@@ -517,6 +562,7 @@ def get_openshift_client(
 
     """
     version = version or config.RUN['client_version']
+    version = expose_nightly_ocp_version(version)
     bin_dir = os.path.expanduser(bin_dir or config.RUN['bin_dir'])
     client_binary_path = os.path.join(bin_dir, 'oc')
     if os.path.isfile(client_binary_path) and force_download:


### PR DESCRIPTION
Currently the builds from URL
https://openshift-release-artifacts.svc.ci.openshift.org/
are removed after 1 week. This allow us to use latest one and don't care
about changing version each week. We can always switch back to specific
version if needed.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>