### PR TITLE
utils: fix unhandled exception type when using bad auth.yaml contents

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1567,7 +1567,7 @@ def get_ocs_olm_operator_tags(limit=100):
     log.info(f"Retrieving OCS OLM Operator tags (limit {limit})")
     try:
         quay_access_token = load_auth_config()['quay']['access_token']
-    except KeyError:
+    except (KeyError, TypeError):
         log.error(
             'Unable to retrieve the access token for quay, please refer to '
             f'the getting started guide ({constants.AUTH_CONFIG_DOCS}) '


### PR DESCRIPTION
I hit this case when I had an empty auth.yaml file. This fix will cause either a missing or empty file to print out the reminder to consult the docs.