### PR TITLE
Increase number of builds per project

### DIFF
--- a/ocs_ci/ocs/jenkins.py
+++ b/ocs_ci/ocs/jenkins.py
@@ -132,7 +132,7 @@ class Jenkins(object):
         """
         log.info(f"Waiting for the build to reach {JENKINS_BUILD_COMPLETE} state")
         for project in self.projects:
-            jenkins_builds = self.get_builds_obj(namespace=project)
+            jenkins_builds = self.get_builds_sorted_by_number(project=project)
             for jenkins_build in jenkins_builds:
                 if (jenkins_build.name, project) not in self.build_completed:
                     try:
@@ -153,6 +153,22 @@ class Jenkins(object):
                         log.error(error_msg)
                         self.print_completed_builds_results()
                         raise UnexpectedBehaviour(error_msg)
+
+    def get_builds_sorted_by_number(self, project):
+        """
+        Get builds per project and sort builds by build name number
+        Args:
+            project (str): project name
+
+        return:
+            jenkins_builds_sorted (lst): list of build (OCS obj)
+        """
+        jenkins_builds_unsorted = self.get_builds_obj(namespace=project)
+        jenkins_builds_sorted = [0] * self.num_of_builds
+        for build in jenkins_builds_unsorted:
+            build_num = int(re.sub("[^0-9]", "", build.name))
+            jenkins_builds_sorted[build_num - 1] = build
+        return jenkins_builds_sorted
 
     def get_jenkins_deploy_pods(self, namespace):
         """

--- a/ocs_ci/ocs/jenkins.py
+++ b/ocs_ci/ocs/jenkins.py
@@ -157,11 +157,13 @@ class Jenkins(object):
     def get_builds_sorted_by_number(self, project):
         """
         Get builds per project and sort builds by build name number
+
         Args:
             project (str): project name
 
-        return:
-            jenkins_builds_sorted (lst): list of build (OCS obj)
+        Returns:
+            List: List of Jenkins build OCS obj
+
         """
         jenkins_builds_unsorted = self.get_builds_obj(namespace=project)
         jenkins_builds_sorted = [0] * self.num_of_builds

--- a/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
+++ b/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
@@ -3,6 +3,8 @@ apiVersion: "v1"
 metadata:
   name: "jax-rs-build"
 spec:
+  successfulBuildsHistoryLimit: 30
+  failedBuildsHistoryLimit: 30
   strategy:
     type: JenkinsPipeline
     jenkinsPipelineStrategy:

--- a/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
+++ b/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
@@ -3,8 +3,8 @@ apiVersion: "v1"
 metadata:
   name: "jax-rs-build"
 spec:
-  successfulBuildsHistoryLimit: 30
-  failedBuildsHistoryLimit: 30
+  successfulBuildsHistoryLimit: 500
+  failedBuildsHistoryLimit: 500
   strategy:
     type: JenkinsPipeline
     jenkinsPipelineStrategy:

--- a/tests/e2e/workloads/jenkins/test_jenkins.py
+++ b/tests/e2e/workloads/jenkins/test_jenkins.py
@@ -36,7 +36,7 @@ class TestJenkinsWorkload(E2ETest):
         jenkins.create_ocs_jenkins_template()
 
     @pytest.mark.usefixtures(jenkins_setup.__name__)
-    def test_jenkins_workload_simple(self, jenkins, num_projects=5, num_of_builds=5):
+    def test_jenkins_workload_simple(self, jenkins, num_projects=30, num_of_builds=12):
         """
         Test jenkins workload
         """

--- a/tests/e2e/workloads/jenkins/test_jenkins.py
+++ b/tests/e2e/workloads/jenkins/test_jenkins.py
@@ -36,7 +36,7 @@ class TestJenkinsWorkload(E2ETest):
         jenkins.create_ocs_jenkins_template()
 
     @pytest.mark.usefixtures(jenkins_setup.__name__)
-    def test_jenkins_workload_simple(self, jenkins, num_projects=30, num_of_builds=12):
+    def test_jenkins_workload_simple(self, jenkins, num_projects=10, num_of_builds=5):
         """
         Test jenkins workload
         """

--- a/tests/e2e/workloads/jenkins/test_jenkins.py
+++ b/tests/e2e/workloads/jenkins/test_jenkins.py
@@ -36,7 +36,7 @@ class TestJenkinsWorkload(E2ETest):
         jenkins.create_ocs_jenkins_template()
 
     @pytest.mark.usefixtures(jenkins_setup.__name__)
-    def test_jenkins_workload_simple(self, jenkins, num_projects=10, num_of_builds=5):
+    def test_jenkins_workload_simple(self, jenkins, num_projects=5, num_of_builds=5):
         """
         Test jenkins workload
         """

--- a/tests/e2e/workloads/jenkins/test_jenkins_node_reboot.py
+++ b/tests/e2e/workloads/jenkins/test_jenkins_node_reboot.py
@@ -49,10 +49,10 @@ class TestJenkinsNodeReboot(E2ETest):
         argnames=['node_type', 'num_projects', 'num_of_builds'],
         argvalues=[
             pytest.param(
-                *[MASTER_MACHINE, 3, 7], marks=pytest.mark.polarion_id("OCS-2202")
+                *[MASTER_MACHINE, 2, 15], marks=pytest.mark.polarion_id("OCS-2202")
             ),
             pytest.param(
-                *[WORKER_MACHINE, 5, 4], marks=pytest.mark.polarion_id("OCS-2178")
+                *[WORKER_MACHINE, 2, 15], marks=pytest.mark.polarion_id("OCS-2178")
             ),
         ]
     )


### PR DESCRIPTION
Signed-off-by: Oded Viner <oviner@redhat.com>

- Sort builds by build name number
- Increase number of builds per project
- Change buildconfig.yaml, save up to 30 builds