### PR TITLE
Increase catalog source wait timeout to 15 minutes

### DIFF
--- a/ocs_ci/ocs/resources/catalog_source.py
+++ b/ocs_ci/ocs/resources/catalog_source.py
@@ -108,7 +108,7 @@ class CatalogSource(OCP):
         return False
 
     @retry(ResourceInUnexpectedState, tries=4, delay=5, backoff=1)
-    def wait_for_state(self, state, timeout=480, sleep=5):
+    def wait_for_state(self, state, timeout=900, sleep=5):
         """
         Wait till state of catalog source resource is the same as required one
         passed in the state parameter.


### PR DESCRIPTION
Based on the discussion in https://bugzilla.redhat.com/show_bug.cgi?id=1770192

8 minutes may not be enough. According to this:

https://github.com/operator-framework/operator-lifecycle-manager/issues/947
https://github.com/operator-framework/operator-lifecycle-manager/issues/1098
https://github.com/operator-framework/operator-lifecycle-manager/pull/974
https://bugzilla.redhat.com/show_bug.cgi?id=1737081

More than 10 minutes have been seen.
Trying 15 minutes. We may need even more?

Signed-off-by: Michael Adam <obnox@redhat.com>