### PR TITLE
Change MCG bucket creation tests markers

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -82,8 +82,6 @@ aws_platform_required = pytest.mark.skipif(
     reason="Tests are not running on AWS deployed cluster"
 )
 
-skip_always = pytest.mark.skipif(True, reason="Test was marked for intentional skipping")
-
 # Filter warnings
 filter_insecure_request_warning = pytest.mark.filterwarnings(
     'ignore::urllib3.exceptions.InsecureRequestWarning'

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -82,6 +82,8 @@ aws_platform_required = pytest.mark.skipif(
     reason="Tests are not running on AWS deployed cluster"
 )
 
+skip_always = pytest.mark.skipif(True, reason="Test was marked for intentional skipping")
+
 # Filter warnings
 filter_insecure_request_warning = pytest.mark.filterwarnings(
     'ignore::urllib3.exceptions.InsecureRequestWarning'

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -48,18 +48,24 @@ class TestBucketCreation:
             ),
             pytest.param(
                 *[3, 'CLI'],
-                marks=[tier1, acceptance, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1298")]
+                marks=[
+                    tier1, acceptance, noobaa_cli_required,
+                    pytest.mark.polarion_id("OCS-1298")
+                ]
             ),
             pytest.param(
                 *[100, 'CLI'],
-                marks=[skip_always, performance, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1825")]
+                marks=[
+                    skip_always, performance, noobaa_cli_required,
+                    pytest.mark.polarion_id("OCS-1825")
+                ]
             ),
             pytest.param(
                 *[1000, 'CLI'],
-                marks=[skip_always, performance, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1828")]
+                marks=[
+                    skip_always, performance, noobaa_cli_required,
+                    pytest.mark.polarion_id("OCS-1828")
+                ]
             ),
         ]
     )

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -3,7 +3,6 @@ import re
 
 import botocore
 import pytest
-from pytest import skip
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1, tier3, noobaa_cli_required, filter_insecure_request_warning,
@@ -21,6 +20,7 @@ class TestBucketCreation:
     Test creation of a bucket
     """
     ERRATIC_TIMEOUTS_SKIP_REASON = 'Skipped because of erratic timeouts'
+
     @pytest.mark.parametrize(
         argnames="amount,interface",
         argvalues=[
@@ -31,14 +31,14 @@ class TestBucketCreation:
             pytest.param(
                 *[100, 'S3'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, pytest.mark.polarion_id("OCS-1823")
                 ]
             ),
             pytest.param(
                 *[1000, 'S3'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, pytest.mark.polarion_id("OCS-1824")
                 ]
             ),
@@ -49,14 +49,14 @@ class TestBucketCreation:
             pytest.param(
                 *[100, 'OC'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, pytest.mark.polarion_id("OCS-1826")
                 ]
             ),
             pytest.param(
                 *[1000, 'OC'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, pytest.mark.polarion_id("OCS-1827")
                 ]
             ),
@@ -70,14 +70,14 @@ class TestBucketCreation:
             pytest.param(
                 *[100, 'CLI'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, noobaa_cli_required, pytest.mark.polarion_id("OCS-1825")
                 ]
             ),
             pytest.param(
                 *[1000, 'CLI'],
                 marks=[
-                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance, noobaa_cli_required, pytest.mark.polarion_id("OCS-1828")
                 ]
             ),

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -5,9 +5,8 @@ import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, tier2, tier3, noobaa_cli_required,
-    filter_insecure_request_warning, acceptance,
-    aws_platform_required
+    tier1, tier3, noobaa_cli_required, filter_insecure_request_warning, acceptance,
+    performance, skip_always
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
@@ -28,48 +27,39 @@ class TestBucketCreation:
                 marks=[pytest.mark.polarion_id("OCS-1298"), tier1, acceptance]
             ),
             pytest.param(
-                *[3, 'CLI'],
-                marks=[tier1, acceptance, noobaa_cli_required,
-                       pytest.mark.polarion_id("OCS-1298")]
+                *[100, 'S3'],
+                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1823")]
+            ),
+            pytest.param(
+                *[1000, 'S3'],
+                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1824")]
             ),
             pytest.param(
                 *[3, 'OC'],
                 marks=[tier1, acceptance, pytest.mark.polarion_id("OCS-1298")]
             ),
             pytest.param(
-                *[100, 'S3'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1823")]
+                *[100, 'OC'],
+                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1826")]
             ),
             pytest.param(
-                *[1000, 'S3'],
-                marks=[
-                    tier2, aws_platform_required,
-                    pytest.mark.polarion_id("OCS-1824")
-                ]
+                *[1000, 'OC'],
+                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1827")]
+            ),
+            pytest.param(
+                *[3, 'CLI'],
+                marks=[tier1, acceptance, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1298")]
             ),
             pytest.param(
                 *[100, 'CLI'],
-                marks=[tier2, noobaa_cli_required,
+                marks=[skip_always, performance, noobaa_cli_required,
                        pytest.mark.polarion_id("OCS-1825")]
             ),
             pytest.param(
                 *[1000, 'CLI'],
-                marks=[
-                    tier2, noobaa_cli_required,
-                    aws_platform_required,
-                    pytest.mark.polarion_id("OCS-1828")
-                ]
-            ),
-            pytest.param(
-                *[100, 'OC'],
-                marks=[tier2, pytest.mark.polarion_id("OCS-1826")]
-            ),
-            pytest.param(
-                *[1000, 'OC'],
-                marks=[
-                    tier2, aws_platform_required,
-                    pytest.mark.polarion_id("OCS-1827")
-                ]
+                marks=[skip_always, performance, noobaa_cli_required,
+                       pytest.mark.polarion_id("OCS-1828")]
             ),
         ]
     )

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -3,10 +3,11 @@ import re
 
 import botocore
 import pytest
+from pytest import skip
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, tier3, noobaa_cli_required, filter_insecure_request_warning, acceptance,
-    performance, skip_always
+    tier1, tier3, noobaa_cli_required, filter_insecure_request_warning,
+    acceptance, performance
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
@@ -19,6 +20,7 @@ class TestBucketCreation:
     """
     Test creation of a bucket
     """
+    ERRATIC_TIMEOUTS_SKIP_REASON = 'Skipped because of erratic timeouts'
     @pytest.mark.parametrize(
         argnames="amount,interface",
         argvalues=[
@@ -28,11 +30,17 @@ class TestBucketCreation:
             ),
             pytest.param(
                 *[100, 'S3'],
-                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1823")]
+                marks=[
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1823")
+                ]
             ),
             pytest.param(
                 *[1000, 'S3'],
-                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1824")]
+                marks=[
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1824")
+                ]
             ),
             pytest.param(
                 *[3, 'OC'],
@@ -40,11 +48,17 @@ class TestBucketCreation:
             ),
             pytest.param(
                 *[100, 'OC'],
-                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1826")]
+                marks=[
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1826")
+                ]
             ),
             pytest.param(
                 *[1000, 'OC'],
-                marks=[skip_always, performance, pytest.mark.polarion_id("OCS-1827")]
+                marks=[
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, pytest.mark.polarion_id("OCS-1827")
+                ]
             ),
             pytest.param(
                 *[3, 'CLI'],
@@ -56,15 +70,15 @@ class TestBucketCreation:
             pytest.param(
                 *[100, 'CLI'],
                 marks=[
-                    skip_always, performance, noobaa_cli_required,
-                    pytest.mark.polarion_id("OCS-1825")
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, noobaa_cli_required, pytest.mark.polarion_id("OCS-1825")
                 ]
             ),
             pytest.param(
                 *[1000, 'CLI'],
                 marks=[
-                    skip_always, performance, noobaa_cli_required,
-                    pytest.mark.polarion_id("OCS-1828")
+                    skip(ERRATIC_TIMEOUTS_SKIP_REASON),
+                    performance, noobaa_cli_required, pytest.mark.polarion_id("OCS-1828")
                 ]
             ),
         ]


### PR DESCRIPTION
* Replace all 'tier2' markers with 'performance'
* Reorder param calls
* Add an always skipif marker

Signed-off-by: Ben <belimele@redhat.com>