### PR TITLE
Not create cephfs when deploying via operator

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -272,6 +272,10 @@ class Deployment(object):
         create_oc_resource(
             'toolbox.yaml', self.cluster_path, _templating, config.ENV_DATA
         )
+        assert pod.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector='app=rook-ceph-tools', resource_count=1, timeout=600
+        )
 
         if not self.ocs_operator_deployment:
             logger.info(f"Waiting {wait_time} seconds...")

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -299,17 +299,16 @@ class Deployment(object):
             logger.info(f"Waiting {wait_time} seconds...")
             time.sleep(wait_time)
 
-        # TODO: Check resources below and move away once handled by operator
-        # Create MDS pods for CephFileSystem
-        fs_data = templating.load_yaml_to_dict(constants.CEPHFILESYSTEM_YAML)
-        fs_data['metadata']['namespace'] = self.namespace
+            # Create MDS pods for CephFileSystem
+            fs_data = templating.load_yaml_to_dict(constants.CEPHFILESYSTEM_YAML)
+            fs_data['metadata']['namespace'] = self.namespace
 
-        ceph_obj = OCS(**fs_data)
-        ceph_obj.create()
-        assert pod.wait_for_resource(
-            condition=constants.STATUS_RUNNING, selector='app=rook-ceph-mds',
-            resource_count=2, timeout=600
-        )
+            ceph_obj = OCS(**fs_data)
+            ceph_obj.create()
+            assert pod.wait_for_resource(
+                condition=constants.STATUS_RUNNING, selector='app=rook-ceph-mds',
+                resource_count=2, timeout=600
+            )
 
         # Check for CephFilesystem creation in ocp
         cfs_data = cfs.get()

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -21,7 +21,7 @@ ROOK_CLUSTER_NAMESPACE = 'openshift-storage'
 OCS_MONITORING_NAMESPACE = 'openshift-monitoring'
 KUBECONFIG_LOCATION = 'auth/kubeconfig'  # relative from cluster_dir
 API_VERSION = "v1"
-CEPHFILESYSTEM_NAME = 'ocsci-cephfs'
+CEPHFILESYSTEM_NAME = 'rook-ceph-cephfilesystem'
 RBD_PROVISIONER = f'{ROOK_CLUSTER_NAMESPACE}.rbd.csi.ceph.com'
 CEPHFS_PROVISIONER = f'{ROOK_CLUSTER_NAMESPACE}.cephfs.csi.ceph.com'
 

--- a/ocs_ci/templates/CSI/cephfs/CephFileSystem.yaml
+++ b/ocs_ci/templates/CSI/cephfs/CephFileSystem.yaml
@@ -2,7 +2,7 @@
 apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
-  name: ocsci-cephfs
+  name: rook-ceph-cephfilesystem
   namespace: openshift-storage
 spec:
 # The metadata pool spec. Must use replication.


### PR DESCRIPTION
The cpehfs is now created by operator, so finishing this TODO.

Fixes: #740

Signed-off-by: Petr Balogh <pbalogh@redhat.com>