### PR TITLE
Fix of issue 1709: test OCS-1306 checks only exp. mon downtime

### DIFF
--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -85,6 +85,7 @@ def check_query_range_result(
     bad_values=(),
     exp_metric_num=None,
     exp_delay=None,
+    exp_good_time=None,
 ):
     """
     Check that result of range query matches given expectations. Useful
@@ -106,6 +107,10 @@ def check_query_range_result(
             time range for which we should tolerate bad values. This is
             useful if you change cluster state and processing of this
             change is expected to take some time.
+        exp_good_time (int): Number of seconds during which we should see
+            good values in the metrics data. When this time passess values
+            can go bad (but can't be invalid). If not specified, good values
+            should be presend during the whole time.
 
     Returns:
         bool: True if result matches given expectations, False otherwise
@@ -145,6 +150,10 @@ def check_query_range_result(
                 if exp_delay is not None and delta.seconds < exp_delay:
                     logger.info(
                         msg + f" but within expected {exp_delay}s delay")
+                elif (exp_good_time is not None
+                        and delta.seconds >= exp_good_time):
+                    logger.info(
+                        msg + f" but after {exp_good_time}s already passed")
                 else:
                     logger.error(msg)
                     bad_value_timestamps.append(dt)

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -123,6 +123,9 @@ def measure_stop_ceph_mon(measurement_dir):
     logger.info(f"Monitors to stop: {mons_to_stop}")
     logger.info(f"Monitors left to run: {mons[:split_index]}")
 
+    # run_time of operation
+    run_time = 60 * 14
+
     def stop_mon():
         """
         Downscale Ceph Monitor deployments for 14 minutes. First 15 minutes
@@ -137,8 +140,6 @@ def measure_stop_ceph_mon(measurement_dir):
         Returns:
             str: Names of downscaled deployments
         """
-        # run_time of operation
-        run_time = 60 * 14
         nonlocal oc
         nonlocal mons_to_stop
         for mon in mons_to_stop:
@@ -150,6 +151,9 @@ def measure_stop_ceph_mon(measurement_dir):
 
     test_file = os.path.join(measurement_dir, 'measure_stop_ceph_mon.json')
     measured_op = measure_operation(stop_mon, test_file)
+
+    # expected minimal downtime of a mon inflicted by this fixture
+    measured_op['min_downtime'] = run_time - (60 * 2)
 
     # get new list of monitors to make sure that new monitors were deployed
     mon_deployments = oc.get(selector=constants.MON_APP_LABEL)['items']

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -60,7 +60,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         bad_values=[1],
         exp_metric_num=1,
         exp_delay=expected_delay)
-    mon_msg = "ceph_osd_up value should be affected by missing osd"
+    mon_msg = "ceph_mon_quorum_status value should be affected by missing mon"
     assert mon_validation, mon_msg
 
 

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -44,6 +44,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         good_values=[1],
         bad_values=[0],
         exp_metric_num=1,
+        exp_good_time=measure_stop_ceph_mon['min_downtime'],
         exp_delay=expected_delay)
     health_msg = "health status should be affected by missing mon"
     assert health_validation, health_msg
@@ -59,6 +60,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         good_values=[0],
         bad_values=[1],
         exp_metric_num=1,
+        exp_good_time=measure_stop_ceph_mon['min_downtime'],
         exp_delay=expected_delay)
     mon_msg = "ceph_mon_quorum_status value should be affected by missing mon"
     assert mon_validation, mon_msg

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -23,6 +23,8 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
     prometheus = PrometheusAPI()
     # time (in seconds) for monitoring to notice the change
     expected_delay = 60
+    # query resolution step used in this test case (number of seconds)
+    query_step = 15
 
     affected_mons = measure_stop_ceph_mon['result']
     # we asked to stop just a single mon ... make this assumption explicit
@@ -38,7 +40,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         query='ceph_health_status',
         start=measure_stop_ceph_mon['start'],
         end=measure_stop_ceph_mon['stop'],
-        step=15)
+        step=query_step)
     health_validation = check_query_range_result(
         result=health_result,
         good_values=[1],
@@ -54,7 +56,8 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         query='ceph_mon_quorum_status{ceph_daemon="%s"}' % ceph_daemon,
         start=measure_stop_ceph_mon['start'],
         end=measure_stop_ceph_mon['stop'],
-        step=15)
+        step=query_step,
+        validate=False)
     mon_validation = check_query_range_result(
         result=mon_result,
         good_values=[0],
@@ -64,6 +67,14 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
         exp_delay=expected_delay)
     mon_msg = "ceph_mon_quorum_status value should be affected by missing mon"
     assert mon_validation, mon_msg
+
+    # since we don't do strict result validation in the previous query, we
+    # are going to check the min. expected size of the reply explicitly, taking
+    # into account the min. expected downtime of the affected ceph mon
+    assert len(mon_result) == 1, "there should be one metric for one mon"
+    min_mon_samples = measure_stop_ceph_mon['min_downtime'] / query_step
+    mon_sample_size = len(mon_result[0]["values"])
+    assert mon_sample_size >= min_mon_samples
 
 
 @tier3


### PR DESCRIPTION
Test case `test_monitoring_shows_mon_down` now checks only exp. mon downtime, which is provided via `measure_stop_ceph_mon` fixture.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/1709