### PR TITLE
Skip multipart upload test

### DIFF
--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -50,6 +50,7 @@ class TestS3MultipartUpload(ManageTest):
     """
     @tier1
     @pytest.mark.polarion_id("OCS-2245")
+    @pytest.mark.skip("Skipped because of https://github.com/red-hat-storage/ocs-ci/issues/2832")
     def test_multipart_upload_operations(self, awscli_pod, rgw_bucket_factory):
         """
         Test Multipart upload operations on bucket and verifies the integrity of the downloaded object

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -50,7 +50,7 @@ class TestS3MultipartUpload(ManageTest):
     """
     @tier1
     @pytest.mark.polarion_id("OCS-2245")
-    @pytest.mark.skip("Skipped because of https://github.com/red-hat-storage/ocs-ci/issues/2832")
+    @pytest.mark.skip(reason="Skipped because of https://github.com/red-hat-storage/ocs-ci/issues/2832")
     def test_multipart_upload_operations(self, awscli_pod, rgw_bucket_factory):
         """
         Test Multipart upload operations on bucket and verifies the integrity of the downloaded object


### PR DESCRIPTION
The test was not supposed to be part of our RGW testing, since it uses a Python S3 client, but we do not have access to the RGW cluster from the code executioner, which means this code cannot run successfully.

This will only be possible to use in a future case where RGW traffic is externalized with an endpoint and becomes accessible from outside the cluster.

Done because of #2832