### PR TITLE
Refine dataclasses dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'pytest==5.3.5',
         'pytest-reportportal==1.10.0',
         'pytest-logger==0.5.1',
-        'dataclasses==0.6',  # For compatibility with python 3.6
+        'dataclasses==0.7;python_version < "3.7"',
         'pytest-html==2.1.1',
         'bs4==0.0.1',
         'gspread==3.6.0',


### PR DESCRIPTION
The previous workaround to dataclasses' requirement on python < 3.6 pins
to the version before the requirement was added; while pinning is of
course a good idea, I wanted to offer a way to pin to the latest version
while preventing the module from being installed at all on python 3.7+,
where the functionality is part of the standard library.

Signed-off-by: Zack Cerza <zack@redhat.com>