### PR TITLE
smallfile | Integrate Internal ElasticSearch

### DIFF
--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -554,8 +554,8 @@ class TestSmallFileWorkload(E2ETest):
         # Getting the OCS version
         (ocs_ver_info, _) = get_ocs_version()
         ocs_ver_full = ocs_ver_info['status']['desired']['version']
-        m = re.match(r"(\d.\d).(\d)-", ocs_ver_full)
-        if m.group(1) is not None:
+        m = re.match(r"(\d.\d).(\d)", ocs_ver_full)
+        if m and m.group(1) is not None:
             ocs_ver = m.group(1)
 
         full_results.add_key('ocs_version', ocs_ver)

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -510,7 +510,8 @@ class TestSmallFileWorkload(E2ETest):
 
         # wait for benchmark pods to get created - takes a while
         for bench_pod in TimeoutSampler(
-            240, 10, get_pod_name_by_pattern, 'smallfile-client', 'my-ripsaw'
+            240, 10, get_pod_name_by_pattern, 'smallfile-client',
+            constants.RIPSAW_NAMESPACE
         ):
             try:
                 if bench_pod[0] is not None:
@@ -519,7 +520,7 @@ class TestSmallFileWorkload(E2ETest):
             except IndexError:
                 log.info("Bench pod not ready yet")
 
-        bench_pod = OCP(kind='pod', namespace='my-ripsaw')
+        bench_pod = OCP(kind='pod', namespace=constants.RIPSAW_NAMESPACE)
         log.info("Waiting for SmallFile benchmark to Run")
         assert bench_pod.wait_for_resource(
             condition=constants.STATUS_RUNNING,
@@ -594,8 +595,7 @@ class TestSmallFileWorkload(E2ETest):
                     test_status = full_results.aggregate_samples_results()
                     full_results.write()
 
-                    # Creating full link to the kibana on the elastic search
-                    # server with full test results.
+                    # Creating full link to the results on the ES server
                     res_link = 'http://'
                     res_link += f'{full_results.server}:{full_results.port}/'
                     res_link += f'{full_results.new_index}/_search?q='


### PR DESCRIPTION
This PR is replacing PR #2249
Re-factoring the test to use internal elasticsearch server to used by the ripsaw

and copy all data from the internal ES to the Main ES.

	# Importing the ocs.elasticsearch module, and creating elasticsearch fixture
	  that will deploy elasticsearch as part of the test.
	# Saving the es info and replace with internal es info
	  in the end of the test, setting it back
	# Adding -- to rsh command to prevent deprecation
	# Adding copy function that copy all data from Internal to external ES
	# Changing the deviation percentage from 5 to 20
	# Adding warning message about the port forwarding
	# Show the results link at the end of the test

Signed-off-by: Avi Liani <alayani@redhat.com>