### PR TITLE
Add option to stop cluster nodes when not in use

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,12 @@ get information on various image version deployed by ocs-ci
    -master or -worker. This can be found by logging into AWS, Selecting the VM
    and clicking on Tags.
 
+# usage to shutdown AWS nodes when nodes are not in use
+  Following cli can be used when you want to shutdown the cluster
+  `ci-pause --cluster-path /home-dir/cluster-path --action [stop|start]`
+  action can be start or stop that performs the required action on all the nodes
+  in the cluster
+
 ## Required configuration
 
 * **AWS credentials** - if you have AWS already configured by `aws configure`,

--- a/ocs_ci/cleanup/aws/cleanup.py
+++ b/ocs_ci/cleanup/aws/cleanup.py
@@ -7,8 +7,9 @@ import os
 import re
 
 from botocore.exceptions import ClientError
-
 from ocs_ci.framework import config
+
+
 from ocs_ci.ocs.constants import CLEANUP_YAML, TEMPLATE_CLEANUP_DIR
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import get_openshift_installer, destroy_cluster

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -365,13 +365,13 @@ class CephCluster(object):
         """
         Set noout flag for maintainance
         """
-        self.toolbox.exec_cmd_on_pod(f"ceph osd set noout")
+        self.toolbox.exec_cmd_on_pod("ceph osd set noout")
 
     def unset_noout(self):
         """
         unset noout flag for peering
         """
-        self.toolbox.exec_cmd_on_pod(f"ceph osd unset noout")
+        self.toolbox.exec_cmd_on_pod("ceph osd unset noout")
 
     def get_user_key(self, user):
         """

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -361,6 +361,18 @@ class CephCluster(object):
         """
         return self.get_user_key('client.admin')
 
+    def set_noout(self):
+        """
+        Set noout flag for maintainance
+        """
+        self.toolbox.exec_cmd_on_pod(f"ceph osd set noout")
+
+    def unset_noout(self):
+        """
+        unset noout flag for peering
+        """
+        self.toolbox.exec_cmd_on_pod(f"ceph osd unset noout")
+
     def get_user_key(self, user):
         """
         Args:

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -200,6 +200,10 @@ DEFAULT_MON_PVC_NAME = "rook-ceph-mon"
 OSD_PVC_GENERIC_LABEL = "ceph.rook.io/DeviceSet"
 CEPH_ROOK_IO_PVC_LABEL = 'ceph.rook.io/pvc'
 
+# Auth Yaml
+OCSCI_DATA_BUCKET = 'ocs-ci-data'
+AUTHYAML = 'auth.yaml'
+
 # OBJ File representing serialized data
 NODE_OBJ_FILE = "node_file.objs"
 NODE_FILE = "nodes.objs"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -200,10 +200,10 @@ DEFAULT_MON_PVC_NAME = "rook-ceph-mon"
 OSD_PVC_GENERIC_LABEL = "ceph.rook.io/DeviceSet"
 CEPH_ROOK_IO_PVC_LABEL = 'ceph.rook.io/pvc'
 
-# Auth Yaml
-OCSCI_DATA_BUCKET = 'ocs-ci-data'
-AUTHYAML = 'auth.yaml'
-
+# OBJ File representing serialized data
+NODE_OBJ_FILE = "node_file.objs"
+NODE_FILE = "nodes.objs"
+INSTANCE_FILE = "instances.objs"
 
 # YAML paths
 TOOL_POD_YAML = os.path.join(

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -45,7 +45,6 @@ class NodesBase(object):
 
     """
     def __init__(self):
-        self.cluster_nodes = get_node_objs()
         self.cluster_path = config.ENV_DATA['cluster_path']
         self.platform = config.ENV_DATA['platform']
         self.deployment_type = config.ENV_DATA['deployment_type']
@@ -288,6 +287,7 @@ class VMWareNodes(NodesBase):
         Make sure all VMs are up by the end of the test
 
         """
+        self.cluster_nodes = get_node_objs()
         vms = self.get_vms(self.cluster_nodes)
         assert vms, (
             f"Failed to get VM objects for nodes {[n.name for n in self.cluster_nodes]}"
@@ -379,16 +379,17 @@ class AWSNodes(NodesBase):
         )
         self.aws.stop_ec2_instances(instances=instances, wait=wait)
 
-    def start_nodes(self, nodes, wait=True):
+    def start_nodes(self, instances, nodes, wait=True):
         """
         Start EC2 instances
 
         Args:
             nodes (list): The OCS objects of the nodes
