### PR TITLE
fix logging issue in ocs_ci.ocs.ocp.OCP.get()

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -209,7 +209,7 @@ class OCP(object):
                 )
                 retry -= 1
                 if not retry:
-                    log.error("Number of attempts to get resource reached!")
+                    log.warning("Number of attempts to get resource reached!")
                     raise
                 else:
                     log.info(


### PR DESCRIPTION
Reporting error in test logs when OCP.get() fails is problematic,
because whether this is actual error from the test point of view or not
can be only understood when taking context of the caller in mind.
So to avoid reporting errors when the call is expected to fail, the
loging is changed to warning level. The actuall error is not lost, as
the code throws an exception in the end anyway.

This is a minimal fix of the problem.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/1355