### PR TITLE
Add ocs-monkey test

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -153,6 +153,7 @@ CRITICAL_ERRORS = [
 ]
 must_gather_pod_label = "must-gather"
 drain_canary_pod_label = "rook-ceph-drain-canary"
+OCS_MONKEY_REPOSITORY = "https://github.com/red-hat-storage/ocs-monkey.git"
 
 # AMQ
 AMQ_NAMESPACE = "myproject"

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -1,0 +1,61 @@
+import logging
+import shlex
+import subprocess
+import os
+import time
+
+from ocs_ci.framework.testlib import ignore_leftovers
+from ocs_ci.utility.utils import clone_repo, run_cmd
+from ocs_ci.ocs import constants
+
+log = logging.getLogger(__name__)
+
+
+@ignore_leftovers
+def test_ocs_monkey():
+    ocs_monkety_dir = '/tmp/ocs-monkey'
+    # ocs-monkey run time in seconds
+    run_time = 3200
+    clone_repo(constants.OCS_MONKEY_REPOSITORY, ocs_monkety_dir)
+    run_cmd(
+        f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}"
+    )
+    workload_run_cmd = f"python workload_runner.py -t {run_time}"
+
+    start_time = time.time()
+    log.info("Starting ocs-monkey")
+    popen_obj = subprocess.Popen(
+        shlex.split(workload_run_cmd),
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        encoding='utf-8', cwd=ocs_monkety_dir
+    )
+
+    while True:
+        output = popen_obj.stdout.readline()
+        # Check whether the process is completed
+        ret = popen_obj.poll()
+        if len(output) == 0 and ret is not None:
+            log.info("ocs-monkey run completed.")
+            assert ret == 0, (
+                f"ocs-monkey exited with return value {ret}. "
+                f"Check logs for details."
+            )
+            break
+        # Stream the output in console
+        if output:
+            log.info(output.strip())
+        # Terminate the process if it is not completed within the specified
+        # time. Give grace period of 600 seconds considering the time
+        # taken for setup
+        if time.time() - start_time > run_time + 600:
+            log.error(
+                f"ocs-monkey did not complete with in the specified run time"
+                f" {run_time} seconds. Killing the process now."
+            )
+            popen_obj.terminate()
+            raise TimeoutError(
+                f"ocs-monkey did not complete with in the specified run time "
+                f"{run_time} seconds. Killed the process after providing "
+                f"grace period of 600 seconds."
+            )


### PR DESCRIPTION
Added a test to run ocs-monkey, a chaos testing suite for OCS.
https://github.com/red-hat-storage/ocs-monkey

Signed-off-by: Jilju Joy <jijoy@redhat.com>