### PR TITLE
Test to validate pvc reattach time Issue #890

### DIFF
--- a/tests/e2e/test_pvc_creation_performance.py
+++ b/tests/e2e/test_pvc_creation_performance.py
@@ -168,7 +168,6 @@ class TestPVCCreationPerformance(E2ETest):
             f"{number_of_pvcs} PVCs creation time took less than a 45 seconds"
         )
 
-
     def test_pvc_reattach_time_performance(self, pvc_factory, teardown_factory):
         """
         Test assign nodeName to a pod using RWX pvc

--- a/tests/e2e/test_pvc_creation_performance.py
+++ b/tests/e2e/test_pvc_creation_performance.py
@@ -6,13 +6,15 @@ import pytest
 import math
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
+import urllib.request
+import time
 from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.testlib import (
     performance, E2ETest, polarion_id, bugzilla
 )
 from tests import helpers
 from ocs_ci.ocs import defaults, constants
-
+from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
@@ -165,3 +167,105 @@ class TestPVCCreationPerformance(E2ETest):
         logging.info(
             f"{number_of_pvcs} PVCs creation time took less than a 45 seconds"
         )
+
+
+    def test_pvc_reattach_time_performance(self, pvc_factory, teardown_factory):
+        """
+        Test assign nodeName to a pod using RWX pvc
+        Performance in test_multiple_pvc_creation_measurement_performance
+        Each kernel (unzipped) is 892M and 61694 files
+        """
+        interface = constants.CEPHFILESYSTEM
+        kernel_url = 'https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.5.tar.gz'
+        download_path = 'tmp'
+        # Number of times we copy the kernel
+        copies = 3
+
+        # Download a linux Kernel
+        import os
+        dir_path = os.path.join(os.getcwd(), download_path)
+        file_path = os.path.join(dir_path, 'file.gz')
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+        urllib.request.urlretrieve(kernel_url, file_path)
+
+        worker_nodes_list = helpers.get_worker_nodes()
+        assert (len(worker_nodes_list) > 1)
+        node_one = worker_nodes_list[0]
+        node_two = worker_nodes_list[1]
+
+        # Create a RWX PVC
+        pvc_obj = pvc_factory(
+            interface=interface, access_mode=constants.ACCESS_MODE_RWX,
+            status=constants.STATUS_BOUND,
+            size='15',
+        )
+
+        # Create a pod on one node
+        logging.info(
+            f"Creating Pod with pvc {pvc_obj.name} on node {node_one}"
+        )
+        pod_obj1 = helpers.create_pod(
+            interface_type=interface, pvc_name=pvc_obj.name,
+            namespace=pvc_obj.namespace, node_name=node_one,
+            pod_dict_path=constants.NGINX_POD_YAML
+        )
+
+        # Confirm that pod is running on the selected_nodes
+        logging.info('Checking whether pods are running on the selected nodes')
+        helpers.wait_for_resource_state(
+            resource=pod_obj1, state=constants.STATUS_RUNNING,
+            timeout=120
+        )
+
+        pod_name = pod_obj1.name
+        pod_path = '/var/lib/www/html'
+
+        _ocp = OCP(namespace=pvc_obj.namespace)
+        rsh_cmd = f"rsync {dir_path} {pod_name}:{pod_path}"
+        _ocp.exec_oc_cmd(rsh_cmd)
+        # doesn't work!
+        # ocp.rsync(src='/tmp/tocopy', dst=pod_path, node=pod_name)
+
+        rsh_cmd = f"exec {pod_name} -- tar xvf {pod_path}/tmp/file.gz -C /var/lib/www/html/tmp"
+        _ocp.exec_oc_cmd(rsh_cmd)
+
+        for x in range(copies):
+            rsh_cmd = f"exec {pod_name} -- mkdir -p {pod_path}/folder{x}"
+            _ocp.exec_oc_cmd(rsh_cmd)
+            rsh_cmd = f"exec {pod_name} -- cp -r {pod_path}/tmp {pod_path}/folder{x}"
+            _ocp.exec_oc_cmd(rsh_cmd)
+
+        rsh_cmd = f"delete pod {pod_name}"
+        _ocp.exec_oc_cmd(rsh_cmd)
+
+        start_time = time.time()
+
+        logging.info(
+            f"Creating Pod with pvc {pvc_obj.name} on node {node_two}"
+        )
+
+        pod_obj2 = helpers.create_pod(
+            interface_type=interface, pvc_name=pvc_obj.name,
+            namespace=pvc_obj.namespace, node_name=node_two,
+            pod_dict_path=constants.NGINX_POD_YAML
+        )
+        pod_name = pod_obj2.name
+        helpers.wait_for_resource_state(
+            resource=pod_obj2, state=constants.STATUS_RUNNING,
+            timeout=120
+        )
+        end_time = time.time()
+        total_time = end_time - start_time
+        if total_time > 60:
+            raise ex.PerformanceException(
+                f"Pod creation time is {total_time} and "
+                f"greater than 60 seconds"
+            )
+        logging.info(
+            f"Pod {pod_name} creation time took {total_time} seconds"
+        )
+
+        teardown_factory(pod_obj2)
+        os.remove(file_path)
+        os.rmdir(dir_path)


### PR DESCRIPTION
Added test for issue #890 (https://github.com/red-hat-storage/ocs-ci/issues/890)
I'm creating a PVC and attach it to a nginx Pod in one Node. Then:
1. Uploading three Kernel copies to the Pod, on the mount points provided by PVC
2. Untar of the Kernel into subfolders of /var/lib/www/html
3. Delete the Pod
4. Create again the Pod on another Node and attach it to the PVC
5. Measure the time to reattach 
Comments welcome!