### PR TITLE
Remove securityContext from container section 

### DIFF
--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -10,6 +10,8 @@ spec:
       labels:
         name: fedorapod
     spec:
+      securityContext:
+        fsGroup: 2000
       serviceAccountName: admin
       restartPolicy: Always
       volumes:
@@ -25,9 +27,6 @@ spec:
             cpu: "150m"
         command: ["/bin/bash", "-ce", "tail -f /dev/null" ]
         imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities: {}
-          privileged: true
         volumeMounts:
         - mountPath: /mnt
           name: fedora-vol


### PR DESCRIPTION
Having this privileged will not allow us to catch this type of [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1777384) 

Because making this privileged dc pod will be able to write on mount point even when normal pod doesn't have permission to write on that mount point

Signed-off-by: prsurve <prsurve@redhat.com>