### PR TITLE
downstream-ci: change stable tagging for versions that use bundles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,15 +134,20 @@ pipeline {
         // quay.io/rhceph-dev/ocs-registry:4.2.2-255.ci -> 4.2.2-255.ci
         def registry_tag = registry_image.split(':')[-1]
         def ocs_version = registry_tag.split('-')[0]
-        // tag ocs-registry container as 'latest-stable-$ocs_version'
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable-${ocs_version}")]
-        // tag ocs-olm-operator container as 'latest-stable'
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable-${ocs_version}")]
         // ocs version with only X.Y
         def short_ocs_version = ocs_version.tokenize(".").take(2).join(".")
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable-${short_ocs_version}")]
-        // tag ocs-olm-operator container as 'latest-stable'
-        build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable-${short_ocs_version}")]
+        if (short_ocs_version.toFloat() < 4.5 ) {
+          // tag ocs-olm-operator container because versions < 4.5 use olm registry containers
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable-${ocs_version}")]
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-olm-operator:latest-stable-${short_ocs_version}")]
+        }
+        else {
+          // tag ocs-bundle-operator and ocs-registry container because versions > 4.5 use bundle index containers
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-bundle-operator:latest-stable-${ocs_version}")]
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-bundle-operator:latest-stable-${short_ocs_version}")]
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable-${ocs_version}")]
+          build job: 'quay-tag-image', parameters: [string(name: "SOURCE_URL", value: "${registry_image}"), string(name: "QUAY_IMAGE_TAG", value: "ocs-registry:latest-stable-${short_ocs_version}")]
+        }
         if( env.UMB_MESSAGE in [true, 'true'] ) {
           def registry_version = registry_tag.split('-')[0]
           def properties = """

--- a/conf/ocs_version/ocs-4.5.yaml
+++ b/conf/ocs_version/ocs-4.5.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:latest-4.5"
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.5"
   default_latest_tag: 'latest-4.5'
   ocs_csv_channel: "stable-4.5"
   default_ocp_version: '4.5'

--- a/conf/ocs_version/ocs-4.6.yaml
+++ b/conf/ocs_version/ocs-4.6.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:latest-4.6"
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.6"
   default_latest_tag: 'latest-4.6'
   ocs_csv_channel: "stable-4.6"
   default_ocp_version: '4.6'

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -606,7 +606,7 @@ MARKETPLACE_NAMESPACE = "openshift-marketplace"
 MONITORING_NAMESPACE = "openshift-monitoring"
 OPERATOR_INTERNAL_SELECTOR = "ocs-operator-internal=true"
 OPERATOR_CS_QUAY_API_QUERY = (
-    'https://quay.io/api/v1/repository/rhceph-dev/ocs-olm-operator/'
+    'https://quay.io/api/v1/repository/rhceph-dev/{image}/'
     'tag/?onlyActiveTags=true&limit={tag_limit}'
 )
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1575,8 +1575,19 @@ def get_ocs_olm_operator_tags(limit=100):
         )
         raise
     headers = {'Authorization': f'Bearer {quay_access_token}'}
+    image = "ocs-registry"
+    try:
+        ocs_version = float(config.ENV_DATA.get('ocs_version'))
+        if ocs_version < 4.5:
+            image = "ocs-olm-operator"
+    except (ValueError, TypeError):
+        log.warning("Invalid ocs_version given, defaulting to ocs-registry image")
+        pass
     resp = requests.get(
-        constants.OPERATOR_CS_QUAY_API_QUERY.format(tag_limit=limit),
+        constants.OPERATOR_CS_QUAY_API_QUERY.format(
+            tag_limit=limit,
+            image=image,
+        ),
         headers=headers
     )
     if not resp.ok:


### PR DESCRIPTION
OCS versions from 4.5 onward should use the ocs-bundle-operator instead of ocs-olm-operator. If the tests pass, make sure to tag ocs-bundle-operator as ``latest-stable-4.*`` instead of ocs-olm-operator for those versions. Also, the old ocs-registry image won't be tagged anymore at all.