### PR TITLE
setup: be more generous in version requirement for kubernetes module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'paramiko==2.4.2',
         'pyyaml>=4.2b1',
         'jinja2==2.10.1',
-        'kubernetes==10.0.1',  # latest openshift requires this version
+        'kubernetes~=10.0.1',  # latest openshift requires this version
         'openshift',
         'boto3',
         'munch',


### PR DESCRIPTION
kubernetes 11.0.0 broke openshift. It requires `~=10.0.1`.
In the previous patch #1645 , the exact version 10.0.1 was required.
This change is relaxing the setup requirement to be `~=10.0.1`.
Not strictly required but may be more future-proof in case 10.0.2 is released and we need it or 10.0.1 would become unavailable.

See https://github.com/red-hat-storage/ocs-ci/issues/1644

Signed-off-by: Michael Adam <obnox@redhat.com>