### PR TITLE
Make sure we use all available zones for workers

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1995,3 +1995,23 @@ def destroy_cluster(installer, cluster_path, log_level="DEBUG"):
         raise
     except Exception:
         log.error(traceback.format_exc())
+
+
+class AZInfo(object):
+    """
+    A class for getting different az numbers across calls
+    """
+    zone_number = 0
+
+    def get_zone_number(self):
+        """
+        Increment current zone_number and perform modulus op
+        to roll-on to next available number
+
+        Returns:
+           int: zone number index
+        """
+        prev = AZInfo.zone_number
+        AZInfo.zone_number += 1
+        AZInfo.zone_number %= get_az_count()
+        return prev


### PR DESCRIPTION
As of now we were randomly chosing cloudformation stack to extract zone info for worker, with this PR we will be iterating  over all available zones and each worker will get a different stack hence different zone. 

Applicable for both RHEL and RHCOS workers.
fixes: https://github.com/red-hat-storage/ocs-ci/issues/2036

Signed-off-by: Shylesh Kumar Mohan <shmohan@redhat.com>