### PR TITLE
Create custom machineset for creating nodes with different instance type and node scale

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -372,6 +372,9 @@ FIO_IO_RW_PARAMS_YAML = os.path.join(
 RSYNC_POD_YAML = os.path.join(
     TEMPLATE_OPENSHIFT_INFRA_DIR, "rsync-pod.yaml"
 )
+MACHINESET_YAML = os.path.join(
+    TEMPLATE_OPENSHIFT_INFRA_DIR, "machine-set.yaml"
+)
 
 ANSIBLE_INVENTORY_YAML = os.path.join(
     "ocp-deployment", "inventory.yaml.j2"

--- a/ocs_ci/templates/openshift-infra/machine-set.yaml
+++ b/ocs_ci/templates/openshift-infra/machine-set.yaml
@@ -1,0 +1,59 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: clusterID
+  name: clusteID-role-aws-zone
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: custerID
+      machine.openshift.io/cluster-api-machineset: clusteID-role-aws-zone
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: custerID
+        machine.openshift.io/cluster-api-machine-role: role
+        machine.openshift.io/cluster-api-machine-type: role
+        machine.openshift.io/cluster-api-machineset: clusteID-role-aws-zone
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/app: app-scale
+      providerSpec:
+        value:
+          ami:
+            id: ami-04a79d8d7cfa540cc
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          blockDevices:
+            - ebs:
+                iops: 0
+                volumeSize: 120
+                volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: custerID-worker-profile
+          instanceType: m4.xlarge
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: availabilityZone
+            region: awsRegion
+          securityGroups:
+            - filters:
+                - name: tag:Name
+                  values:
+                    - custerID-worker-sg
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - custerID-private-availabilityZone
+          tags:
+            - name: kubernetes.io/cluster/custerID
+              value: owned
+          userDataSecret:
+            name: worker-user-data


### PR DESCRIPTION
Create custom machineset for creating nodes with different instance type.
Using this machineset we can scale nodes for app pod creation/deletion.
This will not affect the OCS worker node.

ocs_ci/ocs/constants.py --> Updated with new yaml file path
ocs_ci/ocs/machine.py --> Added function to create and delete machineset
ocs_ci/templates/openshift-infra/machine-set.yaml --> machineset yaml file

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>