### PR TITLE
Add ceph health check in test case teardown

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants, node
+from ocs_ci.utility.utils import ceph_health_check
 from tests.helpers import wait_for_resource_state
 from ocs_ci.framework.testlib import (
     skipif_ocs_version, ManageTest, tier4, tier4b, ignore_leftovers,
@@ -41,6 +42,8 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
         """
         def finalizer():
             nodes.restart_nodes_by_stop_and_start_teardown()
+            assert ceph_health_check(), "Ceph cluster health is not OK"
+            log.info("Ceph cluster health is OK")
         request.addfinalizer(finalizer)
 
     def test_worker_node_restart_during_pvc_expansion(self, nodes):


### PR DESCRIPTION
Add ceph health check in test teardown part of teat case:
ocs-ci/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py::TestNodeRestartDuringPvcExpansion::test_worker_node_restart_during_pvc_expansion

Signed-off-by: Jilju Joy <jijoy@redhat.com>