### PR TITLE
Fix test_pvc_no_space_left

### DIFF
--- a/tests/manage/pv_services/test_no_space_left.py
+++ b/tests/manage/pv_services/test_no_space_left.py
@@ -112,14 +112,12 @@ class TestPVCFullWithIORWX(ManageTest):
             'fs', size=self.pvc_size_gb, io_direction='write', runtime=60
         )
         log.info("Waiting for IO results")
-        catch_error = False
         try:
             self.pod_obj1.get_fio_results()
         except ex.CommandFailed as cf:
             if "No space left on device" not in str(cf):
                 raise
             else:
-                catch_error = True
                 used_space = get_used_space_on_mount_point(self.pod_obj1)
                 assert used_space == '100%', (
                     f"The used space is not 100% but {used_space} which means "
@@ -131,9 +129,6 @@ class TestPVCFullWithIORWX(ManageTest):
                     f"the device is not full"
                 )
                 log.info(f"FIO succeeded to fill the PVC with data")
-        assert catch_error, (
-            "No error raised during FIO to fill the device with data"
-        )
         log.info(
             f"Deleting the first pod and checking used size from the 2nd pod"
         )


### PR DESCRIPTION
Removed check for fio failure. fio need not throw error when trying to utilize 100% space.
The intention of test is to validate full utilization of available space.

Fixes #1106 

Signed-off-by: Jilju Joy <jijoy@redhat.com>