### PR TITLE
Update test to use default cephblockpool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,9 +353,8 @@ def storageclass_factory_fixture(
             sc_obj = helpers.create_resource(**custom_data)
         else:
             secret = secret or secret_factory(interface=interface)
-            ceph_pool = ceph_pool_factory(interface)
             if interface == constants.CEPHBLOCKPOOL:
-                interface_name = ceph_pool.name
+                interface_name = constants.DEFAULT_BLOCKPOOL
             elif interface == constants.CEPHFILESYSTEM:
                 interface_name = helpers.get_cephfs_data_pool_name()
 
@@ -367,7 +366,6 @@ def storageclass_factory_fixture(
                 reclaim_policy=reclaim_policy
             )
             assert sc_obj, f"Failed to create {interface} storage class"
-            sc_obj.ceph_pool = ceph_pool
             sc_obj.secret = secret
 
         instances.append(sc_obj)

--- a/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
@@ -6,7 +6,8 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.utility.utils import TimeoutSampler
 from tests.helpers import (
-    wait_for_resource_state, verify_volume_deleted_in_backend
+    wait_for_resource_state, verify_volume_deleted_in_backend,
+    default_ceph_block_pool
 )
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
@@ -288,7 +289,7 @@ class TestChangeReclaimPolicyOfPv(ManageTest):
         )
 
         # Verify PV using ceph toolbox. Wait for Image/Subvolume to be deleted.
-        pool_name = self.sc_obj.ceph_pool.name if interface == constants.CEPHBLOCKPOOL else None
+        pool_name = default_ceph_block_pool() if interface == constants.CEPHBLOCKPOOL else None
         for pvc_name, uuid in pvc_uuid_map.items():
             try:
                 for ret in TimeoutSampler(


### PR DESCRIPTION
ocs-ci/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
The test is using custom cephblockpool which is created by storageclass_factory.
Modified to use default cephblockpool.

Changed this in storageclass_factory_fixture because creating new cephblockpool
is not a requirement.

Signed-off-by: Jilju Joy <jijoy@redhat.com>