### PR TITLE
Fix quay-tag-image usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,9 +135,9 @@ pipeline {
         def registry_tag = registry_image.split(':')[-1]
         def ocs_version = registry_tag.split('-')[0]
         // tag ocs-registry container as 'latest-stable-$ocs_version'
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable-${ocs_version}")]
+        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "DESTINATION_URL", value: "quay.io/rhceph-dev/ocs-registry:latest-stable-${ocs_version}")]
         // tag ocs-olm-operator container as 'latest-stable'
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable-${ocs_version}")]
+        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "DESTINATION_URL", value: "quay.io/rhceph-dev/ocs-olm-operator:latest-stable-${ocs_version}")]
         if( env.UMB_MESSAGE in [true, 'true'] ) {
           def registry_version = registry_tag.split('-')[0]
           def properties = """


### PR DESCRIPTION
The quay-tag-image Jenkins job now requires full destionation url
instead of image name and tag string.

Signed-off-by: Boris Ranto <branto@redhat.com>