### PR TITLE
Remove cloning of rook repo since we are not using this repo

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -22,10 +22,6 @@ RUN:
   client_version: '4.5.0-0.nightly'
   bin_dir: './bin'
   google_api_secret: '~/.ocs-ci/google_api_secret.json'
-  rook_branch: "master"
-  # We can also specify the tag or specific commit id to checkout by changin
-  # following parameter in custom config file:
-  # rook_to_checkout: "commit_id or tag_name"
   # Following chrome params are for openshift console UI testing
   force_chrome_branch_base: "665006"
   force_chrome_branch_sha256sum: "a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,6 @@ from ocs_ci.utility.environment_check import (
 from ocs_ci.utility.uninstall_openshift_logging import uninstall_cluster_logging
 from ocs_ci.utility.utils import (
     ceph_health_check,
-    get_rook_repo,
     get_ocp_version,
     TimeoutSampler,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1355,13 +1355,6 @@ def multi_pvc_factory_fixture(
     return factory
 
 
-@pytest.fixture(scope="session", autouse=True)
-def rook_repo(request):
-    get_rook_repo(
-        config.RUN['rook_branch'], config.RUN.get('rook_to_checkout')
-    )
-
-
 @pytest.fixture(scope="function")
 def memory_leak_function(request):
     """


### PR DESCRIPTION
Fixes: #2670 

Remove cloning of rook repo since we are not using this repo
keep the code intact incase if we need for future use

Signed-off-by: vavuthu <vavuthu@redhat.com>