### PR TITLE
Add sc_name as option for storageclass_factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,8 @@ def storageclass_factory(
     def factory(
         interface=constants.CEPHBLOCKPOOL,
         secret=None,
-        custom_data=None
+        custom_data=None,
+        sc_name=None
     ):
         """
         Args:
@@ -162,7 +163,8 @@ def storageclass_factory(
             sc_obj = helpers.create_storage_class(
                 interface_type=interface,
                 interface_name=interface_name,
-                secret_name=secret.name
+                secret_name=secret.name,
+                sc_name=sc_name
             )
             assert sc_obj, f"Failed to create {interface} storage class"
             sc_obj.ceph_pool = ceph_pool


### PR DESCRIPTION
many workloads need sc_name initialized inside tests and used by test.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>