### PR TITLE
test_ocs_1012_1015

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -1,6 +1,7 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
+from functools import partial
 
 from ocs_ci.framework.testlib import ManageTest, tier4
 from ocs_ci.framework import config
@@ -8,7 +9,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods, get_mon_pods, get_mgr_pods, get_osd_pods, get_all_pods,
-    get_fio_rw_iops
+    get_fio_rw_iops, get_plugin_pods
 )
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from tests.helpers import (
@@ -51,6 +52,16 @@ log = logging.getLogger(__name__)
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'mds'],
             marks=pytest.mark.polarion_id("OCS-816")
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'cephfsplugin'],
+            marks=pytest.mark.polarion_id("OCS-1012")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'rbdplugin'],
+            marks=[pytest.mark.polarion_id("OCS-1015"), pytest.mark.bugzilla(
+                '1752487'
+            )]
         )
     ]
 )
@@ -188,9 +199,12 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         )
 
         pod_functions = {
-            'mds': get_mds_pods, 'mon': get_mon_pods, 'mgr': get_mgr_pods,
-            'osd': get_osd_pods
+            'mds': partial(get_mds_pods), 'mon': partial(get_mon_pods),
+            'mgr': partial(get_mgr_pods), 'osd': partial(get_osd_pods),
+            'rbdplugin': partial(get_plugin_pods, interface=interface),
+            'cephfsplugin': partial(get_plugin_pods, interface=interface)
         }
+
         disruption = disruption_helpers.Disruptions()
         disruption.set_resource(resource=resource_to_delete)
         executor = ThreadPoolExecutor(


### PR DESCRIPTION
OCS-1012
CEPHFS: Delete csi-cephfsplugin while PVC deletion, Pod deletion and IO are progressing

OCS-1015
RBD: Delete csi-rbdplugin while PVC deletion, Pod deletion and IO are progressing

Signed-off-by: Jilju Joy <jijoy@redhat.com>