### PR TITLE
Skip RGW tests on non-on-prem platforms

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs.constants import (
     ORDER_AFTER_OCS_UPGRADE,
     ORDER_AFTER_UPGRADE,
     CLOUD_PLATFORMS,
+    ON_PREM_PLATFORMS,
 )
 
 # tier marks
@@ -107,6 +108,12 @@ cloud_platform_required = pytest.mark.skipif(
     config.ENV_DATA['platform'].lower() not in CLOUD_PLATFORMS,
     reason="Test runs ONLY on cloud based deployed cluster"
 )
+
+on_prem_platform_required = pytest.mark.skipif(
+    config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS,
+    reason="Test runs ONLY on on-prem based deployed cluster"
+)
+
 
 rh_internal_lab_required = pytest.mark.skipif(
     (config.ENV_DATA['platform'].lower() == 'aws'

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -16,7 +16,7 @@ def pytest_collection_modifyitems(items):
     """
     if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
         for item in items.copy():
-            if r'manage/rgw' in str(item.fspath):
+            if 'manage/rgw' in str(item.fspath):
                 log.info(
                     f"Test {item} is removed from the collected items"
                     f" due to {config.ENV_DATA['platform'].lower()} not being an on-prem platform"

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -1,0 +1,23 @@
+import logging
+from ocs_ci.framework import config
+from ocs_ci.ocs.constants import ON_PREM_PLATFORMS
+
+log = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(items):
+    """
+    A pytest hook to filter out RGW tests
+    when running on cloud platforms
+
+    Args:
+        items: list of collected tests
+
+    """
+    for item in items:
+        if r'manage/rgw' in str(item.fspath):
+            if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
+                log.info(
+                    f'Test: {item} will be skipped due to not running on an on-prem platform'
+                )
+                items.remove(item)

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -14,7 +14,7 @@ def pytest_collection_modifyitems(items):
         items: list of collected tests
 
     """
-    for item in items:
+    for item in items.copy():
         if r'manage/rgw' in str(item.fspath):
             if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
                 log.info(

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -14,9 +14,9 @@ def pytest_collection_modifyitems(items):
         items: list of collected tests
 
     """
-    for item in items.copy():
-        if r'manage/rgw' in str(item.fspath):
-            if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
+    if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
+        for item in items.copy():
+            if r'manage/rgw' in str(item.fspath):
                 log.info(
                     f"Test {item} is removed from the collected items"
                     f" due to {config.ENV_DATA['platform'].lower()} not being an on-prem platform"

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -18,7 +18,7 @@ def pytest_collection_modifyitems(items):
         if r'manage/rgw' in str(item.fspath):
             if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
                 log.info(
-                    f"Test: {item} will be skipped due to {config.ENV_DATA['platform'].lower()}"
-                    f" not being an on-prem platform"
+                    f"Test {item} is removed from the collected items"
+                    f" due to {config.ENV_DATA['platform'].lower()} not being an on-prem platform"
                 )
                 items.remove(item)

--- a/tests/manage/rgw/conftest.py
+++ b/tests/manage/rgw/conftest.py
@@ -18,6 +18,7 @@ def pytest_collection_modifyitems(items):
         if r'manage/rgw' in str(item.fspath):
             if config.ENV_DATA['platform'].lower() not in ON_PREM_PLATFORMS:
                 log.info(
-                    f'Test: {item} will be skipped due to not running on an on-prem platform'
+                    f"Test: {item} will be skipped due to {config.ENV_DATA['platform'].lower()}"
+                    f" not being an on-prem platform"
                 )
                 items.remove(item)


### PR DESCRIPTION
Currently, the tests run on all platforms, including cloud ones that don't have RGW deployed at all.

Added the marker for future uses - it isn't being used in this PR.