### PR TITLE
Run MCG CLI locally instead via operator pod

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -798,6 +798,7 @@ NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"
+NOOBAA_OPERATOR_LOCAL_CLI_PATH = os.path.join(DATA_DIR, "mcg-cli")
 
 # Storage classes provisioners
 OCS_PROVISIONERS = [

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -103,7 +103,9 @@ class MCG(object):
 
         self.s3_client = self.s3_resource.meta.client
 
-        self.operator_pod = Pod(**get_pods_having_label(constants.NOOBAA_OPERATOR_POD_LABEL, self.namespace)[0])
+        self.operator_pod = Pod(**get_pods_having_label(
+            constants.NOOBAA_OPERATOR_POD_LABEL, self.namespace)[0]
+        )
 
         # TODO: Add version verification to see if an additional cp isn't needed
         # If the MCG CLI binary isn't found, copy it from the operator pod

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -103,8 +103,10 @@ class MCG(object):
 
         self.s3_client = self.s3_resource.meta.client
 
-        self.operator_pod = Pod(**get_pods_having_label(
-            constants.NOOBAA_OPERATOR_POD_LABEL, self.namespace)[0]
+        self.operator_pod = Pod(
+            **get_pods_having_label(
+                constants.NOOBAA_OPERATOR_POD_LABEL, self.namespace
+            )[0]
         )
 
         # TODO: Add version verification to see if an additional cp isn't needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     deployment, ignore_leftovers, tier_marks
 )
-from ocs_ci.ocs import constants, ocp, defaults, node, platform_nodes, registry
+from ocs_ci.ocs import constants, ocp, defaults, node, platform_nodes
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CephHealthException
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.cloud_manager import CloudManager
@@ -1515,10 +1515,6 @@ def mcg_obj_fixture(request):
     mcg_obj = MCG()
 
     def finalizer():
-        registry.remove_role_from_user(
-            'cluster-admin', constants.NOOBAA_SERVICE_ACCOUNT,
-            cluster_role=True
-        )
         if config.ENV_DATA['platform'].lower() == 'aws':
             mcg_obj.cred_req_obj.delete()
 


### PR DESCRIPTION
Instead of running the commands directly via the operator pod (which requires the NooBaa serviceaccount to have a `cluster-admin` role), we now copy the binary to the local ...ocs-ci/data/ folder, and run everything from there.