### PR TITLE
AMQ fixture and testcase amq workload when spinning ceph pods

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -483,7 +483,8 @@ class AMQ(object):
             run_in_bg (bool): On true the workload will run in background
 
         Return:
-            result (str): Returns benchmark run information
+            result (str/Thread obj): Returns benchmark run information if run_in_bg is False.
+                Otherwise a thread of the amq workload execution
 
         """
 
@@ -575,7 +576,7 @@ class AMQ(object):
         if run_in_bg:
             executor = ThreadPoolExecutor(1)
             result = executor.submit(
-                self.run_amq_workload_in_bg,
+                self.run_amq_workload,
                 cmd, benchmark_pod_name, tiller_namespace, timeout
             )
             return result
@@ -585,7 +586,7 @@ class AMQ(object):
 
         return result
 
-    def run_amq_workload_in_bg(
+    def run_amq_workload(
         self, command, benchmark_pod_name, tiller_namespace, timeout
     ):
         """
@@ -598,7 +599,7 @@ class AMQ(object):
              timeout (int): Time to complete the run
 
         Returns:
-            Thread: A thread of the amq workload execution
+            result (str): Returns benchmark run information
 
         """
         pod_obj = get_pod_obj(name=f"{benchmark_pod_name}-driver", namespace=tiller_namespace)

--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -453,7 +453,7 @@ class AMQ(object):
         self, benchmark_pod_name="benchmark", kafka_namespace=constants.AMQ_NAMESPACE,
         tiller_namespace=AMQ_BENCHMARK_NAMESPACE,
         num_of_clients=8, worker=None, timeout=3600,
-        amq_workload_yaml=None
+        amq_workload_yaml=None, run_in_bg=False
     ):
         """
         Run benchmark pod and get the results
@@ -479,6 +479,7 @@ class AMQ(object):
                 :producer_rate (int): Producer rate
                 :consumer_backlog_sizegb (int): Size of block in gb
                 :test_duration_minutes (int): Time to run the workloads
+            run_in_bg (bool): On true the workload will run in background
 
         Return:
             result (str): Returns benchmark run information
@@ -569,10 +570,39 @@ class AMQ(object):
         else:
             cmd = "bin/benchmark --drivers /driver_kafka /amq_workload.yaml"
         log.info(f"Run benchmark and running command {cmd} inside the benchmark pod ")
+
+        if run_in_bg:
+            thread = Thread(
+                target=self.run_amq_workload_in_bg, args=(
+                    cmd, benchmark_pod_name, tiller_namespace, timeout
+                ))
+            thread.start()
+            time.sleep(60)
+            return thread
+
         pod_obj = get_pod_obj(name=f"{benchmark_pod_name}-driver", namespace=tiller_namespace)
         result = pod_obj.exec_cmd_on_pod(command=cmd, out_yaml_format=False, timeout=timeout)
 
         return result
