### PR TITLE
Fixes: #1716 aws-cleanup, ci-cleanup: Allow deletion of UPI clusters

### DIFF
--- a/ocs_ci/cleanup/aws/cleanup.py
+++ b/ocs_ci/cleanup/aws/cleanup.py
@@ -21,7 +21,7 @@ from ocs_ci.cleanup.aws import defaults
 FORMAT = (
     '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 )
-logging.basicConfig(format=FORMAT, level=logging.INFO)
+logging.basicConfig(format=FORMAT, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/ocs_ci/cleanup/aws/cleanup.py
+++ b/ocs_ci/cleanup/aws/cleanup.py
@@ -215,7 +215,7 @@ def cluster_cleanup():
     for id in args.cluster:
         cluster_name = id[0].rsplit('-', 1)[0]
         logger.info(f"cleaning up {id[0]}")
-        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0], args.upi[0]))
+        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0], args.upi))
         proc.start()
         procs.append(proc)
     for p in procs:

--- a/ocs_ci/cleanup/aws/cleanup.py
+++ b/ocs_ci/cleanup/aws/cleanup.py
@@ -205,19 +205,17 @@ def cluster_cleanup():
     )
     parser.add_argument(
         '--upi',
-        nargs=1,
-        action='append',
+        action='store_true',
         required=False,
-        help="Cluster name tag"
+        help="For UPI cluster deletion"
     )
     logging.basicConfig(level=logging.DEBUG)
     args = parser.parse_args()
     procs = []
     for id in args.cluster:
-        upi = args.upi[0]
         cluster_name = id[0].rsplit('-', 1)[0]
         logger.info(f"cleaning up {id[0]}")
-        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0], upi))
+        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0], args.upi[0]))
         proc.start()
         procs.append(proc)
     for p in procs:

--- a/ocs_ci/cleanup/aws/cleanup.py
+++ b/ocs_ci/cleanup/aws/cleanup.py
@@ -6,28 +6,35 @@ import threading
 import os
 import re
 
+from botocore.exceptions import ClientError
+
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import CLEANUP_YAML, TEMPLATE_CLEANUP_DIR
-from ocs_ci.utility.utils import get_openshift_installer, run_cmd
+from ocs_ci.utility.utils import get_openshift_installer, destroy_cluster
 from ocs_ci.utility import templating
