### PR TITLE
Test delete rook-ceph-operator during deletion of PVCs and pods

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1103,7 +1103,7 @@ def wait_for_resource_count_change(
     """
     try:
         for sample in TimeoutSampler(
-            timeout, interval, func_to_use, namespace, func_kwargs
+            timeout, interval, func_to_use, namespace, **func_kwargs
         ):
             if func_to_use == pod.get_all_pods:
                 current_num = len(sample)

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -355,7 +355,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # Verify pods are deleted
         for pod_obj in pods_to_delete:
-            pod_obj.ocp.wait_for_delete(pod_obj.name, 180)
+            pod_obj.ocp.wait_for_delete(pod_obj.name, 300)
         log.info("Verified: Pods are deleted.")
 
         # Verify that the mount point is removed from nodes after deleting pod

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -10,7 +10,7 @@ from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods, get_mon_pods, get_mgr_pods, get_osd_pods, get_all_pods,
     get_fio_rw_iops, get_plugin_pods, get_rbdfsplugin_provisioner_pods,
-    get_cephfsplugin_provisioner_pods
+    get_cephfsplugin_provisioner_pods, get_operator_pods
 )
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from tests.helpers import (
@@ -71,6 +71,14 @@ log = logging.getLogger(__name__)
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'rbdplugin_provisioner'],
             marks=pytest.mark.polarion_id("OCS-953")
+        ),
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL, 'operator'],
+            marks=pytest.mark.polarion_id("OCS-934")
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM, 'operator'],
+            marks=pytest.mark.polarion_id("OCS-930")
         )
     ]
 )
@@ -215,7 +223,8 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             'cephfsplugin_provisioner': partial(
                 get_cephfsplugin_provisioner_pods
             ),
-            'rbdplugin_provisioner': partial(get_rbdfsplugin_provisioner_pods)
+            'rbdplugin_provisioner': partial(get_rbdfsplugin_provisioner_pods),
+            'operator': partial(get_operator_pods)
         }
 
         disruption = disruption_helpers.Disruptions()

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -355,7 +355,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # Verify pods are deleted
         for pod_obj in pods_to_delete:
-            pod_obj.ocp.wait_for_delete(pod_obj.name)
+            pod_obj.ocp.wait_for_delete(pod_obj.name, 180)
         log.info("Verified: Pods are deleted.")
 
         # Verify that the mount point is removed from nodes after deleting pod


### PR DESCRIPTION
OCS-930	CEPHFS: Delete Operator while PVC deletion, Pod deletion and IO are progressing
OCS-934	RBD: Delete Operator while PVC deletion, Pod deletion and IO are progressiing

Signed-off-by: Jilju Joy <jijoy@redhat.com>