### PR TITLE
Prevent referenced before assignment exception for backed_by_pvc

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -474,12 +474,12 @@ def validate_cluster_on_pvc(label):
     for pod_obj in ocs_pod_obj:
         pod_volumes = pod_obj.get().get('spec').get('volumes')
         claim_spec_exists = False
+        backed_by_pvc = False
         for volumes in pod_volumes:
             pvc = volumes.get('persistentVolumeClaim')
             if pvc:
                 claim_name = pvc.get('claimName')
                 claim_spec_exists = True
-                backed_by_pvc = False
                 if claim_name in pvc_list:
                     logger.info(
                         f"OCS pod {pod_obj.name} is backed by PVC {claim_name}"


### PR DESCRIPTION
If no volume on pod has `persistentVolumeClaim` key, `backed_by_pvc` variable may be referenced without being assigned inside `validate_cluster_on_pvc` function. This patch ensure variable always has a value.

Prevents `UnboundLocalError: local variable 'backed_by_pvc' referenced before assignment` exception during deployment - instead, we will get nice `One or more pods are not backed by a PVC please check deployment logs`, as intended.