### PR TITLE
Registry Testcase to perform image push pull.

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -22,7 +22,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.utility.templating import dump_data_to_temp_yaml, load_yaml
-from ocs_ci.ocs import defaults
+from ocs_ci.ocs import defaults, constants
 
 
 log = logging.getLogger(__name__)
@@ -762,7 +762,7 @@ def rsync(src, dst, node, dst_node=True, extra_params=""):
     pod_data = load_yaml(RSYNC_POD_YAML)
     pod_data['metadata']['name'] = pod_name
     pod_data['spec']['nodeName'] = node
-    pod = OCP(kind='pod', namespace=defaults.constants.DEFAULT_NAMESPACE)
+    pod = OCP(kind='pod', namespace=constants.DEFAULT_NAMESPACE)
     src = src if dst_node else f"{pod_name}:/host{src}"
     dst = f"{pod_name}:/host{dst}" if dst_node else dst
     try:

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -136,7 +136,7 @@ class OCP(object):
             return yaml.safe_load(out)
         return out
 
-    def exec_oc_debug_cmd(self, node, cmd_list, timeout=600):
+    def exec_oc_debug_cmd(self, node, cmd_list, timeout=300):
         """
         Function to execute "oc debug" command on OCP node
 
@@ -762,7 +762,7 @@ def rsync(src, dst, node, dst_node=True, extra_params=""):
     pod_data = load_yaml(RSYNC_POD_YAML)
     pod_data['metadata']['name'] = pod_name
     pod_data['spec']['nodeName'] = node
-    pod = OCP(kind='pod')
+    pod = OCP(kind='pod', namespace=defaults.constants.DEFAULT_NAMESPACE)
     src = src if dst_node else f"{pod_name}:/host{src}"
     dst = f"{pod_name}:/host{dst}" if dst_node else dst
     try:

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -165,6 +165,25 @@ def add_role_to_user(role_type, user):
     logger.info(f"Role_type {role_type} added to the user {user}")
 
 
+def remove_role_from_user(role_type, user):
+    """
+    Function to remove role to user
+
+    Args:
+        role_type (str): Type of the role to be removed
+        user (str): User of the role
+
+    Raises:
+        AssertionError: When failure in removing role from user
+
+    """
+    ocp_obj = ocp.OCP()
+    role_cmd = f"policy remove-role-from-user {role_type} {user} " \
+               f"-n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+    assert ocp_obj.exec_oc_cmd(command=role_cmd), 'Removing role failed'
+    logger.info(f"Role_type {role_type} removed from user {user}")
+
+
 def enable_route_and_create_ca_for_registry_access():
     """
     Function to enable route and to create ca,
@@ -290,5 +309,4 @@ def check_image_in_registry(image_url):
     if any(image_url in i for i in output):
         logger.info("Image URL present")
         return True
-    else:
-        raise UnexpectedBehaviour("Image url not Present in Registry")
+    raise UnexpectedBehaviour("Image url not Present in Registry")

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -300,9 +300,6 @@ def check_image_in_registry(image_url):
     Args:
         image_url (str): Image url to be verified
 
-    Returns:
-        True : Returns True if present
-
     """
     output = image_list_all()
     output = output.split("\n")

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -306,7 +306,7 @@ def check_image_in_registry(image_url):
     """
     output = image_list_all()
     output = output.split("\n")
-    if any(image_url in i for i in output):
+    if not any(image_url in i for i in output):
+        raise UnexpectedBehaviour("Image url not Present in Registry")
+    else:
         logger.info("Image URL present")
