### PR TITLE
Make sure couchbase-operator namespace is deleted. (#1774)

### DIFF
--- a/ocs_ci/ocs/pillowfight.py
+++ b/ocs_ci/ocs/pillowfight.py
@@ -219,3 +219,8 @@ class PillowFight(object):
             except CommandFailed:
                 log.info(f"{pf_fullpath} object is already deleted")
         rmtree(self.logs)
+        nsinfo = self.pod_obj.exec_oc_cmd(command="get namespace")
+        if self.COUCHBASE_OPERATOR in nsinfo:
+            self.pod_obj.exec_oc_cmd(
+                command=f"delete namespace {self.COUCHBASE_OPERATOR}"
+            )


### PR DESCRIPTION
This does not always happen when the project is deleted.

Signed-off-by: wusui <wusui@redhat.com>