### PR TITLE
Add Raises to the doc for CSV wait_for_phase method

### DIFF
--- a/ocs_ci/ocs/resources/csv.py
+++ b/ocs_ci/ocs/resources/csv.py
@@ -68,6 +68,10 @@ class CSV(OCP):
             timeout (int): Timeout in seconds to wait for desired phase
             sleep (int): Time in seconds to sleep between attempts
 
+        Raises:
+            ResourceInUnexpectedState: In case the CSV is not in expected
+                phase.
+
         """
         self.check_name_is_specified()
         sampler = TimeoutSampler(


### PR DESCRIPTION
We didn't raise an exception when CSV wasn't in desired phase.
Now we should fail if the CSV deployment is not successful.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>