### PR TITLE
Fix function name

### DIFF
--- a/tests/ecosystem/upgrade/test_configuration.py
+++ b/tests/ecosystem/upgrade/test_configuration.py
@@ -22,7 +22,7 @@ def get_crush_map():
     file_decomp = '/tmp/crush_decomp'
     ct_pod.exec_ceph_cmd(f"ceph osd getcrushmap -o {file_comp}")
     ct_pod.exec_ceph_cmd(f"crushtool -d {file_comp} -o {file_decomp}")
-    return ct_pod.exec_bash_cmd_on_pod(f"cat {file_decomp}")
+    return ct_pod.exec_sh_cmd_on_pod(f"cat {file_decomp}")
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
https://github.com/red-hat-storage/ocs-ci/pull/1112 changed name of pod function `exec_bash_cmd_on_pod` to `exec_sh_cmd_on_pod`. This PR fixes the use of it in a test.

Signed-off-by: Filip Balak <fbalak@redhat.com>