### PR TITLE
Erase partition on RDM disk before adding to node

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -299,7 +299,13 @@ class VSPHEREBASE(Deployment):
             devices_available = self.vsphere.available_storage_devices(host)
             if not devices_available:
                 raise RDMDiskNotFound
-            self.attach_rdm_disk(vm, devices_available[0])
+
+            # Erase the partition on the disk before adding to node
+            device = devices_available[0]
+            self.vsphere.erase_partition(host, device)
+
+            # Attach RDM disk to node
+            self.attach_rdm_disk(vm, device)
 
     def attach_rdm_disk(self, vm, device_name):
         """

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -917,3 +917,20 @@ class VSPHERE(object):
                     return each.volume.extent[0].diskName
             except AttributeError:
                 continue
+
+    def erase_partition(self, host, device_path):
+        """
+        Erase the partitions on the disk
+
+        Args:
+            host (vim.HostSystem): Host instance
+            device_path (str): Device path to erase the partition
+               e.g:"/vmfs/devices/disks/naa.910229801b540c0125ef160f3048faba"
+
+        """
+        # set empty partition spec
+        spec = vim.HostDiskPartitionSpec()
+        host.configManager.storageSystem.UpdateDiskPartitions(
+            device_path,
+            spec
+        )


### PR DESCRIPTION
Erasing partition on RDM disk before adding to node.
Erase partition during teardown will be handled separately in another PR since the
logic is different for teardown.

Signed-off-by: vavuthu <vavuthu@redhat.com>