### PR TITLE
skip test_automated_recovery_from_failed_nodes_IPI_reactive shutdown tests with BZ 1845666

### DIFF
--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -62,7 +62,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 *['rbd', 'shutdown'],
                 marks=[
                     pytest.mark.polarion_id("OCS-2102"),
-                    pytest.mark.bugzilla("1830015")
+                    pytest.mark.bugzilla("1845666")
                 ]
             ),
             pytest.param(
@@ -73,7 +73,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 *['cephfs', 'shutdown'],
                 marks=[
                     pytest.mark.polarion_id("OCS-2104"),
-                    pytest.mark.bugzilla("1830015")
+                    pytest.mark.bugzilla("1845666")
                 ]
             ),
             pytest.param(


### PR DESCRIPTION

Signed-off-by: Prasad Desala <tdesala@redhat.com>