### PR TITLE
Disable the bootstrap removal code due to vSphere provider issue

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -540,13 +540,16 @@ class VSPHEREUPI(VSPHEREBASE):
                         logger.error(ex)
                 raise e
 
-            if not config.DEPLOYMENT['preserve_bootstrap_node']:
-                logger.info("removing bootstrap node")
-                os.chdir(self.terraform_data_dir)
-                self.terraform.apply(
-                    self.terraform_var, bootstrap_complete=True
-                )
-                os.chdir(self.previous_dir)
+            # Disabling the bootstrap removal code due to vSphere provider
+            # issue
+            # https://github.com/hashicorp/terraform-provider-vsphere/issues/1111
+            # if not config.DEPLOYMENT['preserve_bootstrap_node']:
+            #     logger.info("removing bootstrap node")
+            #     os.chdir(self.terraform_data_dir)
+            #     self.terraform.apply(
+            #         self.terraform_var, bootstrap_complete=True
+            #     )
+            #     os.chdir(self.previous_dir)
 
             OCP.set_kubeconfig(self.kubeconfig)
 


### PR DESCRIPTION
Disable the bootstrap removal code due to vSphere provider issue
Issue: https://github.com/hashicorp/terraform-provider-vsphere/issues/1111

Choosing to disable the code part instead of passing yaml in MR due to if someone choose to install directly from repo they might hit the issue.

Fixes: #2336 

Signed-off-by: vavuthu <vavuthu@redhat.com>