### PR TITLE
Test to verify ceph block pool is not blocked by another invalid pool…

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -300,7 +300,7 @@ def default_ceph_block_pool():
     return constants.DEFAULT_BLOCKPOOL
 
 
-def create_ceph_block_pool(pool_name=None):
+def create_ceph_block_pool(pool_name=None, failure_domain=None, verify=True):
     """
     Create a Ceph block pool
     ** This method should not be used anymore **
@@ -308,6 +308,9 @@ def create_ceph_block_pool(pool_name=None):
 
     Args:
         pool_name (str): The pool name to create
+        failure_domain (str): Failure domain name
+        verify (bool): True to verify the pool exists after creation,
+                       False otherwise
 
     Returns:
         OCS: An OCS instance for the Ceph block pool
@@ -319,13 +322,14 @@ def create_ceph_block_pool(pool_name=None):
         )
     )
     cbp_data['metadata']['namespace'] = defaults.ROOK_CLUSTER_NAMESPACE
-    cbp_data['spec']['failureDomain'] = get_failure_domin()
+    cbp_data['spec']['failureDomain'] = failure_domain or get_failure_domin()
     cbp_obj = create_resource(**cbp_data)
     cbp_obj.reload()
 
-    assert verify_block_pool_exists(cbp_obj.name), (
-        f"Block pool {cbp_obj.name} does not exist"
-    )
+    if verify:
+        assert verify_block_pool_exists(cbp_obj.name), (
+            f"Block pool {cbp_obj.name} does not exist"
+        )
     return cbp_obj
 
 

--- a/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -29,8 +29,10 @@ def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(teardown_factory):
         f"present in pools list"
     )
 
+    log.info("Create valid ceph block pool")
     cbp_valid = helpers.create_ceph_block_pool(verify=False)
     teardown_factory(cbp_valid)
     assert helpers.verify_block_pool_exists(cbp_valid.name), (
         f"Ceph Block Pool {cbp_valid.name} is not created."
     )
+    log.info(f"Verified: {cbp_valid.name} is created")

--- a/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -1,0 +1,36 @@
+import logging
+
+from tests import helpers
+from ocs_ci.framework.testlib import polarion_id, skipif_ocs_version, tier2
+
+log = logging.getLogger(__name__)
+
+
+@tier2
+@skipif_ocs_version('<4.3')
+@polarion_id('OCS-2130')
+def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(teardown_factory):
+    """
+    Test to verify new ceph block pool can be created without deleting
+    ceph block pool having invalid parameters
+    Verifies bz 1711814
+    """
+    log.info("Trying creating ceph block pool with invalid failure domain.")
+    cbp_invalid = helpers.create_ceph_block_pool(
+        failure_domain='no-failure-domain', verify=False
+    )
+    teardown_factory(cbp_invalid)
+    assert not helpers.verify_block_pool_exists(cbp_invalid.name), (
+        f"Unexpected: Ceph Block Pool {cbp_invalid.name} created with "
+        f"invalid failure domain."
+    )
+    log.info(
+        f"Expected: {cbp_invalid.name} with invalid failure domain is not "
+        f"present in pools list"
+    )
+
+    cbp_valid = helpers.create_ceph_block_pool(verify=False)
+    teardown_factory(cbp_valid)
+    assert helpers.verify_block_pool_exists(cbp_valid.name), (
+        f"Ceph Block Pool {cbp_valid.name} is not created."
+    )


### PR DESCRIPTION
… creation

Test to verify new ceph block pool can be created without deleting
ceph block pool having invalid parameters
Verifies bug https://bugzilla.redhat.com/show_bug.cgi?id=1711814

Signed-off-by: Jilju Joy <jijoy@redhat.com>