### PR TITLE
downstream-ci: fix OCP deployment

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -92,33 +92,36 @@ def get_ocsci_conf():
             region=env['AWS_REGION'],
             base_domain=env['AWS_DOMAIN'],
             worker_instance_type='m5.4xlarge',
+            cluster_namespace="openshift-storage",
+
         ),
     )
     if env.get("DOWNSTREAM") == "true":
         conf_obj['REPORTING'] = dict(us_ds='DS')
     if env.get("OCS_OPERATOR_DEPLOYMENT") == "true":
         conf_obj['DEPLOYMENT'] = dict(
-            ocs_operator_deployment=True,
             ocs_operator_image=env['OCS_OPERATOR_IMAGE'],
-            ocs_registry_image=env['OCS_REGISTRY_IMAGE'],
+            ocs_operator_deployment=True,
+            ocs_operator_storage_cluster_cr="http://pkgs.devel.redhat.com/cgit/containers/ocs-registry/plain/ocs_v1_storagecluster_cr.yaml?h=ocs-4.2-rhel-8",
+            ocs_operator_olm="http://pkgs.devel.redhat.com/cgit/containers/ocs-registry/plain/deploy-with-olm.yaml?h=ocs-4.2-rhel-8",
         )
     else:
         conf_obj['DEPLOYMENT'] = dict(ocs_operator_deployment=False)
-        # Apply image configuration if present
-        image_types = [
-            'rook',
-            'ceph',
-            'ceph_csi',
-            'rook_csi_registrar',
-            'rook_csi_provisioner',
-            'rook_csi_snapshotter',
-            'rook_csi_attacher',
-        ]
-        for image_type in image_types:
-            image_key = f"{image_type}_image"
-            image_value = env.get(image_key.upper())
-            if image_value is not None:
-                conf_obj['ENV_DATA'][image_key] = image_value
+    # Apply image configuration if present
+    image_types = [
+        'rook',
+        'ceph',
+        'ceph_csi',
+        'rook_csi_registrar',
+        'rook_csi_provisioner',
+        'rook_csi_snapshotter',
+        'rook_csi_attacher',
+    ]
+    for image_type in image_types:
+        image_key = f"{image_type}_image"
+        image_value = env.get(image_key.upper())
+        if image_value is not None:
+            conf_obj['ENV_DATA'][image_key] = image_value
     return conf_obj
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
       steps {
         sh """
         source ./venv/bin/activate
-        run-ci -m deployment --deploy --ocsci-conf=ocs-ci-ocs.yaml --cluster-name=${env.CLUSTER_USER}-ocs-ci-${env.BUILD_ID} --cluster-path=cluster --collect-logs
+        run-ci -m deployment --deploy --ocsci-conf=ocs-ci-ocs.yaml --ocsci-conf=conf/ocsci/downstream_config.yaml --cluster-name=${env.CLUSTER_USER}-ocs-ci-${env.BUILD_ID} --cluster-path=cluster --collect-logs
         """
       }
     }


### PR DESCRIPTION
This changes our config to match the downstream_config.yaml
file in ocs-ci. We also pass the original downstream_config.yaml
as an extra --ocsci-conf argument.

The only ocs-operator build I was able to get working was:

http://quay.io/rhceph-dev/ocs-registry:4.2-77.bed1df0.master

Signed-off-by: Andrew Schoen <aschoen@redhat.com>