### PR TITLE
Fix MCG upgrade tests

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -442,6 +442,21 @@ def get_storage_cluster(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
     return sc_obj
 
 
+def get_osd_count():
+    """
+    Get osd count from Storage cluster
+
+    Returns:
+        int: osd count
+
+    """
+    sc = get_storage_cluster()
+    return (
+        int(sc.get().get('items')[0]['spec']['storageDeviceSets'][0]['count'])
+        * int(sc.get().get('items')[0]['spec']['storageDeviceSets'][0]['replica'])
+    )
+
+
 def get_osd_size():
     """
     Get osd size from Storage cluster

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_OPTIMAL
 from tests.manage.mcg.helpers import (
-    retrieve_anon_s3_resource, sync_object_directory
+    retrieve_test_objects_to_pod, sync_object_directory
 )
 
 logger = logging.getLogger(__name__)
@@ -41,43 +41,20 @@ def test_fill_bucket(
     awscli_pod_session.exec_cmd_on_pod(
         command=f'mkdir {LOCAL_TESTOBJS_DIR_PATH}'
     )
-    test_objects = retrieve_anon_s3_resource().Bucket(
-        constants.TEST_FILES_BUCKET
-    ).objects.all()
-
-    for obj in test_objects:
-        logger.info(f'Downloading {obj.key} from AWS test bucket')
-        awscli_pod_session.exec_cmd_on_pod(
-            command=(
-                f'sh -c "wget -P {LOCAL_TESTOBJS_DIR_PATH} '
-                f'https://{constants.TEST_FILES_BUCKET}.s3.amazonaws.com/{obj.key}"'
-            )
-        )
-        DOWNLOADED_OBJS.append(f'{obj.key}')
-        # Use 3x time more objects than there is in test objects pod
-        for i in range(2):
-            awscli_pod_session.exec_cmd_on_pod(
-                command=f'sh -c "'
-                        f'cp {LOCAL_TESTOBJS_DIR_PATH}/{obj.key} '
-                        f'{LOCAL_TESTOBJS_DIR_PATH}/{obj.key}.{i}"'
-            )
-            DOWNLOADED_OBJS.append(f'{obj.key}.{i}')
+    DOWNLOADED_OBJS = retrieve_test_objects_to_pod(
+        awscli_pod_session, LOCAL_TESTOBJS_DIR_PATH
+    )
 
     logger.info('Uploading all pod objects to MCG bucket')
 
-    sync_object_directory(
-        awscli_pod_session,
-        's3://' + constants.TEST_FILES_BUCKET,
-        LOCAL_TESTOBJS_DIR_PATH
-    )
-
-    # Upload test objects to the NooBucket
-    sync_object_directory(
-        awscli_pod_session,
-        LOCAL_TESTOBJS_DIR_PATH,
-        mcg_bucket_path,
-        mcg_obj_session
-    )
+    # Upload test objects to the NooBucket 3 times
+    for i in range(3):
+        sync_object_directory(
+            awscli_pod_session,
+            LOCAL_TESTOBJS_DIR_PATH,
+            f'{mcg_bucket_path}/{i}/',
+            mcg_obj_session
+        )
 
     mcg_obj_session.check_if_mirroring_is_done(bucket.name)
     assert bucket.status == constants.STATUS_BOUND
@@ -94,11 +71,12 @@ def test_fill_bucket(
 
     # Checksum is compared between original and result object
     for obj in DOWNLOADED_OBJS:
-        assert mcg_obj_session.verify_s3_object_integrity(
-            original_object_path=f'{LOCAL_TESTOBJS_DIR_PATH}/{obj}',
-            result_object_path=f'{LOCAL_TEMP_PATH}/{obj}',
-            awscli_pod=awscli_pod_session
-        ), 'Checksum comparision between original and result object failed'
+        for i in range(3):
+            assert mcg_obj_session.verify_s3_object_integrity(
+                original_object_path=f'{LOCAL_TESTOBJS_DIR_PATH}/{obj}',
+                result_object_path=f'{LOCAL_TEMP_PATH}/{i}/{obj}',
+                awscli_pod=awscli_pod_session
+            ), 'Checksum comparison between original and result object failed'
     assert bucket.status == constants.STATUS_BOUND
 
 
@@ -157,7 +135,7 @@ def test_noobaa_postupgrade(
         LOCAL_TEMP_PATH,
         mcg_obj_session
     )
-    assert bucket.phase == constants.STATUS_BOUND
+    assert bucket.status == constants.STATUS_BOUND
 
 
 @aws_platform_required

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -121,9 +121,12 @@ def verify_image_versions(old_images, upgrade_version):
     )
     verify_pods_upgraded(old_images, selector=constants.MGR_APP_LABEL)
     verify_pods_upgraded(old_images, selector=constants.MON_APP_LABEL, count=3)
+    # OSD upgrade have timeout 10mins for new attempt if cluster is not health.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1840729 setting timeout for
+    # 12.5 minutes per OSD
     verify_pods_upgraded(
         old_images, selector=constants.OSD_APP_LABEL, count=osd_count,
-        timeout=1800,
+        timeout=750 * osd_count,
     )
     verify_pods_upgraded(old_images, selector=constants.MDS_APP_LABEL, count=2)
     if config.ENV_DATA.get('platform') == constants.VSPHERE_PLATFORM:

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -17,13 +17,15 @@ from ocs_ci.ocs.ocp import get_images, OCP
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.csv import CSV
 from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
-from ocs_ci.ocs.resources.storage_cluster import ocs_install_verification
+from ocs_ci.ocs.resources.storage_cluster import (
+    get_osd_count,
+    ocs_install_verification
+)
 from ocs_ci.ocs.resources.pod import verify_pods_upgraded
 from ocs_ci.ocs.resources.packagemanifest import (
     get_selector_for_ocs_operator,
     PackageManifest,
 )
-from ocs_ci.ocs.resources.storage_cluster import StorageCluster
 from ocs_ci.ocs.utils import setup_ceph_toolbox
 from ocs_ci.utility.utils import (
     get_latest_ds_olm_tag,
@@ -85,16 +87,8 @@ def verify_image_versions(old_images, upgrade_version):
         upgrade_version (packaging.version.Version): version of OCS
 
     """
-    namespace = config.ENV_DATA['cluster_namespace']
     number_of_worker_nodes = len(get_typed_nodes())
-    storage_cluster = StorageCluster(
-        resource_name=config.ENV_DATA['storage_cluster_name'],
-        namespace=namespace
-    )
-    osd_count = (
-        int(storage_cluster.data['spec']['storageDeviceSets'][0]['count'])
-        * int(storage_cluster.data['spec']['storageDeviceSets'][0]['replica'])
-    )
+    osd_count = get_osd_count()
     verify_pods_upgraded(old_images, selector=constants.OCS_OPERATOR_LABEL)
     verify_pods_upgraded(old_images, selector=constants.OPERATOR_LABEL)
     # in 4.3 app selector nooba have those pods: noobaa-core-ID, noobaa-db-ID,
@@ -263,7 +257,8 @@ def test_upgrade():
         if version_before_upgrade == '4.2' and upgrade_version == '4.3':
             log.info("Force creating Ceph toolbox after upgrade 4.2 -> 4.3")
             setup_ceph_toolbox(force_setup=True)
-        csv_post_upgrade.wait_for_phase("Succeeded", timeout=600)
+        osd_count = get_osd_count()
+        csv_post_upgrade.wait_for_phase("Succeeded", timeout=200 * osd_count)
         post_upgrade_images = get_images(csv_post_upgrade.get())
         old_images, _, _ = get_upgrade_image_info(
             pre_upgrade_images, post_upgrade_images

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -2,7 +2,12 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import polarion_id, pre_upgrade
-from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier1
+from ocs_ci.framework.testlib import (
+    ignore_leftovers,
+    ManageTest,
+    skipif_ocs_version,
+    tier1,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import storage_cluster
@@ -50,6 +55,7 @@ class TestAddCapacity(ManageTest):
         add_capacity_test()
 
 
+@skipif_ocs_version('<4.4')
 @pre_upgrade
 @ignore_leftovers
 @polarion_id('OCS-1191')


### PR DESCRIPTION
Refactored the test to not use `wget` since it's not available on the official AWSCLI Docker image, and thus, on the AWSCLI relay pod.

Also optimized code where possible and replaced an outdated `phase` call with a `status` one

Should be merged after #2176

Fixes #2052, fixes #2179, fixes #2175