+
+    def run_amq_workload_in_bg(
+        self, command, benchmark_pod_name, tiller_namespace, timeout
+    ):
+        """
+        Runs amq workload in bg
+
+        Args:
+             command (str): Command to run on pod
+             benchmark_pod_name (str): Pod name
+             tiller_namespace (str): Namespace of pod
+             timeout (int)
+
+        Returns:
+            Thread: A thread of the amq workload execution
+
+        """
+        pod_obj = get_pod_obj(name=f"{benchmark_pod_name}-driver", namespace=tiller_namespace)
+        return pod_obj.exec_cmd_on_pod(command=command, out_yaml_format=False, timeout=timeout)
 
     def validate_amq_benchmark(self, result, amq_workload_yaml, benchmark_pod_name="benchmark"):
         """

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -426,6 +426,10 @@ AMQ_WORKLOAD_YAML = os.path.join(
     TEMPLATE_AMQ_DIR, "amq_workload.yaml"
 )
 
+AMQ_SIMPLE_WORKLOAD_YAML = os.path.join(
+    TEMPLATE_AMQ_DIR, "amq_simple_workload.yaml"
+)
+
 NGINX_POD_YAML = os.path.join(
     TEMPLATE_APP_POD_DIR, "nginx.yaml"
 )

--- a/ocs_ci/templates/workloads/amq/amq_simple_workload.yaml
+++ b/ocs_ci/templates/workloads/amq/amq_simple_workload.yaml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: 1 topic / 1 partition / 100b
+
+topics: 1
+partitionsPerTopic: 1
+messageSize: 100
+payloadFile: "payload/payload-100b.data"
+subscriptionsPerTopic: 1
+consumerPerSubscription: 1
+producersPerTopic: 1
+producerRate: 50000
+consumerBacklogSizeGB: 0
+testDurationMinutes: 15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ from tests.manage.mcg.helpers import (
 from ocs_ci.ocs.pgsql import Postgresql
 from ocs_ci.ocs.jenkins import Jenkins
 from ocs_ci.ocs.couchbase import CouchBase
+from ocs_ci.ocs.amq import AMQ
 
 log = logging.getLogger(__name__)
 
@@ -2683,3 +2684,62 @@ def ceph_toolbox(request):
     if not (deploy or teardown or skip_ocs):
         # Creating toolbox pod
         setup_ceph_toolbox()
+
+
+@pytest.fixture(scope='function')
+def amq_factory_fixture(request):
+    """
+    AMQ factory fixture
+    """
+    amq = AMQ()
+
+    def factory(
+        sc_name, tiller_namespace, kafka_namespace=constants.AMQ_NAMESPACE,
+        size=100, replicas=3, benchmark_pod_name="benchmark",
+        num_of_clients=8, worker=None, timeout=3600,
+        amq_workload_yaml=None, run_in_bg=False
+    ):
+        """
+        Factory to start amq workload
+
+        Args:
+            sc_name (str): Name of storage clase
+            tiller_namespace (str): Namespace where benchmark pods to be created
+            kafka_namespace (str): Namespace where kafka cluster to be created
+            size (int): Size of the storage
+            replicas (int): Number of kafka and zookeeper pods to be created
+            benchmark_pod_name (str): Name of the benchmark pod
+            num_of_clients (int): Number of clients to be created
+            worker (str) : Loads to create on workloads separated with commas
+                e.g http://benchmark-worker-0.benchmark-worker:8080,
+                http://benchmark-worker-1.benchmark-worker:8080
+            timeout (int): Time to complete the run
+            amq_workload_yaml (dict): Contains amq workloads information keys and values
+            run_in_bg (bool): On true the workload will run in background
+
+        """
+        # Setup kafka cluster
+        amq.setup_amq_cluster(
+            sc_name=sc_name, namespace=kafka_namespace, size=size, replicas=replicas
+        )
+
+        # Run amq benchmark
+        result = amq.run_amq_benchmark(
+            benchmark_pod_name=benchmark_pod_name, kafka_namespace=kafka_namespace,
+            tiller_namespace=tiller_namespace, num_of_clients=num_of_clients, worker=worker,
+            timeout=timeout, amq_workload_yaml=amq_workload_yaml, run_in_bg=run_in_bg
+        )
+
+        return amq, result
+
+    def finalizer():
+        """
+        Clean up
+
+        """
+
+        # Clean up
+        amq.cleanup()
+
+    request.addfinalizer(finalizer)
+    return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2612,13 +2612,13 @@ def amq_factory_fixture(request):
         )
 
         # Run amq benchmark
-        result = amq.run_amq_benchmark(
+        result, queue = amq.run_amq_benchmark(
             benchmark_pod_name=benchmark_pod_name, kafka_namespace=kafka_namespace,
             tiller_namespace=tiller_namespace, num_of_clients=num_of_clients, worker=worker,
             timeout=timeout, amq_workload_yaml=amq_workload_yaml, run_in_bg=run_in_bg
         )
 
-        return amq, result
+        return amq, result, queue
 
     def finalizer():
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2625,7 +2625,6 @@ def amq_factory_fixture(request):
         Clean up
 
         """
-
         # Clean up
         amq.cleanup()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2612,13 +2612,13 @@ def amq_factory_fixture(request):
         )
 
         # Run amq benchmark
