### PR TITLE
Remove nodeName spec from ocs_ci/templates/app-pods/raw_block_pod.yaml

### DIFF
--- a/ocs_ci/templates/app-pods/raw_block_pod.yaml
+++ b/ocs_ci/templates/app-pods/raw_block_pod.yaml
@@ -3,7 +3,6 @@ kind: Pod
 metadata:
   name: test-raw-block-pod
 spec:
-  nodeName: foo
   containers:
     - name: my-container
       image: nginx


### PR DESCRIPTION
Fixes: #1292 
Removed nodeName spec from the template. It will be added by 
helpers.create_pod() dynamically.

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>