### PR TITLE
Temporarily skip tests that utilize datasets that are too big 

### DIFF
--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -17,6 +17,7 @@ LARGE_FILE_KEY = "1000G_2504_high_coverage/data/ERR3239276/NA06985.final.cram"
 FILESIZE_SKIP = pytest.mark.skip('Current test filesize is too large.')
 RUNTIME_SKIP = pytest.mark.skip('Runtime is too long; Code needs to be parallelized')
 
+
 @filter_insecure_request_warning
 class TestObjectIntegrity(ManageTest):
     """

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -14,12 +14,13 @@ logger = logging.getLogger(__name__)
 
 PUBLIC_BUCKET = "1000genomes"
 LARGE_FILE_KEY = "1000G_2504_high_coverage/data/ERR3239276/NA06985.final.cram"
-
+FILESIZE_SKIP = pytest.mark.skip('Current test filesize is too large.')
+RUNTIME_SKIP = pytest.mark.skip('Runtime is too long; Code needs to be parallelized')
 
 @filter_insecure_request_warning
-class TestBucketIntegrity(ManageTest):
+class TestObjectIntegrity(ManageTest):
     """
-    Test data integrity of a bucket
+    Test data integrity of various objects
     """
     @pytest.mark.filterwarnings(
         'ignore::urllib3.exceptions.InsecureRequestWarning'
@@ -63,11 +64,11 @@ class TestBucketIntegrity(ManageTest):
         argvalues=[
             pytest.param(
                 *[1, 'large'],
-                marks=[pytest.mark.polarion_id("OCS-1944"), tier2]
+                marks=[pytest.mark.polarion_id("OCS-1944"), tier2, FILESIZE_SKIP]
             ),
             pytest.param(
                 *[100, 'large'],
-                marks=[pytest.mark.polarion_id("OCS-1946"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1946"), tier3, FILESIZE_SKIP]
             ),
             pytest.param(
                 *[1, 'small'],
@@ -75,11 +76,11 @@ class TestBucketIntegrity(ManageTest):
             ),
             pytest.param(
                 *[1000, 'small'],
-                marks=[pytest.mark.polarion_id("OCS-1951"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1951"), tier3, RUNTIME_SKIP]
             ),
             pytest.param(
                 *[100, 'large_small'],
-                marks=[pytest.mark.polarion_id("OCS-1952"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1952"), tier3, FILESIZE_SKIP]
             ),
         ]
     )
@@ -163,7 +164,7 @@ class TestBucketIntegrity(ManageTest):
 
         # Touch create 1000 empty files in pod
         awscli_pod.exec_cmd_on_pod(command=f'mkdir {original_dir} {result_dir}')
-        command = "for i in $(seq 1 1000); do touch /data/test$i; done"
+        command = "for i in $(seq 1 100); do touch /data/test$i; done"
         awscli_pod.exec_sh_cmd_on_pod(
             command=command,
             sh='sh'
@@ -180,7 +181,7 @@ class TestBucketIntegrity(ManageTest):
         )
 
         # Checksum is compared between original and result object
-        for obj in ('test' + str(i + 1) for i in range(1000)):
+        for obj in ('test' + str(i + 1) for i in range(100)):
             assert mcg_obj.verify_s3_object_integrity(
                 original_object_path=f'{original_dir}/{obj}',
                 result_object_path=f'{result_dir}/{obj}', awscli_pod=awscli_pod

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 PUBLIC_BUCKET = "1000genomes"
 LARGE_FILE_KEY = "1000G_2504_high_coverage/data/ERR3239276/NA06985.final.cram"
-
+FILESIZE_SKIP = pytest.mark.skip('Current test filesize is too large.')
+RUNTIME_SKIP = pytest.mark.skip('Runtime is too long; Code needs to be parallelized')
 
 def pod_io(pods):
     """
@@ -93,11 +94,11 @@ class TestBucketIO(ManageTest):
         argvalues=[
             pytest.param(
                 *[1, 'large'],
-                marks=[pytest.mark.polarion_id("OCS-1944"), tier2]
+                marks=[pytest.mark.polarion_id("OCS-1944"), tier2, FILESIZE_SKIP]
             ),
             pytest.param(
                 *[100, 'large'],
-                marks=[pytest.mark.polarion_id("OCS-1946"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1946"), tier3, FILESIZE_SKIP]
             ),
             pytest.param(
                 *[1, 'small'],
@@ -105,11 +106,11 @@ class TestBucketIO(ManageTest):
             ),
             pytest.param(
                 *[1000, 'small'],
-                marks=[pytest.mark.polarion_id("OCS-1951"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1951"), tier3, RUNTIME_SKIP]
             ),
             pytest.param(
                 *[100, 'large_small'],
-                marks=[pytest.mark.polarion_id("OCS-1952"), tier3]
+                marks=[pytest.mark.polarion_id("OCS-1952"), tier3, FILESIZE_SKIP]
             ),
         ]
     )
@@ -190,7 +191,7 @@ class TestBucketIO(ManageTest):
 
         # Touch create 1000 empty files in pod
         awscli_pod.exec_cmd_on_pod(command=f'mkdir {data_dir}')
-        command = "for i in $(seq 1 1000); do touch /data/test$i; done"
+        command = "for i in $(seq 1 100); do touch /data/test$i; done"
         awscli_pod.exec_sh_cmd_on_pod(
             command=command,
             sh='sh'
@@ -204,7 +205,7 @@ class TestBucketIO(ManageTest):
             obj.key for obj in
             mcg_obj.s3_list_all_objects_in_bucket(bucketname)
         )
-        test_set = set('test' + str(i + 1) for i in range(1000))
+        test_set = set('test' + str(i + 1) for i in range(100))
         assert test_set == obj_set, "File name set does not match"
 
     @pytest.fixture()

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -20,6 +20,7 @@ LARGE_FILE_KEY = "1000G_2504_high_coverage/data/ERR3239276/NA06985.final.cram"
 FILESIZE_SKIP = pytest.mark.skip('Current test filesize is too large.')
 RUNTIME_SKIP = pytest.mark.skip('Runtime is too long; Code needs to be parallelized')
 
+
 def pod_io(pods):
     """
     Running IOs on rbd and cephfs pods


### PR DESCRIPTION
...and take too long to run

A temporary workaround for #1659