### PR TITLE
Fixes the ocs-ci tier2 failure due to leftover PVs in Test case test_pvc_concurrent_deletion_creation.py

### DIFF
--- a/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
@@ -5,56 +5,52 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
 
-from ocs_ci.ocs import exceptions, constants
+from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import tier2, ManageTest, bugzilla
 from ocs_ci.ocs.resources.pvc import delete_pvcs
-from tests.fixtures import (
-    create_rbd_storageclass, create_ceph_block_pool, create_rbd_secret,
-    create_project, create_pvcs
-)
-from tests.helpers import create_multiple_pvcs, wait_for_resource_state
+from tests.helpers import wait_for_resource_state
 
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def test_fixture(request):
-    """
-    Setup and teardown
-    """
-    cls_ref = request.node.cls
-    cls_ref.pvc_objs_new = []
-
-    def finalizer():
-        # Delete newly created PVCs
-        assert delete_pvcs(cls_ref.pvc_objs_new), 'Failed to delete PVCs'
-        log.info(f'Newly created {cls_ref.num_of_pvcs} PVCs are now deleted.')
-
-    request.addfinalizer(finalizer)
-
-
 @bugzilla('1734259')
 @tier2
-@pytest.mark.usefixtures(
-    create_project.__name__,
-    create_rbd_secret.__name__,
-    create_ceph_block_pool.__name__,
-    create_rbd_storageclass.__name__,
-    create_pvcs.__name__,
-    test_fixture.__name__
-)
 class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
     """
     Test to verify concurrent creation and deletion of multiple PVCs
     """
     num_of_pvcs = 100
-    pvc_size = '3Gi'
+    pvc_size = 3
 
-    def test_multiple_pvc_concurrent_creation_deletion(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, multi_pvc_factory):
+        """
+        Create PVCs
+        """
+        self.pvc_objs = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            project=None,
+            storageclass=None,
+            size=self.pvc_size,
+            access_modes=[constants.ACCESS_MODE_RWO],
+            status=constants.STATUS_BOUND,
+            num_of_pvc=self.num_of_pvcs,
+            wait_each=False
+        )
+
+    def test_multiple_pvc_concurrent_creation_deletion(self, multi_pvc_factory):
         """
         To exercise resource creation and deletion
         """
+        proj_obj = self.pvc_objs[0].project
+        storageclass = self.pvc_objs[0].storageclass
+
         executor = ThreadPoolExecutor(max_workers=1)
+
+        # Get PVs
+        pv_objs = []
+        for pvc in self.pvc_objs:
+            pv_objs.append(pvc.backed_pv_obj)
 
         # Start deleting 100 PVCs
         log.info('Start deleting PVCs.')
@@ -64,34 +60,33 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
 
         # Create 100 PVCs
         log.info('Start creating new PVCs')
-        new_pvc_objs = create_multiple_pvcs(
-            sc_name=self.sc_obj.name, namespace=self.namespace,
-            number_of_pvc=self.num_of_pvcs
+        self.new_pvc_objs = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            project=proj_obj,
+            storageclass=storageclass,
+            size=self.pvc_size,
+            access_modes=[constants.ACCESS_MODE_RWO],
+            status='',
+            num_of_pvc=self.num_of_pvcs,
+            wait_each=False
         )
-        for pvc_obj in new_pvc_objs:
+
+        for pvc_obj in self.new_pvc_objs:
             wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
             pvc_obj.reload()
         log.info(f'Newly created {self.num_of_pvcs} PVCs are in Bound state.')
-        self.pvc_objs_new.extend(new_pvc_objs)
 
         # Verify PVCs are deleted
         res = pvc_delete.result()
         assert res, 'Deletion of PVCs failed'
         log.info('PVC deletion was successful.')
-
-        # Clear pvc_objs list to avoid error in 'create_pvcs' fixture
-        self.pvc_objs.clear()
-
-        # Verify PVCs are deleted
         for pvc in self.pvc_objs:
-            try:
-                pvc.get()
-                return False
-            except exceptions.CommandFailed as exp:
-                assert "not found" in str(exp), (
-                    f'Failed to fetch details of PVC {pvc.name}'
-                )
-                log.info(f'Expected: PVC {pvc.name} does not exists')
+            pvc.ocp.wait_for_delete(resource_name=pvc.name)
         log.info(f'Successfully deleted initial {self.num_of_pvcs} PVCs')
+
+        # Verify PVs are deleted
+        for pv_obj in pv_objs:
+            pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
+        log.info(f'Successfully deleted initial {self.num_of_pvcs} PVs')
 
         # TODO: Verify PVs using ceph toolbox. Blocked by Bz 1723656


### PR DESCRIPTION
The Test case  test_pvc_concurrent_deletion_creation.py was intermittently failing in teardown due to PV leftovers. 
E.g. https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/865/

The failure is due to leftover PVs in Released state. There are some knows bugs around it, e.g. BZ#1729853 and it is an intermittent issue.

Plan - test will be updated to use pvc_factory to get rid of this issue - Won't call it as a automation bug fix because it is not automation bug. 

Why we update the test instead of marking some related bug to skip the test ?
 - It is because the bug(PV in released state for long time) is not affecting the test case. The test case is passing. Only teardown is failing.

Also, added check for underlying PV delete once all PVCs are deleted.
@jilju thanks for the help :) 

Signed-off-by: Neha Berry <nberry@redhat.com>