### PR TITLE
Change exec_ceph_cmd() so it won't filter anything of the command output

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -203,7 +203,7 @@ class Pod(OCS):
 
         # For some commands, like "ceph fs ls", the returned output is a list
         if isinstance(out, list):
-            return [item for item in out if item]
+            return [item for item in out if not item == ""]
         return out
 
     def get_storage_path(self, storage_type='fs'):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -203,7 +203,7 @@ class Pod(OCS):
 
         # For some commands, like "ceph fs ls", the returned output is a list
         if isinstance(out, list):
-            return [item for item in out if not item == ""]
+            return [item for item in out]
         return out
 
     def get_storage_path(self, storage_type='fs'):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -188,6 +188,7 @@ class Pod(OCS):
 
         Returns:
             dict: Ceph command output
+            (For some commands, like "ceph fs ls", the returned output is a list)
 
         Raises:
             CommandFailed: In case the pod is not a toolbox pod
@@ -200,10 +201,6 @@ class Pod(OCS):
         if format:
             ceph_cmd += f" --format {format}"
         out = self.exec_cmd_on_pod(ceph_cmd)
-
-        # For some commands, like "ceph fs ls", the returned output is a list
-        if isinstance(out, list):
-            return [item for item in out]
         return out
 
     def get_storage_path(self, storage_type='fs'):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -188,7 +188,7 @@ class Pod(OCS):
 
         Returns:
             dict: Ceph command output
-            (For some commands, like "ceph fs ls", the returned output is a list)
+            list: some commands, like "ceph fs ls", the returned output is a list
 
         Raises:
             CommandFailed: In case the pod is not a toolbox pod


### PR DESCRIPTION
A zero int or float which evaluates to false with the current condition, should not be filtered out.

Fixes: #1152 

Signed-off-by: Gil Klein <gklein@users.noreply.github.com>