### PR TITLE
Fixing in getting indexes

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -812,7 +812,7 @@ class AWSNodes(NodesBase):
         """
         temp = []
         for index in index_list:
-            temp.append(int(index.split('-')[1][2:]))
+            temp.append(int(index.split('-')[-1][2:]))
         temp.sort()
         return temp
 

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -812,7 +812,7 @@ class AWSNodes(NodesBase):
         """
         temp = []
         for index in index_list:
-            temp.append(int(index.split('-')[-1][2:]))
+            temp.append(int(re.findall(r'\d+', index.split('-')[-1])[-1]))
         temp.sort()
         return temp
 


### PR DESCRIPTION
Currently it will fail to get indexes for cluster with
name "jnk-au3c33-t1-no2". We need to split and always get the
last element ( no2 ).

Signed-off-by: vavuthu <vavuthu@redhat.com>