### PR TITLE
Fixed Vsphere and BareMetal naming in codespeed

### DIFF
--- a/ocs_ci/utility/performance_dashboard.py
+++ b/ocs_ci/utility/performance_dashboard.py
@@ -58,7 +58,7 @@ def initialize_data():
     if m and m.group(1) is not None:
         ocs_ver = m.group(1)
     log.info(f'ocs_ver is {ocs_ver_full}')
-    platform = config.ENV_DATA['platform']
+    platform = config.ENV_DATA['platform'].upper()
     if platform.lower() not in ['vsphere', 'baremetal']:
         platform = f'{platform.upper()} {worker_type}'
     data_template['commitid'] = ocs_ver_full


### PR DESCRIPTION
The current keys in the codespeed for the environment variables are in uppercase, this fixes the results that were not getting updated due to case sensitive match.

Signed-off-by: savetisy <savetisy@redhat.com>