### PR TITLE
Try loading MCG credentials from all possible sources

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -20,6 +20,7 @@ from ocs_ci.ocs.constants import (
     CLOUD_PLATFORMS,
     ON_PREM_PLATFORMS,
 )
+from ocs_ci.utility.aws import update_config_from_s3
 from ocs_ci.utility.utils import load_auth_config
 
 # tier marks
@@ -95,8 +96,14 @@ run_this = pytest.mark.run_this
 
 # Skipif marks
 skipif_aws_creds_are_missing = pytest.mark.skipif(
-    load_auth_config().get('AUTH', {}).get('AWS', {}).get('AWS_ACCESS_KEY_ID') is None,
-    reason="AWS credentials weren't found in the local auth.yaml"
+    (
+        load_auth_config().get('AUTH', {}).get('AWS', {}).get('AWS_ACCESS_KEY_ID') is None
+        and update_config_from_s3() is None
+    ),
+    reason=(
+        "AWS credentials weren't found in the local auth.yaml "
+        "and couldn't be fetched from the cloud"
+    )
 )
 
 google_api_required = pytest.mark.skipif(

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -14,6 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility import templating
+from ocs_ci.utility.aws import update_config_from_s3
 from ocs_ci.utility.utils import TimeoutSampler, load_auth_config
 from tests.helpers import create_resource
 logger = logging.getLogger(name=__file__)
@@ -31,7 +32,15 @@ class CloudManager(ABC):
             'AZURE': AzureClient,
             # TODO: Implement - 'IBMCOS': S3Client
         }
-        cred_dict = load_auth_config().get('AUTH')
+        try:
+            logger.info('Trying to load credentials from ocs-ci-data')
+            cred_dict = update_config_from_s3().get('AUTH')
+        except AttributeError:
+            logger.warn(
+                'Failed to load credentials from ocs-ci-data. '
+                'Loading from local auth.yaml'
+            )
+            cred_dict = load_auth_config().get('AUTH')
         for cloud_name in cred_dict:
             if cloud_name in cloud_map:
                 try:

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1274,7 +1274,6 @@ def update_config_from_s3(bucket_name=constants.OCSCI_DATA_BUCKET, filename=cons
         return None
 
 
-
 def delete_cluster_buckets(cluster_name):
     """
     Delete s3 buckets corresponding to a particular OCS cluster

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -3,7 +3,8 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    pre_upgrade, post_upgrade, aws_platform_required, bugzilla
+    pre_upgrade, post_upgrade, aws_platform_required, bugzilla,
+    skipif_aws_creds_are_missing
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.constants import BS_OPTIMAL
@@ -79,6 +80,7 @@ def wait_for_active_pods(job, desired_count, timeout=3):
         return False
 
 
+@skipif_aws_creds_are_missing
 @aws_platform_required
 @pre_upgrade
 def test_fill_bucket(
@@ -141,6 +143,7 @@ def test_fill_bucket(
     assert bucket.status == constants.STATUS_BOUND
 
 
+@skipif_aws_creds_are_missing
 @aws_platform_required
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2038")

--- a/tests/ecosystem/upgrade/test_resources.py
+++ b/tests/ecosystem/upgrade/test_resources.py
@@ -4,7 +4,8 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    ignore_leftovers, pre_upgrade, post_upgrade
+    ignore_leftovers, pre_upgrade, post_upgrade,
+    skipif_aws_creds_are_missing
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import ocp
@@ -14,6 +15,7 @@ from tests import helpers
 log = logging.getLogger(__name__)
 
 
+@skipif_aws_creds_are_missing
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2220")
 def test_storage_pods_running(multiregion_mirror_setup_session):


### PR DESCRIPTION
Right now the tests rely on loading the credentials from the local `auth.yaml`.
This PR also tries retrieving them from our private `ocs-ci-data` bucket, and if it fails - the tests that rely on those credentials will be skipped. (also added missing skip markers that were missing from a few tests)