### PR TITLE
Test case:Verify PVC expansion during rook-ceph, csi pod re-spin

### DIFF
--- a/tests/manage/pv_services/conftest.py
+++ b/tests/manage/pv_services/conftest.py
@@ -1,0 +1,115 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources import pod
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def create_pvcs_and_pods(
+    multi_pvc_factory, pod_factory, service_account_factory
+):
+    """
+    Create rbd, cephfs PVCs and dc pods. To be used for test cases which need
+    rbd and cephfs PVCs with different access modes.
+
+    """
+    def factory(
+        pvc_size=3,
+        access_modes_rbd=None,
+        access_modes_cephfs=None,
+        num_of_rbd_pvc=None,
+        num_of_cephfs_pvc=None
+    ):
+        """
+        Args:
+            pvc_size (int): The requested size for the PVC in GB
+            access_modes_rbd (list): List of access modes. One of the
+                access modes will be chosen for creating each PVC. To specify
+                volume mode, append volume mode in the access mode name
+                separated by '-'. Default is set as
+                ['ReadWriteOnce', 'ReadWriteOnce-Block', 'ReadWriteMany-Block']
+            access_modes_cephfs (list): List of access modes.
+                One of the access modes will be chosen for creating each PVC.
+                Default is set as ['ReadWriteOnce', 'ReadWriteMany']
+            num_of_rbd_pvc (int): Number of rbd PVCs to be created. Value
+                should be greater than or equal to the number of elements in
+                the list 'access_modes_rbd'
+            num_of_cephfs_pvc (int): Number of cephfs PVCs to be created.
+                Value should be greater than or equal to the number of
+                elements in the list 'access_modes_cephfs'
+        Returns:
+            list: OCS instance of pods
+        """
+
+        access_modes_rbd = access_modes_rbd or [
+            constants.ACCESS_MODE_RWO, f'{constants.ACCESS_MODE_RWO}-Block',
+            f'{constants.ACCESS_MODE_RWX}-Block'
+        ]
+
+        access_modes_cephfs = access_modes_cephfs or [
+            constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX
+        ]
+
+        num_of_rbd_pvc = num_of_rbd_pvc or len(access_modes_rbd)
+        num_of_cephfs_pvc = num_of_cephfs_pvc or len(access_modes_cephfs)
+
+        pvcs_rbd = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL, size=pvc_size,
+            access_modes=access_modes_rbd,
+            status=constants.STATUS_BOUND, num_of_pvc=num_of_rbd_pvc,
+            timeout=180
+        )
+
+        project = pvcs_rbd[0].project
+
+        pvcs_cephfs = multi_pvc_factory(
+            interface=constants.CEPHFILESYSTEM, project=project,
+            size=pvc_size, access_modes=access_modes_cephfs,
+            status=constants.STATUS_BOUND, num_of_pvc=num_of_cephfs_pvc,
+            timeout=180
+        )
+        pvcs = pvcs_cephfs + pvcs_rbd
+
+        # Set volume mode on PVC objects
+        for pvc_obj in pvcs:
+            pvc_info = pvc_obj.get()
+            setattr(pvc_obj, 'volume_mode', pvc_info['spec']['volumeMode'])
+
+        sa_obj = service_account_factory(project=project)
+
+        pods_dc = []
+        for pvc_obj in pvcs:
+            if constants.CEPHFS_INTERFACE in pvc_obj.storageclass.name:
+                interface = constants.CEPHFILESYSTEM
+            else:
+                interface = constants.CEPHBLOCKPOOL
+            # Create pods. Create 2 pods if PVC access mode is RWX
+            pod_dc_objs = [
+                pod_factory(
+                    interface=interface, pvc=pvc_obj,
+                    pod_dict_path=constants.FEDORA_DC_YAML,
+                    raw_block_pv=pvc_obj.volume_mode == 'Block',
+                    deployment_config=True, service_account=sa_obj,
+                ) for _ in range(
+                    int(pvc_obj.access_mode != constants.ACCESS_MODE_RWX), 2
+                )
+            ]
+            pods_dc.extend(pod_dc_objs)
+
+        pods = []
+        for pod_dc in pods_dc:
+            pods.extend(pod.get_all_pods(
+                namespace=project.namespace, selector=[pod_dc.name],
+                selector_label='name'
+            ))
+
+        log.info(
+            f"Created {len(pvcs_cephfs)} cephfs PVCs and {len(pvcs_rbd)} rbd "
+            f"PVCs. Created {len(pods)} pods. "
+        )
+        return pvcs, pods
+
+    return factory

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -46,66 +46,12 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
 
     """
     @pytest.fixture(autouse=True)
-    def setup(
-        self, multi_pvc_factory, dc_pod_factory, service_account_factory
-    ):
+    def setup(self, create_pvcs_and_pods):
         """
         Create PVCs and pods
 
         """
-        pvc_size = 10
-        access_modes_cephfs = [
-            constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX
-        ]
-        access_modes_rbd = [
-            constants.ACCESS_MODE_RWO, f'{constants.ACCESS_MODE_RWO}-Block',
-            f'{constants.ACCESS_MODE_RWX}-Block'
-        ]
-
-        pvcs_cephfs = multi_pvc_factory(
-            interface=constants.CEPHFILESYSTEM, size=pvc_size,
-            access_modes=access_modes_cephfs, status=constants.STATUS_BOUND,
-            num_of_pvc=2, timeout=90
-        )
-
-        pvcs_rbd = multi_pvc_factory(
-            interface=constants.CEPHBLOCKPOOL,
-            project=pvcs_cephfs[0].project, size=pvc_size,
-            access_modes=access_modes_rbd,
-            status=constants.STATUS_BOUND, num_of_pvc=3, timeout=90
-        )
-        self.pvcs = pvcs_cephfs + pvcs_rbd
-
-        # Set volume mode on PVC objects
-        for pvc_obj in self.pvcs:
-            pvc_info = pvc_obj.get()
-            setattr(pvc_obj, 'volume_mode', pvc_info['spec']['volumeMode'])
-
-        sa_obj = service_account_factory(project=pvcs_cephfs[0].project)
-
-        self.pods = []
-        for pvc_obj in self.pvcs:
-            if constants.CEPHFS_INTERFACE in pvc_obj.storageclass.name:
-                interface = constants.CEPHFILESYSTEM
-            else:
-                interface = constants.CEPHBLOCKPOOL
-            # Create pods. Create 2 pods if PVC access mode is RWX
-            pod_objs = [
-                dc_pod_factory(
-                    interface=interface,
-                    pvc=pvc_obj,
-                    raw_block_pv=pvc_obj.volume_mode == 'Block',
-                    sa_obj=sa_obj
-                ) for _ in range(
-                    int(pvc_obj.access_mode != constants.ACCESS_MODE_RWX), 2
-                )
-            ]
-            self.pods.extend(pod_objs)
-
-        log.info(
-            f"Created {len(pvcs_cephfs)} cephfs PVCs and {len(pvcs_rbd)} rbd "
-            f"PVCs. Created {len(self.pods)} pods. "
-        )
+        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=10)
 
     def test_resource_deletion_during_pvc_expansion(self, resource_to_delete):
         """

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -51,7 +51,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
         Create PVCs and pods
 
         """
-        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=10)
+        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=10, dc_for_rwx=2)
 
     def test_resource_deletion_during_pvc_expansion(self, resource_to_delete):
         """

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -1,0 +1,186 @@
+import logging
+import pytest
+from concurrent.futures import ThreadPoolExecutor
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version, ManageTest, tier4, tier4b, ignore_leftover_label
+)
+from tests import disruption_helpers
+
+log = logging.getLogger(__name__)
+
+
+@tier4
+@tier4b
+@skipif_ocs_version('<4.5')
+@ignore_leftover_label(constants.drain_canary_pod_label)
+@pytest.mark.parametrize(
+    argnames='resource_to_delete',
+    argvalues=[
+        pytest.param(
+            'mgr', marks=pytest.mark.polarion_id('OCS-2224')
+        ),
+        pytest.param(
+            'osd', marks=pytest.mark.polarion_id('OCS-2225')
+        ),
+        pytest.param(
+            'rbdplugin', marks=pytest.mark.polarion_id('OCS-2226')
+        ),
+        pytest.param(
+            'cephfsplugin', marks=pytest.mark.polarion_id('OCS-2227')
+        ),
+        pytest.param(
+            'rbdplugin_provisioner', marks=pytest.mark.polarion_id('OCS-2228')
+        ),
+        pytest.param(
+            'cephfsplugin_provisioner',
+            marks=pytest.mark.polarion_id('OCS-2229')
+        )
+    ]
+)
+class TestResourceDeletionDuringPvcExpansion(ManageTest):
+    """
+    Tests to verify PVC expansion will be success even if rook-ceph, csi pods
+    are re-spun during the expansion
+
+    """
+    @pytest.fixture(autouse=True)
+    def setup(
+        self, multi_pvc_factory, dc_pod_factory, service_account_factory
+    ):
+        """
+        Create PVCs and pods
+
+        """
+        pvc_size = 10
+        access_modes_cephfs = [
+            constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX
+        ]
+        access_modes_rbd = [
+            constants.ACCESS_MODE_RWO, f'{constants.ACCESS_MODE_RWO}-Block',
+            f'{constants.ACCESS_MODE_RWX}-Block'
+        ]
+
+        pvcs_cephfs = multi_pvc_factory(
+            interface=constants.CEPHFILESYSTEM, size=pvc_size,
+            access_modes=access_modes_cephfs, status=constants.STATUS_BOUND,
+            num_of_pvc=2, timeout=90
+        )
+
+        pvcs_rbd = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            project=pvcs_cephfs[0].project, size=pvc_size,
+            access_modes=access_modes_rbd,
+            status=constants.STATUS_BOUND, num_of_pvc=3, timeout=90
+        )
+        self.pvcs = pvcs_cephfs + pvcs_rbd
+
+        # Set volume mode on PVC objects
+        for pvc_obj in self.pvcs:
+            pvc_info = pvc_obj.get()
+            setattr(pvc_obj, 'volume_mode', pvc_info['spec']['volumeMode'])
+
+        sa_obj = service_account_factory(project=pvcs_cephfs[0].project)
+
+        self.pods = []
+        for pvc_obj in self.pvcs:
+            if constants.CEPHFS_INTERFACE in pvc_obj.storageclass.name:
+                interface = constants.CEPHFILESYSTEM
+            else:
+                interface = constants.CEPHBLOCKPOOL
+            # Create pods. Create 2 pods if PVC access mode is RWX
+            pod_objs = [
+                dc_pod_factory(
+                    interface=interface,
+                    pvc=pvc_obj,
+                    raw_block_pv=pvc_obj.volume_mode == 'Block',
+                    sa_obj=sa_obj
+                ) for _ in range(
+                    int(pvc_obj.access_mode != constants.ACCESS_MODE_RWX), 2
+                )
+            ]
+            self.pods.extend(pod_objs)
+
+        log.info(
+            f"Created {len(pvcs_cephfs)} cephfs PVCs and {len(pvcs_rbd)} rbd "
+            f"PVCs. Created {len(self.pods)} pods. "
+        )
+
+    def test_resource_deletion_during_pvc_expansion(self, resource_to_delete):
+        """
+        Verify PVC expansion will succeed when rook-ceph, csi pods are re-spun
+        during expansion
+
+        """
+        pvc_size_expanded = 30
+        executor = ThreadPoolExecutor(max_workers=len(self.pvcs))
+        disruption_ops = disruption_helpers.Disruptions()
+
+        # Run IO to fill some data
+        log.info(
+            "Running IO on all pods to fill some data before PVC expansion."
+        )
+        for pod_obj in self.pods:
+            storage_type = (
+                'block' if pod_obj.pvc.volume_mode == 'Block' else 'fs'
+            )
+            pod_obj.run_io(
+                storage_type=storage_type, size='4G', io_direction='write',
+                runtime=30, fio_filename=f'{pod_obj.name}_f1'
+            )
+
+        log.info("Wait for IO to complete on pods")
+        for pod_obj in self.pods:
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get('jobs')[0].get('error')
+            assert err_count == 0, (
+                f"IO error on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )
+            log.info(f"Verified IO on pod {pod_obj.name}.")
+        log.info("IO is successful on all pods before PVC expansion.")
+
+        # Select the pod to be deleted
+        disruption_ops.set_resource(resource=resource_to_delete)
+
+        log.info("Expanding all PVCs.")
+        for pvc_obj in self.pvcs:
+            log.info(
+                f"Expanding size of PVC {pvc_obj.name} to {pvc_size_expanded}G"
+            )
+            pvc_obj.expand_proc = executor.submit(
+                pvc_obj.resize_pvc, pvc_size_expanded, True
+            )
+
+        # Delete the pod 'resource_to_delete'
+        disruption_ops.delete_resource()
+
+        # Verify pvc expand status
+        for pvc_obj in self.pvcs:
+            assert pvc_obj.expand_proc.result(), (
+                f"Expansion failed for PVC {pvc_obj.name}"
+            )
+        log.info("PVC expansion was successful on all PVCs")
+
+        # Run IO to fill some data
+        log.info("Write more data after PVC expansion.")
+        for pod_obj in self.pods:
+            storage_type = (
+                'block' if pod_obj.pvc.volume_mode == 'Block' else 'fs'
+            )
+            pod_obj.run_io(
+                storage_type=storage_type, size='10G', io_direction='write',
+                runtime=30, fio_filename=f'{pod_obj.name}_f2'
+            )
+
+        log.info("Wait for IO to complete on all pods")
+        for pod_obj in self.pods:
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get('jobs')[0].get('error')
+            assert err_count == 0, (
+                f"IO error on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )
+            log.info(f"Verified IO on pod {pod_obj.name}.")
+        log.info("IO is successful on all pods after PVC expansion.")

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -75,7 +75,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             )
             pod_obj.run_io(
                 storage_type=storage_type, size='4G', io_direction='write',
-                runtime=30, rate='100M', fio_filename=f'{pod_obj.name}_f1'
+                runtime=30, rate='10M', fio_filename=f'{pod_obj.name}_f1'
             )
 
         log.info("Wait for IO to complete on pods")
@@ -119,7 +119,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             )
             pod_obj.run_io(
                 storage_type=storage_type, size='10G', io_direction='write',
-                runtime=30, rate='100M', fio_filename=f'{pod_obj.name}_f2'
+                runtime=30, rate='10M', fio_filename=f'{pod_obj.name}_f2'
             )
 
         log.info("Wait for IO to complete on all pods")

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -73,7 +73,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             )
             pod_obj.run_io(
                 storage_type=storage_type, size='4G', io_direction='write',
-                runtime=30, fio_filename=f'{pod_obj.name}_f1'
+                runtime=30, rate='100M', fio_filename=f'{pod_obj.name}_f1'
             )
 
         log.info("Wait for IO to complete on pods")
