### PR TITLE
Add fio_storageutilization_min_mbps option

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_3m_3w_prod_memory.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_3m_3w_prod_memory.yaml
@@ -11,3 +11,4 @@ ENV_DATA:
   master_num_cpus: '4'
   master_memory: '16384'
   compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/deployment/vsphere/upi_1az_rhcos_vmfs_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vmfs_3m_3w.yaml
@@ -12,6 +12,7 @@ ENV_DATA:
   master_memory: '16384'
   # Once we will have DC which can handle 64GB we should use those and update here
   compute_memory: '32768'
+  fio_storageutilization_min_mbps: 10.0
 REPORTING:
   polarion:
     deployment_id: 'OCS-1452'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w.yaml
@@ -12,6 +12,7 @@ ENV_DATA:
   master_memory: '16384'
   # Once we will have DC which can handle 64GB we should use those and update here
   compute_memory: '32768'
+  fio_storageutilization_min_mbps: 10.0
 REPORTING:
   polarion:
     deployment_id: 'OCS-1453'

--- a/conf/deployment/vsphere/upi_1az_rhel_3m_3w_prod_memory.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhel_3m_3w_prod_memory.yaml
@@ -21,3 +21,4 @@ ENV_DATA:
   # RHEL nodes, so no need to have big number here.
   compute_memory: '16384'
   rhel_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/deployment/vsphere/upi_1az_rhel_vmfs_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhel_vmfs_3m_3w.yaml
@@ -22,6 +22,7 @@ ENV_DATA:
   compute_memory: '16384'
   # Once we will have DC which can handle 64GB we should use those and update here
   rhel_memory: '32768'
+  fio_storageutilization_min_mbps: 10.0
 REPORTING:
   polarion:
     deployment_id: 'OCS-1446'

--- a/conf/deployment/vsphere/upi_1az_rhel_vsan_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhel_vsan_3m_3w.yaml
@@ -22,6 +22,7 @@ ENV_DATA:
   compute_memory: '16384'
   # Once we will have DC which can handle 64GB we should use those and update here
   rhel_memory: '32768'
+  fio_storageutilization_min_mbps: 10.0
 REPORTING:
   polarion:
     deployment_id: 'OCS-1448'

--- a/conf/ocsci/vsphere-upi-ocs4qe-lab.yaml
+++ b/conf/ocsci/vsphere-upi-ocs4qe-lab.yaml
@@ -6,3 +6,4 @@ DEPLOYMENT:
 ENV_DATA:
   worker_num_cpus: '12'
   master_num_cpus: '4'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/ocsci/vsphere_upi.yaml
+++ b/conf/ocsci/vsphere_upi.yaml
@@ -4,3 +4,4 @@ ENV_DATA:
   deployment_type: 'upi'
   worker_replicas: 3
   master_replicas: 3
+  fio_storageutilization_min_mbps: 10.0

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -108,6 +108,7 @@ ENV_DATA:
   # fixtures, which is used to compute timeout of the write job (so that
   # when actual write speed of the operation is smaller than this value, the
   # workload fixture will fail on a timeout)
+  # the default value used here is based on observations on aws clusters
   fio_storageutilization_min_mbps: 30.0
 
 # This section is related to upgrade

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -104,6 +104,11 @@ ENV_DATA:
   # measurement_dir: '/tmp/ocs_ci_monitoring_measurement/'
   # Default RHCOS image to be used for VmWare deployment
   vm_template: 'rhcos-4.3.0-x86_64-vmware'
+  # minimal write speed of fio as used in workload_fio_storageutilization
+  # fixtures, which is used to compute timeout of the write job (so that
+  # when actual write speed of the operation is smaller than this value, the
+  # workload fixture will fail on a timeout)
+  fio_storageutilization_min_mbps: 30.0
 
 # This section is related to upgrade
 UPGRADE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -401,7 +401,7 @@ def project_factory_fixture(request):
         for instance in instances:
             ocp.switch_to_default_rook_cluster_project()
             instance.delete(resource_name=instance.namespace)
