### PR TITLE
Run OCP and OCS must-gather images for failed tests

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -47,7 +47,8 @@ REPORTING:
     project_id: "OpenShiftContainerStorage"
   # Upstream: 'US' or Downstream: 'DS', used only for reporting (Test Run Name)
   us_ds: 'US'
-  must_gather_image: "quay.io/ocs-dev/ocs-must-gather"
+  ocp_must_gather_image: "quay.io/openshift/origin-must-gather"
+  ocs_must_gather_image: "quay.io/ocs-dev/ocs-must-gather"
 
 # This is the default information about environment. Will be overwritten with
 # --cluster-conf file.yaml data you will pass to the pytest.


### PR DESCRIPTION
It's also required to run the OCP image twice since by default it will not
collect the worker node service logs (where OCS issues might be otherwise
logged).

Fixes: #673
Signed-off-by: Jason Dillaman <dillaman@redhat.com>