### PR TITLE
Separate wait for resource from resource creation

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -40,6 +40,7 @@ TEMPLATE_DEPLOYMENT_CLO = os.path.join(
 
 # Statuses
 STATUS_PENDING = 'Pending'
+STATUS_CONTAINER_CREATING = 'ContainerCreating'
 STATUS_AVAILABLE = 'Available'
 STATUS_RUNNING = 'Running'
 STATUS_TERMINATING = 'Terminating'

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -50,3 +50,13 @@ class UnavailableBuildException(Exception):
 
 class PerformanceException(Exception):
     pass
+
+
+class ResourceWrongStatusException(Exception):
+
+    def __init__(self, resource_name, describe_out):
+        self.resource_name = resource_name
+        self.describe_out = describe_out
+
+    def __str__(self):
+        return f"Resource {self.resource_name} describe output: {self.describe_out}"

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -28,7 +28,7 @@ def create_configmap_cluster_monitoring_pod(sc_name):
     config['alertmanagerMain']['volumeClaimTemplate']['spec']['storageClassName'] = sc_name
     config = yaml.dump(config)
     config_map['data']['config.yaml'] = config
-    assert helpers.create_resource(**config_map, wait=False)
+    assert helpers.create_resource(**config_map)
     ocp = OCP('v1', 'ConfigMap', 'openshift-monitoring')
     assert ocp.get(resource_name='cluster-monitoring-config')
     logger.info("Successfully created configmap cluster-monitoring-config")

--- a/ocs_ci/utility/deployment_openshift_logging.py
+++ b/ocs_ci/utility/deployment_openshift_logging.py
@@ -308,7 +308,7 @@ def create_instance_in_clusterlogging(sc_name=None):
     inst_data = templating.load_yaml_to_dict(constants.CL_INSTANCE_YAML)
     inst_data['spec']['logStore']['elasticsearch']['storage']['storageClassName'] = sc_name
     inst_data['spec']['logStore']['elasticsearch']['storage']['size'] = "200Gi"
-    helpers.create_resource(wait=False, **inst_data)
+    helpers.create_resource(**inst_data)
     oc = ocp.OCP('v1', 'ClusterLogging', 'openshift-logging')
     logging_instance = oc.get(resource_name='instance', out_yaml_format='True')
     if logging_instance:

--- a/tests/e2e/test_pvc_creation_performance.py
+++ b/tests/e2e/test_pvc_creation_performance.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import tier1, E2ETest, polarion_id, bugzilla
 from tests import helpers
 from ocs_ci.ocs import defaults, constants
 
+
 log = logging.getLogger(__name__)
 
 
@@ -46,6 +47,8 @@ class TestPVCCreationPerformance(E2ETest):
         pvc_obj = helpers.create_pvc(
             sc_name=self.sc_obj.name, size=self.pvc_size
         )
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
         teardown_factory(pvc_obj)
         create_time = helpers.measure_pvc_creation_time(
             self.interface, pvc_obj.name
@@ -73,12 +76,12 @@ class TestPVCCreationPerformance(E2ETest):
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
             number_of_pvc=number_of_pvcs,
             size=self.pvc_size,
-            wait=False
         )
         for pvc_obj in pvc_objs:
             teardown_factory(pvc_obj)
         for pvc_obj in pvc_objs:
             helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+            pvc_obj.reload()
         start_time = helpers.get_start_creation_time(
             self.interface, pvc_objs[0].name
         )

--- a/tests/manage/pv_services/test_create_pvc_random_storage_class.py
+++ b/tests/manage/pv_services/test_create_pvc_random_storage_class.py
@@ -97,7 +97,9 @@ def create_pvc(storageclass_list, count=1):
     for i in range(count):
         sc_name = random.choice(storageclass_list)
         PVC_OBJS[i] = helpers.create_pvc(sc_name)
-        log.info(f"{PVC_OBJS[i].name} got created and got Bounded")
+    for pvc_obj in PVC_OBJS:
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
     return True
 
 

--- a/tests/manage/pv_services/test_create_storage_class_pvc.py
+++ b/tests/manage/pv_services/test_create_storage_class_pvc.py
@@ -102,11 +102,15 @@ class TestOSCBasics(ManageTest):
         RBD_PVC_OBJ = helpers.create_pvc(
             sc_name=RBD_SC_OBJ.name, pvc_name=pvc_name
         )
+        helpers.wait_for_resource_state(RBD_PVC_OBJ, constants.STATUS_BOUND)
+        RBD_PVC_OBJ.reload()
         if RBD_PVC_OBJ.backed_pv is None:
             RBD_PVC_OBJ.reload()
         RBD_POD_OBJ = helpers.create_pod(
             interface_type=constants.CEPHBLOCKPOOL, pvc_name=RBD_PVC_OBJ.name
         )
+        helpers.wait_for_resource_state(RBD_POD_OBJ, constants.STATUS_RUNNING)
+        RBD_POD_OBJ.reload()
 
     @pytest.mark.polarion_id("OCS-346")
     def test_basics_cephfs(self, test_fixture_cephfs):
@@ -122,7 +126,11 @@ class TestOSCBasics(ManageTest):
         CEPHFS_PVC_OBJ = helpers.create_pvc(
             sc_name=CEPHFS_SC_OBJ.name, pvc_name=pvc_name
         )
+        helpers.wait_for_resource_state(CEPHFS_PVC_OBJ, constants.STATUS_BOUND)
+        CEPHFS_PVC_OBJ.reload()
         log.info('creating cephfs pod')
         CEPHFS_POD_OBJ = helpers.create_pod(
             interface_type=constants.CEPHFILESYSTEM, pvc_name=CEPHFS_PVC_OBJ.name
         )
+        helpers.wait_for_resource_state(CEPHFS_POD_OBJ, constants.STATUS_RUNNING)
+        CEPHFS_POD_OBJ.reload()

--- a/tests/manage/pv_services/test_delete_create_pvc_same_name.py
+++ b/tests/manage/pv_services/test_delete_create_pvc_same_name.py
@@ -70,7 +70,7 @@ class TestDeleteCreatePVCSameName(ManageTest):
 
         # Check PV is Bound
         pv_obj1 = pvc_obj1.backed_pv_obj
-        assert helpers.wait_for_resource_state(
+        helpers.wait_for_resource_state(
             resource=pv_obj1, state=constants.STATUS_BOUND
         )
 
@@ -85,7 +85,7 @@ class TestDeleteCreatePVCSameName(ManageTest):
             sc_name=pvc_obj1.storageclass.name,
             pvc_name=pvc_obj1.name,
             namespace=pvc_obj1.project.namespace,
-            wait=False
+            do_reload=False
         )
         assert pvc_obj2, "Failed to create PVC"
         pvcs.append(pvc_obj2)
@@ -95,6 +95,6 @@ class TestDeleteCreatePVCSameName(ManageTest):
             resource=pvc_obj2, state=constants.STATUS_BOUND
         )
         pv_obj2 = pvc_obj2.backed_pv_obj
