### PR TITLE
 test automated_recovery_from_failed_nodes_reactive_IPI: Applying WA and teardown enhancements

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -176,12 +176,14 @@ def delete_machine_and_wait_for_it_to_reach_running_state(
     delete_machine(machine_name)
     machine_names_after_delete = [m.name for m in get_machine_objs()]
     machines = get_machines(machine_type=get_machine_type(machine_name))
-    counter = 0
-    for machine in machines:
-        if re.match(machine.name[:-6], machine_name):
-            counter += 1
-    if counter != machineset_replica_count:
-        raise Exception("Unable to find new machine")
+    new_machine_list = [
+        machine for machine in machines if re.match(
+            machine.name[:-6], machine_name
+        )
+    ]
+    assert len(
+        new_machine_list
+    ) == machineset_replica_count, "Unable to find new machine"
     new_machine_name = list(
         set(machine_names_after_delete) - set(machine_names_before_delete)
     )
@@ -191,7 +193,7 @@ def delete_machine_and_wait_for_it_to_reach_running_state(
         for timer in TimeoutSampler(
             300, 5, get_machine_status, machine_obj=new_machine_obj[0]
         ):
-            if timer == 'Running':
+            if timer == constants.STATUS_RUNNING:
                 log.info(
                     f"New spun machine {new_machine_name[0]} reached "
                     f"running state"

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -204,7 +204,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 else:
                     raise
                 log.info("All the dc pods reached running state")
-                wait_for_storage_pods(timeout)
+            wait_for_storage_pods(wait=True)
         except ResourceWrongStatusException:
             if failure == "shutdown":
                 nodes.terminate_nodes(failure_node_obj, wait=True)

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -190,8 +190,9 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
             # DC app pods on the failed node will get automatically created on other
             # running node. Waiting for all dc app pod to reach running state
             try:
+                timeout = 1 if failure == "shutdown" else 720
                 wait_for_dc_app_pods_to_reach_running_state(
-                    dc_pod_obj, timeout=720
+                    dc_pod_obj, timeout=timeout
                 )
             except ResourceWrongStatusException:
                 # Apply WA in BZ-1841611; ocs-ci issue-2212

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -96,7 +96,6 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 *['rbd', 'shutdown'],
                 marks=[
                     pytest.mark.polarion_id("OCS-2102"),
-                    pytest.mark.bugzilla("1830015")
                 ]
             ),
             pytest.param(
@@ -107,7 +106,6 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 *['cephfs', 'shutdown'],
                 marks=[
                     pytest.mark.polarion_id("OCS-2104"),
-                    pytest.mark.bugzilla("1830015")
                 ]
             ),
             pytest.param(


### PR DESCRIPTION
Applied WA mentioned in #2212  and #2341 
*. Applied WA 1841611 and 1847417 to test "automated_recovery_from_failed_nodes_reactive_IPI"
*.  Enhancements in teardown functions in below tests,
a) automated_recovery_from_failed_nodes_reactive_IPI
b) test_node_replacement_proactive.py

Signed-off-by: Prasad Desala <tdesala@redhat.com>