### PR TITLE
BZ 1754287 decorator to test_node_maintenance_restart_activate[master]

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -94,10 +94,8 @@ class TestNodesMaintenance(ManageTest):
         # Perform cluster and Ceph health checks
         self.sanity_helpers.health_check()
 
-    @bugzilla('1778488')
     @tier4
     @tier4b
-    @aws_platform_required
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -102,7 +102,7 @@ class TestNodesMaintenance(ManageTest):
         argnames=["node_type"],
         argvalues=[
             pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1292")),
-            pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1293"))
+            pytest.param(*['master'], marks=[pytest.mark.polarion_id("OCS-1293"), bugzilla('1754287')])
         ]
     )
     def test_node_maintenance_restart_activate(

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -8,8 +8,7 @@ from ocs_ci.ocs.node import (
     drain_nodes, schedule_nodes, get_typed_nodes, wait_for_nodes_status, get_node_objs
 )
 from ocs_ci.framework.testlib import (
-    tier1, tier2, tier3, tier4, tier4b,
-    ManageTest, aws_platform_required, ignore_leftovers, bugzilla
+    tier1, tier2, tier3, tier4, tier4b, ManageTest, ignore_leftovers, bugzilla
 )
 
 from tests.sanity_helpers import Sanity


### PR DESCRIPTION
Due to https://bugzilla.redhat.com/show_bug.cgi?id=1754287, project creation is blocked after a master node failure.

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>