### PR TITLE
 Fixes Issue#810 - Added validation for cluster on PVC during deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -330,11 +330,12 @@ class Deployment(object):
             resource_count=3, timeout=600
         )
         # Validation for cluster on pvc
+        logger.info("Validate mon and OSD are backed by PVCs")
         validate_cluster_on_pvc(label=constants.MON_APP_LABEL)
         validate_cluster_on_pvc(label=constants.DEFAULT_DEVICESET_LABEL)
 
         if not self.ocs_operator_deployment:
-            # Creatig toolbox pod
+            # Creating toolbox pod
             create_oc_resource(
                 'toolbox.yaml', self.cluster_path, _templating,
                 config.ENV_DATA,

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -28,6 +28,7 @@ from ocs_ci.ocs.resources.pod import (
     get_all_pods,
     validate_pods_are_respinned_and_running_state
 )
+from ocs_ci.ocs.cluster import validate_cluster_on_pvc
 
 
 logger = logging.getLogger(__name__)
@@ -328,6 +329,9 @@ class Deployment(object):
             condition='Running', selector='app=rook-ceph-osd',
             resource_count=3, timeout=600
         )
+        # Validation for cluster on pvc
+        validate_cluster_on_pvc(label=constants.MON_APP_LABEL)
+        validate_cluster_on_pvc(label=constants.DEFAULT_DEVICESET_LABEL)
 
         if not self.ocs_operator_deployment:
             # Creatig toolbox pod

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -440,7 +440,8 @@ def validate_cluster_on_pvc(label):
     """
     # Get the PVCs for selected label (MON/OSD)
     ocs_pvc_obj = get_all_pvc_objs(
-        namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=label)
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=label
+    )
 
     # Check all pvc's are in bound state
     for pvc_obj in ocs_pvc_obj:
@@ -470,7 +471,6 @@ def validate_cluster_on_pvc(label):
     # Each mon and osd pod is expected to have only one Claim attached
     claim_found = True
     all_backed_by_pvc = True
-    backed_by_pvc = False
     for pod_obj in ocs_pod_obj:
         pod_volumes = pod_obj.get().get('spec').get('volumes')
         claim_spec_exists = False
@@ -497,7 +497,6 @@ def validate_cluster_on_pvc(label):
                             f"PVC {claim_name} is mounted"
                             f" on pod {pod_obj.name}"
                         )
-
         if not backed_by_pvc:
             logger.error(f"{pod_obj.name} is not backed by designated PVC ")
             all_backed_by_pvc = False
@@ -512,7 +511,7 @@ def validate_cluster_on_pvc(label):
 
     # Even if one OCS POD is not backed by a PVC, fail the deployment
     assert all_backed_by_pvc, (
-        "One or more pods are not backed by a PVC"
+        "One or more pods are not backed by a PVC "
         "please check deployment logs"
     )
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -470,6 +470,7 @@ def validate_cluster_on_pvc(label):
     # Each mon and osd pod is expected to have only one Claim attached
     claim_found = True
     all_backed_by_pvc = True
+    backed_by_pvc = False
     for pod_obj in ocs_pod_obj:
         pod_volumes = pod_obj.get().get('spec').get('volumes')
         claim_spec_exists = False
@@ -506,7 +507,7 @@ def validate_cluster_on_pvc(label):
             logger.error(
                 f"No PersistentVolumeClaim spec found in "
                 f"OCS pod {pod_obj.name}"
-                )
+            )
             claim_found = False
 
     # Even if one OCS POD is not backed by a PVC, fail the deployment

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -18,8 +18,7 @@ import ocs_ci.ocs.constants as constant
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.framework import config
-from ocs_ci.ocs import ocp, constants, defaults
-from ocs_ci.ocs import exceptions
+from ocs_ci.ocs import ocp, constants, defaults, exceptions
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
 
 logger = logging.getLogger(__name__)
@@ -429,17 +428,19 @@ class CephCluster(object):
 
 def validate_cluster_on_pvc(label):
     """
-    Validate creation of PVCs for MON and OSD pods
+    Validate creation of PVCs for MON and OSD pods.
+    Also validate that those PVCs are attached to the OCS pods
 
     Args:
-        label(string): Label for MON and/or OSD PVCs
+        label(string): Label for MON or OSD PVCs
 
     Raises:
