### PR TITLE
Removing print() and using logger.info() in test_pod_exec.py

### DIFF
--- a/tests/libtest/test_pod_exec.py
+++ b/tests/libtest/test_pod_exec.py
@@ -1,8 +1,11 @@
 import os
+import logging
 os.sys.path.append(os.path.dirname(os.getcwd()))
 
 from ocs_ci.framework.testlib import libtest
 from ocs_ci.ocs.resources import pod
+
+logger = logging.getLogger(__name__)
 
 
 @libtest
@@ -12,7 +15,7 @@ def test_main():
 
     out, err, ret = tools_pod.exec_ceph_cmd(ceph_cmd=cmd)
     if out:
-        print(out)
+        logger.info(out)
     if err:
-        print(err)
-    print(ret)
+        logger.error(err)
+    logger.info(ret)

--- a/tests/libtest/test_pod_exec.py
+++ b/tests/libtest/test_pod_exec.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 @libtest
-def test_main():
+def test_pod_exec():
     tools_pod = pod.get_ceph_tools_pod()
     cmd = "ceph osd df"
 


### PR DESCRIPTION
It's not good to have print() statements in a testcase hence changing print() to logger.info() instead.