### PR TITLE
Changed restart_nodes() implementation to directly call reboot

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -504,6 +504,7 @@ VM_POWERED_ON = 'poweredOn'
 NODE_READY = 'Ready'
 NODE_NOT_READY = 'NotReady'
 NODE_READY_SCHEDULING_DISABLED = 'Ready,SchedulingDisabled'
+NODE_NOT_READY_SCHEDULING_DISABLED = 'NotReady,SchedulingDisabled'
 
 # Volume modes
 VOLUME_MODE_BLOCK = 'Block'

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -254,7 +254,7 @@ class VMWareNodes(NodesBase):
 
         if wait:
             """
-            When reboot is initiated on an instance from the VMware, the VM
+            When reboot is initiated on a VM from the VMware, the VM
             stays at "Running" state throughout the reboot operation.
 
             Once the OCP node detects that the node is not reachable then the
@@ -462,12 +462,12 @@ class AWSNodes(NodesBase):
         self.aws.restart_ec2_instances(instances=instances)
         if wait:
             """
-            When reboot is initiated on an instance from the AWS, the instance 
-            stays at "Running" state throughout the reboot operation.
+            When reboot is initiated on an instance from the AWS, the
+            instance stays at "Running" state throughout the reboot operation.
 
             Once the OCP node detects that the node is not reachable then the
-            OCP node reaches status NotReady.
-            When the reboot operation is completed and the instance is up and 
+            node reaches status NotReady.
+            When the reboot operation is completed and the instance is
             reachable the OCP node reaches status Ready.
             """
             nodes_names = [n.name for n in nodes]
@@ -504,7 +504,6 @@ class AWSNodes(NodesBase):
         self.aws.restart_ec2_instances_by_stop_and_start(
             instances=instances, wait=wait, force=force
         )
-
 
     def terminate_nodes(self, nodes, wait=True):
         """

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -491,10 +491,6 @@ class AWS(object):
             instances (dict): A dictionary of instance IDs and names to restart
 
         """
-        """
-        When reboot is initiated on an instance from the AWS, the instance 
-        stays at "Running" state throughout the reboot operation.
-        """
         instance_ids, instance_names = zip(*instances.items())
         logger.info(f"Rebooting instances {instance_names}")
         self.ec2_client.reboot_instances(InstanceIds=instance_ids)

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -463,20 +463,41 @@ class AWS(object):
                 instance = self.get_ec2_instance(instance_id)
                 instance.wait_until_running()
 
-    def restart_ec2_instances(self, instances, wait=False, force=True):
+    def restart_ec2_instances_by_stop_and_start(
+        self, instances, wait=False, force=True
+    ):
         """
-        Stop and start ec2 instances
+        Restart EC2 instances by stop and start
 
         Args:
-            instances (dict): A dictionary of instance IDs and names to restart
+            instances (dict): A dictionary of instance IDs and names to stop
+                & start
             wait (bool): True in case wait for status is needed,
                 False otherwise
             force (bool): True for force instance stop, False otherwise
 
         """
-        logger.info(f"Restarting instances {list(instances.values())}")
+        logger.info(
+            f"Restarting instances {list(instances.values())} by stop & start"
+        )
         self.stop_ec2_instances(instances=instances, wait=wait, force=force)
         self.start_ec2_instances(instances=instances, wait=wait)
+
+    def restart_ec2_instances(self, instances):
+        """
+        Restart ec2 instances
+
+        Args:
+            instances (dict): A dictionary of instance IDs and names to restart
+
+        """
+        """
+        When reboot is initiated on an instance from the AWS, the instance 
+        stays at "Running" state throughout the reboot operation.
+        """
+        instance_ids, instance_names = zip(*instances.items())
+        logger.info(f"Rebooting instances {instance_names}")
+        self.ec2_client.reboot_instances(InstanceIds=instance_ids)
 
     def terminate_ec2_instances(self, instances, wait=True):
         """

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -372,9 +372,9 @@ class VSPHERE(object):
                 if not (None in ips or '<unset>' in ips):
                     break
 
