### PR TITLE
Vsphere rhel installation for OCP 4.5

### DIFF
--- a/ocs_ci/deployment/helpers/vsphere_helpers.py
+++ b/ocs_ci/deployment/helpers/vsphere_helpers.py
@@ -1,0 +1,327 @@
+"""
+This module contains helpers functions needed for deployment
+of clusters on vsphere platform.
+"""
+import json
+import logging
+import os
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.utility.templating import (
+    Templating,
+    load_yaml,
+    dump_data_to_temp_yaml,
+)
+from ocs_ci.utility.utils import (
+    convert_yaml2tfvars, create_directory_path,
+    remove_keys_from_tf_variable_file, replace_content_in_file, run_cmd,
+    upload_file, get_ocp_version, get_infra_id, get_cluster_id,
+)
+from semantic_version import Version
+
+logger = logging.getLogger(__name__)
+
+
+class VSPHEREHELPERS(object):
+    """
+    Helper class for vSphere
+    """
+    def __init__(self):
+        """
+        Initialize required variables
+        """
+        self.cluster_path = config.ENV_DATA['cluster_path']
+        self.kubeconfig = os.path.join(
+            self.cluster_path,
+            config.RUN.get('kubeconfig_location')
+        )
+        self.folder_structure = config.ENV_DATA.get('folder_structure')
+        self.ocp_version = get_ocp_version(seperator="_")
+        self._templating = Templating()
+
+    def generate_terraform_vars_for_scaleup(self, rhcos_ips):
+        """
+        Generates the terraform variables file for scaling nodes
+        """
+        self.scale_up_terraform_dir = os.path.join(
+            self.cluster_path,
+            constants.TERRAFORM_DATA_DIR,
+            constants.SCALEUP_TERRAFORM_DATA_DIR
+        )
+        scale_up_terraform_var_yaml = os.path.join(
+            self.scale_up_terraform_dir,
+            "scale_up_terraform.tfvars.yaml"
+        )
+        config.ENV_DATA['cluster_info_path'] = self.scale_up_terraform_dir
+        config.ENV_DATA['credentials_path'] = self.scale_up_terraform_dir
+
+        if self.folder_structure:
+            logger.info(
+                "Generating terraform variables for "
+                "scaling nodes with folder structure"
+            )
+            scale_up_terraform_var_template_with_folder_structure = (
+                "scale_up_terraform_with_folder_structure.tfvars.j2"
+            )
+            scale_up_terraform_var_template_path_with_folder_structure = (
+                os.path.join(
+                    "ocp-deployment",
+                    scale_up_terraform_var_template_with_folder_structure
+                )
+            )
+
+            scale_up_terraform_config_str_with_folder_structure = (
+                self._templating.render_template(
+                    scale_up_terraform_var_template_path_with_folder_structure,
+                    config.ENV_DATA
+                )
+            )
+
+            with open(scale_up_terraform_var_yaml, "w") as f:
+                f.write(scale_up_terraform_config_str_with_folder_structure)
+
+            scale_up_terraform_var = convert_yaml2tfvars(
+                scale_up_terraform_var_yaml
+            )
+            replace_content_in_file(scale_up_terraform_var, "None", "")
+
+        else:
+            logger.info(
+                "Generating terraform variables for scaling"
+                " nodes without folder structure"
+            )
+            scale_up_terraform_var_template = "scale_up_terraform.tfvars.j2"
+            scale_up_terraform_var_template_path = os.path.join(
+                "ocp-deployment", scale_up_terraform_var_template
+            )
+            scale_up_terraform_config_str = self._templating.render_template(
+                scale_up_terraform_var_template_path, config.ENV_DATA
+            )
+
+            with open(scale_up_terraform_var_yaml, "w") as f:
+                f.write(scale_up_terraform_config_str)
+
+            scale_up_terraform_var = convert_yaml2tfvars(
+                scale_up_terraform_var_yaml
+            )
+
+            # append RHCOS ip list to terraform variable file
+            with open(scale_up_terraform_var, "a+") as fd:
+                fd.write(f"rhcos_list = {json.dumps(rhcos_ips)}")
+
+        logger.info(
+            f"scale-up terraform variable file: {scale_up_terraform_var}"
+        )
+
+        return scale_up_terraform_var
+
+    def modify_scaleup_repo(self):
+        """
+        Modify the scale-up repo. Considering the user experience, removing
+        the access and secret keys and variable from appropriate location
+        in the scale-up repo
+        """
+        # importing here to avoid circular dependancy
+        from ocs_ci.deployment.vmware import change_vm_root_disk_size
+        if self.folder_structure:
+            logger.info("Modifying scaleup repo for folder structure")
+            # modify default_map.yaml
+            default_map_path = os.path.join(
+                constants.CLUSTER_LAUNCHER_VSPHERE_DIR,
+                f"aos-{self.ocp_version}",
+                "default_map.yaml"
+            )
+            dict_data = load_yaml(default_map_path)
+            dict_data['cluster_domain'] = config.ENV_DATA['base_domain']
+            dict_data['vsphere']['vcsa-qe']['datacenter'] = (
+                config.ENV_DATA['vsphere_datacenter']
+            )
+            dict_data['vsphere']['vcsa-qe']['datastore'] = (
+                config.ENV_DATA['vsphere_datastore']
+            )
+            dict_data['vsphere']['vcsa-qe']['network'] = (
+                config.ENV_DATA['vm_network']
+            )
+            dict_data['vsphere']['vcsa-qe']['cpus'] = (
+                config.ENV_DATA['rhel_num_cpus']
+            )
+            dict_data['vsphere']['vcsa-qe']['memory'] = (
+                config.ENV_DATA['rhel_memory']
+            )
+            dict_data['vsphere']['vcsa-qe']['root_volume_size'] = (
+                config.ENV_DATA.get('root_disk_size', '120'))
+
+            dict_data['vsphere']['vcsa-qe']['image'] = (
+                config.ENV_DATA['rhel_template']
+            )
+
+            dump_data_to_temp_yaml(dict_data, default_map_path)
+        else:
+            # remove access and secret key from constants.SCALEUP_VSPHERE_MAIN
+            access_key = 'access_key       = "${var.aws_access_key}"'
+            secret_key = 'secret_key       = "${var.aws_secret_key}"'
+            replace_content_in_file(
+                constants.SCALEUP_VSPHERE_MAIN,
+                f"{access_key}",
+                " "
+            )
+            replace_content_in_file(
+                constants.SCALEUP_VSPHERE_MAIN,
+                f"{secret_key}",
+                " "
+            )
+
+            # remove access and secret key from constants.SCALEUP_VSPHERE_ROUTE53
+            route53_access_key = 'access_key = "${var.access_key}"'
+            route53_secret_key = 'secret_key = "${var.secret_key}"'
+            replace_content_in_file(
+                constants.SCALEUP_VSPHERE_ROUTE53,
+                f"{route53_access_key}",
+                " "
+            )
+            replace_content_in_file(
+                constants.SCALEUP_VSPHERE_ROUTE53,
+                f"{route53_secret_key}",
+                " "
+            )
+
+            replace_content_in_file(
+                constants.SCALEUP_VSPHERE_ROUTE53,
+                "us-east-1",
+                f"{config.ENV_DATA.get('region')}"
+            )
+
+            # remove access and secret variables from scale-up repo
+            remove_keys_from_tf_variable_file(
+                constants.SCALEUP_VSPHERE_VARIABLES,
+                ['aws_access_key', 'aws_secret_key'])
+            remove_keys_from_tf_variable_file(
+                constants.SCALEUP_VSPHERE_ROUTE53_VARIABLES,
+                ['access_key', 'secret_key']
+            )
+
+            # change root disk size
+            change_vm_root_disk_size(constants.SCALEUP_VSPHERE_MACHINE_CONF)
+
+    def generate_cluster_info(self):
+        """
+        Generates the cluster information file
+        """
+        logger.info("Generating cluster information file")
+
+        # get kubeconfig and upload to httpd server
+        kubeconfig = os.path.join(
+            self.cluster_path,
+            config.RUN.get('kubeconfig_location')
+        )
+        remote_path = os.path.join(
+            config.ENV_DATA.get('path_to_upload'),
+            f"{config.RUN.get('run_id')}_kubeconfig"
+        )
+        upload_file(
+            config.ENV_DATA.get('httpd_server'),
+            kubeconfig,
+            remote_path,
+            config.ENV_DATA.get('httpd_server_user'),
+            config.ENV_DATA.get('httpd_server_password')
+        )
+
+        #  Form the kubeconfig url path
+        kubeconfig_url_path = os.path.join(
+            'http://',
+            config.ENV_DATA.get('httpd_server'),
+            remote_path.lstrip('/var/www/html/')
+        )
+        config.ENV_DATA['kubeconfig_url'] = kubeconfig_url_path
+
+        # get the infra_id
+        infra_id = get_infra_id(self.cluster_path)
+        config.ENV_DATA['infra_id'] = infra_id
+
+        # get the cluster id
+        cluster_id = get_cluster_id(self.cluster_path)
+        config.ENV_DATA['cluster_id'] = cluster_id
+
+        # fetch the installer version
+        installer_version_str = run_cmd(
+            f"{config.RUN['bin_dir']}/openshift-install version"
+        )
+        installer_version = installer_version_str.split()[1]
+        config.ENV_DATA['installer_version'] = installer_version
+
+        # get the major and minor version of OCP
+        version_obj = Version(installer_version)
+        ocp_version_x = version_obj.major
+        ocp_version_y = version_obj.minor
+        config.ENV_DATA['ocp_version_x'] = ocp_version_x
+        config.ENV_DATA['ocp_version_y'] = ocp_version_y
+
+        # generate the cluster info yaml file
+        terraform_var_template = "cluster_info.yaml.j2"
+        terraform_var_template_path = os.path.join(
+            "ocp-deployment", terraform_var_template
+        )
+        terraform_config_str = self._templating.render_template(
+            terraform_var_template_path, config.ENV_DATA
+        )
+        logger.info(f"terraform_config_str: {terraform_config_str}")
+        terraform_var_yaml = os.path.join(
+            self.cluster_path,
+            constants.TERRAFORM_DATA_DIR,
+            constants.SCALEUP_TERRAFORM_DATA_DIR,
+            "cluster_info.yaml"
+        )
+
+        with open(terraform_var_yaml, "w") as f:
+            f.write(terraform_config_str)
+
+        # config.ENV_DATA['dns_server'] = config.ENV_DATA['dns']
+        template_vars = (
+            f"\"dns_server: {config.ENV_DATA['dns']}"
+            f"\\nremove_rhcos_worker: 'yes'\\n\""
+        )
+        logger.info(f"template_vars : {template_vars}")
+
+        replace_content_in_file(
+            terraform_var_yaml,
+            "PLACEHOLDER",
+            template_vars
+        )
+        logger.info(f"cluster yaml file: {terraform_var_yaml}")
+
+    def generate_config_yaml(self):
+        """
+        Generate config yaml file
+        """
+        # create config directory in scale_up_terraform_data directory
+        sclaeup_data_config_dir = os.path.join(
+                self.cluster_path,
+                constants.TERRAFORM_DATA_DIR,
+                constants.SCALEUP_TERRAFORM_DATA_DIR,
+                "config"
+            )
+        create_directory_path(sclaeup_data_config_dir)
+
+        #generate config yaml file
+        scale_up_config_var_template = "scale_up_config.yaml.j2"
+        scale_up_config_var_template_path = os.path.join(
+            "ocp-deployment", scale_up_config_var_template
+        )
+        config.ENV_DATA['ssh_key_private'] = (
+            config.DEPLOYMENT['ssh_key_private']
+        )
+        scale_up_config_str = self._templating.render_template(
+            scale_up_config_var_template_path, config.ENV_DATA
+        )
+        logger.info(f"scale_up_config_str: {scale_up_config_str}")
+
+        scale_config_var_yaml = os.path.join(
+            sclaeup_data_config_dir,
+            "config.yaml"
+        )
+
+        with open(scale_config_var_yaml, "w") as f:
+            f.write(scale_up_config_str)
+
+        logger.info(f"scale_config_var_yaml : {scale_config_var_yaml}")

