### PR TITLE
Provide new configurable storage parameters for OSD

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -187,6 +187,24 @@ patch storagecluster/{storagecluster_name} --type='json' -p='[{{"op": "replace",
     ocp.exec_oc_cmd(cmd)
     return True
 
+def add_storage_capacity(capacity, storagecluster_name, namespace=defaults.ROOK_CLUSTER_NAMESPACE):
+    """
+    Add storage capacity to the cluster
+
+    Args:
+        capacity (str): Size of the storage
+        storagecluster_name (str): Name of a storage cluster
+    Returns:
+        bool: True if commands executes successfully
+    """
+    ocp = OCP(namespace=namespace)
+    # ToDo Update patch command with pr https://github.com/red-hat-storage/ocs-ci/pull/803
+    cmd = f'''
+patch storagecluster/{storagecluster_name} --type='json' -p='[{{"op": "replace",
+"path": "/spec/storageDeviceSets/0/dataPVCTemplate/spec/resources/requests/storage", "value":{capacity}}}]'
+            '''
+    ocp.exec_oc_cmd(cmd)
+    return True
 
 def get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
     """

--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -187,6 +187,7 @@ patch storagecluster/{storagecluster_name} --type='json' -p='[{{"op": "replace",
     ocp.exec_oc_cmd(cmd)
     return True
 
+
 def add_storage_capacity(capacity, storagecluster_name, namespace=defaults.ROOK_CLUSTER_NAMESPACE):
     """
     Add storage capacity to the cluster
