### PR TITLE
 Functionality to determine the cluster throughput limit and run IO at a given percentage of it

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,7 +105,7 @@ to the pytest.
    the cluster throughput limit.
 * `--io-load` - IOs throughput target percentage. The value should be
    between 0 to 100. The default is 30 (30%)
-* `--enable-bg-io-logs` - If passed, background IO log messages, will be printed
+* `--enable-bg-io-logs` - If passed, background IO log messages will be printed
 
 ## Examples
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,7 +188,7 @@ run-ci tests/
     --email=<emailid1>,<emailid2>,<emailid3>
  ```
 
-#### Running tests on deployed environment and sending reports
+#### Running tests with background IO load
 
 If you would like to run tests with IO load of 50% in the tests background,
 while background IO log messages are printed, append these arguments to the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,6 +99,13 @@ to the pytest.
   bugzilla_password = yourPassword
   ```
 * `--collect-logs` - to collect OCS logs for failed test cases.
+* `--io-in-bg` - If passed, IO will be running in the test background.
+   The amount of IO load will be determined by the `--io-load` argument, if
+   provided. In case `--io-load` is not provided, IO load is set to 30% of
+   the cluster throughput limit.
+* `--io-load` - IOs throughput target percentage. The value should be
+   between 0 to 100. The default is 30 (30%)
+* `--enable-bg-io-logs` - If passed, background IO log messages, will be printed
 
 ## Examples
 
