### PR TITLE
Stop Ceph Manager alerting test case

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -47,6 +47,7 @@ STATUS_RELEASED = 'Released'
 # Resources / Kinds
 CEPHFILESYSTEM = "CephFileSystem"
 CEPHBLOCKPOOL = "CephBlockPool"
+DEPLOYMENT = "Deployment"
 STORAGECLASS = "StorageClass"
 PV = "PersistentVolume"
 PVC = "PersistentVolumeClaim"

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -110,7 +110,7 @@ class PrometheusAPI(object):
         )
         return response
 
-    def wait_for_alert(self, name, state='pending', timeout=1200, sleep=5):
+    def wait_for_alert(self, name, state=None, timeout=1200, sleep=5):
         """
         Search for alerts that have requested name and state.
 
@@ -118,7 +118,10 @@ class PrometheusAPI(object):
             name (str): Alert name.
             state (str): Alert state. If provided then there are searched
                 alerts with provided state. If not provided then alerts are
-                searched for absence of the alert.
+                searched for absence of the alert. Loop that looks for alerts
+                is broke when there are no alerts returned from API. This
+                is done because API is not returning any alerts that are not
+                in pending or firing state.
             timeout (int): Number of seconds for how long the alert should
                 be searched.
             sleep (int): Number of seconds to sleep in between alert search.
@@ -148,6 +151,8 @@ class PrometheusAPI(object):
                 if len(alerts) > 0:
                     break
             else:
+                # search for missing alerts, search is completed when
+                # there are no alerts with given name
                 alerts = [
                     alert
                     for alert

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -137,7 +137,8 @@ class PrometheusAPI(object):
                     'inhibited': False,
                 }
             )
-            assert alerts_response.ok, 'Prometheus API request failed'
+            msg = f"Request {alerts_response.request.url} failed"
+            assert alerts_response.ok, msg
             if state:
                 alerts = [
                     alert

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -96,10 +96,10 @@ class PrometheusAPI(object):
         pattern = f"/api/v1/{resource}"
         headers = {'Authorization': f"Bearer {self._token}"}
 
-        logger.info(f"GET {self._endpoint + pattern}")
-        logger.info(f"headers={headers}")
-        logger.info(f"verify={self._cacert}")
-        logger.info(f"params={payload}")
+        logger.debug(f"GET {self._endpoint + pattern}")
+        logger.debug(f"headers={headers}")
+        logger.debug(f"verify={self._cacert}")
+        logger.debug(f"params={payload}")
 
         response = requests.get(
             self._endpoint + pattern,

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -119,7 +119,7 @@ class PrometheusAPI(object):
             state (str): Alert state. If provided then there are searched
                 alerts with provided state. If not provided then alerts are
                 searched for absence of the alert. Loop that looks for alerts
-                is broke when there are no alerts returned from API. This
+                is broken when there are no alerts returned from API. This
                 is done because API is not returning any alerts that are not
                 in pending or firing state.
             timeout (int): Number of seconds for how long the alert should

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -3,6 +3,7 @@ import logging
 import os
 import requests
 import tempfile
+import time
 import yaml
 
 from ocs_ci.framework import config
@@ -108,3 +109,55 @@ class PrometheusAPI(object):
             params=payload
         )
         return response
+
+    def wait_for_alert(self, name, state='pending', timeout=1200, sleep=5):
+        """
+        Search for alerts that have requested name and state.
+
+        Args:
+            name (str): Alert name.
+            state (str): Alert state. If provided then there are searched
+                alerts with provided state. If not provided then alerts are
+                searched for absence of the alert.
+            timeout (int): Number of seconds for how long the alert should
+                be searched.
+            sleep (int): Number of seconds to sleep in between alert search.
+
+        Returns:
+            list: List of alert records.
+        """
+        while timeout > 0:
+            alerts_response = self.get(
+                'alerts',
+                payload={
+                    'silenced': False,
+                    'inhibited': False,
+                }
+            )
+            assert alerts_response.ok, 'Prometheus API request failed'
+            if state:
+                alerts = [
+                    alert
+                    for alert
+                    in alerts_response.json().get('data').get('alerts')
+                    if alert.get('labels').get('alertname') == name
+                    and alert.get('state') == state
+                ]
+                logger.info(f"Checking for {name} alerts with state {state}... "
+                            f"{len(alerts)} found")
+                if len(alerts) > 0:
+                    break
+            else:
+                alerts = [
+                    alert
+                    for alert
+                    in alerts_response.json().get('data').get('alerts')
+                    if alert.get('labels').get('alertname') == name
+                ]
+                logger.info(f"Checking for {name} alerts. There should be no alerts ... "
+                            f"{len(alerts)} found")
+                if len(alerts) == 0:
+                    break
+            time.sleep(sleep)
+            timeout -= sleep
+        return alerts

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -55,7 +55,8 @@ def measure_operation(
                     'inhibited': False
                 }
             )
-            assert alerts_response.ok, 'Prometheus API request failed'
+            msg = f"Request {alerts_response.request.url} failed"
+            assert alerts_response.ok, msg
             for alert in alerts_response.json().get('data').get('alerts'):
                 if alert not in alert_list:
                     logger.info(f"Adding {alert} to alert list")

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -36,10 +36,11 @@ def measure_operation(
     """
     def prometheus_log(info, alert_list):
         """
-        Log all alerts from Prometheus API every 10 seconds.
+        Log all alerts from Prometheus API every 3 seconds.
 
         Args:
-            run (bool): When this var turns into False the thread stops.
+            info (dict): Contains run key attribute that controls thread.
+                If `info['run'] == False` then thread will stop
             alert_list (list): List to be populated with alerts
         """
         prometheus = PrometheusAPI()