-        result, queue = amq.run_amq_benchmark(
+        result = amq.run_amq_benchmark(
             benchmark_pod_name=benchmark_pod_name, kafka_namespace=kafka_namespace,
             tiller_namespace=tiller_namespace, num_of_clients=num_of_clients, worker=worker,
             timeout=timeout, amq_workload_yaml=amq_workload_yaml, run_in_bg=run_in_bg
         )
 
-        return amq, result, queue
+        return amq, result
 
     def finalizer():
         """

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -9,26 +9,36 @@ from tests.helpers import default_storage_class
 from tests.disruption_helpers import Disruptions
 from ocs_ci.utility import templating
 from ocs_ci.ocs.resources.pod import get_all_pods
-
+from ocs_ci.ocs.utils import get_pod_name_by_pattern
+from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
 
 
-def respin_amq_app_pod(kafka_namespace):
+def respin_amq_app_pod(kafka_namespace, pod_pattern):
     """
     Respin amq pod
 
     Args:
         kafka_namespace (str): Namespace for kafka
+        pod_pattern (str): The pattern for the pod
 
     """
-    pod = ocp.OCP(kind=constants.POD, namespace=kafka_namespace)
+    pod_obj = ocp.OCP(kind=constants.POD, namespace=kafka_namespace)
     pod_obj_list = get_all_pods(namespace=kafka_namespace)
-    for pod_obj in pod_obj_list:
-        pod_obj.delete()
-        assert pod.wait_for_resource(
-            condition='Running', resource_count=len(pod_obj_list), timeout=300
-        )
+    for pod in TimeoutSampler(
+        300, 10, get_pod_name_by_pattern, pod_pattern, kafka_namespace
+    ):
+        try:
+            if pod is not None:
+                pod_obj.delete(resource_name=pod[0])
+                assert pod_obj.wait_for_resource(
+                    condition='Running', resource_count=len(pod_obj_list), timeout=300
+                )
+                break
+        except IndexError as ie:
+            log.error(" pod doesn't exist")
+            raise ie
 
 
 @ignore_leftovers
@@ -48,9 +58,9 @@ class TestAMQPodRespin(E2ETest):
         """
         sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
         self.amq_workload_dict = templating.load_yaml(constants.AMQ_SIMPLE_WORKLOAD_YAML)
-        self.amq, self.result = amq_factory_fixture(
+        self.amq, self.thread = amq_factory_fixture(
             sc_name=sc_name.name, tiller_namespace="tiller",
-            amq_workload_yaml=self.amq_workload_dict, run_in_bg=False
+            amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
         )
 
     @pytest.mark.parametrize(
@@ -90,7 +100,14 @@ class TestAMQPodRespin(E2ETest):
         """
         # Respin relevant pod
         if pod_name == 'amq':
-            respin_amq_app_pod(kafka_namespace=constants.AMQ_NAMESPACE)
+            pod_pattern_list = [
+                "cluster-operator", "my-cluster-kafka",
+                "my-cluster-zookeeper", "my-connect-cluster-connect",
+                "my-bridge-bridge"]
+            for pod_pattern in pod_pattern_list:
+                respin_amq_app_pod(
+                    kafka_namespace=constants.AMQ_NAMESPACE, pod_pattern=pod_pattern
+                )
         else:
             log.info(f"Respin Ceph pod {pod_name}")
             disruption = Disruptions()
@@ -99,8 +116,10 @@ class TestAMQPodRespin(E2ETest):
 
         # Validate and collect the results
         log.info("Validate amq benchmark is run completely")
+        result = self.thread.result(timeout=1800)
+        log.info(result)
         assert self.amq.validate_amq_benchmark(
-            result=self.result, amq_workload_yaml=self.amq_workload_dict
+            result=result, amq_workload_yaml=self.amq_workload_dict
         ) is not None, (
             "Benchmark did not completely run or might failed in between"
         )

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -99,7 +99,7 @@ class TestAMQPodRespin(E2ETest):
 
         # Validate and collect the results
         log.info("Wait till amq benchmark run complete")
-        self.thread.join()
+        self.thread.join(timeout=3600)
         result = self.queue.get()
         log.info("Validate amq benchmark is run completely")
         assert self.amq.validate_amq_benchmark(

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -48,7 +48,7 @@ class TestAMQPodRespin(E2ETest):
         """
         sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
         self.amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
-        self.amq, self.proc = amq_factory_fixture(
+        self.amq, self.thread = amq_factory_fixture(
             sc_name=sc_name.name, tiller_namespace="tiller",
             amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
         )

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -47,8 +47,8 @@ class TestAMQPodRespin(E2ETest):
 
         """
         sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
-        self.amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
-        self.amq, self.thread, self.queue = amq_factory_fixture(
+        self.amq_workload_dict = templating.load_yaml(constants.AMQ_SIMPLE_WORKLOAD_YAML)
+        self.amq, self.thread = amq_factory_fixture(
             sc_name=sc_name.name, tiller_namespace="tiller",
             amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
         )
@@ -99,8 +99,7 @@ class TestAMQPodRespin(E2ETest):
 
         # Validate and collect the results
         log.info("Wait till amq benchmark run complete")
-        self.thread.join(timeout=3600)
-        result = self.queue.get()
+        result = self.thread.result(timeout=1800)
         log.info("Validate amq benchmark is run completely")
         assert self.amq.validate_amq_benchmark(
             result=result, amq_workload_yaml=self.amq_workload_dict

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -48,9 +48,9 @@ class TestAMQPodRespin(E2ETest):
         """
         sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
         self.amq_workload_dict = templating.load_yaml(constants.AMQ_SIMPLE_WORKLOAD_YAML)
-        self.amq, self.thread = amq_factory_fixture(
+        self.amq, self.result = amq_factory_fixture(
             sc_name=sc_name.name, tiller_namespace="tiller",
-            amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
+            amq_workload_yaml=self.amq_workload_dict, run_in_bg=False
         )
 
     @pytest.mark.parametrize(
@@ -98,11 +98,9 @@ class TestAMQPodRespin(E2ETest):
             disruption.delete_resource()
 
         # Validate and collect the results
-        log.info("Wait till amq benchmark run complete")
-        result = self.thread.result(timeout=1800)
         log.info("Validate amq benchmark is run completely")
         assert self.amq.validate_amq_benchmark(
-            result=result, amq_workload_yaml=self.amq_workload_dict
+            result=self.result, amq_workload_yaml=self.amq_workload_dict
         ) is not None, (
             "Benchmark did not completely run or might failed in between"
         )

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -1,0 +1,108 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.framework.testlib import (
+    E2ETest, workloads, ignore_leftovers
+)
+from tests.helpers import default_storage_class
+from tests.disruption_helpers import Disruptions
+from ocs_ci.utility import templating
+from ocs_ci.ocs.resources.pod import get_all_pods
+
+
+log = logging.getLogger(__name__)
+
+
+def respin_amq_app_pod(kafka_namespace):
+    """
+    Respin amq pod
+
+    Args:
+        kafka_namespace (str): Namespace for kafka
+
+    """
+    pod = ocp.OCP(kind=constants.POD, namespace=kafka_namespace)
+    pod_obj_list = get_all_pods(namespace=kafka_namespace)
+    for pod_obj in pod_obj_list:
+        pod_obj.delete(force=True)
+        assert pod.wait_for_resource(
+            resource_name=pod_obj.name, condition='Running', timeout=300
+        )
+
+
+@ignore_leftovers
+@workloads
+class TestAMQPodRespin(E2ETest):
+    """
+    Test running open messages on amq cluster when backed by rbd
+    and with Ceph pods respin,  amq pod respin
+
+    """
+
+    @pytest.fixture()
+    def amq_setup(self, amq_factory_fixture):
+        """
+        Creates amq cluster and run benchmarks
+
+        """
+        sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
+        self.amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
+        self.amq, self.proc = amq_factory_fixture(
+            sc_name=sc_name.name, tiller_namespace="tiller",
+            amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
+        )
+
+    @pytest.mark.parametrize(
+        argnames=[
+            "pod_name"
+        ],
+        argvalues=[
+            pytest.param(
+                *['osd'], marks=pytest.mark.polarion_id("OCS-1276")
+            ),
+            pytest.param(
+                *['mon'], marks=pytest.mark.polarion_id("OCS-1275")
+            ),
+            pytest.param(
+                *['mgr'], marks=pytest.mark.polarion_id("OCS-2222")
+            ),
+            pytest.param(
+                *['rbdplugin'], marks=pytest.mark.polarion_id("OCS-1277")
+            ),
+            pytest.param(
+                *['rbdplugin_provisioner'], marks=pytest.mark.polarion_id("OCS-1283")
+            ),
+            pytest.param(
+                *['operator'], marks=pytest.mark.polarion_id("OCS-2223")
+            ),
+            pytest.param(
+                *['kafka'], marks=pytest.mark.polarion_id("OCS-1280")
+            )
+        ]
+    )
+    @pytest.mark.usefixtures(amq_setup.__name__)
+    def test_run_amq_respin_pod(self, pod_name):
+        """
+        Test amq workload when spinning ceph pods
+        and restarting amq pods
+
+        """
+        # Respin relevant pod
+        if pod_name == 'amq':
+            respin_amq_app_pod(kafka_namespace=constants.AMQ_NAMESPACE)
+        else:
+            log.info(f"Respin Ceph pod {pod_name}")
+            disruption = Disruptions()
+            disruption.set_resource(resource=f'{pod_name}')
+            disruption.delete_resource()
+
+        # Validate and collect the results
+        log.info("Wait till amq benchmark run complete")
+        result = self.thread.result()
+        log.info("Validate amq benchmark is run completely")
+        assert self.amq.validate_amq_benchmark(
+            result=result, amq_workload_yaml=self.amq_workload_yaml
+        ) is not None, (
+            "Benchmark did not completely run or might failed in between"
+        )

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -48,7 +48,7 @@ class TestAMQPodRespin(E2ETest):
         """
         sc_name = default_storage_class(interface_type=constants.CEPHBLOCKPOOL)
         self.amq_workload_dict = templating.load_yaml(constants.AMQ_WORKLOAD_YAML)
-        self.amq, self.thread = amq_factory_fixture(
+        self.amq, self.thread, self.queue = amq_factory_fixture(
             sc_name=sc_name.name, tiller_namespace="tiller",
             amq_workload_yaml=self.amq_workload_dict, run_in_bg=True
         )
@@ -99,10 +99,11 @@ class TestAMQPodRespin(E2ETest):
 
         # Validate and collect the results
         log.info("Wait till amq benchmark run complete")
-        result = self.thread.result()
+        self.thread.join()
+        result = self.queue.get()
         log.info("Validate amq benchmark is run completely")
         assert self.amq.validate_amq_benchmark(
-            result=result, amq_workload_yaml=self.amq_workload_yaml
+            result=result, amq_workload_yaml=self.amq_workload_dict
         ) is not None, (
             "Benchmark did not completely run or might failed in between"
         )

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.testlib import (
 from tests.helpers import default_storage_class
 from tests.disruption_helpers import Disruptions
 from ocs_ci.utility import templating
-from ocs_ci.ocs.resources.pod import get_all_pods, delete_pods
+from ocs_ci.ocs.resources.pod import get_all_pods
 
 
 log = logging.getLogger(__name__)
@@ -24,10 +24,11 @@ def respin_amq_app_pod(kafka_namespace):
     """
     pod = ocp.OCP(kind=constants.POD, namespace=kafka_namespace)
     pod_obj_list = get_all_pods(namespace=kafka_namespace)
-    delete_pods(pod_obj_list)
-    assert pod.wait_for_resource(
-        condition='Running', resource_count=len(pod_obj_list), timeout=300
-    )
+    for pod_obj in pod_obj_list:
+        pod_obj.delete()
+        assert pod.wait_for_resource(
+            condition='Running', resource_count=len(pod_obj_list), timeout=300
+        )
 
 
 @ignore_leftovers

--- a/tests/e2e/workloads/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/amq/test_amq_pod_respin.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.testlib import (
 from tests.helpers import default_storage_class
 from tests.disruption_helpers import Disruptions
 from ocs_ci.utility import templating
-from ocs_ci.ocs.resources.pod import get_all_pods
+from ocs_ci.ocs.resources.pod import get_all_pods, delete_pods
 
 
 log = logging.getLogger(__name__)
@@ -24,11 +24,10 @@ def respin_amq_app_pod(kafka_namespace):
     """
     pod = ocp.OCP(kind=constants.POD, namespace=kafka_namespace)
     pod_obj_list = get_all_pods(namespace=kafka_namespace)
-    for pod_obj in pod_obj_list:
-        pod_obj.delete(force=True)
-        assert pod.wait_for_resource(
-            resource_name=pod_obj.name, condition='Running', timeout=300
-        )
+    delete_pods(pod_obj_list)
+    assert pod.wait_for_resource(
+        condition='Running', resource_count=len(pod_obj_list), timeout=300
+    )
 
 
 @ignore_leftovers
@@ -77,7 +76,7 @@ class TestAMQPodRespin(E2ETest):
                 *['operator'], marks=pytest.mark.polarion_id("OCS-2223")
             ),
             pytest.param(
-                *['kafka'], marks=pytest.mark.polarion_id("OCS-1280")
+                *['amq'], marks=pytest.mark.polarion_id("OCS-1280")
             )
         ]
     )


### PR DESCRIPTION
- Created fixture for running amq workload
- AMQ workload test cases : spinning ceph pods and restarting amq pods

Signed-off-by: Akarsha <akrai@redhat.com>