### PR TITLE
Change the data reduction threshold from 100MiB to 90MiB, add docs

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -295,7 +295,8 @@ class MCG(object):
 
         try:
             for total_size, total_reduced in TimeoutSampler(140, 5, _retrieve_reduction_data):
-                if total_size - total_reduced > 100 * 1024 * 1024:
+                # 43 * 2 MiBs should be removed thanks to deduplication. The rest is snappy compression.
+                if total_size - total_reduced > 90 * 1024 * 1024:
                     logger.info(
                         'Data reduced:' + str(total_size - total_reduced)
                     )


### PR DESCRIPTION
The MCG data reduction test yields inconsistent compression results.
This threshold should be pretty sound. 86MiB is the mere minimum to test deduplication, and along with compression should be between 93-110MiBs.