### PR TITLE
Add OCP 4.2 config file

### DIFF
--- a/conf/ocsci/ocp-4.2-config.yaml
+++ b/conf/ocsci/ocp-4.2-config.yaml
@@ -1,0 +1,6 @@
+---
+# Use this config for installation of OCP 4.2 cluster
+RUN:
+  client_version: '4.2.0-0.nightly'
+DEPLOYMENT:
+  installer_version: "4.2.0-0.nightly"


### PR DESCRIPTION
For this ticket: https://projects.engineering.redhat.com/browse/OCSQE-166
We need to have also static file for OCP 4.2 to allow us to easily pass
from job parameter which one OCP config file to use for specific
version.

This will be also needed if we decide later on to have OCP 4.3 as a
default.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>