@@ -205,6 +206,7 @@ patch storagecluster/{storagecluster_name} --type='json' -p='[{{"op": "replace",
             '''
     ocp.exec_oc_cmd(cmd)
     return True
+
 
 def get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
     """

--- a/tests/manage/cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/cluster/cluster_expansion/test_add_capacity.py
@@ -16,49 +16,34 @@ logger = logging.getLogger(__name__)
 @tier1
 class TestAddCapacity(ManageTest):
     """
-    Automates adding capacity to the cluster while IOs running
+    Automates adding variable capacity to the cluster while IOs running
     """
-
-    def test_add_capacity(self):
-        """
-        Testing adding capacity to the cluster while IOs running
-        """
-        dt = config.ENV_DATA['deployment_type']
-        if dt == 'ipi':
-            osd_count = pod.get_pod_count(label=constants.OSD_APP_LABEL)
-            storage_cluster = machine_utils.get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
-            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=osd_count + 3)
-            pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
-            assert pod_obj.wait_for_resource(
-                condition=constants.STATUS_RUNNING, selector=constants.OSD_APP_LABEL,
-                resource_count=osd_count + 3, timeout=600
-            ), "OSD pods failed to reach RUNNING state"
-        else:
-            pytest.skip("UPI not yet supported")
-        # ToDo run IOs
-
     @pytest.mark.parametrize(
-        argnames=["multiplier", "capacity"],
+        argnames=["node_multiplier", "capacity"],
         argvalues=[pytest.param(
                 *[3, '2000Gi']),
         ]
     )
-    def test_add_capacity_variable(self, multiplier, capacity):
+    def test_add_capacity(self,node_multiplier, capacity):
         """
-        Testing adding variable capacity to the cluster while IOs running
+        Test to add variable capacity to the OSD cluster while IOs running
+
+        Args:
+        node_multiplier: the number of OSD to add per worker node
+        capacity: the storage capacity of each OSD
         """
         dt = config.ENV_DATA['deployment_type']
         if dt == 'ipi':
             osd_count = pod.get_pod_count(label=constants.OSD_APP_LABEL)
             storage_cluster = machine_utils.get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
             worker_nodes = len(get_typed_nodes())
-            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=worker_nodes*multiplier)
+            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=worker_nodes*node_multiplier)
             machine_utils.add_storage_capacity(storagecluster_name=storage_cluster, capacity=capacity)
             pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
             assert pod_obj.wait_for_resource(
                 condition=constants.STATUS_RUNNING, selector=constants.OSD_APP_LABEL,
-                resource_count=worker_nodes*multiplier, timeout=200
+                resource_count=worker_nodes*node_multiplier, timeout=600
             ), "OSD pods failed to reach RUNNING state"
         else:
             pytest.skip("UPI not yet supported")
-
+        # ToDo run IOs

--- a/tests/manage/cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/cluster/cluster_expansion/test_add_capacity.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from builtins import len
 
 from ocs_ci.framework.testlib import tier1, ignore_leftovers, ManageTest
 from ocs_ci.ocs import machine as machine_utils
@@ -7,7 +8,7 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import defaults
 from ocs_ci.framework import config
-
+from ocs_ci.ocs.node import get_typed_nodes
 logger = logging.getLogger(__name__)
 
 
@@ -35,3 +36,29 @@ class TestAddCapacity(ManageTest):
         else:
             pytest.skip("UPI not yet supported")
         # ToDo run IOs
+
+    @pytest.mark.parametrize(
+        argnames=["multiplier", "capacity"],
+        argvalues=[pytest.param(
+                *[3, '2000Gi']),
+        ]
+    )
+    def test_add_capacity_variable(self, multiplier, capacity):
+        """
+        Testing adding variable capacity to the cluster while IOs running
+        """
+        dt = config.ENV_DATA['deployment_type']
+        if dt == 'ipi':
+            osd_count = pod.get_pod_count(label=constants.OSD_APP_LABEL)
+            storage_cluster = machine_utils.get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+            worker_nodes = len(get_typed_nodes())
+            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=worker_nodes*multiplier)
+            machine_utils.add_storage_capacity(storagecluster_name=storage_cluster, capacity=capacity)
+            pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+            assert pod_obj.wait_for_resource(
+                condition=constants.STATUS_RUNNING, selector=constants.OSD_APP_LABEL,
+                resource_count=worker_nodes*multiplier, timeout=200
+            ), "OSD pods failed to reach RUNNING state"
+        else:
+            pytest.skip("UPI not yet supported")
+

--- a/tests/manage/cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/cluster/cluster_expansion/test_add_capacity.py
@@ -5,7 +5,6 @@ from builtins import len
 from ocs_ci.framework.testlib import tier1, ignore_leftovers, ManageTest
 from ocs_ci.ocs import machine as machine_utils
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import defaults
 from ocs_ci.framework import config
 from ocs_ci.ocs.node import get_typed_nodes
@@ -19,12 +18,16 @@ class TestAddCapacity(ManageTest):
     Automates adding variable capacity to the cluster while IOs running
     """
     @pytest.mark.parametrize(
-        argnames=["node_multiplier", "capacity"],
-        argvalues=[pytest.param(
-                *[3, '2000Gi']),
+        argnames=[
+            "node_multiplier", "capacity"
+        ],
+        argvalues=[
+            pytest.param(
+                *[3, '2000Gi'],
+            ),
         ]
     )
-    def test_add_capacity(self,node_multiplier, capacity):
+    def test_add_capacity(self, node_multiplier, capacity):
         """
         Test to add variable capacity to the OSD cluster while IOs running
 
@@ -34,15 +37,14 @@ class TestAddCapacity(ManageTest):
         """
         dt = config.ENV_DATA['deployment_type']
         if dt == 'ipi':
-            osd_count = pod.get_pod_count(label=constants.OSD_APP_LABEL)
             storage_cluster = machine_utils.get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
             worker_nodes = len(get_typed_nodes())
-            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=worker_nodes*node_multiplier)
+            machine_utils.add_capacity(storagecluster_name=storage_cluster, count=worker_nodes * node_multiplier)
             machine_utils.add_storage_capacity(storagecluster_name=storage_cluster, capacity=capacity)
             pod_obj = ocp.OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
             assert pod_obj.wait_for_resource(
                 condition=constants.STATUS_RUNNING, selector=constants.OSD_APP_LABEL,
-                resource_count=worker_nodes*node_multiplier, timeout=600
+                resource_count=worker_nodes * node_multiplier, timeout=600
             ), "OSD pods failed to reach RUNNING state"
         else:
             pytest.skip("UPI not yet supported")


### PR DESCRIPTION
This PR is to test the new OSD limit we are going to support (which is 3 OSD per node with 2 TB per OSD). I've included configurable parameters to vary the amount of OSDxnode and the OSD storage capacity.