### PR TITLE
Fix issue 2147

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -58,9 +58,10 @@ class Pod(OCS):
         self.pod_data = kwargs
         super(Pod, self).__init__(**kwargs)
 
-        self.temp_yaml = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode='w+', prefix='POD_', delete=False
-        )
+        ) as temp_info:
+            self.temp_yaml = temp_info.name
         self._name = self.pod_data.get('metadata').get('name')
         self._labels = self.get_labels()
         self._roles = []


### PR DESCRIPTION
Fixes: #2147

Previous NamedTemporaryFile calls saved the entrire file
object and did not release the file descriptor.  Now the
calls only save the name of the file (the only data the
code used from the file object).  The NamedTemporaryFile
call is made within a with clause to insure that the
file descriptor is released.

Signed-off-by: wusui <wusui@redhat.com>