### PR TITLE
fix test: test_upgrade_ocp

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -877,26 +877,27 @@ def verify_images_upgraded(old_images, object_data):
     )
 
 
-def confirm_cluster_operator_version(target_version):
+def confirm_cluster_operator_version(target_version, cluster_operator):
     """
-    Check if OCP upgrade process is completed:
-    checks if all ClusterOperator images updated
+    Check if cluster operator upgrade process is completed:
 
     Args:
+        cluster_operator: (str): ClusterOperator name
         target_version (str): expected OCP client
 
     Returns:
         bool: True if success, False if failed
 
     """
-    log.info(f"target_version=: {target_version}")
-    cur_version = get_current_oc_version()
-    log.info(f"current OCP version is: {cur_version}")
+    log.info(f"target_version: {target_version}")
+    cur_version = get_cluster_operator_version(cluster_operator)
+    log.info(f"current {cluster_operator} operator version is: {cur_version}")
     if cur_version == target_version or target_version.startswith(cur_version):
-        log.info(f"cluster operator upgrade to build {target_version} completed")
+        log.info(f"{cluster_operator} cluster operator upgrade to build"
+                 f" {target_version} completed")
         return True
 
-    log.debug(f"upgrade not completed")
+    log.debug(f"{cluster_operator} upgrade not yet completed")
     return False
 
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -915,7 +915,7 @@ def upgrade_ocp(image_path, image):
         f"adm upgrade --to-image={image_path}:{image} "
         f"--allow-explicit-upgrade --force "
     )
-    log.info(f"Upgrading OCP to version: {image}")
+    log.info(f"Upgrading OCP to version: {image} ")
 
 
 def get_current_oc_version():

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -64,7 +64,8 @@ class TestUpgradeOCP(ManageTest):
                     timeout=2700,
                     sleep=60,
                     func=ocp.confirm_cluster_operator_version,
-                    target_version=target_image
+                    target_version=target_image,
+                    cluster_operator=ocp_operator
                 ):
                     logger.info(
                         f"ClusterOperator upgrade "


### PR DESCRIPTION
fixed function: confirm_cluster_operator_version:
 improved logging, added cluster as new argument, now it checks for each cluster operator if upgrade completed correctly

Signed-off-by: aviadp <apolak@redhat.com>