### PR TITLE
skipif_aws_creds_are_missing: Check os.environ

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -98,6 +98,7 @@ run_this = pytest.mark.run_this
 skipif_aws_creds_are_missing = pytest.mark.skipif(
     (
         load_auth_config().get('AUTH', {}).get('AWS', {}).get('AWS_ACCESS_KEY_ID') is None
+        and 'AWS_ACCESS_KEY_ID' not in os.environ
         and update_config_from_s3() is None
     ),
     reason=(


### PR DESCRIPTION
PR #2664 broke our build validation because we use environment variables to
provide AWS credentials.

Signed-off-by: Zack Cerza <zack@redhat.com>