### PR TITLE
Update StatefulSet api version.

### DIFF
--- a/ocs_ci/templates/workloads/pgsql/server/StatefulSet.yaml
+++ b/ocs_ci/templates/workloads/pgsql/server/StatefulSet.yaml
@@ -1,10 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgres
   namespace: my-ripsaw
 spec:
   serviceName: "postgres"
+  selector:
+    matchLabels:
+      app: postgres
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
StatefulSet API version needs to update to run with 4.4 images. 
Fixing pgsql failing https://github.com/red-hat-storage/ocs-ci/issues/1885
