### PR TITLE
Added function to fetch all device paths irrespective of platform

### DIFF
--- a/ocs_ci/utility/localstorage.py
+++ b/ocs_ci/utility/localstorage.py
@@ -1,0 +1,34 @@
+"""
+This module contains local-storage related methods
+"""
+import logging
+import os
+import shutil
+import yaml
+
+from ocs_ci.utility.utils import clone_repo, run_cmd
+from ocs_ci.ocs import constants
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_all_device_paths():
+    """
+    Return all device paths inside worker nodes
+
+    Returns:
+        list : List containing all device paths
+
+    """
+    path = os.path.join(constants.EXTERNAL_DIR, "device-by-id-ocp")
+    clone_repo(constants.OCP_QE_DEVICEPATH_REPO, path)
+    os.chdir(path)
+    logger.info("Running script to fetch device paths...")
+    run_cmd("ansible-playbook devices_by_id.yml")
+    with open("local-storage-block.yaml") as local_storage_block:
+        local_block = yaml.load(local_storage_block, Loader=yaml.FullLoader)
+        dev_paths = local_block["spec"]["storageClassDevices"][0]["devicePaths"]
+    logger.info(f"All devices are {dev_paths}")
+    os.chdir(constants.TOP_DIR)
+    shutil.rmtree(path)
+    return dev_paths


### PR DESCRIPTION
Since there was a requirement to fetch device paths from the worker nodes irrespective of the platform (Aws/Bare Meral etc.)
Added a helper function that does the same.
Signed-off-by: Anubhav Deep <adeep@redhat.com>