### PR TITLE
Add resource limits for fedora pods

### DIFF
--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -19,6 +19,10 @@ spec:
       containers:
       - name: fedora
         image: fedora
+        resources:
+          limits:
+            memory: "500Mi"
+            cpu: "150m"
         command: ["/bin/bash", "-ce", "tail -f /dev/null" ]
         imagePullPolicy: IfNotPresent
         securityContext:


### PR DESCRIPTION
Adding resource limit will avoid more resource consumption by fedora pods

Signed-off-by: prsurve <prsurve@redhat.com>