### PR TITLE
Align ocs-ci with OCP 4.5 ( folder structure ) for vsphere platform

### DIFF
--- a/ocs_ci/deployment/terraform.py
+++ b/ocs_ci/deployment/terraform.py
@@ -73,11 +73,12 @@ class Terraform(object):
 
         """
         logger.info("Destroying the cluster")
-        cmd = f"{self.terraform_installer} destroy '-var-file={tfvars}' -auto-approve {self.path}"
-        if not refresh:
-            cmd = f"{self.terraform_installer} destroy -refresh=false '-var-file={tfvars}' -auto-approve {self.path}"
+        refresh_param = "-refresh=false" if not refresh else ""
+        cmd = (
+            f"{self.terraform_installer} destroy {refresh_param}"
+            f" '-var-file={tfvars}' -auto-approve {self.path}"
+        )
         run_cmd(cmd, timeout=1200)
-
 
     def output(self, tfstate, module, json_format=True):
         """
@@ -116,4 +117,3 @@ class Terraform(object):
         logger.info(f"Destroying the module: {module}")
         cmd = f"terraform destroy -auto-approve -target={module} '-var-file={tfvars}' '{self.path}'"
         run_cmd(cmd, timeout=1200)
-

--- a/ocs_ci/deployment/terraform.py
+++ b/ocs_ci/deployment/terraform.py
@@ -64,7 +64,7 @@ class Terraform(object):
 
         run_cmd(cmd, timeout=1500)
 
-    def destroy(self, tfvars):
+    def destroy(self, tfvars, refresh=True):
         """
         Destroys the cluster
 
@@ -73,11 +73,11 @@ class Terraform(object):
 
         """
         logger.info("Destroying the cluster")
-        run_cmd(
-            f"{self.terraform_installer} destroy '-var-file={tfvars}'"
-            f" -auto-approve {self.path}",
-            timeout=1200,
-        )
+        cmd = f"{self.terraform_installer} destroy '-var-file={tfvars}' -auto-approve {self.path}"
+        if not refresh:
+            cmd = f"{self.terraform_installer} destroy -refresh=false '-var-file={tfvars}' -auto-approve {self.path}"
+        run_cmd(cmd, timeout=1200)
+
 
     def output(self, tfstate, module, json_format=True):
         """
@@ -102,3 +102,18 @@ class Terraform(object):
                 f"{self.terraform_installer} output -state={tfstate} {module}"
             )
         return run_cmd(cmd)
+
+    def destroy_module(self, tfvars, module):
+        """
+        Destroys the particular module/node
+
+        Args:
+            tfvars (str): path to terraform.tfvars file
+            module (str): Module to destroy
+                e.g: constants.BOOTSTRAP_MODULE
+
+        """
+        logger.info(f"Destroying the module: {module}")
+        cmd = f"terraform destroy -auto-approve -target={module} '-var-file={tfvars}' '{self.path}'"
+        run_cmd(cmd, timeout=1200)
+

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -418,8 +418,12 @@ class VSPHEREUPI(VSPHEREBASE):
             generate_terraform_vars_and_update_machine_conf()
 
             # sync guest time with host
+            vm_file = (
+                constants.VM_MAIN if self.folder_structure
+                else constants.INSTALLER_MACHINE_CONF
+            )
             if config.ENV_DATA.get('sync_time_with_host'):
-                sync_time_with_host(constants.INSTALLER_MACHINE_CONF, True)
+                sync_time_with_host(vm_file, True)
 
         def create_config(self):
             """
