### PR TITLE
wait for CSRs based on number of nodes

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -21,7 +21,9 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.ocs.openshift_ops import OCP
 from ocs_ci.utility.bootstrap import gather_bootstrap
-from ocs_ci.utility.csr import approve_pending_csr, wait_for_all_nodes_csr
+from ocs_ci.utility.csr import (
+    approve_pending_csr, wait_for_all_nodes_csr_and_approve
+)
 from ocs_ci.utility.templating import dump_data_to_json, Templating
 from ocs_ci.utility.utils import (
     clone_repo, convert_yaml2tfvars, create_directory_path, read_file_as_str,
@@ -563,10 +565,7 @@ class VSPHEREUPI(VSPHEREBASE):
             # for all the nodes
             ocp_version = get_ocp_version()
             if Version.coerce(ocp_version) >= Version.coerce('4.4'):
-                # before waiting for CSRs to generate, approve
-                # the existing ones if any
-                approve_pending_csr()
-                wait_for_all_nodes_csr()
+                wait_for_all_nodes_csr_and_approve()
 
             approve_pending_csr()
             self.test_cluster()

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -567,7 +567,6 @@ class VSPHEREUPI(VSPHEREBASE):
             if Version.coerce(ocp_version) >= Version.coerce('4.4'):
                 wait_for_all_nodes_csr_and_approve()
 
-            approve_pending_csr()
             self.test_cluster()
 
     def deploy_ocp(self, log_cli_level='DEBUG'):

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -563,6 +563,9 @@ class VSPHEREUPI(VSPHEREBASE):
             # for all the nodes
             ocp_version = get_ocp_version()
             if Version.coerce(ocp_version) >= Version.coerce('4.4'):
+                # before waiting for CSRs to generate, approve
+                # the existing ones if any
+                approve_pending_csr()
                 wait_for_all_nodes_csr()
 
             approve_pending_csr()

--- a/ocs_ci/utility/csr.py
+++ b/ocs_ci/utility/csr.py
@@ -136,7 +136,11 @@ def get_nodes_csr():
     return csr_nodes
 
 
-def wait_for_all_nodes_csr(timeout=900, sleep=10, expected_node_num=None):
+def wait_for_all_nodes_csr_and_approve(
+        timeout=900,
+        sleep=10,
+        expected_node_num=None
+):
     """
     Wait for CSR to generate for nodes
 
@@ -172,3 +176,8 @@ def wait_for_all_nodes_csr(timeout=900, sleep=10, expected_node_num=None):
             f" {expected_node_num} but found {len(csr_nodes.keys())} CSRs."
             f"retrying again"
         )
+        # approve the pending CSRs here since newly added nodes will not
+        # generate CSR till existing CSRs are approved
+        pending_csrs = get_pending_csr()
+        if pending_csrs:
+            approve_csrs(pending_csrs)

--- a/ocs_ci/utility/csr.py
+++ b/ocs_ci/utility/csr.py
@@ -1,7 +1,7 @@
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.ocs import constants, exceptions, ocp
-from ocs_ci.ocs.node import get_all_nodes
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import run_cmd, TimeoutSampler
 
@@ -136,13 +136,14 @@ def get_nodes_csr():
     return csr_nodes
 
 
-def wait_for_all_nodes_csr(timeout=900, sleep=10):
+def wait_for_all_nodes_csr(timeout=900, sleep=10, expected_node_num=None):
     """
     Wait for CSR to generate for nodes
 
     Args:
         timeout (int): Time in seconds to wait
         sleep (int): Sampling time in seconds
+        expected_node_num (int): Number of nodes to verify CSR is generated
 
     Returns:
          bool: True if all nodes are generated CSR
@@ -151,21 +152,23 @@ def wait_for_all_nodes_csr(timeout=900, sleep=10):
         TimeoutExpiredError: in case CSR not found
 
     """
-    pending = False
-    all_nodes = get_all_nodes()
+    if not expected_node_num:
+        # expected number of nodes is total of master, worker nodes and
+        # bootstrapper node
+        expected_node_num = (
+            config.ENV_DATA['master_replicas']
+            + config.ENV_DATA['worker_replicas']
+            + 1
+        )
     for csr_nodes in TimeoutSampler(
-            timeout=timeout, sleep=sleep, func=get_nodes_csr
+        timeout=timeout, sleep=sleep, func=get_nodes_csr
     ):
-        pending_nodes = []
         logger.debug(f"CSR data: {csr_nodes}")
-        for node in all_nodes:
-            if node not in csr_nodes.keys():
-                logger.info(f"{node} CSR is not generated")
-                pending = True
-                pending_nodes.append(node)
-        if not pending:
-            logger.info("CSR generated for all nodes in cluster")
+        if len(csr_nodes.keys()) == expected_node_num:
+            logger.info(f"CSR generated for all {expected_node_num} nodes")
             return
         logger.warning(
-            f"Nodes {pending_nodes} are not generated CSR. retrying again"
+            f"Some nodes are not generated CSRs. Expected"
+            f" {expected_node_num} but found {len(csr_nodes.keys())} CSRs."
+            f"retrying again"
         )

--- a/ocs_ci/utility/csr.py
+++ b/ocs_ci/utility/csr.py
@@ -170,6 +170,7 @@ def wait_for_all_nodes_csr_and_approve(
         logger.debug(f"CSR data: {csr_nodes}")
         if len(csr_nodes.keys()) == expected_node_num:
             logger.info(f"CSR generated for all {expected_node_num} nodes")
+            approve_pending_csr()
             return
         logger.warning(
             f"Some nodes are not generated CSRs. Expected"


### PR DESCRIPTION
Problem:

Current wait_for_all_nodes_csr functionality waits for all
the nodes to generate CSR but we are getting all the nodes using
get_all_nodes. During deployment we have seen some nodes are not shown up
in get_all_nodes and it misses the approving CSR fo rthat node.

Solution:

Add extra parameter "expected_node_num" to wait_for_all_nodes_csr function
so that it will wait till "expected_node_num" number of CSRs generated.
By default, it will get number form config.ENV_DATA

Fixes: #1941 

Signed-off-by: vavuthu <vavuthu@redhat.com>