### PR TITLE
Do not deploy toolbox when operator deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -268,10 +268,12 @@ class Deployment(object):
             resource_count=3, timeout=600
         )
 
-        # Creatig toolbox pod
-        create_oc_resource(
-            'toolbox.yaml', self.cluster_path, _templating, config.ENV_DATA
-        )
+        if not self.ocs_operator_deployment:
+            # Creatig toolbox pod
+            create_oc_resource(
+                'toolbox.yaml', self.cluster_path, _templating,
+                config.ENV_DATA,
+            )
         assert pod.wait_for_resource(
             condition=constants.STATUS_RUNNING,
             selector='app=rook-ceph-tools', resource_count=1, timeout=600


### PR DESCRIPTION
Fixes: #761

The toolbox pod is now added via operator, so we don't want to create
it when deploying via operator.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>