### PR TITLE
Prevent deployment according to cluster name prefix

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -116,8 +116,6 @@ class AWSIPI(AWSBase):
                 log_cli_level (str): openshift installer's log level
                     (default: "DEBUG")
             """
-            # aws_ipi = AWSIPI()
-            # if not aws_ipi.check_cluster_existence():
             logger.info("Deploying OCP cluster")
             logger.info(
                 f"Openshift-installer will be using loglevel:{log_cli_level}"

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -135,7 +135,9 @@ class AWSIPI(AWSBase):
             log_cli_level (str): openshift installer's log level
                 (default: "DEBUG")
         """
-        if self.check_cluster_existence():
+        if self.check_cluster_existence() and not (
+            config.DEPLOYMENT.get('force_deploy_multiple_clusters')
+        ):
             raise SameNamePrefixClusterAlreadyExistsException
         super(AWSIPI, self).deploy_ocp(log_cli_level)
         if not self.ocs_operator_deployment:

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -50,6 +50,7 @@ DEPLOYMENT:
   ocs_operator_nodes_to_tain: 0
   ocs_operator_deployment: True
   ssh_key: "~/.ssh/libra.pub"
+  force_deploy_multiple_clusters: False
 
 # Section for reporting configuration
 REPORTING:

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -80,3 +80,7 @@ class ResourceNameNotSpecifiedException(Exception):
 
 class ResourceInUnexpectedState(Exception):
     pass
+
+
+class SameNamePrefixClusterAlreadyExistsException(Exception):
+    pass


### PR DESCRIPTION
Addresses issue https://github.com/red-hat-storage/ocs-ci/issues/779 - Prevent cluster deployment in case a cluster with the same kerberos ID already exists

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>