### PR TITLE
AWS UPI needs more than 600 seconds as seen in one of the jenkins job…

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1931,7 +1931,7 @@ def destroy_cluster(installer, cluster_path, log_level="DEBUG"):
     try:
         # Execute destroy cluster using OpenShift installer
         log.info(f"Destroying cluster defined in {cluster_path}")
-        run_cmd(destroy_cmd)
+        run_cmd(destroy_cmd, timeout=1200)
     except CommandFailed:
         log.error(traceback.format_exc())
         raise


### PR DESCRIPTION
AWS UPI needs more than 600 seconds as seen in one of the jenkins jobs failure, to be safe double the timeout needed for destroy.

Issue seen in: https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-destroy-ocs-cluster/4649/

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>