### PR TITLE
Change name of load_yaml_to_dict method to load_yaml

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -146,13 +146,13 @@ class Deployment(object):
             namespace=self.namespace
         )
         csv.wait_for_phase("Succeeded")
-        cluster_data = templating.load_yaml_to_dict(
+        cluster_data = templating.load_yaml(
             self.ocs_operator_storage_cluster_cr,
         )
         cluster_data['metadata']['name'] = config.ENV_DATA[
             'storage_cluster_name'
         ]
-        deviceset_data = templating.load_yaml_to_dict(
+        deviceset_data = templating.load_yaml(
             constants.DEVICESET_YAML
         )
         device_size = int(
@@ -304,7 +304,7 @@ class Deployment(object):
             time.sleep(wait_time)
 
             # Create MDS pods for CephFileSystem
-            fs_data = templating.load_yaml_to_dict(constants.CEPHFILESYSTEM_YAML)
+            fs_data = templating.load_yaml(constants.CEPHFILESYSTEM_YAML)
             fs_data['metadata']['namespace'] = self.namespace
 
             ceph_obj = OCS(**fs_data)

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -25,7 +25,7 @@ def create_configmap_cluster_monitoring_pod(sc_name):
 
     """
     logger.info("Creating configmap cluster-monitoring-config")
-    config_map = templating.load_yaml_to_dict(
+    config_map = templating.load_yaml(
         constants.CONFIGURE_PVC_ON_MONITORING_POD
     )
     config = yaml.safe_load(config_map['data']['config.yaml'])

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -26,7 +26,7 @@ class OCS(object):
                 resource's dictionary and use it to pass as **kwargs
                 2) For new resource, use yaml files templates under
                 /templates/CSI like:
-                obj_dict = load_yaml_to_dict(
+                obj_dict = load_yaml(
                     os.path.join(
                         TEMPLATE_DIR, "some_resource.yaml"
                         )

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -268,12 +268,12 @@ class Pod(OCS):
             self.workload_setup(storage_type=storage_type, jobs=jobs)
 
         if io_direction == 'rw':
-            self.io_params = templating.load_yaml_to_dict(
+            self.io_params = templating.load_yaml(
                 constants.FIO_IO_RW_PARAMS_YAML
             )
             self.io_params['rwmixread'] = rw_ratio
         else:
-            self.io_params = templating.load_yaml_to_dict(
+            self.io_params = templating.load_yaml(
                 constants.FIO_IO_PARAMS_YAML
             )
         self.io_params['runtime'] = runtime

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -94,13 +94,13 @@ class RipSaw(object):
         Deploy postgres sql server
         """
         try:
-            pgsql_service = templating.load_yaml_to_dict(
+            pgsql_service = templating.load_yaml(
                 constants.PGSQL_SERVICE_YAML
             )
-            pgsql_cmap = templating.load_yaml_to_dict(
+            pgsql_cmap = templating.load_yaml(
                 constants.PGSQL_CONFIGMAP_YAML
             )
-            pgsql_sset = templating.load_yaml_to_dict(
+            pgsql_sset = templating.load_yaml(
                 constants.PGSQL_STATEFULSET_YAML
             )
             self.pgsql_service = OCS(**pgsql_service)

--- a/ocs_ci/ocs/tests/test_defaults.py
+++ b/ocs_ci/ocs/tests/test_defaults.py
@@ -3,12 +3,12 @@ from ocs_ci.utility import templating
 
 
 def test_yaml_to_dict():
-    assert templating.load_yaml_to_dict(
+    assert templating.load_yaml(
         constants.CEPHFILESYSTEM_YAML
     )['apiVersion'] == 'ceph.rook.io/v1'
-    assert templating.load_yaml_to_dict(
+    assert templating.load_yaml(
         constants.CEPHFILESYSTEM_YAML
     )['spec']['metadataPool']['replicated']['size'] == 3
-    assert templating.load_yaml_to_dict(
+    assert templating.load_yaml(
         constants.CSI_PVC_YAML
     )['spec']['accessModes'] == ['ReadWriteOnce']

--- a/ocs_ci/utility/deployment_openshift_logging.py
+++ b/ocs_ci/utility/deployment_openshift_logging.py
@@ -226,7 +226,7 @@ def create_instance_in_clusterlogging(sc_name=None):
             values, storage class and size details etc.
 
     """
-    inst_data = templating.load_yaml_to_dict(constants.CL_INSTANCE_YAML)
+    inst_data = templating.load_yaml(constants.CL_INSTANCE_YAML)
     inst_data['spec']['logStore']['elasticsearch']['storage']['storageClassName'] = sc_name
     inst_data['spec']['logStore']['elasticsearch']['storage']['size'] = "200Gi"
     node_count = inst_data['spec']['logStore']['elasticsearch']['nodeCount']

--- a/ocs_ci/utility/templating.py
+++ b/ocs_ci/utility/templating.py
@@ -136,7 +136,7 @@ def dump_to_temp_yaml(src_file, dst_file, **kwargs):
         yaml.dump(data, yaml_file)
 
 
-def load_yaml_to_dict(file, multi_document=False):
+def load_yaml(file, multi_document=False):
     """
     Load yaml file (local or from URL) and convert it to dictionary
 
@@ -161,7 +161,7 @@ def load_yaml_to_dict(file, multi_document=False):
 
 def get_n_document_from_yaml(yaml_generator, index=0):
     """
-    Returns n document from yaml generator loaded by load_yaml_to_dict with
+    Returns n document from yaml generator loaded by load_yaml with
     multi_document = True.
 
     Args:

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -52,7 +52,7 @@ class TestPgSQLWorkload(E2ETest):
 
         # Create pgbench benchmark
         log.info("Create resource file for pgbench workload")
-        pg_data = templating.load_yaml_to_dict(constants.PGSQL_BENCHMARK_YAML)
+        pg_data = templating.load_yaml(constants.PGSQL_BENCHMARK_YAML)
         pg_obj = OCS(**pg_data)
         pg_obj.create()
 

--- a/tests/e2e/test_small_file_workload.py
+++ b/tests/e2e/test_small_file_workload.py
@@ -50,7 +50,7 @@ class TestSmallFileWorkload(E2ETest):
         ripsaw.apply_crd('resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml')
 
         log.info("Running SmallFile bench")
-        sf_data = templating.load_yaml_to_dict(constants.SMALLFILE_BENCHMARK_YAML)
+        sf_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
         sf_obj = OCS(**sf_data)
         sf_obj.create()
         # wait for benchmark pods to get created - takes a while

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -125,7 +125,7 @@ def create_pod(
         interface = constants.CEPHFS_INTERFACE
     if dc_deployment:
         pod_dict = pod_dict_path if pod_dict_path else constants.FEDORA_DC_YAML
-    pod_data = templating.load_yaml_to_dict(pod_dict)
+    pod_data = templating.load_yaml(pod_dict)
     pod_name = create_unique_resource_name(
         f'test-{interface}', 'pod'
     )
@@ -223,14 +223,14 @@ def create_secret(interface_type):
     """
     secret_data = dict()
     if interface_type == constants.CEPHBLOCKPOOL:
-        secret_data = templating.load_yaml_to_dict(
+        secret_data = templating.load_yaml(
             constants.CSI_RBD_SECRET_YAML
         )
         secret_data['stringData']['userID'] = constants.ADMIN_USER
         secret_data['stringData']['userKey'] = get_admin_key()
         interface = constants.RBD_INTERFACE
     elif interface_type == constants.CEPHFILESYSTEM:
-        secret_data = templating.load_yaml_to_dict(
+        secret_data = templating.load_yaml(
             constants.CSI_CEPHFS_SECRET_YAML
         )
         del secret_data['stringData']['userID']
@@ -256,7 +256,7 @@ def create_ceph_block_pool(pool_name=None):
     Returns:
         OCS: An OCS instance for the Ceph block pool
     """
-    cbp_data = templating.load_yaml_to_dict(constants.CEPHBLOCKPOOL_YAML)
+    cbp_data = templating.load_yaml(constants.CEPHBLOCKPOOL_YAML)
     cbp_data['metadata']['name'] = (
         pool_name if pool_name else create_unique_resource_name(
             'test', 'cbp'
@@ -282,7 +282,7 @@ def create_ceph_file_system(pool_name=None):
     Returns:
         OCS: An OCS instance for the Ceph file system
     """
-    cfs_data = templating.load_yaml_to_dict(constants.CEPHFILESYSTEM_YAML)
+    cfs_data = templating.load_yaml(constants.CEPHFILESYSTEM_YAML)
     cfs_data['metadata']['name'] = (
         pool_name if pool_name else create_unique_resource_name(
             'test', 'cfs'
@@ -321,7 +321,7 @@ def create_storage_class(
 
     sc_data = dict()
     if interface_type == constants.CEPHBLOCKPOOL:
-        sc_data = templating.load_yaml_to_dict(
+        sc_data = templating.load_yaml(
             constants.CSI_RBD_STORAGECLASS_YAML
         )
         sc_data['parameters'][
@@ -335,7 +335,7 @@ def create_storage_class(
             provisioner if provisioner else defaults.RBD_PROVISIONER
         )
     elif interface_type == constants.CEPHFILESYSTEM:
-        sc_data = templating.load_yaml_to_dict(
+        sc_data = templating.load_yaml(
             constants.CSI_CEPHFS_STORAGECLASS_YAML
         )
         sc_data['parameters'][
@@ -395,7 +395,7 @@ def create_pvc(
     Returns:
         PVC: PVC instance
     """
-    pvc_data = templating.load_yaml_to_dict(constants.CSI_PVC_YAML)
+    pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
     pvc_data['metadata']['name'] = (
         pvc_name if pvc_name else create_unique_resource_name(
             'test', 'pvc'
@@ -953,7 +953,7 @@ def create_serviceaccount(namespace):
         OCS: An OCS instance for the service_account
     """
 
-    service_account_data = templating.load_yaml_to_dict(
+    service_account_data = templating.load_yaml(
         constants.SERVICE_ACCOUNT_YAML
     )
     service_account_data['metadata']['name'] = create_unique_resource_name(

--- a/tests/libtest/test_fio_workload.py
+++ b/tests/libtest/test_fio_workload.py
@@ -45,7 +45,7 @@ class TestFIOWorkload(ManageTest):
             name, path, work_load, storage_type, self.pod_obj
         )
         assert wl.setup()
-        io_params = templating.load_yaml_to_dict(constants.FIO_IO_PARAMS_YAML)
+        io_params = templating.load_yaml(constants.FIO_IO_PARAMS_YAML)
         io_params['runtime'] = runtime
         io_params['size'] = size
 

--- a/tests/manage/pv_services/test_pvc_invalid_inputs.py
+++ b/tests/manage/pv_services/test_pvc_invalid_inputs.py
@@ -34,7 +34,7 @@ def setup(self):
     """
     # Create a storage class
     log.info("Creating a Storage Class")
-    self.sc_data = templating.load_yaml_to_dict(
+    self.sc_data = templating.load_yaml(
         constants.CSI_RBD_STORAGECLASS_YAML
     )
     self.sc_data['metadata']['name'] = helpers.create_unique_resource_name(
@@ -82,7 +82,7 @@ def create_pvc_invalid_name(pvcname):
     Returns:
         None
     """
-    pvc_data = templating.load_yaml_to_dict(constants.CSI_PVC_YAML)
+    pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
     pvc_data['metadata']['name'] = pvcname
     pvc_data['spec']['storageClassName'] = SC_OBJ.name
     pvc_obj = PVC(**pvc_data)
@@ -117,7 +117,7 @@ def create_pvc_invalid_size(pvcsize):
     Returns:
         None
     """
-    pvc_data = templating.load_yaml_to_dict(constants.CSI_PVC_YAML)
+    pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
     pvc_data['metadata']['name'] = "auto"
     pvc_data['spec']['resources']['requests']['storage'] = pvcsize
     pvc_data['spec']['storageClassName'] = SC_OBJ.name

--- a/tests/manage/storageclass/test_create_storageclass_with_same_name.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_same_name.py
@@ -51,7 +51,7 @@ def create_storageclass(sc_name, expect_fail=False):
     """
 
     # Create a storage class
-    sc_data = templating.load_yaml_to_dict(constants.CSI_RBD_STORAGECLASS_YAML)
+    sc_data = templating.load_yaml(constants.CSI_RBD_STORAGECLASS_YAML)
     sc_data['metadata']['name'] = sc_name
     sc_data['parameters']['clusterID'] = defaults.ROOK_CLUSTER_NAMESPACE
 

--- a/tests/manage/storageclass/test_storageclass_invalid.py
+++ b/tests/manage/storageclass/test_storageclass_invalid.py
@@ -103,7 +103,7 @@ class TestStorageClassInvalid(ManageTest):
         Test that Persistent Volume Claim can not be created from misconfigured
         CephFS Storage Class.
         """
-        pvc_data = templating.load_yaml_to_dict(constants.CSI_PVC_YAML)
+        pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
         pvc_name = helpers.create_unique_resource_name('test', 'pvc')
         pvc_data['metadata']['name'] = pvc_name
         pvc_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE

--- a/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -44,7 +44,7 @@ class TestVerifyAllFieldsInScYamlWithOcDescribe(ManageTest):
         output
         """
         log.info(f"Creating a {interface} storage class")
-        self.sc_data = templating.load_yaml_to_dict(
+        self.sc_data = templating.load_yaml(
             getattr(constants, f"CSI_{interface}_STORAGECLASS_YAML")
         )
         self.sc_data['metadata']['name'] = (


### PR DESCRIPTION
This was requested by @vasukulkarni to move this commit from PR #713 .

Changes the name of the method load_yaml_to_dict to just load_yaml.
This is because the method doesn't return just the dict but also generator in case of multi_document=True passed.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>