@@ -56,7 +57,7 @@ def measure_operation(
                 if alert not in alert_list:
                     logger.info(f"Adding {alert} to alert list")
                     alert_list.append(alert)
-            time.sleep(10)
+            time.sleep(3)
 
     if not measure_after:
         start_time = time.time()

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -121,6 +121,9 @@ def workload_stop_ceph_mgr():
         Downscale Ceph Manager deployment for 6 minutes. First 5 minutes
         the alert should be in 'Pending'.
         After 5 minutes it should be 'Firing'.
+        This configuration of monitoring can be observed in ceph-mixins which
+        are used in the project:
+            https://github.com/ceph/ceph-mixins/blob/d22afe8c0da34490cb77e52a202eefcf4f62a869/config.libsonnet#L25
 
         Returns:
             str: Name of downscaled deployment.

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -49,7 +49,7 @@ def measure_operation(
                     'inhibited': False
                 }
             )
-            assert alerts_response.ok is True
+            assert alerts_response.ok is True, 'Prometheus API request failed'
             for alert in alerts_response.json()['data']['alerts']:
                 if alert not in alert_list:
                     logger.info(f"Adding {alert} to alert list")

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import threading
 import time
 
-from ocs_ci.ocs import constants, defaults, ocp
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, ocp
 from ocs_ci.utility.prometheus import PrometheusAPI
 
 
