### PR TITLE
OCS-710: OCP monitoring backed by OCS, Reboot node where MGR is running

### DIFF
--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -132,3 +132,25 @@ def check_pvcdata_collected_on_prometheus(pvc_name):
         )
     logger.info(f"Created pvc {pvc_name} data {pvc_list} is collected on prometheus pod")
     return True
+
+
+def check_ceph_health_status_metrics_on_prometheus(mgr_pod):
+    """
+    Check ceph health status metric is collected on prometheus pod
+
+    Args:
+        mgr_pod (str): Name of the mgr pod
+
+    Returns:
+        (bool): True on success, false otherwise
+
+    """
+    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+    response = prometheus.get(
+        'query?query=ceph_health_status'
+    )
+    ceph_health_metric = json.loads(response.content.decode('utf-8'))
+    return bool(
+        [mgr_pod for health_status in ceph_health_metric.get('data').get(
+            'result') if mgr_pod == health_status.get('metric').get('pod')]
+    )

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -142,7 +142,7 @@ def check_ceph_health_status_metrics_on_prometheus(mgr_pod):
         mgr_pod (str): Name of the mgr pod
 
     Returns:
-        (bool): True on success, false otherwise
+        bool: True on success, false otherwise
 
     """
     prometheus = ocs_ci.utility.prometheus.PrometheusAPI()

--- a/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
+++ b/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs import ocp, constants, defaults
 from ocs_ci.framework.testlib import tier4, E2ETest
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility import aws
-from tests import sanity_helpers
+from tests.sanity_helpers import Sanity
 from ocs_ci.ocs.monitoring import (
     check_pvcdata_collected_on_prometheus,
     check_ceph_health_status_metrics_on_prometheus
@@ -60,6 +60,13 @@ class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
     stored on persistent monitoring
     """
 
+    @pytest.fixture(autouse=True)
+    def init_sanity(self):
+        """
+        Initialize Sanity instance
+        """
+        self.sanity_helpers = Sanity()
+
     @tier4
     def test_monitoring_after_rebooting_node_where_mgr_is_running(self, test_fixture):
         """
@@ -88,7 +95,7 @@ class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
         wait_for_nodes_status()
 
         # Check the node are Ready state and check cluster is health ok
-        sanity_helpers.health_check(nodes=list(instances.values()))
+        self.sanity_helpers.health_check()
 
         # Check for ceph health check metrics is updated with new mgr pod
         wait_to_update_in_prometheus_pod()

--- a/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
+++ b/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
@@ -23,9 +23,10 @@ def test_fixture(pod_factory, num_of_pod=2):
     Setup and teardown
     """
     pod_objs = [
-        pod_factory(interface=constants.CEPHBLOCKPOOL,
-                    status=constants.STATUS_RUNNING
-                    ) for _ in range(num_of_pod)
+        pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            status=constants.STATUS_RUNNING
+        ) for _ in range(num_of_pod)
     ]
 
     # Check for the created pvc metrics on prometheus pod
@@ -38,7 +39,7 @@ def test_fixture(pod_factory, num_of_pod=2):
 
 
 @retry(AssertionError, tries=10, delay=3, backoff=1)
