### PR TITLE
Replace run_cmd with exec_cmd

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -423,10 +423,10 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     Returns:
         (CompletedProcess) A CompletedProcess object of the command that was executed
         CompletedProcess attributes:
-            args: The list or str args passed to run().
-            returncode (str): The exit code of the process, negative for signals.
-            stdout     (str): The standard output (None if not captured).
-            stderr     (str): The standard error (None if not captured).
+        args: The list or str args passed to run().
+        returncode (str): The exit code of the process, negative for signals.
+        stdout     (str): The standard output (None if not captured).
+        stderr     (str): The standard error (None if not captured).
 
     """
     masked_cmd = mask_secrets(cmd, secrets)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -421,7 +421,7 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         CommandFailed: In case the command execution fails
 
     Returns:
-        (str) Decoded stdout of command
+        (CompletedProcess) A CompletedProcess object of the command that was executed
 
     """
     masked_cmd = mask_secrets(cmd, secrets)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -422,6 +422,11 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
 
     Returns:
         (CompletedProcess) A CompletedProcess object of the command that was executed
+        CompletedProcess attributes:
+            args: The list or str args passed to run().
+            returncode (str): The exit code of the process, negative for signals.
+            stdout     (str): The standard output (None if not captured).
+            stderr     (str): The standard error (None if not captured).
 
     """
     masked_cmd = mask_secrets(cmd, secrets)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1,23 +1,29 @@
-import hcl
 import json
 import logging
 import os
 import platform
 import random
+import re
 import shlex
+import smtplib
 import string
 import subprocess
 import time
 import traceback
 from copy import deepcopy
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from shutil import which
 
-
+import hcl
 import requests
 import yaml
-import re
-import smtplib
+from bs4 import BeautifulSoup
+from paramiko import SSHClient, AutoAddPolicy
+from semantic_version import Version
 
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
     CommandFailed,
@@ -27,15 +33,7 @@ from ocs_ci.ocs.exceptions import (
     UnavailableBuildException,
     UnsupportedOSType,
 )
-from ocs_ci.framework import config
-from ocs_ci.ocs import constants, defaults
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 from ocs_ci.utility.retry import retry
-from bs4 import BeautifulSoup
-from paramiko import SSHClient, AutoAddPolicy
-from semantic_version import Version
-
 
 log = logging.getLogger(__name__)
 
@@ -384,6 +382,30 @@ def mask_secrets(plaintext, secrets):
 
 def run_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     """
+    *The deprecated form of exec_cmd.*
+    Run an arbitrary command locally
+
+    Args:
+        cmd (str): command to run
+        secrets (list): A list of secrets to be masked with asterisks
+            This kwarg is popped in order to not interfere with
+            subprocess.run(``**kwargs``)
+        timeout (int): Timeout for the command, defaults to 600 seconds.
+        ignore_error (bool): True if ignore non zero return code and do not
+            raise the exception.
+
+    Raises:
+        CommandFailed: In case the command execution fails
+
+    Returns:
+        (str) Decoded stdout of command
+    """
+    completed_process = exec_cmd(cmd, secrets, timeout, ignore_error, **kwargs)
+    return mask_secrets(completed_process.stdout.decode(), secrets)
+
+
+def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
+    """
     Run an arbitrary command locally
 
     Args:
@@ -406,7 +428,7 @@ def run_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     log.info(f"Executing command: {masked_cmd}")
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
-    r = subprocess.run(
+    completed_process = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -414,23 +436,24 @@ def run_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         timeout=timeout,
         **kwargs
     )
-    masked_stdout = mask_secrets(r.stdout.decode(), secrets)
-    if len(r.stdout) > 0:
+    masked_stdout = mask_secrets(completed_process.stdout.decode(), secrets)
+    if len(completed_process.stdout) > 0:
         log.debug(f"Command stdout: {masked_stdout}")
     else:
         log.debug("Command stdout is empty")
-    masked_stderr = mask_secrets(r.stderr.decode(), secrets)
-    if len(r.stderr) > 0:
+
+    masked_stderr = mask_secrets(completed_process.stderr.decode(), secrets)
+    if len(completed_process.stderr) > 0:
         log.warning(f"Command stderr: {masked_stderr}")
     else:
         log.debug("Command stderr is empty")
-    log.debug(f"Command return code: {r.returncode}")
-    if r.returncode and not ignore_error:
+    log.debug(f"Command return code: {completed_process.returncode}")
+    if completed_process.returncode and not ignore_error:
         raise CommandFailed(
             f"Error during execution of command: {masked_cmd}."
             f"\nError is {masked_stderr}"
         )
-    return masked_stdout
+    return completed_process
 
 
 def run_mcg_cmd(cmd, namespace=None):


### PR DESCRIPTION
Up until today, `run_cmd` didn't return anything but a command's resulting `stdout`.
However, after discussion in the team chat, it was agreed that it'd be more beneficial to return the entirety of the `CompletedProcess` object, for the developers to dissect and use as they wish afterwards.

Thus, `exec_cmd` was created as a replacement that returns the entire object. Backwards compatibility is achieved by calling the new function inside `run_cmd` and then extracting the `stdout` and returning it.

I tried to use `warnings` in order to deprecate the old function, but this resulted in a lot of messages filling up the log, and I'm not sure whether it's a good idea to filter all deprecation warnings. I tried filtering by module, but it didn't seem to have effect.

So far I tested the change on a few tests locally, and everything seems to do well. Any idea what further testing will verify that the changes are correct?

*Also optimized imports in our `utils.py`