### PR TITLE
Various fixes and improvements for NooBaa tests

### DIFF
--- a/ocs_ci/ocs/resources/noobaa.py
+++ b/ocs_ci/ocs/resources/noobaa.py
@@ -101,7 +101,7 @@ class NooBaa(object):
 
         """
         try:
-            self._s3_resource.meta.client.head_bucket(Bucket=bucket.name)
+            self.s3_resource.meta.client.head_bucket(Bucket=bucket.name)
             logger.info(f"{bucket.name} exists")
             return True
         except ClientError:

--- a/tests/manage/noobaa/conftest.py
+++ b/tests/manage/noobaa/conftest.py
@@ -52,19 +52,25 @@ def uploaded_objects(request, noobaa_obj, awscli_pod):
 @pytest.fixture()
 def bucket_factory(request, noobaa_obj):
     """
-    Creates and deletes all buckets that were created as part of the test
+    Create a bucket factory. Calling this fixture creates a new bucket(s).
+    For a custom amount, provide the 'amount' parameter.
 
     Args:
         noobaa_obj (NooBaa): A NooBaa object containing the NooBaa S3 connection credentials
-        amount (int): The amount of buckets to create
-
-    Returns:
-        list: An empty list of buckets
-
     """
     created_bucket_names = []
 
-    def _bucket_factory(amount=1):
+    def _create_buckets(amount=1):
+        """
+        Creates and deletes all buckets that were created as part of the test
+
+        Args:
+            amount (int): The amount of buckets to create
+
+        Returns:
+            list: A list of s3.Bucket objects, containing all the created buckets
+
+        """
         for i in range(amount):
             bucket_name = create_unique_resource_name(
                 resource_description='bucket', resource_type='s3'
@@ -88,7 +94,7 @@ def bucket_factory(request, noobaa_obj):
                 assert not noobaa_obj.s3_verify_bucket_exists(bucket)
     request.addfinalizer(bucket_cleanup)
 
-    return _bucket_factory
+    return _create_buckets
 
 
 @pytest.fixture()

--- a/tests/manage/noobaa/conftest.py
+++ b/tests/manage/noobaa/conftest.py
@@ -85,7 +85,7 @@ def bucket_factory(request, noobaa_obj):
                 logger.info(
                     f"Verifying whether bucket: {bucket.name} exists after deletion"
                 )
-                assert noobaa_obj.s3_verify_bucket_exists(bucket) is False
+                assert not noobaa_obj.s3_verify_bucket_exists(bucket)
     request.addfinalizer(bucket_cleanup)
 
     return _bucket_factory

--- a/tests/manage/noobaa/test_bucket_creation.py
+++ b/tests/manage/noobaa/test_bucket_creation.py
@@ -22,17 +22,13 @@ class TestBucketCreation:
         reason="Tests are not running on AWS deployed cluster"
     )
     @pytest.mark.polarion_id("OCS-1298")
-    def test_s3_bucket_creation(self, noobaa_obj, created_buckets):
+    def test_s3_bucket_creation(self, noobaa_obj, bucket_factory):
         """
         Test bucket creation using the S3 SDK
         """
 
-        for i in range(3):
-            bucketname = create_unique_resource_name(self.__class__.__name__.lower(), 's3-bucket')
-            logger.info(f"Creating new bucket - {bucketname}")
-            created_buckets.append(noobaa_obj.s3_create_bucket(bucketname=bucketname))
         assert set(
-            bucket.name for bucket in created_buckets
+            bucket.name for bucket in bucket_factory(3)
         ).issubset(
             noobaa_obj.s3_list_all_bucket_names()
         )

--- a/tests/manage/noobaa/test_bucket_creation.py
+++ b/tests/manage/noobaa/test_bucket_creation.py
@@ -27,6 +27,12 @@ class TestBucketCreation:
         Test bucket creation using the S3 SDK
         """
 
-        bucketname = create_unique_resource_name(self.__class__.__name__.lower(), 's3-bucket')
-        logger.info(f'Creating new bucket - {bucketname}')
-        created_buckets.append(noobaa_obj.s3_create_bucket(bucketname=bucketname))
+        for i in range(3):
+            bucketname = create_unique_resource_name(self.__class__.__name__.lower(), 's3-bucket')
+            logger.info(f"Creating new bucket - {bucketname}")
+            created_buckets.append(noobaa_obj.s3_create_bucket(bucketname=bucketname))
+        assert set(
+            bucket.name for bucket in created_buckets
+        ).issubset(
+            noobaa_obj.s3_list_all_bucket_names()
+        )

--- a/tests/manage/noobaa/test_bucket_creation.py
+++ b/tests/manage/noobaa/test_bucket_creation.py
@@ -4,7 +4,6 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import tier1
-from tests.helpers import create_unique_resource_name
 
 logger = logging.getLogger(__name__)
 

--- a/tests/manage/noobaa/test_bucket_deletion.py
+++ b/tests/manage/noobaa/test_bucket_deletion.py
@@ -22,14 +22,12 @@ class TestBucketDeletion:
         reason="Tests are not running on AWS deployed cluster"
     )
     @pytest.mark.polarion_id("OCS-1299")