-from ocs_ci.utility.aws import AWS
+from ocs_ci.utility.aws import (
+    AWS, terminate_rhel_workers, destroy_volumes, get_rhel_worker_instances
+)
 from ocs_ci.cleanup.aws import defaults
 
 
 FORMAT = (
     '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 )
-logging.basicConfig(format=FORMAT, level=logging.DEBUG)
+logging.basicConfig(format=FORMAT, level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def cleanup(cluster_name, cluster_id):
+def cleanup(cluster_name, cluster_id, upi=False, no_instances=False):
     """
     Cleanup existing cluster in AWS
 
     Args:
         cluster_name (str): Name of the cluster
         cluster_id (str): Cluster id to cleanup
+        upi (bool): True for UPI cluster, False otherwise
+        no_instances (bool): True if the given cluster doesn't have running instances.
+            (has to be UPI)
 
     """
     data = {'cluster_name': cluster_name, 'cluster_id': cluster_id}
@@ -39,8 +46,63 @@ def cleanup(cluster_name, cluster_id):
         temp.write(cleanup_template)
     bin_dir = os.path.expanduser(config.RUN['bin_dir'])
     oc_bin = os.path.join(bin_dir, "openshift-install")
-    logger.info(f"cleaning up {cluster_id}")
-    run_cmd(f"{oc_bin} destroy cluster --dir {cleanup_path} --log-level=debug")
+
+    if upi:
+        aws = AWS()
+        rhel_workers = get_rhel_worker_instances(cleanup_path)
+        logger.info(f"{cluster_name}'s RHEL workers: {rhel_workers}")
+        if rhel_workers:
+            terminate_rhel_workers(rhel_workers)
+        # Destroy extra volumes
+        destroy_volumes(cluster_name)
+
+        stack_names = list()
+        # Get master, bootstrap and security group stacks
+        for stack_type in ['ma', 'bs', 'sg']:
+            try:
+                stack_names.append(
+                    aws.get_cloudformation_stacks(
+                        pattern=f"{cluster_name}-{stack_type}"
+                    )[0]['StackName']
+                )
+            except ClientError:
+                continue
+
+        # Get the worker stacks
+        worker_index = 0
+        worker_stack_exists = True
+        while worker_stack_exists:
+            try:
+                stack_names.append(
+                    aws.get_cloudformation_stacks(
+                        pattern=f"{cluster_name}-no{worker_index}"
+                    )[0]['StackName']
+                )
+                worker_index += 1
+            except ClientError:
+                worker_stack_exists = False
+
+        logger.info(f"Deleting stacks: {stack_names}")
+        aws.delete_cloudformation_stacks(stack_names)
+
+        if not no_instances:
+            # Destroy the cluster
+            logger.info(f"cleaning up {cluster_id}")
+            destroy_cluster(installer=oc_bin, cluster_path=cleanup_path)
+
+        for stack_type in ['inf', 'vpc']:
+            try:
+                stack_names.append(
+                    aws.get_cloudformation_stacks(
+                        pattern=f"{cluster_name}-{stack_type}"
+                    )[0]['StackName']
+                )
+            except ClientError:
+                continue
+        aws.delete_cloudformation_stacks(stack_names)
+    else:
+        logger.info(f"cleaning up {cluster_id}")
+        destroy_cluster(installer=oc_bin, cluster_path=cleanup_path)
 
 
 def get_clusters_to_delete(time_to_delete, region_name, prefixes_hours_to_spare):
@@ -61,26 +123,8 @@ def get_clusters_to_delete(time_to_delete, region_name, prefixes_hours_to_spare)
             ci-cleanup script and a list of VPCs that are part of cloudformations
 
     """
-    aws = AWS(region_name=region_name)
-    clusters_to_delete = list()
-    cloudformation_vpcs = list()
-    vpcs = aws.ec2_client.describe_vpcs()['Vpcs']
-    vpc_ids = [vpc['VpcId'] for vpc in vpcs]
-    vpc_objs = [aws.ec2_resource.Vpc(vpc_id) for vpc_id in vpc_ids]
-    for vpc_obj in vpc_objs:
-        vpc_tags = vpc_obj.tags
-        vpc_cloudformation = [
-            tag['Value'] for tag in vpc_tags if tag['Key'] == defaults.AWS_CLOUDFORMATION_TAG
-        ]
-        if vpc_cloudformation:
-            cloudformation_vpcs.append(vpc_cloudformation)
-            continue
-        vpc_name = [tag['Value'] for tag in vpc_tags if tag['Key'] == 'Name'][0]
-        cluster_name = vpc_name[:-4]
-        vpc_instances = vpc_obj.instances.all()
-        if not vpc_instances:
-            clusters_to_delete.append(cluster_name)
-        for instance in vpc_instances:
+    def determine_cluster_deletion(ec2_instances, cluster_name):
+        for instance in ec2_instances:
             allowed_running_time = time_to_delete
             do_not_delete = False
             if instance.state["Name"] == "running":
@@ -97,14 +141,57 @@ def get_clusters_to_delete(time_to_delete, region_name, prefixes_hours_to_spare)
                         "%s marked as 'do not delete' and will not be "
                         "destroyed", cluster_name
                     )
+                    return False
                 else:
                     launch_time = instance.launch_time
                     current_time = datetime.datetime.now(launch_time.tzinfo)
                     running_time = current_time - launch_time
                     if running_time.seconds > allowed_running_time:
-                        clusters_to_delete.append(cluster_name)
-                break
-    return clusters_to_delete, cloudformation_vpcs
+                        return True
+            return False
+
+    aws = AWS(region_name=region_name)
+    clusters_to_delete = list()
+    cloudformation_vpc_names = list()
+    vpcs = aws.ec2_client.describe_vpcs()['Vpcs']
+    vpc_ids = [vpc['VpcId'] for vpc in vpcs]
+    vpc_objs = [aws.ec2_resource.Vpc(vpc_id) for vpc_id in vpc_ids]
+    for vpc_obj in vpc_objs:
+        vpc_tags = vpc_obj.tags
+        cloudformation_vpc_name = [
+            tag['Value'] for tag in vpc_tags if tag['Key'] == defaults.AWS_CLOUDFORMATION_TAG
+        ]
+        if cloudformation_vpc_name:
+            cloudformation_vpc_names.append(cloudformation_vpc_name[0])
+            continue
+        vpc_name = [tag['Value'] for tag in vpc_tags if tag['Key'] == 'Name'][0]
+        cluster_name = vpc_name.strip('-vpc')
+        vpc_instances = vpc_obj.instances.all()
+        if not vpc_instances:
+            clusters_to_delete.append(cluster_name)
+            continue
+
+        # Append to clusters_to_delete if cluster should be deleted
+        if determine_cluster_deletion(vpc_instances, cluster_name):
+            clusters_to_delete.append(cluster_name)
+
+    # Get all cloudformation based clusters to delete
+    cf_clusters_to_delete = list()
+    cf_clusters_to_delete_no_instances = list()
+    for vpc_name in cloudformation_vpc_names:
+        instance_dicts = aws.get_instances_by_name_pattern(vpc_name.strip('-vpc'))
+        ec2_instances = [aws.get_ec2_instance(instance_dict['id']) for instance_dict in instance_dicts]
+        if not ec2_instances:
+            cf_clusters_to_delete_no_instances.append(vpc_name.strip('-vpc'))
+            continue
+        cluster_io_tag = [
+            tag['Key'] for tag in ec2_instances[0].tags if 'kubernetes.io/cluster' in tag['Key']
+        ]
+        cluster_name = cluster_io_tag[0].strip('kubernetes.io/cluster/')
+        if determine_cluster_deletion(ec2_instances, cluster_name):
+            cf_clusters_to_delete.append(cluster_name)
+
+    return clusters_to_delete, cf_clusters_to_delete, cf_clusters_to_delete_no_instances
 
 
 def cluster_cleanup():
@@ -116,13 +203,21 @@ def cluster_cleanup():
         required=True,
         help="Cluster name tag"
     )
+    parser.add_argument(
+        '--upi',
+        nargs=1,
+        action='append',
+        required=False,
+        help="Cluster name tag"
+    )
     logging.basicConfig(level=logging.DEBUG)
     args = parser.parse_args()
     procs = []
     for id in args.cluster:
+        upi = args.upi[0]
         cluster_name = id[0].rsplit('-', 1)[0]
         logger.info(f"cleaning up {id[0]}")
-        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0]))
+        proc = threading.Thread(target=cleanup, args=(cluster_name, id[0], upi))
         proc.start()
         procs.append(proc)
     for p in procs:
@@ -198,9 +293,11 @@ def aws_cleanup():
 
     time_to_delete = args.hours * 60 * 60
     region = defaults.AWS_REGION if not args.region else args.region
-    clusters_to_delete, cloudformation_vpcs = get_clusters_to_delete(
-        time_to_delete=time_to_delete, region_name=region,
-        prefixes_hours_to_spare=prefixes_hours_to_spare,
+    clusters_to_delete, cf_clusters_to_delete, cf_clusters_to_delete_no_instances = (
+        get_clusters_to_delete(
+            time_to_delete=time_to_delete, region_name=region,
+            prefixes_hours_to_spare=prefixes_hours_to_spare,
+        )
     )
 
     if not clusters_to_delete:
@@ -217,11 +314,22 @@ def aws_cleanup():
         procs.append(proc)
     for p in procs:
         p.join()
-    if cloudformation_vpcs:
-        logger.warning(
-            "The following cloudformation VPCs were found: %s",
-            cloudformation_vpcs
-        )
+    for cluster in cf_clusters_to_delete:
+        cluster_name = cluster.rsplit('-', 1)[0]
+        logger.info(f"Deleting UPI cluster {cluster_name}")
+        proc = threading.Thread(target=cleanup, args=(cluster_name, cluster, True))
+        proc.start()
+        procs.append(proc)
+    for p in procs:
+        p.join()
+    for cluster in cf_clusters_to_delete_no_instances:
+        cluster_name = cluster
+        logger.info(f"Deleting UPI cluster (without EC2 instances) {cluster_name}")
+        proc = threading.Thread(target=cleanup, args=(cluster_name, cluster, True, True))
+        proc.start()
+        procs.append(proc)
+    for p in procs:
+        p.join()
 
 
 def prefix_hour_mapping(string):

--- a/ocs_ci/cleanup/aws/defaults.py
+++ b/ocs_ci/cleanup/aws/defaults.py
@@ -7,5 +7,5 @@ CLUSTER_PREFIXES_SPECIAL_RULES = {
     'LR5': 120
 }
 MINIMUM_CLUSTER_RUNNING_TIME = 10
-AWS_CLOUDFORMATION_TAG = 'aws:cloudformation:stack-id'
+AWS_CLOUDFORMATION_TAG = 'aws:cloudformation:stack-name'
 CONFIRMATION_ANSWER = 'yes-i-am-sure-i-want-to-proceed'

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -5,11 +5,9 @@ on AWS platform
 import logging
 import os
 import shutil
-import traceback
 from subprocess import PIPE, Popen
 
 import boto3
-from botocore.exceptions import ClientError
 
 from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
 from ocs_ci.framework import config
@@ -17,7 +15,9 @@ from ocs_ci.ocs import constants, exceptions, ocp
 from ocs_ci.ocs.parallel import parallel
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility import templating
-from ocs_ci.utility.aws import AWS as AWSUtil
+from ocs_ci.utility.aws import (
+    AWS as AWSUtil, terminate_rhel_workers, destroy_volumes, get_rhel_worker_instances
+)
 from ocs_ci.utility.bootstrap import gather_bootstrap
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
@@ -185,21 +185,6 @@ class AWSBase(Deployment):
             return True
         return False
 
-    def destroy_volumes(self):
-        try:
-            # Retrieve AWS region from metadata
-            # Find and delete volumes
-            volume_pattern = f"{self.cluster_name}*"
-            logger.debug(f"Finding volumes with pattern: {volume_pattern}")
-            volumes = self.aws.get_volumes_by_name_pattern(volume_pattern)
-            logger.debug(f"Found volumes: \n {volumes}")
-            for volume in volumes:
-                self.aws.detach_and_delete_volume(
-                    self.aws.ec2_resource.Volume(volume['id'])
-                )
-        except Exception:
-            logger.error(traceback.format_exc())
-
 
 class AWSIPI(AWSBase):
     """
@@ -270,7 +255,8 @@ class AWSIPI(AWSBase):
             log_level (str): log level openshift-installer (default: DEBUG)
         """
         super(AWSIPI, self).destroy_cluster(log_level)
-        self.destroy_volumes()
+        cluster_name = self.ocp_deployment.metadata.get('clusterName')
+        destroy_volumes(cluster_name)
 
 
 class AWSUPI(AWSBase):
@@ -794,68 +780,6 @@ class AWSUPI(AWSBase):
         self.create_rhel_instance()
         self.run_ansible_playbook()
 
-    def get_rhel_worker_instances(self):
-        """
-        Get list of rhel worker instance IDs
-
-        Returns:
-            list: list of instance IDs of rhel workers
-
-        """
-        rhel_workers = []
-        worker_pattern = get_infra_id(self.cluster_path) + "*rhel-worker*"
-        worker_filter = [{
-            'Name': 'tag:Name', 'Values': [worker_pattern]
-        }]
-
-        response = self.client.describe_instances(Filters=worker_filter)
-        for worker in response['Reservations']:
-            rhel_workers.append(worker['Instances'][0]['InstanceId'])
-        return rhel_workers
-
-    def terminate_rhel_workers(self, worker_list):
-        """
-        Terminate the RHEL worker instances
-
-        Args:
-            worker_list (list): Instance IDs of rhel workers
-
-        Raises:
-            exceptions.FailedToDeleteInstance: if failed to terminate
-
-        """
-        if not worker_list:
-            logger.info(
-                "No workers in list, skipping termination of RHEL workers"
-            )
-            return
-
-        logging.info(f"Terminating RHEL workers {worker_list}")
-        # Do a dry run of instance termination
-        try:
-            self.client.terminate_instances(
-                InstanceIds=worker_list,
-                DryRun=True,
-            )
-        except self.client.exceptions.ClientError as err:
-            if "DryRunOperation" in str(err):
-                logging.info("Instances can be deleted")
-            else:
-                logging.error("Some of the Instances can't be deleted")
-                raise exceptions.FailedToDeleteInstance()
-        # Actual termination call here
-        self.client.terminate_instances(
-            InstanceIds=worker_list,
-            DryRun=False,
-        )
-        try:
-            waiter = self.client.get_waiter('instance_terminated')
-            waiter.wait(InstanceIds=worker_list)
-            logging.info("Instances are terminated")
-        except self.client.exceptions.WaiterError as ex:
-            logging.error(f"Failed to terminate instances {ex}")
-            raise exceptions.FailedToDeleteInstance()
-
     def destroy_cluster(self, log_level="DEBUG"):
         """
         Destroy OCP cluster for AWS UPI
@@ -863,27 +787,24 @@ class AWSUPI(AWSBase):
         Args:
             log_level (str): log level for openshift-installer (
                 default:DEBUG)
+
         """
         cluster_name = get_cluster_name(self.cluster_path)
         if config.ENV_DATA.get('rhel_workers'):
-            self.terminate_rhel_workers(self.get_rhel_worker_instances())
-        # Destroy extra volumes
-        self.destroy_volumes()
+            terminate_rhel_workers(get_rhel_worker_instances(self.cluster_path))
 
-        # Create cloudformation client
-        cf = boto3.client('cloudformation', region_name=self.region)
+        # Destroy extra volumes
+        destroy_volumes(cluster_name)
 
         # Delete master, bootstrap, security group, and worker stacks
         suffixes = ['ma', 'bs', 'sg']
-        # TODO: read in num_workers in a better way
-        num_workers = int(os.environ.get('num_workers', 3))
+
+        num_workers = config.ENV_DATA['worker_replicas']
         for i in range(num_workers - 1, -1, -1):
             suffixes.insert(0, f'no{i}')
+
         stack_names = [f'{cluster_name}-{suffix}' for suffix in suffixes]
-        for stack_name in stack_names:
-            logger.info("Destroying stack: %s", stack_name)
-            cf.delete_stack(StackName=stack_name)
-            verify_stack_deleted(stack_name)
+        self.aws.delete_cloudformation_stacks(stack_names)
 
         # Call openshift-installer destroy cluster
         super(AWSUPI, self).destroy_cluster(log_level)
@@ -891,31 +812,4 @@ class AWSUPI(AWSBase):
         # Delete inf and vpc stacks
         suffixes = ['inf', 'vpc']
         stack_names = [f'{cluster_name}-{suffix}' for suffix in suffixes]
-        for stack_name in stack_names:
-            logger.info("Destroying stack: %s", stack_name)
-            cf.delete_stack(StackName=stack_name)
-            verify_stack_deleted(stack_name)
-
-
-class StackStatusError(Exception):
-    pass
-
-
-@retry(StackStatusError, tries=20, delay=30, backoff=1)
-def verify_stack_deleted(stack_name):
-    try:
-        cf = boto3.client(
-            'cloudformation', region_name=config.ENV_DATA['region']
-        )
-        result = cf.describe_stacks(StackName=stack_name)
-        stacks = result['Stacks']
-        for stack in stacks:
-            status = stack['StackStatus']
-            raise StackStatusError(
-                f'{stack_name} not deleted yet, current status: {status}.'
-            )
-    except ClientError as e:
-        assert f"Stack with id {stack_name} does not exist" in str(e)
-        logger.info(
-            "Received expected ClientError, stack successfully deleted"
-        )
+        self.aws.delete_cloudformation_stacks(stack_names)

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -254,9 +254,7 @@ class AWSIPI(AWSBase):
         Args:
             log_level (str): log level openshift-installer (default: DEBUG)
         """
-        super(AWSIPI, self).destroy_cluster(log_level)
-        cluster_name = self.ocp_deployment.metadata.get('clusterName')
-        destroy_volumes(cluster_name)
+        destroy_volumes(self.cluster_name)
 
 
 class AWSUPI(AWSBase):

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -4,17 +4,14 @@ This module provides base class for OCP deployment.
 import logging
 import os
 import json
-import traceback
 
 import pytest
 import yaml
 
-from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.openshift_ops import OCP
 from ocs_ci.utility import utils, templating, system
-from ocs_ci.utility.utils import run_cmd
 
 
 logger = logging.getLogger(__name__)
@@ -173,26 +170,13 @@ class OCPDeployment:
 
         Args:
             log_level (str): log level openshift-installer (default: DEBUG)
+
         """
-        logger.info("Destroying the cluster")
-        destroy_cmd = (
-            f"{self.installer} destroy cluster "
-            f"--dir {self.cluster_path} "
-            f"--log-level {log_level}"
+        # Retrieve cluster metadata
+        metadata_file = os.path.join(self.cluster_path, "metadata.json")
+        with open(metadata_file) as f:
+            self.metadata = json.loads(f.read())
+        utils.destroy_cluster(
+            installer=self.installer, cluster_path=self.cluster_path,
+            log_level=log_level
         )
-
-        try:
-            # Retrieve cluster metadata
-            metadata_file = os.path.join(self.cluster_path, "metadata.json")
-            with open(metadata_file) as f:
-                self.metadata = json.loads(f.read())
-
-            # Execute destroy cluster using OpenShift installer
-            logger.info(f"Destroying cluster defined in {self.cluster_path}")
-            run_cmd(destroy_cmd)
-
-        except CommandFailed:
-            logger.error(traceback.format_exc())
-            raise
-        except Exception:
-            logger.error(traceback.format_exc())

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2,9 +2,14 @@ import logging
 import time
 import boto3
 import random
+import traceback
 
+from botocore.exceptions import ClientError
+
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import get_infra_id
 from ocs_ci.framework import config
-from ocs_ci.ocs import constants
+from ocs_ci.ocs import constants, exceptions
 
 logger = logging.getLogger(name=__file__)
 
@@ -13,6 +18,10 @@ SLEEP = 3
 
 
 class AWSTimeoutException(Exception):
+    pass
+
+
+class StackStatusError(Exception):
     pass
 
 
@@ -665,6 +674,57 @@ class AWS(object):
                 self.append_security_group(sg, instance)
                 self.remove_security_group(security_group_id_to_remove, instance)
 
+    @property
+    def cf_client(self):
+        """
+        Property for cloudformation client
+
+        Returns:
+            boto3.client: instance of cloudformation
+
+        """
+        return boto3.client('cloudformation', region_name=self._region_name)
+
+    def get_cloudformation_stacks(self, pattern):
+        """
+        Get cloudformation stacks
+
+        Args:
+            pattern (str): The pattern of the stack name
+
+        """
+        result = self.cf_client.describe_stacks(StackName=pattern)
+        return result['Stacks']
+
+    def delete_cloudformation_stacks(self, stack_names):
+        """
+        Delete cloudformation stacks
+
+        Args:
+            stack_names (list): List of cloudformation stacks
+
+        """
+        @retry(StackStatusError, tries=20, delay=30, backoff=1)
+        def verify_stack_deleted(stack_name):
+            try:
+                stacks = self.get_cloudformation_stacks(stack_name)
+                for stack in stacks:
+                    status = stack['StackStatus']
+                    raise StackStatusError(
+                        f'{stack_name} not deleted yet, current status: {status}.'
+                    )
+            except ClientError as e:
+                assert f"Stack with id {stack_name} does not exist" in str(e)
+                logger.info(
+                    "Received expected ClientError, stack successfully deleted"
+                )
+
+        for stack_name in stack_names:
+            logger.info("Destroying stack: %s", stack_name)
+            self.cf_client.delete_stack(StackName=stack_name)
+        for stack_name in stack_names:
+            verify_stack_deleted(stack_name)
+
 
 def get_instances_ids_and_names(instances):
     """
@@ -720,3 +780,90 @@ def get_vpc_id_by_node_obj(aws_obj, instances):
     vpc_id = aws_obj.get_vpc_id_by_instance_id(instance_id)
 
     return vpc_id
+
+
+def get_rhel_worker_instances(cluster_path):
+    """
+    Get list of rhel worker instance IDs
+
+    Args:
+        cluster_path (str): The cluster path
+
+    Returns:
+        list: list of instance IDs of rhel workers
+
+    """
+    aws = AWS()
+    rhel_workers = []
+    worker_pattern = get_infra_id(cluster_path) + "*rhel-worker*"
+    worker_filter = [{
+        'Name': 'tag:Name', 'Values': [worker_pattern]
+    }]
+
+    response = aws.ec2_client.describe_instances(Filters=worker_filter)
+    if not response['Reservations']:
+        return
+    for worker in response['Reservations']:
+        rhel_workers.append(worker['Instances'][0]['InstanceId'])
+    return rhel_workers
+
+
+def terminate_rhel_workers(worker_list):
+    """
+    Terminate the RHEL worker EC2 instances
+
+    Args:
+        worker_list (list): Instance IDs of rhel workers
+
+    Raises:
+        exceptions.FailedToDeleteInstance: if failed to terminate
+
+    """
+    aws = AWS()
+    if not worker_list:
+        logger.info(
+            "No workers in list, skipping termination of RHEL workers"
+        )
+        return
+
+    logging.info(f"Terminating RHEL workers {worker_list}")
+    # Do a dry run of instance termination
+    try:
+        aws.ec2_client.terminate_instances(InstanceIds=worker_list, DryRun=True)
+    except aws.ec2_client.exceptions.ClientError as err:
+        if "DryRunOperation" in str(err):
+            logging.info("Instances can be deleted")
+        else:
+            logging.error("Some of the Instances can't be deleted")
+            raise exceptions.FailedToDeleteInstance()
+    # Actual termination call here
+    aws.ec2_client.terminate_instances(InstanceIds=worker_list, DryRun=False)
+    try:
+        waiter = aws.ec2_client.get_waiter('instance_terminated')
+        waiter.wait(InstanceIds=worker_list)
+        logging.info("Instances are terminated")
+    except aws.ec2_client.exceptions.WaiterError as ex:
+        logging.error(f"Failed to terminate instances {ex}")
+        raise exceptions.FailedToDeleteInstance()
+
+
+def destroy_volumes(cluster_name):
+    """
+    Destroy cluster volumes
+
+    Args:
+        cluster_name (str): The name of the cluster
+
+    """
+    aws = AWS()
+    try:
+        volume_pattern = f"{cluster_name}*"
+        logger.debug(f"Finding volumes with pattern: {volume_pattern}")
+        volumes = aws.get_volumes_by_name_pattern(volume_pattern)
+        logger.debug(f"Found volumes: \n {volumes}")
+        for volume in volumes:
+            aws.detach_and_delete_volume(
+                aws.ec2_resource.Volume(volume['id'])
+            )
+    except Exception:
+        logger.error(traceback.format_exc())

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -8,8 +8,10 @@ import shlex
 import string
 import subprocess
 import time
+import traceback
 from copy import deepcopy
 from shutil import which
+
 
 import requests
 import yaml
@@ -1907,3 +1909,31 @@ def load_config_file(config_file):
     ) as file_stream:
         custom_config_data = yaml.safe_load(file_stream)
         config.update(custom_config_data)
+
+
+def destroy_cluster(installer, cluster_path, log_level="DEBUG"):
+    """
+    Destroy OCP cluster specific
+
+
+    Args:
+        installer (str): The path to the installer binary
+        cluster_path (str): The path of the cluster
+        log_level (str): log level openshift-installer (default: DEBUG)
+
+    """
+    destroy_cmd = (
+        f"{installer} destroy cluster "
+        f"--dir {cluster_path} "
+        f"--log-level {log_level}"
+    )
+
+    try:
+        # Execute destroy cluster using OpenShift installer
+        log.info(f"Destroying cluster defined in {cluster_path}")
+        run_cmd(destroy_cmd)
+    except CommandFailed:
+        log.error(traceback.format_exc())
+        raise
+    except Exception:
+        log.error(traceback.format_exc())


### PR DESCRIPTION
aws-cleanup, ci-cleanup: Allow deleting UPI clusters, which are cloudformation based.

- Moved destroy cluster functionality to ocs_ci/utility/utils.py to be called from ocs_ci/deployment/ocp.py and ocs_ci/cleanup/aws/cleanup.py
- Moved AWS UPI related functions from ocs_ci/deployment/aws.py to ocs_ci/utility/aws.py
- Allow ci-cleanup to get --upi arg
- Allow aws-cleanup to send also cloudformation based clusters to ci-cleanup so UPI clusters will be deleted


Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>