### PR TITLE
Add conftest.py hook for vSphere (#2779)

### DIFF
--- a/tests/e2e/scale/conftest.py
+++ b/tests/e2e/scale/conftest.py
@@ -15,7 +15,8 @@ def pytest_collection_modifyitems(items):
     """
     skip_list = [
         'test_scale_pvc_expand',
-        'test_ceph_pod_respin_in_scaled_cluster'
+        'test_ceph_pod_respin_in_scaled_cluster',
+        'test_scale_osds_fill_75%_reboot_workers'
     ]
     if config.ENV_DATA['platform'].lower() == constants.VSPHERE_PLATFORM:
         for item in items.copy():

--- a/tests/e2e/scale/conftest.py
+++ b/tests/e2e/scale/conftest.py
@@ -1,0 +1,29 @@
+import logging
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+
+log = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(items):
+    """
+    A pytest hook to skip certain tests when running on vSphere.
+
+    Args:
+        items: list of collected tests
+
+    """
+    skip_list = [
+        'test_scale_pvc_expand',
+        'test_ceph_pod_respin_in_scaled_cluster'
+    ]
+    if config.ENV_DATA['platform'].lower() == constants.VSPHERE_PLATFORM:
+        for item in items.copy():
+            for testname in skip_list:
+                if testname in str(item.fspath):
+                    log.info(
+                        f"Test {item} is removed from the collected items"
+                        f" since it does not run on vSphere"
+                    )
+                    items.remove(item)
+                    break


### PR DESCRIPTION
The test_scale_pvc_expand and test_ceph_pod_respin_in_scaled_cluster
tests should not be run on vms.

Signed-off-by: wusui <wusui@redhat.com>