### PR TITLE
PGSQL workload: updated review comments

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -158,6 +158,11 @@ PGSQL_CONFIGMAP_YAML = os.path.join(
 PGSQL_STATEFULSET_YAML = os.path.join(
     TEMPLATE_PGSQL_SERVER_DIR, "StatefulSet.yaml"
 )
+
+PGSQL_BENCHMARK_YAML = os.path.join(
+    TEMPLATE_PGSQL_DIR, "PGSQL_Benchmark.yaml"
+)
+
 NGINX_POD_YAML = os.path.join(
     TEMPLATE_APP_POD_DIR, "nginx.yaml"
 )

--- a/ocs_ci/templates/workloads/pgsql/PGSQL_Benchmark.yaml
+++ b/ocs_ci/templates/workloads/pgsql/PGSQL_Benchmark.yaml
@@ -1,0 +1,23 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: pgbench-benchmark
+  namespace: my-ripsaw
+spec:
+  workload:
+    name: "pgbench"
+    args:
+      timeout: 5
+      clients:
+        - 20
+      threads: 2
+      transactions: 100
+      cmd_flags: ''
+      init_cmd_flags: ''
+      scaling_factor: 2
+      samples: 5
+      databases:
+        - host: postgres-0.postgres # assuming that postgres was deployed in same namespace as ripsaw i.e. my-ripsaw
+          user: test # Following the values from the configmap
+          password: test
+          db_name: testdb

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -59,9 +59,9 @@ class TestPgSQLWorkload(E2ETest):
         )
         ripsaw.setup_postgresql()
         run_cmd(
-            f'bin/oc wait --for condition=ready pod '
-            f'-l app=postgres '
-            f'--timeout=120s'
+            'bin/oc wait --for condition=ready pod '
+            '-l app=postgres '
+            '--timeout=120s'
         )
 
         # Create pgbench benchmark
