### PR TITLE
Split capacity tests

### DIFF
--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 )
 def test_rbd_capacity_workload_alerts(workload_storageutilization_95p_rbd):
     """
-    Test that there are appropriate alerts when ceph cluster is utilizedi
+    Test that there are appropriate alerts when ceph cluster is utilized
     via RBD interface.
     """
     api = prometheus.PrometheusAPI()

--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -12,55 +12,88 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    argnames='interface',
-    argvalues=[
-        pytest.param(
-            'rbd',
-            marks=[
-                pytest.mark.polarion_id("OCS-899"),
-                pytest.mark.bugzilla('1809248'),
-                tier2,
-                gather_metrics_on_fail(
-                    'ceph_cluster_total_used_bytes', 'cluster:memory_usage_bytes:sum'
-                )
-            ]
-        ),
-        pytest.param(
-            'cephfs',
-            marks=[
-                pytest.mark.polarion_id("OCS-1934"),
-                pytest.mark.bugzilla('1809248'),
-                tier2,
-                gather_metrics_on_fail(
-                    'ceph_cluster_total_used_bytes', 'cluster:memory_usage_bytes:sum'
-                )
-            ]
-        )
-    ]
+@pytest.mark.polarion_id("OCS-899")
+@pytest.mark.bugzilla('1809248')
+@tier2
+@gather_metrics_on_fail(
+    'ceph_cluster_total_used_bytes', 'cluster:memory_usage_bytes:sum'
 )
-def test_capacity_workload_alerts(
-    workload_storageutilization_95p_rbd,
-    workload_storageutilization_95p_cephfs,
-    interface
-):
+def test_rbd_capacity_workload_alerts(workload_storageutilization_95p_rbd):
+    """
+    Test that there are appropriate alerts when ceph cluster is utilizedi
+    via RBD interface.
+    """
+    api = prometheus.PrometheusAPI()
+    measure_end_time = workload_storageutilization_95p_rbd.get('stop')
+
+    # Check utilization on 95%
+    alerts = workload_storageutilization_95p_rbd.get('prometheus_alerts')
+
+    if config.ENV_DATA.get('ocs_version') == '4.2':
+        nearfull_message = (
+            'Storage cluster is nearing full. Expansion is required.'
+        )
+        criticallfull_mesage = (
+            'Storage cluster is critically full and needs immediate expansion'
+        )
+    else:
+        # since OCS 4.3
+        nearfull_message = (
+            'Storage cluster is nearing full. Data deletion or cluster '
+            'expansion is required.'
+        )
+        criticallfull_mesage = (
+            'Storage cluster is critically full and needs immediate data '
+            'deletion or cluster expansion.'
+        )
+
+    for target_label, target_msg, target_states, target_severity in [
+        (
+            constants.ALERT_CLUSTERNEARFULL,
+            nearfull_message,
+            ['pending', 'firing'],
+            'warning'
+        ),
+        (
+            constants.ALERT_CLUSTERCRITICALLYFULL,
+            criticallfull_mesage,
+            ['pending', 'firing'],
+            'error'
+        ),
+    ]:
+        prometheus.check_alert_list(
+            label=target_label,
+            msg=target_msg,
+            alerts=alerts,
+            states=target_states,
+            severity=target_severity,
+            ignore_more_occurences=True
+        )
+        # the time to wait is increased because it takes more time for Ceph
+        # cluster to delete all data
+        pg_wait = 300
+        api.check_alert_cleared(
+            label=target_label,
+            measure_end_time=measure_end_time,
+            time_min=pg_wait
+        )
+
+
+@pytest.mark.polarion_id("OCS-1934")
+@pytest.mark.bugzilla('1809248')
+@tier2
+@gather_metrics_on_fail(
+    'ceph_cluster_total_used_bytes', 'cluster:memory_usage_bytes:sum'
+)
+def test_cephfs_capacity_workload_alerts(workload_storageutilization_95p_cephfs):
     """
     Test that there are appropriate alerts when ceph cluster is utilized.
     """
     api = prometheus.PrometheusAPI()
-    measure_end_time = max([
-        workload_storageutilization_95p_rbd.get('stop'),
-        workload_storageutilization_95p_cephfs.get('stop'),
-    ])
-    if interface == 'rbd':
-        workload_storageutilization_95p = workload_storageutilization_95p_rbd
-    elif interface == 'cephfs':
-        workload_storageutilization_95p = workload_storageutilization_95p_cephfs
+    measure_end_time = workload_storageutilization_95p_cephfs.get('stop')
 
     # Check utilization on 95%
-    alerts = workload_storageutilization_95p.get('prometheus_alerts')
-    # TODO(fbalak): it seems that CephFS utilization triggers only firing
-    # alerts. This needs to be more investigated.
+    alerts = workload_storageutilization_95p_cephfs.get('prometheus_alerts')
 
     if config.ENV_DATA.get('ocs_version') == '4.2':
         nearfull_message = (


### PR DESCRIPTION
This is done for reporting purpose. It is easier to analyse the results because execution of workload fixtures is done separately.

fixes https://github.com/red-hat-storage/ocs-ci/issues/1967

Signed-off-by: Filip Balak <fbalak@redhat.com>