### PR TITLE
Enhancements for openshift-logging

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2159,6 +2159,7 @@ def install_logging(request):
     Setup and teardown
     * The setup will deploy openshift-logging in the cluster
     * The teardown will uninstall cluster-logging from the cluster
+
     """
 
     def finalizer():
@@ -2166,8 +2167,18 @@ def install_logging(request):
 
     request.addfinalizer(finalizer)
 
-    # Checks OCP version
+    csv = ocp.OCP(
+        kind=constants.CLUSTER_SERVICE_VERSION,
+        namespace=constants.OPENSHIFT_LOGGING_NAMESPACE
+    )
+    logging_csv = csv.get().get('items')
+    if logging_csv:
+        log.info("Logging is already configured, Skipping Installation")
+        return
 
+    log.info("Configuring Openshift-logging")
+
+    # Checks OCP version
     ocp_version = get_ocp_version()
 
     # Creates namespace opensift-operators-redhat

--- a/tests/e2e/logging/test_openshift-logging.py
+++ b/tests/e2e/logging/test_openshift-logging.py
@@ -65,7 +65,7 @@ class Testopenshiftloggingonocs(E2ETest):
         helpers.wait_for_resource_state(resource=pod_obj, state=constants.STATUS_RUNNING)
         return pod_obj, pvc_obj
 
-    @retry(ModuleNotFoundError, tries=10, delay=200, backoff=3)
+    @retry(ModuleNotFoundError, tries=5, delay=200, backoff=1)
     def validate_project_exists(self, pvc_obj):
         """
         This function checks whether the new project exists in the

--- a/tests/e2e/logging/test_openshift-logging.py
+++ b/tests/e2e/logging/test_openshift-logging.py
@@ -13,12 +13,14 @@ from tests import helpers, disruption_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_all_pods, get_pod_obj
 from ocs_ci.utility.retry import retry
+from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3
 from ocs_ci.framework.testlib import E2ETest, workloads, tier1, ignore_leftovers
 from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
 
 logger = logging.getLogger(__name__)
 
 
+@skipif_aws_i3
 @pytest.fixture()
 def setup_fixture(install_logging):
     """


### PR DESCRIPTION
Enhancements are listed below
1. If logging already exists in the cluster, skip configuring
2. Modified the code to also support colocated Masters and workers to wait for fluentd pods
3. Skip logging configuration on AWS-i3
4. Reduced the number of retries and delays 
Fixes: #2198 

Signed-off-by: Shrivaibavi Raghaventhiran <sraghave@redhat.com>