### PR TITLE
consider cluster wide proxy configuration in tests

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -103,6 +103,7 @@ MONITORING = 'monitoring'
 CLUSTER_SERVICE_VERSION = 'csv'
 JOB = 'job'
 LOCAL_VOLUME = 'localvolume'
+PROXY = 'Proxy'
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2391,8 +2391,8 @@ def get_cluster_proxies():
     else:
         ocp_obj = ocp.OCP(kind=constants.PROXY, resource_name='cluster')
         proxy_obj = ocp_obj.get()
-        http_proxy = proxy_obj['spec'].get('httpProxy', '')
-        https_proxy = proxy_obj['spec'].get('httpsProxy', '')
+        http_proxy = proxy_obj.get('spec', {}).get('httpProxy', '')
+        https_proxy = proxy_obj.get('spec', {}).get('httpsProxy', '')
     logger.info("Using http_proxy: '%s'", http_proxy)
     logger.info("Using https_proxy: '%s'", https_proxy)
     return http_proxy, https_proxy


### PR DESCRIPTION
If cluster wide proxy is configured (in Proxy configuration object), use it's values for `http_proxy` and `https_proxy` values in tests. This should enable test execution on proxy environment without special manual configuration.

Signed-off-by: Daniel Horak <dahorak@redhat.com>