### PR TITLE
PR to fix get_fio_result() issue in test_pods_are_not_oomkilled_while_running_ios TC

### DIFF
--- a/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
+++ b/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
@@ -66,7 +66,7 @@ class TestPodAreNotOomkilledWhileRunningIO(E2ETest):
 
         log.info(f"Running FIO to fill PVC size: {io_size_mb}")
         self.pod_obj.run_io(
-            'fs', size=io_size_mb, io_direction='write', runtime=600
+            'fs', size=io_size_mb, io_direction='write', runtime=480
         )
 
         log.info("Waiting for IO results")


### PR DESCRIPTION
Updated fio runtime less than 2min of get_fio_result() timeout value.

Did multiple testing to identify the problem, below is analysis and expected fix.
1. fio pod is not getting OOM kill during IO, it's up and running even if there is a timeout error while calling the function get_fio_result()
2. Did run the same fio profile manually using set_trace in pod, IO completed without any issue.
3. The problem I see here is the fio runtime and get_fio_result() function FIO_TIMEOUT value. i.e. both are 600sec wrt this TC. So due to that, run_io starts the IO but get_fio_result() exactly waits for the same TIMEOUT secs and it reports failure.

The script works perfectly if fio_runtime is less than 540sec, so changed it to 480sec.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>