### PR TITLE
Modifying tests to use RWX PVC

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -684,8 +684,8 @@ def multi_pvc_factory(
             storageclass (object): ocs_ci.ocs.resources.ocs.OCS instance
                 of 'StorageClass' kind.
             size (int): The requested size for the PVC
-            access_modes (list): List of access modes. One one the access modes
-                will be chosen for creating PVC. If not specified,
+            access_modes (list): List of access modes. One of the access modes
+                will be chosen for creating each PVC. If not specified,
                 ReadWriteOnce will be selected for all PVCs.
                 eg: ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany']
             access_modes_selection (str): Decides how to select accessMode for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import tempfile
 import pytest
 import threading
 from datetime import datetime
+import random
+from math import floor
 
 from ocs_ci.utility.utils import TimeoutSampler, get_rook_repo
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -302,6 +304,7 @@ def pvc_factory(
             helpers.wait_for_resource_state(pvc_obj, status)
         pvc_obj.storageclass = storageclass
         pvc_obj.project = project
+        pvc_obj.access_mode = access_mode
         instances.append(pvc_obj)
 
         return pvc_obj
@@ -652,14 +655,21 @@ def multi_pvc_factory(
 ):
     """
     Create a Persistent Volume Claims factory. Calling this fixture creates a
-    set of new PVCs.
+    set of new PVCs. Options for PVC creation based on provided assess modes:
+    1. For each PVC, choose random value from the list of access modes
+    2. Create PVCs based on the specified distribution number of access modes.
+       Create sets of PVCs based on the order of access modes.
+    3. Create PVCs based on the specified distribution number of access modes.
+       The order of PVC creation is independent of access mode.
     """
     def factory(
         interface=constants.CEPHBLOCKPOOL,
         project=None,
         storageclass=None,
         size=None,
-        access_mode=constants.ACCESS_MODE_RWO,
+        access_modes=None,
+        access_modes_selection='distribute_sequential',
+        access_mode_dist_ratio=None,
         status=constants.STATUS_BOUND,
         num_of_pvc=1,
         wait_each=False
@@ -674,9 +684,31 @@ def multi_pvc_factory(
             storageclass (object): ocs_ci.ocs.resources.ocs.OCS instance
                 of 'StorageClass' kind.
             size (int): The requested size for the PVC
-            access_mode (str): ReadWriteOnce, ReadOnlyMany or ReadWriteMany.
-                This decides the access mode to be used for the PVC.
-                ReadWriteOnce is default.
+            access_modes (list): List of access modes. One one the access modes
+                will be chosen for creating PVC. If not specified,
+                ReadWriteOnce will be selected for all PVCs.
+                eg: ['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany']
+            access_modes_selection (str): Decides how to select accessMode for
+                each PVC from the options given in 'access_modes' list.
+                Values are 'select_random', 'distribute_random'
+                'select_random' : While creating each PVC, one access mode will
+                    be selected from the 'access_modes' list.
+                'distribute_random' : The access modes in the list
+                    'access_modes' will be distributed based on the values in
+                    'distribute_ratio' and the order in which PVCs are created
+                    will not be based on the access modes. For example, 1st and
+                    6th PVC might have same access mode.
+                'distribute_sequential' :The access modes in the list
+                    'access_modes' will be distributed based on the values in
+                    'distribute_ratio' and the order in which PVCs are created
+                    will be as sets of PVCs of same assess mode. For example,
+                    first set of 10 will be having same access mode followed by
+                    next set of 13 with a different access mode.
+            access_mode_dist_ratio (list): Contains the number of PVCs to be
+                created for each access mode. If not specified, the given list
+                of access modes will be equally distributed among the PVCs.
+                eg: [10,12] for num_of_pvc=22 and
+                access_modes=['ReadWriteOnce', 'ReadWriteMany']
             status (str): If provided then factory waits for object to reach
                 desired state.
             num_of_pvc(int): Number of PVCs to be created
@@ -695,7 +727,30 @@ def multi_pvc_factory(
         project = project or project_factory()
         storageclass = storageclass or storageclass_factory(interface)
 
-        for _ in range(num_of_pvc):
+        access_modes = access_modes or [constants.ACCESS_MODE_RWO]
+
+        access_modes_list = []
+        if access_modes_selection == 'select_random':
+            for _ in range(num_of_pvc):
+                mode = random.choice(access_modes)
+                access_modes_list.append(mode)
+
+        else:
+            if not access_mode_dist_ratio:
+                num_of_modes = len(access_modes)
+                dist_val = floor(num_of_pvc / num_of_modes)
+                access_mode_dist_ratio = [dist_val] * num_of_modes
+                access_mode_dist_ratio[-1] = (
+                    dist_val + (num_of_pvc % num_of_modes)
+                )
+            zipped_share = list(zip(access_modes, access_mode_dist_ratio))
+            for mode, share in zipped_share:
+                access_modes_list.extend([mode] * share)
+
+        if access_modes_selection == 'distribute_random':
+            random.shuffle(access_modes_list)
+
+        for access_mode in access_modes_list:
             pvc_obj = pvc_factory(
                 interface=interface,
                 project=project,

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -111,7 +111,8 @@ class DisruptionBase(ManageTest):
             pod_obj.workload_setup(storage_type='fs')
         log.info("Setup for running IO is completed on pods")
 
-        # Start IO on each pod
+        # Start IO on each pod. RWX PVC will be used on two pods. So split the
+        # size accordingly
         log.info("Starting IO on pods")
         for pod_obj in self.pod_objs:
             if pod_obj.pvc.access_mode == constants.ACCESS_MODE_RWX:

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -68,28 +68,41 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         """
         Create PVCs and pods
         """
+        access_modes = [constants.ACCESS_MODE_RWO]
+        if interface == constants.CEPHFILESYSTEM:
+            access_modes.append(constants.ACCESS_MODE_RWX)
         pvc_objs = multi_pvc_factory(
             interface=interface,
             project=None,
             storageclass=None,
             size=self.pvc_size,
-            access_mode=constants.ACCESS_MODE_RWO,
+            access_modes=access_modes,
+            access_modes_selection='distribute_random',
             status=constants.STATUS_BOUND,
             num_of_pvc=self.num_of_pvcs,
             wait_each=False
         )
 
         pod_objs = []
+        rwx_pod_objs = []
+
+        # Create one pod using each RWO PVC and two pods using each RWX PVC
         for pvc_obj in pvc_objs:
+            if pvc_obj.access_mode == constants.ACCESS_MODE_RWX:
+                pod_obj = pod_factory(pvc=pvc_obj, status="")
+                rwx_pod_objs.append(pod_obj)
             pod_obj = pod_factory(pvc=pvc_obj, status="")
             pod_objs.append(pod_obj)
-        for pod_obj in pod_objs:
+
+        # Wait for pods to be in Running state
+        for pod_obj in pod_objs + rwx_pod_objs:
             wait_for_resource_state(
                 resource=pod_obj, state=constants.STATUS_RUNNING
             )
             pod_obj.reload()
+        log.info(f"Created {len(pod_objs) + len(rwx_pod_objs)} pods.")
 
-        return pvc_objs, pod_objs
+        return pvc_objs, pod_objs, rwx_pod_objs
 
     def delete_pods(self, pods_to_delete):
         """
@@ -107,7 +120,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         Delete ceph/rook pod while PVCs deletion, pods deletion and IO are
         progressing
         """
-        pvc_objs, pod_objs = setup_base
+        pvc_objs, pod_objs, rwx_pod_objs = setup_base
         sc_obj = pvc_objs[0].storageclass
         namespace = pvc_objs[0].project.namespace
 
@@ -116,15 +129,28 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # Select pods to be deleted
         pods_to_delete = pod_objs[:num_of_pods_to_delete]
+        pods_to_delete.extend(
+            [pod for pod_obj in pods_to_delete for pod in rwx_pod_objs if (
+                pod_obj.pvc == pod.pvc
+            )]
+        )
 
         # Select pods to run IO
         io_pods = pod_objs[num_of_pods_to_delete:num_of_pods_to_delete + num_of_io_pods]
+        io_pods.extend(
+            [pod for pod_obj in pods_to_delete for pod in rwx_pod_objs if (
+                pod_obj.pvc == pod.pvc
+            )]
+        )
 
         # Select pods which are having PVCs to delete
         pods_for_pvc = pod_objs[num_of_pods_to_delete + num_of_io_pods:]
-
-        # Select PVCs to delete
-        pvcs_to_delete = pvc_objs[num_of_pods_to_delete + num_of_io_pods:]
+        pvcs_to_delete = [pod_obj.pvc for pod_obj in pods_for_pvc]
+        pods_for_pvc.extend(
+            [pod for pod_obj in pods_to_delete for pod in rwx_pod_objs if (
+                pod_obj.pvc == pod.pvc
+            )]
+        )
 
         pod_functions = {
             'mds': get_mds_pods, 'mon': get_mon_pods, 'mgr': get_mgr_pods,
@@ -192,7 +218,14 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         # Start IO on pods having PVCs to delete to load data
         log.info("Starting IO on pods having PVCs to delete.")
         for pod_obj in pods_for_pvc:
-            pod_obj.run_io(storage_type='fs', size=f'{self.pvc_size - 1}G')
+            if pod_obj.pvc.access_mode == constants.ACCESS_MODE_RWX:
+                io_size = int((self.pvc_size - 1) / 2)
+            else:
+                io_size = self.pvc_size - 1
+            pod_obj.run_io(
+                storage_type='fs', size=f'{io_size}G',
+                fio_filename=f'{pod_obj.name}_io'
+            )
         log.info("IO started on pods having PVCs to delete.")
 
         log.info("Fetching IO results from the pods having PVCs to delete.")
@@ -211,7 +244,14 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         # Start IO on pods to be deleted
         log.info("Starting IO on pods to be deleted.")
         for pod_obj in pods_to_delete:
-            pod_obj.run_io(storage_type='fs', size=f'{self.pvc_size - 1}G')
+            if pod_obj.pvc.access_mode == constants.ACCESS_MODE_RWX:
+                io_size = int((self.pvc_size - 1) / 2)
+            else:
+                io_size = self.pvc_size - 1
+            pod_obj.run_io(
+                storage_type='fs', size=f'{io_size}G',
+                fio_filename=f'{pod_obj.name}_io'
+            )
         log.info("IO started on pods to be deleted.")
 
         # Start deleting PVCs
@@ -224,7 +264,14 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # Start IO on IO pods
         for pod_obj in io_pods:
-            pod_obj.run_io(storage_type='fs', size=f'{self.pvc_size - 1}G')
+            if pod_obj.pvc.access_mode == constants.ACCESS_MODE_RWX:
+                io_size = int((self.pvc_size - 1) / 2)
+            else:
+                io_size = self.pvc_size - 1
+            pod_obj.run_io(
+                storage_type='fs', size=f'{io_size}G',
+                fio_filename=f'{pod_obj.name}_io'
+            )
         log.info("Started IO on IO pods")
 
         # Verify pvc deletion has started


### PR DESCRIPTION
Tests modified to use RWX and RWO PVC:
test_disruptive_during_pod_pvc_deletion_and_io
test_disruptive_during_pod_pvc_deletion

Modified multi_pvc_factory to create PVC based on the
provided access modes

Signed-off-by: Jilju Joy <jijoy@redhat.com>