### PR TITLE
Jenkins: Optionally gather logs on deploy failure

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -95,9 +95,12 @@ def get_ocsci_conf():
             cluster_namespace="openshift-storage",
 
         ),
+        REPORTING=dict(
+            gather_on_deploy_failure=True,
+        )
     )
     if env.get("DOWNSTREAM") == "true":
-        conf_obj['REPORTING'] = dict(us_ds='DS')
+        conf_obj['REPORTING']['us_ds'] = 'DS'
     if env.get("OCS_OPERATOR_DEPLOYMENT") == "true":
         conf_obj['DEPLOYMENT'] = dict(
             ocs_operator_image=env['OCS_OPERATOR_IMAGE'],

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -62,6 +62,7 @@ REPORTING:
   us_ds: 'US'
   ocp_must_gather_image: "quay.io/openshift/origin-must-gather"
   ocs_must_gather_image: "quay.io/ocs-dev/ocs-must-gather"
+  gather_on_deploy_failure: true
 
 # This is the default information about environment. Will be overwritten with
 # --cluster-conf file.yaml data you will pass to the pytest.

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -709,13 +709,15 @@ def run_must_gather(log_dir_path, image, command=None):
         )
 
 
-def collect_ocs_logs(dir_name):
+def collect_ocs_logs(dir_name, ocp=True, ocs=True):
     """
     Collects OCS logs
 
     Args:
         dir_name (str): directory name to store OCS logs. Logs will be stored
             in dir_name suffix with _ocs_logs.
+        ocp (bool): Whether to gather OCP logs
+        ocs (bool): Whether to gather OCS logs
 
     """
     log_dir_path = os.path.join(
@@ -724,11 +726,13 @@ def collect_ocs_logs(dir_name):
         f"{dir_name}_ocs_logs"
     )
 
-    run_must_gather(os.path.join(log_dir_path, 'ocs_must_gather'),
-                    ocsci_config.REPORTING['ocs_must_gather_image'])
+    if ocs:
+        run_must_gather(os.path.join(log_dir_path, 'ocs_must_gather'),
+                        ocsci_config.REPORTING['ocs_must_gather_image'])
 
-    ocp_log_dir_path = os.path.join(log_dir_path, 'ocp_must_gather')
-    ocp_must_gather_image = ocsci_config.REPORTING['ocp_must_gather_image']
-    run_must_gather(ocp_log_dir_path, ocp_must_gather_image)
-    run_must_gather(ocp_log_dir_path, ocp_must_gather_image,
-                    '/usr/bin/gather_service_logs worker')
+    if ocp:
+        ocp_log_dir_path = os.path.join(log_dir_path, 'ocp_must_gather')
+        ocp_must_gather_image = ocsci_config.REPORTING['ocp_must_gather_image']
+        run_must_gather(ocp_log_dir_path, ocp_must_gather_image)
+        run_must_gather(ocp_log_dir_path, ocp_must_gather_image,
+                        '/usr/bin/gather_service_logs worker')


### PR DESCRIPTION
This can be opted-out by setting `REPORTING.gather_on_deploy_failure=False`