### PR TITLE
Improve ocp upgrade

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1138,3 +1138,27 @@ def get_ocp_upgrade_channel():
     operator_version = ocp.get('-o json', out_yaml_format=False)
 
     return operator_version['items'][0]['spec']['channel']
+
+
+def verify_ocp_upgrade_channel(channel_variable):
+    """
+    When upgrade OCP version, verify that subscription channel is same
+    as current one, and patch it if is not.
+
+    Args:
+        channel_variable: new  ocp upgrade subscription channel
+
+    Returns:
+        bool: True if upgrade channel is same as current ocp
+        subscription channel
+
+    """
+    if get_ocp_upgrade_channel() == channel_variable:
+        log.info(f"Channel is {channel_variable}, no patch required")
+        return True
+    else:
+        cmd = f'oc patch clusterversions/version -p \'' \
+              f'{{"spec":{{"channel":"{channel_variable}"}}}}\' --type=merge'
+        ocp = OCP()
+        ocp.exec_oc_cmd(cmd)
+        return False

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1108,9 +1108,19 @@ def verify_cluster_operator_status(cluster_operator):
 
 
 def validate_cluster_version_status():
+    """
+    Verify OCP upgrade is completed, by checking 'oc get clusterversion'
+    status
+
+    Returns:
+        bool: False in case that one of condition flags is invalid:
+        Progressing (should be False), Failing(should be False)
+        or Available (should be True)
+
+    """
     ocp = OCP(kind="clusterversion")
     operator_data = ocp.get('-o json', out_yaml_format=False)
-    conditions = operator_data['items'][0]['status']['conditions']
+    conditions = operator_data['items'][0].get('status').get('conditions')
     for condition in conditions:
         if condition['type'] == 'Progressing' and condition['status'] == 'True':
             log.info('cluster version status is Progressing')
@@ -1131,14 +1141,14 @@ def get_ocp_upgrade_channel():
     Gets OCP upgrade channel
 
     Returns:
-        str: ocp upgrade channel name
+        str: OCP upgrade channel name
 
     """
     ocp = OCP(kind="clusterversion")
     log.info("Gathering Subscription Channel information")
     operator_version = ocp.get('-o json', out_yaml_format=False)
     log.debug(f"cluster version: {operator_version}")
-    channel = operator_version['items'][0]['spec']['channel']
+    channel = operator_version['items'][0].get('spec').get('channel')
     log.info(f"Subscription Channel: {channel}")
 
     return channel
@@ -1150,11 +1160,11 @@ def verify_ocp_upgrade_channel(channel_variable):
     as current one, and patch it if is not.
 
     Args:
-        channel_variable: new  ocp upgrade subscription channel
+        channel_variable (str): New OCP upgrade subscription channel
 
     Returns:
-        bool: True if upgrade channel is same as current ocp
-        subscription channel
+        bool: True if upgrade subscription channel is same as current
+        OCP subscription channel
 
     """
     if get_ocp_upgrade_channel() == channel_variable:

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1185,6 +1185,8 @@ def verify_ocp_upgrade_channel(channel_variable):
         channel_variable (str): New OCP upgrade subscription channel
 
     Returns:
+        bool: True when OCP subscription channel is correct,
+        and no patch needed
 
     """
     current_channel = get_ocp_upgrade_channel()

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1164,8 +1164,10 @@ def patch_ocp_upgrade_channel(channel_variable):
 
     """
     if get_ocp_upgrade_channel() != channel_variable:
-        cmd = f'patch clusterversions/version -p \'' \
-              f'{{"spec":{{"channel":"{channel_variable}"}}}}\' --type=merge'
+        cmd = (
+            f'patch clusterversions/version -p \'{{"spec":'
+            f'{{"channel":"{channel_variable}"}}}}\' --type=merge'
+        )
         ocp = OCP()
         log.info(f"Patching channel into {channel_variable}")
         ocp.exec_oc_cmd(cmd)

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1110,7 +1110,7 @@ def verify_cluster_operator_status(cluster_operator):
 def validate_cluster_version_status():
     ocp = OCP(kind="clusterversion")
     operator_data = ocp.get('-o json', out_yaml_format=False)