@@ -102,8 +103,8 @@ def measure_operation(
 @pytest.fixture(scope="session")
 def workload_stop_ceph_mgr():
     """
-    Downscales Ceph Manager deployment, measures the time when it was downscaled
-    and monitors alerts that were triggered during this event.
+    Downscales Ceph Manager deployment, measures the time when it was
+    downscaled and monitors alerts that were triggered during this event.
 
     Returns:
         dict: Contains information about `start` and `stop` time for stopping
@@ -111,7 +112,7 @@ def workload_stop_ceph_mgr():
     """
     oc = ocp.OCP(
         kind=constants.DEPLOYMENT,
-        namespace=defaults.ROOK_CLUSTER_NAMESPACE
+        namespace=config.ENV_DATA['cluster_namespace']
     )
     mgr_deployments = oc.get(selector=constants.MGR_APP_LABEL)['items']
     mgr = mgr_deployments[0]['metadata']['name']

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -102,9 +102,12 @@ def measure_operation(
 @pytest.fixture(scope="session")
 def workload_stop_ceph_mgr():
     """
+    Downscales Ceph Manager deployment, measures the time when it was downscaled
+    and monitors alerts that were triggered during this event.
+
     Returns:
         dict: Contains information about `start` and `stop` time for stopping
-            Ceph manager node.
+            Ceph Manager pod.
     """
     oc = ocp.OCP(
         kind=constants.DEPLOYMENT,
@@ -117,6 +120,9 @@ def workload_stop_ceph_mgr():
         Downscale Ceph Manager deployment for 6 minutes. First 5 minutes
         the alert should be in 'Pending'.
         After 5 minutes it should be 'Firing'.
+
+        Returns:
+            str: Name of downscaled deployment.
         """
         # run_time of operation
         run_time = 60 * 6

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -21,8 +21,10 @@ def measure_operation(
 
     Args:
         operation (function): Function to be performed.
-        minimal_time (int): Minimal number of seconds to run, it can be more
-            based on given operation.
+        minimal_time (int): Minimal number of seconds to monitor a system.
+            If provided then monitoring of system continues even when
+            operation is finshed. If not specified then measurement is finished
+            when operation is complete.
         metadata (dict): This can contain dictionary object with information
             relevant to test (e.g. volume name, operating host, ...).
         measure_after (bool): Determine if time measurement is done before or
@@ -44,6 +46,7 @@ def measure_operation(
             alert_list (list): List to be populated with alerts
         """
         prometheus = PrometheusAPI()
+        logger.info('Logging of all prometheus alerts started')
         while info.get('run'):
             alerts_response = prometheus.get(
                 'alerts',
@@ -58,6 +61,7 @@ def measure_operation(
                     logger.info(f"Adding {alert} to alert list")
                     alert_list.append(alert)
             time.sleep(3)
+        logger.info('Logging of all prometheus alerts stopped')
 
     if not measure_after:
         start_time = time.time()

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -74,21 +74,15 @@ def measure_operation(
     )
     logging_thread.start()
 
-    try:
-        result = operation()
-        if measure_after:
-            start_time = time.time()
-        passed_time = time.time() - start_time
-        if minimal_time:
-            additional_time = minimal_time - passed_time
-            if additional_time > 0:
-                time.sleep(additional_time)
-        stop_time = time.time()
-    except KeyboardInterrupt:
-        # Thread should be correctly terminated on next few lines
-        # this is done in case of user interuption to make sure that thread
-        # is terminated correctly
-        pass
+    result = operation()
+    if measure_after:
+        start_time = time.time()
+    passed_time = time.time() - start_time
+    if minimal_time:
+        additional_time = minimal_time - passed_time
+        if additional_time > 0:
+            time.sleep(additional_time)
+    stop_time = time.time()
     info['run'] = False
     logging_thread.join()
     logger.info(f"Alerts found during measurement: {alert_list}")

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -60,7 +60,8 @@ def measure_operation(
     if not measure_after:
         start_time = time.time()
 
-    # init logging thread
+    # init logging thread that checks for Prometheus alerts
+    # while workload is running
     # based on https://docs.python.org/3/howto/logging-cookbook.html#logging-from-multiple-threads
     info = {'run': True}
     alert_list = []
@@ -83,6 +84,8 @@ def measure_operation(
         stop_time = time.time()
     except KeyboardInterrupt:
         # Thread should be correctly terminated on next few lines
+        # this is done in case of user interuption to make sure that thread
+        # is terminated correctly
         pass
     info['run'] = False
     logging_thread.join()
@@ -126,6 +129,6 @@ def workload_stop_ceph_mgr():
         return oc.get(mgr)
 
     measured_op = measure_operation(stop_mgr)
-    logger.info(f"Upscaling deployment {mgr} to 1")
+    logger.info(f"Upscaling deployment {mgr} back to 1")
     oc.exec_oc_cmd(f"scale --replicas=1 deployment/{mgr}")
     return measured_op

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 def measure_operation(
-        operation, minimal_time=None, metadata=None, measure_after=False):
+    operation, minimal_time=None, metadata=None, measure_after=False
+):
     """
     Get dictionary with keys 'start', 'stop', 'metadata' and 'result' that
     contain information about start and stop time of given function and its
@@ -41,7 +42,7 @@ def measure_operation(
             alert_list (list): List to be populated with alerts
         """
         prometheus = PrometheusAPI()
-        while info['run']:
+        while info.get('run'):
             alerts_response = prometheus.get(
                 'alerts',
                 payload={
@@ -49,8 +50,8 @@ def measure_operation(
                     'inhibited': False
                 }
             )
-            assert alerts_response.ok is True, 'Prometheus API request failed'
-            for alert in alerts_response.json()['data']['alerts']:
+            assert alerts_response.ok, 'Prometheus API request failed'
+            for alert in alerts_response.json().get('data').get('alerts'):
                 if alert not in alert_list:
                     logger.info(f"Adding {alert} to alert list")
                     alert_list.append(alert)

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -1,0 +1,81 @@
+import pytest
+import logging
+import time
+
+from ocs_ci.ocs import constants, defaults, ocp
+
+
+logger = logging.getLogger(__name__)
+
+def measure_operation(
+        operation, minimal_time=None, metadata=None, measure_after=False):
+    """
+    Get dictionary with keys 'start', 'stop', 'metadata' and 'result' that
+    contain information about start and stop time of given function and its
+    result.
+
+    Args:
+        operation (function): Function to be performed.
+        minimal_time (int): Minimal number of seconds to run, it can be more
+            based on given operation.
+        metadata (dict): This can contain dictionary object with information
+            relevant to test (e.g. volume name, operating host, ...).
+        measure_after (bool): Determine if time measurement is done before or
+            after the operation returns its state. This can be useful e.g.
+            for capacity utilization testing where operation fills capacity
+            and utilized data are measured after the utilization is completed.
+
+    Returns:
+        dict: contains information about `start` and `stop` time of given
+            function and its `result` and provided `metadata`.
+    """
+    if not measure_after:
+        start_time = time.time()
+    result = operation()
+    if measure_after:
+        start_time = time.time()
+    passed_time = time.time() - start_time
+    if minimal_time:
+        additional_time = minimal_time - passed_time
+        if additional_time > 0:
+            time.sleep(additional_time)
+    stop_time = time.time()
+    return {
+        "start": start_time,
+        "stop": stop_time,
+        "result": result,
+        "metadata": metadata
+    }
+
+
+@pytest.fixture(scope="session")
+def workload_stop_ceph_mgr():
+    """
+    Returns:
+        dict: Contains information about `start` and `stop` time for stopping
+            Ceph manager node.
+    """
+    oc = ocp.OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE
+    )
+    mgr = 'rook-ceph-mgr-a'
+
+    def stop_mgr():
+        """
+        Downscale Ceph Manager deployment for 11 minutes.
+        """
+        # run_time of operation
+        run_time = 60 * 2
+        nonlocal oc
+        nonlocal mgr
+        logger.info(f"Downscaling deployment {mgr} to 0")
+        oc.exec_oc_cmd(f"scale --replicas=0 deployment/{mgr}")
+        logger.info(f"Waiting for {run_time} seconds")
+        time.sleep(run_time)
+        return oc.get(mgr)
+
+    measured_op = measure_operation(stop_mgr)
+    logger.info(f"Upscaling deployment {mgr} to 1")
+    oc.exec_oc_cmd(f"scale --replicas=1 deployment/{mgr}")
+    return measured_op

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -113,7 +113,8 @@ def workload_stop_ceph_mgr():
         kind=constants.DEPLOYMENT,
         namespace=defaults.ROOK_CLUSTER_NAMESPACE
     )
-    mgr = 'rook-ceph-mgr-a'
+    mgr_deployments = oc.get(selector=constants.MGR_APP_LABEL)['items']
+    mgr = mgr_deployments[0]['metadata']['name']
 
     def stop_mgr():
         """

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -1,12 +1,15 @@
 import logging
 import time
 
+from ocs_ci.framework.testlib import tier4
 import ocs_ci.utility.prometheus
 
 
 log = logging.getLogger(__name__)
 
 
+@tier4
+@pytest.mark.polarion_id("OCS-1052")
 def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     """
     Test that there is appropriate alert when ceph manager

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -29,10 +29,12 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     assert target_alerts[1]['state'] == 'firing'
 
     # seconds to wait before alert is cleared after measurement is finished
-    time_min = 20
+    time_min = 30
 
-    time_actual = int(time.time())
-    time_sleep = (workload_stop_ceph_mgr['stop'] + time_min) - time_actual
+    time_actual = time.time()
+    time_sleep = int(
+        (workload_stop_ceph_mgr['stop'] + time_min) - time_actual
+    )
     if time_sleep > 0:
         log.info(f"Waiting {time_sleep} seconds "
                  f"({time_min} seconds since measurement end)")

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -19,11 +19,13 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     """
     prometheus = PrometheusAPI()
 
-    alerts = workload_stop_ceph_mgr['prometheus_alerts']
+    alerts = workload_stop_ceph_mgr.get('prometheus_alerts')
     target_label = 'CephMgrIsAbsent'
     target_alerts = [
-        alert for alert in alerts if alert[
-            'labels']['alertname'] == target_label
+        alert
+        for alert
+        in alerts
+        if alert.get('labels').get('alertname') == target_label
     ]
     msg = f"Incorrect number of {target_label} alerts"
     assert len(target_alerts) == 2, msg
@@ -45,7 +47,7 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
 
     time_actual = time.time()
     time_sleep = int(
-        (workload_stop_ceph_mgr['stop'] + time_min) - time_actual
+        (workload_stop_ceph_mgr.get('stop') + time_min) - time_actual
     )
     if time_sleep > 0:
         log.info(f"Waiting for approximately {time_sleep} seconds for alerts "
@@ -59,10 +61,12 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
                     'inhibited': False,
                 }
             )
-            assert alerts_response.ok is True, 'Prometheus API request failed'
+            assert alerts_response.ok, 'Prometheus API request failed'
             target_alerts = [
-                alert for alert in alerts if alert[
-                    'labels']['alertname'] == target_label
+                alert
+                for alert
+                in alerts
+                if alert.get('labels').get('alertname') == target_label
             ]
             log.info(f"Checking for {target_label} alerts... "
                      f"{len(target_alerts)} found")
@@ -79,12 +83,14 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
                 'inhibited': False,
             }
         )
-    assert alerts_response.ok is True, 'Prometheus API request failed'
+    assert alerts_response.ok, 'Prometheus API request failed'
     log.info('Getting Prometheus alerts to check if alert is cleared.')
-    alerts = alerts_response.json()['data']['alerts']
+    alerts = alerts_response.json().get('data').get('alerts')
     log.info(f"Prometheus Alerts: {alerts}")
     target_alerts = [
-        alert for alert in alerts if alert[
-            'labels']['alertname'] == target_label
+        alert
+        for alert
+        in alerts
+        if alert.get('labels').get('alertname') == target_label
     ]
     assert len(target_alerts) == 0, f"Too many {target_label} alerts"

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -51,6 +51,8 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     msg = 'First alert is not in firing state'
     assert target_alerts[1]['state'] == 'firing', msg
 
+    log.info(f"Alerts were triggered correctly during utilization")
+
     # seconds to wait before alert is cleared after measurement is finished
     time_min = 30
 

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 import time
 
 from ocs_ci.framework.testlib import tier4

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -1,0 +1,66 @@
+import logging
+import time
+
+import ocs_ci.utility.prometheus
+
+
+log = logging.getLogger(__name__)
+
+
+def test_ceph_manager_stopped(workload_stop_ceph_mgr):
+    """
+    Test that there is appropriate alert when ceph manager
+    is unavailable and that this alert is cleared when the manager
+    is back online.
+    """
+    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+
+    alerts_response = prometheus.get(
+        'alerts',
+        payload={
+            'silenced': False,
+            'inhibited': False,
+            'start': int(workload_stop_ceph_mgr['start']),
+            'stop': int(workload_stop_ceph_mgr['stop']),
+        }
+    )
+    assert alerts_response.ok is True
+    alerts = alerts_response.json()['data']['alerts']
+    log.info('Getting Prometheus alerts to check if alert is present.')
+    log.info(f"Prometheus Alerts: {alerts}")
+    target_label = 'CephMgrIsAbsent'
+    target_alerts = [alert for alert in alerts if alert['labels']['alertname'] == target_label]
+    assert len(target_alerts) == 1, f"Incorrect number of {target_label} alerts"
+
+    # seconds to wait before alert is cleared
+    wait_clear = 20
+    time.sleep(wait_clear+5)
+    alerts_response = prometheus.get(
+        'alerts',
+        payload={
+            'silenced': False,
+            'inhibited': False,
+            'start': int(workload_stop_ceph_mgr['stop'])+wait_clear,
+            'stop': int(workload_stop_ceph_mgr['stop'])+wait_clear+5,
+        }
+    )
+    assert alerts_response.ok is True
+    log.info('Getting Prometheus alerts to check if alert is cleared.')
+    alerts = alerts_response.json()['data']['alerts']
+    log.info(f"Prometheus Alerts: {alerts}")
+    target_alerts = [alert for alert in alerts if alert['labels']['alertname'] == target_label]
+    assert len(target_alerts) == 0, f"Too many {target_label} alerts"
+
+    alerts_response = prometheus.get(
+        'alerts',
+        payload={
+            'silenced': False,
+            'inhibited': False,
+            'start': int(workload_stop_ceph_mgr['start']),
+            'stop': int(workload_stop_ceph_mgr['stop']),
+        }
+    )
+    assert alerts_response.ok is True
+    alerts = alerts_response.json()['data']['alerts']
+    log.info('Getting Prometheus alerts to check if alert is present.')
+    log.info(f"Prometheus Alerts: {alerts}")

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -25,20 +25,20 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
         alert for alert in alerts if alert[
             'labels']['alertname'] == target_label
     ]
-    assert len(
-        target_alerts) == 2, f"Incorrect number of {target_label} alerts"
-    assert target_alerts[0]['annotations'][
-        'severity_level'
-    ] == 'warning', 'First alert doesn\'t have warning severity'
-    assert target_alerts[0][
-        'state'
-    ] == 'pending', 'First alert is not in pending state'
-    assert target_alerts[1]['annotations'][
-        'severity_level'
-    ] == 'warning', 'Second alert doesn\'t have warning severity'
-    assert target_alerts[1][
-        'state'
-    ] == 'firing', 'First alert is not in firing state'
+    msg = f"Incorrect number of {target_label} alerts"
+    assert len(target_alerts) == 2, msg
+
+    msg = 'First alert doesn\'t have warning severity'
+    assert target_alerts[0]['annotations']['severity_level'] == 'warning', msg
+
+    msg = 'First alert is not in pending state'
+    assert target_alerts[0]['state'] == 'pending', msg
+
+    msg = 'Second alert doesn\'t have warning severity'
+    assert target_alerts[1]['annotations']['severity_level'] == 'warning', msg
+
+    msg = 'First alert is not in firing state'
+    assert target_alerts[1]['state'] == 'firing', msg
 
     # seconds to wait before alert is cleared after measurement is finished
     time_min = 30

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -22,6 +22,7 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     # get alerts from time when manager deployment was scaled down
     alerts = workload_stop_ceph_mgr.get('prometheus_alerts')
     target_label = 'CephMgrIsAbsent'
+    target_msg = 'Storage metrics collector service not available anymore.'
     target_alerts = [
         alert
         for alert
@@ -32,11 +33,17 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     msg = f"Incorrect number of {target_label} alerts"
     assert len(target_alerts) == 2, msg
 
+    msg = 'Alert message is not correct'
+    assert target_alerts[0]['annotations'] == target_msg, msg
+
     msg = 'First alert doesn\'t have warning severity'
     assert target_alerts[0]['annotations']['severity_level'] == 'warning', msg
 
     msg = 'First alert is not in pending state'
     assert target_alerts[0]['state'] == 'pending', msg
+
+    msg = 'Alert message is not correct'
+    assert target_alerts[1]['annotations'] == target_msg, msg
 
     msg = 'Second alert doesn\'t have warning severity'
     assert target_alerts[1]['annotations']['severity_level'] == 'warning', msg

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -19,6 +19,7 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     """
     prometheus = PrometheusAPI()
 
+    # get alerts from time when manager deployment was scaled down
     alerts = workload_stop_ceph_mgr.get('prometheus_alerts')
     target_label = 'CephMgrIsAbsent'
     target_alerts = [
@@ -27,6 +28,7 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
         in alerts
         if alert.get('labels').get('alertname') == target_label
     ]
+    log.info(f"Checking properties of found {target_label} alerts")
     msg = f"Incorrect number of {target_label} alerts"
     assert len(target_alerts) == 2, msg
 
@@ -94,3 +96,4 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
         if alert.get('labels').get('alertname') == target_label
     ]
     assert len(target_alerts) == 0, f"Too many {target_label} alerts"
+    log.info(f"{target_label} alerts were cleared")

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 from ocs_ci.framework.testlib import tier4
-import ocs_ci.utility.prometheus
+from ocs_ci.utility.prometheus import PrometheusAPI
 
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     is unavailable and that this alert is cleared when the manager
     is back online.
     """
-    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+    prometheus = PrometheusAPI()
 
     alerts = workload_stop_ceph_mgr['prometheus_alerts']
     target_label = 'CephMgrIsAbsent'
@@ -27,10 +27,18 @@ def test_ceph_manager_stopped(workload_stop_ceph_mgr):
     ]
     assert len(
         target_alerts) == 2, f"Incorrect number of {target_label} alerts"
-    assert target_alerts[0]['annotations']['severity_level'] == 'warning'
-    assert target_alerts[0]['state'] == 'pending'
-    assert target_alerts[1]['annotations']['severity_level'] == 'warning'
-    assert target_alerts[1]['state'] == 'firing'
+    assert target_alerts[0]['annotations'][
+        'severity_level'
+    ] == 'warning', 'First alert doesn\'t have warning severity'
+    assert target_alerts[0][
+        'state'
+    ] == 'pending', 'First alert is not in pending state'
+    assert target_alerts[1]['annotations'][
+        'severity_level'
+    ] == 'warning', 'Second alert doesn\'t have warning severity'
+    assert target_alerts[1][
+        'state'
+    ] == 'firing', 'First alert is not in firing state'
 
     # seconds to wait before alert is cleared after measurement is finished
     time_min = 30


### PR DESCRIPTION
- Add `DEPLOYMENT` constant.
- Change Prometheus API calling logs from `INFO` to `DEBUG` severity.
- Add `tests/manage/monitoring/conftest.py` with `measure_operation` function that simplifies workload measurement for monitoring.
- Add `workload_stop_ceph_mgr` fixture.
- Add `test_ceph_manager_stopped`.

Signed-off-by: Filip Balak fbalak@redhat.com