### PR TITLE
Setting up the environment variable of KUBECONFIG, only if it is not

### DIFF
--- a/ocs_ci/ocs/openshift_ops.py
+++ b/ocs_ci/ocs/openshift_ops.py
@@ -142,7 +142,9 @@ class OCP(object):
                 "The kubeconfig file %s doesn't exist!", kubeconfig_path
             )
             return False
-        os.environ['KUBECONFIG'] = kubeconfig_path
+        # Setting environment variable on ly if not exist
+        if 'KUBECONFIG' not in os.environ:
+            os.environ['KUBECONFIG'] = kubeconfig_path
         try:
             run_cmd("oc cluster-info")
         except CommandFailed as ex:


### PR DESCRIPTION
defined by the user, outside the script.

Signed-off-by: Avi Liani <alayani@redhat.com>