### PR TITLE
make mcgcli_pod_fixture a prerequisite for mcg_obj fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1583,7 +1583,7 @@ def rgw_obj_fixture(request):
     return RGW()
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='session')
 def mcgcli_pod_fixture(request):
     """
     Grab the MCG CLI tool from the NooBaa operator pod,
@@ -1679,12 +1679,12 @@ def mcgcli_pod_fixture(request):
 
 
 @pytest.fixture()
-def mcg_obj(request):
+def mcg_obj(request, mcgcli_pod_fixture):
     return mcg_obj_fixture(request)
 
 
 @pytest.fixture(scope='session')
-def mcg_obj_session(request):
+def mcg_obj_session(request, mcgcli_pod_fixture):
     return mcg_obj_fixture(request)
 
 

--- a/tests/ecosystem/deployment/test_deployment.py
+++ b/tests/ecosystem/deployment/test_deployment.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 @deployment
 @polarion_id(get_deployment_polarion_id())
-def test_deployment(pvc_factory, pod_factory):
+def test_deployment(pvc_factory, pod_factory, mcgcli_pod_fixture):
     deploy = config.RUN['cli_params'].get('deploy')
     teardown = config.RUN['cli_params'].get('teardown')
     if not teardown or deploy:


### PR DESCRIPTION
In this PR is dropped `autosuse` in `mcgcli_pod_fixture` and making the fixture a prerequisite for `mcg_obj` fixture.
@MeridianExplorer Does it make sense? `mcg_obj` fixture is used in almost all mcg tests. It seems that tests that don't use `mcg_obj` fixture wouldn't benefit from this.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/2821

Signed-off-by: Filip Balak <fbalak@redhat.com>