### PR TITLE
Add build image factory

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -234,6 +234,10 @@ CSI_RBD_POD_YAML = os.path.join(
     TEMPLATE_CSI_RBD_DIR, "pod.yaml"
 )
 
+CSI_RBD_FIO_POD_YAML = os.path.join(
+    TEMPLATE_CSI_RBD_DIR, "fiopod.yaml"
+)
+
 CSI_RBD_RAW_BLOCK_POD_YAML = os.path.join(
     TEMPLATE_APP_POD_DIR, "raw_block_pod.yaml"
 )
@@ -241,6 +245,11 @@ CSI_RBD_RAW_BLOCK_POD_YAML = os.path.join(
 CSI_CEPHFS_POD_YAML = os.path.join(
     TEMPLATE_CSI_FS_DIR, "pod.yaml"
 )
+
+CSI_CEPHFS_FIO_POD_YAML = os.path.join(
+    TEMPLATE_CSI_FS_DIR, "fiopod.yaml"
+)
+
 CSI_RBD_SECRET_YAML = os.path.join(
     TEMPLATE_CSI_RBD_DIR, "secret.yaml"
 )
@@ -298,6 +307,10 @@ SERVICE_ACCOUNT_YAML = os.path.join(
 
 FEDORA_DC_YAML = os.path.join(
     TEMPLATE_APP_POD_DIR, "fedora_dc.yaml"
+)
+
+FIO_DC_YAML = os.path.join(
+    TEMPLATE_APP_POD_DIR, "fio_dc.yaml"
 )
 
 RHEL_7_7_POD_YAML = os.path.join(

--- a/ocs_ci/templates/CSI/cephfs/fiopod.yaml
+++ b/ocs_ci/templates/CSI/cephfs/fiopod.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csicephfs-demo-pod
+spec:
+  containers:
+   - name: fio
+     image: fio
+     volumeMounts:
+       - name: mypvc
+         mountPath: /mnt/fio
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: cephfs-pvc
+       readOnly: false

--- a/ocs_ci/templates/CSI/rbd/fiopod.yaml
+++ b/ocs_ci/templates/CSI/rbd/fiopod.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csirbd-demo-pod
+  namespace: default
+spec:
+  containers:
+   - name: fio
+     image: fio
+     volumeMounts:
+       - name: mypvc
+         mountPath: /mnt/fio
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: rbd-pvc
+       readOnly: false

--- a/ocs_ci/templates/app-pods/fio_dc.yaml
+++ b/ocs_ci/templates/app-pods/fio_dc.yaml
@@ -1,0 +1,45 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: fio_dc_pod
+  labels:
+    app: fiodcpod
+spec:
+  template:
+    metadata:
+      labels:
+        name: fiodcpod
+    spec:
+      securityContext:
+        fsGroup: 2000
+      serviceAccountName: admin
+      restartPolicy: Always
+      volumes:
+      - name: dc-vol
+        persistentVolumeClaim:
+          claimName: tet-2
+      containers:
+      - name: fio
+        image: fio
+        resources:
+          limits:
+            memory: "500Mi"
+            cpu: "150m"
+        command: ["/bin/bash", "-ce", "tail -f /dev/null" ]
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /mnt
+          name: dc-vol
+        livenessProbe:
+          exec:
+            command:
+            - 'sh'
+            - '-ec'
+            - 'df /mnt'
+          initialDelaySeconds: 3
+          periodSeconds: 3
+
+  replicas: 1
+  triggers:
+    - type: ConfigChange
+  paused: false

--- a/ocs_ci/utility/workloads/fio.py
+++ b/ocs_ci/utility/workloads/fio.py
@@ -12,18 +12,12 @@ Note: The above mentioned functions will be invoked from Workload.setup()
 and Workload.run() methods along with user provided parameters.
 """
 import logging
-from time import sleep
-
-from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.utility.retry import retry
-from ocs_ci.utility.workloads.helpers import find_distro, DISTROS
 
 log = logging.getLogger(__name__)
 
 
 # Adding retry here to make this more stable for dpkg lock issues and network
 # issues when installing some packages.
-@retry(CommandFailed, tries=10, delay=10, backoff=1)
 def setup(**kwargs):
     """
     setup fio workload
@@ -37,21 +31,8 @@ def setup(**kwargs):
     Returns:
         bool: True if setup succeeds else False
     """
-    io_pod = kwargs['pod']
-    # For first cut doing simple fio install
-    distro = find_distro(io_pod)
-    pkg_mgr = DISTROS[distro]
-
-    if distro == 'Debian':
-        cmd = f'{pkg_mgr} update'
-        io_pod.exec_cmd_on_pod(cmd, out_yaml_format=False)
-        log.info(
-            "Sleep 5 seconds after update to make sure the lock is released"
-        )
-        sleep(5)
-
-    cmd = f"{pkg_mgr} -y install fio"
-    return io_pod.exec_cmd_on_pod(cmd, out_yaml_format=False)
+    log.info('setup not required as pod is preconfigured with fio')
+    return True
 
 
 def run(**kwargs):

--- a/tests/e2e/workloads/test_pod_from_registry.py
+++ b/tests/e2e/workloads/test_pod_from_registry.py
@@ -21,7 +21,7 @@ class TestRegistryImage(E2ETest):
         Run a pod with image backed by local registry
         """
         pvc_obj = pvc_factory(size=self.pvc_size)
-        image_obj = helpers.create_build_from_docker_image(
+        base_image_obj, image_obj, build_obj = helpers.create_build_from_docker_image(
             namespace=pvc_obj.namespace,
             source_image_label='7',
             image_name='fio',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -137,13 +137,13 @@ def create_pod(
         AssertionError: In case of any failure
     """
     if interface_type == constants.CEPHBLOCKPOOL:
-        pod_dict = pod_dict_path if pod_dict_path else constants.CSI_RBD_POD_YAML
+        pod_dict = pod_dict_path if pod_dict_path else constants.CSI_RBD_FIO_POD_YAML
         interface = constants.RBD_INTERFACE
     else:
         pod_dict = pod_dict_path if pod_dict_path else constants.CSI_CEPHFS_POD_YAML
         interface = constants.CEPHFS_INTERFACE
     if dc_deployment:
-        pod_dict = pod_dict_path if pod_dict_path else constants.FEDORA_DC_YAML
+        pod_dict = pod_dict_path if pod_dict_path else constants.FIO_DC_YAML
     pod_data = templating.load_yaml(pod_dict)
     if not pod_name:
         pod_name = create_unique_resource_name(
@@ -956,7 +956,13 @@ def create_build_from_docker_image(
             image_stream_obj = OCP(
                 kind='ImageStream', resource_name=image_name
             )
-            return image_stream_obj
+            build_obj = OCP(
+                kind='BuildConfig', resource_name=image_name
+            )
+            base_image_stream_obj = OCP(
+                kind='ImageStream', resource_name=source_image
+            )
+            return base_image_stream_obj, image_stream_obj, build_obj
     else:
         raise UnavailableBuildException('Build creation failed')
 


### PR DESCRIPTION
This PR adds a factory to allow creation of custom container images. When a pod is created from pod factory with default params, a fio image is created and saved in the local registry from which fio pods will be created each time. 

Depends on #1460 