### PR TITLE
change OCS-2125 to use fixed storage size

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -400,23 +400,11 @@ def workload_fio_storageutilization(
             ceph_pool_name
         )
 
-    # To handle use case of test_workload_rbd_cephfs_minimal which writes data
-    # to reach a small fraction of the total capacity only (eg. 5%), the test
-    # is going increase the target 2x and try again.
-    if pvc_size <= 0 and target_percentage is not None and target_percentage <= 0.10:
-        new_target_percentage = 2 * target_percentage
-        logger.info(
-            "increasing storage utilization target percentage from %.2f to %.2f",
-            target_percentage,
-            new_target_percentage)
-        target_percentage = new_target_percentage
-        pvc_size = get_storageutilization_size(
-            target_percentage,
-            ceph_pool_name)
-    # If this is still not enough, the test will be skipped, because the idea
-    # of tests reaching a small total utilization is to do just that.
-    # Moreover this will also skip this test case for any other utilization
-    # level, which is easier to read in the test report than the actual
+    # If we are trying to utilize particular percentage of total OCS capacity
+    # and current usage is already higher, the test will be skipped, because
+    # the idea of tests reaching a particular total utilization is to do just
+    # that, and the fixture can't provide expected assumptions to the test.
+    # This skip is also easier to read in the test report than the actual
     # failure with negative pvc size.
     if pvc_size <= 0 and target_percentage is not None:
         skip_msg = (

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -152,19 +152,6 @@ def test_workload_rbd_cephfs(
 
 
 @pytest.mark.libtest
-def test_workload_rbd_cephfs_10g(
-    workload_storageutilization_10g_rbd,
-    workload_storageutilization_10g_cephfs
-):
-    """
-    Test of a workload utilization with constant 10 GiB target.
-    """
-    logger.info(workload_storageutilization_10g_rbd)
-    logger.info(workload_storageutilization_10g_cephfs)
-
-
-@tier1
-@pytest.mark.polarion_id("OCS-2125")
 def test_workload_rbd_cephfs_minimal(
     workload_storageutilization_05p_rbd,
     workload_storageutilization_05p_cephfs
@@ -174,26 +161,36 @@ def test_workload_rbd_cephfs_minimal(
     capacity. This still test the workload, but it's bit faster and (hopefully)
     without big impact on the cluster itself.
 
+    Mostly usefull as a libtest and regression test for
+    https://github.com/red-hat-storage/ocs-ci/issues/1327
+    """
+    logger.info(workload_storageutilization_05p_rbd)
+    logger.info(workload_storageutilization_05p_cephfs)
+
+
+@tier1
+@pytest.mark.polarion_id("OCS-2125")
+def test_workload_rbd_cephfs_10g(
+    workload_storageutilization_10g_rbd,
+    workload_storageutilization_10g_cephfs
+):
+    """
+    Test of a workload utilization with constant 10 GiB target.
+
     In this test we are only checking whether the storage utilization workload
     failed or not. The main point of having this included in tier1 suite is to
     see whether we are able to actually run the fio write workload without any
     direct failure (fio job could fail to be scheduled, fail during writing or
     timeout when write progress is too slow ...).
-
-    Please note that reaching 5% of total OCS capacity means that workload
-    fixtures specified above will try to write data based on current cluster
-    wide storage utilization to meet the specified target. If the current
-    cluster utilization is already above 5%, this will fail. This is targeted
-    to a fresh just installed CI cluster.
     """
     logger.info("checking fio report results as provided by workload fixtures")
     msg = "workload results should be recorded and provided to the test"
-    assert workload_storageutilization_05p_rbd['result'] is not None, msg
-    assert workload_storageutilization_05p_cephfs['result'] is not None, msg
+    assert workload_storageutilization_10g_rbd['result'] is not None, msg
+    assert workload_storageutilization_10g_cephfs['result'] is not None, msg
 
     fio_reports = (
-        ('rbd', workload_storageutilization_05p_rbd['result']['fio']),
-        ('cephfs', workload_storageutilization_05p_cephfs['result']['fio']),
+        ('rbd', workload_storageutilization_10g_rbd['result']['fio']),
+        ('cephfs', workload_storageutilization_10g_cephfs['result']['fio']),
     )
     for vol_type, fio in fio_reports:
         logger.info("starting to check fio run on %s volume", vol_type)


### PR DESCRIPTION
Change OCS-2125 test case to utilize 10G instead of 5% target of total capacity. Polarion test case was updated along with this pull request.

This also removes one special case hack from code of fiojob.workload_fio_storageutilization() function, which is no longer necessary

fixes https://github.com/red-hat-storage/ocs-ci/issues/2038