@@ -79,19 +79,19 @@ class TestPgSQLWorkload(E2ETest):
         time.sleep(wait_time)
 
         pgbench_pod = run_cmd(
-            f'bin/oc get pods -l '
-            f'app=pgbench-client -o name'
+            'bin/oc get pods -l '
+            'app=pgbench-client -o name'
         )
         pgbench_pod = pgbench_pod.split('/')[1]
         run_cmd(
-            f'bin/oc wait --for condition=Initialized '
+            'bin/oc wait --for condition=Initialized '
             f'pods/{pgbench_pod} '
-            f'--timeout=60s'
+            '--timeout=60s'
         )
         run_cmd(
-            f'bin/oc wait --for condition=Complete jobs '
-            f'-l app=pgbench-client '
-            f'--timeout=300s'
+            'bin/oc wait --for condition=Complete jobs '
+            '-l app=pgbench-client '
+            '--timeout=300s'
         )
 
         # Running pgbench and parsing logs

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -52,7 +52,7 @@ class TestPgSQLWorkload(E2ETest):
         This is a basic pgsql workload
         """
         # Deployment postgres
-        log.info(f"Deploying postgres database")
+        log.info("Deploying postgres database")
         ripsaw.apply_crd(
             'resources/crds/'
             'ripsaw_v1alpha1_ripsaw_crd.yaml'
@@ -65,13 +65,13 @@ class TestPgSQLWorkload(E2ETest):
         )
 
         # Create pgbench benchmark
-        log.info(f"Create resource file for pgbench workload")
+        log.info("Create resource file for pgbench workload")
         pg_data = templating.load_yaml_to_dict(constants.PGSQL_BENCHMARK_YAML)
         pg_obj = OCS(**pg_data)
         pg_obj.create()
         # Wait for pgbench pod to be created
         log.info(
-            f"waiting for pgbench benchmark to create, "
+            "waiting for pgbench benchmark to create, "
             f"PGbench pod name: {pg_obj.name} "
         )
         wait_time = 30
@@ -98,18 +98,18 @@ class TestPgSQLWorkload(E2ETest):
         output = run_cmd(f'bin/oc logs {pgbench_pod}')
         pg_output = utils.parse_pgsql_logs(output)
         log.info(
-            f"*******PGBench output log*********\n"
+            "*******PGBench output log*********\n"
             f"{pg_output}"
         )
-        for d in pg_output:
-            latency_avg = d['latency_avg']
+        for data in pg_output:
+            latency_avg = data['latency_avg']
             if not latency_avg:
                 raise UnexpectedBehaviour(
-                    f"PGBench failed to run, "
-                    f"no data found on latency_avg"
+                    "PGBench failed to run, "
+                    "no data found on latency_avg"
                 )
-        log.info(f"PGBench has completed successfully")
+        log.info("PGBench has completed successfully")
 
         # Clean up pgbench benchmark
-        log.info(f"Deleting PG bench benchmark:")
+        log.info("Deleting PG bench benchmark:")
         pg_obj.delete()

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -1,0 +1,115 @@
+"""
+Module to perform PGSQL workload
+"""
+import logging
+import pytest
+import time
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.utility import templating, utils
+from ocs_ci.utility.utils import run_cmd
+from ocs_ci.ocs.ripsaw import RipSaw
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import E2ETest, tier1
+from tests import helpers
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='class')
+def ripsaw(request):
+    # Create Secret and Pool
+    secret = helpers.create_secret(constants.CEPHBLOCKPOOL)
+    pool = helpers.create_ceph_block_pool()
+
+    # Create storage class
+    log.info("Creating a Storage Class")
+    sc = helpers.create_storage_class(
+        sc_name='pgsql-workload',
+        interface_type=constants.CEPHBLOCKPOOL,
+        secret_name=secret.name,
+        interface_name=pool.name
+    )
+    # Create RipSaw Operator
+    ripsaw = RipSaw()
+
+    def teardown():
+        ripsaw.cleanup()
+        sc.delete()
+        secret.delete()
+        pool.delete()
+    request.addfinalizer(teardown)
+    return ripsaw
+
+
+@tier1
+class TestPgSQLWorkload(E2ETest):
+    """
+    Deploy an PGSQL workload using operator
+    """
+    def test_sql_workload_simple(self, ripsaw):
+        """
+        This is a basic pgsql workload
+        """
+        # Deployment postgres
+        log.info(f"Deploying postgres database")
+        ripsaw.apply_crd(
+            'resources/crds/'
+            'ripsaw_v1alpha1_ripsaw_crd.yaml'
+        )
+        ripsaw.setup_postgresql()
+        run_cmd(
+            f'bin/oc wait --for condition=ready pod '
+            f'-l app=postgres '
+            f'--timeout=120s'
+        )
+
+        # Create pgbench benchmark
+        log.info(f"Create resource file for pgbench workload")
+        pg_data = templating.load_yaml_to_dict(constants.PGSQL_BENCHMARK_YAML)
+        pg_obj = OCS(**pg_data)
+        pg_obj.create()
+        # Wait for pgbench pod to be created
+        log.info(
+            f"waiting for pgbench benchmark to create, "
+            f"PGbench pod name: {pg_obj.name} "
+        )
+        wait_time = 30
+        log.info(f"Waiting {wait_time} seconds...")
+        time.sleep(wait_time)
+
+        pgbench_pod = run_cmd(
+            f'bin/oc get pods -l '
+            f'app=pgbench-client -o name'
+        )
+        pgbench_pod = pgbench_pod.split('/')[1]
+        run_cmd(
+            f'bin/oc wait --for condition=Initialized '
+            f'pods/{pgbench_pod} '
+            f'--timeout=60s'
+        )
+        run_cmd(
+            f'bin/oc wait --for condition=Complete jobs '
+            f'-l app=pgbench-client '
+            f'--timeout=300s'
+        )
+
+        # Running pgbench and parsing logs
+        output = run_cmd(f'bin/oc logs {pgbench_pod}')
+        pg_output = utils.parse_pgsql_logs(output)
+        log.info(
+            f"*******PGBench output log*********\n"
+            f"{pg_output}"
+        )
+        for d in pg_output:
+            latency_avg = d['latency_avg']
+            if not latency_avg:
+                raise UnexpectedBehaviour(
+                    f"PGBench failed to run, "
+                    f"no data found on latency_avg"
+                )
+        log.info(f"PGBench has completed successfully")
+
+        # Clean up pgbench benchmark
+        log.info(f"Deleting PG bench benchmark:")
+        pg_obj.delete()


### PR DESCRIPTION
Signed-off-by: Tiffany Nguyen <tunguyen@redhat.com>
Test run log:
```
Collecting Cluster versions
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/tunguyen/OCS/pgsql-pr/ocs-ci, inifile: pytest.ini
plugins: marker-bugzilla-0.9.1.dev2, reportportal-1.0.5, html-1.22.0, logger-0.5.1, metadata-1.8.0
collected 1 item                                                                                                                                              

tests/e2e/test_pgsql.py::TestPgSQLWorkload::test_sql_workload_simple 
----------------------------------------------------------------------- live log setup ------------------------------------------------------------------------
15:02:57 - MainThread - tests.conftest - INFO - All logs located at /tmp/ocs-ci-logs-1566424966
15:02:57 - MainThread - ocs_ci.deployment.factory - INFO - Deployment key = aws_ipi
15:02:57 - MainThread - ocs_ci.deployment.factory - INFO - Current deployment platform: AWS,deployment type: ipi
15:02:57 - MainThread - ocs_ci.utility.utils - INFO - Downloading openshift client (4.2.0-0.nightly-2019-08-21-163601).
15:03:04 - MainThread - ocs_ci.utility.utils - INFO - Executing command: tar xzvf openshift-client.tar.gz oc kubectl
15:03:05 - MainThread - ocs_ci.utility.utils - WARNING - Command warning:: x oc
                                                         x kubectl
15:03:05 - MainThread - ocs_ci.utility.utils - INFO - Executing command: ./bin/oc version
15:03:06 - MainThread - ocs_ci.utility.utils - INFO - OpenShift Client version: Client Version: version.Info{Major:"4", Minor:"2+", GitVersion:"v4.2.0-201908071853+7b9a22b-dirty", GitCommit:"7b9a22b", GitTreeState:"dirty", BuildDate:"2019-08-07T23:34:07Z", GoVersion:"go1.12.6", Compiler:"gc", Platform:"darwin/amd64"}
                                                      Server Version: version.Info{Major:"1", Minor:"14+", GitVersion:"v1.14.0+40a2047", GitCommit:"40a2047", GitTreeState:"clean", BuildDate:"2019-08-18T20:32:27Z", GoVersion:"go1.12.6", Compiler:"gc", Platform:"linux/amd64"}
                                                      OpenShift Version: 4.2.0-0.nightly-2019-08-19-113631
15:03:06 - Dummy-1 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Pod -A -o yaml
15:03:06 - Dummy-2 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get StorageClass -A -o yaml
15:03:06 - Dummy-3 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephFileSystem -A -o yaml
15:03:06 - Dummy-4 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephBlockPool -A -o yaml
15:03:06 - Dummy-5 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get PersistentVolume -A -o yaml
15:03:06 - Dummy-6 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get PersistentVolumeClaim -A -o yaml
15:03:06 - Dummy-7 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Namespace -A -o yaml
15:03:18 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Pod --selector=app=rook-ceph-tools -o yaml
15:03:19 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig rsh rook-ceph-tools-5f5dc75fd5-qrm8j ceph auth get-key client.admin --format json-pretty
15:03:21 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Secret with name secret-test-rbd-129d3b9671604e38956202875ddb0a5d
15:03:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Secretg3ngc1ve -o yaml
15:03:22 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Secret secret-test-rbd-129d3b9671604e38956202875ddb0a5d -o yaml
15:03:22 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding CephBlockPool with name cbp-test-ac54738611bd4708bd3aa478cf4a46b1
15:03:22 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/CephBlockPoolm_pbo05_ -o yaml
15:03:23 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephBlockPool cbp-test-ac54738611bd4708bd3aa478cf4a46b1 -o yaml
15:03:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephBlockPool cbp-test-ac54738611bd4708bd3aa478cf4a46b1 -o yaml
15:03:24 - MainThread - tests.helpers - INFO - Verifying that block pool cbp-test-ac54738611bd4708bd3aa478cf4a46b1 exists
15:03:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Pod --selector=app=rook-ceph-tools -o yaml
15:03:25 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig rsh rook-ceph-tools-5f5dc75fd5-qrm8j ceph osd lspools --format json-pretty
15:03:27 - MainThread - tests.helpers - INFO - POOLS are [{'poolnum': 1, 'poolname': 'ocsci-cephfs-metadata'}, {'poolnum': 2, 'poolname': 'ocsci-cephfs-data0'}, {'poolnum': 4, 'poolname': 'cbp-test-7330d47a0aa04140ae8fd3f1d8794013'}, {'poolnum': 5, 'poolname': 'cbp-test-27a092fffd224bf4897180b803da69b8'}, {'poolnum': 41, 'poolname': 'cbp-test-ce260f5a3fcc41fa9585112eb50e0911'}, {'poolnum': 42, 'poolname': 'cbp-test-8bf76477f4e7403ea0367cb40f6a153a'}, {'poolnum': 55, 'poolname': 'cbp-test-94aa6777744d4dab84b7fa3efd661ecf'}, {'poolnum': 65, 'poolname': 'cbp-test-ac54738611bd4708bd3aa478cf4a46b1'}]
15:03:27 - MainThread - tests.e2e.test_pgsql - INFO - Creating a Storage Class
15:03:27 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding StorageClass with name pgsql-workload
15:03:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/StorageClassamhmo6c4 -o yaml
15:03:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get StorageClass pgsql-workload -o yaml
15:03:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc new-project my-ripsaw
15:03:29 - MainThread - ocs_ci.ocs.ripsaw - INFO - cloning ripsaw in /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/ripsaw_97mhe9bi
------------------------------------------------------------------------ live log call ------------------------------------------------------------------------
15:03:31 - MainThread - tests.e2e.test_pgsql - INFO - Deploying postgres database
15:03:37 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Service with name postgres
15:03:37 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Servicenfeag42x -o yaml
15:03:38 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Service postgres -o yaml
15:03:39 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding ConfigMap with name postgres-config
15:03:39 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/ConfigMapr7jmxizd -o yaml
15:03:39 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get ConfigMap postgres-config -o yaml
15:03:40 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding StatefulSet with name postgres
15:03:40 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/StatefulSetk8jsddcp -o yaml
15:03:40 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get StatefulSet postgres -o yaml
15:03:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod --selector=app=postgres -o yaml
15:03:42 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod postgres-0
15:03:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod --selector=app=postgres -o yaml
15:03:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod postgres-0
15:03:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod --selector=app=postgres -o yaml
15:03:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod postgres-0
15:03:54 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod --selector=app=postgres -o yaml
15:03:54 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get pod postgres-0
15:03:55 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc wait --for condition=ready pod -l app=postgres --timeout=120s
15:03:56 - MainThread - tests.e2e.test_pgsql - INFO - Create resource file for pgbench workload
15:03:56 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Benchmark with name pgbench-benchmark
15:03:56 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Benchmarkl0bpckgy -o yaml
15:03:57 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Benchmark pgbench-benchmark -o yaml
15:03:58 - MainThread - tests.e2e.test_pgsql - INFO - waiting for pgbench benchmark to create, PGbench pod name: pgbench-benchmark 
15:03:58 - MainThread - tests.e2e.test_pgsql - INFO - Waiting 30 seconds...
15:04:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc get pods -l app=pgbench-client -o name
15:04:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc wait --for condition=Initialized pods/pgbench-benchmark-pgbench-1-dbs-client-1-cv9vx
                                                       --timeout=60s
15:04:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc wait --for condition=Complete jobs -l app=pgbench-client --timeout=300s
15:05:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc logs pgbench-benchmark-pgbench-1-dbs-client-1-cv9vx
15:05:21 - MainThread - tests.e2e.test_pgsql - INFO - *******PGBench output log*********
                                                      [{'num_clients': '20', 'latency_avg': '90', 'lat_stddev': '79', 'tps_incl': '214', 'tps_excl': '214'}, {'num_clients': '20', 'latency_avg': '102', 'lat_stddev': '159', 'tps_incl': '188', 'tps_excl': '188'}, {'num_clients': '20', 'latency_avg': '94', 'lat_stddev': '80', 'tps_incl': '207', 'tps_excl': '207'}, {'num_clients': '20', 'latency_avg': '140', 'lat_stddev': '176', 'tps_incl': '139', 'tps_excl': '139'}, {'num_clients': '20', 'latency_avg': '87', 'lat_stddev': '76', 'tps_incl': '220', 'tps_excl': '220'}]
15:05:21 - MainThread - tests.e2e.test_pgsql - INFO - PGBench has completed successfully
15:05:21 - MainThread - tests.e2e.test_pgsql - INFO - Deleting PG bench benchmark:
15:05:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete Benchmark pgbench-benchmark
PASSED                                                                                                                                                  [100%]
---------------------------------------------------------------------- live log teardown ----------------------------------------------------------------------
15:05:25 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc delete project my-ripsaw
15:05:26 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete StatefulSet postgres
15:05:26 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete ConfigMap postgres-config
15:05:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete Service postgres
15:05:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:35 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:39 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:42 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:53 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:05:57 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:06:00 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:06:04 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:06:08 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get namespace my-ripsaw -o yaml
15:06:08 - MainThread - ocs_ci.ocs.ocp - INFO - namespace my-ripsaw got deleted successfully
15:06:08 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete StorageClass pgsql-workload
15:06:09 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete Secret secret-test-rbd-129d3b9671604e38956202875ddb0a5d
15:06:10 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig delete CephBlockPool cbp-test-ac54738611bd4708bd3aa478cf4a46b1
15:06:11 - Dummy-1 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Pod -A -o yaml
15:06:11 - Dummy-7 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get StorageClass -A -o yaml
15:06:11 - Dummy-6 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephFileSystem -A -o yaml
15:06:11 - Dummy-2 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get CephBlockPool -A -o yaml
15:06:11 - Dummy-4 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get PersistentVolume -A -o yaml
15:06:11 - Dummy-5 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get PersistentVolumeClaim -A -o yaml
15:06:11 - Dummy-3 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-ocs-cluster/auth/kubeconfig get Namespace -A -o yaml


================================================================= 1 passed in 204.12 seconds ==================================================================
```
