### PR TITLE
Remove tier4a marker from test_scale_osds_fill_75%_reboot_workers.py

### DIFF
--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants, platform_nodes
 from ocs_ci.ocs.resources.pod import wait_for_dc_app_pods_to_reach_running_state
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers, tier4a
+from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.utility.utils import ceph_health_check
 
 
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 @scale
-@tier4a
 @ignore_leftovers
 @pytest.mark.parametrize(
     argnames=["interface"],


### PR DESCRIPTION
Removing tier4a marker because the test is executing since 1 day 7 hr and it's still running 
Fixes: #1972 

Signed-off-by: Pratik Surve <pratiksurve2130@gmail.com>