### PR TITLE
Adding test cases OCS-945 OCS-952

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -871,3 +871,57 @@ def get_plugin_pods(interface, namespace=None):
     plugins_info = get_pods_having_label(plugin_label, namespace)
     plugin_pods = [Pod(**plugin) for plugin in plugins_info]
     return plugin_pods
+
+
+def plugin_provisioner_leader(interface, namespace=None):
+    """
+    Find csi-cephfsplugin-provisioner or csi-rbdplugin-provisioner leader pod
+
+    Args:
+        interface (str): Interface type. eg: CephBlockPool, CephFileSystem
+        namespace (str): Name of cluster namespace
+
+    Returns:
+        Pod: csi-cephfsplugin-provisioner or csi-rbdplugin-provisioner leader
+            pod
+    """
+    non_leader_msg = 'failed to acquire lease'
+    lease_acq_msg = 'successfully acquired lease'
+    lease_renew_msg = 'successfully renewed lease'
+    leader_pod = ''
+
+    if interface == constants.CEPHBLOCKPOOL:
+        pods = get_rbdfsplugin_provisioner_pods(namespace=namespace)
+    if interface == constants.CEPHFILESYSTEM:
+        pods = get_cephfsplugin_provisioner_pods(namespace=namespace)
+
+    pods_log = {}
+    for pod in pods:
+        pods_log[pod] = get_pod_logs(
+            pod_name=pod.name, container='csi-provisioner'
+        ).split('\n')
+
+    for pod, log_list in pods_log.items():
+        # Reverse the list to find last occurrence of message without
+        # iterating over all elements
+        log_list.reverse()
+        for log_msg in log_list:
+            # Check for last occurrence of leader messages.
+            # This will be the first occurrence in reversed list.
+            if (lease_renew_msg in log_msg) or (lease_acq_msg in log_msg):
+                curr_index = log_list.index(log_msg)
+                # Ensure that there is no non leader message logged after
+                # the last occurrence of leader message
+                if not any(
+                    non_leader_msg in msg for msg in log_list[:curr_index]
+                ):
+                    assert not leader_pod, (
+                        "Couldn't identify plugin provisioner leader pod by "
+                        "analysing the logs. Found more than one match."
+                    )
+                    leader_pod = pod
+                break
+
+    assert leader_pod, "Couldn't identify plugin provisioner leader pod."
+    logger.info(f"Plugin provisioner leader pod is {leader_pod.name}")
+    return leader_pod

--- a/tests/disruption_helpers.py
+++ b/tests/disruption_helpers.py
@@ -20,33 +20,47 @@ class Disruptions:
 
     def set_resource(self, resource):
         self.resource = resource
+        resource_count = 0
         if self.resource == 'mgr':
             self.resource_obj = pod.get_mgr_pods()
-            self.type = 'rook-ceph'
+            self.selector = constants.MGR_APP_LABEL
         if self.resource == 'mon':
             self.resource_obj = pod.get_mon_pods()
-            self.type = 'rook-ceph'
+            self.selector = constants.MON_APP_LABEL
         if self.resource == 'osd':
             self.resource_obj = pod.get_osd_pods()
-            self.type = 'rook-ceph'
+            self.selector = constants.OSD_APP_LABEL
         if self.resource == 'mds':
             self.resource_obj = pod.get_mds_pods()
-            self.type = 'rook-ceph'
+            self.selector = constants.MDS_APP_LABEL
         if self.resource == 'cephfsplugin':
             self.resource_obj = pod.get_plugin_pods(
                 interface=constants.CEPHFILESYSTEM
             )
-            self.type = 'csi'
+            self.selector = constants.CSI_CEPHFSPLUGIN_LABEL
         if self.resource == 'rbdplugin':
             self.resource_obj = pod.get_plugin_pods(
                 interface=constants.CEPHBLOCKPOOL
             )
-            self.type = 'csi'
-        self.resource_count = len(self.resource_obj)
+            self.selector = constants.CSI_RBDPLUGIN_LABEL
+        if self.resource == 'cephfsplugin_provisioner':
+            self.resource_obj = [pod.plugin_provisioner_leader(
+                interface=constants.CEPHFILESYSTEM
+            )]
+            self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+            resource_count = len(pod.get_cephfsplugin_provisioner_pods())
+        if self.resource == 'rbdplugin_provisioner':
+            self.resource_obj = [pod.plugin_provisioner_leader(
+                interface=constants.CEPHBLOCKPOOL
+            )]
+            self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+            resource_count = len(pod.get_rbdfsplugin_provisioner_pods())
+
+        self.resource_count = resource_count or len(self.resource_obj)
 
     def delete_resource(self):
         self.resource_obj[0].delete(force=True)
         assert POD.wait_for_resource(
-            condition='Running', selector=f'app={self.type}-{self.resource}',
+            condition='Running', selector=self.selector,
             resource_count=self.resource_count, timeout=300
         )

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -6,7 +6,8 @@ from functools import partial
 from ocs_ci.framework.testlib import ManageTest, tier4
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
-    get_mds_pods, get_mon_pods, get_mgr_pods, get_osd_pods, get_plugin_pods
+    get_mds_pods, get_mon_pods, get_mgr_pods, get_osd_pods, get_plugin_pods,
+    get_rbdfsplugin_provisioner_pods, get_cephfsplugin_provisioner_pods
 )
 from ocs_ci.utility.utils import TimeoutSampler
 from tests import helpers, disruption_helpers
@@ -55,6 +56,14 @@ log = logging.getLogger(__name__)
             marks=[pytest.mark.polarion_id("OCS-1010"), pytest.mark.bugzilla(
                 '1752487'
             )]
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'cephfsplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-952")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-945")
         )
     ]
 )
@@ -171,7 +180,9 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
             'mds': partial(get_mds_pods), 'mon': partial(get_mon_pods),
             'mgr': partial(get_mgr_pods), 'osd': partial(get_osd_pods),
             'rbdplugin': partial(get_plugin_pods, interface=interface),
-            'cephfsplugin': partial(get_plugin_pods, interface=interface)
+            'cephfsplugin': partial(get_plugin_pods, interface=interface),
+            'cephfsplugin_provisioner': partial(get_cephfsplugin_provisioner_pods),
+            'rbdplugin_provisioner': partial(get_rbdfsplugin_provisioner_pods)
         }
 
         executor = ThreadPoolExecutor(max_workers=len(io_pods))

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -245,7 +245,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Confirm PVCs are Bound
         for pvc_obj in pvc_objs_new:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=120
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
             )
             pvc_obj.reload()
         log.info("Verified: New PVCs are Bound.")


### PR DESCRIPTION
pod.py
Added function to get csi-cephfsplugin-provisioner or csi-rbdplugin-provisioner leader pod

disruption_helpers.py
Added resource types cephfsplugin_provisioner and rbdplugin_provisioner
Using selector to fetch pod details


Signed-off-by: Jilju Joy <jijoy@redhat.com>

