### PR TITLE
ocscilib: Log tracebacks instead of just exceptions

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -423,8 +423,8 @@ def pytest_runtest_makereport(item, call):
         mcg = True if any(x in item.location[0] for x in ['mcg', 'ecosystem']) else False
         try:
             collect_ocs_logs(dir_name=test_case_name, ocp=ocp_logs_collection, mcg=mcg)
-        except Exception as ex:
-            log.error(f"Failed to collect OCS logs. Error: {ex}")
+        except Exception:
+            log.exception("Failed to collect OCS logs")
 
     # Collect Prometheus metrics if specified in gather_metrics_on_fail marker
     if (
@@ -440,8 +440,8 @@ def pytest_runtest_makereport(item, call):
                 call.start,
                 call.stop
             )
-        except Exception as ex:
-            log.error(f"Failed to collect prometheus metrics. Error: {ex}")
+        except Exception:
+            log.exception("Failed to collect prometheus metrics")
 
     # Get the performance metrics when tests fails for scale or performance tag
     from tests.helpers import collect_performance_stats
@@ -453,8 +453,8 @@ def pytest_runtest_makereport(item, call):
         test_case_name = item.name
         try:
             collect_performance_stats(test_case_name)
-        except Exception as ex:
-            log.error(f"Failed to collect performance stats. Error: {ex}")
+        except Exception:
+            log.exception("Failed to collect performance stats")
 
 
 def set_report_portal_tags(config):

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -266,17 +266,14 @@ def gather_version_info_for_report(config):
             if key not in skip_list:
                 config._metadata[key] = val.rsplit('/')[-1]
         gather_version_completed = True
-    except ResourceNotFoundError as ex:
-        log.error(
-            "Problem occurred when looking for some resource! Error: %s",
-            ex
-        )
-    except FileNotFoundError as ex:
-        log.error("File not found! Error: %s", ex)
-    except CommandFailed as ex:
-        log.error("Failed to execute command! Error: %s", ex)
-    except Exception as ex:
-        log.error("Failed to gather version info! Error: %s", ex)
+    except ResourceNotFoundError:
+        log.exception("Problem occurred when looking for some resource!")
+    except FileNotFoundError:
+        log.exception("File not found!")
+    except CommandFailed:
+        log.exception("Failed to execute command!")
+    except Exception:
+        log.exception("Failed to gather version info!")
     finally:
         if not gather_version_completed:
             log.warning(


### PR DESCRIPTION
We were seeing must-gather failures like this:
```
14:33:26 - MainThread - ocs_ci.framework.pytest_customization.ocscilib - ERROR - Failed to collect OCS logs. Error: list index out of range
```

Just not enough information to figure out what was going on. I went through the module and found all the instances of `log.error()` combined with an attempt to display something helpful about the exception, and modified them to use `log.exception()`, which gives you the entire traceback.