### PR TITLE
Its taking more time for benchmark pods to show up

### DIFF
--- a/tests/e2e/test_small_file_workload.py
+++ b/tests/e2e/test_small_file_workload.py
@@ -82,7 +82,7 @@ class TestSmallFileWorkload(E2ETest):
         sf_obj.create()
         # wait for benchmark pods to get created - takes a while
         for bench_pod in TimeoutSampler(
-            40, 3, get_pod_name_by_pattern, 'smallfile-client', 'my-ripsaw'
+            80, 5, get_pod_name_by_pattern, 'smallfile-client', 'my-ripsaw'
         ):
             try:
                 if bench_pod[0] is not None:


### PR DESCRIPTION
Fixes: Issues seen during jenkins run where it timed out for benchmark pods to come up

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>