-        return True
-    raise UnexpectedBehaviour("Image url not Present in Registry")

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -85,19 +85,12 @@ def get_oc_podman_login_cmd():
 
     """
     user = config.RUN['username']
-    filename = os.path.join(
-        config.ENV_DATA['cluster_path'],
-        config.RUN['password_location']
-    )
-    with open(filename) as f:
-        password = f.read()
     helpers.refresh_oc_login_connection()
     ocp_obj = ocp.OCP()
     token = ocp_obj.get_user_token()
     route = get_default_route_name()
     cmd_list = [
         'export KUBECONFIG=/home/core/auth/kubeconfig',
-        f"oc login -u {user} -p {password}",
         f"podman login {route} -u {user} -p {token}"
     ]
     master_list = helpers.get_master_nodes()
@@ -279,3 +272,23 @@ def image_rm(registry_path):
     ocp_obj = ocp.OCP()
     ocp_obj.exec_oc_debug_cmd(node=master_list[0], cmd_list=cmd_list)
     logger.info(f"Image {registry_path} rm successful")
+
+
+def check_image_in_registry(image_url):
+    """
+    Function to check either image present in registry or not
+
+    Args:
+        image_url (str): Image url to be verified
+
+    Returns:
+        True : Returns True if present
+
+    """
+    output = image_list_all()
+    output = output.split("\n")
+    if any(image_url in i for i in output):
+        logger.info("Image URL present")
+        return True
+    else:
+        raise UnexpectedBehaviour("Image url not Present in Registry")

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -293,17 +293,23 @@ def image_rm(registry_path):
     logger.info(f"Image {registry_path} rm successful")
 
 
-def check_image_in_registry(image_url):
+def check_image_exists_in_registry(image_url):
     """
-    Function to check either image present in registry or not
+    Function to check either image exists in registry or not
 
     Args:
         image_url (str): Image url to be verified
+
+    Returns:
+        bool: True if image exists, else False
 
     """
     output = image_list_all()
     output = output.split("\n")
     if not any(image_url in i for i in output):
-        raise UnexpectedBehaviour("Image url not Present in Registry")
+        return_value = False
+        logger.error("Image url not exists in Registry")
     else:
-        logger.info("Image URL present")
+        return_value = True
+        logger.info("Image exists in Registry")
+    return return_value

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -17,7 +17,6 @@ class TestRegistryImagePullPush(E2ETest):
     def test_registry_image_pull_push(self):
         """
         Test case to validate registry image pull and push with OCS backend
-
         """
         image_url = 'docker.io/library/busybox'
 
@@ -25,11 +24,9 @@ class TestRegistryImagePullPush(E2ETest):
         registry.enable_route_and_create_ca_for_registry_access()
 
         # Add roles to user so that user can perform image pull and push to registry
-        registry.add_role_to_user(role_type='registry-viewer', user=config.RUN['username'])
-        registry.add_role_to_user(role_type='registry-editor', user=config.RUN['username'])
-        registry.add_role_to_user(role_type='system:registry', user=config.RUN['username'])
-        registry.add_role_to_user(role_type='admin', user=config.RUN['username'])
-        registry.add_role_to_user(role_type='system:image-builder', user=config.RUN['username'])
+        role_type = ['registry-viewer', 'registry-editor', 'system:registry', 'admin', 'system:image-builder']
+        for role in role_type:
+            registry.add_role_to_user(role_type=role, user=config.RUN['username'])
 
         # Provide write access to registry
         ocp_obj = ocp.OCP()

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -1,0 +1,53 @@
+import logging
+import pytest
+from ocs_ci.framework.testlib import tier1, E2ETest
+from ocs_ci.ocs import ocp, registry, constants
+from ocs_ci.framework import config
+
+logger = logging.getLogger(__name__)
+
+
+class TestRegistryImagePullPush(E2ETest):
+    """
+    Test to check Image push and pull worked with registry backed by OCS
+    """
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-1080")
+    def test_registry_image_pull_push(self):
+        """
+        Test case to validate registry image pull and push with OCS backend
+
+        """
+        image_url = 'docker.io/library/busybox'
+
+        # Get openshift registry route and certificate access
+        registry.enable_route_and_create_ca_for_registry_access()
+
+        # Add roles to user so that user can perform image pull and push to registry
+        registry.add_role_to_user(role_type='registry-viewer', user=config.RUN['username'])
+        registry.add_role_to_user(role_type='registry-editor', user=config.RUN['username'])
+        registry.add_role_to_user(role_type='system:registry', user=config.RUN['username'])
+        registry.add_role_to_user(role_type='admin', user=config.RUN['username'])
+        registry.add_role_to_user(role_type='system:image-builder', user=config.RUN['username'])
+
+        # Provide write access to registry
+        ocp_obj = ocp.OCP()
+        read_only_cmd = f"set env deployment.apps/image-registry REGISTRY_STORAGE_MAINTENANCE_READONLY- " \
+            f"-n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+        ocp_obj.exec_oc_cmd(read_only_cmd)
+
+        # Pull image using podman
+        registry.image_pull(image_url=image_url)
+
+        # Push image to registry using podman
+        registry.image_push(
+            image_url=image_url, namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE
+        )
+
+        # List the images in registry
+        img_list = registry.image_list_all()
+        logger.info(f"Image list {img_list}")
+
+        # Check either image present in registry or not
+        registry.check_image_in_registry(image_url=image_url)

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -3,6 +3,7 @@ import pytest
 from ocs_ci.framework.testlib import tier1, E2ETest, ignore_leftovers
 from ocs_ci.ocs import ocp, registry, constants
 from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,9 @@ class TestRegistryImagePullPush(E2ETest):
         logger.info(f"Image list {img_list}")
 
         # Check either image present in registry or not
-        registry.check_image_in_registry(image_url=image_url)
+        validate = registry.check_image_exists_in_registry(image_url=image_url)
+        if not validate:
+            raise UnexpectedBehaviour("Image URL not present in registry")
 
         # Remove user roles from User
         for role in role_type:

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.testlib import tier1, E2ETest, ignore_leftovers
+from ocs_ci.framework.testlib import workloads, E2ETest, ignore_leftovers
 from ocs_ci.ocs import ocp, registry, constants
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -13,7 +13,7 @@ class TestRegistryImagePullPush(E2ETest):
     Test to check Image push and pull worked with registry backed by OCS
     """
 
