### PR TITLE
Fix in getting OCP version when we have batch version

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1057,7 +1057,7 @@ def get_ocp_version(seperator=None):
     """
     char = seperator if seperator else '.'
     return char.join(
-        config.DEPLOYMENT['installer_version'].split('.')[: -2]
+        config.DEPLOYMENT['installer_version'].split('.')[:2]
     )
 
 


### PR DESCRIPTION
Fix in getting OCP version when we have batch version like 4.2.18

Signed-off-by: vavuthu <vavuthu@redhat.com>

Fixes: #1512 