### PR TITLE
make sure newlines are preserved in OCP.get()

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -106,7 +106,7 @@ class OCP(object):
             command += f"--selector={selector}"
         if out_yaml_format:
             command += " -o yaml"
-        return self.exec_oc_cmd(command)
+        return self.exec_oc_cmd(command, out_yaml_format)
 
     def describe(self, resource_name='', selector=None, all_namespaces=False):
         """


### PR DESCRIPTION
fixes https://github.com/red-hat-storage/ocs-ci/issues/612

Signed-off-by: Martin Bukatovič <mbukatov@redhat.com>