### PR TITLE
Fix scale issues observed during jenkins run

### DIFF
--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -10,6 +10,7 @@ import threading
 from tests import helpers
 from ocs_ci.framework.testlib import scale, E2ETest, polarion_id
 from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import ocsci_log_path
 
 log = logging.getLogger(__name__)
 
@@ -80,11 +81,25 @@ class TestPVCCreationDeletionScale(E2ETest):
             process.join()
 
         # Get pvc_name, require pvc_name to fetch creation time data from log
-        pvc_name_list, pv_name_list = ([] for i in range(2))
+        threads = list()
         for pvc_obj in pvc_objs:
-            pvc_obj.reload()
-            pvc_name_list.append(pvc_obj.name)
-            pv_name_list.append(pvc_obj.backed_pv)
+            process = threading.Thread(target=pvc_obj.reload)
+            process.start()
+            threads.append(process)
+        for process in threads:
+            process.join()
+
+        pvc_name_list, pv_name_list = ([] for i in range(2))
+        threads = list()
+        for pvc_obj in pvc_objs:
+            process1 = threading.Thread(target=pvc_name_list.append(pvc_obj.name))
+            process2 = threading.Thread(target=pv_name_list.append(pvc_obj.backed_pv))
+            process1.start()
+            process2.start()
+            threads.append(process1)
+            threads.append(process2)
+        for process in threads:
+            process.join()
 
         # Get PVC creation time
         pvc_create_time = helpers.measure_pvc_creation_time_bulk(
@@ -93,11 +108,12 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open(f"/tmp/{self.sc_obj}-{access_mode}-create.csv", "w"))
+        log_path = f"{ocsci_log_path()}/{self.sc_obj}-{access_mode}"
+        csv_obj = csv.writer(open(f"{log_path}-creation-time.csv", "w"))
         for k, v in pvc_create_time.items():
             csv_obj.writerow([k, v])
         logging.info(
-            f"Create data present in /tmp/{self.sc_obj}-{access_mode}-create.csv file"
+            f"Create data present in {log_path}-creation-time.csv file"
         )
 
         # Delete PVC
@@ -113,11 +129,11 @@ class TestPVCCreationDeletionScale(E2ETest):
         # Update result to csv file.
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open(f"/tmp/{self.sc_obj}-{access_mode}-delete.csv", "w"))
+        csv_obj = csv.writer(open(f"{log_path}-deletion-time.csv", "w"))
         for k, v in pvc_deletion_time.items():
             csv_obj.writerow([k, v])
         logging.info(
-            f"Delete data present in /tmp/{self.sc_obj}-{access_mode}-delete.csv file"
+            f"Delete data present in {log_path}-deletion-time.csv file"
         )
 
     @polarion_id('OCS-1885')
@@ -166,15 +182,35 @@ class TestPVCCreationDeletionScale(E2ETest):
             process.join()
 
         # Get pvc_name, require pvc_name to fetch creation time data from log
+        threads = list()
+        for fs_obj, rbd_obj in zip(fs_pvc_obj, rbd_pvc_obj):
+            process1 = threading.Thread(target=fs_obj.reload)
+            process2 = threading.Thread(target=rbd_obj.reload)
+            process1.start()
+            process2.start()
+            threads.append(process1)
+            threads.append(process2)
+        for process in threads:
+            process.join()
+
         fs_pvc_name, rbd_pvc_name = ([] for i in range(2))
         fs_pv_name, rbd_pv_name = ([] for i in range(2))
+        threads = list()
         for fs_obj, rbd_obj in zip(fs_pvc_obj, rbd_pvc_obj):
