### PR TITLE
Cluster load: Determine cluster limit by latency growth + use DC pods

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,8 +105,9 @@ to the pytest.
    provided. In case `--io-load` is not provided, IO load is set to 30% of
    the cluster throughput limit.
 * `--io-load` - IOs throughput target percentage. The value should be
-   between 0 to 100. The default is 30 (30%)
-* `--enable-bg-io-logs` - If passed, background IO log messages will be printed
+   between 0 to 100. The default is 50 (50%)
+* `--log-cluster-utilization` - If passed, metrics of the cluster utilization will be
+   printed every 10 seconds
 
 ## Examples
 
@@ -191,9 +192,12 @@ run-ci tests/
 
 #### Running tests with background IO load
 
-If you would like to run tests with IO load of 50% in the tests background,
-while background IO log messages are printed, append these arguments to the
-`run-ci` command: `--io-in-bg --io-load 50 --enable-bg-io-logs`
+If you would like to run tests with IO load of 75% of the cluster throughput limit,
+in the tests background, append these arguments to the `run-ci` command:
+`--io-in-bg --io-load 75`
+
+If you would like metrics of cluster utilization to be logged, every 10 seconds, during
+the test execution, append the `--log-cluster-utilization` argument to the `run-ci` command
 
 #### Destroy of cluster
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -30,8 +30,8 @@ RUN:
   force_chrome_branch_base: "665006"
   force_chrome_branch_sha256sum: "a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
   io_in_bg: False
