### PR TITLE
Allow collect only without running cluster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ matrix:
       env: TOXENV=flake8
     - python: 3.7
       env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=collectonly
+    - python: 3.7
+      env: TOXENV=collectonly

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -98,7 +98,7 @@ def pytest_configure(config):
         config (pytest.config): Pytest config object
 
     """
-    if not config.getoption("--help"):
+    if not (config.getoption("--help") or config.getoption("collectonly")):
         process_cluster_cli_params(config)
         # Add OCS related versions to the html report and remove extraneous metadata
         markers_arg = config.getoption('-m')

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -45,5 +45,5 @@ def pytest_sessionfinish(session, exitstatus):
     """
     send email report
     """
-    if ocsci_config.RUN['cli_params']['email']:
+    if ocsci_config.RUN['cli_params'].get('email'):
         email_reports()

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ commands = py.test \
     --cov=ocs_ci \
     {posargs}
 
+[testenv:collectonly]
+commands = py.test --collect-only tests
+
 [testenv:flake8]
 deps =
     flake8


### PR DESCRIPTION
Fixes issue #628
This allow us to run collect-only option with pytest to check some import errors and collection issues.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>