### PR TITLE
removed workaround for OSD timeout after upgrade

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -111,12 +111,9 @@ def verify_image_versions(old_images, upgrade_version, version_before_upgrade):
     )
     verify_pods_upgraded(old_images, selector=constants.MON_APP_LABEL, count=3)
     verify_pods_upgraded(old_images, selector=constants.MGR_APP_LABEL)
-    # OSD upgrade have timeout 10mins for new attempt if cluster is not health.
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1840729 setting timeout for
-    # 12.5 minutes per OSD
     verify_pods_upgraded(
         old_images, selector=constants.OSD_APP_LABEL, count=osd_count,
-        timeout=750 * osd_count,
+        timeout=600 * osd_count,
     )
     verify_pods_upgraded(old_images, selector=constants.MDS_APP_LABEL, count=2)
     if config.ENV_DATA.get('platform') in constants.ON_PREM_PLATFORMS:

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -111,9 +111,10 @@ def verify_image_versions(old_images, upgrade_version, version_before_upgrade):
     )
     verify_pods_upgraded(old_images, selector=constants.MON_APP_LABEL, count=3)
     verify_pods_upgraded(old_images, selector=constants.MGR_APP_LABEL)
+    osd_timeout = 600 if upgrade_version >= parse_version('4.5') else 750
     verify_pods_upgraded(
         old_images, selector=constants.OSD_APP_LABEL, count=osd_count,
-        timeout=600 * osd_count,
+        timeout=osd_timeout * osd_count,
     )
     verify_pods_upgraded(old_images, selector=constants.MDS_APP_LABEL, count=2)
     if config.ENV_DATA.get('platform') in constants.ON_PREM_PLATFORMS:


### PR DESCRIPTION
with this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1840729 moved to verify, im removing the workaround we had in the code, time out set to 10 minutes again

Signed-off-by: aviadp <apolak@redhat.com>