### PR TITLE
Fix test_automated_recovery_from_failed_nodes_proactive_IPI test failure by adding WA

### DIFF
--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -87,7 +87,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                         name  = pod_obj.name[:-17]
                         command = f"delete deployment {name}"
                         ocp_obj.exec_oc_cmd(command=command)
-                        log.info("Deleted canary pod")
+                        log.info(f"Deleted deployment for pod {pod_obj.name}")
 
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -84,7 +84,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 except ResourceWrongStatusException:
                     if 'rook-ceph-crashcollector' in pod_obj.name:
                         ocp_obj = ocp.OCP()
-                        name  = pod_obj.name[:-17]
+                        name = pod_obj.name[:-17]
                         command = f"delete deployment {name}"
                         ocp_obj.exec_oc_cmd(command=command)
                         log.info(f"Deleted deployment for pod {pod_obj.name}")

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -68,9 +68,14 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
         # Check the pods should be in running state
         all_pod_obj = pod.get_all_pods(wait=True)
         for pod_obj in all_pod_obj:
-            wait_for_resource_state(
-                resource=pod_obj, state=constants.STATUS_RUNNING, timeout=200
-            )
+            # 'rook-ceph-crashcollector' on the failed node stucks at pending
+            # state. BZ 1810014 tracks it.
+            # Ignoring 'rook-ceph-crashcollector' pod health check as WA.
+            # Will revert this WA once the BZ is fixed
+            if 'rook-ceph-crashcollector' not in pod_obj.name:
+                wait_for_resource_state(
+                    resource=pod_obj, state=constants.STATUS_RUNNING, timeout=200
+                )
 
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),


### PR DESCRIPTION
In OCS4.3, post machine delete 'rook-ceph-crashcollector' on the failed node stucks at pending state. BZ 1810014 tracks it.

Instead of skipping the entire test case with this BZ,  as a WA ignoring 'rook-ceph-crashcollector' pod health check so that the functionality will be tested.

Signed-off-by: Prasad Desala <tdesala@redhat.com>