### PR TITLE
update pvc_factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,9 @@ def pvc_factory(
     PVC. For custom PVC provide 'storageclass' parameter.
     """
     instances = []
+    active_project = None
+    active_rbd_storageclass = None
+    active_cephfs_storageclass = None
 
     def factory(
         interface=constants.CEPHBLOCKPOOL,
@@ -263,8 +266,20 @@ def pvc_factory(
             pvc_obj = PVC(**custom_data)
             pvc_obj.create(do_reload=False)
         else:
-            project = project or project_factory()
-            storageclass = storageclass or storageclass_factory(interface)
+            nonlocal active_project
+            nonlocal active_rbd_storageclass
+            nonlocal active_cephfs_storageclass
+
+            project = project or active_project or project_factory()
+            active_project = project
+            if interface == constants.CEPHBLOCKPOOL:
+                storageclass = storageclass or active_rbd_storageclass \
+                    or storageclass_factory(interface)
+                active_rbd_storageclass = storageclass
+            elif interface == constants.CEPHFILESYSTEM:
+                storageclass = storageclass or active_cephfs_storageclass \
+                    or storageclass_factory(interface)
+                active_cephfs_storageclass = storageclass
             pvc_size = f"{size}Gi" if size else None
 
             pvc_obj = helpers.create_pvc(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,14 +274,14 @@ def pvc_factory(
             active_project = project
             if interface == constants.CEPHBLOCKPOOL:
                 storageclass = (
-                    storageclass or active_rbd_storageclass or
-                    storageclass_factory(interface)
+                    storageclass or active_rbd_storageclass
+                    or storageclass_factory(interface)
                 )
                 active_rbd_storageclass = storageclass
             elif interface == constants.CEPHFILESYSTEM:
                 storageclass = (
-                    storageclass or active_cephfs_storageclass or
-                    storageclass_factory(interface)
+                    storageclass or active_cephfs_storageclass
+                    or storageclass_factory(interface)
                 )
                 active_cephfs_storageclass = storageclass
             pvc_size = f"{size}Gi" if size else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,12 +273,16 @@ def pvc_factory(
             project = project or active_project or project_factory()
             active_project = project
             if interface == constants.CEPHBLOCKPOOL:
-                storageclass = storageclass or active_rbd_storageclass \
-                    or storageclass_factory(interface)
+                storageclass = (
+                    storageclass or active_rbd_storageclass or
+                    storageclass_factory(interface)
+                )
                 active_rbd_storageclass = storageclass
             elif interface == constants.CEPHFILESYSTEM:
-                storageclass = storageclass or active_cephfs_storageclass \
-                    or storageclass_factory(interface)
+                storageclass = (
+                    storageclass or active_cephfs_storageclass or
+                    storageclass_factory(interface)
+                )
                 active_cephfs_storageclass = storageclass
             pvc_size = f"{size}Gi" if size else None
 


### PR DESCRIPTION
Store reference for last project and storageclass. If there is not provided custom project or storageclass and there is already created project or storageclass from previous calling of factory function then it can be reused.

Signed-off-by: Filip Balak <fbalak@redhat.com>