### PR TITLE
Add config for us-east-1 region

### DIFF
--- a/conf/ocsci/aws_region_us-east-1.yaml
+++ b/conf/ocsci/aws_region_us-east-1.yaml
@@ -1,0 +1,4 @@
+---
+ENV_DATA:
+  platform: 'aws'
+  region: 'us-east-1'


### PR DESCRIPTION
As this issue was found:
https://github.com/noobaa/noobaa-operator/issues/90
We would like to test with us-east-1 region to see if we have other
issues.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>