### PR TITLE
Change fio container

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2293,7 +2293,7 @@ def fio_job_dict_fixture():
             spec:
               containers:
                 - name: fio
-                  image: quay.io/johnstrunk/fs-performance:latest
+                  image: quay.io/fbalak/fio-fedora:latest
                   command:
                     - "/usr/bin/fio"
                     - "--output-format=json"


### PR DESCRIPTION
This change is done because official distribution of `fio` in Fedora is not build with `http` ioengine (there are missing prerequisites in fio specfile) and in future tests I would like to use `fio` to utilize s3 interfaces.

Signed-off-by: Filip Balak <fbalak@redhat.com>