### PR TITLE
Corrupted Placement Group alert test case

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -314,11 +314,13 @@ NODE_NOT_READY = 'NotReady'
 NODE_READY_SCHEDULING_DISABLED = 'Ready,SchedulingDisabled'
 
 # Alert labels
+ALERT_CLUSTERERRORSTATE = 'CephClusterErrorState'
 ALERT_CLUSTERWARNINGSTATE = 'CephClusterWarningState'
 ALERT_DATARECOVERYTAKINGTOOLONG = 'CephDataRecoveryTakingTooLong'
 ALERT_MGRISABSENT = 'CephMgrIsAbsent'
 ALERT_MONQUORUMATRISK = 'CephMonQuorumAtRisk'
 ALERT_OSDDISKNOTRESPONDING = 'CephOSDDiskNotResponding'
+ALERT_PGREPAIRTAKINGTOOLONG = 'CephPGRepairTakingTooLong'
 
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,10 @@ import re
 import datetime
 import statistics
 import os
+from subprocess import TimeoutExpired
+import tempfile
 import time
+import yaml
 
 from ocs_ci.ocs.ocp import OCP
 
@@ -1419,3 +1422,69 @@ def rsync_kubeconf_to_node(node):
         ocp.rsync(
             src=file_path, dst=f"{node_path}", node=node, dst_node=True
         )
+
+
+def create_dummy_osd(deployment):
+    """
+    Replace one of OSD pods with pod that contains all data from original
+    OSD but doesn't run osd daemon. This can be used e.g. for direct acccess
+    to Ceph Placement Groups.
+
+    Args:
+        deployment (str): Name of deployment to use
+
+    Returns:
+        list: first item is dummy deployment object, second item is dummy pod
+            object
+    """
+    oc = OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=config.ENV_DATA.get('cluster_namespace')
+    )
+    osd_data = oc.get(deployment)
+    dummy_deployment = create_unique_resource_name('dummy', 'osd')
+    osd_data['metadata']['name'] = dummy_deployment
+
+    osd_containers = osd_data.get('spec').get('template').get('spec').get(
+        'containers'
+    )
+    # get osd container spec
+    original_osd_args = osd_containers[0].get('args')
+    osd_data['spec']['template']['spec']['containers'][0]['args'] = []
+    osd_data['spec']['template']['spec']['containers'][0]['command'] = [
+        '/bin/bash',
+        '-c',
+        'sleep infinity'
+    ]
+    osd_file = tempfile.NamedTemporaryFile(
+        mode='w+', prefix=dummy_deployment, delete=False
+    )
+    with open(osd_file.name, "w") as temp:
+        yaml.dump(osd_data, temp)
+    oc.create(osd_file.name)
+
+    # downscale the original deployment and start dummy deployment instead
+    oc.exec_oc_cmd(f"scale --replicas=0 deployment/{deployment}")
+    oc.exec_oc_cmd(f"scale --replicas=1 deployment/{dummy_deployment}")
+
+    osd_list = pod.get_osd_pods()
+    dummy_pod = [pod for pod in osd_list if dummy_deployment in pod.name][0]
+    wait_for_resource_state(
+        resource=dummy_pod,
+        state=constants.STATUS_RUNNING,
+        timeout=60
+    )
+    ceph_init_cmd = '/rook/tini' + ' ' + ' '.join(original_osd_args)
+    try:
+        logger.info('Following command should expire after 7 seconds')
+        dummy_pod.exec_cmd_on_pod(ceph_init_cmd, timeout=7)
+    except TimeoutExpired:
+        logger.info('Killing /rook/tini process')
+        try:
+            dummy_pod.exec_bash_cmd_on_pod(
+                "kill $(ps aux | grep '[/]rook/tini' | awk '{print $2}')"
+            )
+        except CommandFailed:
+            pass
+
+    return dummy_deployment, dummy_pod

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import pytest
-import subprocess
+from subprocess import TimeoutExpired
 import threading
 import tempfile
 import time
