### PR TITLE
Fixes the change in ripsaw's crd directory name

### DIFF
--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -69,7 +69,7 @@ class RipSaw(object):
                 cwd=self.dir,
                 check=True
             )
-            self.crd = 'resources/crd/'
+            self.crd = 'resources/crds/'
             self.operator = 'resources/operator.yaml'
         except (CommandFailed, CalledProcessError)as cf:
             log.error('Error during cloning of ripsaw repository')


### PR DESCRIPTION
ripsaw's crd directory name has been changed from `resources/crd/` to `resources/crds`. This will break all our tests using ripsaw - https://github.com/cloud-bulldozer/ripsaw/tree/master/resources/crds