### PR TITLE
Fix pgsql test

### DIFF
--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -124,6 +124,8 @@ class RipSaw(object):
         run(f'oc delete -f {self.operator}', shell=True, cwd=self.dir)
         run(f'oc delete -f deploy', shell=True, cwd=self.dir)
         run_cmd(f'oc delete project {self.namespace}')
+        # Reset namespace to default 'openshift-storage'
+        run(f'oc project openshift-storage', shell=True)
         if self.pgsql_is_setup:
             self.pgsql_sset.delete()
             self.pgsql_cmap.delete()

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -131,4 +131,3 @@ class RipSaw(object):
             self.pgsql_cmap.delete()
             self.pgsql_service.delete()
         self.ns_obj.wait_for_delete(resource_name=self.namespace)
-

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -131,3 +131,4 @@ class RipSaw(object):
             self.pgsql_cmap.delete()
             self.pgsql_service.delete()
         self.ns_obj.wait_for_delete(resource_name=self.namespace)
+

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -7,11 +7,13 @@ import tempfile
 
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.ocp import switch_to_default_rook_cluster_project
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants
 from subprocess import run, CalledProcessError
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.utility import templating
+
 
 log = logging.getLogger(__name__)
 
@@ -124,8 +126,8 @@ class RipSaw(object):
         run(f'oc delete -f {self.operator}', shell=True, cwd=self.dir)
         run(f'oc delete -f deploy', shell=True, cwd=self.dir)
         run_cmd(f'oc delete project {self.namespace}')
-        # Reset namespace to default 'openshift-storage'
-        run(f'oc project openshift-storage', shell=True)
+        # Reset namespace to default
+        switch_to_default_rook_cluster_project()
         if self.pgsql_is_setup:
             self.pgsql_sset.delete()
             self.pgsql_cmap.delete()

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -14,7 +14,6 @@ from subprocess import run, CalledProcessError
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.utility import templating
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -33,7 +33,6 @@ def ripsaw(request, storageclass_factory):
 
 
 @workloads