-        assert helpers.wait_for_resource_state(
+        helpers.wait_for_resource_state(
             resource=pv_obj2, state=constants.STATUS_BOUND
         )

--- a/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
@@ -5,14 +5,14 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
 
-from ocs_ci.ocs import exceptions
+from ocs_ci.ocs import exceptions, constants
 from ocs_ci.framework.testlib import tier1, ManageTest, bugzilla
 from ocs_ci.ocs.resources.pvc import delete_pvcs
 from tests.fixtures import (
     create_rbd_storageclass, create_ceph_block_pool, create_rbd_secret,
     create_project, create_pvcs
 )
-from tests.helpers import create_multiple_pvcs
+from tests.helpers import create_multiple_pvcs, wait_for_resource_state
 
 log = logging.getLogger(__name__)
 
@@ -68,6 +68,9 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
             sc_name=self.sc_obj.name, namespace=self.namespace,
             number_of_pvc=self.num_of_pvcs
         )
+        for pvc_obj in new_pvc_objs:
+            wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+            pvc_obj.reload()
         log.info(f'Newly created {self.num_of_pvcs} PVCs are in Bound state.')
         self.pvc_objs_new.extend(new_pvc_objs)
 

--- a/tests/manage/pv_services/test_reclaim_policy.py
+++ b/tests/manage/pv_services/test_reclaim_policy.py
@@ -69,7 +69,10 @@ class TestReclaimPolicy(ManageTest):
         pvc_count = len(list_ceph_images())
         pvc_obj = helpers.create_pvc(
             sc_name=self.sc_obj_retain.name,
-            pvc_name=helpers.create_unique_resource_name('retain', 'pvc'))
+            pvc_name=helpers.create_unique_resource_name('retain', 'pvc')
+        )
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
         pv_name = pvc_obj.get()['spec']['volumeName']
         pv_namespace = pvc_obj.get()['metadata']['namespace']
         pv_obj = ocp.OCP(kind='PersistentVolume', namespace=pv_namespace)
