### PR TITLE
Verify osd tree output and ensure it have device set PVC names

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -540,3 +540,83 @@ RBD_PROVISIONER_SECRET = 'rook-csi-rbd-provisioner'
 RBD_NODE_SECRET = 'rook-csi-rbd-node'
 CEPHFS_PROVISIONER_SECRET = 'rook-csi-cephfs-provisioner'
 CEPHFS_NODE_SECRET = 'rook-csi-cephfs-node'
+
+# JSON Schema
+OSD_TREE_ROOT = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'name': {'const': 'default'},
+        'type': {'const': 'root'}, 'type_id': {'const': 11},
+        'children': {'type': 'array', 'items': {'type': 'integer'}}
+    },
+    'required': ['children', 'id', 'name', 'type', 'type_id'],
+    'additionalProperties': False
+}
+
+OSD_TREE_RACK = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'name': {'type': 'string'},
+        'type': {'const': 'rack'}, 'type_id': {'const': 3},
+        'pool_weights': {'type': 'object'},
+        'children': {'type': 'array', 'items': {'type': 'integer'}}
+    },
+    'required': ['children', 'id', 'name', 'pool_weights', 'type', 'type_id'],
+    'additionalProperties': False
+}
+
+OSD_TREE_HOST = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'name': {'type': 'string'},
+        'type': {'const': 'host'}, 'type_id': {'const': 1},
+        'pool_weights': {'type': 'object'},
+        'children': {'type': 'array', 'items': {'type': 'integer'}}
+    },
+    'required': ['children', 'id', 'name', 'pool_weights', 'type', 'type_id'],
+    'additionalProperties': False
+}
+
+OSD_TREE_OSD = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'device_class': {'type': 'string'},
+        'name': {'pattern': 'osd[.][0-9]+'}, 'type': {'const': 'osd'},
+        'type_id': {'const': 0},
+        'crush_weight': {'type': 'number', "minimum": 0, "maximum": 1},
+        'depth': {'type': 'integer'}, 'pool_weights': {'type': 'object'},
+        'exists': {'type': 'integer'}, 'status': {'const': 'up'},
+        'reweight': {'type': 'integer'},
+        'primary_affinity': {'type': 'integer'}
+    },
+    'required': [
+        'crush_weight', 'depth', 'device_class', 'exists', 'id', 'name',
+        'pool_weights', 'primary_affinity', 'reweight', 'status', 'type',
+        'type_id'
+    ],
+    'additionalProperties': False
+}
+
+OSD_TREE_REGION = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'name': {'type': 'string'},
+        'type': {'const': 'region'}, 'type_id': {'const': 10},
+        'pool_weights': {'type': 'object'},
+        'children': {'type': 'array', 'items': {'type': 'integer'}}
+    },
+    'required': ['children', 'id', 'name', 'pool_weights', 'type', 'type_id'],
+    'additionalProperties': False
+}
+
+OSD_TREE_ZONE = {
+    'type': 'object',
+    'properties': {
+        'id': {'type': 'integer'}, 'name': {'type': 'string'},
+        'type': {'const': 'zone'}, 'type_id': {'const': 9},
+        'pool_weights': {'type': 'object'},
+        'children': {'type': 'array', 'items': {'type': 'integer'}}
+    },
+    'required': ['children', 'id', 'name', 'pool_weights', 'type', 'type_id'],
+    'additionalProperties': False
+}

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -383,15 +383,3 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
             f"ceph osd tree output does not contain pvc name {pvc}"
         )
     log.info("Verified device set PVC names in ceph osd tree output.")
