### PR TITLE
google-auth requires setuptools which is >=40.3.0

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ necessary dependencies
     * `python3.7 -m venv <path/to/venv>`
     * `source <path/to/.venv>/bin/activate`
 
-4. Upgrade pip with `pip install --upgrade pip`
+4. Upgrade pip and setuptools with `pip install --upgrade pip setuptools`
 5. Install requirements with `pip install -r requirements.txt`
 
 ## Initial Setup


### PR DESCRIPTION
google-auth requires setuptools which is >=40.3.0

Updating the documentation for upgrading setuptools

Signed-off-by: vavuthu <vavuthu@redhat.com>

Fixes: #970 