### PR TITLE
Add ocs_openshift_ci marker for ocs e2e prow tests

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -38,6 +38,7 @@ destroy = pytest.mark.destroy
 upgrade = pytest.mark.upgrade
 polarion_id = pytest.mark.polarion_id
 bugzilla = pytest.mark.bugzilla
+ocs_openshift_ci = pytest.mark.ocs_openshift_ci
 
 # mark the test class with marker below to ignore leftover check
 ignore_leftovers = pytest.mark.ignore_leftovers

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,7 @@ markers =
     upgrade: upgrade related tests
     polarion_id: ID of test case used for reporting to Polarion
     libtest: marker for library tests which requires a running cluster
+    ocs_openshift_ci: marker for upstream ocs-operator prow e2e tests
 
 
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework.pytest_customization.marks import tier1, ocs_openshift_ci
 
 logger = logging.getLogger(__name__)
 
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.skipif(condition=True, reason="MCG is not deployed")
 @pytest.mark.filterwarnings('ignore::urllib3.exceptions.InsecureRequestWarning')
 @tier1
+@ocs_openshift_ci
 class TestBucketCreation:
     """
     Test creation of a bucket

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework.pytest_customization.marks import tier1, ocs_openshift_ci
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
     'ignore::urllib3.exceptions.InsecureRequestWarning'
 )
 @tier1
+@ocs_openshift_ci
 class TestBucketDeletion:
     """
     Test bucket Creation Deletion of buckets

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -4,7 +4,7 @@ import boto3
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, ocs_openshift_ci
 from ocs_ci.ocs import constants
 from tests.helpers import craft_s3_command
 
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
     reason="Tests are not running on AWS deployed cluster"
 )
 @tier1
+@ocs_openshift_ci
 class TestBucketIO(ManageTest):
     """
     Test IO of a bucket

--- a/tests/manage/pv_services/test_create_storage_class_pvc.py
+++ b/tests/manage/pv_services/test_create_storage_class_pvc.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from tests import helpers
 
 log = logging.getLogger(__name__)
@@ -87,6 +87,7 @@ def teardown_fs():
 
 
 @tier1
+@ocs_openshift_ci
 class TestOSCBasics(ManageTest):
     @pytest.mark.polarion_id("OCS-336")
     def test_basics_rbd(self, test_fixture_rbd):

--- a/tests/manage/pv_services/test_pv_creation.py
+++ b/tests/manage/pv_services/test_pv_creation.py
@@ -10,7 +10,7 @@ import yaml
 from ocs_ci.framework import config
 from ocs_ci.ocs import exceptions, ocp
 from ocs_ci.ocs.constants import TEMPLATE_PV_PVC_DIR
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from ocs_ci.utility import templating, utils
 
 log = logging.getLogger(__name__)
@@ -87,6 +87,7 @@ def verify_pv_exist(pv_name):
 
 
 @tier1
+@ocs_openshift_ci
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from ocs_ci.ocs import constants
 from tests import helpers
 
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 
 
 @tier1
+@ocs_openshift_ci
 @pytest.mark.parametrize(
     argnames=["reclaim_policy"],
     argvalues=[

--- a/tests/manage/pv_services/test_reclaim_policy.py
+++ b/tests/manage/pv_services/test_reclaim_policy.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from tests import helpers
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.resources.pod import list_ceph_images
@@ -55,6 +55,7 @@ def teardown(self):
 
 
 @tier1
+@ocs_openshift_ci
 @pytest.mark.usefixtures(
     create_ceph_block_pool.__name__,
     create_rbd_secret.__name__,

--- a/tests/manage/storageclass/test_create_storageclass_with_same_name.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_same_name.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, defaults
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility import templating
@@ -79,6 +79,7 @@ def create_storageclass(sc_name, expect_fail=False):
 
 
 @tier1
+@ocs_openshift_ci
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )

--- a/tests/manage/storageclass/test_rbd_csi_default_sc.py
+++ b/tests/manage/storageclass/test_rbd_csi_default_sc.py
@@ -5,7 +5,7 @@ Basic test for creating PVC with default StorageClass - RBD-CSI
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, ManageTest, ocs_openshift_ci
 from tests import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ResourceLeftoversException
@@ -51,6 +51,7 @@ def resources(request):
 
 
 @tier1
+@ocs_openshift_ci
 @pytest.mark.usefixtures(
     create_ceph_block_pool.__name__,
     create_rbd_secret.__name__,

--- a/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -5,7 +5,7 @@ from tests import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, ocs_openshift_ci
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret, create_cephfs_secret
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 SC_OBJ = None
 
 
+@ocs_openshift_ci
 @tier1
 @pytest.mark.usefixtures(
     create_rbd_secret.__name__,


### PR DESCRIPTION
We'd like to start running some of the ocs-ci tests on each ocs-operator PR in github.com/openshift/ocs-operator. 

The idea here is that I'd like to start with a small subset of tests that proved to reliably pass in our environment and then slowly expand that list as we gain confidence. In order to have control over what tests we enable without impacting other teams, I've created a new marker called ```ocs-openshift-ci```. 