### PR TITLE
[WIP] Teardown imrovement:

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -612,7 +612,7 @@ class CephCluster(object):
             )
 
     @retry(UnexpectedBehaviour, tries=20, delay=10, backoff=1)
-    def get_rebalance_status(self):
+    def wait_for_rebalance_to_complete(self):
         """
         Calls get_rebalance_status_base with retries
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -611,7 +611,7 @@ class CephCluster(object):
                 and states['count'] == total_pg_count
             )
 
-    @retry(UnexpectedBehaviour, tries=20, delay=10, backoff=1)
+    @retry(RebalanceException, tries=20, delay=10, backoff=1)
     def wait_for_rebalance_to_complete(self):
         """
         Calls get_rebalance_status_base with retries

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -14,6 +14,10 @@ class UnexpectedBehaviour(Exception):
     pass
 
 
+class RebalanceException(Exception):
+    pass
+
+
 class ClassCreationException(Exception):
     pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -975,7 +975,7 @@ def rebalance_checker(request, tier_marks_name):
                 log.info("Ceph rebalance check failed at teardown")
                 # Retrying to increase the chance the cluster health will be OK
                 # for next test
-                ceph_cluster.get_rebalance_status()
+                ceph_cluster.wait_for_rebalance_to_complete()
             finally:
                 raise RebalanceException(
                     f"Ceph cluster health is not OK."

--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -86,7 +86,7 @@ class TestScaleOSDsRebootNodes(E2ETest):
         cluster = CephCluster()
 
         # Get rebalance status
-        rebalance_status = cluster.get_rebalance_status()
+        rebalance_status = cluster.get_rebalance_status_base()
         logger.info(rebalance_status)
         if rebalance_status:
             time_taken = cluster.time_taken_to_complete_rebalance()


### PR DESCRIPTION
 Adding a verification in teardown for the PG state as it have to be clean_active.
 This is a generic validation for situations like in:
 https://github.com/red-hat-storage/ocs-ci/issues/1890

Signed-off-by: ratamir <ratamir@redhat.com>