### PR TITLE
fix one overlooked copypaste error from metric spec

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -163,7 +163,7 @@ def test_ceph_metrics_available():
         "ceph_bluestore_read_lat_count",
         "ceph_pg_degraded",
         "ceph_mon_num_sessions",
-        "ceph_objecter_0x5633ca03ff80_op_rmw",
+        "ceph_objecter_op_rmw",
         "ceph_bluefs_bytes_written_wal",
         "ceph_mon_num_elections",
         "ceph_rocksdb_compact",


### PR DESCRIPTION
This kind of problem has been already addressed in commit 54e85512b61ef60d80d2837242ff6fba9e1108ab, but one occurrence was missed there.