### PR TITLE
Skip test case due to #1547

### DIFF
--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -168,8 +168,10 @@ def add_role_to_user(role_type, user):
 
     """
     ocp_obj = ocp.OCP()
-    role_cmd = f"policy add-role-to-user {role_type} {user} " \
-               f"-n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+    role_cmd = (
+        f"policy add-role-to-user {role_type} {user} "
+        f"-n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
+    )
     assert ocp_obj.exec_oc_cmd(command=role_cmd), 'Adding role failed'
     logger.info(f"Role_type {role_type} added to the user {user}")
 

--- a/tests/e2e/registry/test_registry_image_push_pull.py
+++ b/tests/e2e/registry/test_registry_image_push_pull.py
@@ -16,6 +16,7 @@ class TestRegistryImagePullPush(E2ETest):
     @tier1
     @ignore_leftovers
     @pytest.mark.polarion_id("OCS-1080")
+    @pytest.mark.skip("Skip this test due to https://github.com/red-hat-storage/ocs-ci/issues/1547")
     def test_registry_image_pull_push(self):
         """
         Test case to validate registry image pull and push with OCS backend


### PR DESCRIPTION
Added pytest skip marker to skip registry test case execution due to #1547
Updated formatting in registry.py

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>