### PR TITLE
change method of workload_storageutilization_checksum_rbd to use static size

### DIFF
--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -357,7 +357,7 @@ def workload_storageutilization_checksum_rbd(
         fio_configmap_dict,
         measurement_dir,
         tmp_path,
-        target_percentage=0.10,
+        target_size=10,
         with_checksum=True)
     return measured_op
 


### PR DESCRIPTION
This change is done because utilization tests that should utilize cluster for a small percentage can become flaky because of utilization that is already run.

Signed-off-by: Filip Balak <fbalak@redhat.com>