### PR TITLE
Change default libra to openshift-dev ssh key

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -40,10 +40,10 @@ more details.
 1) connect to the node by:
 
     ```console
-    ssh -i ~/.ssh/libra.pem -t -o StrictHostKeyChecking=no -o ProxyCommand='ssh -A -i ~/.ssh/libra.pem -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service --all-namespaces -l run=ssh-bastion -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}")' core@10.0.130.69 "sudo -i"
+    ssh -i ~/.ssh/openshift-dev.pem -t -o StrictHostKeyChecking=no -o ProxyCommand='ssh -A -i ~/.ssh/openshift-dev.pem -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service --all-namespaces -l run=ssh-bastion -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}")' core@10.0.130.69 "sudo -i"
     ```
 
-    > in case you didn’t use the same location of libra.pem key or you used different one during OCP deployment you have to change the path to the other one.
+    > in case you didn’t use the same location of openshift-dev.pem key or you used different one during OCP deployment you have to change the path to the other one.
 
 ## OC debug
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -86,17 +86,17 @@ to the nodes via known ssh key for QE and engineering.
 To setup the shared public ssh key for your deployment you have to follow
 these steps:
 
-Download private libra ssh key from secret location.
+Download private openshift-dev ssh key from secret location to
+`~/.ssh/openshift-dev.pem`.
 
 ```console
-wget https://secret.url.of.our.key -O ~/.ssh/libra.pem
-chmod 600 ~/.ssh/libra.pem
-ssh-keygen -y -f ~/.ssh/libra.pem > ~/.ssh/libra.pub
+chmod 600 ~/.ssh/openshift-dev.pem
+ssh-keygen -y -f ~/.ssh/openshift-dev.pem > ~/.ssh/openshift-dev.pub
 ```
 
 Ask people on ocs-qe mailing list or chat room if you don't know where to find the
-secret URL for libra key. Or look for this mail thread:
-`SSH key deployed on our nodes` where the URL was mentioned.
+secret URL for openshift-dev key. Or look for this mail thread:
+`Libra ssh key replaced by openshift-dev key` where the URL was mentioned.
 
 If you would like to use a different path, you can overwrite it in the custom
 config file under the DEPLOYMENT section with this key and value:

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -49,7 +49,7 @@ DEPLOYMENT:
   # nodes. See: https://github.com/openshift/ocs-operator
   ocs_operator_nodes_to_tain: 0
   ocs_operator_deployment: True
-  ssh_key: "~/.ssh/libra.pub"
+  ssh_key: "~/.ssh/openshift-dev.pub"
   force_deploy_multiple_clusters: False
   allow_lower_instance_requirements: true
 


### PR DESCRIPTION
We need to change the default of libra ssh key to the new openshift-dev key.