### PR TITLE
Removing the workaround for RSA version since google-auth is compatable with latest rsa version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,6 @@ setup(
         'funcy',
         'semantic-version',
         'jsonschema>=3.2.0',
-        # issue opened for google-cloud-storage
-        # https://github.com/googleapis/python-storage/issues/174
-        # till above issue fixed, manually pointing rsa to 4.0
-        'rsa==4.0',
         'google-cloud-storage',
         'elasticsearch',
         'numpy',


### PR DESCRIPTION
google-auth is compatable with latest rsa version

Signed-off-by: vavuthu <vavuthu@redhat.com>