### PR TITLE
WIP: Do not merge: WA for lib bucket

### DIFF
--- a/conf/ocsci/lib_buckete_wa_after_deploy.yaml
+++ b/conf/ocsci/lib_buckete_wa_after_deploy.yaml
@@ -1,0 +1,4 @@
+---
+ENV_DATA:
+  disable_comunity_operator_source: true
+  lib_bucket_tag_after_ocs_deploy: "v2"

--- a/conf/ocsci/lib_buckete_wa_before_deploy.yaml
+++ b/conf/ocsci/lib_buckete_wa_before_deploy.yaml
@@ -1,0 +1,4 @@
+---
+ENV_DATA:
+  disable_comunity_operator_source: true
+  lib_bucket_tag_before_ocs_deploy: "v2"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -478,6 +478,16 @@ CATALOG_SOURCE_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "catalog-source.yaml"
 )
 
+LIB_BUCKET_CATALOG_SOURCE_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "catalog-lib-bucket.yaml"
+)
+
+LIB_BUCKET_CATALOG_NAME = "lib-bucket-catalog"
+
+LIB_BUCKET_CATALOG_IMAGE = "quay.io/noobaa/lib-bucket-catalog"
+
+COMMUNITY_OPERATORS = "community-operators"
+
 SUBSCRIPTION_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "subscription.yaml"
 )

--- a/ocs_ci/templates/ocs-deployment/catalog-lib-bucket.yaml
+++ b/ocs_ci/templates/ocs-deployment/catalog-lib-bucket.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: lib-bucket-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/noobaa/lib-bucket-catalog:v1


### PR DESCRIPTION
This is WA for testing lib bucket provisioner (LBP) upgrade to V2.

We are not going to merge this but only use for testing.

There are 2 scenarios and config files for them:

- `lib_buckete_wa_after_deploy.yaml`: Testing push of V2 of LBP after OCS is installed.
- `lib_buckete_wa_before_deploy.yaml`: Install OCS with new V2 of LBP - check if we are still able to deploy older version of OCS.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>