### PR TITLE
check/create toolbox when ocs is deployed by other CI tools

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs import workload
 from ocs_ci.ocs import constants, defaults, node
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.utils import setup_ceph_toolbox
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import TimeoutSampler
@@ -335,6 +336,8 @@ def get_ceph_tools_pod():
     ocp_pod_obj = OCP(
         kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace']
     )
+    # setup ceph_toolbox pod if the cluster has been setup by some other CI
+    setup_ceph_toolbox()
     ct_pod_items = ocp_pod_obj.get(
         selector='app=rook-ceph-tools'
     )['items']

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -627,9 +627,14 @@ def get_pod_name_by_pattern(pattern='client', namespace='openshift-storage'):
 
 def setup_ceph_toolbox():
     """
-    Setup ceph-toolbox based
+    Setup ceph-toolbox - also checks if toolbox exists, if it exists it
+    behaves as noop.
     """
     namespace = ocsci_config.ENV_DATA['cluster_namespace']
+    ceph_toolbox = get_pod_name_by_pattern('rook-ceph-tools', namespace)
+    if len(ceph_toolbox) == 1:
+        log.info("Ceph toolbox already exists, skipping")
+        return
     rook_operator = get_pod_name_by_pattern('rook-ceph-operator', namespace)
     out = run_cmd(
         f'oc -n {namespace} get pods {rook_operator[0]} -o yaml',


### PR DESCRIPTION
Check if ceph_toolbox exists and if not create one, this is needed when OCS is deployed by other CI tools

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>