### PR TITLE
Fix Storageclass name and iterate over both RBD and FS

### DIFF
--- a/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
+++ b/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
@@ -24,5 +24,5 @@ spec:
       threads: 4
       file_size: 64
       files: 50000
-      storageclass: ceph-backed
+      storageclass: ocs-storageclass-ceph-rbd
       storagesize: 100Gi


### PR DESCRIPTION
Fix the testcase to use default storageclass and iterate over both RBD and FS

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>