### PR TITLE
Fixing skip_ocs_deployment teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -915,7 +915,7 @@ def health_checker(request, tier_marks_name):
         try:
             teardown = config.RUN['cli_params']['teardown']
             skip_ocs_deployment = config.ENV_DATA['skip_ocs_deployment']
-            if not ( teardown or skip_ocs_deployment ):
+            if not (teardown or skip_ocs_deployment):
                 ceph_health_check_base()
                 log.info("Ceph health check passed at teardown")
         except CephHealthException:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -914,7 +914,8 @@ def health_checker(request, tier_marks_name):
     def finalizer():
         try:
             teardown = config.RUN['cli_params']['teardown']
-            if not teardown:
+            skip_ocs_deployment = config.ENV_DATA['skip_ocs_deployment']
+            if not ( teardown or skip_ocs_deployment ):
                 ceph_health_check_base()
                 log.info("Ceph health check passed at teardown")
         except CephHealthException:


### PR DESCRIPTION
When we use skip_ocs_deployment, teardown is checking for
health_check of OCS cluster. In this PR, we are skipping health_check
for skip_ocs_deployment.

Signed-off-by: vavuthu <vavuthu@redhat.com>

Fixes: #1830 