### PR TITLE
Logging improvements for ocs 530

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -344,10 +344,16 @@ class OCP(object):
                                 return True
                         elif len(sample) == len(in_condition):
                             return True
+                    # preparing logging message with expected number of
+                    # resource items we are waiting for
+                    if resource_count > 0:
+                        exp_num_str = f"all {resource_count}"
+                    else:
+                        exp_num_str = "all"
                     log.info((
                         f"status of {resource_name} item(s) were {actual_status},"
                         f" but we were waiting"
-                        f" for all of them to be {condition}"))
+                        f" for {exp_num_str} of them to be {condition}"))
         except TimeoutExpiredError as ex:
             log.error(f"timeout expired: {ex}")
             log.error((

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -357,6 +357,7 @@ class OCP(object):
                 resource_name,
                 condition,
                 actual_status)
+            raise(ex)
 
         return False
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -326,7 +326,7 @@ class OCP(object):
                             item_name = item.get('metadata').get('name')
                             status = self.get_resource_status(item_name)
                             actual_status.append(status)
-                            if status  == condition:
+                            if status == condition:
                                 in_condition.append(item)
                         except CommandFailed as ex:
                             log.info(

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -296,13 +296,11 @@ class OCP(object):
                 False otherwise
 
         """
-        log.info(
-            ("Waiting for a resource(s) of kind %s identified by name '%s'"
-            " and selector %s to reach desired condition %s"),
-            self._kind,
-            resource_name,
-            selector,
-            condition)
+        log.info((
+            f"Waiting for a resource(s) of kind {self._kind}"
+            f" identified by name '{resource_name}'"
+            f" and selector {selector}"
+            f" to reach desired condition {condition}"))
 
         try:
             for sample in TimeoutSampler(
@@ -314,10 +312,9 @@ class OCP(object):
                     status = self.get_resource_status(resource_name)
                     if status == condition:
                         return True
-                    log.info(
-                        "status of %s was %s, but we were waiting for %s",
-                        resource_name,
-                        status, condition)
+                    log.info((
+                        f"status of {resource_name} was {status},"
+                        f" but we were waiting for {condition}"))
                     actual_status = status
                 # More than 1 resources returned
                 elif sample.get('kind') == 'List':
@@ -343,21 +340,16 @@ class OCP(object):
                                 return True
                         elif len(sample) == len(in_condition):
                             return True
-                    log.info(
-                        ("status of %s item(s) were %s, but we were waiting"
-                        " for all of them to be %s"),
-                        resource_name,
-                        actual_status,
-                        condition)
+                    log.info((
+                        f"status of {resource_name} item(s) were {actual_status},"
+                        f" but we were waiting"
+                        f" for all of them to be {condition}"))
         except TimeoutExpiredError as ex:
-            log.error("timeout expired: %s", ex)
-            log.error(
-                ("Wait for %s resource %s to reach desired condition %s failed"
-                ", last actual status was %s"),
-                self._kind,
-                resource_name,
-                condition,
-                actual_status)
+            log.error(f"timeout expired: {ex}")
+            log.error((
+                f"Wait for {self._kind} resource {resource_name}"
+                f" to reach desired condition {condition} failed,"
+                f" last actual status was {actual_status}"))
             raise(ex)
 
         return False

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -352,8 +352,9 @@ class OCP(object):
         except TimeoutExpiredError as ex:
             log.error("timeout expired: %s", ex)
             log.error(
-                ("Wait for resource %s to reach desired condition %s failed,"
-                " last actual status was %s"),
+                ("Wait for %s resource %s to reach desired condition %s failed"
+                ", last actual status was %s"),
+                self._kind,
                 resource_name,
                 condition,
                 actual_status)

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -302,6 +302,10 @@ class OCP(object):
             f" and selector {selector}"
             f" to reach desired condition {condition}"))
 
+        # actual status of the resource we are waiting for, setting it to None
+        # now prevents UnboundLocalError raised when waiting timeouts
+        actual_status = None
+
         try:
             for sample in TimeoutSampler(
                 timeout, sleep, self.get, resource_name, True, selector

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -165,7 +165,7 @@ class OCP(object):
         if out_yaml_format:
             command += " -o yaml"
         output = self.exec_oc_cmd(command)
-        logging.debug(f"{yaml.dump(output)}")
+        log.debug(f"{yaml.dump(output)}")
         return output
 
     def delete(self, yaml_file=None, resource_name='', wait=True, force=False):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -720,7 +720,8 @@ def validate_pv_delete(pv_name):
 
     try:
         if ocp_pv_obj.get(resource_name=pv_name):
-            raise AssertionError('PV exists after PVC deletion')
+            msg = f"{constants.PV} {pv_name} is not deleted after PVC deletion"
+            raise AssertionError(msg)
 
     except CommandFailed:
         return True


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/631

There are few minor fixes for the logging, each change is in a separate commit. Some of hte changes are demonstrated below:

## Commits befecc615c1d16d6dde80ad1374442702a085060, 7a8c6f84215302e2a376cde2ac6dff2b47826421, 8f928d07d4058e94413975e2473d45a3bb994506 improve logging in OCP.wait_for_resource() method

Before, it was not clear what is the purpose of the repeating get operations,
and what is the actual state of resource which we are waiting for:

```
14:07:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:36 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:37 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:49 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:54 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:54 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:07:58 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:07:59 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:02 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:03 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:07 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:07 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:11 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:12 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:15 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:16 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:19 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:20 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a -o yaml
14:08:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a
14:08:34 - MainThread - tests.helpers - ERROR - PersistentVolume pvc-216d7a12-c279-11e9-a6dc-0625533a766a failed to reach Released
```

Now it's clear what is going on and why:

```
19:41:52 - MainThread - ocs_ci.ocs.ocp - INFO - Waiting for a resource(s) of kind PersistentVolume identified by name 'pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422' and selector None to reach desired condition Released
19:41:52 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:41:53 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:41:54 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m25s, but we were waiting for Released
19:41:57 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:41:57 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:41:58 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m29s, but we were waiting for Released
19:42:01 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:02 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:03 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m33s, but we were waiting for Released
19:42:06 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:06 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:07 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m38s, but we were waiting for Released
19:42:10 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:11 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:11 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m42s, but we were waiting for Released
19:42:14 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:16 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:16 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m47s, but we were waiting for Released
19:42:19 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:20 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:21 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m52s, but we were waiting for Released
19:42:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:25 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:25 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 5m56s, but we were waiting for Released
19:42:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:30 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m, but we were waiting for Released
19:42:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:34 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m5s, but we were waiting for Released
19:42:37 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:38 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:38 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m9s, but we were waiting for Released
19:42:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:42 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:43 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m14s, but we were waiting for Released
19:42:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:47 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m18s, but we were waiting for Released
19:42:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:51 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:51 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m22s, but we were waiting for Released
19:42:54 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 -o yaml
19:42:55 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422
19:42:56 - MainThread - ocs_ci.ocs.ocp - INFO - status of pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 was 6m27s, but we were waiting for Released
19:42:56 - MainThread - ocs_ci.ocs.ocp - ERROR - timeout expired: Timed Out: (60,)
19:42:56 - MainThread - ocs_ci.ocs.ocp - ERROR - Wait for resource pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 to reach desired condition Released failed, last actual status was 6m27s
19:42:56 - MainThread - tests.helpers - ERROR - PersistentVolume pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 failed to reach Released
```

Example of waiting for multiple resources:

```
20:31:27 - MainThread - ocs_ci.ocs.ocp - INFO - Waiting for a resource(s) of kind pv identified by name '' and selector None to reach desired condition Released                                                                                                                                                              
20:31:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv  -o yaml                                                                                                                                                                
20:31:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-000e69cf-c2b4-11e9-a6dc-0625533a766a                                                                                                                                
20:31:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-12e393b2-c5c4-11e9-bdaf-0625533a766a                                                                                                                                
20:31:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-1c521e50-c2aa-11e9-a6dc-0625533a766a                                                                                                                                
20:31:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-216d7a12-c279-11e9-a6dc-0625533a766a                                                                                                                                
20:31:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-26b188c8-c2a6-11e9-9260-02ccc586f422                                                                                                                                
20:31:31 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-4a95f408-c5be-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-515e9e2a-c5b4-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-8296de6d-c2a4-11e9-a6dc-0625533a766a                                                                                                                                
20:31:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:34 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-94980160-c2a7-11e9-ab4c-0a2d85acd846                                                                                                                                
20:31:34 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-b6697e9b-c2b2-11e9-a6dc-0625533a766a                                                                                                                                
20:31:35 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-dac31de0-c5bb-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:36 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-e847ed91-c5b2-11e9-86b3-0a2d85acd846                                                                                                                                
20:31:36 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-f5d5b4d8-c370-11e9-86b3-0a2d85acd846                                                                                                                                
20:31:37 - MainThread - ocs_ci.ocs.ocp - INFO - status of  item(s) were ['3d23h', '115m', '4d', '4d6h', '4d1h', '156m', '3h48m', '4d1h', '55m', '4d', '3d23h', '174m', '3h58m', '3d'], but we were waiting for all of them to be Released                                                                                     
20:31:40 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv  -o yaml                                                                                                                                                                
20:31:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-000e69cf-c2b4-11e9-a6dc-0625533a766a                                                                                                                                
20:31:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-12e393b2-c5c4-11e9-bdaf-0625533a766a                                                                                                                                
20:31:42 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-1c521e50-c2aa-11e9-a6dc-0625533a766a                                                                                                                                
20:31:43 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-216d7a12-c279-11e9-a6dc-0625533a766a                                                                                                                                
20:31:43 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-26b188c8-c2a6-11e9-9260-02ccc586f422                                                                                                                                
20:31:44 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-4a95f408-c5be-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-515e9e2a-c5b4-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-8296de6d-c2a4-11e9-a6dc-0625533a766a                                                                                                                                
20:31:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:47 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-94980160-c2a7-11e9-ab4c-0a2d85acd846                                                                                                                                
20:31:48 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-b6697e9b-c2b2-11e9-a6dc-0625533a766a                                                                                                                                
20:31:48 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-dac31de0-c5bb-11e9-8ae2-02ccc586f422                                                                                                                                
20:31:49 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-e847ed91-c5b2-11e9-86b3-0a2d85acd846                                                                                                                                
20:31:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get pv pvc-f5d5b4d8-c370-11e9-86b3-0a2d85acd846  
```


Note that with this change, issue #591 is directly visible:

```
19:42:56 - MainThread - ocs_ci.ocs.ocp - ERROR - Wait for resource pvc-884a3c18-c5cc-11e9-8ae2-02ccc586f422 to reach desired condition Released failed, last actual status was 6m27s
```

Changes here needs to take into account
https://github.com/red-hat-storage/ocs-ci/issues/632, but in this pull request
the beharior is preserved.

## Commit d50632f533fcc01dbbbe31c5f8b43072c94e435b improve logging in validate_pv_delete()

Before it was not clear what operation is being retried:

```
19:15:57 - MainThread - ocs_ci.utility.retry - WARNING - , Retrying in 5 seconds...
19:16:02 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-8296de6d-c2a4-11e9-a6dc-0625533a766a -o yaml
```

With the fix:

```
20:43:24 - MainThread - ocs_ci.utility.retry - WARNING - PersistentVolume pvc-000e69cf-c2b4-11e9-a6dc-0625533a766a is not deleted, Retrying in 5 seconds...
20:43:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /home/ocsqe/data/cluster-2019-08-19.1/auth/kubeconfig get PersistentVolume pvc-000e69cf-c2b4-11e9-a6dc-0625533a766a -o yaml
```

Moreover the traceback error is faster to understand:

```
>               raise AssertionError(msg)
E               AssertionError: PersistentVolume pvc-000e69cf-c2b4-11e9-a6dc-0625533a766a is not deleted
```
