### PR TITLE
Update test to create rbd block type volume

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,7 +388,6 @@ def pvc_factory_fixture(
         pvc_obj.storageclass = storageclass
         pvc_obj.project = project
         pvc_obj.access_mode = access_mode
-        pvc_obj.volume_mode = volume_mode
         instances.append(pvc_obj)
 
         return pvc_obj

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -228,7 +228,8 @@ class TestPVCDisruption(ManageTest):
 
         # Create one pod using each RWO PVC and two pods using each RWX PVC
         for pvc_obj in pvc_objs:
-            if pvc_obj.volume_mode:
+            pvc_info = pvc_obj.get()
+            if pvc_info['spec']['volumeMode'] == 'Block':
                 pod_dict = constants.CSI_RBD_RAW_BLOCK_POD_YAML
                 raw_block_pv = True
             else:
@@ -356,7 +357,8 @@ class TestPVCDisruption(ManageTest):
         # Do setup on pods for running IO
         logger.info("Setting up pods for running IO.")
         for pod_obj in pod_objs:
-            if pod_obj.pvc.volume_mode:
+            pvc_info = pod_obj.pvc.get()
+            if pvc_info['spec']['volumeMode'] == 'Block':
                 storage_type = 'block'
             else:
                 storage_type = 'fs'
@@ -377,7 +379,8 @@ class TestPVCDisruption(ManageTest):
 
         # Start IO on each pod
         for pod_obj in pod_objs:
-            if pod_obj.pvc.volume_mode:
+            pvc_info = pod_obj.pvc.get()
+            if pvc_info['spec']['volumeMode'] == 'Block':
                 storage_type = 'block'
             else:
                 storage_type = 'fs'
@@ -421,7 +424,8 @@ class TestPVCDisruption(ManageTest):
 
         # Run IO on each of the new pods
         for pod_obj in pod_objs:
-            if pod_obj.pvc.volume_mode:
+            pvc_info = pod_obj.pvc.get()
+            if pvc_info['spec']['volumeMode'] == 'Block':
                 storage_type = 'block'
             else:
                 storage_type = 'fs'


### PR DESCRIPTION
tests/manage/pv_services/test_pvc_disruptive.py
RBD block type volume will be created along with filesyetem type volume mode

tests/conftest.py
Updated multi_pvc_factory_fixture and pvc_factory_fixture to support rbd block type volume
Updated pod_factory_fixture to support rbd block type volume for creating pod

Signed-off-by: Jilju Joy <jijoy@redhat.com>