-def wait_to_update_in_prometheus_pod():
+def wait_to_update_mgrpod_info_prometheus_pod():
 
     logger.info(
         f"Verifying ceph health status metrics is updated after rebooting the node"
@@ -98,7 +99,7 @@ class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
         self.sanity_helpers.health_check()
 
         # Check for ceph health check metrics is updated with new mgr pod
-        wait_to_update_in_prometheus_pod()
+        wait_to_update_mgrpod_info_prometheus_pod()
 
         # Check for the created pvc metrics after rebooting the node where mgr pod was running
         for pod_obj in pod_objs:

--- a/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
+++ b/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
@@ -10,7 +10,7 @@ from ocs_ci.ocs.monitoring import (
     check_pvcdata_collected_on_prometheus,
     check_ceph_health_status_metrics_on_prometheus
 )
-from ocs_ci.ocs.node import wait_for_nodes_status, get_typed_nodes
+from ocs_ci.ocs.node import wait_for_nodes_status
 from ocs_ci.utility.retry import retry
 
 
@@ -77,9 +77,6 @@ class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
         pod_objs = test_fixture
 
         aws_obj = aws.AWS()
-
-        # Get the worker node list
-        workers = get_typed_nodes(node_type='worker')
 
         # Get the mgr pod obj
         mgr_pod_obj = pod.get_mgr_pods()

--- a/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
+++ b/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
@@ -85,11 +85,10 @@ class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
         mgr_pod_obj = pod.get_mgr_pods()
 
         # Get the node where the mgr pod is hosted
-        mgr_node = mgr_pod_obj[0].get().get('spec').get('nodeName')
-        mgr_node = [node for node in workers if node.get().get('metadata').get('name') == mgr_node]
+        mgr_node_obj = pod.get_pod_node(mgr_pod_obj[0])
 
         # Reboot the node where the mgr pod is hosted
-        instances = aws.get_instances_ids_and_names(mgr_node)
+        instances = aws.get_instances_ids_and_names([mgr_node_obj])
         aws_obj.restart_ec2_instances(instances=instances, wait=True, force=True)
 
         # Validate all nodes are in READY state

--- a/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
+++ b/tests/e2e/monitoring/test_reboot_node_where_mgr_running.py
@@ -1,0 +1,100 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import ocp, constants, defaults
+from ocs_ci.framework.testlib import tier4, E2ETest
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility import aws
+from tests import sanity_helpers
+from ocs_ci.ocs.monitoring import (
+    check_pvcdata_collected_on_prometheus,
+    check_ceph_health_status_metrics_on_prometheus
+)
+from ocs_ci.ocs.node import wait_for_nodes_status, get_typed_nodes
+from ocs_ci.utility.retry import retry
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def test_fixture(pod_factory, num_of_pod=2):
+    """
+    Setup and teardown
+    """
+    pod_objs = [
+        pod_factory(interface=constants.CEPHBLOCKPOOL,
+                    status=constants.STATUS_RUNNING
+                    ) for _ in range(num_of_pod)
+    ]
+
+    # Check for the created pvc metrics on prometheus pod
+    for pod_obj in pod_objs:
+        assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+            f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+        )
+
+    return pod_objs
+
+
+@retry(AssertionError, tries=10, delay=3, backoff=1)
+def wait_to_update_in_prometheus_pod():
+
+    logger.info(
+        f"Verifying ceph health status metrics is updated after rebooting the node"
+    )
+    ocp_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    mgr_pod = (
+        ocp_obj.get(selector=constants.MGR_APP_LABEL).get('items')[0].get('metadata').get('name')
+    )
+    assert check_ceph_health_status_metrics_on_prometheus(mgr_pod=mgr_pod), (
+        f"Ceph health status metrics are not updated after the rebooting node where the mgr running"
+    )
+    logger.info("Ceph health status metrics is updated")
+
+
+@pytest.mark.polarion_id("OCS-710")
+class TestRebootNodeWhereMgrRunningAndInteractionWithPrometheus(E2ETest):
+    """
+    Rebooting node where mgr is running shouldn't impact the data/metrics
+    stored on persistent monitoring
+    """
+
+    @tier4
+    def test_monitoring_after_rebooting_node_where_mgr_is_running(self, test_fixture):
+        """
+        Test case to validate rebooting a node where mgr is running
+        should not delete the data collected on prometheus pod
+        """
+        pod_objs = test_fixture
+
+        aws_obj = aws.AWS()
+
+        # Get the worker node list
+        workers = get_typed_nodes(node_type='worker')
+
+        # Get the mgr pod obj
+        mgr_pod_obj = pod.get_mgr_pods()
+
+        # Get the node where the mgr pod is hosted
+        mgr_node = mgr_pod_obj[0].get().get('spec').get('nodeName')
+        mgr_node = [node for node in workers if node.get().get('metadata').get('name') == mgr_node]
+
+        # Reboot the node where the mgr pod is hosted
+        instances = aws.get_instances_ids_and_names(mgr_node)
+        aws_obj.restart_ec2_instances(instances=instances, wait=True, force=True)
+
+        # Validate all nodes are in READY state
+        wait_for_nodes_status()
+
+        # Check the node are Ready state and check cluster is health ok
+        sanity_helpers.health_check(nodes=list(instances.values()))
+
+        # Check for ceph health check metrics is updated with new mgr pod
+        wait_to_update_in_prometheus_pod()
+
+        # Check for the created pvc metrics after rebooting the node where mgr pod was running
+        for pod_obj in pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+            )


### PR DESCRIPTION
Test case to validate rebooting a node where mgr is running should not delete the data collected on prometheus pod.

Signed-off-by: Akarsha <akrai@redhat.com>