@@ -700,8 +704,10 @@ def sync_time_with_host(machine_file, enable=False):
          machine_file (str): machine file to sync the guest time with host
          enable (bool): True to sync guest time with host
     """
+    # terraform will support only lowercase bool
+    enable = str(enable).lower()
     to_change = 'enable_disk_uuid = "true"'
-    sync_time = f"{to_change} sync_time_with_host = \"{enable}\""
+    sync_time = f"{to_change}\n sync_time_with_host = \"{enable}\""
 
     replace_content_in_file(
         machine_file,

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -522,11 +522,17 @@ class VSPHEREUPI(VSPHEREBASE):
             # if not config.DEPLOYMENT['preserve_bootstrap_node']:
             #     logger.info("removing bootstrap node")
             #     os.chdir(self.terraform_data_dir)
-            #     self.terraform.apply(
-            #         self.terraform_var, bootstrap_complete=True
-            #     )
+            #     if self.folder_structure:
+            #         self.terraform.destroy_module(
+            #             self.terraform_var,
+            #             constants.BOOTSTRAP_MODULE
+            #         )
+            #     else:
+            #         self.terraform.apply(
+            #             self.terraform_var, bootstrap_complete=True
+            #         )
             #     os.chdir(self.previous_dir)
-
+            
             OCP.set_kubeconfig(self.kubeconfig)
 
             # wait for all nodes to generate CSR

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -618,15 +618,19 @@ MASTER_IGN = "master.ign"
 WORKER_IGN = "worker.ign"
 
 # vSphere related constants
+VSPHERE_NODE_USER = "core"
 VSPHERE_INSTALLER_BRANCH = "release-4.3"
 VSPHERE_INSTALLER_REPO = "https://github.com/openshift/installer.git"
 VSPHERE_SCALEUP_REPO = "https://code.engineering.redhat.com/gerrit/openshift-misc"
 VSPHERE_DIR = os.path.join(EXTERNAL_DIR, "installer/upi/vsphere/")
 INSTALLER_IGNITION = os.path.join(VSPHERE_DIR, "machine/ignition.tf")
+VM_IFCFG = os.path.join(VSPHERE_DIR, "vm/ifcfg.tmpl")
 INSTALLER_ROUTE53 = os.path.join(VSPHERE_DIR, "route53/main.tf")
 INSTALLER_MACHINE_CONF = os.path.join(VSPHERE_DIR, "machine/main.tf")
+VM_MAIN = os.path.join(VSPHERE_DIR, "vm/main.tf")
 VSPHERE_CONFIG_PATH = os.path.join(TOP_DIR, "conf/ocsci/vsphere_upi_vars.yaml")
 VSPHERE_MAIN = os.path.join(VSPHERE_DIR, "main.tf")
+VSPHERE_VAR = os.path.join(VSPHERE_DIR, "variables.tf")
 TERRAFORM_DATA_DIR = "terraform_data"
 SCALEUP_TERRAFORM_DATA_DIR = "scaleup_terraform_data"
 SCALEUP_VSPHERE_DIR = os.path.join(
@@ -920,3 +924,10 @@ USED_SPACE_QUERY = "ceph_cluster_total_used_bytes"
 # files
 REMOTE_FILE_URL = "http://download.ceph.com/tarballs/ceph_15.1.0.orig.tar.gz"
 FILE_PATH = '/tmp/ceph.tar.gz'
+
+# terraform tfstate modules
+BOOTSTRAP_MODULE = "module.ipam_bootstrap"
+LOAD_BALANCER_MODULE = "module.ipam_lb"
+
+# proxy location
+HAPROXY_LOCATION = "/etc/haproxy/haproxy.conf"

--- a/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
+++ b/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
@@ -1,0 +1,26 @@
+cluster_id: {{ cluster_name }}
+cluster_domain: {{ cluster_domain }}
+base_domain: {{ base_domain | default('qe.rh-ocs.com') }}
+vsphere_server: {{ vsphere_server }}
+vsphere_user: {{ vsphere_user | default('Administrator@vsphere.local') }}
+vsphere_password: {{ vsphere_password }}
+vsphere_cluster: {{ vsphere_cluster }}
+vsphere_datacenter: {{ vsphere_datacenter }}
+vsphere_datastore: {{ vsphere_datastore }}
+vm_template: {{ vm_template }}
+machine_cidr: {{ machine_cidr }}
+control_plane_count: {{ master_replicas | default(3) }}
+compute_count: {{ worker_replicas | default(3) }}
+bootstrap_ignition_path: {{ bootstrap_ignition_path }}
+control_plane_ignition_path: {{ control_plane_ignition_path }}
+compute_ignition_path: {{ compute_ignition_path }}
+ipam: {{ ipam | default('139.178.89.254') }}
+ipam_token: {{ ipam_token }}
+vm_network: {{ vm_network | default('VLAN_172') }}
+control_plane_memory: {{ control_plane_memory | default('16384') }}
+compute_memory: {{ compute_memory | default('16384') }}
+control_plane_num_cpus: {{ control_plane_num_cpus | default('4') }}
+compute_num_cpus: {{ compute_num_cpus | default('12') }}
+vm_dns_addresses: {{ vm_dns_addresses }}
+ssh_public_key_path: {{ ssh_public_key_path | default('~/.ssh/openshift-dev.pub')}}
+folder: {{ folder }}

--- a/ocs_ci/utility/connection.py
+++ b/ocs_ci/utility/connection.py
@@ -1,0 +1,80 @@
+"""
+Module that connects to remote server and execute operations on remote server
+"""
+
+import logging
+
+from paramiko import SSHClient, AutoAddPolicy
+from paramiko.auth_handler import AuthenticationException, SSHException
+
+logger = logging.getLogger(__name__)
+
+
+class Connection(object):
+    """
+    A class that connects to remote server
+    """
+    def __init__(self, host, user=None, private_key=None):
+        """
+        Initialize all required variables
+
+        Args:
+            host (str):
+            user (str): User name to connect
+            private_key (str): Private key  to connect to load balancer
+
+        """
+        self.host = host
+        self.user = user
+        self.private_key = private_key
+        self.client = self._connect()
+
+    def _connect(self):
+        """
+        Get connection to load balancer
+
+        Returns:
+            paramiko.client: Paramiko SSH client connection to load balancer
+
+        Raises:
+            FileNotFoundError: In-case terraform.tfstate file not found
+                in terraform_data directory
+
+        """
+        try:
+            client = SSHClient()
+            client.set_missing_host_key_policy(AutoAddPolicy())
+            client.connect(
+                self.host,
+                username=self.user,
+                key_filename=self.private_key
+            )
+        except AuthenticationException as authException:
+            logger.error(f"Authentication failed: {authException}")
+            raise authException
+        except SSHException as sshException:
+            logger.error(f"SSH connection failed: {sshException}")
+            raise sshException
+
+        return client
+
+    def exec_cmd(self, cmd):
+        """
+        Executes command on server
+
+        Args:
+            cmd (str): Command to run on server
+
+        Returns:
+            tuple: tuple which contains command return code, output and error
+
+        """
+        logger.info(f"Executing cmd: {cmd} on {self.host}")
+        _, out, err = self.client.exec_command(cmd)
+        retcode = out.channel.recv_exit_status()
+        stdout = out.read().decode('ascii').strip("\n")
+        stderr = err.read().decode('ascii').strip("\n")
+        logger.debug(f"retcode: {retcode}")
+        logger.debug(f"stdout: {stdout}")
+        logger.debug(f"stderr: {stderr}")
+        return (retcode, stdout, stderr)

--- a/ocs_ci/utility/load_balancer.py
+++ b/ocs_ci/utility/load_balancer.py
@@ -1,0 +1,106 @@
+"""
+Module that contains all operations related to load balancer in a cluster
+"""
+
+import errno
+import logging
+import os
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.utility.connection import Connection
+from ocs_ci.utility.utils import get_module_ip
+
+logger = logging.getLogger(__name__)
+
+
+class LoadBalancer(object):
+    """
+    A class that handles all operations related to load balancer
+    """
+    def __init__(self, host=None, user=None, private_key=None):
+        """
+        Initialize all required variables
+
+        Args:
+            host (str): Host name or IP address
+            user (str): User name to connect
+            private_key (str): Private key  to connect to load balancer
+
+        """
+        self.host = host or self._get_host()
+        self.user = user or constants.VSPHERE_NODE_USER
+        self.private_key = private_key or os.path.expanduser(
+            config.DEPLOYMENT['ssh_key_private']
+        )
+        self.lb = Connection(self.host, self.user, self.private_key)
+
+    def _get_host(self):
+        """
+        Fetches the Host/IP address from terraform.tfstate file
+
+        Returns:
+             str: IP Address of load balancer
+
+        """
+        self.terraform_state_file = os.path.join(
+            config.ENV_DATA['cluster_path'],
+            "terraform_data",
+            "terraform.tfstate"
+        )
+
+        if not os.path.isfile(self.terraform_state_file):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                self.terraform_state_file
+            )
+        ip_address = get_module_ip(
+            self.terraform_state_file,
+            constants.LOAD_BALANCER_MODULE
+        )
+        return ip_address
+
+    def restart_service(self, service_name):
+        """
+        Restarts the given service
+        """
+        cmd = f"sudo systemctl restart {service_name}"
+        return self.lb.exec_cmd(cmd)
+
+    def restart_haproxy(self):
+        """
+        Restarts haproxy service
+
+        Returns:
+            bool: True if successful restarts of haproxy, False otherwise
+
+        """
+        _rc = False
+        logger.info("Restarting haproxy service on load balancer")
+        retcode, _, _ = self.restart_service("haproxy.service")
+        if retcode:
+            logger.info(
+                "Successfully restarted haproxy service on load balancer"
+            )
+            _rc = True
+        return _rc
+
+    def remove_boostrap_in_proxy(self):
+        """
+        Removes bootstrap IP from haproxy.conf
+        """
+        bootstrap_ip = get_module_ip(
+            self.terraform_state_file,
+            constants.BOOTSTRAP_MODULE
+        )
+        # backup the conf file
+        cmd = (
+            f"sudo cp {constants.HAPROXY_LOCATION}"
+            f" {constants.HAPROXY_LOCATION}_backup"
+        )
+        self.lb.exec_cmd(cmd)
+
+        # remove bootstrap IP
+        cmd = f"sudo sed -i '/{bootstrap_ip}/d' {constants.HAPROXY_LOCATION}"
+        self.lb.exec_cmd(cmd)

--- a/ocs_ci/utility/templating.py
+++ b/ocs_ci/utility/templating.py
@@ -222,3 +222,18 @@ def dump_data_to_json(data, json_file):
     """
     with open(json_file, 'w') as fd:
         json.dump(data, fd)
