### PR TITLE
Chnage path to StorageCluster CR

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -41,7 +41,7 @@ DEPLOYMENT:
   # opened issue here about the version in the name of OLM
   # https://github.com/openshift/ocs-operator/issues/50
   ocs_csv_version: "v0.0.1"
-  ocs_operator_storage_cluster_cr: "https://raw.githubusercontent.com/openshift/ocs-operator/master/deploy/crds/ocs_v1alpha1_storagecluster_cr.yaml"
+  ocs_operator_storage_cluster_cr: "https://raw.githubusercontent.com/openshift/ocs-operator/master/deploy/crds/ocs_v1_storagecluster_cr.yaml"
   ocs_operator_nodes_to_label: 3
   # This is described as a WA for minimal configuration 3/3 worker/master
   # nodes. See: https://github.com/openshift/ocs-operator


### PR DESCRIPTION
The file path changed when moved to api version v1 from v1aplha1
https://github.com/openshift/ocs-operator/commit/8d808499e1eb34f5a4f1936cdff2cef0228ee239

Signed-off-by: Petr Balogh <pbalogh@redhat.com>