### PR TITLE
Check pod/node logs for critical errors

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -115,6 +115,9 @@ MOUNT_POINT = '/var/lib/www/html'
 OCP_QE_MISC_REPO = (
     "http://git.host.prod.eng.bos.redhat.com/git/openshift-misc.git"
 )
+CRITICAL_ERRORS = [
+    "core dumped", "oom_reaper"
+]
 
 OCS_WORKLOADS = "https://github.com/red-hat-storage/ocs-workloads"
 

--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -3,7 +3,7 @@ import logging
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants, defaults
-from tests.helpers import TimeoutSampler
+from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
 log = logging.getLogger(__name__)

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants, exceptions
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs import machine
-from tests.helpers import get_worker_nodes
+import tests.helpers
 from ocs_ci.ocs import ocp
 
 
@@ -234,7 +234,7 @@ def add_new_node_and_label_it(machineset_name):
 
     """
     # Get the initial nodes list
-    initial_nodes = get_worker_nodes()
+    initial_nodes = tests.helpers.get_worker_nodes()
     log.info(f"Current available worker nodes are {initial_nodes}")
 
     # get machineset replica count
@@ -252,7 +252,7 @@ def add_new_node_and_label_it(machineset_name):
     machine.wait_for_new_node_to_be_ready(machineset_name)
 
     # Get the node name of new spun node
-    nodes_after_new_spun_node = get_worker_nodes()
+    nodes_after_new_spun_node = tests.helpers.get_worker_nodes()
     new_spun_node = list(
         set(nodes_after_new_spun_node) - set(initial_nodes)
     )
@@ -267,3 +267,16 @@ def add_new_node_and_label_it(machineset_name):
     log.info(
         f"Successfully labeled {new_spun_node} with OCS storage label"
     )
+
+
+def get_node_logs(node_name):
+    """
+    Get logs from a given node
+
+    pod_name (str): Name of the node
+
+    Returns:
+        str: Output of 'dmesg' run on node
+    """
+    node = OCP(kind='node')
+    return node.exec_oc_debug_cmd(node_name, ["dmesg"])

--- a/tests/e2e/test_small_file_workload.py
+++ b/tests/e2e/test_small_file_workload.py
@@ -13,6 +13,7 @@ from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.ripsaw import RipSaw
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import E2ETest, workloads
+from tests.helpers import get_logs_with_errors
 
 log = logging.getLogger(__name__)
 
@@ -136,3 +137,4 @@ class TestSmallFileWorkload(E2ETest):
             if timeout < (time.time() - start_time):
                 raise TimeoutError(f"Timed out waiting for benchmark to complete")
             time.sleep(30)
+        assert not get_logs_with_errors()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1329,13 +1329,13 @@ def verify_pv_mounted_on_node(node_pv_dict):
             eg: {'node1': ['pv1', 'pv3'], 'node2': ['pv5']}
     """
     existing_pvs = {}
-    for node, pvs in node_pv_dict.items():
-        cmd = f'oc debug nodes/{node} -- df'
+    for node_name, pvs in node_pv_dict.items():
+        cmd = f'oc debug nodes/{node_name} -- df'
         df_on_node = run_cmd(cmd)
-        existing_pvs[node] = []
+        existing_pvs[node_name] = []
         for pv_name in pvs:
             if f"/pv/{pv_name}/" in df_on_node:
-                existing_pvs[node].append(pv_name)
+                existing_pvs[node_name].append(pv_name)
     return existing_pvs
 
 


### PR DESCRIPTION
Fixes #1340

Signed-off-by: Mirek Długosz <mzalewsk@redhat.com>


-----

This is prompted by BZ#1765923. General idea is that we want to catch critical errors and fail test based on them. Ideally, such check should be performed automatically for all tests.

I tried using autouse fixture that added finalizer, but finalizers are run after test has already completed - they can't change "PASSED" test to failed based on additional condition. They can only "ERROR" test in teardown phase. So for now this is additional helper function that test must call directly.

Another drawback - since all `oc` commands and their output is logged in test log, log files will grow in size. In small file test I saw increase from ~2.5 MB to ~3.5 MB, but during development I saw log over 100 MB (!). This is something we should watch out.