@@ -400,7 +400,7 @@ def create_dummy_osd(deployment):
     try:
         logger.info('Following command should expire after 7 seconds')
         dummy_pod.exec_cmd_on_pod(ceph_init_cmd, timeout=7)
-    except subprocess.TimeoutExpired as e:
+    except TimeoutExpired:
         logger.info('Killing /rook/tini process')
         dummy_pod.exec_bash_cmd_on_pod(
             "kill $(ps aux | grep '[/]rook/tini' | awk '{print $2}')"
@@ -441,7 +441,6 @@ def measure_corrupt_pg(measurement_dir):
     logger.info(f"Found Placement Group: {pg}")
 
     dummy_deployment, dummy_pod = create_dummy_osd(osd_deployment)
-
 
     def corrupt_pg():
         """

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -453,19 +453,20 @@ def measure_corrupt_pg(measurement_dir):
         is used in the project:
             https://github.com/ceph/ceph-mixins/blob/d22afe8c0da34490cb77e52a202eefcf4f62a869/config.libsonnet#L23
         There should be also CephClusterErrorState alert that takes 10
-        minutest to be firing.
+        minutest to start firing.
 
         Returns:
-            str: Names of downscaled deployments
+            str: Name of corrupted deployment
         """
         # run_time of operation
-        run_time = 60 * 3
+        run_time = 60 * 11
         nonlocal oc
         nonlocal pool_name
         nonlocal pool_object
         nonlocal dummy_pod
         nonlocal pg
         nonlocal osd_deployment
+        nonlocal dummy_deployment
 
         logger.info(f"Corrupting {pg} PG on {osd_deployment}")
         dummy_pod.exec_bash_cmd_on_pod(
@@ -479,7 +480,7 @@ def measure_corrupt_pg(measurement_dir):
         oc.exec_oc_cmd(f"scale --replicas=1 deployment/{osd_deployment}")
         logger.info(f"Waiting for {run_time} seconds")
         time.sleep(run_time)
-        return pool_name
+        return osd_deployment
 
     test_file = os.path.join(measurement_dir, 'measure_corrupt_pg.json')
     measured_op = measure_operation(corrupt_pg, test_file)

--- a/tests/manage/monitoring/prometheus/test_ceph.py
+++ b/tests/manage/monitoring/prometheus/test_ceph.py
@@ -1,0 +1,46 @@
+import logging
+import pytest
+
+from ocs_ci.framework.testlib import tier4
+from ocs_ci.ocs import constants
+from ocs_ci.utility import prometheus
+
+
+log = logging.getLogger(__name__)
+
+@tier4
+@pytest.mark.polarion_id("OCS-903")
+def test_corrupt_pg_alerts(measure_corrupt_pg):
+    """
+    Test that there are appropriate alerts when Placement group
+    on one OSD is corrupted.ceph manager
+    is unavailable and that this alert is cleared when the manager
+    is back online.
+    """
+    api = prometheus.PrometheusAPI()
+
+    for target_label, target_msg, target_states, target_severity in [
+        (
+            constants.ALERT_PGREPAIRTAKINGTOOLONG,
+            'Self heal problems detected',
+            ['pending'],
+            'warning'
+        ),
+        (
+            constants.ALERT_CLUSTERERRORSTATE,
+            'Storage cluster is in error state',
+            ['pending', 'firing'],
+            'critical'
+        )
+    ]:
+        prometheus.check_alert_list(
+            label=target_label,
+            msg=target_msg,
+            alerts=alerts,
+            states=target_states,
+            severity=target_severity
+        )
+        api.check_alert_cleared(
+            label=target_label,
+            measure_end_time=measure_corrupt_pg.get('stop')
+        )


### PR DESCRIPTION
- Add `test_corrupt_pg_alerts` test case.
- Add `create_dummy_osd` function. This can be used for Ceph storage manipulation as by using osd created by this function there is no lock on osd data.