### PR TITLE
Tier4a ocs upgrade

### DIFF
--- a/ocs_ci/ocs/disruptive_operations.py
+++ b/ocs_ci/ocs/disruptive_operations.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 from ocs_ci.ocs.node import get_typed_nodes, get_node_name
-from ocs_ci.ocs.resources.pod import (get_ocs_operator_pod, get_pod_node)
+from ocs_ci.ocs.resources.pod import get_ocs_operator_pod, get_pod_node
 from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
 from tests.helpers import wait_for_ct_pod_recovery
 

--- a/ocs_ci/ocs/disruptive_operations.py
+++ b/ocs_ci/ocs/disruptive_operations.py
@@ -29,7 +29,10 @@ def worker_node_shutdown(abrupt):
     Shutdown worker node that running ocs-operator pod
 
     Args:
-        abrupt: bool: True if abrupt shutdown, False for permanent shutdown
+        abrupt: (bool): True if abrupt shutdown, False for permanent shutdown
+
+    Raises:
+        AssertionError: in case the ceph-tools pod was not recovered
 
     """
 

--- a/ocs_ci/ocs/disruptive_operations.py
+++ b/ocs_ci/ocs/disruptive_operations.py
@@ -1,0 +1,59 @@
+import logging
+import time
+
+from ocs_ci.ocs.node import get_typed_nodes, get_node_name
+from ocs_ci.ocs.resources.pod import (get_ocs_operator_pod, get_pod_node)
+from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
+from tests.helpers import wait_for_ct_pod_recovery
+
+log = logging.getLogger(__name__)
+
+
+def get_ocs_operator_node_name():
+    """
+    Getting node's name that running ocs-operator pod
+
+    Returns:
+        str: node's name that running ocs-operator pod
+
+    """
+    ocs_operator_pod = get_ocs_operator_pod()
+    log.debug(f"ocs operator pod info: {ocs_operator_pod}")
+    ocs_operator_node = get_pod_node(ocs_operator_pod)
+
+    return get_node_name(ocs_operator_node)
+
+
+def worker_node_shutdown(abrupt):
+    """
+    Shutdown worker node that running ocs-operator pod
+
+    Args:
+        abrupt: bool: True if abrupt shutdown, False for permanent shutdown
+
+    """
+
+    nodes = PlatformNodesFactory().get_nodes_platform()
+    log.info(f"Abrupt {abrupt}")
+    # get ocs-operator node:
+    ocs_operator_node_name = get_ocs_operator_node_name()
+
+    # get workers node objects:
+    node_to_shutdown = list()
+    for node in get_typed_nodes():
+        node_name = get_node_name(node)
+        log.info(f"node: {node_name}, ocs operator node: {ocs_operator_node_name}")
+        if node_name == ocs_operator_node_name:
+            node_to_shutdown.append(node)
+            log.info(f"node to shutdown: {get_node_name(node_to_shutdown[0])}")
+            nodes.stop_nodes(node_to_shutdown)
+            log.info("stop instance - done!")
+            break
+
+    log.info("Sleeping 5 minutes")
+    time.sleep(320)
+    assert wait_for_ct_pod_recovery(), "Ceph tools pod failed to come up on another node"
+    if abrupt:
+        log.info("Abrupt Shutdown")
+        if node_to_shutdown:
+            nodes.start_nodes(nodes=node_to_shutdown)

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -3,30 +3,33 @@ import logging
 from copy import deepcopy
 from pkg_resources import parse_version
 from tempfile import NamedTemporaryFile
+import time
 
-from ocs_ci.deployment.deployment import create_catalog_source
 from ocs_ci.framework import config
+from ocs_ci.deployment.deployment import create_catalog_source
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
 from ocs_ci.ocs.defaults import OCS_OPERATOR_NAME
-from ocs_ci.ocs.node import get_typed_nodes
 from ocs_ci.ocs.ocp import get_images, OCP
+from ocs_ci.ocs.node import get_typed_nodes
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.csv import CSV
 from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
 from ocs_ci.ocs.resources.pod import verify_pods_upgraded
 from ocs_ci.ocs.resources.packagemanifest import (
-    get_selector_for_ocs_operator,
-    PackageManifest,
+    get_selector_for_ocs_operator, PackageManifest,
 )
-from ocs_ci.ocs.resources.storage_cluster import get_osd_count
+from ocs_ci.ocs.resources.storage_cluster import (
+    get_osd_count, ocs_install_verification,
+)
 from ocs_ci.ocs.utils import setup_ceph_toolbox
 from ocs_ci.utility.utils import (
-    get_latest_ds_olm_tag,
-    get_next_version_available_for_upgrade,
-    get_ocs_version_from_image,
-    load_config_file,
+    get_latest_ds_olm_tag, get_next_version_available_for_upgrade,
+    get_ocs_version_from_image, load_config_file, TimeoutSampler,
 )
 from ocs_ci.utility.templating import dump_data_to_temp_yaml
+from ocs_ci.ocs.exceptions import TimeoutException
+
 
 log = logging.getLogger(__name__)
 
@@ -357,9 +360,6 @@ class OCSUpgrade(object):
         """
         Set images for upgrade
 
