### PR TITLE
Improve auth config loading mechanism

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -791,3 +791,10 @@ OCS_PROVISIONERS = [
 bucket_website_action_list = ['PutBucketWebsite', 'GetBucketWebsite', 'PutObject']
 bucket_version_action_list = ['PutBucketVersioning', 'GetBucketVersioning']
 object_version_action_list = ['PutObject', 'GetObjectVersion', 'DeleteObjectVersion']
+
+
+# URLs
+AUTH_CONFIG_DOCS = (
+    'https://ocs-ci.readthedocs.io/en/latest/docs/getting_started.html'
+    '#authentication-config'
+)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1522,8 +1522,6 @@ def load_auth_config():
 
     Raises:
         FileNotFoundError: if the auth config is not found
-        KeyError: if the auth config isn't setup properly
-        requests.RequestException: if the response return code is not ok
 
     Returns:
         dict: A dictionary reprensenting the YAML file
@@ -1548,6 +1546,10 @@ def get_ocs_olm_operator_tags(limit=100):
 
     Args:
         limit: the number of tags to limit the request to
+
+    Raises:
+        KeyError: if the auth config isn't setup properly
+        requests.RequestException: if the response return code is not ok
 
     Returns:
         list: OCS OLM Operator tags


### PR DESCRIPTION
- Take out the existing code from `get_ocs_olm_operator_tags` and put it in a dedicated function in order to allow other functions to use it
- Add a constant leading to the authentication config dogs
