### PR TITLE
Use proper certificates for AWS, S3 and RPC requests

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -779,6 +779,11 @@ NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"
+MCG_CRT_NAME = "service-ca.crt"
+MCG_CRT_REMOTE_PATH = f"/var/run/secrets/kubernetes.io/serviceaccount/..data/{MCG_CRT_NAME}"
+MCG_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{MCG_CRT_NAME}"
+MCG_CRT_AWSCLI_POD_PATH = f"/cert/mcg-{MCG_CRT_NAME}"
+AWSCLI_RELAY_POD_NAME = "awscli-relay-pod"
 
 # Storage classes provisioners
 OCS_PROVISIONERS = [

--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -57,13 +57,13 @@ class OBC(object):
         self.s3_endpoint = mcg.s3_endpoint
 
         self.s3_resource = boto3.resource(
-            's3', verify=False, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
 
         self.s3_client = boto3.client(
-            's3', verify=False, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
@@ -145,13 +145,13 @@ class NoobaaAccount(object):
         self.token = response['reply']['token']
 
         self.s3_resource = boto3.resource(
-            's3', verify=False, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
 
         self.s3_client = boto3.client(
-            's3', verify=False, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -38,9 +38,7 @@ class MCG(object):
         Constructor for the MCG class
         """
         self.namespace = config.ENV_DATA['cluster_namespace']
-
         ocp_obj = OCP(kind='noobaa', namespace=self.namespace)
-        
         self.core_pod = Pod(
             **get_pods_having_label(constants.NOOBAA_CORE_POD_LABEL, self.namespace)[0]
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from time import sleep
 from shutil import copyfile
 
 import pytest
+import pathlib
 import yaml
 from botocore.exceptions import ClientError
 
@@ -1575,13 +1576,27 @@ def awscli_pod_fixture(mcg_obj, created_pods):
 
     Returns:
         pod: A pod running the AWS CLI
+
     """
     awscli_pod_obj = helpers.create_pod(
         namespace=mcg_obj.namespace,
-        pod_dict_path=constants.AWSCLI_POD_YAML
+        pod_dict_path=constants.AWSCLI_POD_YAML,
+        pod_name=constants.AWSCLI_RELAY_POD_NAME
     )
     helpers.wait_for_resource_state(awscli_pod_obj, constants.STATUS_RUNNING)
     created_pods.append(awscli_pod_obj)
+
+    # Verify that the target dir for the self-signed MCG cert exists
+    cert_dir = pathlib.PurePath(constants.MCG_CRT_AWSCLI_POD_PATH).parent
+    awscli_pod_obj.exec_cmd_on_pod(f'mkdir --parents {cert_dir}')
+
+    # Copy the self-signed certificate to use with AWSCLI
+    OCP().exec_oc_cmd(
+        f'cp {constants.MCG_CRT_LOCAL_PATH} '
+        f'{constants.AWSCLI_RELAY_POD_NAME}:'
+        f'{constants.MCG_CRT_AWSCLI_POD_PATH}'
+    )
+
     return awscli_pod_obj
 
 

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -3,9 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    pre_upgrade, post_upgrade,
-    aws_platform_required, filter_insecure_request_warning,
-    bugzilla
+    pre_upgrade, post_upgrade, aws_platform_required, bugzilla
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_OPTIMAL
@@ -21,7 +19,6 @@ DOWNLOADED_OBJS = []
 
 
 @aws_platform_required
-@filter_insecure_request_warning
 @pre_upgrade
 def test_fill_bucket(
     mcg_obj_session,
@@ -106,7 +103,6 @@ def test_fill_bucket(
 
 
 @aws_platform_required
-@filter_insecure_request_warning
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2038")
 def test_noobaa_postupgrade(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1498,7 +1498,7 @@ def delete_deploymentconfig_pods(pod_obj):
                 dc_ocp_obj.wait_for_delete(resource_name=pod_obj.get_labels().get('name'))
 
 
-def craft_s3_command(mcg_obj, cmd):
+def craft_s3_command(mcg_obj, cmd, api=False):
     """
     Crafts the AWS CLI S3 command including the
     login credentials and command to be ran
@@ -1506,55 +1506,26 @@ def craft_s3_command(mcg_obj, cmd):
     Args:
         mcg_obj: An MCG object containing the MCG S3 connection credentials
         cmd: The AWSCLI command to run
+        api: True if the call is for s3api, false if s3
 
     Returns:
         str: The crafted command, ready to be executed on the pod
 
     """
+    api = 'api' if api else ''
     if mcg_obj:
         base_command = (
-            f"sh -c \"AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} "
-            f"AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} "
-            f"AWS_DEFAULT_REGION={mcg_obj.region} "
-            f"aws s3 "
-            f"--endpoint={mcg_obj.s3_endpoint} "
-            f"--no-verify-ssl "
+            f'sh -c "AWS_CA_BUNDLE={constants.MCG_CRT_AWSCLI_POD_PATH} '
+            f'AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} '
+            f'AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} '
+            f'AWS_DEFAULT_REGION={mcg_obj.region} '
+            f'aws s3{api} '
+            f'--endpoint={mcg_obj.s3_endpoint} '
         )
-        string_wrapper = "\""
+        string_wrapper = '"'
     else:
         base_command = (
-            "aws s3 --no-verify-ssl --no-sign-request "
-        )
-        string_wrapper = ''
-
-    return f"{base_command}{cmd}{string_wrapper}"
-
-
-def craft_s3_api_command(mcg_obj, cmd):
-    """
-    Crafts the AWS cli S3 API level commands
-
-    Args:
-        mcg_obj: An MCG object containing the MCG S3 connection credentials
-        cmd: The AWSCLI API command to run
-
-    Returns:
-        str: The crafted command, ready to be executed on the pod
-
-    """
-    if mcg_obj:
-        base_command = (
-            f"sh -c \"AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} "
-            f"AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} "
-            f"AWS_DEFAULT_REGION={mcg_obj.region} "
-            f"aws s3api "
-            f"--endpoint={mcg_obj.s3_endpoint} "
-            f"--no-verify-ssl "
-        )
-        string_wrapper = "\""
-    else:
-        base_command = (
-            "aws s3api --no-verify-ssl --no-sign-request "
+            f"aws s3{api} --no-sign-request "
         )
         string_wrapper = ''
 

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 import boto3
+from botocore.handlers import disable_signing
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -9,9 +10,7 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.resources.pod import get_rgw_pod
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
-from tests.helpers import create_resource
-from tests.helpers import logger, craft_s3_command
-from botocore.handlers import disable_signing
+from tests.helpers import craft_s3_command, create_resource, logger
 
 log = logging.getLogger(__name__)
 

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
 
 import boto3
 
@@ -11,7 +10,7 @@ from ocs_ci.ocs.resources.pod import get_rgw_pod
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
 from tests.helpers import create_resource
-from tests.helpers import logger, craft_s3_command, craft_s3_api_command
+from tests.helpers import logger, craft_s3_command
 from botocore.handlers import disable_signing
 
 log = logging.getLogger(__name__)
@@ -48,21 +47,10 @@ def retrieve_test_objects_to_pod(podobj, target_dir):
         list: A list of the downloaded objects' names
 
     """
-    # Download test objects from the public bucket
-    downloaded_objects = []
-    # Retrieve a list of all objects on the test-objects bucket and downloads them to the pod
-    podobj.exec_cmd_on_pod(command=f'mkdir {target_dir}')
-    public_s3 = retrieve_anon_s3_resource()
-    with ThreadPoolExecutor() as p:
-        for obj in public_s3.Bucket(constants.TEST_FILES_BUCKET).objects.all():
-            logger.info(f'Downloading {obj.key} from AWS test bucket')
-            p.submit(podobj.exec_cmd_on_pod,
-                     command=f'sh -c "'
-                             f'wget -P {target_dir} '
-                             f'https://{constants.TEST_FILES_BUCKET}.s3.amazonaws.com/{obj.key}"'
-                     )
-            downloaded_objects.append(obj.key)
-        return downloaded_objects
+    sync_object_directory(podobj, f's3://{constants.TEST_FILES_BUCKET}', target_dir)
+    downloaded_objects = podobj.exec_cmd_on_pod(f'ls -A1 {target_dir}').split(' ')
+    logger.info(f'Downloaded objects: {downloaded_objects}')
+    return downloaded_objects
 
 
 def sync_object_directory(podobj, src, target, mcg_obj=None):
@@ -176,7 +164,7 @@ def upload_parts(mcg_obj, awscli_pod, bucketname, object_key, body_path, upload_
         )
         # upload_cmd will return ETag, upload_id etc which is then split to get just the ETag
         part = awscli_pod.exec_cmd_on_pod(
-            command=craft_s3_api_command(mcg_obj, upload_cmd), out_yaml_format=False,
+            command=craft_s3_command(mcg_obj, upload_cmd, api=True), out_yaml_format=False,
             secrets=secrets
         ).split("\"")[-3].split("\\")[0]
         parts.append({"PartNumber": count, "ETag": f'"{part}"'})

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -5,8 +5,7 @@ import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, tier3, filter_insecure_request_warning,
-    acceptance, performance
+    tier1, tier3, acceptance, performance
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
@@ -14,7 +13,6 @@ from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 logger = logging.getLogger(__name__)
 
 
-@filter_insecure_request_warning
 class TestBucketCreation:
     """
     Test creation of a bucket

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -5,7 +5,7 @@ import botocore
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, tier3, acceptance, performance, filter_insecure_request_warning
+    tier1, tier3, acceptance, performance
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = 'Skipped because of erratic timeouts'
 
 
-@filter_insecure_request_warning
 class TestBucketDeletion:
     """
     Test bucket Creation Deletion of buckets

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -5,7 +5,6 @@ import botocore.exceptions as boto3exception
 import json
 import uuid
 
-from ocs_ci.framework.pytest_customization.marks import filter_insecure_request_warning
 from ocs_ci.ocs.exceptions import NoBucketPolicyResponse, InvalidStatusCode, UnexpectedBehaviour
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2, tier3, skipif_ocs_version
 from ocs_ci.ocs.resources.bucket_policy import OBC, NoobaaAccount, HttpResponseParser, gen_bucket_policy
@@ -17,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 @skipif_ocs_version('<4.3')
-@filter_insecure_request_warning
 class TestS3BucketPolicy(ManageTest):
     """
     Test Bucket Policies on Noobaa accounts

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -3,8 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1, aws_platform_required,
-    filter_insecure_request_warning, tier4, tier4a
+    tier1, aws_platform_required, tier4, tier4a
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_AUTH_FAILED, BS_OPTIMAL
@@ -15,7 +14,6 @@ from tests.manage.mcg.helpers import retrieve_test_objects_to_pod, sync_object_d
 logger = logging.getLogger(__name__)
 
 
-@filter_insecure_request_warning
 @aws_platform_required
 class TestMultiRegion:
     """

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 import uuid
 
-from ocs_ci.framework.pytest_customization.marks import filter_insecure_request_warning
 from ocs_ci.framework.testlib import (
     ManageTest, tier1
 )
@@ -39,7 +38,6 @@ def setup(pod_obj, bucket_factory):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
-@filter_insecure_request_warning
 class TestS3MultipartUpload(ManageTest):
     """
     Test Multipart upload on Noobaa buckets

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -2,9 +2,6 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import (
-    filter_insecure_request_warning
-)
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2, tier3
 from ocs_ci.ocs import constants
 from tests.manage.mcg import helpers
@@ -18,14 +15,10 @@ FILESIZE_SKIP = pytest.mark.skip('Current test filesize is too large.')
 RUNTIME_SKIP = pytest.mark.skip('Runtime is too long; Code needs to be parallelized')
 
 
-@filter_insecure_request_warning
 class TestObjectIntegrity(ManageTest):
     """
     Test data integrity of various objects
     """
-    @pytest.mark.filterwarnings(
-        'ignore::urllib3.exceptions.InsecureRequestWarning'
-    )
     @pytest.mark.polarion_id("OCS-1321")
     @tier1
     def test_check_object_integrity(self, mcg_obj, awscli_pod, bucket_factory):

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -4,7 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    filter_insecure_request_warning, vsphere_platform_required
+    vsphere_platform_required
 )
 from ocs_ci.framework.testlib import (
     ManageTest, tier1, tier2, tier3, acceptance
@@ -34,7 +34,6 @@ def pod_io(pods):
             p.submit(pod.run_io, 'fs', '1G')
 
 
-@filter_insecure_request_warning
 class TestBucketIO(ManageTest):
     """
     Test IO of a bucket


### PR DESCRIPTION
Up until now we used `verify=False` and `--no-verify` with markers that would suppress `InsecureRequestWarning` warnings. In this PR I retrieve the self-signed certificate in order to use it for verified communication with NooBaa in all of the APIs.

Warning suppressions removed, code optimized in some places.