### PR TITLE
VDBench: adding new node for app pod

### DIFF
--- a/tests/e2e/performance/test_vdbench_workload.py
+++ b/tests/e2e/performance/test_vdbench_workload.py
@@ -47,7 +47,7 @@ def label_nodes(request, with_ocs):
 
     def teardown():
 
-        if with_ocs is True:
+        if with_ocs:
             return
 
         if m_set != '':
@@ -64,7 +64,7 @@ def label_nodes(request, with_ocs):
 
     request.addfinalizer(teardown)
 
-    if with_ocs is True:
+    if with_ocs:
         return
 
     # Add label to the worker nodes
@@ -158,10 +158,11 @@ class TestVDBenchWorkload(E2ETest):
                          marks=pytest.mark.workloads()),
         ],
     )
-    def test_vdbench_workload(self, template, with_ocs, label_nodes, ripsaw,
-                              servers, threads, blocksize, fileio, samples,
-                              width, depth, files, file_size, runtime, pause
-                              ):
+    def test_vdbench_workload(
+        self, template, with_ocs, label_nodes, ripsaw, servers, threads,
+        blocksize, fileio, samples, width, depth, files, file_size, runtime,
+        pause
+    ):
         """
         Run VDBench Workload
 

--- a/tests/e2e/performance/test_vdbench_workload.py
+++ b/tests/e2e/performance/test_vdbench_workload.py
@@ -37,26 +37,55 @@ def retrive_files_from_pod(pod_name, localpath, remotepath):
 
 
 @pytest.fixture(scope='function')
-def label_nodes(request):
+def label_nodes(request, with_ocs):
     """
     Fixture to label the node(s) that will run the application pod.
     That will be all workers node that do not run the OCS cluster.
     """
+
+    m_set = ''  # this will hold machine_set name that added
+
     def teardown():
-        log.info('Clear label form worker (Application) nodes')
-        # Getting all Application nodes
-        app_nodes = machine.get_labeled_nodes(constants.APP_NODE_LABEL)
-        helpers.remove_label_from_worker_node(app_nodes,
-                                              constants.APP_NODE_LABEL)
+
+        if with_ocs is True:
+            return
+
+        if m_set != '':
+            log.info(f'Destroy {m_set}')
+            machine.delete_custom_machineset(m_set)
+        else:
+            log.info('Clear label form worker (Application) nodes')
+            # Getting all Application nodes
+            app_nodes = machine.get_labeled_nodes(constants.APP_NODE_LABEL)
+            log.debug(f'The application nodes are : {app_nodes}')
+            helpers.remove_label_from_worker_node(
+                app_nodes, constants.VDBENCH_NODE_LABEL
+            )
 
     request.addfinalizer(teardown)
 
+    if with_ocs is True:
+        return
+
+    # Add label to the worker nodes
+
     # Getting all OCS nodes (to verify app pod wil not run on)
     ocs_nodes = machine.get_labeled_nodes(constants.OPERATOR_NODE_LABEL)
-    # Add label to the worker nodes
     worker_nodes = helpers.get_worker_nodes()
     # Getting list of free nodes
     free_nodes = list(set(worker_nodes) - set(ocs_nodes))
+
+    if not free_nodes:
+        # No free nodes -  Creating new machineset for application pods
+        log.info('Adding new machineset, with worker for application pod')
+        m_set = machine.create_custom_machineset(label=constants.APP_NODE_LABEL)
+        machine.wait_for_new_node_to_be_ready(m_set)
+
+        free_nodes = machine.get_labeled_nodes(
+            f'node-role.kubernetes.io/app={constants.APP_NODE_LABEL}'
+        )
+
+        # TODO: implement this for VMWare as well.
 
     log.info('Adding the app-node label to Non-OCS workers')
     log.debug(f'The Workers nodes are : {worker_nodes}')
@@ -107,37 +136,39 @@ class TestVDBenchWorkload(E2ETest):
     """
 
     @pytest.mark.parametrize(
-        argnames=['template', 'servers', 'threads', 'blocksize', 'fileio',
-                  'samples', 'width', 'depth', 'files', 'file_size', 'runtime',
-                  'pause'],
+        argnames=['template', 'with_ocs', 'servers', 'threads', 'blocksize',
+                  'fileio', 'samples', 'width', 'depth', 'files', 'file_size',
+                  'runtime', 'pause'],
         argvalues=[
-            pytest.param(*["VDBench-BCurve.yaml",
+            pytest.param(*["VDBench-BCurve.yaml", True,
                            9, 4, ["4k"], "random",
                            1, 4, 3, 256, 5, 600, 5]),
-            pytest.param(*["VDBench-BCurve.yaml",
+            pytest.param(*["VDBench-BCurve.yaml", True,
                            9, 4, ["64k"], "random",
                            1, 4, 3, 256, 5, 600, 5]),
-            pytest.param(*["VDBench-BCurve-FS.yaml",
+            pytest.param(*["VDBench-BCurve-FS.yaml", True,
                            9, 4, ["4k"], "random",
                            1, 4, 3, 256, 5, 600, 5]),
-            pytest.param(*["VDBench-BCurve-FS.yaml",
+            pytest.param(*["VDBench-BCurve-FS.yaml", True,
                            9, 4, ["64k"], "random",
                            1, 4, 3, 256, 5, 600, 5]),
-            pytest.param(*["VDBench-Basic.yaml",
-                           9, 4, ["4k"], "random",
+            pytest.param(*["VDBench-Basic.yaml", True,
+                           9, 4, ["4k", "64k"], "random",
                            1, 4, 3, 256, 5, 600, 1],
                          marks=pytest.mark.workloads()),
         ],
     )
-    def test_vdbench_workload(self, template, label_nodes, ripsaw, servers,
-                              threads, blocksize, fileio, samples, width,
-                              depth, files, file_size, runtime, pause
+    def test_vdbench_workload(self, template, with_ocs, label_nodes, ripsaw,
+                              servers, threads, blocksize, fileio, samples,
+                              width, depth, files, file_size, runtime, pause
                               ):
         """
         Run VDBench Workload
 
         Args :
             template (str) : Name of yaml file that will used as a template
+            with_ocs (bool) : This parameter will indicate if the test will
+                              run on the same nodes as the OCS
             label_nodes (fixture) : This fixture is labeling the worker(s)
                                     that will used for App. pod(s)
             ripsaw (fixture) : Fixture to deploy the ripsaw benchmarking operator
@@ -202,6 +233,9 @@ class TestVDBenchWorkload(E2ETest):
         if len(blocksize) > 0:
             sf_data['spec']['workload']['args']['bs'] = blocksize
             target_results = target_results + '-' + '_'.join(blocksize)
+        if with_ocs:
+            if sf_data['spec']['workload']['args']['pin_server']:
+                del sf_data['spec']['workload']['args']['pin_server']
 
         """
             Calculating the size of the volume that need to be test, it should


### PR DESCRIPTION
Adding new parameter for selecting if the app pod will run on the same
workers as the OCS or on a dedicated worker.
In case of dedicated worker it will create new machineset for that.

This PR is replacing   #1520 
Signed-off-by: Avi Liani <alayani@redhat.com>