### PR TITLE
MCG region fix

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -36,11 +36,11 @@ class MCG(object):
         results = ocp_obj.get()
         self.s3_endpoint = (
             results.get('items')[0].get('status').get('services')
-            .get('serviceS3').get('externalDNS')[0]
+            .get('serviceS3').get('externalDNS')[-1]
         )
         self.mgmt_endpoint = (
             results.get('items')[0].get('status').get('services')
-            .get('serviceMgmt').get('externalDNS')[0]
+            .get('serviceMgmt').get('externalDNS')[-1]
         ) + '/rpc'
         self.region = self.s3_endpoint.split('.')[1]
         creds_secret_name = (


### PR DESCRIPTION
Quick fix to invalid mcg region issue which was supposed to be fixed in #995. 
Noobaa had changed address scheme which resulted in fetching invalid region name.