### PR TITLE
improving logging in run_cmd()

### DIFF
--- a/ocs_ci/utility/tests/test_utils.py
+++ b/ocs_ci/utility/tests/test_utils.py
@@ -1,0 +1,106 @@
+# -*- coding: utf8 -*-
+
+import logging
+
+import pytest
+
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.utility import utils
+
+
+def test_mask_secret_null():
+    """
+    Checking that mask_secret function works with empty arguments.
+    """
+    assert utils.mask_secrets("", None) == ""
+
+
+def test_mask_secret_nosecrets():
+    """
+    Checking that mask_secret function doesn't change plaintext when secrets
+    are not specified.
+    """
+    assert utils.mask_secrets("ls -lh /tmp", None) == "ls -lh /tmp"
+
+
+def test_mask_secret_nomatch():
+    """
+    Checking that mask_secret function works when there is no match.
+    """
+    secrets = [
+        "8bca8d2e-1cd6-4ec0-8e55-9614aa01cf88",
+        "683c08d7-bc07-4d72-b098-46ef00b74aec",
+    ]
+    assert utils.mask_secrets("ls -lh /tmp", secrets) == "ls -lh /tmp"
+
+
+def test_mask_secret_simple_positive():
+    """
+    Checking that mask_secret function works in a simple positive case.
+    """
+    secrets = ["8bca8d2e-1cd6", "683c08d7-bc07"]
+    cmd = "ls -lh /tmp/8bca8d2e /tmp/683c08d7-bc07 /1cd6-4ec0-8e55"
+    cmd_masked_expected = "ls -lh /tmp/8bca8d2e /tmp/***** /1cd6-4ec0-8e55"
+    assert utils.mask_secrets(cmd, secrets) == cmd_masked_expected
+
+
+def test_run_cmd_simple_positive(caplog):
+    """
+    Check simple positive use case for run_cmd, including logging.
+    """
+    caplog.set_level(logging.DEBUG)
+    cmd = "echo -n hello"
+    assert utils.run_cmd(cmd) == "hello"
+    # check that run_cmd logged the run as expected
+    assert caplog.records[0].levelname == 'INFO'
+    assert caplog.records[0].message == f'Executing command: {cmd}'
+    assert caplog.records[1].levelname == 'DEBUG'
+    assert caplog.records[1].message == 'Command stdout: hello'
+    assert caplog.records[2].levelname == 'DEBUG'
+    assert caplog.records[2].message == 'Command stderr is empty'
+    assert caplog.records[3].levelname == 'DEBUG'
+    assert caplog.records[3].message == 'Command return code: 0'
+
+
+def test_run_cmd_simple_negative(caplog):
+    """
+    Check simple negative use case for run_cmd, including logging.
+    """
+    caplog.set_level(logging.DEBUG)
+    cmd = "ls /tmp/this/file/isindeednotthereatall"
+    with pytest.raises(CommandFailed) as excinfo:
+        utils.run_cmd(cmd)
+        assert "No such file or directory" in str(excinfo.value)
+    # check that run_cmd logged the run as expected
+    assert caplog.records[0].levelname == 'INFO'
+    assert caplog.records[0].message == f'Executing command: {cmd}'
+    assert caplog.records[1].levelname == 'DEBUG'
+    assert caplog.records[1].message == 'Command stdout is empty'
+    assert caplog.records[2].levelname == 'WARNING'
+    assert caplog.records[2].message == (
+        "Command stderr: "
+        "ls: cannot access '/tmp/this/file/isindeednotthereatall': "
+        "No such file or directory\n")
+    assert caplog.records[3].levelname == 'DEBUG'
+    assert caplog.records[3].message == 'Command return code: 2'
+
+
+def test_run_cmd_simple_negative_ignoreerror(caplog):
+    """
+    Check simple negative use case for run_cmd with ignore error and logging.
+    """
+    caplog.set_level(logging.DEBUG)
+    cmd = "ls /tmp/this/file/isindeednotthereatall"
+    assert utils.run_cmd(cmd, ignore_error=True) == ""
+    # check that run_cmd logged the run as expected
+    assert caplog.records[0].levelname == 'INFO'
+    assert caplog.records[0].message == f'Executing command: {cmd}'
+    assert caplog.records[1].levelname == 'DEBUG'
+    assert caplog.records[1].message == 'Command stdout is empty'
+    assert caplog.records[2].levelname == 'WARNING'
+    assert caplog.records[2].message == (
+        "Command stderr: "
+        "ls: cannot access '/tmp/this/file/isindeednotthereatall': "
+        "No such file or directory\n")
+    assert caplog.records[3].levelname == 'DEBUG'
+    assert caplog.records[3].message == 'Command return code: 2'

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -411,13 +411,20 @@ def run_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         timeout=timeout,
         **kwargs
     )
