### PR TITLE
Updated registry deployment to use DEFAULT_STORAGECLASS_CEPHFS

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -128,7 +128,6 @@ UPI_INSTALL_SCRIPT = "upi_on_aws-install.sh"
 
 DEFAULT_CLUSTERNAME = 'ocs-storagecluster'
 DEFAULT_BLOCKPOOL = f'{DEFAULT_CLUSTERNAME}-cephblockpool'
-DEFAULT_SC_CEPHFS = "cephfs"
 DEFAULT_ROUTE_CRT = "router-certs-default"
 DEFAULT_NAMESPACE = "default"
 IMAGE_REGISTRY_RESOURCE_NAME = "cluster"

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -22,7 +22,7 @@ def change_registry_backend_to_ocs():
         AssertionError: When failure in change of registry backend to OCS
 
     """
-    sc_name = f"{config.ENV_DATA['storage_cluster_name']}-{constants.DEFAULT_SC_CEPHFS}"
+    sc_name = f"{constants.DEFAULT_STORAGECLASS_CEPHFS}"
     pv_obj = helpers.create_pvc(
         sc_name=sc_name, pvc_name='registry-cephfs-rwx-pvc',
         namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE, size='100Gi',


### PR DESCRIPTION
Updated registry deployment to use DEFAULT_STORAGECLASS_CEPHFS
Removed DEFAULT_SC_CEPHFS from constants.py

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>