-    def test_s3_bucket_delete(self, noobaa_obj, created_buckets):
+    def test_s3_bucket_delete(self, noobaa_obj, bucket_factory):
         """
         Test deletion of bucket using the S3 SDK
         """
-        for bucket in created_buckets:
+
+        for bucket in bucket_factory(3):
             logger.info(f"Deleting bucket: {bucket.name}")
             noobaa_obj.s3_delete_bucket(bucket)
             assert noobaa_obj.s3_verify_bucket_exists(bucket) is False
-            # Removing the bucket in order to exclude it from the teardown
-            # Since it's already removed
-            created_buckets.remove(bucket)

--- a/tests/manage/noobaa/test_bucket_deletion.py
+++ b/tests/manage/noobaa/test_bucket_deletion.py
@@ -1,41 +1,10 @@
 import logging
 import pytest
 
-from tests.helpers import create_unique_resource_name
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import tier1
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture()
-def create_buckets(request, noobaa_obj):
-    """
-    Creates multiple buckets
-    """
-    created_buckets = []
-
-    def verify_bucket():
-        """
-        Verifies whether buckets exists after deletion
-
-        """
-        for bucket in created_buckets:
-            logger.info(f"Verifying whether bucket: {bucket.name} exists"
-                        f" after deletion")
-            assert noobaa_obj.s3_verify_bucket_exists(bucket) is False
-
-    request.addfinalizer(verify_bucket)
-
-    bucket_name = create_unique_resource_name(
-        resource_description='bucket', resource_type='s3'
-    )
-    logger.info(f'Creating bucket: {bucket_name}')
-    created_buckets.append(
-        noobaa_obj.s3_create_bucket(bucketname=bucket_name)
-    )
-
-    return created_buckets
 
 
 @pytest.mark.skipif(condition=True, reason="NooBaa is not deployed")
@@ -53,10 +22,14 @@ class TestBucketDeletion:
         reason="Tests are not running on AWS deployed cluster"
     )
     @pytest.mark.polarion_id("OCS-1299")
-    def test_s3_bucket_delete(self, noobaa_obj, create_buckets):
+    def test_s3_bucket_delete(self, noobaa_obj, created_buckets):
         """
         Test deletion of bucket using the S3 SDK
         """
-        for bucket in create_buckets:
+        for bucket in created_buckets:
             logger.info(f"Deleting bucket: {bucket.name}")
             noobaa_obj.s3_delete_bucket(bucket)
+            assert noobaa_obj.s3_verify_bucket_exists(bucket) is False
+            # Removing the bucket in order to exclude it from the teardown
+            # Since it's already removed
+            created_buckets.remove(bucket)

--- a/tests/manage/noobaa/test_bucket_deletion.py
+++ b/tests/manage/noobaa/test_bucket_deletion.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from ocs_ci.framework import config

--- a/tests/manage/noobaa/test_write_to_bucket.py
+++ b/tests/manage/noobaa/test_write_to_bucket.py
@@ -51,3 +51,9 @@ class TestBucketIO(ManageTest):
                 secrets=[noobaa_obj.access_key_id, noobaa_obj.access_key, noobaa_obj.endpoint]
             )
             uploaded_objects.append(full_object_path)
+
+        assert set(
+            downloaded_files
+        ).issubset(
+            obj.key for obj in noobaa_obj.s3_list_all_objects_in_bucket(bucketname)
+        )

--- a/tests/manage/noobaa/test_write_to_bucket.py
+++ b/tests/manage/noobaa/test_write_to_bucket.py
@@ -22,7 +22,7 @@ class TestBucketIO(ManageTest):
     Test IO of a bucket
     """
     @pytest.mark.polarion_id("OCS-1300")
-    def test_write_file_to_bucket(self, noobaa_obj, awscli_pod, created_buckets, uploaded_objects):
+    def test_write_file_to_bucket(self, noobaa_obj, awscli_pod, bucket_factory, uploaded_objects):
         """
         Test object IO using the S3 SDK
         """
@@ -37,9 +37,7 @@ class TestBucketIO(ManageTest):
             )
             downloaded_files.append(obj.key)
 
-        bucketname = create_unique_resource_name(self.__class__.__name__.lower(), 's3-bucket')
-        logger.info(f'Creating the test bucket - {bucketname}')
-        created_buckets.append(noobaa_obj.s3_create_bucket(bucketname=bucketname))
+        bucketname = bucket_factory(1)[0].name
 
         # Write all downloaded objects to the new bucket
         logger.info(f'Writing objects to bucket')

--- a/tests/manage/noobaa/test_write_to_bucket.py
+++ b/tests/manage/noobaa/test_write_to_bucket.py
@@ -6,7 +6,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.ocs import constants
-from tests.helpers import create_unique_resource_name, craft_s3_command
+from tests.helpers import craft_s3_command
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Implemented new asserts for added assurance
*Moved and merged `create_buckets` into `created_buckets`
*Implemented the ability to create and delete a dynamic amount of buckets
*Fixed an outdated access to a private member that has been changed into a public one

Signed-off-by: Ben <belimele@redhat.com>