-  io_load: null
-  bg_io_logs: False
+  io_load: 50
+  log_utilization: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -104,10 +104,10 @@ def pytest_addoption(parser):
         help="IOs throughput target percentage. Value should be between 0 to 100",
     )
     parser.addoption(
-        '--enable-bg-io-logs',
-        dest='enable_bg_io_logs',
+        '--log-cluster-utilization',
+        dest='log_cluster_utilization',
         action="store_true",
-        help="Enable background IO logs, if --io-in-bg is passed",
+        help="Enable logging of cluster utilization metrics every 10 seconds"
     )
     parser.addoption(
         '--ocs-version',
@@ -316,9 +316,9 @@ def process_cluster_cli_params(config):
         io_load = get_cli_param(config, 'io_load')
         if io_load:
             ocsci_config.RUN['io_load'] = io_load
-        io_bg_logs = get_cli_param(config, 'enable_bg_io_logs')
-        if io_bg_logs:
-            ocsci_config.RUN['io_bg_logs'] = True
+    log_utilization = get_cli_param(config, 'log_cluster_utilization')
+    if log_utilization:
+        ocsci_config.RUN['log_utilization'] = True
     upgrade_ocs_version = get_cli_param(config, "upgrade_ocs_version")
     if upgrade_ocs_version:
         ocsci_config.UPGRADE['upgrade_ocs_version'] = upgrade_ocs_version

--- a/ocs_ci/framework/testlib.py
+++ b/ocs_ci/framework/testlib.py
@@ -4,7 +4,7 @@ from ocs_ci.framework.pytest_customization.marks import *  # noqa: F403
 
 
 @pytest.mark.usefixtures(  # noqa: F405
-    'run_io_in_background', 'environment_checker'
+    'environment_checker'
 )
 class BaseTest:
     """

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,7 +20,9 @@ from ocs_ci.ocs.resources import ocs, storage_cluster
 import ocs_ci.ocs.constants as constant
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import TimeoutSampler, run_cmd, convert_device_size
+from ocs_ci.utility.utils import (
+    TimeoutSampler, run_cmd, convert_device_size, get_trim_mean
+)
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.framework import config
 from ocs_ci.ocs import ocp, constants, exceptions
@@ -590,7 +592,7 @@ class CephCluster(object):
         logging.info(f"The throughput percentage of the cluster is {throughput_percentage}%")
         return throughput_percentage
 
-    def calc_average_throughput(self, samples=5):
+    def calc_trim_mean_throughput(self, samples=8):
         """
         Calculate the cluster average throughput out of a few samples
 
@@ -604,7 +606,7 @@ class CephCluster(object):
         throughput_vals = [
             self.get_cluster_throughput() for _ in range(samples)
         ]
-        return sum(throughput_vals) / samples
+        return round(get_trim_mean(throughput_vals), 3)
 
     def get_rebalance_status(self):
         """

--- a/ocs_ci/ocs/cluster_load.py
+++ b/ocs_ci/ocs/cluster_load.py
@@ -4,12 +4,19 @@ A module for cluster load related functionalities
 """
 import logging
 import time
+from datetime import datetime
+from uuid import uuid4
 
-import ocs_ci.ocs.constants as constant
-from ocs_ci.ocs import constants
+from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.utility.utils import get_trim_mean
+from ocs_ci.utility import templating
+from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.cluster import (
-    CephCluster, get_osd_pods_memory_sum, get_percent_used_capacity
+    get_osd_pods_memory_sum, get_percent_used_capacity
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class ClusterLoad:
@@ -18,263 +25,314 @@ class ClusterLoad:
 
     """
 
-    def __init__(self, propagate_logs=True):
+    def __init__(
+        self, project_factory=None, pvc_factory=None, sa_factory=None,
+        pod_factory=None, target_percentage=None
+    ):
         """
         Initializer for ClusterLoad
 
         Args:
-            propagate_logs (bool): True for logging, False otherwise
+            pvc_factory (function): A call to pvc_factory function
+            sa_factory (function): A call to service_account_factory function
+            pod_factory (function): A call to pod_factory function
+            target_percentage (float): The percentage of cluster load that is
+                required. The value should be greater than 0 and smaller than 1
 
         """
-        self.logger = logging.getLogger(__name__)
-        self.logger.propagate = propagate_logs
-        self.cl_obj = CephCluster()
+        self.prometheus_api = PrometheusAPI()
+        self.pvc_factory = pvc_factory
+        self.sa_factory = sa_factory
+        self.pod_factory = pod_factory
+        self.target_percentage = target_percentage
+        self.cluster_limit = None
+        self.dc_objs = list()
+        self.pvc_objs = list()
+        self.name_suffix = 1
+        self.pvc_size = int(get_osd_pods_memory_sum() * 0.5)
+        self.io_file_size = f"{self.pvc_size * 1000 - 200}M"
+        self.sleep_time = 35
+        if project_factory:
+            project_name = f"{defaults.BG_LOAD_NAMESPACE}-{uuid4().hex[:5]}"
+            self.project = project_factory(project_name=project_name)
 
-    def reach_cluster_load_percentage_in_throughput(
-        self, pvc_factory, pod_factory, target_percentage=0.3, cluster_limit=None
-    ):
+    def increase_load(self, rate=None, wait=True):
         """
-        Reach the cluster throughput limit and then drop to the requested target percentage.
-        The number of pods needed for the desired target percentage is determined by
-        creating pods one by one, while examining if the cluster throughput is increased
-        by more than 10%. When it doesn't increased by more than 10% anymore after
-        the new pod started running IO, it means that the cluster throughput limit is
-        reached. Then, the function deletes the pods that are not needed as they
-        are the difference between the limit (100%) and the target percentage
-        (the default target percentage is 30%). This leaves the number of pods needed
-        running IO for cluster throughput to be around the desired percentage.
+        Create a PVC, a service account and a DeploymentConfig of FIO pod
 
         Args:
-            pvc_factory (function): A call to pvc_factory function
-            pod_factory (function): A call to pod_factory function
-            target_percentage (float): The percentage of cluster load that is required.
-                The value should be greater than 0 and smaller than 1
-            cluster_limit (float): The cluster pre-known throughput limit in Mb/s.
-                If passed, the function will calculate the target throughput based on it
-                multiplied by 'target_percentage'
-
-        Returns:
-            tuple: The cluster limit in Mb/s (float) and the current throughput
-                in Mb/s (float)
+            rate (str): FIO 'rate' value (e.g. '20M')
+            wait (bool): True for waiting for IO to kick in on the
+                newly created pod, False otherwise
 
         """
-        pvc_objs = list()
-        pod_objs = list()
-        limit_reached = False
+        pvc_obj = self.pvc_factory(
+            interface=constants.CEPHBLOCKPOOL, project=self.project,
+            size=self.pvc_size, volume_mode=constants.VOLUME_MODE_BLOCK,
+        )
+        self.pvc_objs.append(pvc_obj)
+        service_account = self.sa_factory(pvc_obj.project)
 
-        # FIO params:
-        # 'runtime' is set with a large value of seconds to
-        # make sure that the pods are running
-        io_run_time = 100**3
-        rate = '200M'
-        bs = '128K'
+        # Set new arguments with the updated file size to be used for
+        # DeploymentConfig of FIO pod creation
+        fio_dc_data = templating.load_yaml(constants.FIO_DC_YAML)
+        args = fio_dc_data.get('spec').get('template').get(
+            'spec'
+        ).get('containers')[0].get('args')
+        new_args = [
+            x for x in args if not x.startswith('--filesize=') and not x.startswith('--rate=')
+        ]
+        new_args.append(f"--filesize={self.io_file_size}")
+        new_args.append(f"--rate={rate}")
+        self.name_suffix += 1
+        dc_obj = self.pod_factory(
+            pvc=pvc_obj, pod_dict_path=constants.FIO_DC_YAML,
+            raw_block_pv=True, deployment_config=True,
+            service_account=service_account, command_args=new_args
+        )
+        self.dc_objs.append(dc_obj)
+        if wait:
+            logger.info(
+                f"Waiting {self.sleep_time} seconds for IO to kick-in on the newly "
+                f"created FIO pod {dc_obj.name}"
+            )
+            time.sleep(self.sleep_time)
 
-        if 0.1 < target_percentage > 0.95:
-            self.logger.warning(
-                f"The target percentage is {target_percentage * 100}% which is not "
-                f"within the accepted range. Therefore, IO will not be started"
+    def decrease_load(self, wait=True):
+        """
+        Delete DeploymentConfig with its pods and the PVC. Then, wait for the
+        IO to be stopped
+
+        Args:
+            wait (bool): True for waiting for IO to drop after the deletion
+                of the FIO pod, False otherwise
+
+        """
+        dc_name = self.dc_objs[-1].name
+        self.dc_objs[-1].delete()
+        self.dc_objs[-1].ocp.wait_for_delete(dc_name)
+        self.dc_objs.remove(self.dc_objs[-1])
+        self.pvc_objs[-1].delete()
+        self.pvc_objs[-1].ocp.wait_for_delete(self.pvc_objs[-1].name)
+        self.pvc_objs.remove(self.pvc_objs[-1])
+        if wait:
+            logger.info(
+                f"Waiting {self.sleep_time} seconds for IO to drop after the deletion of {dc_name}"
+            )
+            time.sleep(self.sleep_time)
+
+    def reach_cluster_load_percentage(self):
+        """
+        Reach the cluster limit and then drop to the given target percentage.
+        The number of pods needed for the desired target percentage is determined by
+        creating pods one by one, while examining the cluster latency. Once the latency
+        is greater than 200 ms and it is growing exponentially, it means that
+        the cluster limit has been reached.
+        Then, dropping to the target percentage by deleting all pods and re-creating
+        ones with smaller value of FIO 'rate' param.
+        This leaves the number of pods needed running IO for cluster load to
+        be around the desired percentage.
+
+        """
+        if not 0.1 < self.target_percentage < 0.95:
+            logger.warning(
+                f"The target percentage is {self.target_percentage * 100}% which is "
+                f"not within the accepted range. Therefore, IO will not be started"
             )
             return
-
-        target_throughput = None
-        if cluster_limit:
-            target_throughput = cluster_limit * target_percentage
-
-        pvc_size = int(get_osd_pods_memory_sum() * 0.75)
-
-        self.logger.info(
-            f"In order to eliminate the OSD pods cache effect, creating 1 pod with a "
-            f"PVC size of {pvc_size} GB, which equals to 0.75 of the memory sum of "
-            f"all the OSD pods. Then, starting IOs on it"
-        )
-        pvc_obj = pvc_factory(
-            interface=constant.CEPHBLOCKPOOL, size=pvc_size,
-            volume_mode=constants.VOLUME_MODE_BLOCK
-        )
-        pvc_objs.append(pvc_obj)
-        pod_obj = pod_factory(
-            pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
-            raw_block_pv=True
-        )
-        pod_objs.append(pod_obj)
-
-        io_file_size = f"{pvc_size-1}G"
-
-        pod_obj.run_io(
-            storage_type='block', size=io_file_size,
-            runtime=io_run_time, rate=rate, bs=bs, rw_ratio=25
-        )
-
-        pvc_size = int(get_osd_pods_memory_sum() * 0.25)
-        pvc_obj = pvc_factory(
-            interface=constant.CEPHBLOCKPOOL, size=pvc_size,
-            volume_mode=constants.VOLUME_MODE_BLOCK
-        )
-        pvc_objs.append(pvc_obj)
-        pod_obj = pod_factory(
-            pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
-            raw_block_pv=True
-        )
-        pod_objs.append(pod_obj)
-
-        current_throughput = self.cl_obj.calc_average_throughput()
-
-        if target_throughput:
-            if current_throughput > target_throughput * 0.8:
-                self.logger.info(
-                    f"Cluster limit has been reached. It is {current_throughput} Mb/s"
-                )
-                limit_reached = True
-
+        low_diff_counter = 0
+        limit_reached = False
+        cluster_limit = None
+        latency_vals = list()
         time_to_wait = 60 * 30
         time_before = time.time()
-        if not target_throughput:
-            self.logger.info(
-                f"\n=====================================================================\n"
-                f"Determining the cluster throughput limit. Once determined, IOs will be"
-                f"\nreduced to load at {target_percentage * 100}% of the cluster limit"
-                f"\n====================================================================="
-            )
 
+        current_iops = self.get_query(query=constants.IOPS_QUERY)
+
+        msg = (
+            "\n======================\nCurrent IOPS: {:.2f}"
+            "\nPrevious IOPS: {:.2f}\n======================"
+        )
+
+        # Creating FIO DeploymentConfig pods one by one, with a large value of FIO
+        # 'rate' arg. This in order to determine the cluster limit faster.
+        # Once determined, these pods will be deleted. Then, new FIO DC pods will be
+        # created, with a smaller value of 'rate' param. This in order to be more
+        # accurate with reaching the target percentage
+        rate = '250M'
         while not limit_reached:
+            self.increase_load(rate=rate)
+            previous_iops = current_iops
+            current_iops = self.get_query(query=constants.IOPS_QUERY)
+            if current_iops > previous_iops:
+                cluster_limit = current_iops
 
-            self.logger.info(
-                f"The cluster average collected throughput BEFORE starting "
-                f"IOs on the newly created pod is {current_throughput} Mb/s"
-            )
+            logger.info(msg.format(current_iops, previous_iops, len(self.dc_objs)))
+            self.print_metrics()
 
-            io_file_size = f"{pvc_size - 1}G"
-            pod_obj.run_io(
-                storage_type='block', size=io_file_size,
-                runtime=io_run_time, rate=rate, bs=bs, rw_ratio=25
-            )
+            latency = self.calc_trim_metric_mean(metric=constants.LATENCY_QUERY) * 1000
+            latency_vals.append(latency)
+            logger.info(f"Latency values: {latency_vals}")
 
-            self.logger.info(
-                f"While IO kicks-in on the previously created pod ({pod_obj.name}), "
-                f"creating a new pod and PVC for the next iteration"
-            )
-            pvc_size = int(get_osd_pods_memory_sum() * 0.25)
-            pvc_obj = pvc_factory(
-                interface=constant.CEPHBLOCKPOOL, size=pvc_size,
-                volume_mode=constants.VOLUME_MODE_BLOCK
-            )
-            pvc_objs.append(pvc_obj)
-            pod_obj = pod_factory(
-                pvc=pvc_obj, pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
-                raw_block_pv=True
-            )
-            pod_objs.append(pod_obj)
-            previous_throughput = current_throughput
-            current_throughput = self.cl_obj.calc_average_throughput()
-            self.logger.info(
-                f"The cluster average collected throughput AFTER starting IOs on the newly"
-                f" created pod is {current_throughput} Mb/s, while before IOs started "
-                f"on the newly created pod it was {previous_throughput}.\nThe number of "
-                f"pods running IOs is {len(pod_objs) - 1}")
-
-            if not target_throughput:
-                if current_throughput > previous_throughput * 0.8 and (
-                    current_throughput > 20
-                ):
-                    tp_diff = (current_throughput / previous_throughput * 100) - 100
-                    if tp_diff < 10:
-                        limit_reached = True
-                        cluster_limit = current_throughput
-                        self.logger.info(
-                            f"\n===================================================\n"
-                            f"The cluster throughput limit is {cluster_limit} Mb/s\n"
-                            f"==================================================="
-                        )
-                    else:
-                        self.logger.info(
-                            f"\n================================================================\n"
-                            f"The throughput difference after starting FIO on the newly created\n"
-                            f"pod is {tp_diff:.2f}%. We are waiting for it to be less than 10%"
-                            f"\n================================================================"
-                        )
-                        continue
-            else:
-                if current_throughput > target_throughput * 0.8:
-                    self.logger.info(
-                        f"Cluster limit has been reached. It is {current_throughput} Mb/s"
-                    )
+            if len(latency_vals) > 1 and latency > 250:
+                # Checking for an exponential growth
+                if latency > latency_vals[0] * 2 ** 7:
+                    logger.info("Latency exponential growth was detected")
                     limit_reached = True
-            if time.time() > time_before + time_to_wait:
-                if not target_throughput:
-                    self.logger.warning(
-                        f"Could not determine the cluster throughput limit "
-                        f"within the given {time_to_wait} timeout. Breaking"
-                    )
-                else:
-                    self.logger.warning(
-                        f"Could not reach the cluster throughput percentage "
-                        f"within the given {time_to_wait} timeout. Breaking"
-                    )
+
+            # In case the latency is greater than 3 seconds,
+            # most chances the limit has been reached
+            if latency > 3000:
+                logger.info(
+                    f"Limit was determined by latency, which is "
+                    f"higher than 3 seconds - {latency} ms"
+                )
                 limit_reached = True
-                cluster_limit = current_throughput
 
-            if current_throughput < 20:
-                if time.time() > time_before + (time_to_wait * 0.5):
-                    self.logger.warning(
-                        f"Waited for {time_to_wait * 0.5} seconds and the"
-                        f" throughput is less than 20 Mb/s. Breaking"
-                    )
-                    cluster_limit = current_throughput
-                if len(pod_objs) > 8:
-                    self.logger.warning(
-                        f"The number of pods running IO is {len(pod_objs)} "
-                        f"and the throughput is less than 20 Mb/s. Breaking"
-                    )
-                    limit_reached = True
-                    cluster_limit = current_throughput
+            # For clusters that their nodes do not meet the minimum
+            # resource requirements, the cluster limit is being reached
+            # while the latency remains low. For that, the cluster limit
+            # needs to be determined by the following condition of IOPS
+            # diff between FIO pod creation iterations
+            iops_diff = (current_iops / previous_iops * 100) - 100
+            low_diff_counter += 1 if -15 < iops_diff < 10 else 0
+            if low_diff_counter > 3:
+                logger.warning(
+                    f"Limit was determined by low IOPS diff between "
+                    f"iterations - {iops_diff:.2f}%"
+                )
+                limit_reached = True
+
+            if time.time() > time_before + time_to_wait:
+                logger.warning(
+                    f"Could not determine the cluster IOPS limit within"
+                    f"\nthe given {time_to_wait} seconds timeout. Breaking"
+                )
+                limit_reached = True
 
             cluster_used_space = get_percent_used_capacity()
-            if cluster_used_space > 50:
-                if not target_throughput:
-                    self.logger.warning(
-                        f"Cluster used space is {cluster_used_space}%. Could not find the "
-                        f"cluster throughput limit before the used spaced reached 50%. Breaking"
-                    )
-                else:
-                    self.logger.warning(
-                        f"Cluster used space is {cluster_used_space}%. Could not reach the "
-                        f"cluster throughput target percentage before the used spaced reached"
-                        f" 50%. Breaking"
-                    )
-                limit_reached = True
-                cluster_limit = current_throughput
-        if not target_throughput:
-            target_throughput = cluster_limit * target_percentage
-            self.logger.info(f"The target throughput is {target_throughput}")
-            current_throughput = cluster_limit
-            self.logger.info(f"The current throughput is {current_throughput}")
-
-            self.logger.info(
-                "Start deleting pods that are running IO one by one while comparing "
-                "the current throughput utilization with the target one. The goal is "
-                "to reach cluster throughput utilization that is more or less the target"
-                " throughput percentage"
-            )
-            while current_throughput > (target_throughput * 1.2) and len(pod_objs) > 1:
-                pod_name = pod_objs[-1].name
-                pod_objs[-1].delete()
-                pod_objs[-1].ocp.wait_for_delete(pod_objs[-1].name)
-                pod_objs.remove(pod_objs[-1])
-                pvc_objs[-1].delete()
-                pvc_objs[-1].ocp.wait_for_delete(pvc_objs[-1].name)
-                pvc_objs.remove(pvc_objs[-1])
-                self.logger.info(f"Waiting for IO to be stopped on pod {pod_name}")
-                time.sleep(10)
-                current_throughput = self.cl_obj.calc_average_throughput()
-                self.logger.info(
-                    f"The cluster average collected throughput after deleting "
-                    f"pod {pod_name} is {current_throughput} Mb/s"
+            if cluster_used_space > 60:
+                logger.warning(
+                    f"Cluster used space is {cluster_used_space}%. Could "
+                    f"not reach the cluster IOPS limit before the "
+                    f"used spaced reached 60%. Breaking"
                 )
+                limit_reached = True
 
-        self.logger.info(
-            f"\n==============================================\n"
-            f"The number of pods that will continue running"
-            f"\nIOs is {len(pod_objs)} at a load of {current_throughput} Mb/s"
-            f"\n=============================================="
+        self.cluster_limit = cluster_limit
+        logger.info(
+            f"\n===================================\nThe cluster IOPS limit "
+            f"is {self.cluster_limit:.2f}\n==================================="
         )
-        return cluster_limit, current_throughput
+        logger.info(
+            f"Deleting all DC FIO pods that have FIO rate parameter of {rate}"
+        )
+        while self.dc_objs:
+            self.decrease_load(wait=False)
+
+        # Creating the first pod of small FIO 'rate' param, to speed up the process.
+        # In the meantime, the load will drop, following the deletion of the
+        # FIO pods with large FIO 'rate' param
+        rate = '15M'
+        logger.info(
+            f"Creating FIO pods with a rate parameter of {rate}, one by "
+            f"one, until the target percentage is reached"
+        )
+        self.increase_load(rate=rate)
+        target_iops = self.cluster_limit * self.target_percentage
+        current_iops = self.get_query(query=constants.IOPS_QUERY)
+        logger.info(f"Target IOPS: {target_iops}")
+        logger.info(f"Current IOPS: {current_iops}")
+
+        while current_iops < target_iops * 0.95:
+            wait = False if current_iops < target_iops / 2 else True
+            self.increase_load(rate=rate, wait=wait)
+            previous_iops = current_iops
+            current_iops = self.get_query(query=constants.IOPS_QUERY)
+            logger.info(msg.format(current_iops, previous_iops, len(self.dc_objs)))
+            self.print_metrics()
+
+        logger.info(
+            f"\n========================================\n"
+            f"The target load, of {self.target_percentage * 100}%, has been reached"
+            f"\n=========================================="
+        )
+
+    def get_query(self, query):
+        """
+        Get query from Prometheus and parse it
+
+        Args:
+            query (str): Query to be done
+
+        Returns:
+            float: the query result
+
+        """
+        now = datetime.now
+        timestamp = datetime.timestamp
+        return float(
+            self.prometheus_api.query(query, str(timestamp(now())))[0]['value'][1]
+        )
+
+    def calc_trim_metric_mean(self, metric=constants.LATENCY_QUERY, samples=5):
+        """
+        Get the trimmed mean of a given metric
+
+        Args:
+            metric (str): The metric to calculate the average result for
+            samples (int): The number of samples to take
+
+        Returns:
+            float: The average result for the metric
+
+        """
+        vals = list()
+        for i in range(samples):
+            vals.append(round(self.get_query(metric), 5))
+            if i == samples - 1:
+                break
+            time.sleep(5)
+        return round(get_trim_mean(vals), 5)
+
+    def get_metrics(self):
+        """
+        Get different cluster load and utilization metrics
+        """
+        return {
+            "throughput": self.get_query(constants.THROUGHPUT_QUERY) * (
+                constants.TP_CONVERSION.get(' B/s')
+            ),
+            "latency": self.get_query(constants.LATENCY_QUERY) * 1000,
+            "iops": self.get_query(constants.IOPS_QUERY),
+            "used_space": self.get_query(constants.USED_SPACE_QUERY) / 1e+9
+        }
+
+    def print_metrics(self):
+        """
+        Print metrics
+
+        """
+        high_latency = 500
+        metrics = self.get_metrics()
+        limit_msg = ""
+        pods_msg = ""
+        if self.cluster_limit:
+            limit_msg = (
+                f"({metrics.get('iops') / self.cluster_limit * 100:.2f}% of the "
+                f"{self.cluster_limit:.1f} limit)\n"
+            )
+        if self.dc_objs:
+            pods_msg = (
+                f"\nNumber of pods running FIO: {len(self.dc_objs)}"
+            )
+        logger.info(
+            f"\n===============================\n"
+            f"Cluster throughput: {metrics.get('throughput'):.2f} MB/s\n"
+            f"Cluster latency: {metrics.get('latency'):.2f} ms\n"
+            f"Cluster IOPS: {metrics.get('iops'):.2f}\n{limit_msg}"
+            f"Cluster used space: {metrics.get('used_space'):.2f} GB{pods_msg}"
+            f"\n==============================="
+        )
+        if metrics.get('latency') > high_latency:
+            logger.warning(f"Cluster latency is higher than {high_latency} ms!")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -475,6 +475,9 @@ FIO_IO_PARAMS_YAML = os.path.join(
 FIO_IO_RW_PARAMS_YAML = os.path.join(
     TEMPLATE_FIO_DIR, "workload_io_rw.yaml"
 )
+FIO_DC_YAML = os.path.join(
+    TEMPLATE_FIO_DIR, "fio_dc.yaml"
+)
 
 # Openshift infra yamls:
 RSYNC_POD_YAML = os.path.join(
@@ -860,3 +863,9 @@ RHCOS = "RHCOS"
 ES_SERVER_IP = '10.0.78.167'
 ES_SERVER_PORT = '9200'
 ES_SERVER_URL = 'https://10.0.78.167:9200'
+
+# Cluster metrics
+THROUGHPUT_QUERY = "(sum(rate(ceph_pool_wr_bytes[1m]) + rate(ceph_pool_rd_bytes[1m])))"
+LATENCY_QUERY = "cluster:ceph_disk_latency:join_ceph_node_disk_irate1m"
+IOPS_QUERY = "sum(rate(ceph_pool_wr[1m])) + sum(rate(ceph_pool_rd[1m]))"
+USED_SPACE_QUERY = "ceph_cluster_total_used_bytes"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -48,3 +48,6 @@ error = "<html><body><h1>Oh. Something bad happened!</h1></body></html>"
 IPMI_INTERFACE_TYPE = "lanplus"
 IPMI_RMCP_PORT = 623
 IPMI_IPMB_ADDRESS = 0x20
+
+# Background load FIO pod name
+BG_LOAD_NAMESPACE = "bg-fio-load"

--- a/ocs_ci/templates/workloads/fio/fio_dc.yaml
+++ b/ocs_ci/templates/workloads/fio/fio_dc.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: fio_dc_raw_block
+  labels:
+    app: fio-benchmark
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fio-benchmark
+    spec:
+      containers:
+        - name: fio
+          image: datawiseio/fio:latest
+          securityContext:
+             capabilities:
+               add: ["SYS_ADMIN"]
+          volumeDevices:
+            - devicePath: /dev/rbdblock
+              name: my-volume
+          command: ["/usr/bin/fio"]
+          args: ["--name=fio-rand-readwrite",
+                 "--filename=/dev/rbdblock",
+                 "--readwrite=randrw",
+                 "--bs=128K",
+                 "--direct=1",
+                 "--numjobs=1",
+                 "--iodepth=4",
+                 "--time_based=1",
+                 "--runtime=1000000",
+                 "--filesize=1G",
+                 "--invalidate=1",
+                 "--rwmixread=25",
+                 "--rate=15M",
+                 "--ioengine=libaio",
+                 "--output-format=json"]
+          imagePullPolicy: IfNotPresent
+      volumes:
+        - name: my-volume
+          persistentVolumeClaim:
+            claimName: test-raw-block-pv

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -93,9 +93,11 @@ def assign_get_values(
 
     for item in items:
         ns = item.get('metadata', {}).get('namespace')
+        if item.get('kind') == constants.PV:
+            ns = item.get('spec').get('claimRef').get('namespace')
         app_label = item.get('metadata', {}).get('labels', {}).get('app')
         if (ns is not None
-                and ns.startswith("openshift-")
+                and ns.startswith(("openshift-", defaults.BG_LOAD_NAMESPACE))
                 and ns != defaults.ROOK_CLUSTER_NAMESPACE):
             log.debug("ignoring item in %s namespace: %s", ns, item)
             continue
@@ -105,7 +107,7 @@ def assign_get_values(
         items_filtered.append(item)
 
     ignored = len(items) - len(items_filtered)
-    log.debug("total %d items are ignored during invironment check", ignored)
+    log.debug("total %d items are ignored during environment check", ignored)
 
     env_status_dict[key] = items_filtered
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -13,6 +13,7 @@ import traceback
 from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from scipy.stats import tmean, scoreatpercentile
 from shutil import which
 
 import hcl
@@ -2057,6 +2058,7 @@ def convert_device_size(unformatted_size, units_to_covert_to):
             return absolute_size
 
 
+<<<<<<< HEAD
 def mirror_image(image):
     """
     Mirror image to mirror image registry.
@@ -2158,3 +2160,30 @@ def update_container_with_mirrored_image(job_pod_dict):
             container = job_pod_dict['spec']['template']['spec']['containers'][0]
         container['image'] = mirror_image(container['image'])
     return job_pod_dict
+
+
+def get_trim_mean(values, percentage=20):
+    """
+    Get the trimmed mean of a list of values.
+    Explanation: This function finds the arithmetic mean of given values,
+    ignoring values outside the given limits.
+
+    Args:
+        values (list): The list of values
+        percentage (int): The percentage to be trimmed
+
+    Returns:
+        float: Trimmed mean. In case trimmed mean calculation fails,
+            the regular mean average is returned
+
+    """
+    lower_limit = scoreatpercentile(values, percentage)
+    upper_limit = scoreatpercentile(values, 100 - percentage)
+    try:
+        return tmean(values, limits=(lower_limit, upper_limit))
+    except ValueError:
+        log.warning(
+            f"Failed to calculate the trimmed mean of {values}. The "
+            f"Regular mean average will be calculated instead"
+        )
+    return sum(values) / len(values)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2058,7 +2058,6 @@ def convert_device_size(unformatted_size, units_to_covert_to):
             return absolute_size
 
 
-<<<<<<< HEAD
 def mirror_image(image):
     """
     Mirror image to mirror image registry.

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'elasticsearch',
         'numpy',
         'python-ipmi',
+        'scipy',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import time
 import random
+import time
 import tempfile
 import textwrap
 import threading
@@ -30,7 +30,7 @@ from ocs_ci.ocs.resources.cloud_manager import CloudManager
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.mcg_bucket import S3Bucket, OCBucket, CLIBucket
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import get_rgw_pod, get_ceph_tools_pod
+from ocs_ci.ocs.resources.pod import get_rgw_pod, delete_deploymentconfig_pods
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
 from ocs_ci.ocs.cluster_load import ClusterLoad
@@ -432,13 +432,15 @@ def project_factory_fixture(request):
     """
     instances = []
 
-    def factory():
+    def factory(project_name=None):
         """
+        Args:
+            project_name (str): The name for the new project
 
         Returns:
             object: ocs_ci.ocs.resources.ocs instance of 'Project' kind.
         """
-        proj_obj = helpers.create_project()
+        proj_obj = helpers.create_project(project_name=project_name)
         instances.append(proj_obj)
         return proj_obj
 
@@ -533,7 +535,7 @@ def pvc_factory_fixture(
         access_mode=constants.ACCESS_MODE_RWO,
         custom_data=None,
         status=constants.STATUS_BOUND,
-        volume_mode=None
+        volume_mode=None,
     ):
         """
         Args:
@@ -588,7 +590,7 @@ def pvc_factory_fixture(
                 size=pvc_size,
                 do_reload=False,
                 access_mode=access_mode,
-                volume_mode=volume_mode
+                volume_mode=volume_mode,
             )
             assert pvc_obj, "Failed to create PVC"
 
@@ -665,7 +667,12 @@ def pod_factory_fixture(request, pvc_factory):
         custom_data=None,
         status=constants.STATUS_RUNNING,
         pod_dict_path=None,
-        raw_block_pv=False
+        raw_block_pv=False,
+        deployment_config=False,
+        service_account=None,
+        replica_count=1,
+        command=None,
+        command_args=None
     ):
         """
         Args:
@@ -681,10 +688,20 @@ def pod_factory_fixture(request, pvc_factory):
             pod_dict_path (str): YAML path for the pod.
             raw_block_pv (bool): True for creating raw block pv based pod,
                 False otherwise.
+            deployment_config (bool): True for DeploymentConfig creation,
+                False otherwise
+            service_account (OCS): Service account object, in case DeploymentConfig
+                is to be created
+            replica_count (int): The replica count for deployment config
+            command (list): The command to be executed on the pod
+            command_args (list): The arguments to be sent to the command running
+                on the pod
 
         Returns:
-            object: helpers.create_pvc instance.
+            object: helpers.create_pod instance
+
         """
+        sa_name = service_account.name if service_account else None
         if custom_data:
             pod_obj = helpers.create_resource(**custom_data)
         else:
@@ -694,20 +711,35 @@ def pod_factory_fixture(request, pvc_factory):
                 namespace=pvc.namespace,
                 interface_type=interface,
                 pod_dict_path=pod_dict_path,
-                raw_block_pv=raw_block_pv
+                raw_block_pv=raw_block_pv,
+                dc_deployment=deployment_config,
+                sa_name=sa_name,
+                replica_count=replica_count,
+                command=command,
+                command_args=command_args
             )
-            assert pod_obj, "Failed to create PVC"
-        instances.append(pod_obj)
+            assert pod_obj, "Failed to create pod"
+        if deployment_config:
+            dc_name = pod_obj.get_labels().get('name')
+            dc_ocp_dict = ocp.OCP(
+                kind=constants.DEPLOYMENTCONFIG, namespace=pod_obj.namespace
+            ).get(resource_name=dc_name)
+            dc_obj = OCS(**dc_ocp_dict)
+            instances.append(dc_obj)
+
+        else:
+            instances.append(pod_obj)
         if status:
             helpers.wait_for_resource_state(pod_obj, status)
             pod_obj.reload()
         pod_obj.pvc = pvc
-
+        if deployment_config:
+            return dc_obj
         return pod_obj
 
     def finalizer():
         """
-        Delete the Pod
+        Delete the Pod or the DeploymentConfig
         """
         for instance in instances:
             instance.delete()
@@ -776,8 +808,22 @@ def teardown_factory_fixture(request):
     return factory
 
 
-@pytest.fixture()
+@pytest.fixture(scope='class')
+def service_account_factory_class(request):
+    return service_account_factory_fixture(request)
+
+
+@pytest.fixture(scope='session')
+def service_account_factory_session(request):
+    return service_account_factory_fixture(request)
+
+
+@pytest.fixture(scope='function')
 def service_account_factory(request):
+    return service_account_factory_fixture(request)
+
+
+def service_account_factory_fixture(request):
     """
     Create a service account
     """
@@ -899,7 +945,7 @@ def dc_pod_factory(
         Delete dc pods
         """
         for instance in instances:
-            helpers.delete_deploymentconfig_pods(instance)
+            delete_deploymentconfig_pods(instance)
 
     request.addfinalizer(finalizer)
     return factory
@@ -1041,23 +1087,41 @@ def log_cli_level(pytestconfig):
     return pytestconfig.getini('log_cli_level') or 'DEBUG'
 
 
-@pytest.fixture(scope="session")
-def run_io_in_background(request, pvc_factory_session, pod_factory_session):
+@pytest.fixture(scope="session", autouse=True)
+def cluster_load(
+    request, project_factory_session, pvc_factory_session,
+    service_account_factory_session, pod_factory_session
+):
     """
     Run IO during the test execution
     """
+    cl_load_obj = None
     if config.RUN.get('io_in_bg'):
-        io_load_param = config.RUN.get('io_load')
-        if io_load_param:
-            io_load = int(io_load_param) * 0.01
-        else:
-            io_load = 0.3
-        io_bg_logs = config.RUN.get('bg_io_logs')
+        io_load = int(config.RUN.get('io_load')) * 0.01
         log.info(
             "\n===================================================\n"
             "Tests will be running while IO is in the background\n"
             "==================================================="
         )
+
+        log.info(
+            "Start running IO in the background. The amount of IO that "
+            "will be written is going to be determined by the cluster "
+            "capabilities according to its limit"
+        )
+
+        cl_load_obj = ClusterLoad(
+            project_factory=project_factory_session,
+            sa_factory=service_account_factory_session,
+            pvc_factory=pvc_factory_session,
+            pod_factory=pod_factory_session,
+            target_percentage=io_load
+        )
+        cl_load_obj.reach_cluster_load_percentage()
+
+    if config.RUN.get('log_utilization') or config.RUN.get('io_in_bg'):
+        if not cl_load_obj:
+            cl_load_obj = ClusterLoad()
 
         temp_file = tempfile.NamedTemporaryFile(
             mode='w+', prefix='test_status', delete=False
@@ -1071,17 +1135,6 @@ def run_io_in_background(request, pvc_factory_session, pod_factory_session):
             with open(temp_file.name, 'w') as t_file:
                 t_file.writelines(status)
 
-        log.info(
-            "Start running IO in the background. The amount of IO that will be written "
-            "is going to be determined by the cluster capabilities according to its "
-            "throughput limit"
-        )
-        cl_load_obj = ClusterLoad()
-        cluster_limit, current_tp = cl_load_obj.reach_cluster_load_percentage_in_throughput(
-            pvc_factory=pvc_factory_session, pod_factory=pod_factory_session,
-            target_percentage=io_load
-        )
-
         set_test_status('running')
 
         def finalizer():
@@ -1094,37 +1147,54 @@ def run_io_in_background(request, pvc_factory_session, pod_factory_session):
 
         request.addfinalizer(finalizer)
 
-        def keep_io_running():
+        def watch_load():
             """
-            This function purpose is to ensure that IO is running also after scenarios
-            in which the IO is stopped due to disruptive operations like node failures.
-            As long as Ceph health is OK, it watches the cluster throughput. In case it
-            is below 60% of the target throughput percentage defined with 'io_load',
-            it calls again reach_cluster_load_percentage_in_throughput()
+            Watch the cluster load by monitoring the cluster latency.
+            In case the latency goes beyond 1 second, start deleting FIO pods.
+            Once latency drops back below 0.5 seconds, re-create the FIO pods
+            to make sure that cluster load is around the target percentage
 
             """
-            cl_load_obj.__init__(propagate_logs=io_bg_logs)
+            initial_num_of_pods = len(cl_load_obj.dc_objs)
             while get_test_status() == 'running':
                 try:
-                    cl_load_obj.cl_obj.toolbox = get_ceph_tools_pod()
-                    if cl_load_obj.cl_obj.is_health_ok():
-                        average_tp = cl_load_obj.cl_obj.calc_average_throughput(samples=10)
-                        if average_tp < current_tp * 0.5:
-                            cl_load_obj.reach_cluster_load_percentage_in_throughput(
-                                pvc_factory=pvc_factory_session,
-                                pod_factory=pod_factory_session,
-                                target_percentage=io_load,
-                                cluster_limit=cluster_limit
+                    cl_load_obj.print_metrics()
+                    if config.RUN.get('io_in_bg'):
+                        latency = cl_load_obj.calc_trim_metric_mean(
+                            constants.LATENCY_QUERY
+                        )
+
+                        if latency > 1 and len(cl_load_obj.dc_objs) > 0:
+                            log.warning(
+                                f"Latency is higher than 1 second ({latency * 1000} ms). "
+                                f"Lowering IO load by deleting an FIO pod that is running "
+                                f"in the test background. Once the latency drops back to "
+                                f"less than 0.5 seconds, FIO pod will be re-spawned"
                             )
+                            cl_load_obj.decrease_load()
+
+                        diff = initial_num_of_pods - len(cl_load_obj.dc_objs)
+                        while latency < 0.5 and diff > 0 and (
+                            get_test_status() == 'running'
+                        ):
+                            log.info(
+                                f"Latency is lower than 0.5 seconds ({latency * 1000} ms). "
+                                f"Re-spinning FIO pod"
+                            )
+                            cl_load_obj.increase_load(rate='15M')
+                            latency = cl_load_obj.calc_trim_metric_mean(
+                                constants.LATENCY_QUERY
+                            )
+                            diff -= 1
+
                 # Any type of exception should be caught and we should continue.
                 # We don't want any test to fail
                 except Exception:
                     continue
-                time.sleep(10)
+                if get_test_status() == 'running':
+                    time.sleep(10)
 
-            set_test_status('terminated')
-
-        thread = threading.Thread(target=keep_io_running)
+        thread = threading.Thread(target=watch_load)
         thread.start()
 
 

--- a/tests/e2e/logging/test_openshift-logging.py
+++ b/tests/e2e/logging/test_openshift-logging.py
@@ -8,10 +8,9 @@ import pytest
 
 import random
 
-
 from tests import helpers, disruption_helpers
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources.pod import get_all_pods, get_pod_obj
+from ocs_ci.ocs.resources.pod import get_all_pods, get_pod_obj, delete_deploymentconfig_pods
 from ocs_ci.utility.retry import retry
 from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3
 from ocs_ci.framework.testlib import E2ETest, workloads, tier1, ignore_leftovers
@@ -43,7 +42,7 @@ class Testopenshiftloggingonocs(E2ETest):
         """
         """
         def finalizer():
-            helpers.delete_deploymentconfig_pods(pod_obj)
+            delete_deploymentconfig_pods(pod_obj)
 
         request.addfinalizer(finalizer)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,6 @@
 import pytest
+
+from ocs_ci.ocs.resources.pod import delete_deploymentconfig_pods
 from tests import helpers
 from ocs_ci.ocs import constants, ocp
 
@@ -295,7 +297,7 @@ def create_dc_pods(request):
         """
         if hasattr(class_instance, 'dc_pod_objs'):
             for pod in class_instance.dc_pod_objs:
-                helpers.delete_deploymentconfig_pods(pod_obj=pod)
+                delete_deploymentconfig_pods(pod_obj=pod)
 
     request.addfinalizer(finalizer)
 


### PR DESCRIPTION
A follow-up on https://github.com/red-hat-storage/ocs-ci/pull/2037 - improvements and fixes for cluster load functionality:

- Detect cluster limit by an exponential increase of the latency
- Instead of background thread to watch the IO load, use DeploymentConfig pods of FIO, which will spin up automatically in case they are stopped during the execution 
- Track cluster latency in the background. Actively adjust the background load in case the latency increases
- Added a few backup mechanisms to determine the cluster limit, in case the latency does not grow exponentially 
- Change the default load from 30% to 50%
- Use Prometheus queries to get the different metrics
- Improve logging
- Change PVC size to be 50% of the sum of the OSD memory pods memory, for all created PVCs
- Examine IOPS instead of throughput 
- Calculate different metrics based on trimmed mean average instead of mean average
- cli param, `--log-cluster-utilization`, to log cluster utilization metrics (latency, IOPS, throughput, used space and number of background FIO pods) every 10 seconds during test execution
- Few other minor fixes

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>
