### PR TITLE
Add timeout (default 600 seconds) for exec_oc_debug_cmd()

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -136,13 +136,14 @@ class OCP(object):
             return yaml.safe_load(out)
         return out
 
-    def exec_oc_debug_cmd(self, node, cmd_list):
+    def exec_oc_debug_cmd(self, node, cmd_list, timeout=600):
         """
         Function to execute "oc debug" command on OCP node
 
         Args:
             node (str): Node name where the command to be executed
             cmd_list (list): List of commands eg: ['cmd1', 'cmd2']
+            timeout (int): timeout for the exec_oc_cmd, defaults to 600 seconds
 
         Returns:
             out (str): Returns output of the executed command/commands
@@ -156,7 +157,7 @@ class OCP(object):
         cmd = f" || echo '{err_msg}';".join(cmd_list)
         debug_cmd = f"debug nodes/{node} -- chroot /host /bin/bash -c \"{cmd}\""
         out = str(self.exec_oc_cmd(
-            command=debug_cmd, out_yaml_format=False
+            command=debug_cmd, out_yaml_format=False, timeout=timeout
         ))
         if err_msg in out:
             raise CommandFailed


### PR DESCRIPTION
Fixes: #1359
 Add timeout parameter to ocs_ci/ocs/ocp.py: exec_oc_debug_cmd()