-            fs_obj.reload()
-            rbd_obj.reload()
-            fs_pvc_name.append(fs_obj.name)
-            rbd_pvc_name.append(rbd_obj.name)
-            fs_pv_name.append(fs_obj.backed_pv)
-            rbd_pv_name.append(rbd_obj.backed_pv)
+            process1 = threading.Thread(target=fs_pvc_name.append(fs_obj.name))
+            process2 = threading.Thread(target=rbd_pvc_name.append(rbd_obj.name))
+            process3 = threading.Thread(target=fs_pv_name.append(fs_obj.backed_pv))
+            process4 = threading.Thread(target=rbd_pv_name.append(rbd_obj.backed_pv))
+            process1.start()
+            process2.start()
+            process3.start()
+            process4.start()
+            threads.append(process1)
+            threads.append(process2)
+            threads.append(process3)
+            threads.append(process4)
+        for process in threads:
+            process.join()
 
         # Get PVC creation time
         fs_pvc_create_time = helpers.measure_pvc_creation_time_bulk(
@@ -187,11 +223,12 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open("/tmp/All-type-PVC-Creation-Scale.csv", "w"))
+        log_path = f"{ocsci_log_path()}/All-type-PVC"
+        csv_obj = csv.writer(open(f"{log_path}-creation-time.csv", "w"))
         for k, v in fs_pvc_create_time.items():
             csv_obj.writerow([k, v])
         logging.info(
-            f"Create data present in /tmp/All-type-PVC-Creation-Scale.csv file"
+            f"Create data present in {log_path}-creation-time.csv file"
         )
 
         # Delete PVC
@@ -211,9 +248,9 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open("/tmp/All-type-PVC-Deletion-Scale.csv", "w"))
+        csv_obj = csv.writer(open(f"{log_path}-deletion-time.csv", "w"))
         for k, v in fs_pvc_deletion_time.items():
             csv_obj.writerow([k, v])
         logging.info(
-            f"Delete data present in /tmp/All-type-PVC-Deletion-Scale.csv file"
+            f"Delete data present in {log_path}-deletion-time.csv file"
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1086,13 +1086,14 @@ def measure_pvc_creation_time(interface, pvc_name):
     return total.total_seconds()
 
 
-def measure_pvc_creation_time_bulk(interface, pvc_name_list):
+def measure_pvc_creation_time_bulk(interface, pvc_name_list, wait_time=60):
     """
     Measure PVC creation time of bulk PVC based on logs.
 
     Args:
         interface (str): The interface backed the PVC
         pvc_name_list (list): List of PVC Names for measuring creation time
+        wait_time (int): Seconds to wait before collecting CSI log
 
     Returns:
         pvc_dict (dict): Dictionary of pvc_name with creation time.
@@ -1100,6 +1101,8 @@ def measure_pvc_creation_time_bulk(interface, pvc_name_list):
     """
     # Get the correct provisioner pod based on the interface
     pod_name = pod.get_csi_provisioner_pod(interface)
+    # due to some delay in CSI log generation added wait
+    time.sleep(wait_time)
     # get the logs from the csi-provisioner containers
     logs = pod.get_pod_logs(pod_name[0], 'csi-provisioner')
     logs += pod.get_pod_logs(pod_name[1], 'csi-provisioner')
@@ -1126,13 +1129,14 @@ def measure_pvc_creation_time_bulk(interface, pvc_name_list):
     return pvc_dict
 
 
-def measure_pv_deletion_time_bulk(interface, pv_name_list):
+def measure_pv_deletion_time_bulk(interface, pv_name_list, wait_time=60):
     """
     Measure PV deletion time of bulk PV, based on logs.
 
     Args:
         interface (str): The interface backed the PV
         pv_name_list (list): List of PV Names for measuring deletion time
+        wait_time (int): Seconds to wait before collecting CSI log
 
     Returns:
         pv_dict (dict): Dictionary of pv_name with deletion time.
@@ -1140,6 +1144,8 @@ def measure_pv_deletion_time_bulk(interface, pv_name_list):
     """
     # Get the correct provisioner pod based on the interface
     pod_name = pod.get_csi_provisioner_pod(interface)
+    # due to some delay in CSI log generation added wait
+    time.sleep(wait_time)
     # get the logs from the csi-provisioner containers
     logs = pod.get_pod_logs(pod_name[0], 'csi-provisioner')
     logs += pod.get_pod_logs(pod_name[1], 'csi-provisioner')


### PR DESCRIPTION
tests/e2e/scale/test_pvc_creation_deletion_scale.py
- Script enhanced to copy creation and deletion csv files to ocs-ci log location
- Script enhanced to parallel execution of code to collect pv and pvc names

tests/helpers.py
- Added waittime of 60 sec to measure_pv_creation_time_bulk
- Added waittime of 60 sec to measure_pv_deletion_time_bulk

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>