### PR TITLE
Fix osd tree schema- remove maximum and minimum value for crush_weight

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -589,7 +589,7 @@ OSD_TREE_OSD = {
         'id': {'type': 'integer'}, 'device_class': {'type': 'string'},
         'name': {'pattern': 'osd[.][0-9]+'}, 'type': {'const': 'osd'},
         'type_id': {'const': 0},
-        'crush_weight': {'type': 'number', "minimum": 0, "maximum": 1},
+        'crush_weight': {'type': 'number'},
         'depth': {'type': 'integer'}, 'pool_weights': {'type': 'object'},
         'exists': {'type': 'integer'}, 'status': {'const': 'up'},
         'reweight': {'type': 'integer'},


### PR DESCRIPTION
Removed maximum and minimum value check for crush_weight using schema. Schema had a maximum value parameter for crush_weight which was set to 1. The value can be more than 1.
Signed-off-by: Jilju Joy <jijoy@redhat.com>