### PR TITLE
Remove aws_platform_required marker from test_node_maintenance_restart_activate

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -19,7 +19,6 @@ from ocs_ci.framework.testlib import (
     ManageTest, aws_platform_required, ignore_leftovers,
     ipi_deployment_required, skipif_bm
 )
-from ocs_ci.framework import config
 from tests.sanity_helpers import Sanity
 from ocs_ci.ocs.resources import pod
 from tests.helpers import (
@@ -168,13 +167,8 @@ class TestNodesMaintenance(ManageTest):
         # Maintenance the node (unschedule and drain). The function contains logging
         drain_nodes([typed_node_name])
 
-        platform = config.ENV_DATA['platform']
-
         # Restarting the node
-        if platform == 'baremetal':
-            nodes.restart_nodes(nodes=typed_nodes)
-        else:
-            nodes.restart_nodes(nodes=typed_nodes, wait=False)
+        nodes.restart_nodes(nodes=typed_nodes, wait=False)
 
         try:
             wait_for_nodes_status(

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -19,7 +19,7 @@ from ocs_ci.framework.testlib import (
     ManageTest, aws_platform_required, ignore_leftovers,
     ipi_deployment_required
 )
-
+from ocs_ci.framework import config
 from tests.sanity_helpers import Sanity
 from ocs_ci.ocs.resources import pod
 from tests.helpers import (
@@ -157,8 +157,15 @@ class TestNodesMaintenance(ManageTest):
         # Maintenance the node (unschedule and drain). The function contains logging
         drain_nodes([typed_node_name])
 
+        platform = config.ENV_DATA['platform']
+
         # Restarting the node
-        nodes.restart_nodes(nodes=typed_nodes, wait=False)
+        if platform == 'vsphere':
+            nodes.restart_nodes(nodes=typed_nodes, force=True, wait=False)
+        elif platform == 'baremetal':
+            nodes.restart_nodes(nodes=typed_nodes)
+        else:
+            nodes.restart_nodes(nodes=typed_nodes, wait=False)
 
         wait_for_nodes_status(
             node_names=[typed_node_name],

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -129,7 +129,6 @@ class TestNodesMaintenance(ManageTest):
 
     @tier4
     @tier4b
-    @aws_platform_required
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -17,7 +17,7 @@ from ocs_ci.ocs.node import (
 from ocs_ci.framework.testlib import (
     tier1, tier2, tier3, tier4, tier4b,
     ManageTest, aws_platform_required, ignore_leftovers,
-    ipi_deployment_required
+    ipi_deployment_required, skipif_bm
 )
 from ocs_ci.framework import config
 from tests.sanity_helpers import Sanity
@@ -129,6 +129,7 @@ class TestNodesMaintenance(ManageTest):
 
     @tier4
     @tier4b
+    @skipif_bm
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -194,7 +194,7 @@ class TestNodesMaintenance(ManageTest):
 
         wait_for_nodes_status(
             node_names=[typed_node_name],
-            status=constants.NODE_READY_SCHEDULING_DISABLED, timeout=360
+            status=constants.NODE_READY_SCHEDULING_DISABLED
         )
 
         # Mark the node back to schedulable


### PR DESCRIPTION
Modify the below test case to run on different platforms. Currently the test case is running only on AWS platform.

tests/manage/z_cluster/nodes/test_nodes_maintenance.py::TestNodesMaintenance::test_node_maintenance_restart_activate
Enabling the test case to run on BM is tracked here - https://github.com/red-hat-storage/ocs-ci/issues/2679

Closes #2286 