### PR TITLE
Fix the get_az_count() function to default to 3.

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1206,7 +1206,7 @@ def get_az_count():
     elif config.ENV_DATA.get('platform') == 'vsphere':
         return 1
     else:
-        return 3
+        return 1
 
 
 @retry((CephHealthException, CommandFailed), tries=20, delay=30, backoff=1)


### PR DESCRIPTION
When the configuration sets none of the variables
worker_availability_zones, availability_zone_count,
or platform is not equal to 'vmware', then the get_az_count()
function currently returns "3" as a default.

When there are actually less than 3 zones, this leads to
errors in the post-install deployment checks that check
for the failure domain being set to "zone" in the crush map.

The safe default is one zone.

Signed-off-by: Michael Adam <obnox@redhat.com>