### PR TITLE
Test to verify must_gather_commands

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -644,3 +644,28 @@ OSD_TREE_ZONE = {
 
 # gather bootstrap
 GATHER_BOOTSTRAP_PATTERN = 'openshift-install gather bootstrap --help'
+
+# must-gather commands output files
+MUST_GATHER_COMMANDS = [
+    'ceph_versions', 'ceph_status', 'ceph_report', 'ceph_pg_dump',
+    'ceph_osd_tree', 'ceph_osd_stat', 'ceph_osd_dump', 'ceph_osd_df_tree',
+    'ceph_osd_crush_show-tunables', 'ceph_osd_crush_dump', 'ceph_mon_stat',
+    'ceph_mon_dump', 'ceph_mgr_dump', 'ceph_mds_stat', 'ceph_health_detail',
+    'ceph_fs_ls', 'ceph_fs_dump', 'ceph_df', 'ceph_auth_list',
+    'ceph-volume_lvm_list'
+]
+
+MUST_GATHER_COMMANDS_JSON = [
+    'ceph_versions_--format_json-pretty', 'ceph_status_--format_json-pretty',
+    'ceph_report_--format_json-pretty', 'ceph_pg_dump_--format_json-pretty',
+    'ceph_osd_tree_--format_json-pretty', 'ceph_osd_stat_--format_json-pretty',
+    'ceph_osd_dump_--format_json-pretty',
+    'ceph_osd_df_tree_--format_json-pretty',
+    'ceph_osd_crush_show-tunables_--format_json-pretty',
+    'ceph_osd_crush_dump_--format_json-pretty',
+    'ceph_mon_stat_--format_json-pretty', 'ceph_mon_dump_--format_json-pretty',
+    'ceph_mgr_dump_--format_json-pretty', 'ceph_mds_stat_--format_json-pretty',
+    'ceph_health_detail_--format_json-pretty',
+    'ceph_fs_ls_--format_json-pretty', 'ceph_fs_dump_--format_json-pretty',
+    'ceph_df_--format_json-pretty', 'ceph_auth_list_--format_json-pretty'
+]

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -75,6 +75,9 @@ class TestMustGather(ManageTest):
         Tests functionality of: oc adm must-gather
 
         """
+        # Fetch pod details
+        pods = pod.get_all_pods(namespace='openshift-storage')
+        pods = [each.name for each in pods]
 
         # Make logs root directory
         logger.info("Creating logs Directory")
@@ -89,8 +92,6 @@ class TestMustGather(ManageTest):
         # Compare running pods list to "/pods" subdirectories
         logger.info("Checking logs tree")
         logs = self.get_log_directories(directory)
-        pods = pod.get_all_pods(namespace='openshift-storage')
-        pods = [each.name for each in pods if 'must-gather' not in each.name]
         logger.info(f"Logs: {logs}")
         logger.info(f"pods list: {pods}")
         assert set(sorted(logs)) == set(sorted(pods)), (

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -90,13 +90,12 @@ class TestMustGather(ManageTest):
         logger.info("Checking logs tree")
         logs = self.get_log_directories(directory)
         pods = pod.get_all_pods(namespace='openshift-storage')
-        pods = [each.name for each in pods]
+        pods = [each.name for each in pods if 'must-gather' not in each.name]
         logger.info(f"Logs: {logs}")
         logger.info(f"pods list: {pods}")
         assert set(sorted(logs)) == set(sorted(pods)), (
-            "List of openshift-storage pods are not equal to list of "
-            "logs directories list of pods: {pods}"
-            f"list of log directories: {logs}"
+            f"List of openshift-storage pods are not equal to list of logs "
+            f"directories list of pods: {pods} list of log directories: {logs}"
         )
 
         # 2nd test: Verify logs file are not empty

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -91,7 +91,11 @@ class TestMustGather(ManageTest):
 
         # Compare running pods list to "/pods" subdirectories
         logger.info("Checking logs tree")
-        logs = self.get_log_directories(directory)
+        logs = [
+            logs for logs in self.get_log_directories(directory) if (
+                'must-gather' not in logs
+            )
+        ]
         logger.info(f"Logs: {logs}")
         logger.info(f"pods list: {pods}")
         assert set(sorted(logs)) == set(sorted(pods)), (


### PR DESCRIPTION
Verifies:
Bug [1776723](https://bugzilla.redhat.com/show_bug.cgi?id=1776723) - must_gather_command folder does not have any ceph command output files
Bug [1757863](https://bugzilla.redhat.com/show_bug.cgi?id=1757863) - most must_gather_commands files with output of ceph commands are empty


Signed-off-by: Jilju Joy <jijoy@redhat.com>