-    log.debug(f"Command output: {r.stdout.decode()}")
-    if r.stderr and not r.returncode:
-        log.warning(f"Command warning: {mask_secrets(r.stderr.decode(), secrets)}")
+    if len(r.stdout) > 0:
+        log.debug(f"Command stdout: {r.stdout.decode()}")
+    else:
+        log.debug(f"Command stdout is empty")
+    masked_stderr = mask_secrets(r.stderr.decode(), secrets)
+    if len(r.stderr) > 0:
+        log.warning(f"Command stderr: {masked_stderr}")
+    else:
+        log.debug(f"Command stderr is empty")
+    log.debug(f"Command return code: {r.returncode}")
     if r.returncode and not ignore_error:
         raise CommandFailed(
             f"Error during execution of command: {masked_cmd}."
-            f"\nError is {mask_secrets(r.stderr.decode(), secrets)}"
+            f"\nError is {masked_stderr}"
         )
     return mask_secrets(r.stdout.decode(), secrets)
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -414,12 +414,12 @@ def run_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     if len(r.stdout) > 0:
         log.debug(f"Command stdout: {r.stdout.decode()}")
     else:
-        log.debug(f"Command stdout is empty")
+        log.debug("Command stdout is empty")
     masked_stderr = mask_secrets(r.stderr.decode(), secrets)
     if len(r.stderr) > 0:
         log.warning(f"Command stderr: {masked_stderr}")
     else:
-        log.debug(f"Command stderr is empty")
+        log.debug("Command stderr is empty")
     log.debug(f"Command return code: {r.returncode}")
     if r.returncode and not ignore_error:
         raise CommandFailed(


### PR DESCRIPTION
This change improves logging in `run_cmd()` utility function so that all aspects of a cmd run (stdout, stderr and retcode) are always logged with at least DEBUG level, so that one can read test DEBUG logs to immediately understand what happened without knowledge of run_cmd internals.

In a positive use case like `run_cmd("echo -n hello")` a test log would contain:

```
19:01:25 - MainThread - ocs_ci.utility.utils - INFO - Executing command: echo -n hello
19:01:25 - MainThread - ocs_ci.utility.utils - DEBUG - Command stdout: hello    
19:01:25 - MainThread - ocs_ci.utility.utils - DEBUG - Command stderr is empty  
19:01:25 - MainThread - ocs_ci.utility.utils - DEBUG - Command return code: 0
```

In a negative use case like `run_cmd("ls /tmp/this/file/isindeednotthereatal")`, log would contain:

```
19:02:12 - MainThread - ocs_ci.utility.utils - INFO - Executing command: ls /tmp/this/file/isindeednotthereatall
19:02:12 - MainThread - ocs_ci.utility.utils - DEBUG - Command stdout is empty  
19:02:12 - MainThread - ocs_ci.utility.utils - WARNING - Command stderr: ls: cannot access '/tmp/this/file/isindeednotthereatall': No such file or directory
19:02:12 - MainThread - ocs_ci.utility.utils - DEBUG - Command return code: 2 
```

and `CommandFailed` exception with stderr message would be raised (no change here).

These cases are covered in unit tests.

Based on experience with debugging a CI run.

fixes https://github.com/red-hat-storage/ocs-ci/issues/1606

