### PR TITLE
DC based app pods - Node failure helper functions

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -12,6 +12,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs import machine
 import tests.helpers
 from ocs_ci.ocs import ocp
+from ocs_ci.ocs.resources import pod
 
 
 log = logging.getLogger(__name__)
@@ -393,3 +394,49 @@ def node_network_failure(node_names, wait=True):
             node_names=node_names, status=constants.NODE_NOT_READY
         )
     return True
+
+
+def get_osd_running_nodes():
+    """
+    Gets the osd running node names
+
+    Returns:
+        list: OSD node names
+
+    """
+    return [
+        pod.get_pod_node(osd_node).name for osd_node in pod.get_osd_pods()
+    ]
+
+
+def get_app_pod_running_nodes(pod_obj):
+    """
+    Gets the app pod running node names
+
+    Args:
+        pod_obj (list): List of app pod objects
+
+    Returns:
+        list: App pod running node names
+
+    """
+    return [pod.get_pod_node(node).name for node in pod_obj]
+
+
+def get_both_osd_and_app_pod_running_node(
+        osd_running_nodes, app_pod_running_nodes
+):
+    """
+     Gets both osd and app pod running node names
+
+     Args:
+         osd_running_nodes(list): List of osd running node names
+         app_pod_running_nodes(list): List of app pod running node names
+
+     Returns:
+         list: Both OSD and app pod running node names
+
+     """
+    common_nodes = list(set(osd_running_nodes) & set(app_pod_running_nodes))
+    log.info(f"Common node is {common_nodes}")
+    return common_nodes

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -420,7 +420,7 @@ def get_app_pod_running_nodes(pod_obj):
         list: App pod running node names
 
     """
-    return [pod.get_pod_node(node).name for node in pod_obj]
+    return [pod.get_pod_node(obj_pod).name for obj_pod in pod_obj]
 
 
 def get_both_osd_and_app_pod_running_node(

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -424,7 +424,7 @@ def get_app_pod_running_nodes(pod_obj):
 
 
 def get_both_osd_and_app_pod_running_node(
-        osd_running_nodes, app_pod_running_nodes
+    osd_running_nodes, app_pod_running_nodes
 ):
     """
      Gets both osd and app pod running node names

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1178,3 +1178,21 @@ def get_noobaa_pods(noobaa_label=constants.NOOBAA_APP_LABEL, namespace=None):
     noobaa_pods = [Pod(**noobaa) for noobaa in noobaas]
 
     return noobaa_pods
+
+
+def wait_for_dc_app_pods_to_reach_running_state(dc_pod_obj):
+    """
+    Wait for DC app pods to reach running state
+
+    Args:
+        dc_pod_obj (list): list of dc app pod objects
+
+    """
+    for pod_obj in dc_pod_obj:
+        name = pod_obj.get_labels().get('name')
+        dpod_list = get_all_pods(selector_label=f"name={name}", wait=True)
+        for dpod in dpod_list:
+            if '-1-deploy' not in dpod.name:
+                helpers.wait_for_resource_state(
+                    dpod, constants.STATUS_RUNNING, timeout=1200
+                )


### PR DESCRIPTION
Helper functions for DC based app pods which will require during node failure cases.
*. get_osd_running_nodes
*. get_app_pod_running_nodes
*. get_both_osd_and_app_pod_running_node
*. wait_for_dc_app_pods_to_reach_running_state

Signed-off-by: Prasad Desala <tdesala@redhat.com>