### PR TITLE
Increase memory limit of fedora pod

### DIFF
--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -23,7 +23,7 @@ spec:
         image: fedora
         resources:
           limits:
-            memory: "500Mi"
+            memory: "800Mi"
             cpu: "150m"
         command: ["/bin/bash", "-ce", "tail -f /dev/null" ]
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Increase memory to resolve issue while running fio.
```
Command stdout: fio: pid=4003, err=12/file:filesetup.c:224, func=write, error=Cannot allocate memory
```
Signed-off-by: Jilju Joy <jijoy@redhat.com>