### PR TITLE
Improve verify_health to utilize TimeoutSampler and wait for bucket

### DIFF
--- a/ocs_ci/ocs/resources/mcg_bucket.py
+++ b/ocs_ci/ocs/resources/mcg_bucket.py
@@ -61,6 +61,7 @@ class MCGBucket(ABC):
         Abstract health verification method
 
         """
+        logger.info(f'Waiting for {self.name} to be healthy')
         try:
             for health_check in TimeoutSampler(timeout, interval, self.internal_verify_health):
                 if health_check:

--- a/ocs_ci/ocs/resources/mcg_bucket.py
+++ b/ocs_ci/ocs/resources/mcg_bucket.py
@@ -52,13 +52,20 @@ class MCGBucket(ABC):
         the appropriate implementation
 
         """
-        status = self.internal_status
-        logger.info(f"{self.name} status is {status}")
-        return status
+        status_var = self.internal_status
+        logger.info(f"{self.name} status is {status_var}")
+        return status_var
 
     def verify_health(self, timeout=30, interval=5):
         """
         Abstract health verification method
+
+        Args:
+            timeout (int): Timeout for the check, in seconds
+            interval (int): Interval to wait between checks, in seconds
+
+        Returns:
+            (bool): True if the bucket is healthy, False otherwise
 
         """
         logger.info(f'Waiting for {self.name} to be healthy')
@@ -71,7 +78,7 @@ class MCGBucket(ABC):
                     logger.info(f'{self.name} is unhealthy. Rechecking.')
         except TimeoutExpiredError:
             logger.error(
-                'The bucket did not reach a healthy state within the time limit.'
+                f'{self.name} did not reach a healthy state within {timeout} seconds.'
             )
             assert False
 

--- a/ocs_ci/ocs/resources/mcg_bucket.py
+++ b/ocs_ci/ocs/resources/mcg_bucket.py
@@ -58,7 +58,9 @@ class MCGBucket(ABC):
 
     def verify_health(self, timeout=30, interval=5):
         """
-        Abstract health verification method
+        Health verification function that tries to verify
+        the a bucket's health by using its appropriate internal_verify_health
+        function until a given time limit is reached
 
         Args:
             timeout (int): Timeout for the check, in seconds


### PR DESCRIPTION
Added a TimeoutSampler because we simply wouldn't wait for buckets, although they sometimes take a while to become healthy