### PR TITLE
OCS-579-Drain node where the prometheus pod is hosted

### DIFF
--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -169,7 +169,7 @@ def prometheus_health_check(name='monitoring', kind='ClusterOperator'):
     health_info = ocp_obj.get(resource_name=name)
     health_conditions = health_info.get('status').get('conditions')
 
-     # Check prometheus is degraded
+    # Check prometheus is degraded
     # If degraded, degraded value will be True, AVAILABLE is False
     available = False
     degraded = True
@@ -181,5 +181,5 @@ def prometheus_health_check(name='monitoring', kind='ClusterOperator'):
             logging.info("Prometheus cluster degraded value is set false")
             degraded = False
 
-     if available and not degraded:
+    if available and not degraded:
         return True

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -154,3 +154,32 @@ def check_ceph_health_status_metrics_on_prometheus(mgr_pod):
         [mgr_pod for health_status in ceph_health_metric.get('data').get(
             'result') if mgr_pod == health_status.get('metric').get('pod')]
     )
+
+
+def prometheus_health_check(name='monitoring', kind='ClusterOperator'):
+    """
+    Return true if the prometheus cluster is healthy
+     Args:
+        name (str) : Name of the resources
+        kind (str): Kind of the resource
+     Returns:
+         bool : True on prometheus health is ok, false otherwise
+     """
+    ocp_obj = OCP(kind=kind)
+    health_info = ocp_obj.get(resource_name=name)
+    health_conditions = health_info.get('status').get('conditions')
+
+     # Check prometheus is degraded
+    # If degraded, degraded value will be True, AVAILABLE is False
+    available = False
+    degraded = True
+    for i in health_conditions:
+        if {('type', 'Available'), ('status', 'True')}.issubset(set(i.items())):
+            logging.info("Prometheus cluster available value is set true")
+            available = True
+        if {('status', 'False'), ('type', 'Degraded')}.issubset(set(i.items())):
+            logging.info("Prometheus cluster degraded value is set false")
+            degraded = False
+
+     if available and not degraded:
+        return True

--- a/ocs_ci/ocs/monitoring.py
+++ b/ocs_ci/ocs/monitoring.py
@@ -183,3 +183,6 @@ def prometheus_health_check(name='monitoring', kind='ClusterOperator'):
 
     if available and not degraded:
         return True
+
+    logging.error(f"Prometheus cluster is degraded {health_conditions}")
+    return False

--- a/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
+++ b/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
@@ -56,9 +56,6 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
         """
         pod_objs = test_fixture
 
-        # # Get the worker node list
-        # worker_nodes = node.get_typed_nodes(node_type='worker')
-
         # Get the prometheus pod
         pod_obj_list = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
 
@@ -84,6 +81,8 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
             POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
             assert POD.wait_for_resource(
                 condition='Running', selector=f'app=prometheus', timeout=60
+            ), (
+                f"One or more prometheus pods are not in running state"
             )
 
             # Validate prometheus pod is re-spinned on new healthy node

--- a/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
+++ b/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
@@ -37,7 +37,7 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
     @pytest.fixture(autouse=True)
     def test_fixture(self, pod_factory, num_of_pod=3):
         """
-        Setup and teardown
+        Create resources for the test
         """
         self.pod_objs = [
             pod_factory(

--- a/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
+++ b/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
@@ -2,37 +2,24 @@ import logging
 import pytest
 
 from ocs_ci.ocs import ocp, constants, defaults, node
-from ocs_ci.framework.testlib import tier4, E2ETest, bugzilla
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import tier4, E2ETest, bugzilla, ignore_leftovers
 from tests.sanity_helpers import Sanity
-from ocs_ci.ocs.monitoring import check_pvcdata_collected_on_prometheus
+from ocs_ci.ocs.monitoring import (
+    check_pvcdata_collected_on_prometheus,
+    prometheus_health_check
+)
 from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.utils import ceph_health_check
+
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def test_fixture(pod_factory, num_of_pod=3):
-    """
-    Setup and teardown
-    """
-    pod_objs = [
-        pod_factory(
-            interface=constants.CEPHBLOCKPOOL,
-            status=constants.STATUS_RUNNING
-        ) for _ in range(num_of_pod)
-    ]
-
-    # Check for the created pvc metrics on prometheus pod
-    for pod_obj in pod_objs:
-        assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
-            f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
-        )
-
-    return pod_objs
-
-
 @bugzilla('1744204')
 @pytest.mark.polarion_id("OCS-579")
+@tier4
+@ignore_leftovers
 class TestDrainNodeWherePrometheusPodHosted(E2ETest):
     """
     When the node is drained where the prometheus pod is hosted,
