### PR TITLE
set nrfiles=8 in storage utilization fio config

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -418,6 +418,7 @@ def workload_fio_storageutilization(
         blocksize=4k
         ioengine=libaio
         directory=/mnt/target
+        nrfiles=8
         """)
 
     # When we ask for checksum to be generated for all files written in the


### PR DESCRIPTION
This increases [number of files fio writes to](https://fio.readthedocs.io/en/latest/fio_man.html#cmdoption-arg-nrfiles) on the target volume from 1
to 8, so that fio doesn't hit max_file_size limit on cephfs volume as
long as the volume size is smaller than 8 TiB.

fixes https://github.com/red-hat-storage/ocs-ci/issues/1959