### PR TITLE
Fix return code mismatch for unit tests running on OSX

### DIFF
--- a/ocs_ci/utility/tests/test_utils.py
+++ b/ocs_ci/utility/tests/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf8 -*-
 
 import logging
+from sys import platform
 
 import pytest
 
@@ -94,7 +95,8 @@ def test_run_cmd_simple_negative(caplog):
     assert caplog.records[2].message.startswith("Command stderr: ls:")
     assert "No such file or directory" in caplog.records[2].message
     assert caplog.records[3].levelname == 'DEBUG'
-    assert caplog.records[3].message == 'Command return code: 2'
+    return_code = 1 if platform == 'darwin' else 2
+    assert caplog.records[3].message == f'Command return code: {return_code}'
 
 
 def test_run_cmd_simple_negative_with_secrets(caplog):
@@ -132,4 +134,5 @@ def test_run_cmd_simple_negative_ignoreerror(caplog):
     assert caplog.records[2].message.startswith("Command stderr: ls:")
     assert "No such file or directory" in caplog.records[2].message
     assert caplog.records[3].levelname == 'DEBUG'
-    assert caplog.records[3].message == 'Command return code: 2'
+    return_code = 1 if platform == 'darwin' else 2
+    assert caplog.records[3].message == f'Command return code: {return_code}'


### PR DESCRIPTION
Fixes: #2528 

Signed-off-by: Coady LaCroix <clacroix@redhat.com>