### PR TITLE
Fix noobaa pod checking after deployment

### DIFF
--- a/tests/ecosystem/deployment/test_deployment.py
+++ b/tests/ecosystem/deployment/test_deployment.py
@@ -78,7 +78,7 @@ def ocs_install_verification():
     assert pod.wait_for_resource(
         condition=constants.STATUS_RUNNING,
         selector=constants.NOOBAA_APP_LABEL,
-        resource_count=2,
+        resource_count=1,
         timeout=timeout
     )
     # local-storage-operator


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/992

there is only one noobaa pod after deployment, fix the check for verification

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>