### PR TITLE
Increase 'oc login' timeout

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -132,6 +132,7 @@ IMAGE_REGISTRY_RESOURCE_NAME = "cluster"
 ADMIN_USER = 'admin'
 GB = 1024 ** 3
 GB2KB = 1024 ** 2
+WEEK2SEC = '604800s'
 
 # Reclaim Policy
 RECLAIM_POLICY_RETAIN = 'Retain'

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 import yaml
 
-from ocs_ci.ocs.constants import RSYNC_POD_YAML, STATUS_RUNNING
+from ocs_ci.ocs.constants import RSYNC_POD_YAML, STATUS_RUNNING, WEEK2SEC
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     NotSupportedFunctionError,
@@ -356,7 +356,9 @@ class OCP(object):
         Returns:
             str: output of login command
         """
-        command = f"oc login -u {user} -p {password}"
+        command = (
+            f"oc login -u {user} -p {password} --request-timeout={WEEK2SEC}"
+        )
         status = run_cmd(command)
         return status
 


### PR DESCRIPTION
 The default is 24h which is not enough for tier4 tests.
 Increased to 1 week

Signed-off-by: ratamir <ratamir@redhat.com>