### PR TITLE
Get the resource "real" status

### DIFF
--- a/tests/manage/cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/cluster/nodes/test_nodes_restart.py
@@ -128,7 +128,7 @@ class TestNodesRestart(ManageTest):
         logger.info(
             f"Waiting for pod {provisioner_pod_name} to reach status Terminating"
         )
-        assert provisioner_pod.ocp.temp_wait_for_resource(
+        assert provisioner_pod.ocp.wait_for_resource(
             timeout=300, resource_name=provisioner_pod.name,
             condition=constants.STATUS_TERMINATING
         ), f"{interface} provisioner pod failed to reach status Terminating"
@@ -137,7 +137,7 @@ class TestNodesRestart(ManageTest):
         logger.info(
             f"Waiting for pod {provisioner_pod_name} to reach status Running"
         )
-        assert provisioner_pod.ocp.temp_wait_for_resource(
+        assert provisioner_pod.ocp.wait_for_resource(
             timeout=600, condition=constants.STATUS_RUNNING, selector=selector,
             resource_count=1
         ), f"{interface} provisioner pod failed to reach status Running"


### PR DESCRIPTION
 Using 'oc get' command not in the yaml format, calculates the resource
 state in more accurate way and we should use it to fetch the status

Signed-off-by: ratamir <ratamir@redhat.com>