@@ -109,7 +109,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             )
         log.info("PVC expansion was successful on all PVCs")
 
-        # Run IO to fill some data
+        # Run IO to fill more data
         log.info("Write more data after PVC expansion.")
         for pod_obj in self.pods:
             storage_type = (
@@ -117,7 +117,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             )
             pod_obj.run_io(
                 storage_type=storage_type, size='10G', io_direction='write',
-                runtime=30, fio_filename=f'{pod_obj.name}_f2'
+                runtime=30, rate='100M', fio_filename=f'{pod_obj.name}_f2'
             )
 
         log.info("Wait for IO to complete on all pods")

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -51,7 +51,9 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
         Create PVCs and pods
 
         """
-        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=10, dc_for_rwx=2)
+        self.pvcs, self.pods = create_pvcs_and_pods(
+            pvc_size=10, pods_for_rwx=2
+        )
 
     def test_resource_deletion_during_pvc_expansion(self, resource_to_delete):
         """


### PR DESCRIPTION
Test cases to verify PVC expansion will succeed when rook-ceph, csi pods are re-spun during expansion

OCS-2224 - FT-PvcExpand-Delete MGR pod while expanding PVC
OCS-2225 - FT-PvcExpand-Delete OSD pod while expanding PVC
OCS-2226 - FT-PvcExpand-Delete rbdplugin pod while expanding PVC
OCS-2227 - FT-PvcExpand-Delete cephfsplugin pod while expanding PVC
OCS-2228 - FT-PvcExpand-Delete rbdplugin-provisioner leader pod while expanding PVC
OCS-2229 - FT-PvcExpand-Delete cephfsplugin-provisioner leader pod while expanding PVC

Signed-off-by: Jilju Joy <jijoy@redhat.com>