-        Args:
-            upgrade_version: (str): version to be upgraded
-
         """
         ocs_catalog = CatalogSource(
             resource_name=constants.OPERATOR_CATALOG_SOURCE_NAME,
@@ -392,3 +392,65 @@ class OCSUpgrade(object):
             with NamedTemporaryFile() as cs_yaml:
                 dump_data_to_temp_yaml(cs_data, cs_yaml.name)
                 ocs_catalog.apply(cs_yaml.name)
+
+
+def run_ocs_upgrade(operation=None, *operation_args, **operation_kwargs):
+    """
+    Run upgrade procedure of OCS cluster
+
+    Args:
+        operation: (function): Function to run
+        operation_args: (iterable): Function's arguments
+        operation_kwargs: (map): Function's keyword arguments
+
+    """
+
+    ceph_cluster = CephCluster()
+    upgrade_ocs = OCSUpgrade(
+        namespace=config.ENV_DATA['cluster_namespace'],
+        version_before_upgrade=config.ENV_DATA.get("ocs_version"),
+        ocs_registry_image=config.UPGRADE.get('upgrade_ocs_registry_image'),
+        upgrade_in_current_source=config.UPGRADE.get('upgrade_in_current_source', False)
+    )
+    upgrade_version = upgrade_ocs.get_upgrade_version()
+    assert upgrade_ocs.get_parsed_versions()[1] >= upgrade_ocs.get_parsed_versions()[0], (
+        f"Version you would like to upgrade to: {upgrade_version} "
+        f"is not higher or equal to the version you currently running: "
+        f"{upgrade_ocs.version_before_upgrade}"
+    )
+    csv_name_pre_upgrade = upgrade_ocs.get_csv_name_pre_upgrade()
+    pre_upgrade_images = upgrade_ocs.get_pre_upgrade_image(csv_name_pre_upgrade)
+    upgrade_ocs.load_version_config_file(upgrade_version)
+    with CephHealthMonitor(ceph_cluster):
+        channel = upgrade_ocs.set_upgrade_channel()
+        upgrade_ocs.set_upgrade_images()
+        upgrade_ocs.update_subscription(channel)
+        if operation:
+            log.info(f"Calling test function: {operation}")
+            _ = _ = operation(*operation_args, **operation_kwargs)
+            # Workaround for issue #2531
+            time.sleep(30)
+            # End of workaround
+
+        for sample in TimeoutSampler(
+            timeout=725,
+            sleep=5,
+            func=upgrade_ocs.check_if_upgrade_completed,
+            channel=channel,
+            csv_name_pre_upgrade=csv_name_pre_upgrade,
+        ):
+            try:
+                if sample:
+                    log.info("Upgrade success!")
+                    break
+            except TimeoutException:
+                raise TimeoutException("No new CSV found after upgrade!")
+        old_image = upgrade_ocs.get_images_post_upgrade(
+            channel, pre_upgrade_images, upgrade_version
+        )
+    verify_image_versions(old_image, upgrade_ocs.get_parsed_versions()[1])
+    ocs_install_verification(
+        timeout=600, skip_osd_distribution_check=True,
+        ocs_registry_image=upgrade_ocs.ocs_registry_image,
+        post_upgrade_verification=True,
+    )

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -427,7 +427,7 @@ def run_ocs_upgrade(operation=None, *operation_args, **operation_kwargs):
         upgrade_ocs.update_subscription(channel)
         if operation:
             log.info(f"Calling test function: {operation}")
-            _ = _ = operation(*operation_args, **operation_kwargs)
+            _ = operation(*operation_args, **operation_kwargs)
             # Workaround for issue #2531
             time.sleep(30)
             # End of workaround

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -517,6 +517,25 @@ def get_rgw_pods(rgw_label=constants.RGW_APP_LABEL, namespace=None):
     return [Pod(**rgw) for rgw in rgws]
 
 
+def get_ocs_operator_pod(ocs_label=constants.OCS_OPERATOR_LABEL, namespace=None):
+    """
+    Fetches info about rgw pods in the cluster
+
+    Args:
+        ocs_label (str): label associated with ocs_operator pod
+            (default: defaults.OCS_OPERATOR_LABEL)
+        namespace (str): Namespace in which ceph cluster lives
+            (default: none)
+
+    Returns:
+        Pod object: ocs_operator pod object
+    """
+    namespace = namespace or config.ENV_DATA['cluster_namespace']
+    ocs_operator = get_pods_having_label(ocs_label, namespace)
+    ocs_operator_pod = Pod(**ocs_operator[0])
+    return ocs_operator_pod
+
+
 def list_ceph_images(pool_name='rbd'):
     """
     Args:

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -10,6 +10,19 @@ from ocs_ci.ocs.ocs_upgrade import run_ocs_upgrade
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def teardown(request, nodes):
+
+    def finalizer():
+        """
+        Make sure all nodes are up again
+
+        """
+        nodes.restart_nodes_by_stop_and_start_teardown()
+
+    request.addfinalizer(finalizer)
+
+
 @pytest.mark.polarion_id("OCS-1579")
 def test_worker_node_abrupt_shutdown():
     """

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -1,19 +1,41 @@
 import logging
 
+import pytest
+
 from ocs_ci.framework.testlib import ocs_upgrade
-from ocs_ci.framework import config
-from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
-from ocs_ci.ocs.resources.storage_cluster import (
-    ocs_install_verification
-)
-from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.ocs.ocs_upgrade import (
-    verify_image_versions,
-    OCSUpgrade,
-)
-from ocs_ci.ocs.exceptions import TimeoutException
+from ocs_ci.ocs.disruptive_operations import worker_node_shutdown
+from ocs_ci.ocs.ocs_upgrade import run_ocs_upgrade
+
 
 log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    argnames=["operation"], argvalues=[
+        pytest.param(
+            worker_node_shutdown, marks=pytest.mark.polarion_id("OCS-1579")
+        ),
+    ]
+)
+def test_worker_node_abrupt_shutdown(operation):
+    log.info("Starting disruptive test function: "
+             "test_worker_node_abrupt_shutdown")
+    abrupt = True
+    run_ocs_upgrade(operation, abrupt)
+
+
+@pytest.mark.parametrize(
+    argnames=["operation"], argvalues=[
+        pytest.param(
+            worker_node_shutdown, marks=pytest.mark.polarion_id("OCS-1575")
+        ),
+    ]
+)
+def test_worker_node_permanent_shutdown(operation):
+    log.info("Starting disruptive test function:"
+             " test_worker_node_permanent_shutdown")
+    abrupt = False
+    run_ocs_upgrade(operation, abrupt)
 
 
 @ocs_upgrade
@@ -22,45 +44,5 @@ def test_upgrade():
     Tests upgrade procedure of OCS cluster
 
     """
