### PR TITLE
Run amq benchmark pod and get test results

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -464,8 +464,8 @@ class AMQ(object):
             tiller_namespace (str): Namespace where tiller pod needs to be created
             num_of_clients (int): Number of clients to be created
             worker (str) : Loads to create on workloads separated with commas
-             e.g http://benchmark-worker-0.benchmark-worker:8080,
-                 http://benchmark-worker-1.benchmark-worker:8080
+                e.g http://benchmark-worker-0.benchmark-worker:8080,
+                http://benchmark-worker-1.benchmark-worker:8080
             timeout (int): Time to complete the run
             workload_name (str): Name of the workloads
             topics (int): Number of topics created
@@ -475,6 +475,7 @@ class AMQ(object):
             subscriptions_per_topic (int): Number of subscriptions per topic
             consumer_per_subscription (int): Number of consumers per subscription
             producers_per_topic (int): Number of producers per topic
+            producer_rate (int): Producer rate
             consumer_backlog_sizegb (int): Size of block in gb
             test_duration_minutes (int): Time to run the workloads
 
@@ -509,7 +510,7 @@ class AMQ(object):
         try:
             log.info(f'Install helm on {self.dir}')
             wget_cmd = f"wget -c --read-timeout=5 --tries=0 {url}"
-            untar_cmd = f"tar -zxvf helm-v2.16.1-linux-amd64.tar.gz"
+            untar_cmd = "tar -zxvf helm-v2.16.1-linux-amd64.tar.gz"
             tiller_cmd = (
                 f"linux-amd64/helm init --tiller-namespace {tiller_namespace}"
                 f" --service-account {tiller_namespace}"
@@ -603,7 +604,7 @@ class AMQ(object):
         if worker:
             cmd = f"bin/benchmark --drivers /driver_kafka --workers {worker} /amq_workload.yaml"
         else:
-            cmd = f"bin/benchmark --drivers /driver_kafka /amq_workload.yaml"
+            cmd = "bin/benchmark --drivers /driver_kafka /amq_workload.yaml"
         log.info(f"Run benchmark and running command {cmd} inside the benchmark pod ")
         pod_obj = get_pod_obj(name=f"{name}-driver", namespace=tiller_namespace)
         result = pod_obj.exec_cmd_on_pod(command=cmd, out_yaml_format=False, timeout=timeout)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -393,8 +393,29 @@ COUCHBASE_OPERATOR = 'couchbase-operator-namespace'
 HELLO_WORLD_PRODUCER_YAML = os.path.join(
     TEMPLATE_AMQ_DIR, "hello-world-producer.yaml"
 )
+
 HELLO_WORLD_CONSUMER_YAML = os.path.join(
     TEMPLATE_AMQ_DIR, "hello-world-consumer.yaml"
+)
+
+AMQ_RBAC_YAML = os.path.join(
+    TEMPLATE_AMQ_DIR, "rbac.yaml"
+)
+
+AMQ_BENCHMARK_POD_YAML = os.path.join(
+    TEMPLATE_AMQ_DIR, "benchmark"
+)
+
+AMQ_BENCHMARK_VALUE_YAML = os.path.join(
+    AMQ_BENCHMARK_POD_YAML, "values.yaml"
+)
+
+AMQ_DRIVER_KAFKA_YAML = os.path.join(
+    TEMPLATE_AMQ_DIR, "driver-kafka.yaml"
+)
+
+AMQ_WORKLOAD_YAML = os.path.join(
+    TEMPLATE_AMQ_DIR, "amq_workload.yaml"
 )
 
 NGINX_POD_YAML = os.path.join(

--- a/ocs_ci/templates/workloads/amq/amq_workload.yaml
+++ b/ocs_ci/templates/workloads/amq/amq_workload.yaml
@@ -17,10 +17,10 @@
 # under the License.
 #
 
-name: 1 topic / 1 partition / 1Kb
+name: 3 topic / 16 partition / 1Kb
 
-topics: 1
-partitionsPerTopic: 1
+topics: 3
+partitionsPerTopic: 16
 keyDistributor: "NO_KEY"
 messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"

--- a/ocs_ci/templates/workloads/amq/amq_workload.yaml
+++ b/ocs_ci/templates/workloads/amq/amq_workload.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: 1 topic / 1 partition / 1Kb
+
+topics: 1
+partitionsPerTopic: 1
+keyDistributor: "NO_KEY"
+messageSize: 1024
+payloadFile: "payload/payload-1Kb.data"
+subscriptionsPerTopic: 1
+consumerPerSubscription: 1
+producersPerTopic: 1
+producerRate: 50000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/ocs_ci/templates/workloads/amq/benchmark/Chart.yaml
+++ b/ocs_ci/templates/workloads/amq/benchmark/Chart.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+appVersion: "0.0.1"
+description: A Helm chart for running the Open Messaging Benchmark in Kubernetes
+name: openmessaging-benchmark
+version: 0.0.1
+sources:
+  - https://github.com/openmessaging/openmessaging-benchmark
+maintainers:
+  - name: Jerry Peng

--- a/ocs_ci/templates/workloads/amq/benchmark/templates/_helpers.tpl
+++ b/ocs_ci/templates/workloads/amq/benchmark/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "benchmark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "benchmark.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "benchmark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "workers" -}}
+{{- $nodeCount := .numWorkers | int }}
+  {{- range $index0 := until $nodeCount -}}
+    {{- $index1 := $index0 | add1 -}}
+http://benchmark-worker-{{ $index0 }}.benchmark-worker:8080{{ if ne $index1 $nodeCount }},{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/ocs_ci/templates/workloads/amq/benchmark/templates/benchmark-worker.yaml
+++ b/ocs_ci/templates/workloads/amq/benchmark/templates/benchmark-worker.yaml
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    app: {{ .Release.Name }}
+    component: worker
+spec:
+  serviceName: {{ .Release.Name }}-worker
+  replicas: {{ .Values.numWorkers }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+        component: worker
+    spec:
+      containers:
+        - name: {{ .Release.Name }}-worker
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          image: {{ .Values.image }}
+          command: ["sh", "-c"]
+          args:
+            - >
+              bin/benchmark-worker
+          ports:
+            - containerPort: 8080
+            - containerPort: 8081
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    app: {{ .Release.Name }}
+    component: worker
+    role: worker
+spec:
+  ports:
+    - port: 8080
+      name: http
+    - port: 8081
+      name: stats
+  clusterIP: None
+  selector:
+    app: {{ .Release.Name }}
+    component: worker

--- a/ocs_ci/templates/workloads/amq/benchmark/templates/benchmark.yaml
+++ b/ocs_ci/templates/workloads/amq/benchmark/templates/benchmark.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-driver
+  labels:
+    app: {{ .Release.Name }}
+    role: driver
+spec:
+  containers:
+    - name: {{ .Release.Name }}-driver
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      image: {{ .Values.image }}
+      env:
+        - name: NUM_WORKERS
+          value: "{{ .Values.numWorkers }}"
+        - name: WORKERS
+          value: '{{ template "workers" .Values }}'
+      command: ["sh", "-c"]
+      args:
+        - >
+          echo "bin/benchmark --drivers {{ .Values.driver }} --workers $WORKERS {{ .Values.workload }}" > example-run.sh &&
+          tail -f /dev/null

--- a/ocs_ci/templates/workloads/amq/benchmark/values.yaml
+++ b/ocs_ci/templates/workloads/amq/benchmark/values.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+numWorkers: 8
+image: openmessaging/openmessaging-benchmark:latest
+imagePullPolicy: Always
+workload: workloads/1-topic-16-partitions-1kb.yaml
+driver: driver-pulsar/pulsar.yaml

--- a/ocs_ci/templates/workloads/amq/driver-kafka.yaml
+++ b/ocs_ci/templates/workloads/amq/driver-kafka.yaml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+name: Kafka
+driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
+
+# Kafka client-specific configuration
+replicationFactor: 3
+
+topicConfig: |
+  min.insync.replicas=2
+
+commonConfig: |
+  bootstrap.servers=my-cluster-kafka-bootstrap.myproject.svc.cluster.local:9092
+
+producerConfig: |
+  acks=all
+  linger.ms=1
+  batch.size=131072
+
+consumerConfig: |
+  auto.offset.reset=earliest
+  enable.auto.commit=false

--- a/ocs_ci/templates/workloads/amq/rbac.yaml
+++ b/ocs_ci/templates/workloads/amq/rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: tiller
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: tiller
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: ""

--- a/tests/e2e/workloads/amq/test_amq_streamer_creation.py
+++ b/tests/e2e/workloads/amq/test_amq_streamer_creation.py
@@ -29,13 +29,10 @@ class TestAMQBasics(E2ETest):
         argvalues=[
             pytest.param(
                 constants.CEPHBLOCKPOOL, marks=pytest.mark.polarion_id("OCS-2217")
-            ),
-            pytest.param(
-                constants.CEPHFILESYSTEM, marks=pytest.mark.polarion_id("OCS-2218")
             )
         ]
     )
-    def test_install_amq_cephfs(self, interface, test_fixture_amq):
+    def test_install_and_run_amq_benchmark(self, interface, test_fixture_amq):
         """
         Create amq cluster and run open messages on it
 

--- a/tests/e2e/workloads/amq/test_amq_streamer_creation.py
+++ b/tests/e2e/workloads/amq/test_amq_streamer_creation.py
@@ -1,10 +1,10 @@
 import logging
 import pytest
-import time
 
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.amq import AMQ
+from ocs_ci.utility import templating
 from tests.helpers import default_storage_class
 
 log = logging.getLogger(__name__)
@@ -46,15 +46,10 @@ class TestAMQBasics(E2ETest):
         # Deploy amq cluster
         test_fixture_amq.setup_amq_cluster(sc.name)
 
-        # Run open messages
-        test_fixture_amq.create_messaging_on_amq()
-
-        # Wait for some time to generate msg
-        waiting_time = 60
-        log.info(f"Waiting for {waiting_time}sec to generate msg")
-        time.sleep(waiting_time)
-
-        # Check messages are sent and received
-        threads = test_fixture_amq.run_in_bg()
-        for t in threads:
-            t.join()
+        # Run benchmark
+        amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
+        amq_workload_dict['producersPerTopic'] = 3
+        amq_workload_dict['consumerPerSubscription'] = 3
+        assert test_fixture_amq.run_amq_benchmark(amq_workload_yaml=amq_workload_dict) is not None, (
+            "Failed to run amq benchmark pod"
+        )

--- a/tests/e2e/workloads/amq/test_amq_streamer_creation.py
+++ b/tests/e2e/workloads/amq/test_amq_streamer_creation.py
@@ -50,6 +50,7 @@ class TestAMQBasics(E2ETest):
         amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
         amq_workload_dict['producersPerTopic'] = 3
         amq_workload_dict['consumerPerSubscription'] = 3
-        assert test_fixture_amq.run_amq_benchmark(amq_workload_yaml=amq_workload_dict) is not None, (
-            "Failed to run amq benchmark pod"
+        result = test_fixture_amq.run_amq_benchmark(amq_workload_yaml=amq_workload_dict)
+        assert test_fixture_amq.validate_amq_benchmark(result, amq_workload_dict) is not None, (
+            "Benchmark did not completely run or might failed in between"
         )


### PR DESCRIPTION
Creates amq benchmark pods and get the test results. And also supports creation of multiple topics, partitions, producer, consumer pods.

Signed-off-by: Akarsha <akrai@redhat.com>