### PR TITLE
Add build acceptance mark to be used by jenkins downstream run

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -16,6 +16,9 @@ tier4 = pytest.mark.tier4(value=4)
 
 tier_marks = [tier1, tier2, tier3, tier4]
 
+# build acceptance
+acceptance = pytest.mark.acceptance
+
 # team marks
 
 e2e = pytest.mark.e2e

--- a/tests/e2e/test_jenkins_simulation.py
+++ b/tests/e2e/test_jenkins_simulation.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from ocs_ci.framework.testlib import ManageTest, workloads
+from ocs_ci.framework.testlib import ManageTest, workloads, acceptance
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,7 @@ class TestJenkinsSimulation(ManageTest):
     Run simulation for "Jenkins" - git clone
     """
 
+    @acceptance
     @workloads
     def test_git_clone(self, pod):
         """

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -3,7 +3,8 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, noobaa_cli_required, aws_platform_required, filter_insecure_request_warning
+    tier1, noobaa_cli_required, aws_platform_required,
+    filter_insecure_request_warning, acceptance
 )
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 @filter_insecure_request_warning
 @aws_platform_required
+@acceptance
 @tier1
 class TestBucketCreation:
     """

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -3,7 +3,8 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, noobaa_cli_required, aws_platform_required, filter_insecure_request_warning
+    tier1, noobaa_cli_required, aws_platform_required, acceptance,
+    filter_insecure_request_warning
 )
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 @filter_insecure_request_warning
 @aws_platform_required
+@acceptance
 @tier1
 class TestBucketDeletion:
     """

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -4,7 +4,7 @@ import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import aws_platform_required, filter_insecure_request_warning
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, acceptance
 from ocs_ci.ocs import constants
 from tests.helpers import craft_s3_command
 
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 @filter_insecure_request_warning
 @aws_platform_required
+@acceptance
 @tier1
 class TestBucketIO(ManageTest):
     """

--- a/tests/manage/pv_services/test_create_storage_class_pvc.py
+++ b/tests/manage/pv_services/test_create_storage_class_pvc.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, acceptance, ManageTest
 from tests import helpers
 
 log = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ def teardown_fs():
     CEPHFS_SC_OBJ.delete()
 
 
+@acceptance
 @tier1
 class TestOSCBasics(ManageTest):
     @pytest.mark.polarion_id("OCS-336")

--- a/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import ManageTest, tier1, tier3
+from ocs_ci.framework.testlib import ManageTest, tier1, tier3, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources import pod
@@ -127,6 +127,7 @@ class BaseDynamicPvc(ManageTest):
             self.sc_obj.delete()
 
 
+@acceptance
 @tier1
 @pytest.mark.usefixtures(
     create_ceph_block_pool.__name__,
@@ -282,6 +283,7 @@ class TestRWXDynamicPvc(BaseDynamicPvc):
 
         self.dynamic_pvc_base(interface_type, reclaim_policy)
 
+    @acceptance
     @tier1
     @pytest.mark.bugzilla("1750916")
     @pytest.mark.bugzilla("1751866")

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
 from tests import helpers
@@ -19,6 +19,7 @@ class TestPvcAssignPodNode(ManageTest):
     OCS-1258 - CephFS: Assign nodeName to a POD using RWX PVC
     """
 
+    @acceptance
     @tier1
     @pytest.mark.parametrize(
         argnames=["interface"],
@@ -74,6 +75,7 @@ class TestPvcAssignPodNode(ManageTest):
         pod_obj.run_io(storage_type='fs', size='512M', runtime=30)
         pod.get_fio_rw_iops(pod_obj)
 
+    @acceptance
     @tier1
     @pytest.mark.polarion_id("OCS-1258")
     def test_rwx_pvc_assign_pod_node(self, pvc_factory, teardown_factory):

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -9,7 +9,7 @@ import pytest
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from tests import helpers
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier1, acceptance, ManageTest
 from ocs_ci.utility import templating
 from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import pod
@@ -91,6 +91,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
     Testing after pvc deletion the size is returned to backendpool
     """
 
+    @acceptance
     @tier1
     def test_pvc_delete_and_verify_size_is_returned_to_backend_pool(self):
         """


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/940

use acceptance mark that can be used by downstream jenkins to run CI tests for build acceptance. All of 8 tests selected are positive tests and cover basic
CSI, MCG and POD IO.

Collect-only run:

```
<Package /Users/vasukulkarni/ocs-ci/tests/e2e>
  <Module test_jenkins_simulation.py>
    <Class TestJenkinsSimulation>
        <Function test_git_clone[RBD]>
        <Function test_git_clone[CephFS]>
<Package /Users/vasukulkarni/ocs-ci/tests/manage/mcg>
  <Module test_bucket_creation.py>
    <Class TestBucketCreation>
        <Function test_s3_bucket_creation>
        <Function test_cli_bucket_creation>
        <Function test_oc_bucket_creation>
  <Module test_bucket_deletion.py>
    <Class TestBucketDeletion>
        <Function test_s3_bucket_delete>
        <Function test_cli_bucket_delete>
        <Function test_oc_bucket_delete>
  <Module test_write_to_bucket.py>
    <Class TestBucketIO>
        <Function test_write_file_to_bucket>
        <Function test_data_reduction>
<Package /Users/vasukulkarni/ocs-ci/tests/manage/pv_services>
  <Module test_create_storage_class_pvc.py>
    <Class TestOSCBasics>
        <Function test_basics_rbd>
        <Function test_basics_cephfs>
  <Module test_dynamic_pvc_accessmodes_with_reclaim_policies.py>
    <Class TestRWODynamicPvc>
        <Function test_rwo_dynamic_pvc[CephBlockPool-Retain]>
        <Function test_rwo_dynamic_pvc[CephBlockPool-Delete]>
        <Function test_rwo_dynamic_pvc[CephFileSystem-Retain]>
        <Function test_rwo_dynamic_pvc[CephFileSystem-Delete]>
    <Class TestRWXDynamicPvc>
        <Function test_rwx_dynamic_pvc[CephFileSystem-Retain]>
        <Function test_rwx_dynamic_pvc[CephFileSystem-Delete]>
  <Module test_pvc_assign_pod_node.py>
    <Class TestPvcAssignPodNode>
        <Function test_rwo_pvc_assign_pod_node[CephBlockPool]>
        <Function test_rwo_pvc_assign_pod_node[CephFileSystem]>
        <Function test_rwx_pvc_assign_pod_node>
  <Module test_pvc_delete_verify_size_is_returned_to_backendpool.py>
    <Class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool>
        <Function test_pvc_delete_and_verify_size_is_returned_to_backend_pool>
```


Signed-off-by: Vasu Kulkarni <vasu@redhat.com>