-    ceph_cluster = CephCluster()
-    upgrade_ocs = OCSUpgrade(
-        namespace=config.ENV_DATA['cluster_namespace'],
-        version_before_upgrade=config.ENV_DATA.get("ocs_version"),
-        ocs_registry_image=config.UPGRADE.get('upgrade_ocs_registry_image'),
-        upgrade_in_current_source=config.UPGRADE.get('upgrade_in_current_source', False)
-    )
-    upgrade_version = upgrade_ocs.get_upgrade_version()
-    assert upgrade_ocs.get_parsed_versions()[1] >= upgrade_ocs.get_parsed_versions()[0], (
-        f"Version you would like to upgrade to: {upgrade_version} "
-        f"is not higher or equal to the version you currently running: "
-        f"{upgrade_ocs.version_before_upgrade}"
-    )
-    csv_name_pre_upgrade = upgrade_ocs.get_csv_name_pre_upgrade()
-    pre_upgrade_images = upgrade_ocs.get_pre_upgrade_image(csv_name_pre_upgrade)
-    upgrade_ocs.load_version_config_file(upgrade_version)
-    with CephHealthMonitor(ceph_cluster):
-        channel = upgrade_ocs.set_upgrade_channel()
-        upgrade_ocs.set_upgrade_images()
-        upgrade_ocs.update_subscription(channel)
-        for sample in TimeoutSampler(
-            timeout=725,
-            sleep=5,
-            func=upgrade_ocs.check_if_upgrade_completed,
-            channel=channel,
-            csv_name_pre_upgrade=csv_name_pre_upgrade,
-        ):
-            try:
-                if sample:
-                    log.info("Upgrade success!")
-                    break
-            except TimeoutException:
-                raise TimeoutException("No new CSV found after upgrade!")
-        old_image = upgrade_ocs.get_images_post_upgrade(
-            channel, pre_upgrade_images, upgrade_version
-        )
-    verify_image_versions(old_image, upgrade_ocs.get_parsed_versions()[1])
-    ocs_install_verification(
-        timeout=600, skip_osd_distribution_check=True,
-        ocs_registry_image=upgrade_ocs.ocs_registry_image,
-        post_upgrade_verification=True,
-    )
+
+    run_ocs_upgrade()

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -10,7 +10,7 @@ from ocs_ci.ocs.ocs_upgrade import run_ocs_upgrade
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def teardown(request, nodes):
 
     def finalizer():
