### PR TITLE
Adding production device size as '2TB' for perf and scale testing

### DIFF
--- a/conf/ocsci/production_device_size_e2e.yaml
+++ b/conf/ocsci/production_device_size_e2e.yaml
@@ -1,0 +1,5 @@
+---
+#This config file holds the disk size in GB for production.
+#This device size is to be used for all performance and scale testing.
+ENV_DATA:
+  device_size: '2048'


### PR DESCRIPTION
For all performance and scale testing, we will need to run the tests with the actual device size planned for OCS. i.e., 2TB. This PR adds a config to create devices with 2 TB. 

p.s., We are not updating production_device_size.yaml to 2 TB as running CI jobs (which are mostly functional tests) with 2TB OSDs would be an overkill.