### PR TITLE
Verify status of osd-prepare pods after adding capacity

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -3,7 +3,7 @@ from ocs_ci.framework.pytest_customization.marks import polarion_id
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier1
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources import storage_cluster, pod
+from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.utility.utils import ceph_health_check
 
 

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -3,7 +3,7 @@ from ocs_ci.framework.pytest_customization.marks import polarion_id
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier1
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources import storage_cluster
+from ocs_ci.ocs.resources import storage_cluster, pod
 from ocs_ci.utility.utils import ceph_health_check
 
 
@@ -29,6 +29,15 @@ class TestAddCapacity(ManageTest):
             selector='app=rook-ceph-osd',
             resource_count=result * 3
         )
+
+        # Verify status of rook-ceph-osd-prepare pods. Verifies bug 1769061
+        pod.wait_for_resource(
+            timeout=300,
+            condition=constants.STATUS_COMPLETED,
+            selector=constants.OSD_PREPARE_APP_LABEL,
+            resource_count=result * 3
+        )
+
         ceph_health_check(
             namespace=config.ENV_DATA['cluster_namespace'], tries=80
         )


### PR DESCRIPTION
Updated test_add_capacity to verify osd-prepare pod status is 'Completed'
after adding capacity.
Verifies bug [1769061](https://bugzilla.redhat.com/show_bug.cgi?id=1769061)

Signed-off-by: Jilju Joy <jijoy@redhat.com>