### PR TITLE
prometheus range query method with example

### DIFF
--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -1,10 +1,13 @@
 import base64
+import functools
 import logging
+import operator
 import os
 import requests
 import tempfile
 import time
 import yaml
+from datetime import datetime
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults
@@ -171,6 +174,68 @@ class PrometheusAPI(object):
             params=payload
         )
         return response
+
+    def query_range(self, query, start, end, step, timeout=None, validate=True):
+        """
+        Perform Prometheus `range query`_. This is a simple wrapper over
+        ``get()`` method with plumbing code for range queries, additional
+        validation and logging.
+
+        Args:
+            query (str): Prometheus expression query string.
+            start (str): start timestamp (rfc3339 or unix timestamp)
+            end (str): end timestamp (rfc3339 or unix timestamp)
+            step (float): Query resolution step width as float number of
+                seconds.
+            timeout (str): Evaluation timeout in duration format. Optional.
+            validate (bool): Perform basic validation on the response.
+                Optional, ``True`` is the default. Use ``False`` when you
+                expect query to fail eg. during negative testing.
+
+        Returns:
+            list: result of the query
+
+        .. _`range query`: https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
+        """
+        query_payload = {
+            'query': query,
+            'start': start,
+            'end': end,
+            'step': step,
+            }
+        if timeout is not None:
+            query_payload['timeout'] = timeout
+        # Human readable summary of the query (details are logged by get
+        # method itself with debug level).
+        logger.info((
+            f"Performing prometheus range query '{query}' "
+            f"over a time range ({start}, {end})"))
+        resp = self.get('query_range', payload=query_payload)
+        content = yaml.safe_load(resp.content)
+        if validate:
+            # If this fails, Prometheus instance is so broken that test can't
+            # be performed.
+            assert content["status"] == "success"
+            # For a range query, we should always get a matrix result type, as
+            # noted in Prometheus documentation, see:
+            # https://prometheus.io/docs/prometheus/latest/querying/api/#range-vectors
+            assert content["data"]["resultType"] == "matrix"
+            # All metric sample series has the same size.
+            sizes = []
+            for metric in content["data"]["result"]:
+                sizes.append(len(metric["values"]))
+            assert all(size == sizes[0] for size in sizes)
+            # Check that we don't have holes in the response. If this fails,
+            # our Prometheus instance is missing some part of the data we are
+            # asking it about. For positive test cases, this is most likely a
+            # test blocker product bug.
+            start_dt = datetime.utcfromtimestamp(start)
+            end_dt = datetime.utcfromtimestamp(end)
+            duration = end_dt - start_dt
+            exp_samples = duration.seconds / step
+            assert exp_samples - 1 <= sizes[0] <= exp_samples + 1
+        # return actual result of the query
+        return content["data"]["result"]
 
     def wait_for_alert(self, name, state=None, timeout=1200, sleep=5):
         """

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -1,7 +1,5 @@
 import base64
-import functools
 import logging
-import operator
 import os
 import requests
 import tempfile
@@ -201,8 +199,7 @@ class PrometheusAPI(object):
             'query': query,
             'start': start,
             'end': end,
-            'step': step,
-            }
+            'step': step}
         if timeout is not None:
             query_payload['timeout'] = timeout
         # Human readable summary of the query (details are logged by get
@@ -224,7 +221,8 @@ class PrometheusAPI(object):
             sizes = []
             for metric in content["data"]["result"]:
                 sizes.append(len(metric["values"]))
-            assert all(size == sizes[0] for size in sizes)
+            msg = "Metric sample series doesn't have the same size."
+            assert all(size == sizes[0] for size in sizes), msg
             # Check that we don't have holes in the response. If this fails,
             # our Prometheus instance is missing some part of the data we are
             # asking it about. For positive test cases, this is most likely a

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -42,7 +42,6 @@ import logging
 from datetime import datetime
 
 import pytest
-import yaml
 
 from ocs_ci.utility.prometheus import PrometheusAPI
 
@@ -83,7 +82,7 @@ def test_workload_rbd(workload_storageutilization_50p_rbd):
             values.append(value)
         assert all(value == values[0] for value in values)
         osd_stat_bytes.append(values[0])
-    assert(value == osd_stat_bytes[0] for value in osd_stat_bytes)
+    assert all(value == osd_stat_bytes[0] for value in osd_stat_bytes)
     # Compute expected value of'ceph_osd_stat_bytes_used, based on percentage
     # utilized by the fixture.
     percentage = workload_storageutilization_50p_rbd['result']['target_p']
@@ -100,7 +99,7 @@ def test_workload_rbd(workload_storageutilization_50p_rbd):
             # a demonstration after all)
             logger.info(f"{dt}: {value} B")
             # checking the value, with 10% error margin in each direction
-            assert expected_value*0.90 <= value <= expected_value*1.10
+            assert expected_value * 0.90 <= value <= expected_value * 1.10
 
 
 @pytest.mark.libtest

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -110,7 +110,6 @@ def test_workload_rbd(workload_storageutilization_50p_rbd):
     assert not at_least_one_value_out_of_range
 
 
-
 @pytest.mark.libtest
 def test_workload_rbd_in_some_other_way(workload_storageutilization_50p_rbd):
     """


### PR DESCRIPTION
This branch adds `query_range` function to Prometheus class, implementing qe wrapper for range queries usable for metrics testing. The test provided is just a libtest demonstration.