### PR TITLE
Refactor tests to work on OCS 4.5, work around missing `service-ca.crt`

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -805,10 +805,9 @@ NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"
 NOOBAA_OPERATOR_LOCAL_CLI_PATH = os.path.join(DATA_DIR, "mcg-cli")
-MCG_CRT_NAME = "service-ca.crt"
-MCG_CRT_REMOTE_PATH = f"/var/run/secrets/kubernetes.io/serviceaccount/..data/{MCG_CRT_NAME}"
-MCG_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{MCG_CRT_NAME}"
-MCG_CRT_AWSCLI_POD_PATH = f"/cert/mcg-{MCG_CRT_NAME}"
+DEFAULT_INGRESS_CRT = "router-ca.crt"
+DEFAULT_INGRESS_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{DEFAULT_INGRESS_CRT}"
+DEFAULT_INGRESS_CRT_REMOTE_PATH = f"/cert/{DEFAULT_INGRESS_CRT}"
 AWSCLI_RELAY_POD_NAME = "awscli-relay-pod"
 
 # Storage classes provisioners

--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -57,13 +57,13 @@ class OBC(object):
         self.s3_endpoint = mcg.s3_endpoint
 
         self.s3_resource = boto3.resource(
-            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.DEFAULT_INGRESS_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
 
         self.s3_client = boto3.client(
-            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.DEFAULT_INGRESS_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
@@ -145,13 +145,13 @@ class NoobaaAccount(object):
         self.token = response['reply']['token']
 
         self.s3_resource = boto3.resource(
-            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.DEFAULT_INGRESS_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )
 
         self.s3_client = boto3.client(
-            's3', verify=constants.MCG_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
+            's3', verify=constants.DEFAULT_INGRESS_CRT_LOCAL_PATH, endpoint_url=self.s3_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key
         )

--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -32,14 +32,6 @@ class OBC(object):
         """
         self.obc_name = obc
         self.namespace = config.ENV_DATA['cluster_namespace']
-        obc_obj = OCP(namespace=self.namespace, kind='ObjectBucketClaim')
-        assert obc_obj.wait_for_resource(
-            condition=constants.STATUS_BOUND,
-            resource_name=self.obc_name,
-            column='PHASE',
-            resource_count=1,
-            timeout=60
-        ), "OBC did not reach BOUND Phase, cannot initialize OBC credentials"
         obc_resource = OCP(namespace=self.namespace, kind='ObjectBucketClaim', resource_name=self.obc_name)
         obc_results = obc_resource.get()
         self.ob_name = obc_results.get('spec').get('ObjectBucketName')

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -766,14 +766,11 @@ class MCG(object):
             assert os.path.isfile(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH), (
                 f'MCG CLI file not found at {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}'
             )
-            assert 'ELF' in exec_cmd(
-                f'file {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}'
-            ).stdout.decode(), (
-                f"{constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH } doesn't seem like an ELF file",
-                " and was probably not copied properly"
-            )
             assert os.access(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH, os.X_OK), (
                 "The MCG CLI binary does not have execution permissions"
+            )
+            assert _compare_cli_hashes(), (
+                "Binary hash doesn't match the one on the operator pod"
             )
 
     @property

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -54,6 +54,12 @@ class MCG(object):
         )
 
         self.retrieve_noobaa_cli_binary()
+
+        """
+        The certificate will be copied on each mcg_obj instantiation since
+        the process is so light and quick, that the time required for the redundant
+        copy is neglible in comparison to the time a hash comparison will take.
+        """
         retrieve_default_ingress_crt()
 
         get_noobaa = OCP(kind='noobaa', namespace=self.namespace).get()

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -23,6 +23,7 @@ from tests.helpers import (
     calc_local_file_md5_sum
 )
 import subprocess
+import stat
 
 logger = logging.getLogger(name=__file__)
 
@@ -756,7 +757,11 @@ class MCG(object):
             )
             subprocess.run(cmd, shell=True)
             # Add an executable bit in order to allow usage of the binary
-            exec_cmd(f'chmod +x {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}')
+            current_file_permissions = os.stat(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH)
+            os.chmod(
+                constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH,
+                current_file_permissions.st_mode | stat.S_IEXEC
+            )
             # Make sure the binary was copied properly and has the correct permissions
             assert os.path.isfile(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH)
             assert 'ELF' in exec_cmd(f'file {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}').stdout.decode()

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -44,15 +44,6 @@ class MCG(object):
             **get_pods_having_label(constants.NOOBAA_CORE_POD_LABEL, self.namespace)[0]
         )
 
-        # Copy the self-signed certificate to the local runner
-        # For usage with boto3 (in case the cert isn't found)
-        if not os.path.isfile(constants.MCG_CRT_LOCAL_PATH):
-            ocp_obj.exec_oc_cmd(
-                f'cp {self.core_pod.name}:'
-                f'{constants.MCG_CRT_REMOTE_PATH} '
-                f'{constants.MCG_CRT_LOCAL_PATH}'
-            )
-
         results = ocp_obj.get()
         self.s3_endpoint = (
             results.get('items')[0].get('status').get('services')

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -668,7 +668,7 @@ class MCG(object):
                 if pool.get('name') == backingstore_name:
                     current_state = pool.get('mode')
                     logger.info(
-                        f'Current state of backingstore ''{backingstore_name} '
+                        f'Current state of backingstore {backingstore_name} '
                         f'is {current_state}'
                     )
                     if current_state == desired_state:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -763,9 +763,18 @@ class MCG(object):
                 current_file_permissions.st_mode | stat.S_IEXEC
             )
             # Make sure the binary was copied properly and has the correct permissions
-            assert os.path.isfile(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH)
-            assert 'ELF' in exec_cmd(f'file {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}').stdout.decode()
-            assert os.access(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH, os.X_OK)
+            assert os.path.isfile(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH), (
+                f'MCG CLI file not found at {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}'
+            )
+            assert 'ELF' in exec_cmd(
+                f'file {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH}'
+            ).stdout.decode(), (
+                f"{constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH } doesn't seem like an ELF file",
+                " and was probably not copied properly"
+            )
+            assert os.access(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH, os.X_OK), (
+                "The MCG CLI binary does not have execution permissions"
+            )
 
     @property
     def status(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2381,4 +2381,3 @@ def measurement_dir(tmp_path):
         )
         os.mkdir(measurement_dir)
     return measurement_dir
-  

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1729,7 +1729,10 @@ def bucket_factory_fixture(request, mcg_obj):
         'cli': CLIBucket
     }
 
-    def _create_buckets(amount=1, interface='S3', *args, **kwargs):
+    def _create_buckets(
+        amount=1, interface='S3',
+        verify_health=True, *args, **kwargs
+    ):
         """
         Creates and deletes all buckets that were created as part of the test
 
@@ -1752,14 +1755,17 @@ def bucket_factory_fixture(request, mcg_obj):
             bucket_name = helpers.create_unique_resource_name(
                 resource_description='bucket', resource_type=interface.lower()
             )
-            created_buckets.append(
-                bucketMap[interface.lower()](
-                    mcg_obj,
-                    bucket_name,
-                    *args,
-                    **kwargs
-                )
+            created_bucket = bucketMap[interface.lower()](
+                mcg_obj,
+                bucket_name,
+                *args,
+                **kwargs
             )
+            created_buckets.append(created_bucket)
+            if verify_health:
+                assert created_bucket.verify_health(), (
+                    f"{bucket_name} did not reach a healthy state in time."
+                )
         return created_buckets
 
     def bucket_cleanup():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2335,7 +2335,7 @@ def retrieve_mcg_certificate(request):
     """
     mcg_core_pod = Pod(
         **get_pods_having_label(
-            constants.NOOBAA_CORE_POD_LABEL, 
+            constants.NOOBAA_CORE_POD_LABEL,
             config.ENV_DATA['cluster_namespace']
         )[0]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.resources.pod import (
-  get_rgw_pod, get_ceph_tools_pod, 
-  Pod, get_pods_having_label, get_rgw_pod
+    get_rgw_pod, get_ceph_tools_pod,
+    Pod, get_pods_having_label
 )
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,7 @@ from ocs_ci.ocs.resources.cloud_manager import CloudManager
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import (
-    get_rgw_pod, get_ceph_tools_pod,
-    Pod, get_pods_having_label
-)
+from ocs_ci.ocs.resources.pod import get_rgw_pod, get_ceph_tools_pod
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
 from ocs_ci.ocs.cluster_load import ClusterLoad
@@ -2325,34 +2322,6 @@ def fio_job_dict_fixture():
         """)
     job_dict = yaml.safe_load(template)
     return job_dict
-
-
-@pytest.fixture(scope='session', autouse=True)
-def retrieve_mcg_certificate(request):
-    """
-    Copy the self-signed certificate from the noobaa-core pod
-    to the local code runner for usage with boto3
-    """
-    mcg_core_pod = Pod(
-        **get_pods_having_label(
-            constants.NOOBAA_CORE_POD_LABEL,
-            config.ENV_DATA['cluster_namespace']
-        )[0]
-    )
-
-    OCP(
-        namespace=config.ENV_DATA['cluster_namespace']
-    ).exec_oc_cmd(
-        f'cp {mcg_core_pod.name}:'
-        f'{constants.MCG_CRT_REMOTE_PATH} '
-        f'{constants.MCG_CRT_LOCAL_PATH}',
-        out_yaml_format=False
-    )
-
-    def crt_cleanup():
-        os.remove(constants.MCG_CRT_LOCAL_PATH)
-
-    request.addfinalizer(crt_cleanup)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from ocs_ci.ocs.resources.cloud_manager import CloudManager
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import get_rgw_pod
+from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label, get_rgw_pod
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
 from ocs_ci.utility import aws
@@ -2328,13 +2328,22 @@ def fio_job_dict_fixture():
 
 
 @pytest.fixture(scope='session', autouse=True)
-def retrieve_mcg_certificate(request, mcg_obj_session):
+def retrieve_mcg_certificate(request):
     """
     Copy the self-signed certificate from the noobaa-core pod
     to the local code runner for usage with boto3
     """
-    OCP(namespace=mcg_obj_session.namespace).exec_oc_cmd(
-        f'cp {mcg_obj_session.core_pod.name}:'
+    mcg_core_pod = Pod(
+        **get_pods_having_label(
+            constants.NOOBAA_CORE_POD_LABEL, 
+            config.ENV_DATA['cluster_namespace']
+        )[0]
+    )
+
+    OCP(
+        namespace=config.ENV_DATA['cluster_namespace']
+    ).exec_oc_cmd(
+        f'cp {mcg_core_pod.name}:'
         f'{constants.MCG_CRT_REMOTE_PATH} '
         f'{constants.MCG_CRT_LOCAL_PATH}',
         out_yaml_format=False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1577,16 +1577,19 @@ def awscli_pod_fixture(mcg_obj, created_pods):
     helpers.wait_for_resource_state(awscli_pod_obj, constants.STATUS_RUNNING)
     created_pods.append(awscli_pod_obj)
 
+    # FIXME: Use service-ca.crt instead of copying the Ingress crt into the pod
+    # https://github.com/red-hat-storage/ocs-ci/issues/2260
+
     # Verify that the target dir for the self-signed MCG cert exists
-    cert_dir = pathlib.PurePath(constants.MCG_CRT_AWSCLI_POD_PATH).parent
+    cert_dir = pathlib.PurePath(constants.DEFAULT_INGRESS_CRT_REMOTE_PATH).parent
     awscli_pod_obj.exec_cmd_on_pod(f'mkdir --parents {cert_dir}')
 
     # Copy the self-signed certificate to use with AWSCLI
     # Use cat and sed since the pod does not have tar or rsync
     cmd = (
-        f"cat {constants.MCG_CRT_LOCAL_PATH} | "
+        f"cat {constants.DEFAULT_INGRESS_CRT_LOCAL_PATH} | "
         f"oc exec -i -n {mcg_obj.namespace} {constants.AWSCLI_RELAY_POD_NAME} "
-        f"-- sed -n 'w {constants.MCG_CRT_AWSCLI_POD_PATH}'"
+        f"-- sed -n 'w {constants.DEFAULT_INGRESS_CRT_REMOTE_PATH}'"
     )
     subprocess.run(cmd, shell=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2333,7 +2333,7 @@ def retrieve_mcg_certificate(request, mcg_obj_session):
     Copy the self-signed certificate from the noobaa-core pod
     to the local code runner for usage with boto3
     """
-    OCP.exec_oc_cmd(
+    OCP().exec_oc_cmd(
         f'cp {mcg_obj_session.core_pod.name}:'
         f'{constants.MCG_CRT_REMOTE_PATH} '
         f'{constants.MCG_CRT_LOCAL_PATH}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2333,10 +2333,11 @@ def retrieve_mcg_certificate(request, mcg_obj_session):
     Copy the self-signed certificate from the noobaa-core pod
     to the local code runner for usage with boto3
     """
-    OCP().exec_oc_cmd(
+    OCP(namespace=mcg_obj_session.namespace).exec_oc_cmd(
         f'cp {mcg_obj_session.core_pod.name}:'
         f'{constants.MCG_CRT_REMOTE_PATH} '
-        f'{constants.MCG_CRT_LOCAL_PATH}'
+        f'{constants.MCG_CRT_LOCAL_PATH}',
+        out_yaml_format=False
     )
 
     def crt_cleanup():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2325,3 +2325,21 @@ def fio_job_dict_fixture():
         """)
     job_dict = yaml.safe_load(template)
     return job_dict
+
+
+@pytest.fixture(scope='session', autouse=True)
+def retrieve_mcg_certificate(request, mcg_obj_session):
+    """
+    Copy the self-signed certificate from the noobaa-core pod
+    to the local code runner for usage with boto3
+    """
+    OCP.exec_oc_cmd(
+        f'cp {mcg_obj_session.core_pod.name}:'
+        f'{constants.MCG_CRT_REMOTE_PATH} '
+        f'{constants.MCG_CRT_LOCAL_PATH}'
+    )
+
+    def crt_cleanup():
+        os.remove(constants.MCG_CRT_LOCAL_PATH)
+
+    request.addfinalizer(crt_cleanup)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1577,7 +1577,7 @@ def craft_s3_command(cmd, mcg_obj=None, api=False):
         string_wrapper = '"'
     else:
         base_command = (
-            f"aws s3{api} --no-sign-request "
+            f"aws s3{api} "
         )
         string_wrapper = ''
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,36 +1,36 @@
 """
 Helper functions file for OCS QE
 """
-import logging
-import re
+import base64
 import datetime
 import hashlib
-import statistics
-import os
-from subprocess import TimeoutExpired, run, PIPE
-import tempfile
-import time
-import yaml
 import json
+import logging
+import os
+import re
+import statistics
+import tempfile
 import threading
-
-from ocs_ci.ocs.ocp import OCP
-
-from uuid import uuid4
-from ocs_ci.ocs.exceptions import (
-    TimeoutExpiredError,
-    UnexpectedBehaviour,
-    UnavailableBuildException
-)
+import time
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.ocs import constants, defaults, ocp, node
-from ocs_ci.utility import templating
+from subprocess import PIPE, TimeoutExpired, run
+from uuid import uuid4
+
+import yaml
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, defaults, node, ocp
+from ocs_ci.ocs.exceptions import (
+    CommandFailed, ResourceWrongStatusException,
+    TimeoutExpiredError, UnavailableBuildException,
+    UnexpectedBehaviour
+)
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod, pvc
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
+from ocs_ci.utility import templating
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler, ocsci_log_path, run_cmd
-from ocs_ci.framework import config
 
 logger = logging.getLogger(__name__)
 
@@ -1567,7 +1567,7 @@ def craft_s3_command(cmd, mcg_obj=None, api=False):
     api = 'api' if api else ''
     if mcg_obj:
         base_command = (
-            f'sh -c "AWS_CA_BUNDLE={constants.MCG_CRT_AWSCLI_POD_PATH} '
+            f'sh -c "AWS_CA_BUNDLE={constants.DEFAULT_INGRESS_CRT_REMOTE_PATH} '
             f'AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} '
             f'AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} '
             f'AWS_DEFAULT_REGION={mcg_obj.region} '
@@ -2274,3 +2274,24 @@ def calc_local_file_md5_sum(path):
     with open(path, 'rb') as file_to_hash:
         file_as_bytes = file_to_hash.read()
     return hashlib.md5(file_as_bytes).hexdigest()
+
+
+def retrieve_default_ingress_crt():
+    """
+    Copy the default ingress certificate from the router-ca secret
+    to the local code runner for usage with boto3.
+
+    The certificate will be copied on each mcg_obj instantiation since
+    the process is light and quick, that the time required for the redundant
+    copy is neglible in comparison to the time a hash comparison will take.
+    """
+    default_ingress_crt_b64 = OCP(
+        kind='secret',
+        namespace='openshift-ingress-operator',
+        resource_name='router-ca'
+    ).get().get('data').get('tls.crt')
+
+    decoded_crt = base64.b64decode(default_ingress_crt_b64).decode('utf-8')
+
+    with open(constants.DEFAULT_INGRESS_CRT_LOCAL_PATH, 'w') as crtfile:
+        crtfile.write(decoded_crt)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2281,9 +2281,6 @@ def retrieve_default_ingress_crt():
     Copy the default ingress certificate from the router-ca secret
     to the local code runner for usage with boto3.
 
-    The certificate will be copied on each mcg_obj instantiation since
-    the process is light and quick, that the time required for the redundant
-    copy is neglible in comparison to the time a hash comparison will take.
     """
     default_ingress_crt_b64 = OCP(
         kind='secret',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ Helper functions file for OCS QE
 import logging
 import re
 import datetime
+import hashlib
 import statistics
 import os
 from subprocess import TimeoutExpired, run, PIPE
@@ -2257,3 +2258,19 @@ def validate_pods_are_running_and_not_restarted(
     logger.error(f"Pod is in {pod_state} state and restart count of pod {restart_count}")
     logger.info(f"{pod_obj}")
     return False
+
+
+def calc_local_file_md5_sum(path):
+    """
+    Calculate and return the MD5 checksum of a local file
+
+    Arguments:
+        path(str): The path to the file
+
+    Returns:
+        str: The MD5 checksum
+
+    """
+    with open(path, 'rb') as file_to_hash:
+        file_as_bytes = file_to_hash.read()
+    return hashlib.md5(file_as_bytes).hexdigest()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1577,7 +1577,7 @@ def craft_s3_command(cmd, mcg_obj=None, api=False):
         string_wrapper = '"'
     else:
         base_command = (
-            f"aws s3{api} "
+            f"aws s3{api} --no-sign-request "
         )
         string_wrapper = ''
 

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -80,11 +80,11 @@ class TestBucketCreation:
     )
     def test_bucket_creation(self, bucket_factory, amount, interface):
         """
-        Test bucket creation using the S3 SDK, OC command or MCG CLI
+        Test bucket creation using the S3 SDK, OC command or MCG CLI.
+        The factory checks the bucket's health by default.
         """
 
-        for bucket in bucket_factory(amount, interface):
-            assert bucket.verify_health()
+        bucket_factory(amount, interface)
 
     @pytest.mark.parametrize(
         argnames="amount,interface",
@@ -109,14 +109,16 @@ class TestBucketCreation:
         Negative test with duplicate bucket creation using the S3 SDK, OC
         command or MCG CLI
         """
-        expected_err = "Already ?Exists"
+        expected_err = "BucketAlready|Already ?Exists"
         bucket_map = {
             's3': S3Bucket,
             'oc': OCBucket,
             'cli': CLIBucket
         }
         bucket_set = set(
-            bucket.name for bucket in bucket_factory(amount, interface)
+            bucket.name for bucket in bucket_factory(
+                amount, interface, verify_health=False
+            )
         )
         for bucket_name in bucket_set:
             try:


### PR DESCRIPTION
<Title> 

Also added better handling of CLI binary and `service-ca.crt` copying.