### PR TITLE
OCS-605: ocs monitoring when one OSD pod down

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -271,7 +271,8 @@ class OCP(object):
         command = f"apply -f {yaml_file}"
         return self.exec_oc_cmd(command)
 
-    def patch(self, resource_name, params, type='json'):
+
+    def patch(self, resource_name, params, type=''):
         """
         Applies changes to resources
 
@@ -284,8 +285,12 @@ class OCP(object):
             bool: True in case if changes are applied. False otherwise
 
         """
+
         params = "\'" + f"{params}" + "\'"
-        command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"
+        if type:
+            command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"
+        else:
+            command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params}""
         log.info(f"Command: {command}")
         result = self.exec_oc_cmd(command)
         if 'patched' in result:

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -289,7 +289,7 @@ class OCP(object):
         if type:
             command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"
         else:
-            command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params}""
+            command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params}"
         log.info(f"Command: {command}")
         result = self.exec_oc_cmd(command)
         if 'patched' in result:

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -271,7 +271,6 @@ class OCP(object):
         command = f"apply -f {yaml_file}"
         return self.exec_oc_cmd(command)
 
-
     def patch(self, resource_name, params, type=''):
         """
         Applies changes to resources
@@ -279,13 +278,13 @@ class OCP(object):
         Args:
             resource_name (str): Name of the resource
             params (str): Changes to be added to the resource
+                e.g: params = '{"spec": {"replicas": 0}}'
             type (str): Type of the operation
 
         Returns:
             bool: True in case if changes are applied. False otherwise
 
         """
-
         params = "\'" + f"{params}" + "\'"
         if type:
             command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"

--- a/tests/e2e/monitoring/test_monitoring_when_osd_down.py
+++ b/tests/e2e/monitoring/test_monitoring_when_osd_down.py
@@ -60,7 +60,7 @@ class TestMonitoringWhenOSDDown(E2ETest):
         # Make one of the osd down(first one)
         ocp_obj = ocp.OCP(kind=constants.DEPLOYMENT, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
 
-        params = {'spec': {'replicas': 0}}
+        params = '{"spec": {"replicas": 0}}'
         name = osd_pod_list[0].get().get('metadata').get('name')
         assert ocp_obj.patch(resource_name=name[:-17], params=params), (
             f"Failed to change the replica count of osd {name} to 0"
@@ -79,7 +79,7 @@ class TestMonitoringWhenOSDDown(E2ETest):
             )
 
         # Make osd up which was down
-        params = {'spec': {'replicas': 1}}
+        params = '{"spec": {"replicas": 1}}'
         assert ocp_obj.patch(resource_name=name[:-17], params=params), (
             f"Failed to change the replica count of osd {name} to 1"
         )

--- a/tests/e2e/monitoring/test_monitoring_when_osd_down.py
+++ b/tests/e2e/monitoring/test_monitoring_when_osd_down.py
@@ -1,0 +1,83 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants, ocp, defaults
+from ocs_ci.framework.testlib import tier4, E2ETest
+from tests.sanity_helpers import Sanity
+from ocs_ci.ocs.monitoring import check_pvcdata_collected_on_prometheus
+from ocs_ci.ocs.resources import pod
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.polarion_id("OCS-605")
+@tier4
+class TestMonitoringWhenOSDDown(E2ETest):
+    """
+    When one of the osd pod is down, there shouldn't be any functional impact on prometheus pod
+    and also all data/metrics should be collected correctly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_sanity(self):
+        """
+        Initialize Sanity instance
+        """
+        self.sanity_helpers = Sanity()
+
+    @pytest.fixture(autouse=True)
+    def test_fixture(self, pod_factory, num_of_pod=3):
+        """
+        Create resources for the test
+        """
+        self.pod_objs = [
+            pod_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                status=constants.STATUS_RUNNING
+            ) for _ in range(num_of_pod)
+        ]
+
+        # Check for the created pvc metrics on prometheus pod
+        for pod_obj in self.pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+            )
+
+    def test_monitoring_when_osd_down(self, pod_factory):
+        """
+        Test case to validate monitoring when osd is down
+        """
+
+        # Get osd pods
+        osd_pod_list = pod.get_osd_pods()
+
+        # Make one of the osd down(first one)
+        ocp_obj = ocp.OCP(kind=constants.DEPLOYMENT, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+
+        params = {'spec': {'replicas': 0}}
+        name = osd_pod_list[0].get().get('metadata').get('name')
+        assert ocp_obj.patch(resource_name=name[:-17], params=params), (
+            f"Failed to change the replica count of osd {name} to 0"
+        )
+
+        # Validate osd is down
+        pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+        pod_obj.wait_for_delete(resource_name=name), (
+            f"Resources is not deleted {name}"
+        )
+
+        # Check for the created pvc metrics when osd is down
+        for pod_obj in self.pod_objs:
+            assert check_pvcdata_collected_on_prometheus(pod_obj.pvc.name), (
+                f"On prometheus pod for created pvc {pod_obj.pvc.name} related data is not collected"
+            )
+
+        # Make osd up which was down
+        params = {'spec': {'replicas': 1}}
+        assert ocp_obj.patch(resource_name=name[:-17], params=params), (
+            f"Failed to change the replica count of osd {name} to 1"
+        )
+
+        # Validate osd is up and ceph health is ok
+        self.sanity_helpers.health_check()

--- a/tests/e2e/monitoring/test_monitoring_when_osd_down.py
+++ b/tests/e2e/monitoring/test_monitoring_when_osd_down.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, ocp, defaults
-from ocs_ci.framework.testlib import tier4, E2ETest
+from ocs_ci.framework.testlib import tier4, E2ETest, ignore_leftovers
 from tests.sanity_helpers import Sanity
 from ocs_ci.ocs.monitoring import check_pvcdata_collected_on_prometheus
 from ocs_ci.ocs.resources import pod
@@ -32,6 +32,7 @@ def create_pods(pod_factory, num_of_pod=3):
     return pod_objs
 
 
+@ignore_leftovers
 @pytest.mark.polarion_id("OCS-605")
 @tier4
 class TestMonitoringWhenOSDDown(E2ETest):


### PR DESCRIPTION
A testcase to validate when one of the osd is down, there shouldn't be any functional impact on prometheus pod and also all data/metrics should be collected correctly. 

Signed-off-by: Akarsha <akrai@redhat.com>