### PR TITLE
Set registry to managed state after OCP deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -163,19 +163,24 @@ class Deployment(object):
                 node=node, cmd_list=cmd_list
             )
         # end of workaround
+        self.set_registry_to_managed_state()
         self.add_stage_cert()
-        # In order to be able to deploy from stage we need to change
-        # image registry config to Managed state.
-        # More described in BZs:
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1806593
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1807471#c3
-        # We need to change to managed state as described here:
-        # https://github.com/red-hat-storage/ocs-ci/issues/1436
-        # So this is not suppose to be deleted as WA case we really need to do
-        # this operation for OCS deployment as was originally done here:
-        # https://github.com/red-hat-storage/ocs-ci/pull/1437
-        # Currently it has to be moved here to enable CA certificate to be
-        # properly propagated for the stage deployment as mentioned in BZ.
+
+    def set_registry_to_managed_state(self):
+        """
+        In order to be able to deploy from stage we need to change
+        image registry config to Managed state.
+        More described in BZs:
+        https://bugzilla.redhat.com/show_bug.cgi?id=1806593
+        https://bugzilla.redhat.com/show_bug.cgi?id=1807471#c3
+        We need to change to managed state as described here:
+        https://github.com/red-hat-storage/ocs-ci/issues/1436
+        So this is not suppose to be deleted as WA case we really need to do
+        this operation for OCS deployment as was originally done here:
+        https://github.com/red-hat-storage/ocs-ci/pull/1437
+        Currently it has to be moved here to enable CA certificate to be
+        properly propagated for the stage deployment as mentioned in BZ.
+        """
         if(config.ENV_DATA['platform'] not in constants.CLOUD_PLATFORMS):
             run_cmd(
                 f'oc patch {constants.IMAGE_REGISTRY_CONFIG} --type merge -p '

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -164,6 +164,27 @@ class Deployment(object):
             )
         # end of workaround
         self.add_stage_cert()
+        # In order to be able to deploy from stage we need to change
+        # image registry config to Managed state.
+        # More described in BZs:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1806593
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1807471#c3
+        # We need to change to managed state as described here:
+        # https://github.com/red-hat-storage/ocs-ci/issues/1436
+        # So this is not suppose to be deleted as WA case we really need to do
+        # this operation for OCS deployment as was originally done here:
+        # https://github.com/red-hat-storage/ocs-ci/pull/1437
+        # Currently it has to be moved here to enable CA certificate to be
+        # properly propagated for the stage deployment as mentioned in BZ.
+        if(config.ENV_DATA['platform'] not in constants.CLOUD_PLATFORMS):
+            run_cmd(
+                f'oc patch {constants.IMAGE_REGISTRY_CONFIG} --type merge -p '
+                f'\'{{"spec":{{"storage": {{"emptyDir":{{}}}}}}}}\''
+            )
+            run_cmd(
+                f'oc patch {constants.IMAGE_REGISTRY_CONFIG} --type merge -p '
+                f'\'{{"spec":{{"managementState": "Managed"}}}}\''
+            )
 
     def label_and_taint_nodes(self):
         """

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -37,15 +37,6 @@ def change_registry_backend_to_ocs():
         resource_name=constants.IMAGE_REGISTRY_RESOURCE_NAME, params=param_cmd, format_type='json'
     ), f"Registry pod storage backend to OCS is not success"
 
-    if(config.ENV_DATA['platform'] not in constants.CLOUD_PLATFORMS):
-        run_cmd(
-            f'oc patch {constants.IMAGE_REGISTRY_CONFIG} --type merge -p '
-            f'\'{{"spec":{{"managementState": "Managed"}}}}\''
-        )
-        logger.info(
-            "Waiting 30 seconds after change managementState of image-registry."
-        )
-        time.sleep(30)
     # Validate registry pod status
     validate_registry_pod_status()
 


### PR DESCRIPTION
In order to fix stage deployment on OCP 4.3 we need to move change of
registry to managed state after the deployment of OCP.

Fixes: #1706

Signed-off-by: Petr Balogh <pbalogh@redhat.com>