### PR TITLE
Fix converged RGW OBC SC name

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 import boto3
 from tests.helpers import (
     create_resource, create_unique_resource_name,
-    storagecluster_independent_check
+    retrieve_rgw_storageclass_name
 )
 
 from ocs_ci.framework import config
@@ -390,11 +390,7 @@ class RGWOCBucket(OCBucket):
             self.name = create_unique_resource_name('oc', 'obc')
         obc_data['metadata']['name'] = self.name
         obc_data['spec']['bucketName'] = self.name
-        if storagecluster_independent_check():
-            sc_name = constants.INDEPENDENT_DEFAULT_STORAGECLASS_RGW
-        else:
-            sc_name = constants.DEFAULT_STORAGECLASS_RGW
-        obc_data['spec']['storageClassName'] = sc_name
+        obc_data['spec']['storageClassName'] = retrieve_rgw_storageclass_name()
         obc_data['metadata']['namespace'] = self.namespace
         create_resource(**obc_data)
 

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -3,7 +3,10 @@ import logging
 from abc import ABC, abstractmethod
 
 import boto3
-from tests.helpers import create_resource, create_unique_resource_name
+from tests.helpers import (
+    create_resource, create_unique_resource_name,
+    storagecluster_independent_check
+)
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -387,7 +390,11 @@ class RGWOCBucket(OCBucket):
             self.name = create_unique_resource_name('oc', 'obc')
         obc_data['metadata']['name'] = self.name
         obc_data['spec']['bucketName'] = self.name
-        obc_data['spec']['storageClassName'] = constants.INDEPENDENT_DEFAULT_STORAGECLASS_RGW
+        if storagecluster_independent_check():
+            sc_name = constants.INDEPENDENT_DEFAULT_STORAGECLASS_RGW
+        else:
+            sc_name = constants.DEFAULT_STORAGECLASS_RGW
+        obc_data['spec']['storageClassName'] = sc_name
         obc_data['metadata']['namespace'] = self.namespace
         create_resource(**obc_data)
 

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -1,7 +1,6 @@
 from ocs_ci.framework import config
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs import constants
-from tests.helpers import storagecluster_independent_check
+from tests.helpers import retrieve_rgw_storageclass_name
 
 
 class RGW(object):
@@ -11,15 +10,9 @@ class RGW(object):
 
     def __init__(self, namespace=None):
         self.namespace = namespace if namespace else config.ENV_DATA['cluster_namespace']
-
-        if storagecluster_independent_check():
-            sc_name = constants.INDEPENDENT_DEFAULT_STORAGECLASS_RGW
-        else:
-            sc_name = constants.DEFAULT_STORAGECLASS_RGW
-
         self.storageclass = OCP(
             kind='storageclass', namespace=namespace,
-            resource_name=sc_name
+            resource_name=retrieve_rgw_storageclass_name()
         )
         self.s3_internal_endpoint = self.storageclass.get().get('parameters').get('endpoint')
         self.region = self.storageclass.get().get('parameters').get('region')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2372,6 +2372,14 @@ def storagecluster_independent_check():
     )
 
 
+def retrieve_rgw_storageclass_name():
+    if storagecluster_independent_check():
+        sc_name = constants.INDEPENDENT_DEFAULT_STORAGECLASS_RGW
+    else:
+        sc_name = constants.DEFAULT_STORAGECLASS_RGW
+    return sc_name
+
+
 def get_pv_size(storageclass=None):
     """
     Get Pv size from requested storageclass


### PR DESCRIPTION
Up until now, the independent mode SC name was always used. This PR is supposed to fix it by using `storagecluster_independent_check` in order to return the proper SC name that's supposed to be used by OBCs