### PR TITLE
Don't fail when channel info is missing because of issues/1338

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -170,9 +170,14 @@ def pytest_configure(config):
                 config._metadata['OCS operator'] = (
                     get_ocs_build_number()
                 )
-            mods = get_version_info(
-                namespace=ocsci_config.ENV_DATA['cluster_namespace']
-            )
+            try:
+                mods = get_version_info(
+                    namespace=ocsci_config.ENV_DATA['cluster_namespace']
+                )
+            except Exception as ex:
+                msg = "get_version_info failed, version report won't be complete:"
+                log.error(msg + str(ex))
+                mods = {}
             skip_list = ['ocs-operator']
             for key, val in mods.items():
                 if key not in skip_list:

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -13,7 +13,7 @@ import pytest
 
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework.exceptions import ClusterPathNotProvidedError, ClusterNameNotProvidedError, ClusterNameLengthError
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, ResourceNotFoundError
 from ocs_ci.utility.utils import (
     dump_config_to_file,
     get_cluster_version,
@@ -150,40 +150,62 @@ def pytest_configure(config):
         del config._metadata['Platform']
 
         config._metadata['Test Run Name'] = get_testrun_name()
+        gather_version_info_for_report(config)
 
-        try:
-            # add cluster version
-            clusterversion = get_cluster_version()
-            config._metadata['Cluster Version'] = clusterversion
 
-            # add ceph version
-            ceph_version = get_ceph_version()
-            config._metadata['Ceph Version'] = ceph_version
+def gather_version_info_for_report(config):
+    """
+    This function gather all version related info used for report.
 
-            # add csi versions
-            csi_versions = get_csi_versions()
-            config._metadata['cephfsplugin'] = csi_versions.get('csi-cephfsplugin')
-            config._metadata['rbdplugin'] = csi_versions.get('csi-rbdplugin')
+    Args:
+        config (pytest.config): Pytest config object
+    """
+    gather_version_completed = False
+    try:
+        # add cluster version
+        clusterversion = get_cluster_version()
+        config._metadata['Cluster Version'] = clusterversion
 
-            # add ocs operator version
-            if ocsci_config.REPORTING['us_ds'] == 'DS':
-                config._metadata['OCS operator'] = (
-                    get_ocs_build_number()
-                )
-            try:
-                mods = get_version_info(
-                    namespace=ocsci_config.ENV_DATA['cluster_namespace']
-                )
-            except Exception as ex:
-                msg = "get_version_info failed, version report won't be complete:"
-                log.error(msg + str(ex))
-                mods = {}
-            skip_list = ['ocs-operator']
-            for key, val in mods.items():
-                if key not in skip_list:
-                    config._metadata[key] = val.rsplit('/')[-1]
-        except (FileNotFoundError, CommandFailed):
-            pass
+        # add ceph version
+        ceph_version = get_ceph_version()
+        config._metadata['Ceph Version'] = ceph_version
+
+        # add csi versions
+        csi_versions = get_csi_versions()
+        config._metadata['cephfsplugin'] = csi_versions.get('csi-cephfsplugin')
+        config._metadata['rbdplugin'] = csi_versions.get('csi-rbdplugin')
+
+        # add ocs operator version
+        if ocsci_config.REPORTING['us_ds'] == 'DS':
+            config._metadata['OCS operator'] = (
+                get_ocs_build_number()
+            )
+        mods = {}
+        mods = get_version_info(
+            namespace=ocsci_config.ENV_DATA['cluster_namespace']
+        )
+        skip_list = ['ocs-operator']
+        for key, val in mods.items():
+            if key not in skip_list:
+                config._metadata[key] = val.rsplit('/')[-1]
+        gather_version_completed = True
+    except ResourceNotFoundError as ex:
+        log.error(
+            "Problem ocurred when looking for some resource! Error: %s",
+            ex
+        )
+    except FileNotFoundError as ex:
+        log.error("File not found! Error: %s", ex)
+    except CommandFailed as ex:
+        log.error("Failed to execute command! Error: %s", ex)
+    except Exception as ex:
+        log.error("Failed to gather version info! Error: %s", ex)
+    finally:
+        if not gather_version_completed:
+            log.warning(
+                "Failed to gather version details! The report of version might"
+                "not be complete!"
+            )
 
 
 def get_cli_param(config, name_of_param, default=None):

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -130,6 +130,10 @@ class NodeNotFoundError(Exception):
     pass
 
 
+class ResourceNotFoundError(Exception):
+    pass
+
+
 class UnsupportedPlatformError(Exception):
     pass
 

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -70,7 +70,14 @@ class PackageManifest(OCP):
 
         """
         self.check_name_is_specified()
-        return self.data['status']['defaultChannel']
+        try:
+            return self.data['status']['defaultChannel']
+        except KeyError as ex:
+            log.error(
+                "Can't get default channel for package manifest. "
+                "Value of self.data attribute: " + str(self.data)
+            )
+            raise ex
 
     def get_channels(self):
         """
@@ -85,7 +92,14 @@ class PackageManifest(OCP):
 
         """
         self.check_name_is_specified()
-        return self.data['status']['channels']
+        try:
+            return self.data['status']['channels']
+        except KeyError as ex:
+            log.error(
+                "Can't get channels for package manifest. "
+                "Value of self.data attribute: " + str(self.data)
+            )
+            raise ex
 
     def get_current_csv(self, channel=None):
         """

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -111,7 +111,7 @@ class PackageManifest(OCP):
         except KeyError as ex:
             log.error(
                 "Can't get channels for package manifest. "
-                "Value of self.data attribute: " + str(self.data)
+                "Value of self.data attribute: %s", str(self.data)
             )
             raise ex
 

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -89,7 +89,7 @@ class PackageManifest(OCP):
         except KeyError as ex:
             log.error(
                 "Can't get default channel for package manifest. "
-                "Value of self.data attribute: " + str(self.data)
+                "Value of self.data attribute: %s", str(self.data)
             )
             raise ex
 

--- a/ocs_ci/ocs/resources/test_packagemanifest.py
+++ b/ocs_ci/ocs/resources/test_packagemanifest.py
@@ -7,8 +7,11 @@ from ocs_ci.ocs.exceptions import ResourceNameNotSpecifiedException
 
 
 def test_pm_null():
-    pm = PackageManifest()
-    assert pm is not None
+    """
+    Test that creation of PackageManifest object without any constructor
+    agruments works (object is created, no exceptions are raised).
+    """
+    PackageManifest()
 
 
 def test_pm_null_get_default_channel():

--- a/ocs_ci/ocs/resources/test_packagemanifest.py
+++ b/ocs_ci/ocs/resources/test_packagemanifest.py
@@ -1,9 +1,13 @@
 # -*- coding: utf8 -*-
+from unittest.mock import patch
 
 import pytest
 
 from ocs_ci.ocs.resources.packagemanifest import PackageManifest
-from ocs_ci.ocs.exceptions import ResourceNameNotSpecifiedException
+from ocs_ci.ocs.exceptions import (
+    ResourceNameNotSpecifiedException,
+    ResourceNotFoundError,
+)
 
 
 def test_pm_null():
@@ -20,22 +24,24 @@ def test_pm_null_get_default_channel():
         pm.get_default_channel()
 
 
-def test_pm_get_default_channel_missing():
+def test_no_resource_found_for_packagemanifest():
     """
-    Test that when we run into issue #1338, PackageManifest object still
-    behaves in the same way as before.
+    Test that when we run into issue #1338, when no PackageManifest object
+    found.
 
     This unit test serves two purposes:
     - to show what exactly happens to PackageManifest during issue #1338
     - demonstrate that PackageManifest API remains unchanged
     """
-    pm = PackageManifest(resource_name='foobar')
     # based on value of _data attribute when packagemanifest data are missing
     # as reported in https://github.com/red-hat-storage/ocs-ci/issues/1338
-    pm._data = {
+    data_with_no_item = {
         'apiVersion': 'v1',
         'items': [],
         'kind': 'List',
-        'metadata': {'resourceVersion': '', 'selfLink': ''}}
-    with pytest.raises(KeyError):
-        pm.get_default_channel()
+        'metadata': {'resourceVersion': '', 'selfLink': ''}
+    }
+    with patch("ocs_ci.ocs.ocp.OCP.get", return_value=data_with_no_item):
+        pm = PackageManifest(resource_name='foo', selector='bar')
+        with pytest.raises(ResourceNotFoundError):
+            pm.get_default_channel()

--- a/ocs_ci/ocs/resources/test_packagemanifest.py
+++ b/ocs_ci/ocs/resources/test_packagemanifest.py
@@ -18,6 +18,14 @@ def test_pm_null_get_default_channel():
 
 
 def test_pm_get_default_channel_missing():
+    """
+    Test that when we run into issue #1338, PackageManifest object still
+    behaves in the same way as before.
+
+    This unit test serves two purposes:
+    - to show what exactly happens to PackageManifest during issue #1338
+    - demonstrate that PackageManifest API remains unchanged
+    """
     pm = PackageManifest(resource_name='foobar')
     # based on value of _data attribute when packagemanifest data are missing
     # as reported in https://github.com/red-hat-storage/ocs-ci/issues/1338

--- a/ocs_ci/ocs/resources/test_packagemanifest.py
+++ b/ocs_ci/ocs/resources/test_packagemanifest.py
@@ -1,0 +1,30 @@
+# -*- coding: utf8 -*-
+
+import pytest
+
+from ocs_ci.ocs.resources.packagemanifest import PackageManifest
+from ocs_ci.ocs.exceptions import ResourceNameNotSpecifiedException
+
+
+def test_pm_null():
+    pm = PackageManifest()
+    assert pm is not None
+
+
+def test_pm_null_get_default_channel():
+    pm = PackageManifest()
+    with pytest.raises(ResourceNameNotSpecifiedException):
+        pm.get_default_channel()
+
+
+def test_pm_get_default_channel_missing():
+    pm = PackageManifest(resource_name='foobar')
+    # based on value of _data attribute when packagemanifest data are missing
+    # as reported in https://github.com/red-hat-storage/ocs-ci/issues/1338
+    pm._data = {
+        'apiVersion': 'v1',
+        'items': [],
+        'kind': 'List',
+        'metadata': {'resourceVersion': '', 'selfLink': ''}}
+    with pytest.raises(KeyError):
+        pm.get_default_channel()


### PR DESCRIPTION
Make the ocs-ci code more robust so that running test is possible even during problem with packagemanifest as reported in https://github.com/red-hat-storage/ocs-ci/issues/1338 (which would make pytest crash immediately otherwise).

This fixes ocs-ci part of the problem covered in https://github.com/red-hat-storage/ocs-ci/issues/1338 