### PR TITLE
Fix failure in test_must_gather 

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -877,7 +877,6 @@ MUST_GATHER_COMMANDS = [
     'ceph_osd_crush_show-tunables', 'ceph_osd_crush_dump', 'ceph_mon_stat',
     'ceph_mon_dump', 'ceph_mgr_dump', 'ceph_mds_stat', 'ceph_health_detail',
     'ceph_fs_ls', 'ceph_fs_dump', 'ceph_df', 'ceph_auth_list',
-    'ceph-volume_lvm_list'
 ]
 
 MUST_GATHER_COMMANDS_JSON = [

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -130,18 +130,24 @@ class TestMustGather(ManageTest):
                 break
 
         # Verify that command output files are present as expected
-        assert sorted(constants.MUST_GATHER_COMMANDS) == sorted(files), (
+        assert set(constants.MUST_GATHER_COMMANDS).issubset(files), (
             f"Actual and expected commands output files are not matching.\n"
             f"Actual: {files}\nExpected: {constants.MUST_GATHER_COMMANDS}"
         )
+        if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(files):
+            logger.warning("There are more actual must gather"
+                           " commands than expected")
 
         # Verify that files for command output in json are present as expected
         commands_json = os.listdir(json_output_dir)
-        assert sorted(constants.MUST_GATHER_COMMANDS_JSON) == sorted(commands_json), (
+        assert set(constants.MUST_GATHER_COMMANDS_JSON).issubset(commands_json), (
             f"Actual and expected json output commands files are not "
             f"matching.\nActual: {commands_json}\n"
             f"Expected: {constants.MUST_GATHER_COMMANDS_JSON}"
         )
+        if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(commands_json):
+            logger.warning("There are more actual must gather"
+                           " commands than expected")
 
         # Verify that command output files are not empty
         empty_files = []

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -135,8 +135,9 @@ class TestMustGather(ManageTest):
             f"Actual: {files}\nExpected: {constants.MUST_GATHER_COMMANDS}"
         )
         if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(files):
-            logger.warning("There are more actual must gather"
-                           " commands than expected")
+            logger.warning(
+                "There are more actual must gather commands than expected"
+            )
 
         # Verify that files for command output in json are present as expected
         commands_json = os.listdir(json_output_dir)
@@ -146,8 +147,9 @@ class TestMustGather(ManageTest):
             f"Expected: {constants.MUST_GATHER_COMMANDS_JSON}"
         )
         if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(commands_json):
-            logger.warning("There are more actual must gather"
-                           " commands than expected")
+            logger.warning(
+                "There are more actual must gather commands than expected"
+            )
 
         # Verify that command output files are not empty
         empty_files = []


### PR DESCRIPTION
change must_gather commands assertion not to fail if there is more actual commands than expected
with current solution, test will pass with warning if actual list of commands is greater than expected (but all expected commands exists)

fix issue:  #2560
Signed-off-by: aviadp <apolak@redhat.com>