+            instances (dict): instance-id and name dict
             wait (bool): True for waiting the instances to start, False otherwise
 
         """
-        instances = self.get_ec2_instances(nodes)
+        instances = instances or self.get_ec2_instances(nodes)
         assert instances, (
             f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
         )

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -379,7 +379,7 @@ class AWSNodes(NodesBase):
         )
         self.aws.stop_ec2_instances(instances=instances, wait=wait)
 
-    def start_nodes(self, instances, nodes, wait=True):
+    def start_nodes(self, instances=None, nodes=None, wait=True):
         """
         Start EC2 instances
 

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -507,6 +507,7 @@ class AWSNodes(NodesBase):
 
         """
         # Get the cluster nodes ec2 instances
+        self.cluster_nodes = get_node_objs()
         ec2_instances = self.get_ec2_instances(self.cluster_nodes)
         assert ec2_instances, (
             f"Failed to get ec2 instances for nodes {[n.name for n in self.cluster_nodes]}"

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -164,6 +164,21 @@ class OCS(object):
     def delete_temp_yaml_file(self):
         utils.delete_file(self.temp_yaml.name)
 
+    def __getstate__(self):
+        """
+        unset attributes for serializing the object
+        """
+        self_dict = self.__dict__
+        del self.temp_yaml
+        return self_dict
+
+    def __setstate__(self, d):
+        """
+        reset attributes for serializing the object
+        """
+        self.temp_yaml = None
+        self.__dict__.update(d)
+
 
 def get_version_info(namespace=None):
     operator_selector = get_selector_for_ocs_operator()

--- a/ocs_ci/pause/pause.py
+++ b/ocs_ci/pause/pause.py
@@ -15,6 +15,12 @@ from ocs_ci.ocs.constants import (
     NODE_OBJ_FILE, NODE_FILE, INSTANCE_FILE
 )
 
+FORMAT = (
+    '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+)
+logging.basicConfig(format=FORMAT, level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
 
 def cycle_nodes(cluster_path, action):
     """
@@ -35,18 +41,24 @@ def cycle_nodes(cluster_path, action):
         kls = platform_nodes.PlatformNodesFactory()
         nodes = kls.get_nodes_platform()
         with open(instance_file, "wb") as instance_file:
+            log.info("Storing ocs instances objects")
             pickle.dump(nodes.get_ec2_instances(nodes=node_objs), instance_file)
         with open(nodes_file, "wb") as node_file:
+            log.info("Storing ocp nodes objects")
             pickle.dump(nodes, node_file)
         with open(node_obj_file, "wb") as node_obj_file:
+            log.info("Stopping all nodes")
             pickle.dump(node_objs, node_obj_file)
             nodes.stop_nodes(nodes=node_objs)
     elif action == 'start':
         with open(instance_file, "rb") as instance_file:
+            log.info("Reading instance objects")
             instances = pickle.load(instance_file)
         with open(nodes_file, "rb") as node_file:
+            log.info("Reading ocp nodes object")
             nodes = pickle.load(node_file)
         with open(node_obj_file, "rb") as node_obj_file:
+            log.info("Starting ocs nodes")
             node_objs = pickle.load(node_obj_file)
             nodes.start_nodes(instances=instances, nodes=node_objs)
             unset_noout()