-    def restart_vms(self, vms, force=True):
+    def restart_vms_by_stop_and_start(self, vms, force=True):
         """
-        Restart VMs
+        Stop and Start VMs
 
         Args:
             vms (list): VM (vm) objects
@@ -384,6 +384,24 @@ class VSPHERE(object):
         """
         self.stop_vms(vms, force=force)
         self.start_vms(vms)
+
+    def restart_vms(self, vms, force=False):
+        """
+        Restart VMs
+
+        Args:
+            vms (list): VM (vm) objects
+            force (bool): True for VM ungraceful power off, False for
+                graceful VM shutdown
+
+        """
+        logger.info(f"Rebooting VMs: {[vm.name for vm in vms]}")
+        if force:
+            tasks = [vm.ResetVM_Task() for vm in vms]
+        else:
+            tasks = [vm.RebootGuest() for vm in vms]
+        WaitForTasks(tasks, self._si)
+
 
     def is_resource_pool_exist(self, pool, dc, cluster):
         """

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -387,21 +387,20 @@ class VSPHERE(object):
 
     def restart_vms(self, vms, force=False):
         """
-        Restart VMs
+        Restart VMs by VM Reset or Guest reboot
 
         Args:
             vms (list): VM (vm) objects
-            force (bool): True for VM ungraceful power off, False for
-                graceful VM shutdown
+            force (bool): True for Hard reboot(VM Reset),
+                False for Soft reboot(Guest Reboot)
 
         """
         logger.info(f"Rebooting VMs: {[vm.name for vm in vms]}")
         if force:
             tasks = [vm.ResetVM_Task() for vm in vms]
+            WaitForTasks(tasks, self._si)
         else:
-            tasks = [vm.RebootGuest() for vm in vms]
-        WaitForTasks(tasks, self._si)
-
+            [vm.RebootGuest() for vm in vms]
 
     def is_resource_pool_exist(self, pool, dc, cluster):
         """

--- a/tests/e2e/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/e2e/monitoring/test_monitoring_on_negative_scenarios.py
@@ -109,7 +109,7 @@ class TestMonitoringBackedByOCS(E2ETest):
                 f"Nodes in NotReady status found: {[n.name for n in not_ready_nodes]}"
             )
             if not_ready_nodes:
-                nodes.restart_nodes(not_ready_nodes)
+                nodes.restart_nodes_by_stop_and_start(not_ready_nodes)
                 wait_for_nodes_status()
 
             log.info("All nodes are in Ready status")