@@ -47,14 +34,30 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
         """
         self.sanity_helpers = Sanity()
 
-    @tier4
-    def test_monitoring_after_draining_node_where_prometheus_hosted(self, test_fixture, pod_factory):
+    @pytest.fixture(autouse=True)
+    def test_fixture(self, pod_factory, num_of_pod=3):
+        """
+        Setup and teardown
+        """
+        self.pod_objs = [
+            pod_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                status=constants.STATUS_RUNNING
+            ) for _ in range(num_of_pod)
+        ]
+
+        # Check for the created pvc metrics on prometheus pod
+        for pod_obj in self.pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+            )
+
+    def test_monitoring_after_draining_node_where_prometheus_hosted(self):
         """
         Test case to validate when node is drained where prometheus
         is hosted, prometheus pod should re-spin on new healthy node
         and shouldn't be any data/metrics loss
         """
-        pod_objs = test_fixture
 
         # Get the prometheus pod
         pod_obj_list = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
@@ -80,16 +83,16 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
             # Validate all prometheus pod is running
             POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
             assert POD.wait_for_resource(
-                condition='Running', selector=f'app=prometheus', timeout=60
+                condition='Running', selector='app=prometheus', timeout=60
             ), (
-                f"One or more prometheus pods are not in running state"
+                "One or more prometheus pods are not in running state"
             )
 
             # Validate prometheus pod is re-spinned on new healthy node
             pod_info = pod_obj.get()
             new_node = pod_info['spec']['nodeName']
             assert new_node not in prometheus_node, (
-                f'Promethues pod not re-spinned on new node'
+                'Promethues pod not re-spinned on new node'
             )
             logger.info(f"Prometheus pod re-spinned on new node {new_node}")
 
@@ -98,14 +101,29 @@ class TestDrainNodeWherePrometheusPodHosted(E2ETest):
                 f"Old pvc not found after restarting the prometheus pod {pod_obj.name}"
             )
 
+            # Validate the prometheus health is ok
+            assert prometheus_health_check(), (
+                "Prometheus cluster health is not OK"
+            )
+
             # Mark the nodes back to schedulable
             node.schedule_nodes([prometheus_node])
 
-            # Check the node are Ready state and check cluster is health ok
-            self.sanity_helpers.health_check()
+            # Verify health of ceph cluster
+            assert ceph_health_check(
+                namespace=config.ENV_DATA["cluster_namespace"]
+            )
+
+        # Check the node are Ready state and check cluster is health ok
+        self.sanity_helpers.health_check()
+
+        # Validate the prometheus health is ok
+        assert prometheus_health_check(), (
+            "Prometheus cluster health is not OK"
+        )
 
         # Check for the created pvc metrics after rebooting the master nodes
-        for pod_obj in pod_objs:
+        for pod_obj in self.pod_objs:
             assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
                 f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
             )

--- a/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
+++ b/tests/e2e/monitoring/test_when_node_drained_where_prometheus_hosted.py
@@ -1,0 +1,112 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import ocp, constants, defaults, node
+from ocs_ci.framework.testlib import tier4, E2ETest, bugzilla
+from tests.sanity_helpers import Sanity
+from ocs_ci.ocs.monitoring import check_pvcdata_collected_on_prometheus
+from ocs_ci.ocs.resources import pod
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def test_fixture(pod_factory, num_of_pod=3):
+    """
+    Setup and teardown
+    """
+    pod_objs = [
+        pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            status=constants.STATUS_RUNNING
+        ) for _ in range(num_of_pod)
+    ]
+
+    # Check for the created pvc metrics on prometheus pod
+    for pod_obj in pod_objs:
+        assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+            f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+        )
+
+    return pod_objs
+
+
+@bugzilla('1744204')
+@pytest.mark.polarion_id("OCS-579")
+class TestDrainNodeWherePrometheusPodHosted(E2ETest):
+    """
+    When the node is drained where the prometheus pod is hosted,
+    the pod should be re-spin on new healthy node.
+    They should not be any loss of the data/metrics which was collected before.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_sanity(self):
+        """
+        Initialize Sanity instance
+        """
+        self.sanity_helpers = Sanity()
+
+    @tier4
+    def test_monitoring_after_draining_node_where_prometheus_hosted(self, test_fixture, pod_factory):
+        """
+        Test case to validate when node is drained where prometheus
+        is hosted, prometheus pod should re-spin on new healthy node
+        and shouldn't be any data/metrics loss
+        """
+        pod_objs = test_fixture
+
+        # # Get the worker node list
+        # worker_nodes = node.get_typed_nodes(node_type='worker')
+
+        # Get the prometheus pod
+        pod_obj_list = pod.get_all_pods(namespace=defaults.OCS_MONITORING_NAMESPACE, selector=['prometheus'])
+
+        for pod_obj in pod_obj_list:
+
+            # Get the pvc which mounted on prometheus pod
+            pod_info = pod_obj.get()
+            pvc_name = pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName']
+
+            # Get the node where the prometheus pod is hosted
+            prometheus_pod_obj = pod_obj.get()
+            prometheus_node = prometheus_pod_obj['spec']['nodeName']
+
+            # Drain node where the prometheus pod hosted
+            node.drain_nodes([prometheus_node])
+
+            # Validate node is in SchedulingDisabled state
+            node.wait_for_nodes_status(
+                [prometheus_node], status=constants.NODE_READY_SCHEDULING_DISABLED
+            )
+
+            # Validate all prometheus pod is running
+            POD = ocp.OCP(kind=constants.POD, namespace=defaults.OCS_MONITORING_NAMESPACE)
+            assert POD.wait_for_resource(
+                condition='Running', selector=f'app=prometheus', timeout=60
+            )
+
+            # Validate prometheus pod is re-spinned on new healthy node
+            pod_info = pod_obj.get()
+            new_node = pod_info['spec']['nodeName']
+            assert new_node not in prometheus_node, (
+                f'Promethues pod not re-spinned on new node'
+            )
+            logger.info(f"Prometheus pod re-spinned on new node {new_node}")
+
+            # Validate same pvc is mounted on prometheus pod
+            assert pod_info['spec']['volumes'][0]['persistentVolumeClaim']['claimName'] in pvc_name, (
+                f"Old pvc not found after restarting the prometheus pod {pod_obj.name}"
+            )
+
+            # Mark the nodes back to schedulable
+            node.schedule_nodes([prometheus_node])
+
+            # Check the node are Ready state and check cluster is health ok
+            self.sanity_helpers.health_check()
+
+        # Check for the created pvc metrics after rebooting the master nodes
+        for pod_obj in pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+            )


### PR DESCRIPTION
Test case to validate when node is drained where prometheus is hosted, prometheus pod should re-spin on new healthy node and shouldn't be any data/metrics loss

Signed-off-by: Akarsha <akrai@redhat.com>