### PR TITLE
Jenkins: Skip base64 if Unicode decoding fails

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -73,7 +73,7 @@ def write_pull_secret():
     # base64-encoded.
     try:
         secret = base64.b64decode(secret).decode()
-    except binascii.Error:
+    except (binascii.Error, UnicodeDecodeError):
         pass
     with open(os.path.join(secret_dir, 'pull-secret'), 'w') as secret_file:
         secret_file.write(secret)


### PR DESCRIPTION
This just works around an issue where the pull secret might appear to be valid base64, but isn't.