### PR TITLE
Added decorator ipi_deployment_required to test test_simultaneous_drain_of_two_ocs_nodes

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -16,7 +16,8 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.framework.testlib import (
     tier1, tier2, tier3, tier4, tier4b,
-    ManageTest, aws_platform_required, ignore_leftovers
+    ManageTest, aws_platform_required, ignore_leftovers,
+    ipi_deployment_required
 )
 
 from tests.sanity_helpers import Sanity
@@ -246,6 +247,7 @@ class TestNodesMaintenance(ManageTest):
     @tier4
     @tier4b
     @aws_platform_required
+    @ipi_deployment_required
     @pytest.mark.parametrize(
         argnames=["interface"],
         argvalues=[


### PR DESCRIPTION
test_simultaneous_drain_of_two_ocs_nodes is not having decorator ipi_deployment_required.
So, this test is being picked for execution in AWS-UPI and failing.

https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/8188/testReport/junit/tests.manage.z_cluster.nodes.test_nodes_maintenance/TestNodesMaintenance/test_simultaneous_drain_of_two_ocs_nodes_cephfs_/

Signed-off-by: Prasad Desala <tdesala@redhat.com>