### PR TITLE
Temporarily disable add_capacity test

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -5,8 +5,12 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.utility.utils import ceph_health_check
+import pytest
 
 
+@pytest.mark.skip(
+    reason="Temporarily disabling test as it prevents other tests from running"
+)
 @pre_upgrade
 @ignore_leftovers
 @tier1


### PR DESCRIPTION
Temporarily skip add capacity test to allow other runs to complete. 

Please see - https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/7379/

