### PR TITLE
Couchbase:  workload running for longer time

### DIFF
--- a/ocs_ci/ocs/couchbase.py
+++ b/ocs_ci/ocs/couchbase.py
@@ -208,21 +208,25 @@ class CouchBase(PillowFight):
                     f'but only found {len(cb_wrk_pods)}'
                 )
 
-    def run_workload(self, replicas, run_in_bg=False):
+    def run_workload(self, replicas, num_items=None, num_threads=None, run_in_bg=False):
         """
         Running workload with pillow fight operator
         Args:
             replicas (int): Number of pods
+            num_items (str): Number of items to be loaded to the cluster
+            num_threads (str): Number of threads
             run_in_bg (bool) : Optional run IOs in background
 
         """
         self.result = None
+        logging.info('Running IOs...')
         if run_in_bg:
-            logging.info('Running IOs...')
             executor = ThreadPoolExecutor(1)
-            self.result = executor.submit(PillowFight.run_pillowfights, self, replicas=replicas)
+            self.result = executor.submit(PillowFight.run_pillowfights, self, replicas=replicas,
+                                          num_items=num_items, num_threads=num_threads
+                                          )
             return self.result
-        PillowFight.run_pillowfights(self, replicas=replicas)
+        PillowFight.run_pillowfights(self, replicas=replicas, num_items=num_items, num_threads=num_threads)
 
     def analyze_run(self, skip_analyze=False):
         """

--- a/ocs_ci/ocs/couchbase.py
+++ b/ocs_ci/ocs/couchbase.py
@@ -213,8 +213,8 @@ class CouchBase(PillowFight):
         Running workload with pillow fight operator
         Args:
             replicas (int): Number of pods
-            num_items (str): Number of items to be loaded to the cluster
-            num_threads (str): Number of threads
+            num_items (int): Number of items to be loaded to the cluster
+            num_threads (int): Number of threads
             run_in_bg (bool) : Optional run IOs in background
 
         """

--- a/ocs_ci/ocs/pillowfight.py
+++ b/ocs_ci/ocs/pillowfight.py
@@ -60,11 +60,16 @@ class PillowFight(object):
         self.up_check = OCP(namespace=constants.COUCHBASE_OPERATOR)
         self.logs = tempfile.mkdtemp(prefix='pf_logs_')
 
-    def run_pillowfights(self, replicas=1):
+    def run_pillowfights(self, replicas=1, num_items=None, num_threads=None):
         """
         loop through all the yaml files extracted from the pillowfight repo
         and run them.  Run oc logs on the results and save the logs in self.logs
         directory
+
+        Args:
+            replicas (int): Number of pod replicas
+            num_items (str): Number of items to be loaded to the cluster
+            num_threads (str): Number of threads
 
         """
         ocp_local = OCP(namespace=self.namespace)
@@ -80,7 +85,12 @@ class PillowFight(object):
                 # for basic-fillowfight.yaml
                 pfight = templating.load_yaml(pf_fullpath)
                 pfight['metadata']['name'] = 'pillowfight-rbd-simple' + f"{i}"
-
+                # num of items
+                pfight['spec']['template']['spec']['containers'][0]['command'][4] = str(
+                    num_items) if num_items else '20000'
+                # num of threads
+                pfight['spec']['template']['spec']['containers'][0]['command'][13] = str(
+                    num_threads) if num_threads else '20'
                 lpillowfight = OCS(**pfight)
                 lpillowfight.create()
 

--- a/ocs_ci/ocs/pillowfight.py
+++ b/ocs_ci/ocs/pillowfight.py
@@ -68,8 +68,8 @@ class PillowFight(object):
 
         Args:
             replicas (int): Number of pod replicas
-            num_items (str): Number of items to be loaded to the cluster
-            num_threads (str): Number of threads
+            num_items (int): Number of items to be loaded to the cluster
+            num_threads (int): Number of threads
 
         """
         ocp_local = OCP(namespace=self.namespace)

--- a/ocs_ci/templates/workloads/couchbase/server/pillowfight/basic-pillowfight.yaml
+++ b/ocs_ci/templates/workloads/couchbase/server/pillowfight/basic-pillowfight.yaml
@@ -12,6 +12,6 @@ spec:
         image: couchbaseutils/pillowfight:v2.9.3
         command: ["cbc-pillowfight",
                   "-U", "couchbase://cb-example-0000.cb-example.couchbase-operator-namespace.svc:8091/default?select_bucket=true",
-                  "-I", "10000", "-m", "1000", "-M", "1000",
+                  "-I", "10000", "-m", "1000", "-M", "10000",
                   "-c", "10000", "-T", "-t", "1", "-u", "Administrator", "-P", "password"]
       restartPolicy: Never


### PR DESCRIPTION
With increasing the number of items to be loaded and the number of threads, IOs will be running for a longer time(like 7-8 minutes each pod) which was very short previously 