### PR TITLE
Add more bucket and OBC deletion cases

### DIFF
--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -76,4 +76,4 @@ def rm_object_recursive(podobj, target, mcg_obj, option=''):
         out_yaml_format=False,
         secrets=[mcg_obj.access_key_id, mcg_obj.access_key,
                  mcg_obj.s3_endpoint]
-        )
+    )

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -55,3 +55,25 @@ def sync_object_directory(podobj, src, target, mcg_obj=None):
         secrets=secrets
     ), 'Failed to sync objects'
     # Todo: check that all objects were synced successfully
+
+
+def rm_object_recursive(podobj, target, mcg_obj, option=''):
+    """
+    Remove bucket objects with --recursive option
+
+    Args:
+        podobj  (OCS): The pod on which to execute the commands and download
+                       the objects to
+        target (str): Fully qualified bucket target path
+        mcg_obj (MCG, optional): The MCG object to use in case the target or
+                                 source are in an MCG
+        option (str): Extra s3 remove command option
+
+    """
+    rm_command = f"rm s3://{target} --recursive {option}"
+    podobj.exec_cmd_on_pod(
+        command=craft_s3_command(mcg_obj, rm_command),
+        out_yaml_format=False,
+        secrets=[mcg_obj.access_key_id, mcg_obj.access_key,
+                 mcg_obj.s3_endpoint]
+        )

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -50,16 +50,6 @@ class TestBucketDeletion:
                 marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
             ),
             pytest.param(
-                *[100, 'CLI'],
-                marks=[tier2, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1865")]
-            ),
-            pytest.param(
-                *[1000, 'CLI'],
-                marks=[tier2, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1866")]
-            ),
-            pytest.param(
                 *[100, 'OC'],
                 marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
             ),

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -1,11 +1,19 @@
 import logging
 
+import boto3
+import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1, noobaa_cli_required, acceptance,
     filter_insecure_request_warning
 )
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
+from ocs_ci.utility.utils import run_mcg_cmd
+from tests.helpers import craft_s3_command, create_unique_resource_name
 
 logger = logging.getLogger(__name__)
 
@@ -17,34 +25,179 @@ class TestBucketDeletion:
     """
     Test bucket Creation Deletion of buckets
     """
-    @pytest.mark.polarion_id("OCS-1299")
-    def test_s3_bucket_delete(self, mcg_obj, bucket_factory):
+    @pytest.mark.parametrize(
+        argnames="amount,interface",
+        argvalues=[
+            pytest.param(
+                *[3, 'S3'],
+                marks=[pytest.mark.polarion_id("OCS-1299"), tier1, acceptance]
+            ),
+            pytest.param(
+                *[3, 'CLI'],
+                marks=[tier1, acceptance, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1299")]
+            ),
+            pytest.param(
+                *[3, 'OC'],
+                marks=[tier1, acceptance, pytest.mark.polarion_id("OCS-1299")]
+            ),
+            pytest.param(
+                *[100, 'S3'],
+                marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
+            ),
+            pytest.param(
+                *[1000, 'S3'],
+                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
+            ),
+            pytest.param(
+                *[100, 'CLI'],
+                marks=[tier2, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1865")]
+            ),
+            pytest.param(
+                *[1000, 'CLI'],
+                marks=[tier2, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1866")]
+            ),
+            pytest.param(
+                *[100, 'OC'],
+                marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
+            ),
+            pytest.param(
+                *[1000, 'OC'],
+                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
+            ),
+        ]
+    )
+    def test_bucket_delete(self, mcg_obj, bucket_factory, amount, interface):
         """
-        Test deletion of bucket using the S3 SDK
+        Test deletion of bucket using the S3 SDK, MCG CLI and OC
         """
-        for bucket in bucket_factory(3, 'S3'):
+        for bucket in bucket_factory(amount, interface):
             logger.info(f"Deleting bucket: {bucket.name}")
             bucket.delete()
             assert not mcg_obj.s3_verify_bucket_exists(bucket.name), (
                 f"Found {bucket.name} that should've been removed"
             )
 
-    @noobaa_cli_required
-    def test_cli_bucket_delete(self, mcg_obj, bucket_factory):
+    @pytest.mark.parametrize(
+        argnames="interface",
+        argvalues=[
+            pytest.param(
+                *['S3'],
+                marks=[pytest.mark.polarion_id("OCS-1867"), tier3]
+            ),
+            pytest.param(
+                *['CLI'],
+                marks=[tier1, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1868")]
+            ),
+            pytest.param(
+                *['OC'],
+                marks=[tier1, pytest.mark.polarion_id("OCS-1868")]
+            ),
+        ]
+    )
+    def test_bucket_delete_with_objects(self, mcg_obj, interface, awscli_pod):
         """
-        Test deletion of buckets using the MCG CLI
+        Negative test with deletion of bucket has objects stored in.
         """
-        for bucket in bucket_factory(3, 'CLI'):
-            bucket.delete()
-            assert not mcg_obj.cli_verify_bucket_exists(bucket.name), (
-                f"Found {bucket.name} that should've been removed"
-            )
+        bucket_map = {
+            's3': S3Bucket,
+            'oc': OCBucket,
+            'cli': CLIBucket}
+        bucketname = create_unique_resource_name(
+            resource_description='bucket', resource_type=interface.lower())
+        try:
+            bucket = bucket_map[interface.lower()](mcg_obj, bucketname)
 
-    def test_oc_bucket_delete(self, mcg_obj, bucket_factory):
-        """
-        Test deletion of buckets using OC commands
-        """
-        for bucket in bucket_factory(3, 'OC'):
-            logger.info(f"Deleting bucket: {bucket.name}")
+            downloaded_files = []
+            logger.info(f"aws s3 endpoint is {mcg_obj.s3_endpoint}")
+            logger.info(f"aws region is {mcg_obj.region}")
+            public_s3 = boto3.resource('s3', region_name=mcg_obj.region)
+            for obj in public_s3.Bucket(constants.TEST_FILES_BUCKET
+                                        ).objects.all():
+                # Download test object(s)
+                logger.info(f'Downloading {obj.key}')
+                cmd = f'wget https://{constants.TEST_FILES_BUCKET}'
+                cmd += f'.s3.{mcg_obj.region}.amazonaws.com/{obj.key}'
+                awscli_pod.exec_cmd_on_pod(command=cmd)
+                downloaded_files.append(obj.key)
+
+            # Write all downloaded objects to the new bucket
+            logger.info(f'Writing objects to bucket')
+            for obj_name in downloaded_files:
+                full_object_path = f"s3://{bucketname}/{obj_name}"
+                copycommand = f"cp {obj_name} {full_object_path}"
+                assert 'Completed' in awscli_pod.exec_cmd_on_pod(
+                    command=craft_s3_command(mcg_obj, copycommand),
+                    out_yaml_format=False,
+                    secrets=[mcg_obj.access_key_id, mcg_obj.access_key,
+                             mcg_obj.s3_endpoint]
+                )
+
+            logger.info(f"Deleting bucket: {bucketname}")
+            if interface == "S3":
+                try:
+                    s3_del = mcg_obj.s3_resource.Bucket(bucketname).delete()
+                    assert not s3_del, ("Unexpected s3 delete non-empty "
+                                        "OBC succeed")
+                except botocore.exceptions.ClientError as err:
+                    assert "BucketNotEmpty" in str(err), ("Couldn't verify "
+                                                          "delete non-empty "
+                                                          "OBC with s3")
+                    logger.info(f"Delete non-empty OBC {bucketname} failed as "
+                                "expected")
+        finally:
             bucket.delete()
-            assert not mcg_obj.oc_verify_bucket_exists(bucket.name)
+
+    @pytest.mark.parametrize(
+        argnames="interface",
+        argvalues=[
+            pytest.param(
+                *['S3'],
+                marks=[pytest.mark.polarion_id("OCS-1400"), tier3]
+            ),
+            pytest.param(
+                *['CLI'],
+                marks=[tier3, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1400")]
+            ),
+            pytest.param(
+                *['OC'],
+                marks=[tier3, pytest.mark.polarion_id("OCS-1400")]
+            ),
+        ]
+    )
+    def test_nonexist_bucket_delete(self, mcg_obj, interface):
+        """
+        Negative test with deletion of non-exist OBC.
+        """
+        name = "test_nonexist_bucket_name"
+        if interface == "S3":
+            try:
+                s3_del = mcg_obj.s3_resource.Bucket(name).delete()
+                assert not s3_del, ("Unexpected s3 delete non-exist "
+                                    "OBC succeed")
+            except botocore.exceptions.ClientError as err:
+                assert "NoSuchBucket" in str(err), ("Couldn't verify "
+                                                    "delete non-exist "
+                                                    "OBC with s3")
+        elif interface == "OC":
+            try:
+                oc_del = OCP(kind='obc', namespace=mcg_obj.namespace
+                             ).delete(resource_name=name)
+                assert oc_del, "Unexpected oc delete non-exist OBC succeed"
+            except CommandFailed as err:
+                assert "NotFound" in str(err), ("Couldn't verify delete "
+                                                "non-exist OBC with oc")
+        elif interface == "CLI":
+            try:
+                cli_del = run_mcg_cmd(f'obc delete {name}')
+                assert cli_del, "Unexpected cli delete non-exist OBC succeed"
+            except CommandFailed as err:
+                assert "Could not delete OBC" in str(err), ("Couldn't verify "
+                                                            "delete non-exist "
+                                                            "OBC with cli")
+        logger.info(f"Delete non-exist OBC {name} failed as "
+                    "expected")

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -5,8 +5,8 @@ import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, tier2, tier3, noobaa_cli_required, acceptance,
-    filter_insecure_request_warning
+    tier1, tier3, noobaa_cli_required, acceptance,
+    performance, filter_insecure_request_warning
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
@@ -16,6 +16,7 @@ from tests.helpers import create_unique_resource_name
 from tests.manage.mcg import helpers
 
 logger = logging.getLogger(__name__)
+ERRATIC_TIMEOUTS_SKIP_REASON = 'Skipped because of erratic timeouts'
 
 
 @filter_insecure_request_warning
@@ -41,20 +42,32 @@ class TestBucketDeletion:
             ),
             pytest.param(
                 *[100, 'S3'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
+                marks=[
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1865")
+                ]
             ),
             pytest.param(
                 *[100, 'OC'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1915")]
+                marks=[
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1915")
+                ]
             ),
             pytest.param(
                 *[1000, 'S3'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
+                marks=[
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1866")
+                ]
             ),
-            # pytest.param(
-            #     *[1000, 'OC'],
-            #     marks=[tier2, pytest.mark.polarion_id("OCS-1916")]
-            # ),
+            pytest.param(
+                *[1000, 'OC'],
+                marks=[
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1916")
+                ]
+            ),
         ]
     )
     def test_bucket_delete(self, mcg_obj, bucket_factory, amount, interface):

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -30,12 +30,12 @@ class TestBucketDeletion:
         argvalues=[
             pytest.param(
                 *[3, 'S3'],
-                marks=[pytest.mark.polarion_id("OCS-1299"), tier1, acceptance]
+                marks=[pytest.mark.polarion_id("OCS-1939"), tier1, acceptance]
             ),
             pytest.param(
                 *[3, 'CLI'],
                 marks=[tier1, acceptance, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1299")]
+                       pytest.mark.polarion_id("OCS-1940")]
             ),
             pytest.param(
                 *[3, 'OC'],
@@ -129,12 +129,12 @@ class TestBucketDeletion:
         argvalues=[
             pytest.param(
                 *['S3'],
-                marks=[pytest.mark.polarion_id("OCS-1400"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1942"), tier3]
             ),
             pytest.param(
                 *['CLI'],
                 marks=[tier3, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1400")]
+                       pytest.mark.polarion_id("OCS-1941")]
             ),
             pytest.param(
                 *['OC'],

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -106,9 +106,11 @@ class TestBucketDeletion:
         bucket_map = {
             's3': S3Bucket,
             'oc': OCBucket,
-            'cli': CLIBucket}
+            'cli': CLIBucket
+        }
         bucketname = create_unique_resource_name(
-            resource_description='bucket', resource_type=interface.lower())
+            resource_description='bucket', resource_type=interface.lower()
+        )
         try:
             bucket = bucket_map[interface.lower()](mcg_obj, bucketname)
 
@@ -117,21 +119,24 @@ class TestBucketDeletion:
             data_dir = '/data'
             full_object_path = f"s3://{bucketname}"
             helpers.retrieve_test_objects_to_pod(awscli_pod, data_dir)
-            helpers.sync_object_directory(awscli_pod, data_dir,
-                                          full_object_path, mcg_obj)
+            helpers.sync_object_directory(
+                awscli_pod, data_dir, full_object_path, mcg_obj
+            )
 
             logger.info(f"Deleting bucket: {bucketname}")
             if interface == "S3":
                 try:
                     s3_del = mcg_obj.s3_resource.Bucket(bucketname).delete()
-                    assert not s3_del, ("Unexpected s3 delete non-empty "
-                                        "OBC succeed")
+                    assert not s3_del, (
+                        "Unexpected s3 delete non-empty OBC succeed"
+                    )
                 except botocore.exceptions.ClientError as err:
-                    assert "BucketNotEmpty" in str(err), ("Couldn't verify "
-                                                          "delete non-empty "
-                                                          "OBC with s3")
-                    logger.info(f"Delete non-empty OBC {bucketname} failed as "
-                                "expected")
+                    assert "BucketNotEmpty" in str(err), (
+                        "Couldn't verify delete non-empty OBC with s3"
+                    )
+                    logger.info(
+                        f"Delete non-empty OBC {bucketname} failed as expected"
+                    )
         finally:
             bucket.delete()
 
@@ -161,30 +166,34 @@ class TestBucketDeletion:
         if interface == "S3":
             try:
                 s3_del = mcg_obj.s3_resource.Bucket(name).delete()
-                assert not s3_del, ("Unexpected s3 delete non-exist "
-                                    "OBC succeed")
+                assert not s3_del, (
+                    "Unexpected s3 delete non-exist OBC succeed"
+                )
             except botocore.exceptions.ClientError as err:
-                assert "NoSuchBucket" in str(err), ("Couldn't verify "
-                                                    "delete non-exist "
-                                                    "OBC with s3")
+                assert "NoSuchBucket" in str(err), (
+                    "Couldn't verify delete non-exist OBC with s3"
+                )
         elif interface == "OC":
             try:
-                oc_del = OCP(kind='obc', namespace=mcg_obj.namespace
-                             ).delete(resource_name=name)
+                oc_del = OCP(
+                    kind='obc', namespace=mcg_obj.namespace
+                ).delete(resource_name=name)
                 assert oc_del, "Unexpected oc delete non-exist OBC succeed"
             except CommandFailed as err:
-                assert "NotFound" in str(err), ("Couldn't verify delete "
-                                                "non-exist OBC with oc")
+                assert "NotFound" in str(err), (
+                    "Couldn't verify delete non-exist OBC with oc"
+                )
         elif interface == "CLI":
             try:
                 cli_del = run_mcg_cmd(f'obc delete {name}')
                 assert cli_del, "Unexpected cli delete non-exist OBC succeed"
             except CommandFailed as err:
-                assert "Could not delete OBC" in str(err), ("Couldn't verify "
-                                                            "delete non-exist "
-                                                            "OBC with cli")
-        logger.info(f"Delete non-exist OBC {name} failed as "
-                    "expected")
+                assert "Could not delete OBC" in str(err), (
+                    "Couldn't verify delete non-exist OBC with cli"
+                )
+        logger.info(
+            f"Delete non-exist OBC {name} failed as expected"
+        )
 
     @pytest.mark.bugzilla("1753109")
     @pytest.mark.polarion_id("OCS-1924")
@@ -194,7 +203,8 @@ class TestBucketDeletion:
         Test with deletion of bucket has 1T objects stored in.
         """
         bucketname = create_unique_resource_name(
-            resource_description='bucket', resource_type='s3')
+            resource_description='bucket', resource_type='s3'
+        )
         try:
             bucket = S3Bucket(mcg_obj, bucketname)
             logger.info(f"aws s3 endpoint is {mcg_obj.s3_endpoint}")
@@ -208,8 +218,9 @@ class TestBucketDeletion:
             logger.info(f'Writing objects to bucket')
             for i in range(3175):
                 full_object_path = f"s3://{bucketname}/{i}/"
-                helpers.sync_object_directory(awscli_pod, data_dir,
-                                              full_object_path, mcg_obj)
+                helpers.sync_object_directory(
+                    awscli_pod, data_dir, full_object_path, mcg_obj
+                )
 
             # Delete bucket content use aws rm with --recursive option.
             # The object_versions.delete function does not work with objects

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -19,8 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 @filter_insecure_request_warning
-@acceptance
-@tier1
 class TestBucketDeletion:
     """
     Test bucket Creation Deletion of buckets
@@ -46,17 +44,17 @@ class TestBucketDeletion:
                 marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
             ),
             pytest.param(
-                *[1000, 'S3'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
-            ),
-            pytest.param(
                 *[100, 'OC'],
                 marks=[tier2, pytest.mark.polarion_id("OCS-1915")]
             ),
             pytest.param(
-                *[1000, 'OC'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1916")]
+                *[1000, 'S3'],
+                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
             ),
+            # pytest.param(
+            #     *[1000, 'OC'],
+            #     marks=[tier2, pytest.mark.polarion_id("OCS-1916")]
+            # ),
         ]
     )
     def test_bucket_delete(self, mcg_obj, bucket_factory, amount, interface):

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -5,7 +5,7 @@ import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, noobaa_cli_required, acceptance,
+    tier1, tier2, tier3, noobaa_cli_required, acceptance,
     filter_insecure_request_warning
 )
 from ocs_ci.ocs.exceptions import CommandFailed

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -51,11 +51,11 @@ class TestBucketDeletion:
             ),
             pytest.param(
                 *[100, 'OC'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1865")]
+                marks=[tier2, pytest.mark.polarion_id("OCS-1915")]
             ),
             pytest.param(
                 *[1000, 'OC'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1866")]
+                marks=[tier2, pytest.mark.polarion_id("OCS-1916")]
             ),
         ]
     )
@@ -80,7 +80,7 @@ class TestBucketDeletion:
             pytest.param(
                 *['CLI'],
                 marks=[tier1, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1868")]
+                       pytest.mark.polarion_id("OCS-1917")]
             ),
             pytest.param(
                 *['OC'],


### PR DESCRIPTION
Add test case for delete 100 and 1000 buckets and OBCs, delete                                                                                                                                                                            
non-empty bucket and OBC, delete non-existant bucket and OBC.                                                                                                                                                                             
                                                                                                                                                                                                                                              
Signed-off-by: Wayne Sun <gsun@redhat.com> 