@@ -24,7 +24,7 @@ def teardown(request, nodes):
 
 
 @pytest.mark.polarion_id("OCS-1579")
-def test_worker_node_abrupt_shutdown():
+def test_worker_node_abrupt_shutdown(teardown):
     """
     Test OCS upgrade with disruption of shutting down worker node,
     for 5.5 minutes
@@ -37,7 +37,7 @@ def test_worker_node_abrupt_shutdown():
 
 
 @pytest.mark.polarion_id("OCS-1575")
-def test_worker_node_permanent_shutdown():
+def test_worker_node_permanent_shutdown(teardown):
     """
     Test OCS upgrade with disruption of shutting down worker node
 

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -13,10 +13,10 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1579")
 def test_worker_node_abrupt_shutdown():
     """
-        Test OCS upgrade with disruption of shutting down worker node,
-        for 5.5 minutes
+    Test OCS upgrade with disruption of shutting down worker node,
+    for 5.5 minutes
 
-        """
+    """
     log.info(
         "Starting disruptive function: test_worker_node_abrupt_shutdown"
     )

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -10,32 +10,29 @@ from ocs_ci.ocs.ocs_upgrade import run_ocs_upgrade
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    argnames=["operation"], argvalues=[
-        pytest.param(
-            worker_node_shutdown, marks=pytest.mark.polarion_id("OCS-1579")
-        ),
-    ]
-)
-def test_worker_node_abrupt_shutdown(operation):
-    log.info("Starting disruptive test function: "
-             "test_worker_node_abrupt_shutdown")
-    abrupt = True
-    run_ocs_upgrade(operation, abrupt)
+@pytest.mark.polarion_id("OCS-1579")
+def test_worker_node_abrupt_shutdown():
+    """
+        Test OCS upgrade with disruption of shutting down worker node,
+        for 5.5 minutes
+
+        """
+    log.info(
+        "Starting disruptive function: test_worker_node_abrupt_shutdown"
+    )
+    run_ocs_upgrade(operation=worker_node_shutdown, abrupt=True)
 
 
-@pytest.mark.parametrize(
-    argnames=["operation"], argvalues=[
-        pytest.param(
-            worker_node_shutdown, marks=pytest.mark.polarion_id("OCS-1575")
-        ),
-    ]
-)
-def test_worker_node_permanent_shutdown(operation):
-    log.info("Starting disruptive test function:"
-             " test_worker_node_permanent_shutdown")
-    abrupt = False
-    run_ocs_upgrade(operation, abrupt)
+@pytest.mark.polarion_id("OCS-1575")
+def test_worker_node_permanent_shutdown():
+    """
+    Test OCS upgrade with disruption of shutting down worker node
+
+    """
+    log.info(
+        "Starting disruptive function: test_worker_node_permanent_shutdown"
+    )
+    run_ocs_upgrade(operation=worker_node_shutdown, abrupt=False)
 
 
 @ocs_upgrade


### PR DESCRIPTION
- moved test_ocs_upgrade code to helper file
- added dictionary with tier4 tests and arguments
- create class for tier4 tests with worker_node_shutdown function
- added 2 test function: worker node shutdown - abrupt and permanent
- some minor fixes 