### PR TITLE
Set pytest to version 5.3.5 because 5.4.0 is breaking unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'openshift',
         'boto3',
         'munch',
-        'pytest',
+        'pytest==5.3.5',
         'pytest-reportportal==1.0.5',
         'pytest-logger',
         'dataclasses',  # For compatibility with python 3.6


### PR DESCRIPTION
Fixes: #1646 

Signed-off-by: Coady LaCroix <clacroix@redhat.com>