### PR TITLE
Fix error message for non terminated instances

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -95,11 +95,11 @@ class AWSBase(Deployment):
             ins for ins in instance_objs if ins.state
             .get('Code') != constants.INSTANCE_TERMINATED
         ]
-        logger.error(
-            f"Non terminated EC2 instances with the same name prefix were found"
-            f" {[ins.id for ins in non_terminated_instances]}"
-        )
         if non_terminated_instances:
+            logger.error(
+                f"Non terminated EC2 instances with the same name prefix were"
+                f" found: {[ins.id for ins in non_terminated_instances]}"
+            )
             return True
         return False
 


### PR DESCRIPTION
Do not print error message about non terminated instances when there are no such instances present.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/808