### PR TITLE
Move 4.2 to use RC builds as default

### DIFF
--- a/conf/ocs_version/ocs-4.2.yaml
+++ b/conf/ocs_version/ocs-4.2.yaml
@@ -1,7 +1,7 @@
 ---
 DEPLOYMENT:
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:latest-4.2"
-  default_latest_tag: 'latest-4.2'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:4.2-rc"
+  default_latest_tag: '4.2-rc'
 ENV_DATA:
   logging_version: '4.2'
   ocs_version: '4.2'


### PR DESCRIPTION
Cause of they created new 4.2 build which is not RC:
https://quay.io/repository/rhceph-dev/ocs-olm-operator?tab=tags

It's currently upgrading to this latest build but our jobs
are not aligned yet to provide specific build.

So with this fix we will be able to continu testing upgrade.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>