--- a/ocs_ci/pause/pause.py
+++ b/ocs_ci/pause/pause.py
@@ -1,0 +1,88 @@
+import argparse
+import logging
+import pickle
+
+import os
+
+from ocs_ci.framework import config
+from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs import platform_nodes
+from ocs_ci.ocs.node import get_node_objs
+from ocs_ci.utility.retry import retry
+
+from ocs_ci.ocs.constants import (
+    NODE_OBJ_FILE, NODE_FILE, INSTANCE_FILE
+)
+
+
+def cycle_nodes(cluster_path, action):
+    """
+    Start/Stop AWS nodes to save costs when not in use.
+
+    Args:
+        cluster_path(str): location of cluster path that has auth files
+        action (str): action to perform either start or stop
+
+    """
+    node_obj_file = os.path.join(cluster_path, NODE_OBJ_FILE)
+    nodes_file = os.path.join(cluster_path, NODE_FILE)
+    instance_file = os.path.join(cluster_path, INSTANCE_FILE)
+    if action == 'stop':
+        ceph = CephCluster()
+        ceph.set_noout()
+        node_objs = get_node_objs()
+        kls = platform_nodes.PlatformNodesFactory()
+        nodes = kls.get_nodes_platform()
+        with open(instance_file, "wb") as instance_file:
+            pickle.dump(nodes.get_ec2_instances(nodes=node_objs), instance_file)
+        with open(nodes_file, "wb") as node_file:
+            pickle.dump(nodes, node_file)
+        with open(node_obj_file, "wb") as node_obj_file:
+            pickle.dump(node_objs, node_obj_file)
+            nodes.stop_nodes(nodes=node_objs)
+    elif action == 'start':
+        with open(instance_file, "rb") as instance_file:
+            instances = pickle.load(instance_file)
+        with open(nodes_file, "rb") as node_file:
+            nodes = pickle.load(node_file)
+        with open(node_obj_file, "rb") as node_obj_file:
+            node_objs = pickle.load(node_obj_file)
+            nodes.start_nodes(instances=instances, nodes=node_objs)
+            unset_noout()
+
+
+@retry((CommandFailed), tries=10, delay=10, backoff=1)
+def unset_noout():
+    """
+    unset_noout with 10 retries and delay of 10 seconds.
+    """
+    ceph = CephCluster()
+    ceph.unset_noout()
+
+
+def cluster_pause():
+    """
+    Entry point to start/stop cluster nodes - AWS only
+
+    """
+    parser = argparse.ArgumentParser(description='Start/Stop Cluster Nodes - AWS Only')
+    parser.add_argument(
+        '--cluster-path',
+        action='store',
+        required=True,
+        help="Location of cluster path that was used during installation "
+    )
+    parser.add_argument(
+        '--action',
+        nargs='?',
+        required=True,
+        choices=('start', 'stop'),
+        help=""
+    )
+    logging.basicConfig(level=logging.INFO)
+    args = parser.parse_args()
+    cluster_path = os.path.expanduser(args.cluster_path)
+    config.ENV_DATA['cluster_path'] = cluster_path
+    os.environ["KUBECONFIG"] = os.path.join(cluster_path, config.RUN['kubeconfig_location'])
+    cycle_nodes(cluster_path, args.action)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             'run-ci=ocs_ci.framework.main:main',
             'report-version=ocs_ci.ocs.version:main',
             'ci-cleanup=ocs_ci.cleanup.aws.cleanup:cluster_cleanup',
+            'ci-pause=ocs_ci.pause.pause:cluster_pause',
             'aws-cleanup=ocs_ci.cleanup.aws.cleanup:aws_cleanup'
         ],
     },

--- a/tests/e2e/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/e2e/monitoring/test_monitoring_on_negative_scenarios.py
@@ -434,7 +434,7 @@ class TestMonitoringBackedByOCS(E2ETest):
             log.info(f"Waiting for {waiting_time} seconds")
             time.sleep(waiting_time)
 
-            nodes.start_nodes([prometheus_node_obj])
+            nodes.start_nodes(nodes=[prometheus_node_obj])
 
             # Validate all nodes are in READY state
             wait_for_nodes_status()

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -228,7 +228,7 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
                     f"{self.osd_worker_node[0].name} instance"
                 )
             else:
-                nodes.start_nodes(self.osd_worker_node, wait=True)
+                nodes.start_nodes(nodes=self.osd_worker_node, wait=True)
             log.info(
                 f"Successfully started node : "
                 f"{self.osd_worker_node[0].name} instance"
@@ -304,7 +304,7 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
                 new_osd = pod_obj
                 break
 
-        nodes.start_nodes(self.osd_worker_node, wait=True)
+        nodes.start_nodes(nodes=self.osd_worker_node, wait=True)
         log.info(
             f"Successfully powered on node: {self.osd_worker_node[0].name}"
         )


### PR DESCRIPTION
Add option to stop cluster nodes when not in use, this can reduce the overall AWS cost and speed up cluster bring up.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>