### PR TITLE
Address key error failure for vmwre UPI run

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -476,6 +476,7 @@ config_keys_patterns_to_censor = ['passw', 'token', 'secret']
 
 # repos
 OCP4_2_REPO = os.path.join(REPO_DIR, "ocp_4_2.repo")
+OCP4_3_REPO = os.path.join(REPO_DIR, "ocp_4_3.repo")
 
 # packages
 RHEL_POD_PACKAGES = ["openssh-clients", "openshift-ansible", "openshift-clients", "jq"]
@@ -527,7 +528,8 @@ WORKER_LABEL = "node-role.kubernetes.io/worker"
 
 # Rep mapping
 REPO_MAPPING = {
-    '4.2.0': OCP4_2_REPO
+    '4.2.0': OCP4_2_REPO,
+    '4.3.0': OCP4_3_REPO
 }
 
 # Cluster name limits


### PR DESCRIPTION
Signed-off-by: Shylesh Kumar <shmohan@redhat.com>

To address jenkins failure 
```
 self.ocp_repo = constants.REPO_MAPPING[version]
E       KeyError: '4.3.0'
``` from the run 
 https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/4703