### PR TITLE
Fix TC test_detach_attach_2_data_volumes failures

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -72,6 +72,7 @@ STATUS_BOUND = 'Bound'
 STATUS_RELEASED = 'Released'
 STATUS_COMPLETED = 'Completed'
 STATUS_ERROR = 'Error'
+STATUS_CLBO = 'CrashLoopBackOff'
 
 # NooBaa statuses
 BS_AUTH_FAILED = 'AUTH_FAILED'

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -101,10 +101,10 @@ class TestDiskFailures(ManageTest):
                 raise
         else:
             """
-            Wait for worker volume to be re-attached automatically 
+            Wait for worker volume to be re-attached automatically
             to the node
             """
-            assert nodes.wait_for_volume_attach(data_volume),(
+            assert nodes.wait_for_volume_attach(data_volume), (
                 f"Volume {data_volume} failed to be re-attached to worker "
                 f"node {worker}"
             )
@@ -151,19 +151,19 @@ class TestDiskFailures(ManageTest):
             # Detach the volume (logging is done inside the function)
             try:
                 nodes.detach_volume(
-                worker_and_volume['volume'], worker_and_volume['worker']
+                    worker_and_volume['volume'], worker_and_volume['worker']
                 )
             except AWSTimeoutException as e:
                 if "Volume state: in-use" in e:
                     logger.info(
-                    f"Volume {worker_and_volume['volume']} re-attached "
-                    f"successfully to worker "
-                    f"node {worker_and_volume['worker']}")
+                        f"Volume {worker_and_volume['volume']} re-attached "
+                        f"successfully to worker "
+                        f"node {worker_and_volume['worker']}")
                 else:
                     raise
             else:
                 """
-                Wait for worker volume to be re-attached automatically 
+                Wait for worker volume to be re-attached automatically
                 to the node
                 """
                 assert nodes.wait_for_volume_attach(

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -55,7 +55,7 @@ class TestDiskFailures(ManageTest):
                     'status'
                 ).get(
                     'containerStatuses'
-                )[0].get('state') == 'CrashLoopBackOff':
+                )[0].get('state') == constants.STATUS_CLBO:
                     node_obj = get_pod_node(pod)
                     nodes.restart_nodes([node_obj])
                     node.wait_for_nodes_status([node_obj.name])


### PR DESCRIPTION
- Fixes #2211 
-  Improvement in cleanup to handle node restart if the osd stays at CLBO state

Signed-off-by: Prasad Desala <tdesala@redhat.com>