### PR TITLE
Make sure that open calls use file descriptors that can be closed Fixes: #1889

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -933,7 +933,8 @@ def email_reports():
     msg['To'] = ", ".join(recipients)
 
     html = config.RUN['cli_params']['--html']
-    html_data = open(os.path.expanduser(html)).read()
+    with open(os.path.expanduser(html)) as fd:
+        html_data = fd.read()
     soup = BeautifulSoup(html_data, "html.parser")
 
     parse_html_for_email(soup)

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -109,9 +109,10 @@ class TestPVCCreationDeletionScale(E2ETest):
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
         log_path = f"{ocsci_log_path()}/{self.sc_obj}-{access_mode}"
-        csv_obj = csv.writer(open(f"{log_path}-creation-time.csv", "w"))
-        for k, v in pvc_create_time.items():
-            csv_obj.writerow([k, v])
+        with open(f"{log_path}-creation-time.csv", "w") as fd:
+            csv_obj = csv.writer(fd)
+            for k, v in pvc_create_time.items():
+                csv_obj.writerow([k, v])
         logging.info(
             f"Create data present in {log_path}-creation-time.csv file"
         )
@@ -129,9 +130,10 @@ class TestPVCCreationDeletionScale(E2ETest):
         # Update result to csv file.
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open(f"{log_path}-deletion-time.csv", "w"))
-        for k, v in pvc_deletion_time.items():
-            csv_obj.writerow([k, v])
+        with open(f"{log_path}-deletion-time.csv", "w") as fd:
+            csv_obj = csv.writer(fd)
+            for k, v in pvc_deletion_time.items():
+                csv_obj.writerow([k, v])
         logging.info(
             f"Delete data present in {log_path}-deletion-time.csv file"
         )
@@ -224,9 +226,10 @@ class TestPVCCreationDeletionScale(E2ETest):
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
         log_path = f"{ocsci_log_path()}/All-type-PVC"
-        csv_obj = csv.writer(open(f"{log_path}-creation-time.csv", "w"))
-        for k, v in fs_pvc_create_time.items():
-            csv_obj.writerow([k, v])
+        with open(f"{log_path}-creation-time.csv", "w") as fd:
+            csv_obj = csv.writer(fd)
+            for k, v in fs_pvc_create_time.items():
+                csv_obj.writerow([k, v])
         logging.info(
             f"Create data present in {log_path}-creation-time.csv file"
         )
@@ -248,9 +251,10 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        csv_obj = csv.writer(open(f"{log_path}-deletion-time.csv", "w"))
-        for k, v in fs_pvc_deletion_time.items():
-            csv_obj.writerow([k, v])
+        with open(f"{log_path}-deletion-time.csv", "w") as fd:
+            csv_obj = csv.writer(fd)
+            for k, v in fs_pvc_deletion_time.items():
+                csv_obj.writerow([k, v])
         logging.info(
             f"Delete data present in {log_path}-deletion-time.csv file"
         )

--- a/tests/manage/storageclass/test_storageclass_invalid.py
+++ b/tests/manage/storageclass/test_storageclass_invalid.py
@@ -79,7 +79,8 @@ def invalid_storageclass(request):
     yaml_path = os.path.join(
         request.param['template_dir'], "storageclass.yaml"
     )
-    yaml_data = yaml.safe_load(open(yaml_path, 'r'))
+    with open(yaml_path, 'r') as fd:
+        yaml_data = yaml.safe_load(fd)
     yaml_data.update(request.param['values'])
     storageclass = OCS(**yaml_data)
     sc_data = storageclass.create()


### PR DESCRIPTION
Fixes: #1889

Make sure that open calls use file descriptors that can be closed.

Signed-off-by: wusui <wusui@redhat.com>