### PR TITLE
Adding block type RWO pvc in tests

### DIFF
--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -275,7 +275,7 @@ class TestPVCDisruption(ManageTest):
         # Get number of pods of type 'resource_to_delete'
         num_of_resource_to_delete = len(pod_functions[resource_to_delete]())
 
-        num_of_pvc = 6
+        num_of_pvc = 12
         namespace = self.proj_obj.namespace
 
         # Fetch the number of Pods and PVCs
@@ -295,7 +295,12 @@ class TestPVCDisruption(ManageTest):
         # Modify access_modes list to create rbd `block` type volume with
         # RWX access mode. RWX is not supported in non-block type rbd
         if interface == constants.CEPHBLOCKPOOL:
-            access_modes.append(f'{constants.ACCESS_MODE_RWX}-Block')
+            access_modes.extend(
+                [
+                    f'{constants.ACCESS_MODE_RWO}-Block',
+                    f'{constants.ACCESS_MODE_RWX}-Block'
+                ]
+            )
 
         # Start creation of PVCs
         bulk_pvc_create = executor.submit(

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -25,7 +25,7 @@ class DisruptionBase(ManageTest):
     """
     Base class for disruptive operations
     """
-    num_of_pvcs = 10
+    num_of_pvcs = 12
     pvc_size = 3
 
     def verify_resource_deletion(self, func_to_use, previous_num):
@@ -363,7 +363,12 @@ class TestDeleteResourceDuringPodPvcDeletion(DisruptionBase):
         # Modify access_modes list to create rbd `block` type volume with
         # RWX access mode. RWX is not supported in filesystem type rbd
         if interface == constants.CEPHBLOCKPOOL:
-            access_modes.append(f'{constants.ACCESS_MODE_RWX}-Block')
+            access_modes.extend(
+                [
+                    f'{constants.ACCESS_MODE_RWO}-Block',
+                    f'{constants.ACCESS_MODE_RWX}-Block'
+                ]
+            )
 
         pvc_objs = multi_pvc_factory(
             interface=interface,


### PR DESCRIPTION
Updated below tests to create rbd block type RWO volume
tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
tests/manage/pv_services/test_pvc_disruptive.py

Signed-off-by: Jilju Joy <jijoy@redhat.com>