### PR TITLE
skip leftover checks for tier3 and tier4 by default and add disruptive mark

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -43,6 +43,9 @@ bugzilla = pytest.mark.bugzilla
 # mark the test class with marker below to ignore leftover check
 ignore_leftovers = pytest.mark.ignore_leftovers
 
+# mark the test that are disruptive in nature and avoid leftover_checks
+disruptive = pytest.mark.disruptive
+
 # testing marker this is just for testing purpose if you want to run some test
 # under development, you can mark it with @run_this and run pytest -m run_this
 run_this = pytest.mark.run_this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from ocs_ci.utility.spreadsheet.spreadsheet_api import GoogleSpreadSheetAPI
 from ocs_ci.utility import aws
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    deployment, destroy, ignore_leftovers
+    deployment, destroy, ignore_leftovers, tier2, tier3, tier4, disruptive
 )
 from ocs_ci.utility.environment_check import (
     get_status_before_execution, get_status_after_execution
@@ -714,9 +714,11 @@ def cluster(request, log_cli_level):
 
 @pytest.fixture(scope='class')
 def environment_checker(request):
-    node = request.node
-    # List of marks for which we will ignore the leftover checker
-    marks_to_ignore = [m.mark for m in [deployment, destroy, ignore_leftovers]]
+    marks_to_ignore = [
+        deployment, destroy, ignore_leftovers,
+        tier2, tier3, tier4, disruptive
+    ]
+    marks_to_ignore = [m.mark for m in marks_to_ignore]
     for mark in node.iter_markers():
         if mark in marks_to_ignore:
             return


### PR DESCRIPTION
skip leftover checks for tier3 and tier4 by default and also add disruptive marker that will skip environment checker

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/737

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>