### PR TITLE
Basic node maintenance tests

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -219,4 +219,4 @@ INSTANCE_SHUTTING_DOWN = 32
 # Node statuses
 NODE_READY = 'Ready'
 NODE_NOT_READY = 'NotReady'
-NODE_SCHEDULING_DISABLED = 'SchedulingDisabled'
+NODE_READY_SCHEDULING_DISABLED = 'Ready,SchedulingDisabled'

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -35,7 +35,7 @@ def get_node_objs(node_names=None):
 
 def get_typed_nodes(node_type='worker', num_of_nodes=None):
     """
-    Get cluster nodes according to the node type (e.g. worker, master) and the
+    Get cluster's nodes according to the node type (e.g. worker, master) and the
     number of requested nodes from that type
 
     Args:
@@ -144,6 +144,5 @@ def maintenance_nodes(node_names):
 
     """
     unschedule_nodes(node_names)
-    from ipdb import set_trace; set_trace()
     log.info(f'Moving nodes {node_names} to maintenance')
     drain_nodes(node_names)

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -69,6 +69,10 @@ def wait_for_nodes_status(node_names=None, status=constants.NODE_READY, timeout=
         timeout (int): The number in seconds to wait for the nodes to reach
             the status
 
+    Raises:
+        ResourceWrongStatusException: In case one or more nodes haven't
+            reached the desired state
+
     """
     if not node_names:
         node_names = [node.name for node in get_node_objs()]

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -57,7 +57,7 @@ def get_typed_nodes(node_type='worker', num_of_nodes=None):
     return typed_nodes
 
 
-def wait_for_nodes_status(node_names=None, status=constants.NODE_READY, timeout=120):
+def wait_for_nodes_status(node_names=None, status=constants.NODE_READY, timeout=180):
     """
     Wait until all nodes are in the given status
 

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -440,8 +440,8 @@ def get_instances_ids_and_names(instances):
 
     """
     return {
-        'i-' + instance.get('spec').get('providerID').partition('i-')[-1]:
-        instance.get('metadata').get('name') for instance in instances
+        'i-' + instance.get().get('spec').get('providerID').partition('i-')[-1]:
+        instance.get().get('metadata').get('name') for instance in instances
     }
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -67,8 +67,10 @@ def wait_for_resource_state(resource, state, timeout=60):
         state (str): The status to wait for
         timeout (int): Time in seconds to wait
 
-    Returns:
-        bool: True if resource reached the desired state, False otherwise
+    Raises:
+        ResourceWrongStatusException: In case the resource hasn't
+            reached the desired state
+
     """
     try:
         resource.ocp.wait_for_resource(

--- a/tests/manage/cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/cluster/nodes/test_nodes_maintenance.py
@@ -30,8 +30,8 @@ def schedule_nodes(request):
 @bugzilla('1734162')
 class TestNodesMaintenance(ManageTest):
     """
-    Test basic flow of maintenance and activate operations,
-    followed by cluster functionality and health checks
+    Test basic flows of maintenance (unschedule and drain) and
+    activate operations, followed by cluster functionality and health checks
 
     """
     @tier1
@@ -47,7 +47,7 @@ class TestNodesMaintenance(ManageTest):
         OCS-1269/OCS-1272:
         - Maintenance (mark as unscheduable and drain) 1 worker/master node
         - Check cluster functionality by creating resources
-        (pools, storageclasses, PVCs, pods - both CephFS and RBD)
+          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
         - Mark the node as scheduable
         - Check cluster and Ceph health
 
@@ -84,9 +84,9 @@ class TestNodesMaintenance(ManageTest):
         OCS-1273/OCs-1271:
         - Maintenance (mark as unscheduable and drain) 2 worker/master nodes
         - Mark the nodes as scheduable
-        (pools, storageclasses, PVCs, pods - both CephFS and RBD)
         - Check cluster and Ceph health
         - Check cluster functionality by creating resources
+          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
 
         """
         # Get 2 nodes
@@ -109,19 +109,14 @@ class TestNodesMaintenance(ManageTest):
         sanity_helpers.delete_resources(resources)
 
     @tier2
-    @pytest.mark.parametrize(
-        argnames=["node_type"],
-        argvalues=[
-            pytest.param(*[['worker', 'master']], marks=pytest.mark.polarion_id("OCS-1274")),
-        ]
-    )
-    def test_2_nodes_different_types(self, resources, schedule_nodes, node_types):
+    @pytest.mark.polarion_id("OCS-1274")
+    def test_2_nodes_different_types(self, resources, schedule_nodes):
         """
         OCS-1274:
         - Maintenance (mark as unscheduable and drain) 1 worker node and 1
-        master node
+          master node
         - Check cluster functionality by creating resources
-        (pools, storageclasses, PVCs, pods - both CephFS and RBD)
+          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
         - Mark the nodes as scheduable
         - Check cluster and Ceph health
 
@@ -130,7 +125,7 @@ class TestNodesMaintenance(ManageTest):
         nodes = [
             node.get_typed_nodes(
                 node_type=node_type, num_of_nodes=1
-            )[0] for node_type in node_types
+            )[0] for node_type in ['worker', 'master']
         ]
 
         node_names = [typed_node.name for typed_node in nodes]

--- a/tests/manage/cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/cluster/nodes/test_nodes_maintenance.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.ocs import constants
-from ocs_ci.ocs import node
+from ocs_ci.ocs import constants, node
 from ocs_ci.framework.testlib import tier1, ManageTest, bugzilla
 
 from tests import sanity_helpers
@@ -11,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
-def activate_nodes(request):
+def schedule_nodes(request):
     """
-    Activate all cluster nodes in case any of them are in
-    SchedulingDisabled status
+    Make sure that all cluster nodes are in Ready state and if not, change them back to
+    Ready state by marking them as scheduble
 
     """
     def finalizer():
@@ -37,7 +36,7 @@ class TestNodesMaintenance(ManageTest):
 
     """
     @pytest.mark.polarion_id("OCS-1269")
-    def test_worker_maintenance(self, resources, activate_nodes):
+    def test_worker_maintenance(self, resources, schedule_nodes):
         """
         Maintenance and activate 1 worker node and check
         cluster functionality and health
@@ -50,6 +49,9 @@ class TestNodesMaintenance(ManageTest):
         # Maintenance the worker node (unschedule and drain)
         node.maintenance_nodes([worker_node_name])
 
+        # Check basic cluster functionality by creating resources
+        # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
+        # run IO and delete the resources
         sanity_helpers.create_resources(resources)
         sanity_helpers.delete_resources(resources)
 

--- a/tests/manage/cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/cluster/nodes/test_nodes_maintenance.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture()
 def schedule_nodes(request):
     """
-    Make sure that all cluster's nodes are in Ready state and if not,
+    Make sure that all cluster's nodes are in 'Ready' state and if not,
     change them back to 'Ready' state by marking them as scheduble
 
     """

--- a/tests/manage/cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/cluster/nodes/test_nodes_maintenance.py
@@ -1,0 +1,60 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs import node
+from ocs_ci.framework.testlib import tier1, ManageTest, bugzilla
+
+from tests import sanity_helpers
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def activate_nodes(request):
+    """
+    Activate all cluster nodes in case any of them are in
+    SchedulingDisabled status
+
+    """
+    def finalizer():
+        scheduling_disabled_nodes = [
+            n.name for n in node.get_node_objs() if n.ocp.get_resource_status(
+                n.name
+            ) == constants.NODE_READY_SCHEDULING_DISABLED
+        ]
+        if scheduling_disabled_nodes:
+            node.schedule_nodes(scheduling_disabled_nodes)
+    request.addfinalizer(finalizer)
+
+
+@tier1
+@bugzilla('1734162')
+class TestNodesMaintenance(ManageTest):
+    """
+    Test basic flow of maintenance and activate operations,
+    followed by cluster functionality and health checks
+
+    """
+    @pytest.mark.polarion_id("OCS-1269")
+    def test_worker_maintenance(self, resources, activate_nodes):
+        """
+        Maintenance and activate 1 worker node and check
+        cluster functionality and health
+
+        """
+        # Get 1 worker node
+        worker_nodes = node.get_typed_nodes(node_type='worker', num_of_nodes=1)
+        worker_node_name = worker_nodes[0].name
+
+        # Maintenance the worker node (unschedule and drain)
+        node.maintenance_nodes([worker_node_name])
+
+        sanity_helpers.create_resources(resources)
+        sanity_helpers.delete_resources(resources)
+
+        # Mark the worker node back to schedulable
+        node.schedule_nodes([worker_node_name])
+
+        # Perform cluster and Ceph health checks
+        sanity_helpers.health_check([worker_node_name])

--- a/tests/manage/cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/cluster/nodes/test_nodes_maintenance.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 @pytest.fixture()
 def schedule_nodes(request):
     """
-    Make sure that all cluster nodes are in Ready state and if not, change them back to
-    Ready state by marking them as scheduble
+    Make sure that all cluster's nodes are in Ready state and if not,
+    change them back to 'Ready' state by marking them as scheduble
 
     """
     def finalizer():

--- a/tests/sanity_helpers.py
+++ b/tests/sanity_helpers.py
@@ -15,9 +15,7 @@ def health_check(nodes):
     """
     Perform Ceph and cluster health checks
     """
-    assert node.wait_for_nodes_status(nodes), (
-        f"Not all nodes reached status {constants.NODE_READY}"
-    )
+    node.wait_for_nodes_status(nodes)
     ceph_cluster = CephCluster()
     assert ceph_health_check(
         namespace=config.ENV_DATA['cluster_namespace']


### PR DESCRIPTION
- OCS-1269, OCS-1272 -  Maintenance (unschedule and drain) 1 worker/master node and check cluster functionality, then mark the node as scheduble and check cluster and Ceph health

- OCS-1273, OCS-1271 - Maintenance (unschedule and drain), mark as scheduble 2 worker/master nodes and check cluster functionality and health

- OCS-1274 - Maintenance (unschedule and drain) 1 worker+master nodes and check cluster functionality, then mark the nodes as scheduble and check cluster and Ceph health


Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>