### PR TITLE
collect performance stats when OCS operation fails for scale and perfomance test cases

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -30,6 +30,7 @@ from ocs_ci.ocs.constants import (
     CLUSTER_NAME_MIN_CHARACTERS,
     OCP_VERSION_CONF_DIR,
 )
+from tests.helpers import collect_performance_stats
 
 __all__ = [
     "pytest_addoption",
@@ -382,3 +383,11 @@ def pytest_runtest_makereport(item, call):
             call.start,
             call.stop
         )
+
+    # Get the performance metrics when tests fails for scale or performance tag
+    if (
+        (rep.when == "setup" or rep.when == "call")
+        and rep.failed
+        and (item.get_closest_marker('scale') or item.get_closest_marker('performance'))
+    ):
+        collect_performance_stats()

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -30,7 +30,6 @@ from ocs_ci.ocs.constants import (
     CLUSTER_NAME_MIN_CHARACTERS,
     OCP_VERSION_CONF_DIR,
 )
-from tests.helpers import collect_performance_stats
 
 __all__ = [
     "pytest_addoption",
@@ -385,6 +384,7 @@ def pytest_runtest_makereport(item, call):
         )
 
     # Get the performance metrics when tests fails for scale or performance tag
+    from tests.helpers import collect_performance_stats
     if (
         (rep.when == "setup" or rep.when == "call")
         and rep.failed

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -302,6 +302,12 @@ def get_node_resource_utilization_from_adm_top(nodename=None, node_type='worker'
     node_names = [nodename] if nodename else [
         node.name for node in get_typed_nodes(node_type=node_type)
     ]
+
+    # Validate node is in Ready state
+    wait_for_nodes_status(
+        node_names, status=constants.NODE_READY, timeout=30
+    )
+
     obj = ocp.OCP()
     resource_utilization_all_nodes = obj.exec_oc_cmd(
         command='adm top nodes', out_yaml_format=False

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2134,12 +2134,16 @@ def collect_performance_stats():
     # ToDo: Get iops and throughput percentage of each nodes
 
     # Get the cpu and memory of each nodes from adm top
-    master_node_utilization_from_adm_top = node.get_node_resource_utilization_from_adm_top(node_type='master')
-    worker_node_utilization_from_adm_top = node.get_node_resource_utilization_from_adm_top(node_type='worker')
+    master_node_utilization_from_adm_top = \
+        node.get_node_resource_utilization_from_adm_top(node_type='master')
+    worker_node_utilization_from_adm_top = \
+        node.get_node_resource_utilization_from_adm_top(node_type='worker')
 
     # Get the cpu and memory from describe of nodes
-    master_node_utilization_from_oc_describe = node.get_node_resource_utilization_from_oc_describe(node_type='master')
-    worker_node_utilization_from_oc_describe = node.get_node_resource_utilization_from_oc_describe(node_type='worker')
+    master_node_utilization_from_oc_describe = \
+        node.get_node_resource_utilization_from_oc_describe(node_type='master')
+    worker_node_utilization_from_oc_describe = \
+        node.get_node_resource_utilization_from_oc_describe(node_type='worker')
 
     performance_stats['iops_percentage'] = iops_percentage
     performance_stats['throughput_percentage'] = throughput_percentage

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,7 +30,6 @@ from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler, ocsci_log_path, run_cmd
 from ocs_ci.framework import config
-from ocs_ci.ocs.cluster import CephCluster
 
 logger = logging.getLogger(__name__)
 
@@ -2114,6 +2113,8 @@ def collect_performance_stats():
         CPU, memory consumption of each nodes
 
     """
+    from ocs_ci.ocs.cluster import CephCluster
+
     log_dir_path = os.path.join(
         os.path.expanduser(config.RUN['log_dir']),
         f"failed_testcase_ocs_logs_{config.RUN['run_id']}",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2133,14 +2133,20 @@ def collect_performance_stats():
 
     # ToDo: Get iops and throughput percentage of each nodes
 
-    # Get the cpu and memory of each nodes
-    master_node_utilization = node.get_node_resource_utilization(node_type='master')
-    worker_node_utilization = node.get_node_resource_utilization(node_type='worker')
+    # Get the cpu and memory of each nodes from adm top
+    master_node_utilization_from_adm_top = node.get_node_resource_utilization_from_adm_top(node_type='master')
+    worker_node_utilization_from_adm_top = node.get_node_resource_utilization_from_adm_top(node_type='worker')
+
+    # Get the cpu and memory from describe of nodes
+    master_node_utilization_from_oc_describe = node.get_node_resource_utilization_from_oc_describe(node_type='master')
+    worker_node_utilization_from_oc_describe = node.get_node_resource_utilization_from_oc_describe(node_type='worker')
 
     performance_stats['iops_percentage'] = iops_percentage
     performance_stats['throughput_percentage'] = throughput_percentage
-    performance_stats['master_node_utilization'] = master_node_utilization
-    performance_stats['worker_node_utilization'] = worker_node_utilization
+    performance_stats['master_node_utilization'] = master_node_utilization_from_adm_top
+    performance_stats['worker_node_utilization'] = worker_node_utilization_from_adm_top
+    performance_stats['master_node_utilization_from_oc_describe'] = master_node_utilization_from_oc_describe
+    performance_stats['worker_node_utilization_from_oc_describe'] = worker_node_utilization_from_oc_describe
 
     file_name = os.path.join(log_dir_path, 'performance')
     with open(file_name, 'w') as outfile:


### PR DESCRIPTION
Collect performance stats and saves them in file in json format.
Performance stats include:
- IOPs and throughput percentage of cluster
- CPU, memory consumption of each nodes

Signed-off-by: Akarsha <akrai@redhat.com>