### PR TITLE
Jenkins: Don't write AWS creds to disk

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import base64
 import binascii
 import os
@@ -6,6 +7,26 @@ import yaml
 
 from os import environ as env
 from configparser import ConfigParser
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--skip-aws',
+        dest='aws',
+        action='store_false',
+    )
+    parser.add_argument(
+        '--skip-pull-secret',
+        dest='pull_secret',
+        action='store_false',
+    )
+    parser.add_argument(
+        '--skip-ocsci-conf',
+        dest='ocsci_conf',
+        action='store_false',
+    )
+    return parser.parse_args()
 
 
 def write_aws_creds():
@@ -91,6 +112,10 @@ def write_ocsci_conf():
 
 
 if __name__ == "__main__":
-    write_aws_creds()
-    write_pull_secret()
-    write_ocsci_conf()
+    args = parse_args()
+    if args.aws:
+        write_aws_creds()
+    if args.pull_secret:
+        write_pull_secret()
+    if args.ocsci_conf:
+        write_ocsci_conf()

--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -89,7 +89,16 @@ def get_ocsci_conf():
         ),
     )
     # Apply image configuration if present
-    for image_type in ['rook', 'ceph']:
+    image_types = [
+        'rook',
+        'ceph',
+        'ceph_csi',
+        'rook_csi_registrar',
+        'rook_csi_provisioner',
+        'rook_csi_snapshotter',
+        'rook_csi_attacher',
+    ]
+    for image_type in image_types:
         image_key = f"{image_type}_image"
         image_value = env.get(image_key.upper())
         if image_value is not None:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 // This Jenkinsfile is intended to be used with a companion jenkins-job-builder
 // definition. It requires the following parameters:
 //   AWS_DOMAIN
-//   AWS_PROFILE
 //   AWS_REGION
 //   CLUSTER_USER
 // It also requires credentials with these IDs to be present in the CI system:
@@ -18,6 +17,9 @@ pipeline {
   environment {
     AWS_SHARED_CREDENTIALS_FILE = "${env.WORKSPACE}/.aws/credentials"
     AWS_CONFIG_FILE = "${env.WORKSPACE}/.aws/config"
+    AWS_ACCESS_KEY_ID = credentials('openshift-dev-aws-access-key-id')
+    AWS_SECRET_ACCESS_KEY = credentials('openshift-dev-aws-secret-access-key')
+    PULL_SECRET = credentials('openshift-pull-secret')
   }
   stages {
     stage("Setup") {
@@ -34,18 +36,8 @@ pipeline {
           pip3 install tox
           pip3 install -r requirements.txt
           python3 setup.py develop
+          python3 ./.functional_ci_setup.py --skip-aws
           """
-        withCredentials(
-          [
-            string(credentialsId: 'openshift-dev-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
-            string(credentialsId: 'openshift-dev-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
-            string(credentialsId: 'openshift-pull-secret', variable: 'PULL_SECRET')
-          ]) {
-            sh '''
-              source ./venv/bin/activate
-              python3 ./.functional_ci_setup.py
-            '''
-          }
       }
     }
     stage("Lint") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,8 @@ pipeline {
             sudo yum install -y /usr/sbin/postfix
             sudo systemctl start postfix
           fi
+          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
           python3 -V
           pip3 install --user virtualenv
           python3 -m virtualenv venv


### PR DESCRIPTION
There's much less of a risk of exposing credentials via the workspace if we just never write them to disk.