### PR TITLE
Adding tests in test_pvc_disruptive

### DIFF
--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -115,6 +115,30 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'run_io', 'cephfsplugin'],
             marks=pytest.mark.polarion_id("OCS-1017")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'create_pvc', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-941")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'create_pod', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-940")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'run_io', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-942")
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'create_pvc', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-948")
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'create_pod', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-947")
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'run_io', 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-949")
         )
     ]
 )
@@ -197,7 +221,9 @@ class TestPVCDisruption(ManageTest):
             'mds': partial(pod.get_mds_pods), 'mon': partial(pod.get_mon_pods),
             'mgr': partial(pod.get_mgr_pods), 'osd': partial(pod.get_osd_pods),
             'rbdplugin': partial(pod.get_plugin_pods, interface=interface),
-            'cephfsplugin': partial(pod.get_plugin_pods, interface=interface)
+            'cephfsplugin': partial(pod.get_plugin_pods, interface=interface),
+            'cephfsplugin_provisioner': partial(pod.get_cephfsplugin_provisioner_pods),
+            'rbdplugin_provisioner': partial(pod.get_rbdfsplugin_provisioner_pods)
         }
 
         # Get number of pods of type 'resource_to_delete'
@@ -236,7 +262,7 @@ class TestPVCDisruption(ManageTest):
                 get_all_pvcs, initial_num_of_pvc, namespace
             )
             assert ret, "Wait timeout: PVCs are not being created."
-            logging.info(
+            logger.info(
                 f"PVCs creation has started."
             )
             DISRUPTION_OPS.delete_resource()
@@ -249,7 +275,7 @@ class TestPVCDisruption(ManageTest):
                 resource=pvc_obj, state=constants.STATUS_BOUND, timeout=120
             )
             pvc_obj.reload()
-        logging.info("Verified: PVCs are Bound.")
+        logger.info("Verified: PVCs are Bound.")
 
         # Start creating pods
         bulk_pod_create = executor.submit(
@@ -262,7 +288,7 @@ class TestPVCDisruption(ManageTest):
                 pod.get_all_pods, initial_num_of_pods, namespace
             )
             assert ret, "Wait timeout: Pods are not being created."
-            logging.info(
+            logger.info(
                 f"Pods creation has started."
             )
             DISRUPTION_OPS.delete_resource()
@@ -275,7 +301,7 @@ class TestPVCDisruption(ManageTest):
                 resource=pod_obj, state=constants.STATUS_RUNNING
             )
             pod_obj.reload()
-        logging.info("Verified: All pods are Running.")
+        logger.info("Verified: All pods are Running.")
 
         # Do setup on pods for running IO
         logger.info("Setting up pods for running IO.")
@@ -301,19 +327,19 @@ class TestPVCDisruption(ManageTest):
                 storage_type='fs', size='1G', runtime=10,
                 fio_filename=f'{pod_obj.name}_io_file1'
             )
-        logging.info("FIO started on all pods.")
+        logger.info("FIO started on all pods.")
 
         if operation_to_disrupt == 'run_io':
             DISRUPTION_OPS.delete_resource()
 
-        logging.info("Fetching FIO results.")
+        logger.info("Fetching FIO results.")
         for pod_obj in pod_objs:
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
                 f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
             )
-        logging.info("Verified FIO result on pods.")
+        logger.info("Verified FIO result on pods.")
 
         # Delete pods
         for pod_obj in pod_objs:
@@ -342,14 +368,14 @@ class TestPVCDisruption(ManageTest):
                 fio_filename=f'{pod_obj.name}_io_file2'
             )
 
-        logging.info("Fetching FIO results from new pods")
+        logger.info("Fetching FIO results from new pods")
         for pod_obj in pod_objs:
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
                 f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
             )
-        logging.info("Verified FIO result on new pods.")
+        logger.info("Verified FIO result on new pods.")
 
         # Verify number of pods of type 'resource_to_delete'
         final_num_resource_to_delete = len(pod_functions[resource_to_delete]())

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -129,15 +129,21 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
             marks=pytest.mark.polarion_id("OCS-942")
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, 'create_pvc', 'rbdplugin_provisioner'],
+            *[
+                constants.CEPHFILESYSTEM, 'create_pvc',
+                'cephfsplugin_provisioner'
+            ],
             marks=pytest.mark.polarion_id("OCS-948")
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, 'create_pod', 'rbdplugin_provisioner'],
+            *[
+                constants.CEPHFILESYSTEM, 'create_pod',
+                'cephfsplugin_provisioner'
+            ],
             marks=pytest.mark.polarion_id("OCS-947")
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, 'run_io', 'rbdplugin_provisioner'],
+            *[constants.CEPHFILESYSTEM, 'run_io', 'cephfsplugin_provisioner'],
             marks=pytest.mark.polarion_id("OCS-949")
         )
     ]
@@ -222,8 +228,12 @@ class TestPVCDisruption(ManageTest):
             'mgr': partial(pod.get_mgr_pods), 'osd': partial(pod.get_osd_pods),
             'rbdplugin': partial(pod.get_plugin_pods, interface=interface),
             'cephfsplugin': partial(pod.get_plugin_pods, interface=interface),
-            'cephfsplugin_provisioner': partial(pod.get_cephfsplugin_provisioner_pods),
-            'rbdplugin_provisioner': partial(pod.get_rbdfsplugin_provisioner_pods)
+            'cephfsplugin_provisioner': partial(
+                pod.get_cephfsplugin_provisioner_pods
+            ),
+            'rbdplugin_provisioner': partial(
+                pod.get_rbdfsplugin_provisioner_pods
+            )
         }
 
         # Get number of pods of type 'resource_to_delete'


### PR DESCRIPTION
OCS-940	RBD: Delete csi-rbdplugin-provisioner while creating app pods in bulk
OCS-941	RBD: Delete csi-rbdplugin-provisioner while creating RWO and RWX PVCs in bulk
OCS-942	RBD: Delete csi-rbdplugin-provisioner while running IO
OCS-947	CEPHFS: Delete csi-cephfsplugin-provisioner while creating app pods in bulk
OCS-948	CEPHFS: Delete csi-cephfsplugin-provisioner while creating RWO and RWX PVCs in bulk
OCS-949	CEPHFS: Delete csi-cephfsplugin-provisioner while running IO