### PR TITLE
Upgrade the default worker instance type from m4.large to m4.xlarge

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -77,3 +77,4 @@ ENV_DATA:
   # but only once when move to new version like v15.
   ceph_image: 'ceph/ceph:v14.2.2-20190826'
   rook_image: 'rook/ceph:master'
+  worker_instance_type: 'm4.xlarge'

--- a/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
@@ -4,7 +4,7 @@ compute:
   - name: worker
     platform:
       aws:
-        type: {{ worker_instance_type | default('m4.large') }}
+        type: {{ worker_instance_type | default('m4.xlarge') }}
 {% if worker_availability_zones %}
         zones:
   {% for zone in worker_availability_zones %}


### PR DESCRIPTION
For NooBaa deployment (requires a minimum of m4.xlarge worker machine)