### PR TITLE
Move ocs-ci to use OCP/OCS 4.3 as default

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -19,7 +19,7 @@ RUN:
   cli_params: {}  # this will be filled with CLI parameters data
   # If the client version ends with .nightly, the version will be exposed
   # to the latest accepted OCP nightly build version
-  client_version: '4.2.0-0.nightly'
+  client_version: '4.3.0-0.nightly'
   bin_dir: './bin'
   google_api_secret: '~/.ocs-ci/google_api_secret.json'
   rook_branch: "master"
@@ -39,15 +39,15 @@ DEPLOYMENT:
   # if the installer version ends with .nightly, the version will be exposed
   # to the latest accepted OCP nightly build version. You can also use the
   # specific build version like: "4.2.0-0.nightly-2019-08-06-195545"
-  installer_version: "4.2.0-0.nightly"
+  installer_version: "4.3.0-0.nightly"
   force_download_installer: True
   force_download_client: True
   # You can overwrite csv channel version by following parameter
   # ocs_csv_channel: "alpha"
   # you can overwrite the image for ocs operator catalog source by following parameter:
   # ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:4.2-32.9b6c93e.master"
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:latest-4.2"
-  default_latest_tag: 'latest-4.2'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:latest-4.3"
+  default_latest_tag: 'latest-4.3'
   ocs_operator_nodes_to_label: 3
   # This is described as a WA for minimal configuration 3/3 worker/master
   # nodes. See: https://github.com/openshift/ocs-operator
@@ -96,8 +96,10 @@ ENV_DATA:
   worker_replicas: 3
   skip_ocp_deployment: false
   skip_ocs_deployment: false
-  logging_version: '4.2'
-  ocs_version: '4.2'
+  logging_version: '4.3'
+  ocs_version: '4.3'
   # uncomment to use custom directory for storing measurement data related to
   # monitoring tests, otherwise generate temporary directory for each test run
   # measurement_dir: '/tmp/ocs_ci_monitoring_measurement/'
+  # Default RHCOS image to be used for VmWare deployment
+  vm_template: 'rhcos-4.3.0-x86_64-vmware'


### PR DESCRIPTION
Infra ticket: https://projects.engineering.redhat.com/browse/OCSQE-216

Signed-off-by: Petr Balogh <pbalogh@redhat.com>