### PR TITLE
Test case to validate Multipart Upload on buckets

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -683,7 +683,8 @@ class MCG(object):
             Bucket=bucketname,
             Key=object_key,
             UploadId=upload_id,
-            MultipartUpload={"Parts": parts})
+            MultipartUpload={"Parts": parts}
+        )
         return result
 
     def abort_multipart_upload(self, bucketname, object_key):
@@ -697,13 +698,13 @@ class MCG(object):
             list : List of aborted upload ids
 
         """
-        aborted = []
         multipart_list = self.s3_client.list_multipart_uploads(Bucket=bucketname)
-        print("Aborting", len(multipart_list), "uploads")
+        logger.info(f"Aborting{len(multipart_list)} uploads")
         if "Uploads" in multipart_list:
-            for i in multipart_list["Uploads"]:
-                upload_id = i["UploadId"]
-                aborted.append(
-                    self.s3_client.abort_multipart_upload(
-                        Bucket=bucketname, Key=object_key, UploadId=upload_id))
-        return aborted
+            return [
+                self.s3_client.abort_multipart_upload(
+                    Bucket=bucketname, Key=object_key, UploadId=upload["UploadId"]
+                ) for upload in multipart_list["Uploads"]
+            ]
+        else:
+            return None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1511,6 +1511,38 @@ def craft_s3_command(mcg_obj, cmd):
     return f"{base_command}{cmd}{string_wrapper}"
 
 
+def craft_s3_api_command(mcg_obj, cmd):
+    """
+    Crafts the AWS cli S3 API level commands including the
+    login credentials and command to be ran
+
+    Args:
+        mcg_obj: An MCG object containing the MCG S3 connection credentials
+        cmd: The AWSCLI API command to run
+
+    Returns:
+        str: The crafted command, ready to be executed on the pod
+
+    """
+    if mcg_obj:
+        base_command = (
+            f"sh -c \"AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} "
+            f"AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} "
+            f"AWS_DEFAULT_REGION={mcg_obj.region} "
+            f"aws s3api "
+            f"--endpoint={mcg_obj.s3_endpoint} "
+            f"--no-verify-ssl "
+        )
+        string_wrapper = "\""
+    else:
+        base_command = (
+            f"aws s3api --no-verify-ssl --no-sign-request "
+        )
+        string_wrapper = ''
+
+    return f"{base_command}{cmd}{string_wrapper}"
+
+
 def wait_for_resource_count_change(
     func_to_use, previous_num, namespace, change_type='increase',
     min_difference=1, timeout=20, interval=2, **func_kwargs

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1513,8 +1513,7 @@ def craft_s3_command(mcg_obj, cmd):
 
 def craft_s3_api_command(mcg_obj, cmd):
     """