--- a/ocs_ci/deployment/helpers/vsphere_helpers.py
+++ b/ocs_ci/deployment/helpers/vsphere_helpers.py
@@ -265,7 +265,6 @@ class VSPHEREHELPERS(object):
         terraform_config_str = self._templating.render_template(
             terraform_var_template_path, config.ENV_DATA
         )
-        logger.info(f"terraform_config_str: {terraform_config_str}")
         terraform_var_yaml = os.path.join(
             self.cluster_path,
             constants.TERRAFORM_DATA_DIR,
@@ -281,7 +280,6 @@ class VSPHEREHELPERS(object):
             f"\"dns_server: {config.ENV_DATA['dns']}"
             f"\\nremove_rhcos_worker: 'yes'\\n\""
         )
-        logger.info(f"template_vars : {template_vars}")
 
         replace_content_in_file(
             terraform_var_yaml,
@@ -296,14 +294,14 @@ class VSPHEREHELPERS(object):
         """
         # create config directory in scale_up_terraform_data directory
         sclaeup_data_config_dir = os.path.join(
-                self.cluster_path,
-                constants.TERRAFORM_DATA_DIR,
-                constants.SCALEUP_TERRAFORM_DATA_DIR,
-                "config"
-            )
+            self.cluster_path,
+            constants.TERRAFORM_DATA_DIR,
+            constants.SCALEUP_TERRAFORM_DATA_DIR,
+            "config"
+        )
         create_directory_path(sclaeup_data_config_dir)
 
-        #generate config yaml file
+        # generate config yaml file
         scale_up_config_var_template = "scale_up_config.yaml.j2"
         scale_up_config_var_template_path = os.path.join(
             "ocp-deployment", scale_up_config_var_template
@@ -314,8 +312,6 @@ class VSPHEREHELPERS(object):
         scale_up_config_str = self._templating.render_template(
             scale_up_config_var_template_path, config.ENV_DATA
         )
-        logger.info(f"scale_up_config_str: {scale_up_config_str}")
-
         scale_config_var_yaml = os.path.join(
             sclaeup_data_config_dir,
             "config.yaml"
@@ -324,4 +320,4 @@ class VSPHEREHELPERS(object):
         with open(scale_config_var_yaml, "w") as f:
             f.write(scale_up_config_str)
 
-        logger.info(f"scale_config_var_yaml : {scale_config_var_yaml}")
+        logger.debug(f"scaleup config yaml file : {scale_config_var_yaml}")

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -153,8 +153,8 @@ class OCPINSTALLRHEL(object):
             constants.TERRAFORM_DATA_DIR,
             constants.INVENTORY_FILE
         )
-        logger.info(f"inventory_config_str: {inventory_config_str}")
-        logger.info(f"inventory_yaml: {inventory_yaml}")
+        logger.debug(f"inventory_config_str: {inventory_config_str}")
+        logger.debug(f"inventory_yaml: {inventory_yaml}")
         with open(inventory_yaml, "w") as f:
             f.write(inventory_config_str)
 
@@ -189,7 +189,6 @@ class OCPINSTALLRHEL(object):
         inventory_data_haproxy['workers'] = compute_address
 
         logger.info("Generating inventory file for haproxy")
-        logger.info(f"inventory_data_haproxy: {inventory_data_haproxy}")
         _templating = Templating()
         inventory_template_path_haproxy = os.path.join(
             "ocp-deployment", constants.INVENTORY_TEMPLATE_HAPROXY
@@ -202,8 +201,8 @@ class OCPINSTALLRHEL(object):
             constants.TERRAFORM_DATA_DIR,
             constants.INVENTORY_FILE_HAPROXY
         )
-        logger.info(f"inventory_config_haproxy_str: {inventory_config_haproxy_str}")
-        logger.info(f"inventory_yaml: {inventory_yaml_haproxy}")
+        logger.debug(f"inventory contents for haproxy: {inventory_config_haproxy_str}")
+        logger.debug(f"inventory yaml: {inventory_yaml_haproxy}")
         with open(inventory_yaml_haproxy, "w") as f:
             f.write(inventory_config_haproxy_str)
 

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -9,7 +9,8 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import upload
 from ocs_ci.utility.templating import Templating
 from ocs_ci.utility.utils import (
-    create_rhelpod, get_ocp_repo
+    create_rhelpod, get_ocp_repo, get_module_ip, get_ocp_version,
+    run_cmd,
 )
 
 
@@ -32,6 +33,17 @@ class OCPINSTALLRHEL(object):
                      'rhel1-2.vavuthu.qe.rh-ocs.com']
 
         """
+        self.terraform_state_file = os.path.join(
+            config.ENV_DATA['cluster_path'],
+            "terraform_data",
+            "terraform.tfstate"
+        )
+        self.haproxy_playbook = os.path.join(
+            constants.CLUSTER_LAUNCHER_VSPHERE_DIR,
+            f"aos-{get_ocp_version('_')}",
+            "ansible_haproxy_configure",
+            "main.yml"
+        )
         self.rhel_worker_nodes = rhel_worker_nodes
         self.ssh_key_pem = config.DEPLOYMENT['ssh_key_private']
         self.pod_ssh_key_pem = os.path.join(
@@ -96,8 +108,24 @@ class OCPINSTALLRHEL(object):
         upload(self.pod_name, self.ops_mirror_pem, constants.PEM_PATH)
         upload(self.pod_name, self.kubeconfig, constants.POD_UPLOADPATH)
         upload(self.pod_name, self.pull_secret_path, constants.POD_UPLOADPATH)
+        if config.ENV_DATA['folder_structure']:
+            inventory_yaml_haproxy = self.create_inventory_for_haproxy()
+            upload(
+                self.pod_name,
+                inventory_yaml_haproxy,
+                constants.POD_UPLOADPATH
+            )
+            cmd = (
+                f"ansible-playbook -i {inventory_yaml_haproxy} "
+                f"{self.haproxy_playbook} --private-key={self.ssh_key_pem} -v"
+            )
+            run_cmd(cmd)
         self.inventory_yaml = self.create_inventory()
-        upload(self.pod_name, self.inventory_yaml, constants.POD_UPLOADPATH)
+        upload(
+            self.pod_name,
+            self.inventory_yaml,
+            constants.POD_UPLOADPATH
+        )
 
     def create_inventory(self):
         """
@@ -132,19 +160,69 @@ class OCPINSTALLRHEL(object):
 
         return inventory_yaml
 
+    def create_inventory_for_haproxy(self):
+        """
+        Creates the inventory file for haproxy
+
+        Returns:
+            str: Path to inventory file for haproxy
+
+        """
+        inventory_data_haproxy = {}
+        inventory_data_haproxy['ssh_key_private'] = self.ssh_key_pem
+        inventory_data_haproxy['platform'] = config.ENV_DATA['platform']
+        inventory_data_haproxy['rhel_worker_nodes'] = self.rhel_worker_nodes
+        lb_address = get_module_ip(
+            self.terraform_state_file,
+            constants.LOAD_BALANCER_MODULE
+        )
+        control_plane_address = get_module_ip(
+            self.terraform_state_file,
+            constants.CONTROL_PLANE
+        )
+        compute_address = get_module_ip(
+            self.terraform_state_file,
+            constants.COMPUTE_MODULE
+        )
+        inventory_data_haproxy['lb'] = lb_address
+        inventory_data_haproxy['masters'] = control_plane_address
+        inventory_data_haproxy['workers'] = compute_address
+
+        logger.info("Generating inventory file for haproxy")
+        logger.info(f"inventory_data_haproxy: {inventory_data_haproxy}")
+        _templating = Templating()
+        inventory_template_path_haproxy = os.path.join(
+            "ocp-deployment", constants.INVENTORY_TEMPLATE_HAPROXY
+        )
+        inventory_config_haproxy_str = _templating.render_template(
+            inventory_template_path_haproxy, inventory_data_haproxy
+        )
+        inventory_yaml_haproxy = os.path.join(
+            self.cluster_path,
+            constants.TERRAFORM_DATA_DIR,
+            constants.INVENTORY_FILE_HAPROXY
+        )
+        logger.info(f"inventory_config_haproxy_str: {inventory_config_haproxy_str}")
+        logger.info(f"inventory_yaml: {inventory_yaml_haproxy}")
+        with open(inventory_yaml_haproxy, "w") as f:
+            f.write(inventory_config_haproxy_str)
+
+        return inventory_yaml_haproxy
+
     def prepare_rhel_nodes(self):
         """
         Prepare RHEL nodes for OCP installation
         """
         for node in self.rhel_worker_nodes:
             # set the hostname
-            cmd = f"sudo hostnamectl set-hostname {node}"
-            self.rhelpod.exec_cmd_on_node(
-                node,
-                self.pod_ssh_key_pem,
-                cmd,
-                user=constants.VM_RHEL_USER
-            )
+            if not config.ENV_DATA['folder_structure']:
+                cmd = f"sudo hostnamectl set-hostname {node}"
+                self.rhelpod.exec_cmd_on_node(
+                    node,
+                    self.pod_ssh_key_pem,
+                    cmd,
+                    user=constants.VM_RHEL_USER
+                )
 
             # upload ocp repo to node
             # considering normal user doesn't have permissions

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -716,6 +716,7 @@ VSPHERE_NODE_USER = "core"
 VSPHERE_INSTALLER_BRANCH = "release-4.3"
 VSPHERE_INSTALLER_REPO = "https://github.com/openshift/installer.git"
 VSPHERE_SCALEUP_REPO = "https://code.engineering.redhat.com/gerrit/openshift-misc"
+VSPHERE_CLUSTER_LAUNCHER = "https://gitlab.cee.redhat.com/aosqe/cluster-launcher.git"
 VSPHERE_DIR = os.path.join(EXTERNAL_DIR, "installer/upi/vsphere/")
 INSTALLER_IGNITION = os.path.join(VSPHERE_DIR, "machine/ignition.tf")
 VM_IFCFG = os.path.join(VSPHERE_DIR, "vm/ifcfg.tmpl")
@@ -736,6 +737,14 @@ SCALEUP_VSPHERE_VARIABLES = os.path.join(SCALEUP_VSPHERE_DIR, "variables.tf")
 SCALEUP_VSPHERE_ROUTE53 = os.path.join(SCALEUP_VSPHERE_DIR, "route53/vsphere-rhel-dns.tf")
 SCALEUP_VSPHERE_ROUTE53_VARIABLES = os.path.join(SCALEUP_VSPHERE_DIR, "route53/variables.tf")
 SCALEUP_VSPHERE_MACHINE_CONF = os.path.join(SCALEUP_VSPHERE_DIR, "machines/vsphere-rhel-machine.tf")
+
+# cluster-launcher
+CLUSTER_LAUNCHER_VSPHERE_DIR = os.path.join(
+    EXTERNAL_DIR,
+    "cluster-launcher/v4-scaleup/ocp4-rhel-scaleup/"
+)
+CLUSTER_LAUNCHER_MACHINE_CONF = "vsphere/machines/vsphere-rhel-machine.tf"
+
 TERRAFORM_VARS = "terraform.tfvars"
 VM_DISK_TYPE = "thin"
 VM_DISK_MODE = "persistent"
@@ -797,6 +806,9 @@ SUPPORTED_BROWSERS = (CHROME_BROWSER)
 # Inventory
 INVENTORY_TEMPLATE = "inventory.yaml.j2"
 INVENTORY_FILE = "inventory.yaml"
+
+INVENTORY_TEMPLATE_HAPROXY = "inventory_haproxy.yaml.j2"
+INVENTORY_FILE_HAPROXY = "inventory_haproxy.yaml"
 
 # users
 VM_RHEL_USER = "test"
@@ -1067,6 +1079,7 @@ FILE_PATH = '/tmp/ceph.tar.gz'
 BOOTSTRAP_MODULE = "module.ipam_bootstrap"
 LOAD_BALANCER_MODULE = "module.ipam_lb"
 COMPUTE_MODULE = "module.ipam_compute"
+CONTROL_PLANE = "module.ipam_control_plane"
 
 # proxy location
 HAPROXY_LOCATION = "/etc/haproxy/haproxy.conf"

--- a/ocs_ci/templates/ocp-deployment/cluster_info.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/cluster_info.yaml.j2
@@ -1,0 +1,26 @@
+{
+  "TEMPLATE_VARS": {{ template_vars | default('PLACEHOLDER') }},
+  "GENERAL": {
+    "PLATFORM": {{ platform | default('vsphere') }},
+    "PLATFORM_NAME": {{ platform_name | default('vsphere_vcsa-qe') }},
+    "NETWORK_TYPE": {{ network_type | default('normal') }},
+    "CUSTOMER_VPC_ENABLE": {{ vpc_enable | default('no') }}
+  },
+  "INSTALLER": {
+    "KUBECONFIG_URL": {{ kubeconfig_url }},
+    "METADATA": {
+      "clusterName": {{ cluster_name }},
+      "clusterID": {{ cluster_id }},
+      "infraID": {{ infra_id }},
+      "vsphere": {
+        "vCenter": {{ vsphere_server }},
+        "username": {{ vsphere_user | default('Administrator@vsphere.local') }},
+        "password": {{ vsphere_password }}
+      }
+    },
+    "VERSION": {{ installer_version }},
+    "VER_X": {{ ocp_version_x }},
+    "VER_Y": {{ ocp_version_y }},
+    "INFRA_ID": {{ infra_id }}
+  }
+}

--- a/ocs_ci/templates/ocp-deployment/inventory_haproxy.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/inventory_haproxy.yaml.j2
@@ -1,0 +1,31 @@
+[OSEv3:children]
+masters
+workers
+lb
+bootstrap
+
+[OSEv3:vars]
+ansible_become=True
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o VerifyHostKeyDNS=yes'
+ansible_ssh_private_key_file={{ssh_key_private}}
+ocp_platform={{ platform }}
+
+
+[lb]
+{% for node in lb %}
+{{ node }} ansible_user=core
+{% endfor %}
+
+[masters]
+{% for node in masters %}
+{{ node }} ansible_user=core
+{% endfor %}
+
+[workers]
+{% for node in workers %}
+{{ node }} ansible_user=core
+{% endfor %}
+
+{% for node in rhel_worker_nodes %}
+{{ node }} ansible_user=test
+{% endfor %}

--- a/ocs_ci/templates/ocp-deployment/scale_up_config.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/scale_up_config.yaml.j2
@@ -1,0 +1,34 @@
+services:
+ vsphere_vcsa-qe:
+    install_base_domain: {{ base_domain }}
+    connect:
+      host: {{ vsphere_server }}
+      insecure: {{ insecure | default('true') }}
+      user: {{ vsphere_user | default('Administrator@vsphere.local') }}
+      password: {{ vsphere_password }}
+    common:
+      cluster: {{ vsphere_cluster }}
+      datacenter: {{ vsphere_datacenter }}
+      datastore: {{ vsphere_datastore }}
+      CIDR: {{ machine_cidr }}
+      network: {{ vm_network | default('VM Network') }}
+    create_opts:
+      type: {{ create_type | default(':clone') }}
+      clone_opts:
+        from_vm: {{ rhel_template | default('rhel77_ocs4qe') }}
+        target_resource_pool: {{ target_resource_pool | default('null') }}
+    host_connect_opts:
+      user: {{ host_user | default('root') }}
+      ssh_private_key: {{ ssh_key_private }}
+      class: {{ host_class | default('SSHAccessibleHost') }}
+    ipam_server:
+      host: {{ ipam | default('139.178.89.254') }}
+      token: {{ ipam_token }}
+    cloud_type: {{ platform }}
+
+ AWS-CI:
+    # <<: *AWSPriv
+    awscred: {{ aws_creds_path | default('~/.aws') }}
+    config_opts:
+      region: {{ region | default('us-east-2')}}
+    install_base_domain: {{ base_domain }}

--- a/ocs_ci/templates/ocp-deployment/scale_up_terraform_with_folder_structure.tfvars.j2
+++ b/ocs_ci/templates/ocp-deployment/scale_up_terraform_with_folder_structure.tfvars.j2
@@ -1,0 +1,6 @@
+BUILD_NUMBER: {{ build_number | default('1275') }}
+RHEL_WORKER_COUNT: {{ nodes_scaleup_count | default('3') }}
+CLUSTER_INFO_PATH: {{ cluster_info_path }}
+CREDS_ROOT_PATH: {{ credentials_path }}
+EXTRA_VARS: {{ extra_vars | default("")}}
+PLATFORM: {{ platform | default('vsphere') }}

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2642,4 +2642,3 @@ def get_cluster_id(cluster_path):
     with open(metadata_file) as f:
         metadata = json.load(f)
     return metadata["clusterID"]
-

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2625,3 +2625,21 @@ def skipif_upgraded_from(version_list):
     except Exception as err:
         log.error(str(err))
         return False
+
+
+def get_cluster_id(cluster_path):
+    """
+    Get ClusterID from metadata.json in given cluster_path
+
+    Args:
+        cluster_path: path to cluster install directory
+
+    Returns:
+        str: metadata.json['clusterID']
+
+    """
+    metadata_file = os.path.join(cluster_path, "metadata.json")
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+    return metadata["clusterID"]
+


### PR DESCRIPTION
Fixes: #2544 

This PR contains following important commits

760bcd692d0f3ee2aa140adff44c62bb0f89d814 : Adding cluster_info and config jinja2 templates
10b2a887c21abdeecb0b319e49e0b112458a8dee : Adding inventory_proxy and scale_up_terraform_with_folder_structure jinja2
    templates for RHEL - vSphere
477c68297339f41dc043fade97e2df7dae3e03b0 : Adding constants and utility functions for RHEL deployment for OCP 4.5-vsphere
c703e183febba999f7f4217a27727022072456b4 : Adding vsphere helper module and generate haproxy config for OCP 4.5
a14756faf4d16222100cf6ca9bcb730c2f2b4809 : Supporting RHEL installation for OCP 4.5 in vSphere platform
47c816653bc1d64cda81be6058053855ce44859b : Add destroy functionality for RHEL on OCP 4.5 and removed unused code

Signed-off-by: vavuthu vavuthu@redhat.com