### PR TITLE
Allow pre-commit check-yaml to allow multi-document yaml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     - id: check-docstring-first
     - id: check-json
     - id: check-yaml
+      args: [--multi]
     - id: debug-statements
     - id: end-of-file-fixer
     - id: trailing-whitespace


### PR DESCRIPTION
Fixes: #1674 

Signed-off-by: Coady LaCroix <clacroix@redhat.com>