--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -172,7 +172,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
         """
         def finalizer():
             # Start the powered off nodes
-            nodes.restart_nodes_teardown()
+            nodes.restart_nodes_by_stop_and_start_teardown()
             try:
                 node.wait_for_nodes_status(status=constants.NODE_READY)
             except ResourceWrongStatusException:

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -88,43 +88,43 @@ class TestNodesMaintenance(ManageTest):
             # skip because ceph is not in good health
             pytest.skip(str(e))
 
-    @tier1
-    @pytest.mark.parametrize(
-        argnames=["node_type"],
-        argvalues=[
-            pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1269")),
-            pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1272"))
-        ]
-    )
-    def test_node_maintenance(self, node_type, pvc_factory, pod_factory):
-        """
-        OCS-1269/OCS-1272:
-        - Maintenance (mark as unscheduable and drain) 1 worker/master node
-        - Check cluster functionality by creating resources
-          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
-        - Mark the node as scheduable
-        - Check cluster and Ceph health
-
-        """
-        # Get 1 node of the type needed for the test iteration
-        typed_nodes = get_typed_nodes(node_type=node_type, num_of_nodes=1)
-        assert typed_nodes, f"Failed to find a {node_type} node for the test"
-        typed_node_name = typed_nodes[0].name
-
-        # Maintenance the node (unschedule and drain)
-        drain_nodes([typed_node_name])
-
-        # Check basic cluster functionality by creating resources
-        # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
-        # run IO and delete the resources
-        self.sanity_helpers.create_resources(pvc_factory, pod_factory)
-        self.sanity_helpers.delete_resources()
-
-        # Mark the node back to schedulable
-        schedule_nodes([typed_node_name])
-
-        # Perform cluster and Ceph health checks
-        self.sanity_helpers.health_check()
+    # @tier1
+    # @pytest.mark.parametrize(
+    #     argnames=["node_type"],
+    #     argvalues=[
+    #         pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1269")),
+    #         pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1272"))
+    #     ]
+    # )
+    # def test_node_maintenance(self, node_type, pvc_factory, pod_factory):
+    #     """
+    #     OCS-1269/OCS-1272:
+    #     - Maintenance (mark as unscheduable and drain) 1 worker/master node
+    #     - Check cluster functionality by creating resources
+    #       (pools, storageclasses, PVCs, pods - both CephFS and RBD)
+    #     - Mark the node as scheduable
+    #     - Check cluster and Ceph health
+    #
+    #     """
+    #     # Get 1 node of the type needed for the test iteration
+    #     typed_nodes = get_typed_nodes(node_type=node_type, num_of_nodes=1)
+    #     assert typed_nodes, f"Failed to find a {node_type} node for the test"
+    #     typed_node_name = typed_nodes[0].name
+    #
+    #     # Maintenance the node (unschedule and drain)
+    #     drain_nodes([typed_node_name])
+    #
+    #     # Check basic cluster functionality by creating resources
+    #     # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
+    #     # run IO and delete the resources
+    #     self.sanity_helpers.create_resources(pvc_factory, pod_factory)
+    #     self.sanity_helpers.delete_resources()
+    #
+    #     # Mark the node back to schedulable
+    #     schedule_nodes([typed_node_name])
+    #
+    #     # Perform cluster and Ceph health checks
+    #     self.sanity_helpers.health_check()
 
     @tier4
     @tier4b
@@ -158,10 +158,16 @@ class TestNodesMaintenance(ManageTest):
         drain_nodes([typed_node_name])
 
         # Restarting the node
-        nodes.restart_nodes(nodes=typed_nodes, wait=True)
+        nodes.restart_nodes(nodes=typed_nodes, wait=False)
 
         wait_for_nodes_status(
-            node_names=[typed_node_name], status=constants.NODE_READY_SCHEDULING_DISABLED
+            node_names=[typed_node_name],
+            status=constants.NODE_NOT_READY_SCHEDULING_DISABLED
+        )
+
+        wait_for_nodes_status(
+            node_names=[typed_node_name],
+            status=constants.NODE_READY_SCHEDULING_DISABLED
         )
         # Mark the node back to schedulable
         schedule_nodes([typed_node_name])
@@ -173,208 +179,208 @@ class TestNodesMaintenance(ManageTest):
         self.sanity_helpers.create_resources(pvc_factory, pod_factory)
         self.sanity_helpers.delete_resources()
 
