### PR TITLE
Add user_factory

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -56,6 +56,7 @@ TEMPLATE_DEPLOYMENT_EO = os.path.join(
 TEMPLATE_DEPLOYMENT_CLO = os.path.join(
     TEMPLATE_DEPLOYMENT_LOGGING, "clusterlogging_operator"
 )
+TEMPLATE_AUTHENTICATION_DIR = os.path.join(TEMPLATE_DIR, 'authentication')
 DATA_DIR = os.path.join(TOP_DIR, 'data')
 ROOK_REPO_DIR = os.path.join(DATA_DIR, 'rook')
 ROOK_EXAMPLES_DIR = os.path.join(
@@ -529,6 +530,11 @@ OPERATOR_SOURCE_SECRET_YAML = os.path.join(
 OPERATOR_SOURCE_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "operator-source.yaml"
 )
+
+HTPASSWD_IDP_YAML = os.path.join(
+    TEMPLATE_AUTHENTICATION_DIR, 'htpasswd_provider.yaml'
+)
+
 
 OPERATOR_SOURCE_NAME = "ocs-operatorsource"
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -108,6 +108,7 @@ CLUSTER_OPERATOR = 'ClusterOperator'
 MONITORING = 'monitoring'
 CLUSTER_SERVICE_VERSION = 'csv'
 JOB = 'job'
+OAUTH = 'OAuth'
 LOCAL_VOLUME = 'localvolume'
 PROXY = 'Proxy'
 MACHINECONFIGPOOL = "MachineConfigPool"

--- a/ocs_ci/templates/authentication/htpasswd_provider.yaml
+++ b/ocs_ci/templates/authentication/htpasswd_provider.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: my_htpasswd_provider 
+    mappingMethod: claim 
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret

--- a/ocs_ci/utility/users.py
+++ b/ocs_ci/utility/users.py
@@ -1,0 +1,56 @@
+import os
+
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import run_cmd
+
+def add_htpasswd_user(username, password, htpasswd_path):
+    """
+    Create a new user credentials with provided username and password.
+    These will be saved in file located on htpasswd_path. The file will
+    be created if it doesn't exist.
+
+    Args:
+        username (str): Name of a new user
+        password (str): Password for a new user
+        htpasswd_path (str): Path to httpasswd file
+
+    """
+    if os.path.isfile(htpasswd_path):
+        create = ''
+    else:
+        create = ' -c'
+    run_cmd(f"htpasswd{create} -B -b {htpasswd_path} {username} {password}")
+
+
+def create_htpasswd_secret(htpasswd_path, replace=False):
+    """
+    Create or update htpass-secret secret from file located on htpasswd_path.
+
+    Args:
+        htpasswd_path (str): Path to httpasswd file
+        replace (bool): If secret already exists then this will replace it
+
+    """
+    kubeconfig = os.getenv('KUBECONFIG')
+    if replace:
+        replace = (
+            f" --dry-run -o yaml | oc replace -f - --kubeconfig {kubeconfig}"
+        )
+    else:
+        replace = ''
+
+    cmd = (
+        f"oc create secret generic htpass-secret "
+        f"--from-file=htpasswd=users.htpasswd -n openshift-config "
+        f"--kubeconfig {kubeconfig}{replace}"
+    )
+    run_cmd(cmd)
+
+
+def create_htpasswd_idp():
+    """
+    Create OAuth identity provider of HTPasswd type. It uses htpass-secret
+    secret as a source for list of users.
+
+    """
+    cmd = f"oc apply -f {constants.HTPASSWD_IDP_YAML}"

--- a/ocs_ci/utility/users.py
+++ b/ocs_ci/utility/users.py
@@ -1,7 +1,9 @@
 import os
+import random
+import string
 
 from ocs_ci.ocs import constants
-from ocs_ci.utility.utils import run_cmd
+from ocs_ci.utility.utils import exec_cmd
 
 def add_htpasswd_user(username, password, htpasswd_path):
     """
@@ -16,10 +18,10 @@ def add_htpasswd_user(username, password, htpasswd_path):
 
     """
     if os.path.isfile(htpasswd_path):
-        create = ''
+        cmd = ['htpasswd', '-B', '-b', htpasswd_path, username, password]
     else:
-        create = ' -c'
-    run_cmd(f"htpasswd{create} -B -b {htpasswd_path} {username} {password}")
+        cmd = ['htpasswd',  '-c', '-B', '-b', htpasswd_path, username, password]
+    exec_cmd(cmd)
 
 
 def create_htpasswd_secret(htpasswd_path, replace=False):
@@ -34,17 +36,26 @@ def create_htpasswd_secret(htpasswd_path, replace=False):
     kubeconfig = os.getenv('KUBECONFIG')
     if replace:
         replace = (
-            f" --dry-run -o yaml | oc replace -f - --kubeconfig {kubeconfig}"
+            f" --dry-run -o yaml | oc replace --kubeconfig {kubeconfig} -f -"
         )
     else:
         replace = ''
 
     cmd = (
         f"oc create secret generic htpass-secret "
-        f"--from-file=htpasswd=users.htpasswd -n openshift-config "
+        f"--from-file=htpasswd={htpasswd_path} -n openshift-config "
         f"--kubeconfig {kubeconfig}{replace}"
     )
-    run_cmd(cmd)
+    exec_cmd(cmd)
+
+
+def delete_htpasswd_secret():
+    """
+    Delete HTPasswd secret.
+
+    """
+    cmd = f"oc delete secret htpass-secret -n openshift-config"
+    exec_cmd(cmd)
 
 
 def create_htpasswd_idp():
@@ -54,3 +65,83 @@ def create_htpasswd_idp():
 
     """
     cmd = f"oc apply -f {constants.HTPASSWD_IDP_YAML}"
+    exec_cmd(cmd)
+
+
+def user_factory(request, htpasswd_path):
+    """
+    Create a user factory.
+
+    Args:
+        request (obj): request fixture
+        htpasswd_path (str): Path to htpasswd file
+
+    Returns:
+        func: User factory function
+
+    """
+    _users = []
+
+    def _factory(
+        username=None,
+        password=None,
+    ):
+        """
+        Create a new user.
+
+        Args:
+            username (str): Username of a new user. If not proided then
+                set it to random string
+            password (str): Password of a new user. If not provided then
+                set it to random string
+
+        Returns:
+            tuple: username and password of a new user
+
+        """
+        if not username:
+            # Generate random username from letters and numbers starting
+            # with letter. Length is between 1 and 11 characters.
+            username = random.choice(string.ascii_letters)
+            username = username + ''.join(
+                random.choice(
+                    string.ascii_letters + string.digits
+                ) for _ in range(random.randint(0, 10))
+            )
+        if not password:
+            # Generate random password from letters, numbers and special
+            # characters. Length is between 6 and 15 characters.
+            password = ''.join(
+                random.choice(
+                    string.ascii_letters + string.digits + string.punctuation
+                ) for _ in range(random.randint(6, 15))
+            )
+        add_htpasswd_user(username, password, htpasswd_path)
+        if not _users:
+            create_htpasswd_secret(htpasswd_path)
+        else:
+            users.create_htpasswd_secret(htpasswd_path, replace=True)
+
+        # : is a delimiter in htpasswd file and it will ensure that only full
+        # usernames are deleted
+        _users.append(f"{username}:")
+
+        return (username, password)
+
+    def _finalizer():
+        """
+        Delete all users created by the factory
+
+        """
+        with open(htpasswd_path) as f:
+            htpasswd = f.readlines()
+        new_htpasswd = [
+            line for line in htpasswd if line.startswith(tuple(_users))
+        ]
+        with open(htpasswd_path, 'w+') as f:
+            for line in new_htpasswd:
+                f.write(line)
+        create_htpasswd_secret(htpasswd_path, replace=True)
+
+    request.addfinalizer(_finalizer)
+    return _factory

--- a/ocs_ci/utility/users.py
+++ b/ocs_ci/utility/users.py
@@ -5,6 +5,7 @@ import string
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import exec_cmd
 
+
 def add_htpasswd_user(username, password, htpasswd_path):
     """
     Create a new user credentials with provided username and password.
@@ -20,7 +21,7 @@ def add_htpasswd_user(username, password, htpasswd_path):
     if os.path.isfile(htpasswd_path):
         cmd = ['htpasswd', '-B', '-b', htpasswd_path, username, password]
     else:
-        cmd = ['htpasswd',  '-c', '-B', '-b', htpasswd_path, username, password]
+        cmd = ['htpasswd', '-c', '-B', '-b', htpasswd_path, username, password]
     exec_cmd(cmd)
 
 
@@ -54,7 +55,7 @@ def delete_htpasswd_secret():
     Delete HTPasswd secret.
 
     """
-    cmd = f"oc delete secret htpass-secret -n openshift-config"
+    cmd = "oc delete secret htpass-secret -n openshift-config"
     exec_cmd(cmd)
 
 
@@ -120,7 +121,7 @@ def user_factory(request, htpasswd_path):
         if not _users:
             create_htpasswd_secret(htpasswd_path)
         else:
-            users.create_htpasswd_secret(htpasswd_path, replace=True)
+            create_htpasswd_secret(htpasswd_path, replace=True)
 
         # : is a delimiter in htpasswd file and it will ensure that only full
         # usernames are deleted

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -372,7 +372,8 @@ def mask_secrets(plaintext, secrets):
     Replace secrets in plaintext with asterisks
 
     Args:
-        plaintext (str): The plaintext to remove the secrets from
+        plaintext (str or list): The plaintext to remove the secrets from or
+            list of strings to remove secrets from
         secrets (list): List of secret strings to replace in the plaintext
 
     Returns:
@@ -381,7 +382,12 @@ def mask_secrets(plaintext, secrets):
     """
     if secrets:
         for secret in secrets:
-            plaintext = plaintext.replace(secret, '*' * 5)
+            if isinstance(plaintext, list):
+                plaintext = [
+                    string.replace(secret, '*' * 5) for string in plaintext
+                ]
+            else:
+                plaintext = plaintext.replace(secret, '*' * 5)
     return plaintext
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2642,7 +2642,7 @@ def htpasswd_identity_provider(request):
         #     resource_name='cluster',
         #     params=f'[{ "op": "remove", "path": "/spec/identityProviders" }]'
         # )
-        users.delete_htpasswd_secret()
+        # users.delete_htpasswd_secret()
 
     request.addfinalizer(finalizer)
     return cluster

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from ocs_ci.ocs.cluster_load import ClusterLoad, wrap_msg
 from ocs_ci.utility import aws
 from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
 from ocs_ci.utility import templating
+from ocs_ci.utility import users
 from ocs_ci.utility.environment_check import (
     get_status_before_execution, get_status_after_execution
 )
@@ -2603,6 +2604,72 @@ def multi_dc_pod(multi_pvc_factory, dc_pod_factory, service_account_factory):
         return dc_pods
 
     return factory
+
+
+@pytest.fixture(scope='session')
+def htpasswd_path(tmpdir_factory):
+    """
+    Returns:
+        string: Path to HTPasswd file with additional usernames
+
+    """
+    return str(tmpdir_factory.mktemp('idp_data').join('users.htpasswd'))
+
+
+@pytest.fixture(scope='session')
+def htpasswd_identity_provider(request):
+    """
+    Creates HTPasswd Identity provider.
+
+    Returns:
+        object: OCS object representing OCP OAuth object with HTPasswd IdP
+
+    """
+    users.create_htpasswd_idp()
+    cluster = OCS(
+        kind=constants.OAUTH,
+        metadata={'name': 'cluster'}
+    )
+    cluster.reload()
+
+    def finalizer():
+        """
+        Remove HTPasswd IdP
+
+        """
+        # TODO(fbalak): remove HTPasswd identityProvider
+        # cluster.ocp.patch(
+        #     resource_name='cluster',
+        #     params=f'[{ "op": "remove", "path": "/spec/identityProviders" }]'
+        # )
+        users.delete_htpasswd_secret()
+
+    request.addfinalizer(finalizer)
+    return cluster
+
+
+@pytest.fixture(scope='function')
+def user_factory(
+    request,
+    htpasswd_identity_provider,
+    htpasswd_path
+):
+    return users.user_factory(
+        request,
+        htpasswd_path
+    )
+
+
+@pytest.fixture(scope='session')
+def user_factory_session(
+    request,
+    htpasswd_identity_provider,
+    htpasswd_path
+):
+    return users.user_factory(
+        request,
+        htpasswd_path
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/libtest/test_user.py
+++ b/tests/libtest/test_user.py
@@ -1,11 +1,20 @@
 import logging
+import os
+from time import sleep
 
 from ocs_ci.utility.utils import exec_cmd
 
 logger = logging.getLogger(__name__)
 
 
-def test_bucket_creation(user_factory):
+def test_user_creation(user_factory):
     user = user_factory()
-    exec_cmd(['oc', 'login', '-u', user[0], '-p', user[1]])
+    kubeconfig = os.getenv('KUBECONFIG')
+    kube_data = ""
+    with open(kubeconfig, 'r') as kube_file:
+        kube_data = kube_file.readlines()
+    sleep(30)
+    exec_cmd(['oc', 'login', '-u', user[0], '-p', user[1]], secrets=[user[1]])
     exec_cmd(['oc', 'logout'])
+    with open(kubeconfig, 'w') as kube_file:
+        kube_file.writelines(kube_data)

--- a/tests/libtest/test_user.py
+++ b/tests/libtest/test_user.py
@@ -1,0 +1,12 @@
+import logging
+import pytest
+
+from ocs_ci.utility.utils import exec_cmd
+
+logger = logging.getLogger(__name__)
+
+
+def test_bucket_creation(user_factory):
+    user = user_factory()
+    exec_cmd(['oc', 'login', '-u', user[0], '-p', user[1]])
+    exec_cmd(['oc', 'logout'])

--- a/tests/libtest/test_user.py
+++ b/tests/libtest/test_user.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 
 from ocs_ci.utility.utils import exec_cmd
 


### PR DESCRIPTION
Users created by the factory will be used for Prometheus API communication - this will help to run monitoring tests on IBM cloud and other platforms that doesn't generate kubeadmin-password file.