### PR TITLE
Registry backed by OCS and registry library functions

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -14,7 +14,7 @@ from ocs_ci.utility.utils import (
     run_cmd, ceph_health_check, is_cluster_running, get_latest_ds_olm_tag
 )
 from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
-from ocs_ci.ocs import constants, ocp, defaults
+from ocs_ci.ocs import constants, ocp, defaults, registry
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.csv import CSV
 from ocs_ci.ocs.resources.ocs import OCS
@@ -480,6 +480,9 @@ class Deployment(object):
 
             # Validate the pvc are mounted on pods
             validate_pvc_are_mounted_on_monitoring_pods(pods_list)
+
+        # Change registry backend to OCS CEPHFS RWX PVC
+        registry.change_registry_backend_to_ocs()
 
         # Verify health of ceph cluster
         # TODO: move destroy cluster logic to new CLI usage pattern?

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -70,6 +70,8 @@ POD = "Pod"
 ROUTE = "Route"
 NODE = "Node"
 DEPLOYMENTCONFIG = "deploymentconfig"
+CONFIG = "Config"
+
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"
 ROLE = 'Role'
@@ -92,6 +94,8 @@ ROOK_REPOSITORY = "https://github.com/rook/rook.git"
 OPENSHIFT_MACHINE_API_NAMESPACE = "openshift-machine-api"
 OPENSHIFT_LOGGING_NAMESPACE = "openshift-logging"
 OPENSHIFT_OPERATORS_REDHAT_NAMESPACE = "openshift-operators-redhat"
+OPENSHIFT_IMAGE_REGISTRY_NAMESPACE = "openshift-image-registry"
+OPENSHIFT_INGRESS_NAMESPACE = "openshift-ingress"
 MASTER_MACHINE = "master"
 WORKER_MACHINE = "worker"
 MOUNT_POINT = '/var/lib/www/html'
@@ -102,6 +106,10 @@ UPI_INSTALL_SCRIPT = "upi_on_aws-install.sh"
 
 DEFAULT_SECRET = 'rook-ceph-csi'
 DEFAULT_BLOCKPOOL = 'rbd'
+DEFAULT_SC_CEPHFS = "rook-ceph-cephfs"
+DEFAULT_ROUTE_CRT = "router-certs-default"
+IMAGE_REGISTRY_RESOURCE_NAME = "cluster"
+
 # encoded value of 'admin'
 ADMIN_USER = 'admin'
 GB = 1024 ** 3

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -241,6 +241,24 @@ class OCP(object):
         command = f"apply -f {yaml_file}"
         return self.exec_oc_cmd(command)
 
+    def patch(self, resource_name, params, type='json'):
+        """
+        Applies changes to resources
+        Args:
+            resource_name (str): Name of the resource
+            params (dict): Changes to be added to the resource
+            type (str): Type of the operation
+        Returns:
+            bool: True in case if changes are applied. False otherwise
+        """
+        params = "\'" + params + "\'"
+        command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"
+        log.info(f"Command: {command}")
+        result = self.exec_oc_cmd(command)
+        if 'patched' in result:
+            return True
+        return False
+
     def add_label(self, resource_name, label):
         """
         Adds a new label for this pod

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -244,14 +244,17 @@ class OCP(object):
     def patch(self, resource_name, params, type='json'):
         """
         Applies changes to resources
+
         Args:
             resource_name (str): Name of the resource
-            params (dict): Changes to be added to the resource
+            params (str): Changes to be added to the resource
             type (str): Type of the operation
+
         Returns:
             bool: True in case if changes are applied. False otherwise