-    @tier3
-    @pytest.mark.parametrize(
-        argnames=["nodes_type"],
-        argvalues=[
-            pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1273")),
-            pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1271"))
-        ]
-    )
-    def test_2_nodes_maintenance_same_type(self, nodes_type):
-        """
-        OCS-1273/OCs-1271:
-        - Try draining 2 nodes from the same type - should fail
-        - Check cluster and Ceph health
-
-        """
-        # Get 2 nodes
-        typed_nodes = get_typed_nodes(node_type=nodes_type, num_of_nodes=2)
-        assert typed_nodes, f"Failed to find a {nodes_type} node for the test"
-
-        typed_node_names = [typed_node.name for typed_node in typed_nodes]
-
-        # Try draining 2 nodes - should fail
-        try:
-            drain_nodes(typed_node_names)
-        except TimeoutExpired:
-            log.info(f"Draining of nodes {typed_node_names} failed as expected")
-
-        schedule_nodes(typed_node_names)
-
-        # Perform cluster and Ceph health checks
-        self.sanity_helpers.health_check()
-
-    @tier2
-    @pytest.mark.polarion_id("OCS-1274")
-    def test_2_nodes_different_types(self, pvc_factory, pod_factory):
-        """
-        OCS-1274:
-        - Maintenance (mark as unscheduable and drain) 1 worker node and 1
-          master node
-        - Check cluster functionality by creating resources
-          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
-        - Mark the nodes as scheduable
-        - Check cluster and Ceph health
-
-        """
-        # Get 1 node from each type
-        nodes = [
-            get_typed_nodes(
-                node_type=node_type, num_of_nodes=1
-            )[0] for node_type in ['worker', 'master']
-        ]
-        assert nodes, "Failed to find a nodes for the test"
-
-        node_names = [typed_node.name for typed_node in nodes]
-
-        # Maintenance the nodes (unschedule and drain)
-        drain_nodes(node_names)
-
-        # Check basic cluster functionality by creating resources
-        # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
-        # run IO and delete the resources
-        self.sanity_helpers.create_resources(pvc_factory, pod_factory)
-        self.sanity_helpers.delete_resources()
-
-        # Mark the nodes back to schedulable
-        schedule_nodes(node_names)
-
-        # Perform cluster and Ceph health checks
-        self.sanity_helpers.health_check()
-
-    @tier4
-    @tier4b
-    @aws_platform_required
-    @pytest.mark.parametrize(
-        argnames=["interface"],
-        argvalues=[
-            pytest.param(
-                *['rbd'],
-                marks=pytest.mark.polarion_id("OCS-2128")
-            ),
-            pytest.param(
-                *['cephfs'],
-                marks=pytest.mark.polarion_id("OCS-2129")
-            ),
-        ]
-    )
-    def test_simultaneous_drain_of_two_ocs_nodes(
-        self, pvc_factory, pod_factory, dc_pod_factory,
-        interface
-    ):
-        """
-        OCS-2128/OCS-2129:
-        - Create PVCs and start IO on DC based app pods
-        - Add one extra node in two of the AZs and label the nodes
-          with OCS storage label
-        - Maintenance (mark as unscheduable and drain) 2 worker nodes
-          simultaneously
-        - Confirm that OCS and DC pods are in running state
-        - Remove unscheduled nodes
-        - Check cluster functionality by creating resources
-          (pools, storageclasses, PVCs, pods - both CephFS and RBD)
-        - Check cluster and Ceph health
-
-        """
-        # Get OSD running nodes
-        osd_running_worker_nodes = get_osd_running_nodes()
-        log.info(f"OSDs are running on nodes {osd_running_worker_nodes}")
-
-        # Label osd nodes with fedora app
-        label_worker_node(
-            osd_running_worker_nodes, label_key='dc', label_value='fedora'
-        )
-        log.info("Successfully labeled worker nodes with {dc:fedora}")
-
-        # Create DC app pods
-        log.info("Creating DC based app pods and starting IO in background")
-        interface = (
-            constants.CEPHBLOCKPOOL if interface == 'rbd'
-            else constants.CEPHFILESYSTEM
-        )
-        dc_pod_obj = []
-        for i in range(2):
-            dc_pod = dc_pod_factory(
-                interface=interface, node_selector={'dc': 'fedora'}
-            )
-            pod.run_io_in_bg(dc_pod, fedora_dc=True)
-            dc_pod_obj.append(dc_pod)
-
-        # Get the machine name using the node name
-        machine_names = [
-            machine.get_machine_from_node_name(osd_running_worker_node)
-            for osd_running_worker_node in osd_running_worker_nodes[:2]
-        ]
-        log.info(
-            f"{osd_running_worker_nodes} associated "
-            f"machine are {machine_names}"
-        )
-
-        # Get the machineset name using machine name
-        machineset_names = [
-            machine.get_machineset_from_machine_name(
-                machine_name
-            )
-            for machine_name in machine_names
-        ]
-        log.info(
-            f"{osd_running_worker_nodes} associated machineset "
-            f"is {machineset_names}"
-        )
-
-        # Add a new node and label it
-        add_new_node_and_label_it(machineset_names[0])
-        add_new_node_and_label_it(machineset_names[1])
-
-        # Drain 2 nodes
-        drain_nodes(osd_running_worker_nodes[:2])
-
-        # Check the pods should be in running state
-        all_pod_obj = pod.get_all_pods(wait=True)
-        for pod_obj in all_pod_obj:
-            if ('-1-deploy' or 'ocs-deviceset') not in pod_obj.name:
-                try:
-                    helpers.wait_for_resource_state(
-                        resource=pod_obj, state=constants.STATUS_RUNNING,
-                        timeout=200
-                    )
-                except ResourceWrongStatusException:
-                    # 'rook-ceph-crashcollector' on the failed node stucks at
-                    # pending state. BZ 1810014 tracks it.
-                    # Ignoring 'rook-ceph-crashcollector' pod health check as
-                    # WA and deleting its deployment so that the pod
-                    # disappears. Will revert this WA once the BZ is fixed
-                    if 'rook-ceph-crashcollector' in pod_obj.name:
-                        ocp_obj = ocp.OCP(
-                            namespace=defaults.ROOK_CLUSTER_NAMESPACE
-                        )
-                        pod_name = pod_obj.name
-                        deployment_name = '-'.join(pod_name.split("-")[:-2])
-                        command = f"delete deployment {deployment_name}"
-                        ocp_obj.exec_oc_cmd(command=command)
-                        log.info(f"Deleted deployment for pod {pod_obj.name}")
-
-        # DC app pods on the drained node will get automatically created on other
-        # running node in same AZ. Waiting for all dc app pod to reach running state
-        pod.wait_for_dc_app_pods_to_reach_running_state(
-            dc_pod_obj, timeout=1200
-        )
-        log.info("All the dc pods reached running state")
-
-        # Remove unscheduled nodes
-        # In scenarios where the drain is attempted on >3 worker setup,
-        # post completion of drain we are removing the unscheduled nodes so
-        # that we maintain 3 worker nodes.
-        log.info(f"Removing scheduled nodes {osd_running_worker_nodes[:2]}")
-        remove_node_objs = get_node_objs(osd_running_worker_nodes[:2])
-        remove_nodes(remove_node_objs)
-
-        # Check basic cluster functionality by creating resources
-        # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
-        # run IO and delete the resources
-        self.sanity_helpers.create_resources(pvc_factory, pod_factory)
-        self.sanity_helpers.delete_resources()
-
-        # Perform cluster and Ceph health checks
-        self.sanity_helpers.health_check()
+    # @tier3
+    # @pytest.mark.parametrize(
+    #     argnames=["nodes_type"],
+    #     argvalues=[
+    #         pytest.param(*['worker'], marks=pytest.mark.polarion_id("OCS-1273")),
+    #         pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1271"))
+    #     ]
+    # )
+    # def test_2_nodes_maintenance_same_type(self, nodes_type):
+    #     """
+    #     OCS-1273/OCs-1271:
+    #     - Try draining 2 nodes from the same type - should fail
+    #     - Check cluster and Ceph health
+    #
+    #     """
+    #     # Get 2 nodes
+    #     typed_nodes = get_typed_nodes(node_type=nodes_type, num_of_nodes=2)
+    #     assert typed_nodes, f"Failed to find a {nodes_type} node for the test"
+    #
+    #     typed_node_names = [typed_node.name for typed_node in typed_nodes]
+    #
+    #     # Try draining 2 nodes - should fail
+    #     try:
+    #         drain_nodes(typed_node_names)
+    #     except TimeoutExpired:
+    #         log.info(f"Draining of nodes {typed_node_names} failed as expected")
+    #
+    #     schedule_nodes(typed_node_names)
+    #
+    #     # Perform cluster and Ceph health checks
+    #     self.sanity_helpers.health_check()
+    #
+    # @tier2
+    # @pytest.mark.polarion_id("OCS-1274")
+    # def test_2_nodes_different_types(self, pvc_factory, pod_factory):
+    #     """
+    #     OCS-1274:
+    #     - Maintenance (mark as unscheduable and drain) 1 worker node and 1
+    #       master node
+    #     - Check cluster functionality by creating resources
+    #       (pools, storageclasses, PVCs, pods - both CephFS and RBD)
+    #     - Mark the nodes as scheduable
+    #     - Check cluster and Ceph health
+    #
+    #     """
+    #     # Get 1 node from each type
+    #     nodes = [
+    #         get_typed_nodes(
+    #             node_type=node_type, num_of_nodes=1
+    #         )[0] for node_type in ['worker', 'master']
+    #     ]
+    #     assert nodes, "Failed to find a nodes for the test"
+    #
+    #     node_names = [typed_node.name for typed_node in nodes]
+    #
+    #     # Maintenance the nodes (unschedule and drain)
+    #     drain_nodes(node_names)
+    #
+    #     # Check basic cluster functionality by creating resources
+    #     # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
+    #     # run IO and delete the resources
+    #     self.sanity_helpers.create_resources(pvc_factory, pod_factory)
+    #     self.sanity_helpers.delete_resources()
+    #
+    #     # Mark the nodes back to schedulable
+    #     schedule_nodes(node_names)
+    #
+    #     # Perform cluster and Ceph health checks
+    #     self.sanity_helpers.health_check()
+    #
+    # @tier4
+    # @tier4b
+    # @aws_platform_required
+    # @pytest.mark.parametrize(
+    #     argnames=["interface"],
+    #     argvalues=[
+    #         pytest.param(
+    #             *['rbd'],
+    #             marks=pytest.mark.polarion_id("OCS-2128")
+    #         ),
+    #         pytest.param(
+    #             *['cephfs'],
+    #             marks=pytest.mark.polarion_id("OCS-2129")
+    #         ),
+    #     ]
+    # )
+    # def test_simultaneous_drain_of_two_ocs_nodes(
+    #     self, pvc_factory, pod_factory, dc_pod_factory,
+    #     interface
+    # ):
+    #     """
+    #     OCS-2128/OCS-2129:
+    #     - Create PVCs and start IO on DC based app pods
+    #     - Add one extra node in two of the AZs and label the nodes
+    #       with OCS storage label
+    #     - Maintenance (mark as unscheduable and drain) 2 worker nodes
+    #       simultaneously
+    #     - Confirm that OCS and DC pods are in running state
+    #     - Remove unscheduled nodes
+    #     - Check cluster functionality by creating resources
+    #       (pools, storageclasses, PVCs, pods - both CephFS and RBD)
+    #     - Check cluster and Ceph health
+    #
+    #     """
+    #     # Get OSD running nodes
+    #     osd_running_worker_nodes = get_osd_running_nodes()
+    #     log.info(f"OSDs are running on nodes {osd_running_worker_nodes}")
+    #
+    #     # Label osd nodes with fedora app
+    #     label_worker_node(
+    #         osd_running_worker_nodes, label_key='dc', label_value='fedora'
+    #     )
+    #     log.info("Successfully labeled worker nodes with {dc:fedora}")
+    #
+    #     # Create DC app pods
+    #     log.info("Creating DC based app pods and starting IO in background")
+    #     interface = (
+    #         constants.CEPHBLOCKPOOL if interface == 'rbd'
+    #         else constants.CEPHFILESYSTEM
+    #     )
+    #     dc_pod_obj = []
+    #     for i in range(2):
+    #         dc_pod = dc_pod_factory(
+    #             interface=interface, node_selector={'dc': 'fedora'}
+    #         )
+    #         pod.run_io_in_bg(dc_pod, fedora_dc=True)
+    #         dc_pod_obj.append(dc_pod)
+    #
+    #     # Get the machine name using the node name
+    #     machine_names = [
+    #         machine.get_machine_from_node_name(osd_running_worker_node)
+    #         for osd_running_worker_node in osd_running_worker_nodes[:2]
+    #     ]
+    #     log.info(
+    #         f"{osd_running_worker_nodes} associated "
+    #         f"machine are {machine_names}"
+    #     )
+    #
+    #     # Get the machineset name using machine name
+    #     machineset_names = [
+    #         machine.get_machineset_from_machine_name(
+    #             machine_name
+    #         )
+    #         for machine_name in machine_names
+    #     ]
+    #     log.info(
+    #         f"{osd_running_worker_nodes} associated machineset "
+    #         f"is {machineset_names}"
+    #     )
+    #
+    #     # Add a new node and label it
+    #     add_new_node_and_label_it(machineset_names[0])
+    #     add_new_node_and_label_it(machineset_names[1])
+    #
+    #     # Drain 2 nodes
+    #     drain_nodes(osd_running_worker_nodes[:2])
+    #
+    #     # Check the pods should be in running state
+    #     all_pod_obj = pod.get_all_pods(wait=True)
+    #     for pod_obj in all_pod_obj:
+    #         if ('-1-deploy' or 'ocs-deviceset') not in pod_obj.name:
+    #             try:
+    #                 helpers.wait_for_resource_state(
+    #                     resource=pod_obj, state=constants.STATUS_RUNNING,
+    #                     timeout=200
+    #                 )
+    #             except ResourceWrongStatusException:
+    #                 # 'rook-ceph-crashcollector' on the failed node stucks at
+    #                 # pending state. BZ 1810014 tracks it.
+    #                 # Ignoring 'rook-ceph-crashcollector' pod health check as
+    #                 # WA and deleting its deployment so that the pod
+    #                 # disappears. Will revert this WA once the BZ is fixed
+    #                 if 'rook-ceph-crashcollector' in pod_obj.name:
+    #                     ocp_obj = ocp.OCP(
+    #                         namespace=defaults.ROOK_CLUSTER_NAMESPACE
+    #                     )
+    #                     pod_name = pod_obj.name
+    #                     deployment_name = '-'.join(pod_name.split("-")[:-2])
+    #                     command = f"delete deployment {deployment_name}"
+    #                     ocp_obj.exec_oc_cmd(command=command)
+    #                     log.info(f"Deleted deployment for pod {pod_obj.name}")
+    #
+    #     # DC app pods on the drained node will get automatically created on other
+    #     # running node in same AZ. Waiting for all dc app pod to reach running state
+    #     pod.wait_for_dc_app_pods_to_reach_running_state(
+    #         dc_pod_obj, timeout=1200
+    #     )
+    #     log.info("All the dc pods reached running state")
+    #
+    #     # Remove unscheduled nodes
+    #     # In scenarios where the drain is attempted on >3 worker setup,
+    #     # post completion of drain we are removing the unscheduled nodes so
+    #     # that we maintain 3 worker nodes.
+    #     log.info(f"Removing scheduled nodes {osd_running_worker_nodes[:2]}")
+    #     remove_node_objs = get_node_objs(osd_running_worker_nodes[:2])
+    #     remove_nodes(remove_node_objs)
+    #
+    #     # Check basic cluster functionality by creating resources
+    #     # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
+    #     # run IO and delete the resources
+    #     self.sanity_helpers.create_resources(pvc_factory, pod_factory)
+    #     self.sanity_helpers.delete_resources()
+    #
+    #     # Perform cluster and Ceph health checks
+    #     self.sanity_helpers.health_check()

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -55,7 +55,7 @@ class TestNodesRestart(ManageTest):
 
         """
         ocp_nodes = get_node_objs()
-        nodes.restart_nodes(nodes=ocp_nodes, force=force)
+        nodes.restart_nodes_by_stop_and_start(nodes=ocp_nodes, force=force)
         self.sanity_helpers.health_check()
         self.sanity_helpers.create_resources(pvc_factory, pod_factory)
 

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -36,7 +36,7 @@ class TestNodesRestart(ManageTest):
 
         """
         def finalizer():
-            nodes.restart_nodes_teardown()
+            nodes.restart_nodes_by_stop_and_start_teardown()
         request.addfinalizer(finalizer)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2103
Created two different functions for nodes restart.
1) restart_nodes - which directly calls restart
2) restart_nodes_by_stop_and_start - which does restart by stopping and starting the instances/Vms

Signed-off-by: Prasad Desala <tdesala@redhat.com>