### PR TITLE
Fix typos in deployment add_node method

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -491,9 +491,9 @@ class Deployment(object):
 
     def add_node(self):
         """
-        Implement platform specif add_node in child class
+        Implement platform-specific add_node in child class
         """
-        raise NotImplementedError("add node functionality node implemented")
+        raise NotImplementedError("add node functionality not implemented")
 
     def patch_default_sc_to_non_default(self):
         """


### PR DESCRIPTION
Noticed these typos when I was going through source code to better understand tool capabilities and code flow.

Signed-off-by: Mirek Długosz <mzalewsk@redhat.com>