-    Crafts the AWS cli S3 API level commands including the
-    login credentials and command to be ran
+    Crafts the AWS cli S3 API level commands
 
     Args:
         mcg_obj: An MCG object containing the MCG S3 connection credentials

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -123,10 +123,11 @@ def write_individual_s3_objects(mcg_obj, awscli_pod, bucket_factory, downloaded_
 def upload_parts(mcg_obj, awscli_pod, bucketname, object_key, body_path, upload_id, uploaded_parts):
     """
     Uploads individual parts to a bucket
+
     Args:
         mcg_obj (obj): An MCG object containing the MCG S3 connection credentials
         awscli_pod (pod): A pod running the AWSCLI tools
-        bucketname: Name of the bucket to upload parts on
+        bucketname (str): Name of the bucket to upload parts on
         object_key (list): Unique object Identifier
         body_path (str): Path of the directory on the aws pod which contains the parts to be uploaded
         upload_id (str): Multipart Upload-ID
@@ -139,9 +140,12 @@ def upload_parts(mcg_obj, awscli_pod, bucketname, object_key, body_path, upload_
     parts = []
     secrets = [mcg_obj.access_key_id, mcg_obj.access_key, mcg_obj.s3_endpoint]
     for count, part in enumerate(uploaded_parts, 1):
-        upload_cmd = f'upload-part --bucket {bucketname} --key {object_key}' \
-            f' --part-number {count} --body {body_path}/{part} ' \
-            f'--upload-id {upload_id}'
+        upload_cmd = (
+            f'upload-part --bucket {bucketname} --key {object_key}'
+            f' --part-number {count} --body {body_path}/{part}'
+            f' --upload-id {upload_id}'
+        )
+        # upload_cmd will return ETag, upload_id etc which is then split to get just the ETag
         part = awscli_pod.exec_cmd_on_pod(
             command=craft_s3_api_command(mcg_obj, upload_cmd), out_yaml_format=False,
             secrets=secrets

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -4,7 +4,7 @@ import boto3
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_rgw_pod
-from tests.helpers import logger, craft_s3_command
+from tests.helpers import logger, craft_s3_command, craft_s3_api_command
 
 
 def retrieve_test_objects_to_pod(podobj, target_dir):
@@ -118,3 +118,33 @@ def write_individual_s3_objects(mcg_obj, awscli_pod, bucket_factory, downloaded_
             command=craft_s3_command(mcg_obj, copycommand), out_yaml_format=False,
             secrets=[mcg_obj.access_key_id, mcg_obj.access_key, mcg_obj.s3_endpoint]
         )
+
+
+def upload_parts(mcg_obj, awscli_pod, bucketname, object_key, body_path, upload_id, uploaded_parts):
+    """
+    Uploads individual parts to a bucket
+    Args:
+        mcg_obj (obj): An MCG object containing the MCG S3 connection credentials
+        awscli_pod (pod): A pod running the AWSCLI tools
+        bucketname: Name of the bucket to upload parts on
+        object_key (list): Unique object Identifier
+        body_path (str): Path of the directory on the aws pod which contains the parts to be uploaded
+        upload_id (str): Multipart Upload-ID
+        uploaded_parts (list): list containing the name of the parts to be uploaded
+
+    Returns:
+        list: List containing the ETag of the parts
+
+    """
+    parts = []
+    secrets = [mcg_obj.access_key_id, mcg_obj.access_key, mcg_obj.s3_endpoint]
+    for count, part in enumerate(uploaded_parts, 1):
+        upload_cmd = f'upload-part --bucket {bucketname} --key {object_key}' \
+            f' --part-number {count} --body {body_path}/{part} ' \
+            f'--upload-id {upload_id}'
+        part = awscli_pod.exec_cmd_on_pod(
+            command=craft_s3_api_command(mcg_obj, upload_cmd), out_yaml_format=False,
+            secrets=secrets
+        ).split("\"")[-3].split("\\")[0]
+        parts.append({"PartNumber": count, "ETag": f'"{part}"'})
+    return parts

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -18,7 +18,7 @@ def setup(pod_obj, bucket_factory):
 
      Args:
         pod_obj (Pod): A pod running the AWS CLI tools
-        bucket_factory: bucket_factory: Calling this fixture creates a new bucket(s)
+        bucket_factory: Calling this fixture creates a new bucket(s)
 
     Returns:
         Tuple: Returns tuple containing the params used in this test case
@@ -62,6 +62,7 @@ class TestS3MultipartUpload(ManageTest):
         logger.info(f'Listing the Multipart Upload : {mcg_obj.list_multipart_upload(bucket)}')
 
         # Uploading individual parts to the Bucket
+        logger.info(f'Uploading individual parts to the bucket {bucket}')
         uploaded_parts = helpers.upload_parts(mcg_obj, awscli_pod, bucket, key, res_dir, upload_id, parts)
 
         # Listing the Uploaded parts

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -80,4 +80,3 @@ class TestS3MultipartUpload(ManageTest):
             original_object_path=f'{origin_dir}/{key}',
             result_object_path=f'{res_dir}/{key}', awscli_pod=awscli_pod
         ), 'Checksum comparision between original and result object failed'
-

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -1,0 +1,83 @@
+import logging
+
+import pytest
+import uuid
+
+from ocs_ci.framework.pytest_customization.marks import filter_insecure_request_warning
+from ocs_ci.framework.testlib import (
+    ManageTest, tier1
+)
+from tests.manage.mcg import helpers
+
+logger = logging.getLogger(__name__)
+
+
+def setup(pod_obj, bucket_factory):
+    """
+    Setup function
+
+     Args:
+        pod_obj (Pod): A pod running the AWS CLI tools
+        bucket_factory: bucket_factory: Calling this fixture creates a new bucket(s)
+
+    Returns:
+        Tuple: Returns tuple containing the params used in this test case
+
+    """
+    bucket = bucket_factory(amount=1, interface='OC')[0].name
+    object_key = "ObjKey-" + str(uuid.uuid4().hex)
+    origin_dir = "/aws/objectdir"
+    res_dir = "/aws/partsdir"
+    full_object_path = f"s3://{bucket}"
+    # Creates a 500MB file and splits it into multiple parts
+    pod_obj.exec_cmd_on_pod(
+        f'sh -c "mkdir {origin_dir}; mkdir {res_dir}; '
+        f'dd if=/dev/urandom of={origin_dir}/{object_key} bs=1MB count=500; '
+        f'split -a 1 -b 41m {origin_dir}/{object_key} {res_dir}/part"'
+    )
+    parts = pod_obj.exec_cmd_on_pod(f'sh -c "ls -1 {res_dir}"').split()
+    return bucket, object_key, origin_dir, res_dir, full_object_path, parts
+
+
+@filter_insecure_request_warning
+class TestS3MultipartUpload(ManageTest):
+    """
+    Test Multipart upload on Noobaa buckets
+    """
+    @pytest.mark.polarion_id("OCS-1387")
+    @tier1
+    def test_multipart_upload_operations(self, mcg_obj, awscli_pod, bucket_factory):
+        """
+        Test Multipart upload operations on bucket and verifies the integrity of the downloaded object
+        """
+        bucket, key, origin_dir, res_dir, object_path, parts = setup(awscli_pod, bucket_factory)
+
+        # Abort all Multipart Uploads for this Bucket (optional, for starting over)
+        logger.info(f'Aborting any Multipart Upload on bucket:{bucket}')
+        mcg_obj.abort_multipart_upload(bucket, key)
+
+        # Create & list Multipart Upload on the Bucket
+        logger.info(f'Initiating Multipart Upload on Bucket: {bucket} with Key {key}')
+        upload_id = mcg_obj.create_multipart_upload(bucket, key)
+        logger.info(f'Listing the Multipart Upload : {mcg_obj.list_multipart_upload(bucket)}')
+
+        # Uploading individual parts to the Bucket
+        uploaded_parts = helpers.upload_parts(mcg_obj, awscli_pod, bucket, key, res_dir, upload_id, parts)
+
+        # Listing the Uploaded parts
+        logger.info(f'Listing the individual parts : {mcg_obj.list_uploaded_parts(bucket, key, upload_id)}')
+
+        # Completing the Multipart Upload
+        logger.info(f'Completing the Multipart Upload on bucket: {bucket}')
+        logger.info(mcg_obj.complete_multipart_upload(bucket, key, upload_id, uploaded_parts))
+
+        # Checksum Validation: Downloading the object after completing Multipart Upload and verifying its integrity
+        logger.info(f'Downloading the completed multipart object from MCG bucket to awscli pod')
+        helpers.sync_object_directory(
+            awscli_pod, object_path, res_dir, mcg_obj
+        )
+        assert mcg_obj.verify_s3_object_integrity(
+            original_object_path=f'{origin_dir}/{key}',
+            result_object_path=f'{res_dir}/{key}', awscli_pod=awscli_pod
+        ), 'Checksum comparision between original and result object failed'
+


### PR DESCRIPTION
This test case covers Multipart Upload which allows the user to upload a single object as a set of parts. After all parts of your object are uploaded, S3 then presents the data as a single object. With this feature you can create parallel uploads.