### PR TITLE
Check the deployment prerequisites before downloading the installer

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -343,6 +343,14 @@ class AWSUPI(AWSBase):
             )
             os.symlink(absolute_cluster_path, install_dir)
 
+        def download_installer(self):
+            """
+            Overriding download_installer from parent. Perform all necessary
+            prerequisites for AWSUPI here.
+            """
+
+            super(AWSUPI.OCPDeployment, self).download_installer()
+
             # NOT A CLEAN APPROACH: copy openshift-install and oc binary to
             # script path because upi script expects it to be present in
             # script dir

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -106,6 +106,7 @@ class Deployment(object):
         """
         self.ocp_deployment = self.OCPDeployment()
         self.ocp_deployment.deploy_prereq()
+        self.ocp_deployment.download_installer()
         self.ocp_deployment.deploy(log_cli_level)
         # logging the cluster UUID so that we can ask for it's telemetry data
         cluster_id = run_cmd("oc get clusterversion version -o jsonpath='{.spec.clusterID}'")

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -28,7 +28,7 @@ class OCPDeployment:
         self.metadata = {}
         self.deployment_platform = config.ENV_DATA['platform'].lower()
         self.deployment_type = config.ENV_DATA['deployment_type'].lower()
-        self.installer = self.download_installer()
+        self.installer = None
         self.cluster_path = config.ENV_DATA['cluster_path']
 
     def download_installer(self):
@@ -42,7 +42,7 @@ class OCPDeployment:
             config.RUN['cli_params'].get('deploy')
             and config.DEPLOYMENT['force_download_installer']
         )
-        return utils.get_openshift_installer(
+        self.installer = utils.get_openshift_installer(
             config.DEPLOYMENT['installer_version'],
             force_download=force_download
         )


### PR DESCRIPTION
Fixes #1195 by running `deploy_prereq()` to run before `download_installer()`

Signed-off-by: Gil Klein <gklein@users.noreply.github.com>