-
-    # Verify OSDs are listed as sdd
-    log.info("Verify OSDs are listed as sdd in ceph osd tree output.")
-    for num in range(len(deviceset_pvcs)):
-        re_exp = f'ssd [0-9]*.[0-9]*[ ]*osd.{num}'
-        match = re.search(re_exp, osd_tree)
-        log.info(match)
-        assert match, (
-            f"One or more OSDs are not listed as sdd in ceph osd tree output."
-            f" No match for expression {re_exp}"
-        )
-    log.info("Verified OSDs are listed as sdd in ceph osd tree output.")

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -373,6 +373,6 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
     osd_tree = ct_pod.exec_ceph_cmd(ceph_cmd='ceph osd tree', format='')
     for pvc in deviceset_pvcs:
         assert f'host {pvc.name}' in osd_tree, (
-            f"ceph osd tree output does not contain pvc name {pvc}"
+            f"ceph osd tree output does not contain pvc name {pvc.name}"
         )
     log.info("Verified device set PVC names in ceph osd tree output.")

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -189,7 +189,7 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
 
     """
     from ocs_ci.ocs.node import get_typed_nodes
-    from ocs_ci.ocs.resources.pvc import get_all_pvcs
+    from ocs_ci.ocs.resources.pvc import get_deviceset_pvcs
     from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
     number_of_worker_nodes = len(get_typed_nodes())
     namespace = config.ENV_DATA['cluster_namespace']
@@ -368,17 +368,11 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
 
     # Verify ceph osd tree have device set PVC names specified
     log.info("Checking for device set PVC names in ceph osd tree output.")
-    deviceset_pvcs = [
-        item['metadata']['name'] for item in get_all_pvcs(
-            namespace=namespace
-        )['items'] if item['metadata']['name'].startswith(
-            constants.DEFAULT_DEVICESET_PVC_NAME
-        )
-    ]
+    deviceset_pvcs = get_deviceset_pvcs()
     ct_pod = get_ceph_tools_pod()
     osd_tree = ct_pod.exec_ceph_cmd(ceph_cmd='ceph osd tree', format='')
     for pvc in deviceset_pvcs:
-        assert f'host {pvc}' in osd_tree, (
+        assert f'host {pvc.name}' in osd_tree, (
             f"ceph osd tree output does not contain pvc name {pvc}"
         )
     log.info("Verified device set PVC names in ceph osd tree output.")

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -388,6 +388,10 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
         validate(instance=item, schema=schemas[item['type']])
         if item['type'] == 'host':
             deviceset_pvcs.remove(item['name'])
+    assert not deviceset_pvcs, (
+        f"These device set PVCs are not given in ceph osd tree output "
+        f"- {deviceset_pvcs}"
+    )
     log.info(
         "Verified ceph osd tree output. Device set PVC names are given in the "
         "output."

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -393,5 +393,5 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
         "output."
     )
 
-    # TODO: Verify ceph osd tree output have osd listed as sdd
+    # TODO: Verify ceph osd tree output have osd listed as ssd
     # TODO: Verify ceph osd tree output have zone or rack based on AZ

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -17,8 +17,6 @@ from ocs_ci.ocs.resources.packagemanifest import (
 from ocs_ci.ocs.resources.storage_cluster import StorageCluster
 from ocs_ci.utility import utils
 from ocs_ci.utility import templating
-from ocs_ci.ocs.resources.pvc import get_all_pvcs
-from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +190,8 @@ def ocs_install_verification(timeout=600, skip_osd_distribution_check=False):
 
     """
     from ocs_ci.ocs.node import get_typed_nodes
+    from ocs_ci.ocs.resources.pvc import get_all_pvcs
+    from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
     number_of_worker_nodes = len(get_typed_nodes())
     namespace = config.ENV_DATA['cluster_namespace']
     log.info("Verifying OCS installation")

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -4,7 +4,6 @@ General OCS object
 import logging
 import yaml
 import tempfile
-import re
 
 from ocs_ci.framework import config
 from ocs_ci.ocs.ocp import OCP, get_images

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -198,6 +198,28 @@ def get_all_pvc_objs(namespace=None, selector=None):
     return [PVC(**pvc) for pvc in all_pvcs['items']]
 
 
+def get_deviceset_pvcs():
+    """
+    Get the deviceset PVCs
+
+    Returns:
+        list: The deviceset PVCs OCS objects
+
+    Raises:
+        AssertionError: In case the deviceset PVCs are not found
+
+    """
+    ocs_pvc_obj = get_all_pvc_objs(
+        namespace=config.ENV_DATA['cluster_namespace']
+    )
+    deviceset_pvcs = []
+    for pvc_obj in ocs_pvc_obj:
+        if pvc_obj.name.startswith(constants.DEFAULT_DEVICESET_PVC_NAME):
+            deviceset_pvcs.append(pvc_obj)
+    assert deviceset_pvcs, "Failed to find the deviceset PVCs"
+    return deviceset_pvcs
+
+
 def get_deviceset_pvs():
     """
     Get the deviceset PVs
@@ -209,10 +231,5 @@ def get_deviceset_pvs():
         AssertionError: In case the deviceset PVCs are not found
 
     """
-    ocs_pvc_obj = get_all_pvc_objs(namespace=config.ENV_DATA['cluster_namespace'])
-    deviceset_pvcs = []
-    for pvc_obj in ocs_pvc_obj:
-        if pvc_obj.name.startswith(constants.DEFAULT_DEVICESET_PVC_NAME):
-            deviceset_pvcs.append(pvc_obj)
-    assert deviceset_pvcs, "Failed to find the deviceset PVCs"
+    deviceset_pvcs = get_deviceset_pvcs()
     return [pvc.backed_pv_obj for pvc in deviceset_pvcs]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'pytest-ordering',
         'funcy',
         'semantic-version',
+        'jsonschema>=3.2.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Updated ocs_install_verification function to verify ceph osd tree output.

ceph osd tree output structure and values are verified.
Using JSON Schema to validate the output.
Presence of device set PVC names is also verified along with this. (Verifies bug https://bugzilla.redhat.com/show_bug.cgi?id=1765154)
Implemented in this way because there are more checks to be done
in the output. Added as TODO.

Signed-off-by: Jilju Joy <jijoy@redhat.com>