-            instance.wait_for_delete(instance.namespace)
+            instance.wait_for_delete(instance.namespace, timeout=300)
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -662,9 +662,14 @@ def workload_fio_storageutilization(
     fio_objs = [fio_pvc_dict, fio_configmap_dict, fio_job_dict]
     fio_job_file = ObjectConfFile(fixture_name, fio_objs, project, tmp_path)
 
-    # how long do we let the job running while writing data to the volume
-    # TODO: increase this value or make it configurable
-    write_timeout = pvc_size * 30  # seconds
+    # How long do we let the job running while writing data to the volume?
+    # Based on min. fio write speed of the enviroment ...
+    fio_min_mbps = config.ENV_DATA['fio_storageutilization_min_mbps']
+    logger.info(
+        "Assuming %.2f MB/s is a minimal write speed of fio.", fio_min_mbps)
+    # ... we compute max. time we are going to wait for fio to write all data
+    min_time_to_write_gb = 1 / (fio_min_mbps / 2**10)
+    write_timeout = pvc_size * min_time_to_write_gb  # seconds
     logger.info((
         f"fixture will wait {write_timeout} seconds for the Job "
         f"to write {pvc_size} Gi data on OCS backed volume"))

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -712,18 +712,17 @@ def workload_fio_storageutilization(
         except TimeoutExpiredError as ex:
             # report some high level error as well
             msg = (
-                "Job fio failed to write %.2f Gi data on OCS backed volume "
-                "in expected time %.2f seconds.")
-            logger.error(msg, pvc_size, write_timeout)
+                f"Job fio failed to write {pvc_size} Gi data on OCS backed "
+                f"volume in expected time {write_timeout} seconds.")
+            logger.error(msg)
             # TODO: if the job is still running, report more specific error
             # message instead of the generic one which is pushed to ex. below
-            msg += (
-                " If the fio pod were still runing "
-                "(see 'last actual status was' in some previous log message), "
-                "this is caused either by "
-                "severe product performance regression "
-                "or by a misconfiguration of the cluster (ping infra team).")
-            ex.args = ex.args + (msg,)
+            ex.message = msg + (
+                " If the fio pod were still runing"
+                " (see 'last actual status was' in some previous log message),"
+                " this is caused either by"
+                " severe product performance regression"
+                " or by a misconfiguration of the clusterr, ping infra team.")
             raise(ex)
         pod_data = ocp_pod.get()
 

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -783,6 +783,28 @@ def workload_fio_storageutilization(
 
 
 @pytest.fixture
+def workload_storageutilization_05p_rbd(
+        project,
+        fio_pvc_dict,
+        fio_job_dict,
+        fio_configmap_dict,
+        measurement_dir,
+        tmp_path):
+    target_percentage = 0.05
+    fixture_name = "workload_storageutilization_05p_rbd"
+    measured_op = workload_fio_storageutilization(
+        fixture_name,
+        target_percentage,
+        project,
+        fio_pvc_dict,
+        fio_job_dict,
+        fio_configmap_dict,
+        measurement_dir,
+        tmp_path)
+    return measured_op
+
+
+@pytest.fixture
 def workload_storageutilization_50p_rbd(
         project,
         fio_pvc_dict,
@@ -839,6 +861,28 @@ def workload_storageutilization_95p_rbd(
         supported_configuration):
     target_percentage = 0.95
     fixture_name = "workload_storageutilization_95p_rbd"
+    measured_op = workload_fio_storageutilization(
+        fixture_name,
+        target_percentage,
+        project,
+        fio_pvc_dict,
+        fio_job_dict,
+        fio_configmap_dict,
+        measurement_dir,
+        tmp_path)
+    return measured_op
+
+
+@pytest.fixture
+def workload_storageutilization_05p_cephfs(
+        project,
+        fio_pvc_dict,
+        fio_job_dict,
+        fio_configmap_dict,
+        measurement_dir,
+        tmp_path):
+    target_percentage = 0.05
+    fixture_name = "workload_storageutilization_05p_cephfs"
     measured_op = workload_fio_storageutilization(
         fixture_name,
         target_percentage,

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -2,7 +2,8 @@
 """
 Test cases in this file are demonstrating usage of workload storage utilization
 fixtures, and are not expected to be executed in any real test run (hence
-all tests are marked with ``libtest`` marker).
+all tests are marked with ``libtest`` marker - with exception of the most
+simple test case).
 
 You can execute test cases here to run the workflow implemented in the
 fixtures. Assuming that you are in root directory of ``ocs-ci`` repository and
@@ -42,6 +43,7 @@ from datetime import datetime
 
 import pytest
 
+from ocs_ci.framework.testlib import tier1
 from ocs_ci.utility.prometheus import PrometheusAPI
 
 
@@ -149,7 +151,8 @@ def test_workload_rbd_cephfs(
     logger.info(workload_storageutilization_50p_cephfs)
 
 
-@pytest.mark.libtest
+@tier1
+@pytest.mark.polarion_id("OCS-2125")
 def test_workload_rbd_cephfs_minimal(
     workload_storageutilization_05p_rbd,
     workload_storageutilization_05p_cephfs
@@ -158,6 +161,36 @@ def test_workload_rbd_cephfs_minimal(
     Similar to test_workload_rbd_cephfs, but using only 5% of total OCS
     capacity. This still test the workload, but it's bit faster and (hopefully)
     without big impact on the cluster itself.
+
+    In this test we are only checking whether the storage utilization workload
+    failed or not. The main point of having this included in tier1 suite is to
+    see whether we are able to actually run the fio write workload without any
+    direct failure (fio job could fail to be scheduled, fail during writing or
+    timeout when write progress is too slow ...).
+
+    Please note that reaching 5% of total OCS capacity means that workload
+    fixtures specified above will try to write data based on current cluster
+    wide storage utilization to meet the specified target. If the current
+    cluster utilization is already above 5%, this will fail. This is targeted
+    to a fresh just installed CI cluster.
     """
-    logger.info(workload_storageutilization_05p_rbd)
-    logger.info(workload_storageutilization_05p_cephfs)
+    logger.info("checking fio report results as provided by workload fixtures")
+    msg = "workload results were recorded and provided to the test"
+    assert workload_storageutilization_05p_rbd['result'] is not None, msg
+    assert workload_storageutilization_05p_cephfs['result'] is not None, msg
+
+    fio_reports = (
+        ('rbd', workload_storageutilization_05p_rbd['result']['fio']),
+        ('cephfs', workload_storageutilization_05p_cephfs['result']['fio']),
+    )
+    for vol_type, fio in fio_reports:
+        logger.info("starting to check fio run on %s volume", vol_type)
+        msg = "single fio job were executed in each workload run"
+        assert len(fio['jobs']) == 1, msg
+        logger.info(
+            "fio (version %s) executed %s job on %s volume",
+            fio['fio version'],
+            fio['jobs'][0]['jobname'],
+            vol_type)
+        msg = f"no errors are reported by fio writing on {vol_type} volume"
+        assert fio['jobs'][0]['error'] == 0, msg

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -175,7 +175,7 @@ def test_workload_rbd_cephfs_minimal(
     to a fresh just installed CI cluster.
     """
     logger.info("checking fio report results as provided by workload fixtures")
-    msg = "workload results were recorded and provided to the test"
+    msg = "workload results should be recorded and provided to the test"
     assert workload_storageutilization_05p_rbd['result'] is not None, msg
     assert workload_storageutilization_05p_cephfs['result'] is not None, msg
 
@@ -185,12 +185,12 @@ def test_workload_rbd_cephfs_minimal(
     )
     for vol_type, fio in fio_reports:
         logger.info("starting to check fio run on %s volume", vol_type)
-        msg = "single fio job were executed in each workload run"
+        msg = "single fio job should be executed in each workload run"
         assert len(fio['jobs']) == 1, msg
         logger.info(
             "fio (version %s) executed %s job on %s volume",
             fio['fio version'],
             fio['jobs'][0]['jobname'],
             vol_type)
-        msg = f"no errors are reported by fio writing on {vol_type} volume"
+        msg = f"no errors should be reported by fio writing on {vol_type} volume"
         assert fio['jobs'][0]['error'] == 0, msg

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -147,3 +147,17 @@ def test_workload_rbd_cephfs(
     """
     logger.info(workload_storageutilization_50p_rbd)
     logger.info(workload_storageutilization_50p_cephfs)
+
+
+@pytest.mark.libtest
+def test_workload_rbd_cephfs_minimal(
+    workload_storageutilization_05p_rbd,
+    workload_storageutilization_05p_cephfs
+):
+    """
+    Similar to test_workload_rbd_cephfs, but using only 5% of total OCS
+    capacity. This still test the workload, but it's bit faster and (hopefully)
+    without big impact on the cluster itself.
+    """
+    logger.info(workload_storageutilization_05p_rbd)
+    logger.info(workload_storageutilization_05p_cephfs)


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/1551

This pull request:
- [x] introduces new option `fio_storageutilization_min_mbps` with minimal write speed (MB/s) which is used to calculate write timeout in workload_fio_storageutilization fixtures
- [x] select proper defaults in proper places, so that vmware runs are executed with smaller value of `fio_storageutilization_min_mbps` option
- [x] adds new libtest test case for testing this with 5% of total OCS capacity (assuming run on a new cluster, for a validation of this PR - otherwise it's not really practical)
- [x] improve logging/error reporting in case of this event
- [x] repurpose the minimal workload libtest case into a simple tier1 test case (as suggested by Elad)

With this PR, a workload fixture run will report into log messages like this:

```
2020-02-28 14:43:32,737 - INFO - tests.manage.monitoring.conftest.workload_fio_storageutilization.669 - Assuming 30.00 MB/s is a minimal write speed of fio.
2020-02-28 14:43:32,738 - INFO - tests.manage.monitoring.conftest.workload_fio_storageutilization.674 - fixture will wait 136.53333333333333 seconds for the Job to write 4 Gi data on OCS backed volume
```

One more line (`Job fio failed to write ...`) is reported in the log when the fio job workload fails on the timeout:

```
16:17:08 - MainThread - ocs_ci.ocs.ocp - INFO - status of  at column STATUS - item(s) were ['Running'], but we were waiting for all 1 of them to be Completed
16:17:08 - MainThread - ocs_ci.ocs.ocp - ERROR - timeout expired: Timed Out: (10.24,)
16:17:08 - MainThread - ocs_ci.ocs.ocp - ERROR - Wait for Pod resource  at column STATUS to reach desired condition Completed failed, last actual status was ['Running']
16:17:08 - MainThread - tests.manage.monitoring.conftest - ERROR - Job fio failed to write 3.00 Gi data on OCS backed volume in expected time 10.24 seconds.
```