### PR TITLE
fix ocs_operator_storage_cluster_cr url

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -41,7 +41,7 @@ DEPLOYMENT:
   # opened issue here about the version in the name of OLM
   # https://github.com/openshift/ocs-operator/issues/50
   ocs_csv_version: "v0.0.1"
-  ocs_operator_storage_cluster_cr: "https://raw.githubusercontent.com/openshift/ocs-operator/master/deploy/crds/ocs_v1alpha1_storagecluster_cr.yaml"
+  ocs_operator_storage_cluster_cr: "https://raw.githubusercontent.com/openshift/ocs-operator/master/deploy/crds/ocs_v1_storagecluster_cr.yaml"
   ocs_operator_nodes_to_label: 3
   # This is described as a WA for minimal configuration 3/3 worker/master
   # nodes. See: https://github.com/openshift/ocs-operator


### PR DESCRIPTION
- the file ocs_v1alpha1_storagecluster_cr.yaml was renamed to
  ocs_v1_storagecluster_cr.yaml (https://github.com/openshift/ocs-operator/tree/master/deploy/crds)
- fixes https://github.com/red-hat-storage/ocs-ci/issues/723

Signed-off-by: Daniel Horak <dahorak@redhat.com>