### PR TITLE
DO NOT MERGE: Smallfile change log parsing

### DIFF
--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -250,6 +250,46 @@ class SmallFileResultsAnalyse(object):
         Aggregation results from all hosts in single sample
         (each host is actually a pod)
 
+        Example of log to parse :
+
+                                     version : 3.1
+                               hosts in test : None
+                            launch by daemon : False
+                       top test directory(s) : ['/mnt/pvc/smallfile_test_data']
+                                   operation : create
+                                files/thread : 50000
+                                     threads : 4
+               record size (KB, 0 = maximum) : 0
+                              file size (KB) : 4
+                      file size distribution : fixed
+                               files per dir : 100
+                                dirs per dir : 10
+                  threads share directories? : N
+                             filename prefix :
+                             filename suffix :
+                 hash file number into dir.? : N
+                         fsync after modify? : N
+              pause between files (microsec) : 50
+                 minimum directories per sec : 50
+                        finish all requests? : Y
+                                  stonewall? : Y
+                     measure response times? : Y
+                                verify read? : Y
+                                    verbose? : False
+                              log to stderr? : False
+            total threads = 4
+            total files = 200000
+            total IOPS = 12980
+            total data =     0.763 GiB
+            100.00% of requested files processed, warning threshold is  70.00
+            elapsed time =    17.079
+            files/sec = 12980.622480
+            IOPS = 12980.622480
+            MiB/sec = 50.705557
+            2020-05-04T13:50:01Z - INFO     - MainProcess - trigger_smallfile:
+                completed sample 1 for operation create , results in /var/tmp/RESULTS/1/create.json
+
+
         Args:
             host_res (dict): dictionary of host results - user for multi hosts
                              test

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -307,14 +307,14 @@ class SmallFileResultsAnalyse(object):
         else:
 
             """
-            Each test can do some operations, so i am running loop on all
+            Each test can do some operations, so it is running loop on all
             operations that we have in this particular test.
 
             """
             for op in self.results['operations']:
 
                 """
-                For each operation, I am looking for all interesting lines
+                For each operation, it is looking for all interesting lines
                 that need to be parse.
 
                 """

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -22,14 +22,10 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 
-"""
-Defining dictionary of keywords to look in the logs, foreach keyword we have the
-key-name in the final results output, the separate character to split the line
-in the log file, the position of the result and the numpy operation to use when
-we have more then one pod in the test.
-
-"""
-
+# Defining dictionary of keywords to look in the logs, foreach keyword we have
+# the key-name in the final results output, the separate character to split the
+# line in the log file, the position of the result and the numpy operation to
+# use when we have more then one pod in the test.
 keys_to_pars = {
     'files/thread': {
         'name': 'Files_per_Treads', 'sep': ' ', 'pos': -1, 'op': None
@@ -457,24 +453,20 @@ class TestSmallFileWorkload(E2ETest):
         # wait for benchmark pods to get created - takes a while
         clients = sf_data['spec']['workload']['args']['clients']
         log.info(f'Going to run on {clients} pods, waiting for pods to start')
-        count = 10  # total number of retry for all benchmark pods to start
         small_file_client_pods = {}
-        while count > 0:
-            for bench_pod in TimeoutSampler(
-                120, 5, get_pod_name_by_pattern, 'smallfile-client', 'my-ripsaw'
-            ):
-                try:
-                    if len(bench_pod) == clients:
-                        log.info(f'The list of benchmark pods is {bench_pod}')
-                        for bpod in bench_pod:
-                            small_file_client_pods[bpod] = SmallFileLogParser(
-                                bpod)
-                        small_file_client_pod = bench_pod
-                        count = 0
-                        break
-                except IndexError:
-                    log.info('Bench pod not ready yet')
-            count -= 1
+        for bench_pod in TimeoutSampler(
+            1200, 5, get_pod_name_by_pattern, 'smallfile-client', 'my-ripsaw'
+        ):
+            try:
+                if len(bench_pod) == clients:
+                    log.info(f'The list of benchmark pods is {bench_pod}')
+                    for bpod in bench_pod:
+                        small_file_client_pods[bpod] = SmallFileLogParser(
+                            bpod)
+                    small_file_client_pod = bench_pod
+                    break
+            except IndexError:
+                log.info('Bench pod not ready yet')
 
         # make sure all pods started
         assert len(small_file_client_pod) == clients, \

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -17,11 +17,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import E2ETest, performance
 from tests.helpers import get_logs_with_errors
 from ocs_ci.ocs.exceptions import CommandFailed
-<<<<<<< HEAD
-from elasticsearch import (Elasticsearch, exceptions as ESExp)
-=======
 from elasticsearch import (Elasticsearch, exceptions as esexp)
->>>>>>> e430e25a... Changing the way all test data collected, pars it from the logs insted of
 import numpy as np
 
 log = logging.getLogger(__name__)
@@ -184,9 +180,6 @@ class SmallFileResultsAnalyse(object):
         self.new_index = crd['spec']['es_index'] + '-fullres'
         self.all_results = {}
 
-        # WA for Cloud environment where pod can not send results to ES
-        self.dont_check = False
-
         # make sure we have connection to the elastic search server
         log.info(f'Connecting to ES {self.server} on port {self.port}')
         try:
@@ -242,33 +235,6 @@ class SmallFileResultsAnalyse(object):
         """
         self.results.update({key: value})
 
-<<<<<<< HEAD
-    def read(self):
-        """
-        Reading all test records from the elasticsearch server into dictionary
-        inside this object
-
-        """
-
-        query = {'query': {'match': {'uuid': self.uuid}}}
-        log.info('Reading all data from ES server')
-        try:
-            self.all_results = self.es.search(
-                index=self.index, body=query, size=self.records
-            )
-            log.info(self.all_results)
-
-            if self.all_results['hits']['hits'] == []:
-                log.warning(
-                    'No data in ES server, disabling results calculation')
-                self.dont_check = True
-        except ESExp.NotFoundError:
-            log.warning(
-                'No data in ES server, disabling results calculation')
-            self.dont_check = True
-
-=======
->>>>>>> e430e25a... Changing the way all test data collected, pars it from the logs insted of
     def write(self):
         """
         Writing the results to the elasticsearch server
@@ -409,18 +375,6 @@ class TestSmallFileWorkload(E2ETest):
         """
 
         sf_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
-<<<<<<< HEAD
-
-        # getting the name and email  of the user that running the test.
-        try:
-            user = run_cmd('git config --get user.name').strip()
-            email = run_cmd('git config --get user.email').strip()
-        except CommandFailed:
-            # if no git user define, use the default user from the CR file
-            user = sf_data['spec']['test_user']
-            email = ''
-=======
->>>>>>> e430e25a... Changing the way all test data collected, pars it from the logs insted of
 
         # getting the name and email  of the user that running the test.
         log.info(f'Getting the Username and email of the running user')
@@ -435,10 +389,6 @@ class TestSmallFileWorkload(E2ETest):
 
         log.info('Apply Operator CRD')
         ripsaw.apply_crd('resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml')
-<<<<<<< HEAD
-=======
-
->>>>>>> e430e25a... Changing the way all test data collected, pars it from the logs insted of
         if interface == constants.CEPHBLOCKPOOL:
             storageclass = constants.DEFAULT_STORAGECLASS_RBD
         else:
@@ -515,14 +465,10 @@ class TestSmallFileWorkload(E2ETest):
             )
 
         start_time = time.time()
-<<<<<<< HEAD
 
         # After testing manually, changing the timeout
         timeout = 3600
-=======
-        timeout = 1800
         log.info('The SmallFile benchmark is Running')
->>>>>>> e430e25a... Changing the way all test data collected, pars it from the logs insted of
 
         """
         Getting the UUID from inside the benchmark pod (first one - since all
@@ -574,7 +520,7 @@ class TestSmallFileWorkload(E2ETest):
                                      time.strftime('%Y-%m-%dT%H:%M:%SGMT',
                                                    time.gmtime()))
                 full_results.read()
-                if not full_results.dont_check:
+
             finished = 0
             for smf_pod in small_file_client_pod:
                 logs = bench_pod.exec_oc_cmd(

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -377,7 +377,7 @@ class TestSmallFileWorkload(E2ETest):
         sf_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
 
         # getting the name and email  of the user that running the test.
-        log.info(f'Getting the Username and email of the running user')
+        log.info('Getting the Username and email of the running user')
         try:
             user = run_cmd('git config --get user.name').strip()
             email = run_cmd('git config --get user.email').strip()
@@ -521,7 +521,6 @@ class TestSmallFileWorkload(E2ETest):
                 if 'RUN STATUS DONE' in logs:
                     log.info(f'The pod {smf_pod} finished !')
                     finished += 1
-
 
             if finished == clients:
                 full_results.add_key('end_time',

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 """
 Defining dictionary of keywords to look in the logs, foreach keyword we have the
-key-name in the final results output, the seperate charecter to split the line
+key-name in the final results output, the separate character to split the line
 in the log file, the position of the result and the numpy operation to use when
 we have more then one pod in the test.
 
@@ -64,7 +64,7 @@ keys_to_pars = {
 class SmallFileLogParser(object):
 
     """
-    This class is reading the benchmark pod logs, and pars it
+    This class is reading the benchmark pod logs, and parse it
 
     """
     def __init__(self, pod):
@@ -252,6 +252,7 @@ class SmallFileResultsAnalyse(object):
     def aggregate_host_results(self, host_res):
         """
         Aggregation results from all hosts in single sample
+        (each host is actually a pod)
 
         Args:
             host_res (dict): dictionary of host results - user for multi hosts
@@ -268,12 +269,37 @@ class SmallFileResultsAnalyse(object):
             self.results['full-res'] = host_res
             log.info('This is the first pod - return results as is')
         else:
+
+            """
+            Each test can do some operations, so i am running loop on all
+            operations that we have in this particular test.
+
+            """
             for op in self.results['operations']:
+
+                """
+                For each operation, I am looking for all interesting lines
+                that need to be parse.
+
+                """
                 for key in keys_to_pars.keys():
                     key_name = keys_to_pars[key]['name']
                     oper = keys_to_pars[key]['op']
-                    if oper:
+                    if oper:  # if operation to do on samples op is not None
+
+                        """
+                        Not all operations must have all information
+                        (e.g. create operation does not have IOPS)
+
+                        """
                         if key_name in self.results['full-res'][op]:
+
+                            """
+                            For each samples combine the host information (that
+                            passed as parameter) to the total results by using
+                            the particular operation (e.g. sum or average)
+
+                            """
                             for index in range(self.results['samples']):
                                 cur_data = self.results[
                                     'full-res'][op][key_name][index]

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -511,15 +511,6 @@ class TestSmallFileWorkload(E2ETest):
         log.debug(f'The Initial results object is : {full_results}')
 
         while True:
-            logs = bench_pod.exec_oc_cmd(
-                f'logs {small_file_client_pod}',
-                out_yaml_format=False
-            )
-            if "RUN STATUS DONE" in logs:
-                full_results.add_key('end_time',
-                                     time.strftime('%Y-%m-%dT%H:%M:%SGMT',
-                                                   time.gmtime()))
-                full_results.read()
 
             finished = 0
             for smf_pod in small_file_client_pod:
@@ -530,14 +521,7 @@ class TestSmallFileWorkload(E2ETest):
                 if 'RUN STATUS DONE' in logs:
                     log.info(f'The pod {smf_pod} finished !')
                     finished += 1
-                else:
-                    full_results.add_key('end_time',
-                                         time.strftime('%Y-%m-%dT%H:%M:%SGMT',
-                                                       time.gmtime()))
-                    full_results.read()
-                    full_results.add_key('hosts', full_results.get_clients_list())
-                    full_results.init_full_results()
-                    full_results.aggregate_host_results()
+
 
             if finished == clients:
                 full_results.add_key('end_time',


### PR DESCRIPTION
Changing the way results are pars. instead of reading results from elasticsearch (since it is not pushing results to ES when the test run in the public cloud), the results are parse from the log(s) file(s).
It also support running with more then one pod (for scaling).

One more change is the samples deviation results from 5% to 20% - this will changed when we will have hardware and network infra. that will run the test properly.

The test results are print in the log and also push to Internal elasticsearch server, in the future it will be push to codespeed server. 