### PR TITLE
WIP - cleanup destroy cluster test

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,7 +132,7 @@ run-ci tests/
 
 If you would like to destroy existing cluster you can run following command:
 ```bash
-run-ci -m deployment \
+run-ci -m destroy \
     --cluster-name kerberos_ID-ocs-deployment \
     --cluster-path /home/my_user/my-ocs-dir tests/ \
     --teardown

--- a/tests/ecosystem/destroy/test_destroy_cluster.py
+++ b/tests/ecosystem/destroy/test_destroy_cluster.py
@@ -1,8 +1,7 @@
 import logging
 
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import EcosystemTest, destroy
-from ocs_ci.utility.utils import destroy_cluster
+from ocs_ci.framework import config
 
 log = logging.getLogger(__name__)
 
@@ -10,5 +9,13 @@ log = logging.getLogger(__name__)
 @destroy
 class TestDestroy(EcosystemTest):
     def test_destroy_cluster(self, log_cli_level):
-        log.info("Running OCS cluster destroy")
-        destroy_cluster(config.ENV_DATA['cluster_path'], log_cli_level)
+        teardown = config.RUN['cli_params'].get('teardown')
+        if teardown:
+            log.info(
+                "Cluster will be destroyed during teardown part of this test."
+            )
+        else:
+            log.warning(
+                "Command line parameter --teardown was not provided, "
+                "cluster will not be destroyed!"
+            )


### PR DESCRIPTION
- do not try to destroy cluster twice in `test_destroy_cluster` test (once as part of the test and second time during teardown)
- remove old unused `destroy_cluster()` function
- doc update: suggest `test_destroy_cluster` (marked as `destroy`) for cluster teardown instead of `test_cluster_is_running` (marked as `deployment`). The later require properly running cluster, otherwise it will fail on the check, despite the fact that the cluster is properly destroyed during the teardown phase.