### PR TITLE
Testing basics of RBD RWX raw block pv support:OSC-750 and OCS-751

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -145,6 +145,10 @@ CSI_RBD_POD_YAML = os.path.join(
     TEMPLATE_CSI_RBD_DIR, "pod.yaml"
 )
 
+CSI_RBD_RAW_BLOCK_POD_YAML = os.path.join(
+    TEMPLATE_APP_POD_DIR, "raw_block_pod.yaml"
+)
+
 CSI_CEPHFS_POD_YAML = os.path.join(
     TEMPLATE_CSI_FS_DIR, "pod.yaml"
 )

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -247,6 +247,7 @@ FIO_IO_RW_PARAMS_YAML = os.path.join(
 # constants
 RBD_INTERFACE = 'rbd'
 CEPHFS_INTERFACE = 'cephfs'
+RAW_BLOCK_DEVICE = '/dev/block'
 
 # EC2 instance statuses
 INSTANCE_PENDING = 0

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -184,15 +184,20 @@ class Pod(OCS):
             return [item for item in out if item]
         return out
 
-    def get_mount_path(self):
+    def get_storage_path(self, storage_type):
         """
-        Get the pod volume mount path
+        Get the pod volume mount path or device path
 
         Returns:
-            str: The mount path of the volume on the pod (e.g. /var/lib/www/html/)
+            str: The mount path of the volume on the pod (e.g. /var/lib/www/html/) if storage_type is fs
+                 else device path of raw block pv
         """
         # TODO: Allow returning a path of a specified volume of a specified
         #  container
+        if storage_type == 'block':
+            return self.pod_data.get('spec').get('containers')[0].get(
+                'volumeDevices')[0].get('devicePath')
+
         return (
             self.pod_data.get(
                 'spec'
@@ -209,7 +214,7 @@ class Pod(OCS):
         """
         work_load = 'fio'
         name = f'test_workload_{work_load}'
-        path = self.get_mount_path()
+        path = self.get_storage_path(storage_type)
         # few io parameters for Fio
 
         self.wl_obj = workload.WorkLoad(

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -184,7 +184,7 @@ class Pod(OCS):
             return [item for item in out if item]
         return out
 
-    def get_storage_path(self, storage_type):
+    def get_storage_path(self, storage_type='fs'):
         """
         Get the pod volume mount path or device path
 

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -102,8 +102,36 @@ class PVC(OCS):
         """
         return self.data.get('spec').get('accessModes')[0]
 
+    def backed_sc(self):
+        """
+        Returns the storage class of pvc object in namespace
+
+        Returns:
+            str: Storage class name
+        """
+        return self.data.get('spec').get('storageClassName')
+
+    @property
+    def backed_reclaim_policy(self):
+        """
+        Returns the reclaim policy of pvc in namespace
+
+        Returns:
+            str: Reclaim policy Reclaim or Delete
+        """
+
+        data = dict()
+        data['api_version'] = self.api_version
+        data['kind'] = 'StorageClass'
+        data['metadata'] = {
+            'name': self.backed_sc, 'namespace': self.namespace
+        }
+        sc_obj = OCS(**data)
+        sc_obj.reload()
+        return sc_obj.get().get('reclaimPolicy')
+
     def verify_pv_exists_in_backend(
-            self, pool_name
+        self, pool_name
     ):
         """
         Verifies given pv exists in ceph backend

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -112,7 +112,7 @@ class PVC(OCS):
         return self.data.get('spec').get('storageClassName')
 
     @property
-    def backed_reclaim_policy(self):
+    def reclaim_policy(self):
         """
         Returns the reclaim policy of pvc in namespace
 

--- a/ocs_ci/templates/app-pods/raw_block_pod.yaml
+++ b/ocs_ci/templates/app-pods/raw_block_pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-raw-block-pod
+spec:
+  nodeName: foo
+  containers:
+    - name: my-container
+      image: nginx
+      securityContext:
+         capabilities:
+           add: ["SYS_ADMIN"]
+      volumeDevices:
+        - devicePath: /dev/block
+          name: my-volume
+      imagePullPolicy: IfNotPresent
+  volumes:
+    - name: my-volume
+      persistentVolumeClaim:
+        claimName: test-raw-block-pv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def ceph_pool_factory(request):
 def storageclass_factory(
     request,
     ceph_pool_factory,
-    secret_factory
+    secret_factory,
 ):
     """
     Create a storage class factory. Default is RBD based.
@@ -136,7 +136,8 @@ def storageclass_factory(
         interface=constants.CEPHBLOCKPOOL,
         secret=None,
         custom_data=None,
-        sc_name=None
+        sc_name=None,
+        reclaim_policy=constants.RECLAIM_POLICY_DELETE
     ):
         """
         Args:
@@ -148,6 +149,7 @@ def storageclass_factory(
                 by using these data. Parameters `block_pool` and `secret`
                 are not useds but references are set if provided.
             sc_name (str): Name of the storage class
+            reclaim_policy (str): Reclaim policy for storageclass
 
         Returns:
             object: helpers.create_storage_class instance with links to
@@ -167,7 +169,8 @@ def storageclass_factory(
                 interface_type=interface,
                 interface_name=interface_name,
                 secret_name=secret.name,
-                sc_name=sc_name
+                sc_name=sc_name,
+                reclaim_policy=reclaim_policy
             )
             assert sc_obj, f"Failed to create {interface} storage class"
             sc_obj.ceph_pool = ceph_pool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,7 +431,7 @@ def teardown_factory(request):
                     instance.name
                 )
                 if instance.kind == constants.PVC:
-                    if instance.backed_reclaim_policy == constants.RECLAIM_POLICY_DELETE:
+                    if instance.reclaim_policy == constants.RECLAIM_POLICY_DELETE:
                         helpers.validate_pv_delete(instance.backed_pv)
     request.addfinalizer(finalizer)
     return factory

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -92,10 +92,14 @@ def create_rbd_storageclass(request):
 
     request.addfinalizer(finalizer)
 
+    if not hasattr(class_instance, 'reclaim_policy'):
+        class_instance.reclaim_policy = constants.RECLAIM_POLICY_DELETE
+
     class_instance.sc_obj = helpers.create_storage_class(
         interface_type=constants.CEPHBLOCKPOOL,
         interface_name=class_instance.cbp_obj.name,
         secret_name=class_instance.rbd_secret_obj.name,
+        reclaim_policy=class_instance.reclaim_policy
     )
     assert class_instance.sc_obj, "Failed to create storage class"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -385,6 +385,8 @@ def create_pvc(
         do_reload (bool): True for wait for reloading PVC after its creation, False otherwise
         access_mode (str): The access mode to be used for the PVC
         volume_mode (str): Volume mode for rbd RWX pvc i.e. 'Block'
+
+    Returns:
         PVC: PVC instance
     """
     pvc_data = templating.load_yaml_to_dict(constants.CSI_PVC_YAML)
@@ -693,13 +695,8 @@ def get_all_pvs():
     )
     return ocp_pv_obj.get()
 
-# Todo
 
-
-'''
-To revert the counts of tries and delay after bz1726266
-'''
-
+# TODO: revert counts of tries and delay,BZ 1726266
 
 @retry(AssertionError, tries=20, delay=10, backoff=1)
 def validate_pv_delete(pv_name):
@@ -720,7 +717,7 @@ def validate_pv_delete(pv_name):
 
     try:
         if ocp_pv_obj.get(resource_name=pv_name):
-            raise AssertionError
+            raise AssertionError('PV exists after PVC deletion')
 
     except CommandFailed:
         return True

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,7 +93,7 @@ def create_pod(
     interface_type=None, pvc_name=None,
     do_reload=True, namespace=defaults.ROOK_CLUSTER_NAMESPACE,
     node_name=None, pod_dict_path=None, sa_name=None, dc_deployment=False,
-    raw_block_pv=False
+    raw_block_pv=False, raw_block_device=constants.RAW_BLOCK_DEVICE
 ):
     """
     Create a pod
@@ -108,6 +108,7 @@ def create_pod(
         sa_name (str): Serviceaccount name
         dc_deployment (bool): True if creating pod as deploymentconfig
         raw_block_pv (bool): True for creating raw block pv based pod, False otherwise
+        raw_block_device (str): raw block device for the pod
     Returns:
         Pod: A Pod instance
 
@@ -141,8 +142,9 @@ def create_pod(
             pod_data['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] = pvc_name
 
     if interface_type == constants.CEPHBLOCKPOOL and raw_block_pv:
-        pod_data['spec']['containers'][0]['volumeDevices'][0]['devicePath'] = '/dev/block'
-        pod_data['spec']['containers'][0]['volumeDevices'][0]['name'] = pod_data['spec']['volumes'][0]['name']
+        pod_data['spec']['containers'][0]['volumeDevices'][0]['devicePath'] = raw_block_device
+        pod_data['spec']['containers'][0]['volumeDevices'][0]['name'] = pod_data.get('spec').get('volumes')[
+            0].get('name')
 
     if node_name:
         pod_data['spec']['nodeName'] = node_name

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -1,0 +1,167 @@
+import logging
+import random
+from concurrent.futures import ThreadPoolExecutor
+import pytest
+
+from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.ocs.exceptions import ResourceLeftoversException
+from ocs_ci.ocs import constants, defaults, ocp
+
+from tests.fixtures import (
+    create_ceph_block_pool,
+    create_rbd_secret,
+    create_project
+)
+from tests import helpers
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def resources(request):
+    """
+       Delete the resources created during the test
+       Returns:
+           tuple: empty lists of resources
+       """
+    pods, pvcs, storageclass, rp = ([] for _ in range(4))
+
+    def finalizer():
+        """
+            Delete the resources created during the test
+            """
+        failed_to_delete = []
+        for pod_list in pods:
+            for pod in pod_list:
+                log.info(pod.delete())
+                try:
+                    pod.ocp.wait_for_delete(pod.name)
+                except TimeoutError:
+                    failed_to_delete.append(pod)
+
+        for pvc in pvcs:
+            log.info(pvc.delete())
+            if rp[0] == 'Delete':
+                helpers.validate_pv_delete(pvc.backed_pv)
+            else:
+                ocp_pv_obj = ocp.OCP(
+                    kind=constants.PV,
+                    namespace=defaults.ROOK_CLUSTER_NAMESPACE
+                )
+                ocp_pv_obj.delete(resource_name=pvc.backed_pv)
+            try:
+                pvc.ocp.wait_for_delete(pvc.name)
+            except TimeoutError:
+                failed_to_delete.append(pvc)
+        for sc in storageclass:
+            log.info(sc.delete())
+            try:
+                sc.ocp.wait_for_delete(sc.name)
+            except TimeoutError:
+                failed_to_delete.append(sc)
+
+        if failed_to_delete:
+            raise ResourceLeftoversException(
+                f"Failed to delete resources: {failed_to_delete}"
+            )
+
+    request.addfinalizer(finalizer)
+
+    return pods, pvcs, storageclass, rp
+
+
+@tier1
+@pytest.mark.usefixtures(
+    create_project.__name__,
+    create_rbd_secret.__name__,
+    create_ceph_block_pool.__name__,
+)
+@pytest.mark.parametrize(
+    argnames=["reclaim_policy"],
+    argvalues=[
+        pytest.param(
+            *[constants.RECLAIM_POLICY_DELETE],
+            marks=pytest.mark.polarion_id("OCS-750")
+        ),
+        pytest.param(
+            *[constants.RECLAIM_POLICY_RETAIN],
+            marks=pytest.mark.polarion_id("OCS-751"))
+    ]
+)
+class TestRawBlockPV(ManageTest):
+
+    def test_raw_block_pv(self, reclaim_policy, resources):
+        """
+        Testing basic creation of app pod with RBD RWX raw block pv support
+        """
+        pods, pvcs, storageclass, rp = resources
+        rp.append(reclaim_policy)
+
+        storageclass.append(
+            helpers.create_storage_class(
+                interface_type=constants.CEPHBLOCKPOOL,
+                interface_name=self.cbp_obj.name,
+                secret_name=self.rbd_secret_obj.name,
+                reclaim_policy=reclaim_policy
+            )
+        )
+
+        pvc_mb = helpers.create_pvc(
+            sc_name=storageclass[0].name, size='500Mi',
+            access_mode=constants.ACCESS_MODE_RWX,
+            wait=True, namespace=self.namespace,
+            volume_mode='Block'
+        )
+
+        pvc_gb = helpers.create_pvc(
+            sc_name=storageclass[0].name, size='10Gi',
+            access_mode=constants.ACCESS_MODE_RWX,
+            wait=True, namespace=self.namespace,
+            volume_mode='Block'
+        )
+
+        pvc_tb = helpers.create_pvc(
+            sc_name=storageclass[0].name, size='1Ti',
+            access_mode=constants.ACCESS_MODE_RWX,
+            wait=True, namespace=self.namespace,
+            volume_mode='Block'
+        )
+
+        pvcs.extend([pvc_mb, pvc_gb, pvc_tb])
+        pvc_mb_pods = [(helpers.create_pod(
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_mb.name,
+            wait=True, namespace=self.namespace,
+            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
+        )) for _ in range(3)]
+
+        pvc_gb_pods = [(helpers.create_pod(
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_gb.name,
+            wait=True, namespace=self.namespace,
+            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
+        ))for _ in range(3)]
+
+        pvc_tb_pods = [(helpers.create_pod(
+            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_tb.name,
+            wait=True, namespace=self.namespace,
+            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
+        ))for _ in range(3)]
+
+        pods.extend([pvc_mb_pods, pvc_gb_pods, pvc_tb_pods])
+        storage_type = 'block'
+
+        with ThreadPoolExecutor() as p:
+            for pod in pvc_mb_pods:
+                logging.info(f'running io on pod {pod.name}')
+                p.submit(
+                    pod.run_io, storage_type=storage_type, size=f'{random.randint(10,200)}M',
+                )
+            for pod in pvc_gb_pods:
+                logging.info(f'running io on pod {pod.name}')
+                p.submit(
+                    pod.run_io, storage_type=storage_type, size=f'{random.randint(1,5)}G',
+                )
+            for pod in pvc_tb_pods:
+                logging.info(f'running io on pod {pod.name}')
+                p.submit(
+                    pod.run_io, storage_type=storage_type, size=f'{random.randint(10,15)}G',
+                )

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, bugzilla
 from ocs_ci.ocs import constants
 
 from tests.fixtures import (
@@ -57,7 +57,8 @@ class BaseRawBlockPV(ManageTest):
 
         for pvc in pvcs:
             helpers.wait_for_resource_state(
-                resource=pvc, state=constants.STATUS_BOUND)
+                resource=pvc, state=constants.STATUS_BOUND
+            )
 
         pvs = [pvc.backed_pv_obj for pvc in pvcs]
 
@@ -69,7 +70,9 @@ class BaseRawBlockPV(ManageTest):
             raw_block_pv=True,
             pod_dict_path=pod_dict,
             node_name=random.choice(
-                worker_nodes))) for _ in range(3)
+                worker_nodes)
+        )
+        ) for _ in range(3)
         ]
 
         pvc_gb_pods = [(helpers.create_pod(
@@ -79,7 +82,9 @@ class BaseRawBlockPV(ManageTest):
             raw_block_pv=True,
             pod_dict_path=pod_dict,
             node_name=random.choice(
-                worker_nodes))) for _ in range(3)
+                worker_nodes)
+        )
+        ) for _ in range(3)
         ]
 
         pvc_tb_pods = [(helpers.create_pod(
@@ -89,7 +94,10 @@ class BaseRawBlockPV(ManageTest):
             raw_block_pv=True,
             pod_dict_path=pod_dict,
             node_name=random.choice(
-                worker_nodes))) for _ in range(3)
+                worker_nodes
+            )
+        )
+        ) for _ in range(3)
         ]
 
         def flatten(l):
@@ -140,6 +148,7 @@ class TestRawBlockPVRetain(BaseRawBlockPV):
         teardown_factory(pods)
 
 
+@bugzilla('1726266')
 @tier1
 @pytest.mark.polarion_id("OCS-751")
 @pytest.mark.usefixtures(

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -2,151 +2,103 @@ import logging
 import random
 from concurrent.futures import ThreadPoolExecutor
 import pytest
+from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 
 from ocs_ci.framework.testlib import tier1, ManageTest
-from ocs_ci.ocs.exceptions import ResourceLeftoversException
-from ocs_ci.ocs import constants, defaults, ocp
+from ocs_ci.ocs import constants
 
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret,
-    create_project
+    create_project,
+    create_rbd_storageclass
 )
 from tests import helpers
 
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def resources(request):
-    """
-       Delete the resources created during the test
-       Returns:
-           tuple: empty lists of resources
-       """
-    pods, pvcs, storageclass, rp = ([] for _ in range(4))
-
-    def finalizer():
-        """
-            Delete the resources created during the test
-            """
-        failed_to_delete = []
-        for pod_list in pods:
-            for pod in pod_list:
-                log.info(pod.delete())
-                try:
-                    pod.ocp.wait_for_delete(pod.name)
-                except TimeoutError:
-                    failed_to_delete.append(pod)
-
-        for pvc in pvcs:
-            log.info(pvc.delete())
-            if rp[0] == 'Delete':
-                helpers.validate_pv_delete(pvc.backed_pv)
-            else:
-                ocp_pv_obj = ocp.OCP(
-                    kind=constants.PV,
-                    namespace=defaults.ROOK_CLUSTER_NAMESPACE
-                )
-                ocp_pv_obj.delete(resource_name=pvc.backed_pv)
-            try:
-                pvc.ocp.wait_for_delete(pvc.name)
-            except TimeoutError:
-                failed_to_delete.append(pvc)
-        for sc in storageclass:
-            log.info(sc.delete())
-            try:
-                sc.ocp.wait_for_delete(sc.name)
-            except TimeoutError:
-                failed_to_delete.append(sc)
-
-        if failed_to_delete:
-            raise ResourceLeftoversException(
-                f"Failed to delete resources: {failed_to_delete}"
-            )
-
-    request.addfinalizer(finalizer)
-
-    return pods, pvcs, storageclass, rp
-
-
 @tier1
 @pytest.mark.usefixtures(
     create_project.__name__,
-    create_rbd_secret.__name__,
-    create_ceph_block_pool.__name__,
 )
-@pytest.mark.parametrize(
-    argnames=["reclaim_policy"],
-    argvalues=[
-        pytest.param(
-            *[constants.RECLAIM_POLICY_DELETE],
-            marks=pytest.mark.polarion_id("OCS-750")
-        ),
-        pytest.param(
-            *[constants.RECLAIM_POLICY_RETAIN],
-            marks=pytest.mark.polarion_id("OCS-751"))
-    ]
-)
-class TestRawBlockPV(ManageTest):
+class BaseRawBlockPV(ManageTest):
+    """
+    Base class for creating pvc,pods and run IOs
+    """
 
-    def test_raw_block_pv(self, reclaim_policy, resources):
+    def raw_block_pv(self):
         """
         Testing basic creation of app pod with RBD RWX raw block pv support
         """
-        pods, pvcs, storageclass, rp = resources
-        rp.append(reclaim_policy)
-
-        storageclass.append(
-            helpers.create_storage_class(
-                interface_type=constants.CEPHBLOCKPOOL,
-                interface_name=self.cbp_obj.name,
-                secret_name=self.rbd_secret_obj.name,
-                reclaim_policy=reclaim_policy
-            )
-        )
-
+        worker_nodes = helpers.get_worker_nodes()
         pvc_mb = helpers.create_pvc(
-            sc_name=storageclass[0].name, size='500Mi',
+            sc_name=self.sc_obj.name, size='500Mi',
             access_mode=constants.ACCESS_MODE_RWX,
-            wait=True, namespace=self.namespace,
+            namespace=self.namespace,
             volume_mode='Block'
         )
 
         pvc_gb = helpers.create_pvc(
-            sc_name=storageclass[0].name, size='10Gi',
+            sc_name=self.sc_obj.name, size='10Gi',
             access_mode=constants.ACCESS_MODE_RWX,
-            wait=True, namespace=self.namespace,
+            namespace=self.namespace,
             volume_mode='Block'
         )
 
         pvc_tb = helpers.create_pvc(
-            sc_name=storageclass[0].name, size='1Ti',
+            sc_name=self.sc_obj.name, size='1Ti',
             access_mode=constants.ACCESS_MODE_RWX,
-            wait=True, namespace=self.namespace,
+            namespace=self.namespace,
             volume_mode='Block'
         )
 
-        pvcs.extend([pvc_mb, pvc_gb, pvc_tb])
+        pvcs = [pvc_mb, pvc_gb, pvc_tb]
+
+        for pvc in pvcs:
+            helpers.wait_for_resource_state(
+                resource=pvc, state=constants.STATUS_BOUND)
+
+        pvs = [pvc.backed_pv_obj for pvc in pvcs]
+
+        pod_dict = constants.CSI_RBD_RAW_BLOCK_POD_YAML
         pvc_mb_pods = [(helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_mb.name,
-            wait=True, namespace=self.namespace,
-            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
-        )) for _ in range(3)]
+            interface_type=constants.CEPHBLOCKPOOL,
+            pvc_name=pvc_mb.name,
+            namespace=self.namespace,
+            raw_block_pv=True,
+            pod_dict_path=pod_dict,
+            node_name=random.choice(
+                worker_nodes))) for _ in range(3)
+        ]
 
         pvc_gb_pods = [(helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_gb.name,
-            wait=True, namespace=self.namespace,
-            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
-        ))for _ in range(3)]
+            interface_type=constants.CEPHBLOCKPOOL,
+            pvc_name=pvc_gb.name,
+            namespace=self.namespace,
+            raw_block_pv=True,
+            pod_dict_path=pod_dict,
+            node_name=random.choice(
+                worker_nodes))) for _ in range(3)
+        ]
 
         pvc_tb_pods = [(helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_tb.name,
-            wait=True, namespace=self.namespace,
-            pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML
-        ))for _ in range(3)]
+            interface_type=constants.CEPHBLOCKPOOL,
+            pvc_name=pvc_tb.name,
+            namespace=self.namespace,
+            raw_block_pv=True,
+            pod_dict_path=pod_dict,
+            node_name=random.choice(
+                worker_nodes))) for _ in range(3)
+        ]
 
-        pods.extend([pvc_mb_pods, pvc_gb_pods, pvc_tb_pods])
+        def flatten(l):
+            return [item for sublist in l for item in sublist]
+        pods = [pvc_mb_pods, pvc_gb_pods, pvc_tb_pods]
+        pods = flatten(pods)
+        for pod in pods:
+            helpers.wait_for_resource_state(
+                resource=pod, state=constants.STATUS_RUNNING, timeout=120)
         storage_type = 'block'
 
         with ThreadPoolExecutor() as p:
@@ -165,3 +117,40 @@ class TestRawBlockPV(ManageTest):
                 p.submit(
                     pod.run_io, storage_type=storage_type, size=f'{random.randint(10,15)}G',
                 )
+
+        for pod in pods:
+            get_fio_rw_iops(pod)
+        return pods, pvcs, pvs
+
+
+@tier1
+@pytest.mark.polarion_id("OCS-750")
+@pytest.mark.usefixtures(
+    create_rbd_secret.__name__,
+    create_ceph_block_pool.__name__,
+    create_rbd_storageclass.__name__,
+)
+class TestRawBlockPVRetain(BaseRawBlockPV):
+    reclaim_policy = constants.RECLAIM_POLICY_RETAIN
+
+    def test_raw_block_pv(self, teardown_factory):
+        pods, pvcs, pvs = self.raw_block_pv()
+        teardown_factory(pvs)
+        teardown_factory(pvcs)
+        teardown_factory(pods)
+
+
+@tier1
+@pytest.mark.polarion_id("OCS-751")
+@pytest.mark.usefixtures(
+    create_rbd_secret.__name__,
+    create_ceph_block_pool.__name__,
+    create_rbd_storageclass.__name__,
+)
+class TestRawBlockPVDelete(BaseRawBlockPV):
+    reclaim_policy = constants.RECLAIM_POLICY_DELETE
+
+    def test_raw_block_pv(self, teardown_factory):
+        pods, pvcs, _ = self.raw_block_pv()
+        teardown_factory(pvcs)
+        teardown_factory(pods)


### PR DESCRIPTION
tests/manage/pv_services/test_raw_block_pv.py
Testing basics of RBD RWX raw block pv feature

ocs_ci/ocs/constants.py
Added pod template for rbd raw block pv

tests/helpers.py
Added parameter volume_mode to create_pvc() for creating raw block pv
Modified number of retries of function validate_pv_delete() due to bz1726266

ocs_ci/ocs/resources/pod.py
For block IOs, added path of block device