### PR TITLE
Fix MCG multi-region test

### DIFF
--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -70,7 +70,8 @@ class TestMultiRegion:
         Test multi-region bucket creation using the S3 SDK
         """
 
-        bucket_name, backingstore1, backingstore2 = multiregion_mirror_setup
+        bucket, backingstore1, backingstore2 = multiregion_mirror_setup
+        bucket_name = bucket.name
 
         # Download test objects from the public bucket
         downloaded_objs = retrieve_test_objects_to_pod(awscli_pod, '/aws/original/')


### PR DESCRIPTION
The `multiregion_mirror_setup` code was changed to return an object instead of a name. Updating the test code to comply with the change.