### PR TITLE
Work around copying the MCG cert to the AWSCLI pod

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from math import floor
 from random import randrange
 from time import sleep
 from shutil import copyfile
+import subprocess
 
 import pytest
 import pathlib
@@ -1587,11 +1588,13 @@ def awscli_pod_fixture(mcg_obj, created_pods):
     awscli_pod_obj.exec_cmd_on_pod(f'mkdir --parents {cert_dir}')
 
     # Copy the self-signed certificate to use with AWSCLI
-    OCP().exec_oc_cmd(
-        f'cp {constants.MCG_CRT_LOCAL_PATH} '
-        f'{constants.AWSCLI_RELAY_POD_NAME}:'
-        f'{constants.MCG_CRT_AWSCLI_POD_PATH}'
+    # Use cat and sed since the pod does not have tar or rsync
+    cmd = (
+        f"cat {constants.MCG_CRT_LOCAL_PATH} | "
+        f"oc exec -i -n {mcg_obj.namespace} {constants.AWSCLI_RELAY_POD_NAME} "
+        f"-- sed -n 'w {constants.MCG_CRT_AWSCLI_POD_PATH}'"
     )
+    subprocess.run(cmd, shell=True)
 
     return awscli_pod_obj
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1549,7 +1549,7 @@ def delete_deploymentconfig_pods(pod_obj):
                 dc_ocp_obj.wait_for_delete(resource_name=pod_obj.get_labels().get('name'))
 
 
-def craft_s3_command(mcg_obj, cmd, api=False):
+def craft_s3_command(cmd, mcg_obj=None, api=False):
     """
     Crafts the AWS CLI S3 command including the
     login credentials and command to be ran

--- a/tests/manage/mcg/helpers.py
+++ b/tests/manage/mcg/helpers.py
@@ -163,7 +163,7 @@ def upload_parts(mcg_obj, awscli_pod, bucketname, object_key, body_path, upload_
         )
         # upload_cmd will return ETag, upload_id etc which is then split to get just the ETag
         part = awscli_pod.exec_cmd_on_pod(
-            command=craft_s3_command(mcg_obj, upload_cmd, api=True), out_yaml_format=False,
+            command=craft_s3_command(upload_cmd, mcg_obj, api=True), out_yaml_format=False,
             secrets=secrets
         ).split("\"")[-3].split("\\")[0]
         parts.append({"PartNumber": count, "ETag": f'"{part}"'})


### PR DESCRIPTION
The workaround was needed after we changed the AWSCLI pod's image *and* started verifying ther MCG certificates. We tested each change separately, but not together - and thus they were merged.

Also fix the signature of `craft_s3_command` that wasn't updated properly in a #2080 