### PR TITLE
Move the platform nodes initialization to platform_nodes.py

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -25,6 +25,19 @@ from ocs_ci.utility.utils import (
 logger = logging.getLogger(__name__)
 
 
+def initialize_nodes():
+    """
+    Return an instance of the relevant platform nodes class
+    (e.g. AWSNodes, VMWareNodes) to be later used in the test
+    for nodes related operations, like nodes restart,
+    detach/attach volume, etc.
+
+    """
+    factory = PlatformNodesFactory()
+    nodes = factory.get_nodes_platform()
+    return nodes
+
+
 class PlatformNodesFactory:
     """
     A factory class to get specific nodes platform object

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     deployment, ignore_leftovers, tier_marks
 )
-from ocs_ci.ocs import constants, ocp, defaults, node, platform_nodes, registry
+from ocs_ci.ocs import constants, ocp, defaults, node, registry
+from ocs_ci.ocs.platform_nodes import initialize_nodes
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CephHealthException
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.cloud_manager import CloudManager
@@ -1609,9 +1610,7 @@ def nodes():
     detach/attach volume, etc.
 
     """
-    factory = platform_nodes.PlatformNodesFactory()
-    nodes = factory.get_nodes_platform()
-    return nodes
+    return initialize_nodes()
 
 
 @pytest.fixture()

--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -12,7 +12,8 @@ from ocs_ci.ocs.cluster import count_cluster_osd, validate_osd_utilization
 from ocs_ci.framework import config
 from ocs_ci.ocs.node import get_typed_nodes, wait_for_nodes_status
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs import constants, platform_nodes
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.platform_nodes import initialize_nodes
 from ocs_ci.ocs.resources.pod import wait_for_dc_app_pods_to_reach_running_state
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
@@ -100,8 +101,7 @@ class TestScaleOSDsRebootNodes(E2ETest):
         # Rolling reboot on worker nodes
         worker_nodes = get_typed_nodes(node_type='worker')
 
-        factory = platform_nodes.PlatformNodesFactory()
-        nodes = factory.get_nodes_platform()
+        nodes = initialize_nodes()
 
         for node in worker_nodes:
             nodes.restart_nodes(nodes=[node])

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.node import (
     add_new_node_and_label_it
 )
 from ocs_ci.framework.testlib import (
-    tier1, tier2, tier3, tier4, tier4b,
+    tier1, tier2, tier3, tier4, tier4b, bugzilla,
     ManageTest, aws_platform_required, ignore_leftovers
 )
 
@@ -128,7 +128,7 @@ class TestNodesMaintenance(ManageTest):
 
     @tier4
     @tier4b
-    @aws_platform_required
+    @bugzilla('1835908')
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[
@@ -158,7 +158,7 @@ class TestNodesMaintenance(ManageTest):
         drain_nodes([typed_node_name])
 
         # Restarting the node
-        nodes.restart_nodes(nodes=typed_nodes, wait=True)
+        nodes.restart_nodes(nodes=typed_nodes)
 
         wait_for_nodes_status(
             node_names=[typed_node_name], status=constants.NODE_READY_SCHEDULING_DISABLED


### PR DESCRIPTION
* platform nodes instance initialization moved to platform_nodes.py to be used from both tests and infra
* removed aws_platfrom_required decorator from tests.manage.z_cluster.nodes.test_nodes_maintenance.TestNodesMaintenance.test_node_maintenance_restart_activate

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>