### PR TITLE
Remove the 1TB object deletion test from Tier3 because of a long execution time

### DIFF
--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -197,7 +197,6 @@ class TestBucketDeletion:
 
     @pytest.mark.bugzilla("1753109")
     @pytest.mark.polarion_id("OCS-1924")
-    @tier3
     def test_s3_bucket_delete_1t_objects(self, mcg_obj, awscli_pod):
         """
         Test with deletion of bucket has 1T objects stored in.


### PR DESCRIPTION
The test takes around 8 hours to execute because of the time it takes to retrieve and write all the objects to the NooBucket.
It should still be run outside of tiered runs in order to verify we don't experience a regression.