### PR TITLE
Verify that CSI driver object contains provisioner names

### DIFF
--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -342,3 +342,10 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
             assert not node_names.count(node) > 1, (
                 "OSD's are not distributed evenly across worker nodes"
             )
+
+    # Verify that CSI driver object contains provisioner names
+    log.info("Verifying CSI driver object contains provisioner names.")
+    csi_driver = OCP(kind="CSIDriver")
+    assert {defaults.CEPHFS_PROVISIONER, defaults.RBD_PROVISIONER} == (
+        {item['metadata']['name'] for item in csi_driver.get()['items']}
+    )


### PR DESCRIPTION
The CSI driver object should have provisioner names mentioned. Adding this verification in ocs_install_verification function.

Fixes #1332  
Signed-off-by: Jilju Joy <jijoy@redhat.com>