### PR TITLE
Add new 4.3.1 to repo map for OCP RHEL

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -538,7 +538,8 @@ WORKER_LABEL = "node-role.kubernetes.io/worker"
 # Rep mapping
 REPO_MAPPING = {
     '4.2.0': OCP4_2_REPO,
-    '4.3.0': OCP4_3_REPO
+    '4.3.0': OCP4_3_REPO,
+    '4.3.1': OCP4_3_REPO,
 }
 
 # Cluster name limits


### PR DESCRIPTION
This is quick fix for the issue below.
Fixes: #1561

We will need to do better fix for this to have it dynamically.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>