### PR TITLE
check_file_existence: Avoid TypeError

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -474,6 +474,8 @@ def check_file_existence(pod_obj, file_path):
         bool: True if the file exist, False otherwise
     """
     ret = pod_obj.exec_cmd_on_pod(f"bash -c \"find {file_path}\"")
+    if not ret:
+        return False
     if re.search(file_path, ret):
         return True
     return False


### PR DESCRIPTION
When the result of pod_obj.exec_cmd_on_pod() is None, we're getting a
TypeError from re.search(). Avoid that and return False instead.

Signed-off-by: Zack Cerza <zack@redhat.com>