### PR TITLE
Skip TestRemoveMonFromCluster

### DIFF
--- a/tests/manage/z_cluster/test_remove_mon_from_cluster.py
+++ b/tests/manage/z_cluster/test_remove_mon_from_cluster.py
@@ -55,6 +55,7 @@ def run_io_on_pool(pool_obj):
 
 @tier4
 @tier4c
+@pytest.mark.skip("Test case is disabled, as per requirement not to support this scenario")
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-355")
 class TestRemoveMonFromCluster(ManageTest):

--- a/tests/manage/z_cluster/test_remove_mon_from_cluster.py
+++ b/tests/manage/z_cluster/test_remove_mon_from_cluster.py
@@ -9,7 +9,7 @@ Polarion-ID- OCS-355
 import logging
 import pytest
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework.testlib import tier4, tier4c, ManageTest, ignore_leftovers
+from ocs_ci.framework.testlib import ManageTest, ignore_leftovers
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
 from tests.helpers import run_io_with_rados_bench, delete_cephblockpools, create_ceph_block_pool
@@ -53,11 +53,11 @@ def run_io_on_pool(pool_obj):
     )
 
 
-@tier4
-@tier4c
-@pytest.mark.skip("Test case is disabled, as per requirement not to support this scenario")
+# Test case is disabled, as per requirement not to support this scenario (PR 2025)
+# tier4
+# tier4c
 @ignore_leftovers
-@pytest.mark.polarion_id("OCS-355")
+# @pytest.mark.polarion_id("OCS-355")
 class TestRemoveMonFromCluster(ManageTest):
     pool_obj = ""
 


### PR DESCRIPTION
This test case should be disabled, as it was marked as inactive in Polarion (OCS-355) and also, this scenario should not be supported.
Thanks @sidhant-agrawal for raising this 

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>