### PR TITLE
Add 3 minutes to wait for bucket quota alert

### DIFF
--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -622,7 +622,7 @@ def measure_noobaa_exceed_bucket_quota(
         nonlocal bucket_name
         nonlocal awscli_pod
         # run_time of operation
-        run_time = 60 * 11
+        run_time = 60 * 14
         awscli_pod.exec_cmd_on_pod(
             'dd if=/dev/zero of=/tmp/testfile bs=1M count=500'
         )

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 
 from ocs_ci.framework.testlib import polarion_id, bugzilla, tier4, tier4a
 from ocs_ci.ocs import constants

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import tier4, tier4a
+from ocs_ci.framework.testlib import polarion_id, bugzilla, tier4, tier4a
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
@@ -11,7 +11,8 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4a
-@pytest.mark.polarion_id("OCS-1254")
+@polarion_id("OCS-1254")
+@bugzilla("1835290")
 def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
     """
     Test that there are appropriate alerts when NooBaa Bucket Quota is reached.


### PR DESCRIPTION
The test is currently flaky. This change should improve the stability of the test.