### PR TITLE
Fix storage cluster name to use default name as in UI

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -72,7 +72,7 @@ REPORTING:
 # --cluster-conf file.yaml data you will pass to the pytest.
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
-  storage_cluster_name: 'rook-ceph'
+  storage_cluster_name: 'openshift-storage'
   storage_device_sets_name: "storageDeviceSets"
   cluster_namespace: 'openshift-storage'
   monitoring_enabled: true

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -72,7 +72,7 @@ REPORTING:
 # --cluster-conf file.yaml data you will pass to the pytest.
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
-  storage_cluster_name: 'openshift-storage'
+  storage_cluster_name: 'ocs-storagecluster'
   storage_device_sets_name: "storageDeviceSets"
   cluster_namespace: 'openshift-storage'
   monitoring_enabled: true

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -112,7 +112,7 @@ UPI_INSTALL_SCRIPT = "upi_on_aws-install.sh"
 
 DEFAULT_SECRET = 'rook-ceph-csi'
 DEFAULT_BLOCKPOOL = 'rbd'
-DEFAULT_SC_CEPHFS = "rook-ceph-cephfs"
+DEFAULT_SC_CEPHFS = "cephfs"
 DEFAULT_ROUTE_CRT = "router-certs-default"
 IMAGE_REGISTRY_RESOURCE_NAME = "cluster"
 

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -21,7 +21,7 @@ ROOK_CLUSTER_NAMESPACE = 'openshift-storage'
 OCS_MONITORING_NAMESPACE = 'openshift-monitoring'
 KUBECONFIG_LOCATION = 'auth/kubeconfig'  # relative from cluster_dir
 API_VERSION = "v1"
-CEPHFILESYSTEM_NAME = 'rook-ceph-cephfilesystem'
+CEPHFILESYSTEM_NAME = 'ocs-storagecluster-cephfilesystem'
 RBD_PROVISIONER = f'{ROOK_CLUSTER_NAMESPACE}.rbd.csi.ceph.com'
 CEPHFS_PROVISIONER = f'{ROOK_CLUSTER_NAMESPACE}.cephfs.csi.ceph.com'
 

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -22,8 +22,9 @@ def change_registry_backend_to_ocs():
         AssertionError: When failure in change of registry backend to OCS
 
     """
+    sc_name = f"{config.ENV_DATA['storage_cluster_name']}-{constants.DEFAULT_SC_CEPHFS}"
     pv_obj = helpers.create_pvc(
-        sc_name=constants.DEFAULT_SC_CEPHFS, pvc_name='registry-cephfs-rwx-pvc',
+        sc_name=sc_name, pvc_name='registry-cephfs-rwx-pvc',
         namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE, size='100Gi',
         access_mode=constants.ACCESS_MODE_RWX
     )


### PR DESCRIPTION
The discussion was brought up in email where in CI we are using 'rook-ceph' as clustername which is different from what UI method uses. 

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>