+
+
+def json_to_dict(json_file):
+    """
+    Converts JSON to dictionary format
+
+    Args:
+        json_file (str): file path to json file
+
+    Returns:
+         dict: JSON data in dictionary format
+
+    """
+    with open(json_file, 'r') as fd:
+        return json.loads(fd.read())

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2320,3 +2320,16 @@ def get_terraform(version=None, bin_dir=None):
     os.chdir(previous_dir)
 
     return terraform_binary_path
+
+
+def set_aws_region(region=None):
+    """
+    Exports environment variable AWS_REGION
+
+    Args:
+        region (str): AWS region to export
+
+    """
+    log.debug("Exporting environment variable AWS_REGION")
+    region = region or config.ENV_DATA['region']
+    os.environ['AWS_REGION'] = region


### PR DESCRIPTION
This PR will align ocs-ci with OCP4.5 folder structure

Below are few important commits

a5b320107824529551cf2e678c4d99c1c0c9cf7c : re-org the structure to accomodate the ocp45 ( folder structure )
cfc4a7c97c086a5e06eade0d6faebf8f1ee21646 : Adding new jinja template for ocp45 ( folder structure )
363e06b8489d195c185da0c49dcb2cf6a68aa673 : Adding connection and load balancer modules
54dd538377912797838864d37d70eaa8b284d48c : Including OCP45 folder structure and other helper functions
64b4adfc8a7c11e354c0da01b8f6646eb2a4bfaf : Sync guest time with host
ec181acf2a9541234dd54a3c9bde8cd1f0c95196 : Removing bootstrap node
cdf663c5c5fbd09c87ab20e1200f78a5509070da : Destroy functionality to support folder structure
7ca3f340dc7abf843ac137db3cd2da049e331a40 : Include retry mechanism for get_pending_csr
3c7fc86f906ee70ccd615a5ffd13de27ae57f479 : Module to fetch bootstap and loadbalancer IP from terraform state file
