### PR TITLE
Remove BZ decrators from node drain tests

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -16,7 +16,7 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.framework.testlib import (
     tier1, tier2, tier3, tier4, tier4b,
-    ManageTest, aws_platform_required, ignore_leftovers, bugzilla
+    ManageTest, aws_platform_required, ignore_leftovers
 )
 
 from tests.sanity_helpers import Sanity
@@ -33,7 +33,6 @@ log = logging.getLogger(__name__)
 @pytest.fixture(autouse=True)
 def teardown(request):
     """
-
     Tear down function
 
     """
@@ -60,7 +59,6 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
-@bugzilla('1818613')
 @ignore_leftovers
 class TestNodesMaintenance(ManageTest):
     """
@@ -135,7 +133,7 @@ class TestNodesMaintenance(ManageTest):
         argnames=["node_type"],
         argvalues=[
             pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1292")),
-            pytest.param(*['master'], marks=[pytest.mark.polarion_id("OCS-1293"), bugzilla('1754287')])
+            pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1293"))
         ]
     )
     def test_node_maintenance_restart_activate(


### PR DESCRIPTION
Removing Bugzilla decorators for:
- https://bugzilla.redhat.com/show_bug.cgi?id=1818613 - Seems like reproduced when cluster is not in health OK. Now that other tests that were running prior to node drain tests, like add capacity, are stable, this BZ should not occur. 
- https://bugzilla.redhat.com/show_bug.cgi?id=1754287 - BZ verrified

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>