### PR TITLE
Added skipif_external_mode for existing automated scale tests

### DIFF
--- a/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
+++ b/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
@@ -6,6 +6,9 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import utils
 from ocs_ci.ocs.scale_lib import FioPodScale
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode
+)
 
 log = logging.getLogger(__name__)
 
@@ -34,6 +37,7 @@ def fioscale(request):
 
 @scale
 @ignore_leftovers
+@skipif_external_mode
 @pytest.mark.parametrize(
     argnames="resource_to_delete",
     argvalues=[

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -14,6 +14,9 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility import utils
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode
+)
 
 log = logging.getLogger(__name__)
 
@@ -106,6 +109,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
 
 @scale
 @ignore_leftovers
+@skipif_external_mode
 @pytest.mark.parametrize(
     argnames="resource_to_delete",
     argvalues=[

--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -15,9 +15,11 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants, platform_nodes
 from ocs_ci.ocs.resources.pod import wait_for_dc_app_pods_to_reach_running_state
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode, skipif_aws_i3
+)
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 @scale
 @ignore_leftovers
+@skipif_external_mode
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[


### PR DESCRIPTION
Updated tests which can't be executed in external mode with skipif_external_mode marker

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>