+
         """
-        params = "\'" + params + "\'"
+        params = "\'" + f"{params}" + "\'"
         command = f"patch {self.kind} {resource_name} -n {self.namespace} -p {params} --type {type}"
         log.info(f"Command: {command}")
         result = self.exec_oc_cmd(command)

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -258,7 +258,7 @@ def image_list_all():
     Function to list the images in the podman registry
 
     Returns:
-        list_cmd_output
+        image_list_output (str): Images present in cluster
     """
     cmd_list = get_oc_podman_login_cmd()
     cmd_list.append(f"podman image list --format json")

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -1,0 +1,282 @@
+import logging
+import time
+import base64
+import os
+
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.utils import run_cmd
+from tests import helpers
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.framework import config
+
+
+logger = logging.getLogger(__name__)
+
+
+def change_registry_backend_to_ocs():
+    """
+    Function to deploy registry with OCS backend.
+
+    Raises:
+        AssertionError: When failure in change of registry backend to OCS
+    """
+    pv_obj = helpers.create_pvc(
+        sc_name=constants.DEFAULT_SC_CEPHFS, pvc_name='registry-cephfs-rwx-pvc',
+        namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE, size='100Gi',
+        access_mode=constants.ACCESS_MODE_RWX
+    )
+    helpers.wait_for_resource_state(pv_obj, 'Bound')
+    ocp_obj = ocp.OCP(
+        kind=constants.CONFIG, namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE
+    )
+    param_cmd = f'[{{"op": "add", "path": "/spec/storage", "value": {{"pvc": {{"claim": "{pv_obj.name}"}}}}}}]'
+    assert ocp_obj.patch(
+        resource_name=constants.IMAGE_REGISTRY_RESOURCE_NAME, params=param_cmd
+    ), f"Registry pod storage backend to OCS is not success"
+
+    # Validate registry pod status
+    validate_registry_pod_status()
+
+    # Validate pvc mount in the registry pod
+    validate_pvc_mount_on_registry_pod()
+
+
+def get_registry_pod_obj():
+    """
+    Function to get registry pod obj
+
+    Returns:
+        pod_obj (obj): Registry pod obj
+
+    Raises:
+        UnexpectedBehaviour: When image-registry pod is not present.
+    """
+    # Sometimes when there is a update in config crd, there will be 2 registry pods
+    # i.e. old pod will be terminated and new pod will be up based on new crd
+    # so below loop waits till old pod terminates
+    wait_time = 30
+    iteration = 0
+    while True:
+        iteration += 1
+        pod_data = pod.get_pods_having_label(
+            label='docker-registry=default', namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE
+        )
+        pod_obj = [pod.Pod(**data) for data in pod_data]
+        if len(pod_obj) == 1:
+            break
+        elif len(pod_obj) == 0:
+            raise UnexpectedBehaviour("Image-registry pod not present")
+        elif iteration > 6:
+            raise UnexpectedBehaviour("Waited for 3 mins Image-registry pod is not in Running state")
+        else:
+            logger.info(f"Waiting for 30 sec's for registry pod to be up iteration {iteration}")
+            time.sleep(wait_time)
+    return pod_obj
+
+
+def get_oc_podman_login_cmd():
+    """
+    Function to get oc and podman login commands on node
+
+    Returns:
+        cmd_list (list): List of cmd for oc/podman login
+    """
+    user = config.RUN['username']
+    filename = os.path.join(
+        config.ENV_DATA['cluster_path'],
+        config.RUN['password_location']
+    )
+    with open(filename) as f:
+        password = f.read()
+    helpers.refresh_oc_login_connection()
+    ocp_obj = ocp.OCP()
+    token = ocp_obj.get_user_token()
+    route = get_default_route_name()
+    cmd_list = [
+        'export KUBECONFIG=/home/core/auth/kubeconfig',
+        f"oc login -u {user} -p {password}",
+        f"podman login {route} -u {user} -p {token}"
+    ]
+    master_list = helpers.get_master_nodes()
+    helpers.rsync_kubeconf_to_node(node=master_list[0])
+    return cmd_list
+
+
+def validate_pvc_mount_on_registry_pod():
+    """
+    Function to validate pvc mounted on the registry pod
+
+    Raises:
+        AssertionError: When PVC mount not present in the registry pod
+    """
+    pod_obj = get_registry_pod_obj()
+    mount_point = pod_obj[0].exec_cmd_on_pod(command="mount")
+    assert "/registry" in mount_point, f"pvc is not mounted on pod {pod_obj.name}"
+    logger.info("Verified pvc is mounted on image-registry pod")
+
+
+def validate_registry_pod_status():
+    """
+    Function to validate registry pod status
+    """
+    pod_obj = get_registry_pod_obj()
+    helpers.wait_for_resource_state(pod_obj[0], state=constants.STATUS_RUNNING)
+
+
+def validate_all_image_registry_pod_status():
+    """
+    Function to validate all image-registry pod status
+    """
+    pass
+
+
+def validate_data_at_backend():
+    """
+    Function to validate image_push data from ceph
+    """
+    pass
+
+
+def get_registry_pvc():
+    """
+    Function to get registry pvc
+
+    Returns:
+        pvc_name (str): Returns name of the OCS pvc backed for registry
+    """
+    pod_obj = get_registry_pod_obj()
+    return pod.get_pvc_name(pod_obj)
+
+
+def get_default_route_name():
+    """
+    Function to get default route name
+
+    Returns:
+        route_name (str): Returns default route name
+    """
+    ocp_obj = ocp.OCP()
+    route_cmd = f"get route -n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE} -o yaml"
+    route_dict = ocp_obj.exec_oc_cmd(command=route_cmd)
+    return route_dict.get('items')[0].get('spec').get('host')
+
+
+def add_role_to_user(role_type, user):
+    """
+    Function to add role to user
+
+    Args:
+        role_type (str): Type of the role to be added
+        user (str): User to be added for the role
+
+    Raises:
+        AssertionError: When failure in adding new role to user
+    """
+    ocp_obj = ocp.OCP()
+    role_cmd = f"policy add-role-to-user {role_type} {user} -n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+    assert ocp_obj.exec_oc_cmd(command=role_cmd), f"Adding role failed"
+    logger.info(f"Role_type {role_type} added to the user {user}")
+
+
+def enable_route_and_create_ca_for_registry_access():
+    """
+    Function to enable route and to create ca,
+    copy to respective location for registry access
+
+    Raises:
+        AssertionError: When failure in enabling registry default route
+    """
+    ocp_obj = ocp.OCP(
+        kind=constants.CONFIG, namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE
+    )
+    assert ocp_obj.patch(
+        resource_name=constants.IMAGE_REGISTRY_RESOURCE_NAME,
+        params='{"spec": {"defaultRoute": true}}', type='merge'
+    ), f"Registry pod defaultRoute enable is not success"
+    logger.info(f"Enabled defaultRoute to true")
+    ocp_obj = ocp.OCP()
+    crt_cmd = f"get secret {constants.DEFAULT_ROUTE_CRT} -n {constants.OPENSHIFT_INGRESS_NAMESPACE} -o yaml"
+    crt_dict = ocp_obj.exec_oc_cmd(command=crt_cmd)
+    crt = crt_dict.get('data').get('tls.crt')
+    route = get_default_route_name()
+    if not os.path.exists('/tmp/secret'):
+        run_cmd(cmd='mkdir /tmp/secret')
+    with open(f"/tmp/secret/{route}.crt", "wb") as temp:
+        temp.write(base64.b64decode(crt))
+    master_list = helpers.get_master_nodes()
+    ocp.rsync(
+        src=f"/tmp/secret/", dst='/etc/pki/ca-trust/source/anchors',
+        node=master_list[0], dst_node=True
+    )
+    ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=['update-ca-trust enable'])
+    logger.info(f"Created base64 secret, copied to source location and enabled ca-trust")
+
+
+def image_pull(image_url):
+    """
+    Function to pull images from repositories
+
+    Args:
+        image_url (str): Image url container image repo link
+    """
+    cmd_list = get_oc_podman_login_cmd()
+    cmd_list.append(f"podman pull {image_url}")
+    master_list = helpers.get_master_nodes()
+    ocp_obj = ocp.OCP()
+    ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=cmd_list)
+
+
+def image_push(image_url, namespace):
+    """
+    Function to push images to destination
+
+    Args:
+        image_url (str): Image url container image repo link
+        namespace (str): Image to be uploaded namespace
+
+    Returns:
+        registry_path (str): Uploaded image path
+    """
+    cmd_list = get_oc_podman_login_cmd()
+    route = get_default_route_name()
+    split_image_url = image_url.split("/")
+    tag_name = split_image_url[-1]
+    img_path = f"{route}/{namespace}/{tag_name}"
+    cmd_list.append(f"podman tag {image_url} {img_path}")
+    cmd_list.append(f"podman push {img_path}")
+    master_list = helpers.get_master_nodes()
+    ocp_obj = ocp.OCP()
+    ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=cmd_list)
+    logger.info(f"Pushed {img_path} to registry")
+    image_list_all()
+    return img_path
+
+
+def image_list_all():
+    """
+    Function to list the images in the podman registry
+
+    Returns:
+        list_cmd_output
+    """
+    cmd_list = get_oc_podman_login_cmd()
+    cmd_list.append(f"podman image list --format json")
+    master_list = helpers.get_master_nodes()
+    ocp_obj = ocp.OCP()
+    return ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=cmd_list)
+
+
+def image_rm(registry_path):
+    """
+    Function to remove images from registry
+
+    Args:
+        registry_path (str): Image registry path
+    """
+    cmd_list = get_oc_podman_login_cmd()
+    cmd_list.append(f"podman rm {registry_path}")
+    master_list = helpers.get_master_nodes()
+    ocp_obj = ocp.OCP()
+    ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=cmd_list)
+    logger.info(f"Image {registry_path} rm successful")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1393,6 +1393,9 @@ def refresh_oc_login_connection(user=None, password=None):
 def rsync_kubeconf_to_node(node):
     """
     Function to copy kubeconfig to OCP node
+
+    Args:
+        node (str): OCP node to copy kubeconfig if not present
     """
     # ocp_obj = ocp.OCP()
     filename = os.path.join(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -774,7 +774,8 @@ def get_master_nodes():
     Fetches all master nodes.
 
     Returns:
-        list: List of names of worker nodes
+        list: List of names of master nodes
+
     """
     label = 'node-role.kubernetes.io/master'
     ocp_node_obj = ocp.OCP(kind=constants.NODE)
@@ -1377,6 +1378,7 @@ def refresh_oc_login_connection(user=None, password=None):
     Args:
         user (str): Username to login
         password (str): Password to login
+
     """
     user = user or config.RUN['username']
     if not password:
@@ -1396,6 +1398,7 @@ def rsync_kubeconf_to_node(node):
 
     Args:
         node (str): OCP node to copy kubeconfig if not present
+
     """
     # ocp_obj = ocp.OCP()
     filename = os.path.join(
@@ -1409,11 +1412,12 @@ def rsync_kubeconf_to_node(node):
     ocp_obj = ocp.OCP()
     check_auth = 'auth'
     check_conf = 'kubeconfig'
-    if check_auth not in ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=['ls /home/core/']):
+    node_path = '/home/core/'
+    if check_auth not in ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=[f"ls {node_path}"]):
         ocp.rsync(
-            src=file_path, dst='/home/core/', node=node, dst_node=True
+            src=file_path, dst=f"{node_path}", node=node, dst_node=True
         )
-    elif check_conf not in ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=['ls /home/core/auth']):
+    elif check_conf not in ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=[f"ls {node_path}auth"]):
         ocp.rsync(
-            src=file_path, dst='/home/core/', node=node, dst_node=True
+            src=file_path, dst=f"{node_path}", node=node, dst_node=True
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1405,9 +1405,7 @@ def rsync_kubeconf_to_node(node):
         config.ENV_DATA['cluster_path'],
         config.RUN['kubeconfig_location']
     )
-    str_split = filename.split('/')
-    str_split = str_split[:-1]
-    file_path = '/'.join(str_split)
+    file_path = os.path.dirname(filename)
     master_list = get_master_nodes()
     ocp_obj = ocp.OCP()
     check_auth = 'auth'


### PR DESCRIPTION
Updated deployment.py to change registry backend to OCS CEPHFS RWX PVC
registry.py -- registry library functions python file
ocp.py -- added new function to perform path operation in crd
constants.py -- added new constants regarding registry deployment
Requirements KNIP: https://jira.coreos.com/browse/KNIP-1080

Signed-off-by: ramkiperiy <rperiyas@redhat.com>