-         Assertions on failures
+         AssertionError: If PVC is not mounted on one or more OCS pods
 
     """
     # Get the PVCs for selected label (MON/OSD)
-    ocs_pvc_obj = get_all_pvc_objs(namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=label)
+    ocs_pvc_obj = get_all_pvc_objs(
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=label)
 
     # Check all pvc's are in bound state
     for pvc_obj in ocs_pvc_obj:
@@ -447,42 +448,75 @@ def validate_cluster_on_pvc(label):
             f"PVC {pvc_obj.name} is not Bound"
         )
         logger.info(f"PVC {pvc_obj.name} is in Bound state")
+
     # Get OCS pod names based on selected label
     if label == constants.MON_APP_LABEL:
-        ocs_pod_obj = pod.get_mon_pods(mon_label=label, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+        ocs_pod_obj = pod.get_mon_pods(
+            mon_label=label, namespace=defaults.ROOK_CLUSTER_NAMESPACE
+        )
     if label == constants.DEFAULT_DEVICESET_LABEL:
-        ocs_pod_obj = pod.get_osd_pods(osd_label=constants.OSD_APP_LABEL, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+        ocs_pod_obj = pod.get_osd_pods(
+            osd_label=constants.OSD_APP_LABEL,
+            namespace=defaults.ROOK_CLUSTER_NAMESPACE
+        )
 
     # Create a pvc list for requested label
     pvc_list = []
     for pvc_obj in ocs_pvc_obj:
         pvc_list.append(pvc_obj.name)
-    # Check if PVC is mounted on designated OCS pod, loop over all PVCs in the list
+
+    # Check if PVC is mounted on designated OCS pod
+    # loop over all PVCs in the pvc_list
     # Each mon and osd pod is expected to have only one Claim attached
-    _rc = True
+    claim_found = True
+    all_backed_by_pvc = True
     for pod_obj in ocs_pod_obj:
         pod_volumes = pod_obj.get().get('spec').get('volumes')
-        pvc_exists = False
+        claim_spec_exists = False
         for volumes in pod_volumes:
             pvc = volumes.get('persistentVolumeClaim')
             if pvc:
-                claimName = pvc.get('claimName')
-                pvc_exists = True
-                if claimName in pvc_list:
-                    logger.info(f"OCS pod {pod_obj.name} is backed by PVC {claimName}")
+                claim_name = pvc.get('claimName')
+                claim_spec_exists = True
+                backed_by_pvc = False
+                if claim_name in pvc_list:
+                    logger.info(
+                        f"OCS pod {pod_obj.name} is backed by PVC {claim_name}"
+                    )
+                    # If backed by PVC, set backed_by_pvc = True
+                    backed_by_pvc = True
 
-                    # Check if Mon PVC is mounted within pod as /var/lib/ceph/mon/ceph-x
+                    # Check if Mon PVC is mounted as /var/lib/ceph/mon/ceph-x
                     if label == constants.MON_APP_LABEL:
                         mount_point = pod_obj.exec_cmd_on_pod(command="df -kh")
-                        assert "/var/lib/ceph/mon/ceph" in mount_point, f"pvc is not mounted on pod {pod_obj.name}"
-                        logger.info(f"{claimName} is mounted on pod {pod_obj.name}")
+                        assert "/var/lib/ceph/mon/ceph" in mount_point, (
+                            f"pvc is not mounted on pod {pod_obj.name}"
+                        )
+                        logger.info(
+                            f"PVC {claim_name} is mounted"
+                            f" on pod {pod_obj.name}"
+                        )
 
-        # If no PVC for an OCS POD, print error and continue checking other pods
-        if not pvc_exists:
-            logger.error(f"No PVC spec found in OCS pod {pod_obj.name}")
-            _rc = False
-    # Even if one OCS POD as no PVC attached, fail the deployment
-    assert _rc, (
-        f"At least one pod didn't have the PVC attached, "
-        f"please check deployment logs"
+        if not backed_by_pvc:
+            logger.error(f"{pod_obj.name} is not backed by designated PVC ")
+            all_backed_by_pvc = False
+
+        # If no PVC is mounted, print error and continue checking other pods
+        if not claim_spec_exists:
+            logger.error(
+                f"No PersistentVolumeClaim spec found in "
+                f"OCS pod {pod_obj.name}"
+                )
+            claim_found = False
+
+    # Even if one OCS POD is not backed by a PVC, fail the deployment
+    assert all_backed_by_pvc, (
+        "One or more pods are not backed by a PVC"
+        "please check deployment logs"
+    )
+
+    # Even if one OCS POD as PVC spec, fail the deployment
+    assert claim_found, (
+        "Claim name doesn't exists in spec of one or more pods "
+        "please check deployment logs"
     )


### PR DESCRIPTION
Fixes Issue #810 

1. Added check for ceph pvcs - mon and osd are BOUND
2. Validate the OSD and MON pods are backed by ceph PVCs
3. Validate that the PVC is mounted on MON pod. 
P.S - In OSD, it is attached with volumeMode Block, hence no similar check can be done

Signed-off-by: Neha Berry <nberry@redhat.com>