### PR TITLE
Fix hard failure when unable to get csv version for reporting

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -223,12 +223,15 @@ def pytest_configure(config):
         config._metadata['Test Run Name'] = get_testrun_name()
         gather_version_info_for_report(config)
 
-        ocs_csv = get_ocs_csv()
-        ocs_csv_version = ocs_csv.data['spec']['version']
-        config.addinivalue_line(
-            "rp_launch_tags", f"ocs_csv_version:{ocs_csv_version}"
-        )
-
+        try:
+            ocs_csv = get_ocs_csv()
+            ocs_csv_version = ocs_csv.data['spec']['version']
+            config.addinivalue_line(
+                "rp_launch_tags", f"ocs_csv_version:{ocs_csv_version}"
+            )
+        except ResourceNotFoundError:
+            # might be using exisitng cluster path using GUI installation
+            log.info("Unable to get CSV version for Reporting")
 
 def gather_version_info_for_report(config):
     """

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -231,7 +231,8 @@ def pytest_configure(config):
             )
         except ResourceNotFoundError:
             # might be using exisitng cluster path using GUI installation
-            log.info("Unable to get CSV version for Reporting")
+            log.warning("Unable to get CSV version for Reporting")
+
 
 def gather_version_info_for_report(config):
     """


### PR DESCRIPTION
Partial Fixes (5): https://github.com/red-hat-storage/ocs-ci/issues/2704

We dont have redhat-operator-internal selector when installed via GUI so the get_csv call fails, we can safely ignore this error.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>