### PR TITLE
add another ocp upgrade validation - check cluter operator status

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -988,15 +988,19 @@ def verify_cluster_operator_status(cluster_operator):
         cluster_operator (str): OCP cluster operator name
 
     Returns:
-        True if cluster operator status is valid
-        False if cluster operator status is "degraded" or "progressing"
+        bool: True if cluster operator status is valid, False if cluster operator status
+        is "degraded" or "progressing"
 
     """
-    ocp = OCP()
-    oc_json = ocp.exec_oc_cmd(
-        f'get clusteroperators {cluster_operator} -o json', out_yaml_format=False
+    # ocp = OCP()
+    # oc_json = ocp.exec_oc_cmd(
+    #     f'get clusteroperators {cluster_operator} -o json', out_yaml_format=False
+    # )
+    ocp = OCP(kind='clusteroperators')
+    operator_data = ocp.get(
+        resource_name=f'{cluster_operator} -o json', out_yaml_format=False
     )
-    operator_data = json.loads(oc_json)
+    # operator_data = json.loads(oc_json)
     conditions = operator_data['status']['conditions']
     for condition in conditions:
         if condition['type'] == 'Degraded' and condition['status'] == 'True':

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -992,10 +992,6 @@ def verify_cluster_operator_status(cluster_operator):
         is "degraded" or "progressing"
 
     """
-    # ocp = OCP()
-    # oc_json = ocp.exec_oc_cmd(
-    #     f'get clusteroperators {cluster_operator} -o json', out_yaml_format=False
-    # )
     ocp = OCP(kind='clusteroperators')
     operator_data = ocp.get(
         resource_name=f'{cluster_operator} -o json', out_yaml_format=False

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -77,7 +77,7 @@ class TestUpgradeOCP(ManageTest):
 
             # post upgrade validation: check cluster operator status
             for ocp_operator in self.cluster_operators:
-                logger.info(f"Checking cluster status of {ocp_operator}:")
+                logger.info(f"Checking cluster status of {ocp_operator}")
                 for sampler in TimeoutSampler(
                     timeout=2700,
                     sleep=60,

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -74,3 +74,19 @@ class TestUpgradeOCP(ManageTest):
                     )
                     if sampler:
                         break
+
+            # post upgrade validation: check cluster operator status
+            for ocp_operator in self.cluster_operators:
+                logger.info(f"Checking cluster status of {ocp_operator}:")
+                for sampler in TimeoutSampler(
+                    timeout=2700,
+                    sleep=60,
+                    func=ocp.verify_cluster_operator_status,
+                    cluster_operator=ocp_operator
+                ):
+                    logger.info(
+                        f"ClusterOperator status is  "
+                        f"{'valid' if sampler else 'status is not valid'}"
+                    )
+                    if sampler:
+                        break


### PR DESCRIPTION
This PR checks for each ClusterOperator if its status is "degraded" or "progressing", to avoid rare cases when cluster operator version has been updated but update not yet completed

added function: verify_cluster_operator_status, added this validation as another testing stage

Signed-off-by: aviadp <apolak@redhat.com>