-    @tier1
+    @workloads
     @ignore_leftovers
     @pytest.mark.polarion_id("OCS-1080")
     def test_registry_image_pull_push(self):

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -25,14 +25,18 @@ class TestRegistryImagePullPush(E2ETest):
         registry.enable_route_and_create_ca_for_registry_access()
 
         # Add roles to user so that user can perform image pull and push to registry
-        role_type = ['registry-viewer', 'registry-editor', 'system:registry', 'admin', 'system:image-builder']
+        role_type = ['registry-viewer', 'registry-editor',
+                     'system:registry', 'admin', 'system:image-builder']
         for role in role_type:
             registry.add_role_to_user(role_type=role, user=config.RUN['username'])
 
         # Provide write access to registry
         ocp_obj = ocp.OCP()
-        read_only_cmd = f"set env deployment.apps/image-registry REGISTRY_STORAGE_MAINTENANCE_READONLY- " \
-            f"-n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+        read_only_cmd = (
+            f"set env deployment.apps/image-registry"
+            f" REGISTRY_STORAGE_MAINTENANCE_READONLY- -n "
+            f"{constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+        )
         ocp_obj.exec_oc_cmd(read_only_cmd)
 
         # Pull image using podman
@@ -49,3 +53,7 @@ class TestRegistryImagePullPush(E2ETest):
 
         # Check either image present in registry or not
         registry.check_image_in_registry(image_url=image_url)
+
+        # Remove user roles from User  
+        for role in role_type:
+            registry.remove_role_from_user(role_type=role, user=config.RUN['username'])

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.testlib import tier1, E2ETest
+from ocs_ci.framework.testlib import tier1, E2ETest, ignore_leftovers
 from ocs_ci.ocs import ocp, registry, constants
 from ocs_ci.framework import config
 
@@ -13,6 +13,7 @@ class TestRegistryImagePullPush(E2ETest):
     """
 
     @tier1
+    @ignore_leftovers
     @pytest.mark.polarion_id("OCS-1080")
     def test_registry_image_pull_push(self):
         """

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -54,6 +54,6 @@ class TestRegistryImagePullPush(E2ETest):
         # Check either image present in registry or not
         registry.check_image_in_registry(image_url=image_url)
 
-        # Remove user roles from User  
+        # Remove user roles from User
         for role in role_type:
             registry.remove_role_from_user(role_type=role, user=config.RUN['username'])


### PR DESCRIPTION
Modified ocs_ci/ocs/ocp.py exec_oc_debug_cmd function timeout to 300 sec
Modified ocs_ci/ocs/ocp.py rsync function to get namespace from OCP obj
Modified ocs_ci/ocs/registry.py updated function get_oc_podman_login_cmd
Added ocs_ci/ocs/registry.py function check_image_in_registry

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>