### PR TITLE
downstream-ci: change parameters for the quay-tag-image job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,9 @@ pipeline {
         // quay.io/rhceph-dev/ocs-registry:4.2-58.e59ca0f.master -> 4.2-58.e59ca0f.master
         def registry_tag = registry_image.split(':')[-1]
         // tag ocs-registry container as 'latest-stable'
-        build job: 'quay-tag-image', parameters: [string(name: "IMAGE_URL", value: "quay.io/rhceph-dev/ocs-registry"), string(name: "CURRENT_TAG", value: "${registry_tag}"), string(name: "NEW_TAG", value: "latest-stable")]
+        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable")]
+        // tag ocs-olm-operator container as 'latest-stable'
+        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable")]
         if( env.UMB_MESSAGE in [true, 'true'] ) {
           def registry_version = registry_tag.split('-')[0]
           def properties = """


### PR DESCRIPTION
We're changing the parameters to our quay-tag-image job and
need to update them here as well. We also want to tag the
ocs-olm-operator container as latest-stable.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>