### PR TITLE
Workaround for BZ 1778488 and fix for test_2_nodes_maintenance_same_type

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -396,11 +396,16 @@ def get_ceph_tools_pod():
     ocp_pod_obj = OCP(
         kind=constants.POD, namespace=config.ENV_DATA['cluster_namespace']
     )
-    # setup ceph_toolbox pod if the cluster has been setup by some other CI
-    setup_ceph_toolbox()
+
     ct_pod_items = ocp_pod_obj.get(
         selector='app=rook-ceph-tools'
     )['items']
+    if not ct_pod_items:
+        # setup ceph_toolbox pod if the cluster has been setup by some other CI
+        setup_ceph_toolbox()
+        ct_pod_items = ocp_pod_obj.get(
+            selector='app=rook-ceph-tools'
+        )['items']
     assert ct_pod_items, "No Ceph tools pod found"
 
     # In the case of node failure, the CT pod will be recreated with the old

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -67,7 +67,8 @@ class TestNodesMaintenance(ManageTest):
         - Check cluster and Ceph health
 
         """
-        # Get 1 node
+        # Get a list of 2 nodes. Pick one of them after checking
+        # which one does't have the rook operator running on
         typed_nodes = get_typed_nodes(node_type=node_type, num_of_nodes=2)
         typed_node_name = typed_nodes[0].name
         # Workaround for BZ 1778488 - https://github.com/red-hat-storage/ocs-ci/issues/1222
@@ -115,7 +116,8 @@ class TestNodesMaintenance(ManageTest):
           (pools, storageclasses, PVCs, pods - both CephFS and RBD)
 
         """
-        # Get 1 node
+        # Get a list of 2 nodes. Pick one of them after checking
+        # which one does't have the rook operator running on
         typed_nodes = get_typed_nodes(node_type=node_type, num_of_nodes=2)
         assert typed_nodes, f"Failed to find a {node_type} node for the test"
         typed_node_name = typed_nodes[0].name


### PR DESCRIPTION
Addresses https://github.com/red-hat-storage/ocs-ci/issues/1222 and fixes the failure in tests.manage.z_cluster.nodes.test_nodes_maintenance.TestNodesMaintenance.test_2_nodes_maintenance_same_type

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>