### PR TITLE
Remove default pre-pull of images

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -133,26 +133,13 @@ def create_pod(
         AssertionError: In case of any failure
     """
     if interface_type == constants.CEPHBLOCKPOOL:
+        pod_dict = pod_dict_path if pod_dict_path else constants.CSI_RBD_POD_YAML
         interface = constants.RBD_INTERFACE
-        if pod_dict_path:
-            pod_dict = pod_dict_path
-        else:
-            pod_dict = constants.CSI_RBD_POD_YAML
-            pull_images('nginx')
     else:
+        pod_dict = pod_dict_path if pod_dict_path else constants.CSI_CEPHFS_POD_YAML
         interface = constants.CEPHFS_INTERFACE
-        if pod_dict_path:
-            pod_dict = pod_dict_path
-        else:
-            pod_dict = constants.CSI_CEPHFS_POD_YAML
-            pull_images('nginx')
-
     if dc_deployment:
-        if pod_dict_path:
-            pod_dict = pod_dict_path
-        else:
-            pod_dict = constants.FEDORA_DC_YAML
-            pull_images('fedora')
+        pod_dict = pod_dict_path if pod_dict_path else constants.FEDORA_DC_YAML
     pod_data = templating.load_yaml(pod_dict)
     if not pod_name:
         pod_name = create_unique_resource_name(


### PR DESCRIPTION
Fixes #1524 

All scale tests failed as a result of the pre-pull of container images when done in bulk - https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/4856/