### PR TITLE
Avoid connecting to server when setting up new cluster

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -582,7 +582,7 @@ def get_openshift_client(
         # return to the previous working directory
         os.chdir(previous_dir)
 
-    client_version = run_cmd(f"{client_binary_path} version")
+    client_version = run_cmd(f"{client_binary_path} version --client")
     log.info(f"OpenShift Client version: {client_version}")
 
     return client_binary_path


### PR DESCRIPTION
use --client option to avoid connecting to server, server may not exist when setting up new cluster

should also fix: https://github.com/red-hat-storage/ocs-ci/issues/961

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>