### PR TITLE
[openshift-logging] Use correct helper function name

### DIFF
--- a/tests/e2e/logging/test_openshift-logging.py
+++ b/tests/e2e/logging/test_openshift-logging.py
@@ -108,7 +108,7 @@ class Test_openshift_logging_on_ocs(E2ETest):
         """
         """
         def finalizer():
-            helpers.delete_deploymentconfig(pod_obj)
+            helpers.delete_deploymentconfig_pods(pod_obj)
 
         request.addfinalizer(finalizer)
 


### PR DESCRIPTION
74271475 (#1267) renamed `delete_deploymentconfig` to
`delete_deploymentconfig_pods`. Then a07a1184 (#1349) reverted this
change in openshift logging test, probably by mistake. Re-revert it and
use correct new name again.

Signed-off-by: Mirek Długosz <mzalewsk@redhat.com>