### PR TITLE
Fix creation of anonymous boto3 S3 resource

### DIFF
--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -10,7 +10,9 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_OPTIMAL
-from tests.manage.mcg.helpers import retrieve_anon_s3_resource, sync_object_directory
+from tests.manage.mcg.helpers import (
+    retrieve_anon_s3_resource, sync_object_directory
+)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -10,9 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_OPTIMAL
-from tests.manage.mcg.helpers import (
-    sync_object_directory
-)
+from tests.manage.mcg.helpers import retrieve_anon_s3_resource, sync_object_directory
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +43,7 @@ def test_fill_bucket(
     awscli_pod_session.exec_cmd_on_pod(
         command=f'mkdir {LOCAL_TESTOBJS_DIR_PATH}'
     )
-    test_objects = boto3.resource('s3').Bucket(
+    test_objects = retrieve_anon_s3_resource().Bucket(
         constants.TEST_FILES_BUCKET
     ).objects.all()
 

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -1,6 +1,5 @@
 import logging
 
-import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -27,7 +27,7 @@ def retrieve_anon_s3_resource():
 
     Returns:
         boto3.resource(): An anonymous S3 resource
-        
+
     """
     anon_s3_resource = boto3.resource('s3')
     anon_s3_resource.meta.client.meta.events.register(

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -12,8 +12,25 @@ from ocs_ci.utility import templating
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
 from tests.helpers import create_resource
 from tests.helpers import logger, craft_s3_command, craft_s3_api_command
+from botocore.handlers import disable_signing
 
 log = logging.getLogger(__name__)
+
+
+def retrieve_anon_s3_resource():
+    """
+    Returns an anonymous boto3 S3 resource by creating one and disabling signing
+
+    Disabling signing isn't documented anywhere, and this solution is based on
+    a comment by an AWS developer:
+    https://github.com/boto/boto3/issues/134#issuecomment-116766812
+
+    Returns:
+        boto3.resource(): An anonymous S3 resource
+    """
+    anon_s3_resource = boto3.resource('s3')
+    anon_s3_resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+    return anon_s3_resource
 
 
 def retrieve_test_objects_to_pod(podobj, target_dir):
@@ -32,7 +49,7 @@ def retrieve_test_objects_to_pod(podobj, target_dir):
     downloaded_objects = []
     # Retrieve a list of all objects on the test-objects bucket and downloads them to the pod
     podobj.exec_cmd_on_pod(command=f'mkdir {target_dir}')
-    public_s3 = boto3.resource('s3')
+    public_s3 = retrieve_anon_s3_resource()
     with ThreadPoolExecutor() as p:
         for obj in public_s3.Bucket(constants.TEST_FILES_BUCKET).objects.all():
             logger.info(f'Downloading {obj.key} from AWS test bucket')

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -27,6 +27,7 @@ def retrieve_anon_s3_resource():
 
     Returns:
         boto3.resource(): An anonymous S3 resource
+        
     """
     anon_s3_resource = boto3.resource('s3')
     anon_s3_resource.meta.client.meta.events.register(

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -29,7 +29,9 @@ def retrieve_anon_s3_resource():
         boto3.resource(): An anonymous S3 resource
     """
     anon_s3_resource = boto3.resource('s3')
-    anon_s3_resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+    anon_s3_resource.meta.client.meta.events.register(
+        'choose-signer.s3.*', disable_signing
+    )
     return anon_s3_resource
 
 

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2, tier3
 from ocs_ci.ocs import constants
 from tests.manage.mcg import helpers
+from tests.manage.mcg.helpers import retrieve_anon_s3_resource
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ class TestObjectIntegrity(ManageTest):
 
         # Download the file to pod
         awscli_pod.exec_cmd_on_pod(command=f'mkdir {original_dir} {result_dir}')
-        public_s3 = boto3.client('s3')
+        public_s3 = retrieve_anon_s3_resource()
         download_files = []
         # Use obj_key as prefix to download multiple files for large_small
         # case, it also works with single file

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -1,6 +1,5 @@
 import logging
 
-import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants
 from tests.manage.mcg import helpers
+from tests.manage.mcg.helpers import retrieve_anon_s3_resource
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +133,7 @@ class TestBucketIO(ManageTest):
 
         # Download the file to pod
         awscli_pod.exec_cmd_on_pod(command=f'mkdir {data_dir}')
-        public_s3 = boto3.client('s3')
+        public_s3 = retrieve_anon_s3_resource()
         download_files = []
         # Use obj_key as prefix to download multiple files for large_small
         # case, it also works with single file

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -1,7 +1,6 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
-import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (


### PR DESCRIPTION
Up until today, we didn't actually use an anonymous S3 client for MCG testing - it (semi-secretly) relied on the local AWS credentials.
Fixed.