### PR TITLE
Fix storageCluster CR for BZ1782110

### DIFF
--- a/ocs_ci/templates/ocs-deployment/storage-cluster.yaml
+++ b/ocs_ci/templates/ocs-deployment/storage-cluster.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   storageDeviceSets:
   - name: ocs-deviceset
-    count: 3
+    count: 1
+    replica: 3
     resources: {}
     placement: {}
     dataPVCTemplate:


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/1170

As mentioned in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1782110
We should use:
replica: 3
count: 1

in storage cluster specs

Signed-off-by: Petr Balogh <pbalogh@redhat.com>