### PR TITLE
Change the AWS credential verification bucketname to be random

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -328,7 +328,9 @@ class MCG(object):
                     aws_access_key_id=aws_access_key_id,
                     aws_secret_access_key=aws_access_key
                 )
-                test_bucket = s3_res.create_bucket(Bucket='noobaa-test-creds-verification')
+                test_bucket = s3_res.create_bucket(
+                    Bucket=create_unique_resource_name('cred-verify', 's3-bucket')
+                )
                 test_bucket.delete()
                 return True
 


### PR DESCRIPTION
I suspect that multiple test runs have failed because of an attempt to create an S3 bucket with a name that already exists.
This randoms the name and prevents further mishaps that may be caused by this.