### PR TITLE
Adding test cases OCS-946 and OCS-953

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -9,7 +9,8 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods, get_mon_pods, get_mgr_pods, get_osd_pods, get_all_pods,
-    get_fio_rw_iops, get_plugin_pods
+    get_fio_rw_iops, get_plugin_pods, get_rbdfsplugin_provisioner_pods,
+    get_cephfsplugin_provisioner_pods
 )
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from tests.helpers import (
@@ -62,6 +63,14 @@ log = logging.getLogger(__name__)
             marks=[pytest.mark.polarion_id("OCS-1015"), pytest.mark.bugzilla(
                 '1752487'
             )]
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'cephfsplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-946")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'rbdplugin_provisioner'],
+            marks=pytest.mark.polarion_id("OCS-953")
         )
     ]
 )
@@ -202,7 +211,11 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             'mds': partial(get_mds_pods), 'mon': partial(get_mon_pods),
             'mgr': partial(get_mgr_pods), 'osd': partial(get_osd_pods),
             'rbdplugin': partial(get_plugin_pods, interface=interface),
-            'cephfsplugin': partial(get_plugin_pods, interface=interface)
+            'cephfsplugin': partial(get_plugin_pods, interface=interface),
+            'cephfsplugin_provisioner': partial(
+                get_cephfsplugin_provisioner_pods
+            ),
+            'rbdplugin_provisioner': partial(get_rbdfsplugin_provisioner_pods)
         }
 
         disruption = disruption_helpers.Disruptions()
@@ -354,12 +367,12 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         # Verify PVCs are deleted
         for pvc_obj in pvcs_to_delete:
             pvc_obj.ocp.wait_for_delete(pvc_obj.name)
-        logging.info("Verified: PVCs are deleted.")
+        log.info("Verified: PVCs are deleted.")
 
         # Verify PVs are deleted
         for pv_obj in pv_objs:
             pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=300)
-        logging.info("Verified: PVs are deleted.")
+        log.info("Verified: PVs are deleted.")
 
         # Verify PV using ceph toolbox. Image/Subvolume should be deleted.
         for pvc_name, uuid in pvc_uuid_map.items():


### PR DESCRIPTION
OCS-946	RBD: Delete csi-rbdplugin-provisioner while PVC deletion, Pod deletion and IO are progressiing
OCS-953	CEPHFS: Delete csi-cephfsplugin-provisioner while PVC deletion, Pod deletion and IO are progressing

Signed-off-by: Jilju Joy <jijoy@redhat.com>