### PR TITLE
Improve run_io_in_background fixture

### DIFF
--- a/conf/ocsci/io_in_bg.yaml
+++ b/conf/ocsci/io_in_bg.yaml
@@ -1,0 +1,4 @@
+---
+# This config file will enable IO to be running in the background
+RUN:
+  io_in_bg: True

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -29,6 +29,7 @@ RUN:
   # Following chrome params are for openshift console UI testing
   force_chrome_branch_base: "665006"
   force_chrome_branch_sha256sum: "a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
+  io_in_bg: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1045,9 +1045,9 @@ def run_io_in_background(request, pod_factory_session):
     """
     if config.RUN['cli_params'].get('io_in_bg') or config.RUN['io_in_bg']:
         log.info(
-            f"\n===================================================\n"
-            f"Tests will be running while IO is in the background\n"
-            f"==================================================="
+            "\n===================================================\n"
+            "Tests will be running while IO is in the background\n"
+            "==================================================="
         )
 
         g_sheet = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1039,12 +1039,16 @@ def log_cli_level(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def run_io_in_background(request):
+def run_io_in_background(request, pod_factory_session):
     """
     Run IO during the test execution
     """
-    if config.RUN['cli_params'].get('io_in_bg'):
-        log.info(f"Tests will be running while IO is in the background")
+    if config.RUN['cli_params'].get('io_in_bg') or config.RUN['io_in_bg']:
+        log.info(
+            f"\n===================================================\n"
+            f"Tests will be running while IO is in the background\n"
+            f"==================================================="
+        )
 
         g_sheet = None
         if config.RUN['google_api_secret']:
@@ -1093,38 +1097,9 @@ def run_io_in_background(request):
                 log.info(f"Read: {result[0]}")
                 log.info(f"Write: {result[1]}")
 
-            if pod_obj:
-                pod_obj.delete()
-                pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
-            if pvc_obj:
-                pvc_obj.delete()
-                pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
-            if sc_obj:
-                sc_obj.delete()
-            if cbp_obj:
-                cbp_obj.delete()
-            if secret_obj:
-                secret_obj.delete()
-
         request.addfinalizer(finalizer)
 
-        secret_obj = helpers.create_secret(
-            interface_type=constants.CEPHBLOCKPOOL
-        )
-        cbp_obj = helpers.create_ceph_block_pool()
-        sc_obj = helpers.create_storage_class(
-            interface_type=constants.CEPHBLOCKPOOL,
-            interface_name=cbp_obj.name,
-            secret_name=secret_obj.name
-        )
-        pvc_obj = helpers.create_pvc(sc_name=sc_obj.name, size='2Gi')
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
-        pvc_obj.reload()
-        pod_obj = helpers.create_pod(
-            interface_type=constants.CEPHBLOCKPOOL, pvc_name=pvc_obj.name
-        )
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
-        pod_obj.reload()
+        pod_obj = pod_factory_session(interface=constants.CEPHBLOCKPOOL)
 
         def run_io_in_bg():
             """


### PR DESCRIPTION
* Adjust tests.conftest.run_io_in_background to use factory pod fixture
* Create a config file to allow IO in background

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>