### PR TITLE
Fix upgrade test to apply changes in subscription

### DIFF
--- a/conf/upgrade/upgrade_in_current_source.yaml
+++ b/conf/upgrade/upgrade_in_current_source.yaml
@@ -1,0 +1,6 @@
+---
+# This configuration file is for upgrade purpose in current OCS source.
+# Mainly upgrade from live content to live content like 4.2 to 4.3
+# or from stage to stage content between different channels.
+UPGRADE:
+  upgrade_in_current_source: True


### PR DESCRIPTION
Fixes: #1718

Also with this change it should allow us now to test upgrade on existing
source like live to live content or stage to stage with only change of
channel in the subscription.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>