### PR TITLE
Improve logging in tests

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -116,6 +116,7 @@ class Pod(OCS):
         Raises:
             Exception: In case of exception from FIO
         """
+        logger.info(f"Waiting for FIO results from pod {self.name}")
         try:
             result = self.fio_thread.result(FIO_TIMEOUT)
             if result:
@@ -592,7 +593,6 @@ def get_fio_rw_iops(pod_obj):
     Args:
         pod_obj (Pod): The object of the pod
     """
-    logging.info(f"Waiting for IO results from pod {pod_obj.name}")
     fio_result = pod_obj.get_fio_results()
     logging.info(f"FIO output: {fio_result}")
     logging.info("IOPs after FIO:")

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -239,6 +239,7 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in pod_objs:
+            log.info(f"Waiting for IO setup to complete on pod {pod_obj.name}")
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -268,11 +269,13 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
 
         log.info("Fetching FIO results.")
         for pod_obj in pod_objs:
+            log.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
                 f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
             )
+            log.info(f"FIO is success on pod {pod_obj.name}")
         log.info("Verified FIO result on pods.")
 
         # Delete pods
@@ -306,11 +309,13 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
 
         log.info("Fetching FIO results from new pods")
         for pod_obj in pod_objs:
+            log.info(f"Fetching FIO result from the pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
                 f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
             )
+            log.info(f"FIO is success on pod {pod_obj.name}")
         log.info("Verified FIO result on new pods.")
 
         # Verify number of pods of type 'resource_to_delete'

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -269,7 +269,6 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
 
         log.info("Fetching FIO results.")
         for pod_obj in pod_objs:
-            log.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -309,7 +308,6 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
 
         log.info("Fetching FIO results from new pods")
         for pod_obj in pod_objs:
-            log.info(f"Fetching FIO result from the pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
@@ -254,7 +254,6 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
         # Verify IO
         log.info("Fetching IO results from IO pods.")
         for pod_obj in io_pods:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -348,7 +347,6 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
 
         log.info("Fetching IO results from newly created pods")
         for pod_obj in pod_objs_re:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
@@ -182,6 +182,7 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in io_pods:
+            log.info(f"Waiting for IO setup to complete on pod {pod_obj.name}")
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -253,6 +254,7 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
         # Verify IO
         log.info("Fetching IO results from IO pods.")
         for pod_obj in io_pods:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -346,6 +348,7 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
 
         log.info("Fetching IO results from newly created pods")
         for pod_obj in pod_objs_re:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
@@ -413,7 +413,6 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
 
         log.info("Fetching IO results from the pods.")
         for pod_obj in io_pods:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
@@ -284,6 +284,7 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in pod_objs + rwx_pod_objs:
+            log.info(f"Waiting for IO setup to complete on pod {pod_obj.name}")
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -412,6 +413,7 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
 
         log.info("Fetching IO results from the pods.")
         for pod_obj in io_pods:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -362,7 +362,6 @@ class TestPVCDisruption(ManageTest):
 
         logger.info("Fetching FIO results.")
         for pod_obj in pod_objs:
-            logger.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -401,7 +400,6 @@ class TestPVCDisruption(ManageTest):
 
         logger.info("Fetching FIO results from new pods")
         for pod_obj in pod_objs:
-            logger.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -330,6 +330,9 @@ class TestPVCDisruption(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in pod_objs:
+            logger.info(
+                f"Waiting for IO setup to complete on pod {pod_obj.name}"
+            )
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -359,6 +362,7 @@ class TestPVCDisruption(ManageTest):
 
         logger.info("Fetching FIO results.")
         for pod_obj in pod_objs:
+            logger.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -397,6 +401,7 @@ class TestPVCDisruption(ManageTest):
 
         logger.info("Fetching FIO results from new pods")
         for pod_obj in pod_objs:
+            logger.info(f"Fetching FIO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -214,6 +214,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in io_pods:
+            log.info(f"Waiting for IO setup to complete on pod {pod_obj.name}")
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -282,6 +283,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Verify IO
         log.info("Fetching IO results from IO pods.")
         for pod_obj in io_pods:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -375,6 +377,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         log.info("Fetching IO results from newly created pods")
         for pod_obj in pod_objs_re:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -283,7 +283,6 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Verify IO
         log.info("Fetching IO results from IO pods.")
         for pod_obj in io_pods:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (
@@ -377,7 +376,6 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         log.info("Fetching IO results from newly created pods")
         for pod_obj in pod_objs_re:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -310,6 +310,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # Wait for setup on pods to complete
         for pod_obj in pod_objs + rwx_pod_objs:
+            log.info(f"Waiting for IO setup to complete on pod {pod_obj.name}")
             for sample in TimeoutSampler(
                 180, 2, getattr, pod_obj, 'wl_setup_done'
             ):
@@ -434,6 +435,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         log.info("Fetching IO results from the pods.")
         for pod_obj in io_pods:
+            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -435,7 +435,6 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         log.info("Fetching IO results from the pods.")
         for pod_obj in io_pods:
-            log.info(f"Fetching IO result from pod {pod_obj.name}")
             fio_result = pod_obj.get_fio_results()
             err_count = fio_result.get('jobs')[0].get('error')
             assert err_count == 0, (


### PR DESCRIPTION
Adding more logs in tests for easier analysis. 

tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
tests/manage/pv_services/test_pvc_disruptive.py
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py


Signed-off-by: Jilju Joy <jijoy@redhat.com>