-@tier1
 class TestPgSQLWorkload(E2ETest):
     """
     Deploy an PGSQL workload using operator
@@ -58,7 +57,7 @@ class TestPgSQLWorkload(E2ETest):
 
         # Wait for pgbench pod to be created
         for pgbench_pod in TimeoutSampler(
-            60, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
+            120, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
         ):
             try:
                 if pgbench_pod[0] is not None:

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -10,7 +10,7 @@ from ocs_ci.utility.utils import run_cmd, TimeoutSampler
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.ripsaw import RipSaw
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import E2ETest, tier1, workloads
+from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 log = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class TestPgSQLWorkload(E2ETest):
 
         # Wait for pgbench pod to be created
         for pgbench_pod in TimeoutSampler(
-            120, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
+            180, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
         ):
             try:
                 if pgbench_pod[0] is not None:
@@ -95,3 +95,4 @@ class TestPgSQLWorkload(E2ETest):
         # Clean up pgbench benchmark
         log.info("Deleting PG bench benchmark")
         pg_obj.delete()
+

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -57,7 +57,7 @@ class TestPgSQLWorkload(E2ETest):
 
         # Wait for pgbench pod to be created
         for pgbench_pod in TimeoutSampler(
-            180, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
+            300, 3, get_pod_name_by_pattern, 'pgbench-1-dbs-client', 'my-ripsaw'
         ):
             try:
                 if pgbench_pod[0] is not None:

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -95,4 +95,3 @@ class TestPgSQLWorkload(E2ETest):
         # Clean up pgbench benchmark
         log.info("Deleting PG bench benchmark")
         pg_obj.delete()
-

--- a/tests/e2e/test_pgsql.py
+++ b/tests/e2e/test_pgsql.py
@@ -77,7 +77,7 @@ class TestPgSQLWorkload(E2ETest):
         )
 
         # Running pgbench and parsing logs
-        output = run_cmd(f'bin/oc logs {pgbench_client_pod}')
+        output = run_cmd(f'oc logs {pgbench_client_pod}')
         pg_output = utils.parse_pgsql_logs(output)
         log.info(
             "*******PGBench output log*********\n"


### PR DESCRIPTION
Fixed timeout, removed tier1 and added switching back to namespace "openshift-storage" after cleanup.

``` 
Collecting Cluster versions
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0
rootdir: /Users/tunguyen/OCS/ocs-ci, inifile: pytest.ini
plugins: marker-bugzilla-0.9.1.dev2, reportportal-1.0.5, html-1.22.0, logger-0.5.1, metadata-1.8.0
collected 1 item                                                                                                                                  

tests/e2e/test_pgsql.py::TestPgSQLWorkload::test_sql_workload_simple 
----------------------------------------------------------------- live log setup ------------------------------------------------------------------
13:39:10 - MainThread - tests.conftest - INFO - All logs located at /tmp/ocs-ci-logs-1568320740
13:39:10 - MainThread - ocs_ci.deployment.factory - INFO - Deployment key = aws_ipi
13:39:10 - MainThread - ocs_ci.deployment.factory - INFO - Current deployment platform: AWS,deployment type: ipi
13:39:14 - MainThread - ocs_ci.utility.utils - INFO - Executing command: ./bin/oc version
13:39:15 - MainThread - ocs_ci.utility.utils - INFO - OpenShift Client version: Client Version: version.Info{Major:"4", Minor:"2+", GitVersion:"v4.2.0-201908071853+7b9a22b-dirty", GitCommit:"7b9a22b", GitTreeState:"dirty", BuildDate:"2019-08-07T23:34:07Z", GoVersion:"go1.12.6", Compiler:"gc", Platform:"darwin/amd64"}
                                                      Server Version: version.Info{Major:"1", Minor:"14+", GitVersion:"v1.14.6+cf0149f", GitCommit:"cf0149f", GitTreeState:"clean", BuildDate:"2019-09-11T23:11:17Z", GoVersion:"go1.12.8", Compiler:"gc", Platform:"linux/amd64"}
                                                      OpenShift Version: 4.2.0-0.nightly-2019-09-12-114308
13:39:15 - MainThread - ocs_ci.utility.utils - INFO - The rook directory /Users/tunguyen/OCS/ocs-ci/data/rook already exists, ocs-ci will skip the clone of rook repository.
13:39:15 - MainThread - ocs_ci.utility.utils - INFO - Fetching latest changes from rook repository.
13:39:15 - MainThread - ocs_ci.utility.utils - INFO - Executing command: git fetch --all
13:39:16 - MainThread - ocs_ci.utility.utils - WARNING - Command warning: From https://github.com/rook/rook
                                                            af2c1d24..2f9db0e1  release-1.1 -> origin/release-1.1
13:39:16 - MainThread - ocs_ci.utility.utils - INFO - Checkout rook repository to specific branch: master
13:39:16 - MainThread - ocs_ci.utility.utils - INFO - Executing command: git checkout master
13:39:16 - MainThread - ocs_ci.utility.utils - WARNING - Command warning: Already on 'master'
13:39:16 - MainThread - ocs_ci.utility.utils - INFO - Reset branch: master with latet changes
13:39:16 - MainThread - ocs_ci.utility.utils - INFO - Executing command: git reset --hard origin/master
13:39:16 - Dummy-1 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod  -A -o yaml
13:39:16 - Dummy-2 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get StorageClass  -A -o yaml
13:39:16 - Dummy-3 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephFileSystem  -A -o yaml
13:39:16 - Dummy-4 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephBlockPool  -A -o yaml
13:39:16 - Dummy-5 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get PersistentVolume  -A -o yaml
13:39:16 - Dummy-6 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get PersistentVolumeClaim  -A -o yaml
13:39:16 - Dummy-7 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Namespace  -A -o yaml
13:39:23 - MainThread - tests.e2e.test_pgsql - INFO - Creating a Storage Class
13:39:23 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod  -n openshift-storage --selector=app=rook-ceph-tools -o yaml
13:39:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod rook-ceph-tools-5f5dc75fd5-qhksz -n openshift-storage
13:39:24 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig rsh rook-ceph-tools-5f5dc75fd5-qhksz ceph auth get-key client.admin --format json-pretty
13:39:26 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Secret with name secret-test-rbd-5db26c061da04da989841a84ad544ce3
13:39:26 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: v1
                                                           kind: Secret
                                                           metadata:
                                                             name: secret-test-rbd-5db26c061da04da989841a84ad544ce3
                                                             namespace: openshift-storage
                                                           stringData:
                                                             userID: admin
                                                             userKey: AQCmi3pdOeEjLRAAKzBlw1OOsXgUWC6CUhKlKA==
13:39:26 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Secretjcv63t8k -o yaml
13:39:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Secret secret-test-rbd-5db26c061da04da989841a84ad544ce3 -n openshift-storage -o yaml
13:39:27 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding CephBlockPool with name cbp-test-17acea49509343b9ab1b984d2bfb13d3
13:39:27 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: ceph.rook.io/v1
                                                           kind: CephBlockPool
                                                           metadata:
                                                             name: cbp-test-17acea49509343b9ab1b984d2bfb13d3
                                                             namespace: openshift-storage
                                                           spec:
                                                             annotations: null
                                                             failureDomain: host
                                                             replicated:
                                                               size: 3
13:39:27 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/CephBlockPoolb2ac43y6 -o yaml
13:39:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephBlockPool cbp-test-17acea49509343b9ab1b984d2bfb13d3 -n openshift-storage -o yaml
13:39:28 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephBlockPool cbp-test-17acea49509343b9ab1b984d2bfb13d3 -n openshift-storage -o yaml
13:39:29 - MainThread - tests.helpers - INFO - Verifying that block pool cbp-test-17acea49509343b9ab1b984d2bfb13d3 exists
13:39:29 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod  -n openshift-storage --selector=app=rook-ceph-tools -o yaml
13:39:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod rook-ceph-tools-5f5dc75fd5-qhksz -n openshift-storage
13:39:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig rsh rook-ceph-tools-5f5dc75fd5-qhksz ceph osd lspools --format json-pretty
13:39:32 - MainThread - tests.helpers - INFO - POOLS are [{'poolnum': 1, 'poolname': 'ocsci-cephfs-metadata'}, {'poolnum': 2, 'poolname': 'ocsci-cephfs-data0'}, {'poolnum': 6, 'poolname': 'cbp-test-17acea49509343b9ab1b984d2bfb13d3'}]
13:39:32 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding StorageClass with name pgsql-workload
13:39:32 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: storage.k8s.io/v1
                                                           kind: StorageClass
                                                           metadata:
                                                             name: pgsql-workload
                                                             namespace: openshift-storage
                                                           parameters:
                                                             clusterID: openshift-storage
                                                             csi.storage.k8s.io/node-stage-secret-name: secret-test-rbd-5db26c061da04da989841a84ad544ce3
                                                             csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
                                                             csi.storage.k8s.io/provisioner-secret-name: secret-test-rbd-5db26c061da04da989841a84ad544ce3
                                                             csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
                                                             imageFeatures: layering
                                                             imageFormat: '2'
                                                             pool: cbp-test-17acea49509343b9ab1b984d2bfb13d3
                                                           provisioner: openshift-storage.rbd.csi.ceph.com
                                                           reclaimPolicy: Delete
13:39:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/StorageClasst8efed32 -o yaml
13:39:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get StorageClass pgsql-workload -n openshift-storage -o yaml
13:39:35 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc new-project my-ripsaw
13:39:36 - MainThread - ocs_ci.ocs.ripsaw - INFO - cloning ripsaw in /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/ripsaw_rrq3xni5
------------------------------------------------------------------ live log call ------------------------------------------------------------------
13:39:38 - MainThread - tests.e2e.test_pgsql - INFO - Deploying postgres database
13:39:45 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Service with name postgres
13:39:45 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: v1
                                                           kind: Service
                                                           metadata:
                                                             labels:
                                                               name: postgres
                                                             name: postgres
                                                             namespace: my-ripsaw
                                                           spec:
                                                             clusterIP: None
                                                             ports:
                                                             - port: 5432
                                                               targetPort: 5432
                                                             selector:
                                                               role: postgres
13:39:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Service_my1u1jx -o yaml
13:39:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Service postgres -n my-ripsaw -o yaml
13:39:46 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding ConfigMap with name postgres-config
13:39:46 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: v1
                                                           data:
                                                             PGDATA: /var/lib/postgresql/data/pgdata
                                                             POSTGRES_DB: testdb
                                                             POSTGRES_PASSWORD: test
                                                             POSTGRES_USER: test
                                                           kind: ConfigMap
                                                           metadata:
                                                             labels:
                                                               app: postgres
                                                             name: postgres-config
                                                             namespace: my-ripsaw
13:39:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/ConfigMap4frevot7 -o yaml
13:39:46 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get ConfigMap postgres-config -n my-ripsaw -o yaml
13:39:47 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding StatefulSet with name postgres
13:39:47 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: apps/v1beta1
                                                           kind: StatefulSet
                                                           metadata:
                                                             name: postgres
                                                             namespace: my-ripsaw
                                                           spec:
                                                             replicas: 1
                                                             serviceName: postgres
                                                             template:
                                                               metadata:
                                                                 labels:
                                                                   app: postgres
                                                                   role: postgres
                                                               spec:
                                                                 containers:
                                                                 - envFrom:
                                                                   - configMapRef:
                                                                       name: postgres-config
                                                                   image: postgres:10.4
                                                                   imagePullPolicy: IfNotPresent
                                                                   name: postgres
                                                                   ports:
                                                                   - containerPort: 5432
                                                                   volumeMounts:
                                                                   - mountPath: /var/lib/postgresql/data
                                                                     name: postgres-persistent-storage
                                                             volumeClaimTemplates:
                                                             - metadata:
                                                                 annotations:
                                                                   volume.beta.kubernetes.io/storage-class: pgsql-workload
                                                                 name: postgres-persistent-storage
                                                               spec:
                                                                 accessModes:
                                                                 - ReadWriteOnce
                                                                 resources:
                                                                   requests:
                                                                     storage: 10Gi
13:39:47 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/StatefulSet57l_bdhk -o yaml
13:39:49 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get StatefulSet postgres -n my-ripsaw -o yaml
13:39:49 - MainThread - ocs_ci.ocs.ocp - INFO - Waiting for a resource(s) of kind pod identified by name '' and selector app=postgres to reach desired condition Running
13:39:49 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod  --selector=app=postgres -o yaml
13:39:55 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod postgres-0
13:39:57 - MainThread - ocs_ci.ocs.ocp - INFO - status of  item(s) were ['ContainerCreating'], but we were waiting for all of them to be Running
13:40:00 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod  --selector=app=postgres -o yaml
13:40:01 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod postgres-0
13:40:01 - MainThread - ocs_ci.ocs.ocp - INFO - status of  item(s) were ['ContainerCreating'], but we were waiting for all of them to be Running
13:40:04 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod  --selector=app=postgres -o yaml
13:40:05 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod postgres-0
13:40:05 - MainThread - tests.e2e.test_pgsql - INFO - Create resource file for pgbench workload
13:40:05 - MainThread - ocs_ci.ocs.resources.ocs - INFO - Adding Benchmark with name pgbench-benchmark
13:40:05 - MainThread - ocs_ci.utility.templating - INFO - apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
                                                           kind: Benchmark
                                                           metadata:
                                                             name: pgbench-benchmark
                                                             namespace: my-ripsaw
                                                           spec:
                                                             workload:
                                                               args:
                                                                 clients:
                                                                 - 20
                                                                 cmd_flags: ''
                                                                 databases:
                                                                 - db_name: testdb
                                                                   host: postgres-0.postgres
                                                                   password: test
                                                                   user: test
                                                                 init_cmd_flags: ''
                                                                 samples: 5
                                                                 scaling_factor: 2
                                                                 threads: 2
                                                                 timeout: 5
                                                                 transactions: 100
                                                               name: pgbench
13:40:05 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig create -f /var/folders/7q/vqqry9kd00s1yprtq83pfy540000gn/T/Benchmark4dvq1ew8 -o yaml
13:40:07 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Benchmark pgbench-benchmark -n my-ripsaw -o yaml
13:40:08 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:08 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:11 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:12 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:15 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:16 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:19 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:19 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:22 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:23 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:26 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:26 - MainThread - tests.e2e.test_pgsql - INFO - Bench pod not ready yet
13:40:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pods -o name
13:40:30 - MainThread - ocs_ci.ocs.utils - INFO - pod name match found appending pgbench-1-dbs-client-1-ba68e674-wpj4n
13:40:30 - MainThread - tests.e2e.test_pgsql - INFO - Waiting for pgbench_client to complete
13:40:30 - MainThread - ocs_ci.ocs.ocp - INFO - Waiting for a resource(s) of kind pod identified by name 'pgbench-1-dbs-client-1-ba68e674-wpj4n' and selector None to reach desired condition Completed
13:40:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:40:31 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:40:31 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was ContainerCreating, but we were waiting for Completed
13:40:41 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:40:42 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:40:42 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was Running, but we were waiting for Completed
13:40:52 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:40:53 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:40:54 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was Running, but we were waiting for Completed
13:41:04 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:41:09 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:41:11 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was Running, but we were waiting for Completed
13:41:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:41:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:41:22 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was Running, but we were waiting for Completed
13:41:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:41:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:41:33 - MainThread - ocs_ci.ocs.ocp - INFO - status of pgbench-1-dbs-client-1-ba68e674-wpj4n was Running, but we were waiting for Completed
13:41:43 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n -o yaml
13:41:43 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get pod pgbench-1-dbs-client-1-ba68e674-wpj4n
13:41:44 - MainThread - ocs_ci.utility.utils - INFO - Executing command: bin/oc logs pgbench-1-dbs-client-1-ba68e674-wpj4n
13:41:45 - MainThread - tests.e2e.test_pgsql - INFO - *******PGBench output log*********
                                                      [{'num_clients': '20', 'latency_avg': '100', 'lat_stddev': '80', 'tps_incl': '191', 'tps_excl': '192'}, {'num_clients': '20', 'latency_avg': '101', 'lat_stddev': '84', 'tps_incl': '189', 'tps_excl': '189'}, {'num_clients': '20', 'latency_avg': '119', 'lat_stddev': '184', 'tps_incl': '164', 'tps_excl': '164'}, {'num_clients': '20', 'latency_avg': '100', 'lat_stddev': '85', 'tps_incl': '191', 'tps_excl': '191'}, {'num_clients': '20', 'latency_avg': '104', 'lat_stddev': '94', 'tps_incl': '170', 'tps_excl': '170'}]
13:41:45 - MainThread - tests.e2e.test_pgsql - INFO - PGBench has completed successfully
13:41:45 - MainThread - tests.e2e.test_pgsql - INFO - Deleting PG bench benchmark
13:41:45 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete Benchmark pgbench-benchmark
PASSED                                                                                                                                      [100%]
---------------------------------------------------------------- live log teardown ----------------------------------------------------------------
13:41:48 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc delete project my-ripsaw
13:41:49 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete StatefulSet postgres
13:41:50 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete ConfigMap postgres-config
13:41:51 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n my-ripsaw --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete Service postgres
13:41:51 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:41:55 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:41:58 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:02 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:05 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:09 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:13 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:21 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:30 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get namespace my-ripsaw -o yaml
13:42:32 - MainThread - ocs_ci.ocs.ocp - INFO - namespace my-ripsaw got deleted successfully
13:42:32 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete StorageClass pgsql-workload
13:42:33 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get StorageClass pgsql-workload -o yaml
13:42:34 - MainThread - ocs_ci.ocs.ocp - INFO - StorageClass pgsql-workload got deleted successfully
13:42:34 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete Secret secret-test-rbd-5db26c061da04da989841a84ad544ce3
13:42:34 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Secret secret-test-rbd-5db26c061da04da989841a84ad544ce3 -n openshift-storage -o yaml
13:42:35 - MainThread - ocs_ci.ocs.ocp - INFO - Secret secret-test-rbd-5db26c061da04da989841a84ad544ce3 got deleted successfully
13:42:35 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig delete CephBlockPool cbp-test-17acea49509343b9ab1b984d2bfb13d3
13:42:36 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephBlockPool cbp-test-17acea49509343b9ab1b984d2bfb13d3 -n openshift-storage -o yaml
13:42:36 - MainThread - ocs_ci.ocs.ocp - INFO - CephBlockPool cbp-test-17acea49509343b9ab1b984d2bfb13d3 got deleted successfully
13:42:36 - Dummy-8 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Pod  -A -o yaml
13:42:36 - Dummy-9 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get StorageClass  -A -o yaml
13:42:36 - Dummy-10 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephFileSystem  -A -o yaml
13:42:36 - Dummy-11 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get CephBlockPool  -A -o yaml
13:42:36 - Dummy-12 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get PersistentVolume  -A -o yaml
13:42:36 - Dummy-13 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get PersistentVolumeClaim  -A -o yaml
13:42:36 - Dummy-14 - ocs_ci.utility.utils - INFO - Executing command: oc --kubeconfig /Users/tunguyen/OCS/tunguyen-cluster2/auth/kubeconfig get Namespace  -A -o yaml


=========================================================== 1 passed in 214.35 seconds ============================================================
```