### PR TITLE
Remove extra worker_instance_type from sample config

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -98,7 +98,6 @@ ENV_DATA:
   rook_csi_attacher_image: 'quay.io/openshift/origin-csi-external-attacher:4.2'
   # End of the unused parameters for operator deployment
   # --------------------------------------------------------------------------
-  worker_instance_type: 'm4.xlarge'
   # uncomment to use custom directory for storing measurement data related to
   # monitoring tests, otherwise generate temporary directory for each test run
   # measurement_dir: '/tmp/ocs_ci_monitoring_measurement/'


### PR DESCRIPTION
worker_instance_type is listed twice: on line 81 and on line 101. This
removes second one.

Signed-off-by: Mirek Długosz <mzalewsk@redhat.com>