### PR TITLE
Fix for version conflict for rsa module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ setup(
         'funcy',
         'semantic-version',
         'jsonschema>=3.2.0',
+        # issue opened for google-cloud-storage
+        # https://github.com/googleapis/python-storage/issues/174
+        # till above issue fixed, manually pointing rsa to 4.0
+        'rsa==4.0',
         'google-cloud-storage',
         'elasticsearch',
         'numpy',


### PR DESCRIPTION
With the recent release of rsa (4.1), google-cloud-storage module
is incompatable with rsa 4.1. Hence pointing to 4.0 version of rsa
in this PR

Fixes: #2283 
Signed-off-by: vavuthu <vavuthu@redhat.com>