@@ -90,7 +93,10 @@ class TestReclaimPolicy(ManageTest):
         """
         pvc_obj = helpers.create_pvc(
             sc_name=self.sc_obj_delete.name,
-            pvc_name=helpers.create_unique_resource_name('delete', 'pvc'))
+            pvc_name=helpers.create_unique_resource_name('delete', 'pvc')
+        )
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+        pvc_obj.reload()
         pv_name = pvc_obj.get()['spec']['volumeName']
         pv_namespace = pvc_obj.get()['metadata']['namespace']
         pv_obj = ocp.OCP(kind='PersistentVolume', namespace=pv_namespace)

--- a/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
@@ -114,10 +114,9 @@ class TestCreateMultipleScWithSamePoolName(ManageTest):
             pvcs.append(
                 helpers.create_pvc(storageclasses[i].name)
             )
-            log.info(
-                f"PVC: {pvcs[i].name} created successfully using "
-                f"{storageclasses[i].name}"
-            )
+        for pvc in pvcs:
+            helpers.wait_for_resource_state(pvc, constants.STATUS_BOUND)
+            pvc.reload()
 
         # Create app pod and mount each PVC
         for i in range(3):
@@ -125,10 +124,12 @@ class TestCreateMultipleScWithSamePoolName(ManageTest):
             pods.append(
                 helpers.create_pod(
                     interface_type=interface_type, pvc_name=pvcs[i].name,
-                    desired_status=constants.STATUS_RUNNING,
-                    wait=True, namespace=defaults.ROOK_CLUSTER_NAMESPACE
+                    namespace=defaults.ROOK_CLUSTER_NAMESPACE
                 )
             )
+            for pod in pods:
+                helpers.wait_for_resource_state(pod, constants.STATUS_RUNNING)
+                pod.reload()
             log.info(
                 f"{pods[i].name} created successfully and "
                 f"mounted {pvcs[i].name}"

--- a/tests/manage/storageclass/test_create_storageclass_with_wrong_provisioner.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_wrong_provisioner.py
@@ -57,7 +57,7 @@ class TestCreateStorageClassWithWrongProvisioner(ManageTest):
         )
 
         # Create PVC
-        pvc_obj = helpers.create_pvc(sc_name=sc_obj.name, wait=False)
+        pvc_obj = helpers.create_pvc(sc_name=sc_obj.name, do_reload=False)
 
         # Check PVC status
         pvc_output = pvc_obj.get()

--- a/tests/manage/storageclass/test_rbd_csi_default_sc.py
+++ b/tests/manage/storageclass/test_rbd_csi_default_sc.py
@@ -74,18 +74,17 @@ class TestBasicPVCOperations(ManageTest):
             )
         )
         log.info("Creating a PVC")
-        pvc.append(
-            helpers.create_pvc(
-                sc_name=storageclass[0].name, wait=True,
-            )
-        )
+        pvc.append(helpers.create_pvc(sc_name=storageclass[0].name))
+        for pvc_obj in pvc:
+            helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
+            pvc_obj.reload()
         log.info(
             f"Creating a pod on with pvc {pvc[0].name}"
         )
-        pod.append(
-            helpers.create_pod(
-                interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc[0].name,
-                desired_status=constants.STATUS_RUNNING, wait=True,
-                pod_dict_path=constants.NGINX_POD_YAML
-            )
+        pod_obj = helpers.create_pod(
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc[0].name,
+            pod_dict_path=constants.NGINX_POD_YAML
         )
+        pod.append(pod_obj)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+        pod_obj.reload()

--- a/tests/sanity_helpers.py
+++ b/tests/sanity_helpers.py
@@ -73,6 +73,9 @@ def create_resources(resources, run_io=True):
     pvcs.append(helpers.create_pvc(
         sc_name=storageclasses[1].name, namespace=projects[0].namespace)
     )
+    for pvc in pvcs:
+        helpers.wait_for_resource_state(pvc, constants.STATUS_BOUND)
+        pvc.reload()
 
     # Pods
     pods.append(
@@ -87,6 +90,10 @@ def create_resources(resources, run_io=True):
             namespace=projects[0].namespace
         )
     )
+    for pod in pods:
+        helpers.wait_for_resource_state(pod, constants.STATUS_RUNNING)
+        pod.reload()
+
     if run_io:
         # Run IO
         for pod in pods:


### PR DESCRIPTION
In order to be able to delete a resource in the teardown, we should get the resource object, even if the wait for this resource has ended with a  failure.