-    conditions = operator_data['items'][0]['status']['condition']
+    conditions = operator_data['items'][0]['status']['conditions']
     for condition in conditions:
         if condition['type'] == 'Progressing' and condition['status'] == 'True':
             log.info('cluster version status is Progressing')
@@ -1135,9 +1135,13 @@ def get_ocp_upgrade_channel():
 
     """
     ocp = OCP(kind="clusterversion")
+    log.info("Gathering Subscription Channel information")
     operator_version = ocp.get('-o json', out_yaml_format=False)
+    log.debug(f"cluster version: {operator_version}")
+    channel = operator_version['items'][0]['spec']['channel']
+    log.info(f"Subscription Channel: {channel}")
 
-    return operator_version['items'][0]['spec']['channel']
+    return channel
 
 
 def verify_ocp_upgrade_channel(channel_variable):
@@ -1160,5 +1164,6 @@ def verify_ocp_upgrade_channel(channel_variable):
         cmd = f'oc patch clusterversions/version -p \'' \
               f'{{"spec":{{"channel":"{channel_variable}"}}}}\' --type=merge'
         ocp = OCP()
+        log.info(f"Patching channel into {channel_variable}")
         ocp.exec_oc_cmd(cmd)
         return False

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1154,26 +1154,44 @@ def get_ocp_upgrade_channel():
     return channel
 
 
+def patch_ocp_upgrade_channel(channel_variable):
+    """
+    Using 'oc patch clusterversion' if new OCP upgrade channel is
+    different than current one
+
+    Args:
+        channel_variable (str): New OCP upgrade subscription channel
+
+    """
+    if get_ocp_upgrade_channel() != channel_variable:
+        cmd = f'patch clusterversions/version -p \'' \
+              f'{{"spec":{{"channel":"{channel_variable}"}}}}\' --type=merge'
+        ocp = OCP()
+        log.info(f"Patching channel into {channel_variable}")
+        ocp.exec_oc_cmd(cmd)
+
+    else:
+        log.info("No patch needed")
+
+
 def verify_ocp_upgrade_channel(channel_variable):
     """
     When upgrade OCP version, verify that subscription channel is same
-    as current one, and patch it if is not.
+    as current one
 
     Args:
         channel_variable (str): New OCP upgrade subscription channel
 
     Returns:
-        bool: True if upgrade subscription channel is same as current
-        OCP subscription channel
 
     """
-    if get_ocp_upgrade_channel() == channel_variable:
+    current_channel = get_ocp_upgrade_channel()
+    if current_channel == channel_variable:
         log.info(f"Channel is {channel_variable}, no patch required")
+
         return True
     else:
-        cmd = f'oc patch clusterversions/version -p \'' \
-              f'{{"spec":{{"channel":"{channel_variable}"}}}}\' --type=merge'
-        ocp = OCP()
-        log.info(f"Patching channel into {channel_variable}")
-        ocp.exec_oc_cmd(cmd)
+        log.info(f"Current subscription channel is  {current_channel}")
+        log.info(f"Required subscription channel is {channel_variable}")
+
         return False

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -104,7 +104,7 @@ class TestUpgradeOCP(ManageTest):
             logger.info("Checking clusterversion status")
             for sampler in TimeoutSampler(
                 timeout=900,
-                sleep=60,
+                sleep=15,
                 func=ocp.validate_cluster_version_status
             ):
                 if sampler:

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -52,9 +52,10 @@ class TestUpgradeOCP(ManageTest):
             self.cluster_operators = ocp.get_all_cluster_operators()
             logger.info(f" oc version: {ocp.get_current_oc_version()}")
             # Verify Upgrade subscription channel:
+            ocp.patch_ocp_upgrade_channel(ocp_channel)
             for sampler in TimeoutSampler(
                 timeout=250,
-                sleep=120,
+                sleep=15,
                 func=ocp.verify_ocp_upgrade_channel,
                 channel_variable=ocp_channel
             ):


### PR DESCRIPTION
Added two more validations:
Before upgrade - checks if new subscription channel is same as current, and use `oc patch` command if not
After upgrade - checks status of `oc get clusterversion`