### PR TITLE
Verify secret names in default storage class

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -520,3 +520,9 @@ MON_PDB = "rook-ceph-mon-pdb"
 # Root Disk size
 CURRENT_VM_ROOT_DISK_SIZE = '60'
 VM_ROOT_DISK_SIZE = '120'
+
+# Secrets
+RBD_PROVISIONER_SECRET = 'rook-csi-rbd-provisioner'
+RBD_NODE_SECRET = 'rook-csi-rbd-node'
+CEPHFS_PROVISIONER_SECRET = 'rook-csi-cephfs-provisioner'
+CEPHFS_NODE_SECRET = 'rook-csi-cephfs-node'

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -352,10 +352,14 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
 
     # Verify node and provisioner secret names in storage class
     log.info("Verifying node and provisioner secret names in storage class.")
-    sc_rbd = storage_class.get(resource_name='ocs-storagecluster-ceph-rbd')
-    sc_cephfs = storage_class.get(resource_name='ocs-storagecluster-cephfs')
-    assert sc_rbd['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == 'rook-csi-rbd-node'
-    assert sc_rbd['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == 'rook-csi-rbd-provisioner'
-    assert sc_cephfs['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == 'rook-csi-cephfs-node'
-    assert sc_cephfs['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == 'rook-csi-cephfs-provisioner'
+    sc_rbd = storage_class.get(
+        resource_name=constants.DEFAULT_STORAGECLASS_RBD
+    )
+    sc_cephfs = storage_class.get(
+        resource_name=constants.DEFAULT_STORAGECLASS_CEPHFS
+    )
+    assert sc_rbd['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == constants.RBD_NODE_SECRET
+    assert sc_rbd['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == constants.RBD_PROVISIONER_SECRET
+    assert sc_cephfs['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == constants.CEPHFS_NODE_SECRET
+    assert sc_cephfs['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == constants.CEPHFS_PROVISIONER_SECRET
     log.info("Verified node and provisioner secret names in storage class.")

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -349,3 +349,13 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
     assert {defaults.CEPHFS_PROVISIONER, defaults.RBD_PROVISIONER} == (
         {item['metadata']['name'] for item in csi_driver.get()['items']}
     )
+
+    # Verify node and provisioner secret names in storage class
+    log.info("Verifying node and provisioner secret names in storage class.")
+    sc_rbd = storage_class.get(resource_name='ocs-storagecluster-ceph-rbd')
+    sc_cephfs = storage_class.get(resource_name='ocs-storagecluster-cephfs')
+    assert sc_rbd['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == 'rook-csi-rbd-node'
+    assert sc_rbd['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == 'rook-csi-rbd-provisioner'
+    assert sc_cephfs['parameters']['csi.storage.k8s.io/node-stage-secret-name'] == 'rook-csi-cephfs-node'
+    assert sc_cephfs['parameters']['csi.storage.k8s.io/provisioner-secret-name'] == 'rook-csi-cephfs-provisioner'
+    log.info("Verified node and provisioner secret names in storage class.")


### PR DESCRIPTION
Verify node and provisioner secret names in ocs-storagecluster-ceph-rbd and ocs-storagecluster-cephfs storage class. There should be different secrets for provisioning and mount.

Fixes #1322 

Signed-off-by: Jilju Joy <jijoy@redhat.com>