### PR TITLE
properly handle empty section in default config

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -44,7 +44,10 @@ class Config:
         Return a fresh copy of the default configuration
         """
         with open(DEFAULT_CONFIG_PATH) as file_stream:
-            return yaml.safe_load(file_stream)
+            return {
+                k: (v if v is not None else {})
+                for (k, v) in yaml.safe_load(file_stream).items()
+            }
 
     def update(self, user_dict: dict):
         """

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -142,11 +142,9 @@ UPGRADE:
 AUTH:
     test_quay_auth: test_secret
 
-# This section is for FLEXY, this is just dummy variable to have
-# FLEXY section here, all the defaults for FLEXY will be in
-# flexy_default_config.yaml
+# This section is for FLEXY, any variable in this section will be copied into
+# flexy env file
 FLEXY:
-  flexy_deploy: false
 
 # Defines the configuration of Independent Ceph Cluster
 INDEPENDENT_MODE:


### PR DESCRIPTION
Allow empty section in default config.

Without this change, empty section in `default_config.yaml` cause unit test `TestConfig.test_defaults` fails this way:

```
self = <ocs_ci.framework.tests.test_config.TestConfig object at 0x7f14a9c35b80>

    def test_defaults(self):
        config_sections = framework.config.to_dict().keys()
        for section_name in config_sections:
            section = getattr(framework.config, section_name)
>           assert section == framework.config.get_defaults()[section_name]
E           assert {} == None

ocs_ci/framework/tests/test_config.py:16: AssertionError
```
because empty section returns `None` instead of `{}`.

Signed-off-by: Daniel Horak <dahorak@redhat.com>