### PR TITLE
Warn about misconfiguration with MCG

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -172,3 +172,7 @@ class PendingCSRException(Exception):
 
 class RDMDiskNotFound(Exception):
     pass
+
+
+class CredReqSecretNotFound(Exception):
+    pass

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -406,15 +406,23 @@ class MCG(object):
         sleep(5)
 
         secret_ocp_obj = OCP(kind='secret', namespace=self.namespace)
-        cred_req_secret_dict = secret_ocp_obj.get(resource_name=creds_request.name, retry=5)
+        try:
+            cred_req_secret_dict = secret_ocp_obj.get(resource_name=creds_request.name, retry=5)
+            aws_access_key_id = base64.b64decode(
+                cred_req_secret_dict.get('data').get('aws_access_key_id')
+            ).decode('utf-8')
+            aws_access_key = base64.b64decode(
+                cred_req_secret_dict.get('data').get('aws_secret_access_key')
+            ).decode('utf-8')
+        except CommandFailed:
+            logger.error(
+                'Failed to retrieve credentials request secret'
 
-        aws_access_key_id = base64.b64decode(
-            cred_req_secret_dict.get('data').get('aws_access_key_id')
-        ).decode('utf-8')
-
-        aws_access_key = base64.b64decode(
-            cred_req_secret_dict.get('data').get('aws_secret_access_key')
-        ).decode('utf-8')
+            )
+            assert False, (
+                'Please make sure that the cluster used is an AWS cluster, '
+                'or that the `platform` var in your config is correct.'
+            )
 
         def _check_aws_credentials():
             try:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -11,7 +11,7 @@ from botocore.client import ClientError
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.exceptions import CommandFailed, CredReqSecretNotFound, TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_pods_having_label, Pod
@@ -413,7 +413,7 @@ class MCG(object):
                 'Failed to retrieve credentials request secret'
 
             )
-            assert False, (
+            raise CredReqSecretNotFound(
                 'Please make sure that the cluster used is an AWS cluster, '
                 'or that the `platform` var in your config is correct.'
             )

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -411,7 +411,6 @@ class MCG(object):
         except CommandFailed:
             logger.error(
                 'Failed to retrieve credentials request secret'
-
             )
             raise CredReqSecretNotFound(
                 'Please make sure that the cluster used is an AWS cluster, '

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -408,12 +408,6 @@ class MCG(object):
         secret_ocp_obj = OCP(kind='secret', namespace=self.namespace)
         try:
             cred_req_secret_dict = secret_ocp_obj.get(resource_name=creds_request.name, retry=5)
-            aws_access_key_id = base64.b64decode(
-                cred_req_secret_dict.get('data').get('aws_access_key_id')
-            ).decode('utf-8')
-            aws_access_key = base64.b64decode(
-                cred_req_secret_dict.get('data').get('aws_secret_access_key')
-            ).decode('utf-8')
         except CommandFailed:
             logger.error(
                 'Failed to retrieve credentials request secret'
@@ -423,6 +417,13 @@ class MCG(object):
                 'Please make sure that the cluster used is an AWS cluster, '
                 'or that the `platform` var in your config is correct.'
             )
+
+        aws_access_key_id = base64.b64decode(
+            cred_req_secret_dict.get('data').get('aws_access_key_id')
+        ).decode('utf-8')
+        aws_access_key = base64.b64decode(
+            cred_req_secret_dict.get('data').get('aws_secret_access_key')
+        ).decode('utf-8')
 
         def _check_aws_credentials():
             try:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -421,6 +421,7 @@ class MCG(object):
         aws_access_key_id = base64.b64decode(
             cred_req_secret_dict.get('data').get('aws_access_key_id')
         ).decode('utf-8')
+
         aws_access_key = base64.b64decode(
             cred_req_secret_dict.get('data').get('aws_secret_access_key')
         ).decode('utf-8')


### PR DESCRIPTION
Meant to remedy a case in which `run-ci` is ran on `non-AWS` clusters, with `AWS` as the platform under `ENV_VARS`. Made the error clearer and more concise.