### PR TITLE
Add bugzilla marker to tests which delete rook-ceph-operator

### DIFF
--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -152,27 +152,45 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'create_pvc', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-927")
+            marks=[
+                pytest.mark.polarion_id("OCS-927"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'create_pod', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-925")
+            marks=[
+                pytest.mark.polarion_id("OCS-925"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'run_io', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-928")
+            marks=[
+                pytest.mark.polarion_id("OCS-928"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'create_pvc', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-937")
+            marks=[
+                pytest.mark.polarion_id("OCS-937"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'create_pod', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-936")
+            marks=[
+                pytest.mark.polarion_id("OCS-936"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'run_io', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-938")
+            marks=[
+                pytest.mark.polarion_id("OCS-938"),
+                pytest.mark.bugzilla('1815078')
+            ]
         )
     ]
 )

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -300,19 +300,31 @@ class DisruptionBase(ManageTest):
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'delete_pvcs', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-932")
+            marks=[
+                pytest.mark.polarion_id("OCS-932"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'delete_pods', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-931")
+            marks=[
+                pytest.mark.polarion_id("OCS-931"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'delete_pvcs', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-926")
+            marks=[
+                pytest.mark.polarion_id("OCS-926"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'delete_pods', 'operator'],
-            marks=pytest.mark.polarion_id("OCS-935")
+            marks=[
+                pytest.mark.polarion_id("OCS-935"),
+                pytest.mark.bugzilla('1815078')
+            ]
         )
     ]
 )

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -69,11 +69,17 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'operator'],
-            marks=pytest.mark.polarion_id("OCS-933")
+            marks=[
+                pytest.mark.polarion_id("OCS-933"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'operator'],
-            marks=pytest.mark.polarion_id("OCS-929")
+            marks=[
+                pytest.mark.polarion_id("OCS-929"),
+                pytest.mark.bugzilla('1815078')
+            ]
         )
     ]
 )

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -78,11 +78,17 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, 'operator'],
-            marks=pytest.mark.polarion_id("OCS-934")
+            marks=[
+                pytest.mark.polarion_id("OCS-934"),
+                pytest.mark.bugzilla('1815078')
+            ]
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, 'operator'],
-            marks=pytest.mark.polarion_id("OCS-930")
+            marks=[
+                pytest.mark.polarion_id("OCS-930"),
+                pytest.mark.bugzilla('1815078')
+            ]
         )
     ]
 )


### PR DESCRIPTION
Skip tests due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1815078

Signed-off-by: Jilju Joy <jijoy@redhat.com>