@@ -180,6 +187,12 @@ run-ci tests/
     --html=report.html --self-contained-html \
     --email=<emailid1>,<emailid2>,<emailid3>
  ```
+
+#### Running tests on deployed environment and sending reports
+
+If you would like to run tests with IO load of 50% in the tests background,
+while background IO log messages are printed, append these arguments to the
+`run-ci` command: `--io-in-bg --io-load 50 --enable-bg-io-logs`
 
 #### Destroy of cluster
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -30,6 +30,8 @@ RUN:
   force_chrome_branch_base: "665006"
   force_chrome_branch_sha256sum: "a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
   io_in_bg: False
+  io_load: null
+  bg_io_logs: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.
@@ -130,4 +132,3 @@ UPGRADE:
 # or ping in ocs infra chat room.
 AUTH:
     test_quay_auth: test_secret
-  

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -92,11 +92,22 @@ def pytest_addoption(parser):
         help="Collect OCS logs when test case failed",
     )
     parser.addoption(
-        '--io_in_bg',
+        '--io-in-bg',
         dest='io_in_bg',
         action="store_true",
         default=False,
         help="Run IO in the background",
+    )
+    parser.addoption(
+        '--io-load',
+        dest='io_load',
+        help="IOs throughput target percentage. Value should be between 0 to 100",
+    )
+    parser.addoption(
+        '--enable-bg-io-logs',
+        dest='enable_bg_io_logs',
+        action="store_true",
+        help="Enable background IO logs, if --io-in-bg is passed",
     )
     parser.addoption(
         '--ocs-version',
@@ -299,7 +310,15 @@ def process_cluster_cli_params(config):
     ocsci_config.DEPLOYMENT['live_deployment'] = live_deployment or (
         ocsci_config.DEPLOYMENT.get('live_deployment', False)
     )
-    ocsci_config.RUN['cli_params']['io_in_bg'] = get_cli_param(config, "io_in_bg", default=False)
+    io_in_bg = get_cli_param(config, 'io_in_bg')
+    if io_in_bg:
+        ocsci_config.RUN['io_in_bg'] = True
+        io_load = get_cli_param(config, 'io_load')
+        if io_load:
+            ocsci_config.RUN['io_load'] = io_load
+        io_bg_logs = get_cli_param(config, 'enable_bg_io_logs')
+        if io_bg_logs:
+            ocsci_config.RUN['io_bg_logs'] = True
     upgrade_ocs_version = get_cli_param(config, "upgrade_ocs_version")
     if upgrade_ocs_version:
         ocsci_config.UPGRADE['upgrade_ocs_version'] = upgrade_ocs_version

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -954,7 +954,6 @@ def validate_pg_balancer():
 
 def get_percent_used_capacity():
     """
-    ***This function was taken from PR 1996***
     Function to calculate the percentage of used capacity in a cluster
 
     Returns:

--- a/ocs_ci/ocs/cluster_load.py
+++ b/ocs_ci/ocs/cluster_load.py
@@ -1,0 +1,280 @@
+"""
+A module for cluster load related functionalities
+
+"""
+import logging
+import time
+
+import ocs_ci.ocs.constants as constant
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import (
+    CephCluster, get_osd_pods_memory_sum, get_percent_used_capacity
+)
+
+
+class ClusterLoad:
+    """
+    A class for cluster load functionalities
+
+    """
+
+    def __init__(self, propagate_logs=True):
+        """
+        Initializer for ClusterLoad
+
+        Args:
+            propagate_logs (bool): True for logging, False otherwise
+
+        """
+        self.logger = logging.getLogger(__name__)
+        self.logger.propagate = propagate_logs
+        self.cl_obj = CephCluster()
+
+    def reach_cluster_load_percentage_in_throughput(
+        self, pvc_factory, pod_factory, target_percentage=0.3, cluster_limit=None
+    ):
+        """
+        Reach the cluster throughput limit and then drop to the requested target percentage.
+        The number of pods needed for the desired target percentage is determined by
+        creating pods one by one, while examining if the cluster throughput is increased
+        by more than 10%. When it doesn't increased by more than 10% anymore after
+        the new pod started running IO, it means that the cluster throughput limit is
+        reached. Then, the function deletes the pods that are not needed as they
+        are the difference between the limit (100%) and the target percentage
+        (the default target percentage is 30%). This leaves the number of pods needed
+        running IO for cluster throughput to be around the desired percentage.
+
+        Args:
+            pvc_factory (function): A call to pvc_factory function
+            pod_factory (function): A call to pod_factory function
+            target_percentage (float): The percentage of cluster load that is required.
+                The value should be greater than 0 and smaller than 1
+            cluster_limit (float): The cluster pre-known throughput limit in Mb/s.
+                If passed, the function will calculate the target throughput based on it
+                multiplied by 'target_percentage'
+
+        Returns:
+            tuple: The cluster limit in Mb/s (float) and the current throughput
+                in Mb/s (float)
+
+        """
+        pvc_objs = list()
+        pod_objs = list()
+        limit_reached = False
+
+        # FIO params:
+        # 'runtime' is set with a large value of seconds to
+        # make sure that the pods are running
+        io_run_time = 100**3
+        rate = '200M'
+        bs = '256K'
+
+        if 0.1 < target_percentage > 0.95:
+            self.logger.warning(
+                f"The target percentage is {target_percentage * 100}% which is not "
+                f"within the accepted range. Therefore, IO will not be started"
+            )
+            return
+
+        target_throughput = None
+        if cluster_limit:
+            target_throughput = cluster_limit * target_percentage
+
+        pvc_size = int(get_osd_pods_memory_sum() * 0.75)
+
+        self.logger.info(
+            f"In order to eliminate the OSD pods cache effect, creating 1 pod with a "
+            f"PVC size of {pvc_size} GB, which equals to 0.75 of the memory sum of "
+            f"all the OSD pods. Then, starting IOs on it"
+        )
+        pvc_obj = pvc_factory(
+            interface=constant.CEPHBLOCKPOOL, size=pvc_size,
+            volume_mode=constants.VOLUME_MODE_BLOCK
+        )
+        pvc_objs.append(pvc_obj)
+        pod_obj = pod_factory(
+            pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
+            raw_block_pv=True
+        )
+        pod_objs.append(pod_obj)
+
+        io_file_size = f"{pvc_size-1}G"
+
+        pod_obj.run_io(
+            storage_type='block', size=io_file_size,
+            runtime=io_run_time, rate=rate, bs=bs, rw_ratio=25
+        )
+
+        pvc_size = int(get_osd_pods_memory_sum() * 0.25)
+        pvc_obj = pvc_factory(
+            interface=constant.CEPHBLOCKPOOL, size=pvc_size,
+            volume_mode=constants.VOLUME_MODE_BLOCK
+        )
+        pvc_objs.append(pvc_obj)
+        pod_obj = pod_factory(
+            pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
+            raw_block_pv=True
+        )
+        pod_objs.append(pod_obj)
+
+        current_throughput = self.cl_obj.calc_average_throughput()
+
+        if target_throughput:
+            if current_throughput > target_throughput * 0.8:
+                self.logger.info(
+                    f"Cluster limit has been reached. It is {current_throughput} Mb/s"
+                )
+                limit_reached = True
+
+        time_to_wait = 60 * 30
+        time_before = time.time()
+        if not target_throughput:
+            self.logger.info(
+                f"\n=====================================================================\n"
+                f"Determining the cluster throughput limit. Once determined, IOs will be"
+                f"\nreduced to load at {target_percentage * 100}% of the cluster limit"
+                f"\n====================================================================="
+            )
+
+        while not limit_reached:
+
+            self.logger.info(
+                f"The cluster average collected throughput BEFORE starting "
+                f"IOs on the newly created pod is {current_throughput} Mb/s"
+            )
+
+            io_file_size = f"{pvc_size - 1}G"
+            pod_obj.run_io(
+                storage_type='block', size=io_file_size,
+                runtime=io_run_time, rate=rate, bs=bs, rw_ratio=25
+            )
+
+            self.logger.info(
+                f"While IO kicks-in on the previously created pod ({pod_obj.name}), "
+                f"creating a new pod and PVC for the next iteration"
+            )
+            pvc_size = int(get_osd_pods_memory_sum() * 0.25)
+            pvc_obj = pvc_factory(
+                interface=constant.CEPHBLOCKPOOL, size=pvc_size,
+                volume_mode=constants.VOLUME_MODE_BLOCK
+            )
+            pvc_objs.append(pvc_obj)
+            pod_obj = pod_factory(
+                pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
+                raw_block_pv=True
+            )
+            pod_objs.append(pod_obj)
+            previous_throughput = current_throughput
+            current_throughput = self.cl_obj.calc_average_throughput()
+            self.logger.info(
+                f"The cluster average collected throughput AFTER starting IOs on the newly"
+                f" created pod is {current_throughput} Mb/s, while before IOs started "
+                f"on the newly created pod it was {previous_throughput}.\nThe number of "
+                f"pods running IOs is {len(pod_objs) - 1}")
+
+            if not target_throughput:
+                if current_throughput > previous_throughput * 0.8 and (
+                    current_throughput > 20
+                ):
+                    tp_diff = (current_throughput / previous_throughput * 100) - 100
+                    if tp_diff < 10:
+                        limit_reached = True
+                        cluster_limit = current_throughput
+                        self.logger.info(
+                            f"\n===================================================\n"
+                            f"The cluster throughput limit is {cluster_limit} Mb/s\n"
+                            f"==================================================="
+                        )
+                    else:
+                        self.logger.info(
+                            f"\n================================================================\n"
+                            f"The throughput difference after starting FIO on the newly created\n"
+                            f"pod is {tp_diff:.2f}%. We are waiting for it to be less than 10%"
+                            f"\n================================================================"
+                        )
+                        continue
+            else:
+                if current_throughput > target_throughput * 0.8:
+                    self.logger.info(
+                        f"Cluster limit has been reached. It is {current_throughput} Mb/s"
+                    )
+                    limit_reached = True
+            if time.time() > time_before + time_to_wait:
+                if not target_throughput:
+                    self.logger.warning(
+                        f"Could not determine the cluster throughput limit "
+                        f"within the given {time_to_wait} timeout. Breaking"
+                    )
+                else:
+                    self.logger.warning(
+                        f"Could not reach the cluster throughput percentage "
+                        f"within the given {time_to_wait} timeout. Breaking"
+                    )
+                limit_reached = True
+                cluster_limit = current_throughput
+
+            if current_throughput < 20:
+                if time.time() > time_before + (time_to_wait * 0.5):
+                    self.logger.warning(
+                        f"Waited for {time_to_wait * 0.5} seconds and the"
+                        f" throughput is less than 20 Mb/s. Breaking"
+                    )
+                    cluster_limit = current_throughput
+                if len(pod_objs) > 8:
+                    self.logger.warning(
+                        f"The number of pods running IO is {len(pod_objs)} "
+                        f"and the throughput is less than 20 Mb/s. Breaking"
+                    )
+                    limit_reached = True
+                    cluster_limit = current_throughput
+
+            cluster_used_space = get_percent_used_capacity()
+            if cluster_used_space > 50:
+                if not target_throughput:
+                    self.logger.warning(
+                        f"Cluster used space is {cluster_used_space}%. Could not find the "
+                        f"cluster throughput limit before the used spaced reached 50%. Breaking"
+                    )
+                else:
+                    self.logger.warning(
+                        f"Cluster used space is {cluster_used_space}%. Could not reach the "
+                        f"cluster throughput target percentage before the used spaced reached"
+                        f" 50%. Breaking"
+                    )
+                limit_reached = True
+                cluster_limit = current_throughput
+        if not target_throughput:
+            target_throughput = cluster_limit * target_percentage
+            self.logger.info(f"The target throughput is {target_throughput}")
+            current_throughput = cluster_limit
+            self.logger.info(f"The current throughput is {current_throughput}")
+
+            self.logger.info(
+                "Start deleting pods that are running IO one by one while comparing "
+                "the current throughput utilization with the target one. The goal is "
+                "to reach cluster throughput utilization that is more or less the target"
+                " throughput percentage"
+            )
+            while current_throughput > (target_throughput * 1.2) and len(pod_objs) > 1:
+                pod_name = pod_objs[-1].name
+                pod_objs[-1].delete()
+                pod_objs[-1].ocp.wait_for_delete(pod_objs[-1].name)
+                pod_objs.remove(pod_objs[-1])
+                pvc_objs[-1].delete()
+                pvc_objs[-1].ocp.wait_for_delete(pvc_objs[-1].name)
+                pvc_objs.remove(pvc_objs[-1])
+                self.logger.info(f"Waiting for IO to be stopped on pod {pod_name}")
+                time.sleep(10)
+                current_throughput = self.cl_obj.calc_average_throughput()
+                self.logger.info(
+                    f"The cluster average collected throughput after deleting "
+                    f"pod {pod_name} is {current_throughput} Mb/s"
+                )
+
+        self.logger.info(
+            f"\n==============================================\n"
+            f"The number of pods that will continue running"
+            f"\nIOs is {len(pod_objs)} at a load of {current_throughput} Mb/s"
+            f"\n=============================================="
+        )
+        return cluster_limit, current_throughput

--- a/ocs_ci/ocs/cluster_load.py
+++ b/ocs_ci/ocs/cluster_load.py
@@ -67,7 +67,7 @@ class ClusterLoad:
         # make sure that the pods are running
         io_run_time = 100**3
         rate = '200M'
-        bs = '256K'
+        bs = '128K'
 
         if 0.1 < target_percentage > 0.95:
             self.logger.warning(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -823,3 +823,8 @@ AUTH_CONFIG_DOCS = (
     'https://ocs-ci.readthedocs.io/en/latest/docs/getting_started.html'
     '#authentication-config'
 )
+
+# Conversions
+TP_CONVERSION = {
+    ' B/s': 0.000000976562, ' KiB/s': 0.000976562, ' MiB/s': 1
+}

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2015,3 +2015,42 @@ class AZInfo(object):
         AZInfo.zone_number += 1
         AZInfo.zone_number %= get_az_count()
         return prev
+
+
+def convert_device_size(unformatted_size, units_to_covert_to):
+    """
+    Convert a string representing a size to an int according to the given units
+    to convert to
+
+    Args:
+        unformatted_size (str): The size to convert (i.e, '1Gi'/'100Mi')
+        units_to_covert_to (str): The units to convert the size to (i.e, TB/GB/MB)
+
+    Returns:
+        int: The converted size
+
+    """
+    units = unformatted_size[-2:]
+    absolute_size = int(unformatted_size[:-2])
+
+    if units_to_covert_to == 'TB':
+        if units == 'Ti':
+            return absolute_size
+        elif units == 'Gi':
+            return absolute_size * 1024
+        elif units == 'Mi':
+            return absolute_size * 1024 * 1024
+    elif units_to_covert_to == 'GB':
+        if units == 'Ti':
+            return absolute_size / 1024
+        elif units == 'Gi':
+            return absolute_size
+        elif units == 'Mi':
+            return absolute_size * 1024
+    elif units_to_covert_to == 'MB':
+        if units == 'Ti':
+            return absolute_size / 1024 / 1024
+        elif units == 'Gi':
+            return absolute_size / 1024
+        elif units == 'Mi':
+            return absolute_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 import random
 import tempfile
 import textwrap
@@ -28,16 +29,16 @@ from ocs_ci.ocs.resources.cloud_manager import CloudManager
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import get_rgw_pod
+from ocs_ci.ocs.resources.pod import get_rgw_pod, get_ceph_tools_pod
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
+from ocs_ci.ocs.cluster_load import ClusterLoad
 from ocs_ci.utility import aws
 from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
 from ocs_ci.utility import templating
 from ocs_ci.utility.environment_check import (
     get_status_before_execution, get_status_after_execution
 )
-from ocs_ci.utility.spreadsheet.spreadsheet_api import GoogleSpreadSheetAPI
 from ocs_ci.utility.uninstall_openshift_logging import uninstall_cluster_logging
 from ocs_ci.utility.utils import (
     TimeoutSampler, get_rook_repo, get_ocp_version, ceph_health_check
@@ -686,7 +687,6 @@ def pod_factory_fixture(request, pvc_factory):
             pod_obj = helpers.create_resource(**custom_data)
         else:
             pvc = pvc or pvc_factory(interface=interface)
-
             pod_obj = helpers.create_pod(
                 pvc_name=pvc.name,
                 namespace=pvc.namespace,
@@ -1040,26 +1040,23 @@ def log_cli_level(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def run_io_in_background(request, pod_factory_session):
+def run_io_in_background(request, pvc_factory_session, pod_factory_session):
     """
     Run IO during the test execution
     """
-    if config.RUN['cli_params'].get('io_in_bg') or config.RUN['io_in_bg']:
+    if config.RUN.get('io_in_bg'):
+        io_load_param = config.RUN.get('io_load')
+        if io_load_param:
+            io_load = int(io_load_param) * 0.01
+        else:
+            io_load = 0.3
+        io_bg_logs = config.RUN.get('bg_io_logs')
         log.info(
             "\n===================================================\n"
             "Tests will be running while IO is in the background\n"
             "==================================================="
         )
 
-        g_sheet = None
-        if config.RUN['google_api_secret']:
-            g_sheet = GoogleSpreadSheetAPI("IO BG results", 0)
-        else:
-            log.warning(
-                "Google API secret was not found. IO won't be reported to "
-                "a Google spreadsheet"
-            )
-        results = list()
         temp_file = tempfile.NamedTemporaryFile(
             mode='w+', prefix='test_status', delete=False
         )
@@ -1072,63 +1069,60 @@ def run_io_in_background(request, pod_factory_session):
             with open(temp_file.name, 'w') as t_file:
                 t_file.writelines(status)
 
+        log.info(
+            "Start running IO in the background. The amount of IO that will be written "
+            "is going to be determined by the cluster capabilities according to its "
+            "throughput limit"
+        )
+        cl_load_obj = ClusterLoad()
+        cluster_limit, current_tp = cl_load_obj.reach_cluster_load_percentage_in_throughput(
+            pvc_factory=pvc_factory_session, pod_factory=pod_factory_session,
+            target_percentage=io_load
+        )
+
         set_test_status('running')
 
         def finalizer():
             """
-            Delete the resources created during setup, used for
-            running IO in the test background
+            Stop the thread that executed keep_io_running()
             """
             set_test_status('finished')
-            try:
-                for status in TimeoutSampler(90, 3, get_test_status):
-                    if status == 'terminated':
-                        break
-            except TimeoutExpiredError:
-                log.warning(
-                    "Background IO was still in progress before IO "
-                    "thread termination"
-                )
             if thread:
                 thread.join()
 
-            log.info("Background IO has stopped")
-            for result in results:
-                log.info(f"IOPs after FIO for pod {pod_obj.name}:")
-                log.info(f"Read: {result[0]}")
-                log.info(f"Write: {result[1]}")
-
         request.addfinalizer(finalizer)
 
-        pod_obj = pod_factory_session(interface=constants.CEPHBLOCKPOOL)
+        def keep_io_running():
+            """
+            This function purpose is to ensure that IO is running also after scenarios
+            in which the IO is stopped due to disruptive operations like node failures.
+            As long as Ceph health is OK, it watches the cluster throughput. In case it
+            is below 60% of the target throughput percentage defined with 'io_load',
+            it calls again reach_cluster_load_percentage_in_throughput()
 
-        def run_io_in_bg():
             """
-            Run IO by executing FIO and deleting the file created for FIO on
-            the pod, in a while true loop. Will be running as long as
-            the test is running.
-            """
+            cl_load_obj.__init__(propagate_logs=io_bg_logs)
             while get_test_status() == 'running':
-                pod_obj.run_io('fs', '1G')
-                result = pod_obj.get_fio_results()
-                reads = result.get('jobs')[0].get('read').get('iops')
-                writes = result.get('jobs')[0].get('write').get('iops')
-                if g_sheet:
-                    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                    g_sheet.insert_row([now, reads, writes])
+                try:
+                    cl_load_obj.cl_obj.toolbox = get_ceph_tools_pod()
+                    if cl_load_obj.cl_obj.is_health_ok():
+                        average_tp = cl_load_obj.cl_obj.calc_average_throughput(samples=10)
+                        if average_tp < current_tp * 0.5:
+                            cl_load_obj.reach_cluster_load_percentage_in_throughput(
+                                pvc_factory=pvc_factory_session,
+                                pod_factory=pod_factory_session,
+                                target_percentage=io_load,
+                                cluster_limit=cluster_limit
+                            )
+                # Any type of exception should be caught and we should continue.
+                # We don't want any test to fail
+                except Exception:
+                    continue
+                time.sleep(10)
 
-                results.append((reads, writes))
-
-                file_path = os.path.join(
-                    pod_obj.get_storage_path(storage_type='fs'),
-                    pod_obj.io_params['filename']
-                )
-                pod_obj.exec_cmd_on_pod(f'rm -rf {file_path}')
             set_test_status('terminated')
 
-        log.info("Start running IO in the test background")
-
-        thread = threading.Thread(target=run_io_in_bg)
+        thread = threading.Thread(target=keep_io_running)
         thread.start()
 
 


### PR DESCRIPTION
Reach the target throughput load percentage, and keep it running throughout the test suite execution. 
The number of pods needed for the desired target percentage is determined by creating pods one by one, while examining if the cluster throughput is increased by more than 10%. When it doesn't increased by more than 10% anymore after the new pod started running IO, it means that the cluster throughput limit is reached. Then, the function deletes the pods that are not needed as they are the difference between the limit (100%) and the target percentage (the default target percentage is 30%). This leaves the number of pods needed running IO for cluster throughput to be around the desired percentage.

To be used by https://github.com/red-hat-storage/ocs-ci/blob/5cee08d83ea59d0acae5255c04ef9d51995f61fd/tests/conftest.py#L1042

Also fixes https://github.com/red-hat-storage/ocs-ci/issues/2081

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>