### PR TITLE
Collecting must gather after every status of deployment

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -97,6 +97,7 @@ def get_ocsci_conf():
         ),
         REPORTING=dict(
             gather_on_deploy_failure=True,
+            gather_on_deploy_success=True,
         )
     )
     if env.get("DOWNSTREAM") == "true":

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -123,6 +123,8 @@ class Deployment(object):
         if not config.ENV_DATA['skip_ocs_deployment']:
             try:
                 self.deploy_ocs()
+                if config.REPORTING['gather_on_deploy_success']:
+                    collect_ocs_logs('deployment', ocp=False, status_failure=False)
             except Exception as e:
                 logger.error(e)
                 if config.REPORTING['gather_on_deploy_failure']:

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -91,6 +91,7 @@ REPORTING:
   ocs_must_gather_image: "quay.io/rhceph-dev/ocs-must-gather"
   default_ocs_must_gather_latest_tag: 'latest-4.6'
   gather_on_deploy_failure: true
+  gather_on_deploy_success: true
 
 # This is the default information about environment.
 ENV_DATA:

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -783,7 +783,7 @@ def collect_noobaa_db_dump(log_dir_path):
     )
 
 
-def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False):
+def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False, status_failure=True):
     """
     Collects OCS logs
 
@@ -793,6 +793,8 @@ def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False):
         ocp (bool): Whether to gather OCP logs
         ocs (bool): Whether to gather OCS logs
         mcg (bool): True for collecting MCG logs (noobaa db dump)
+        status_failure (bool): Whether the collection is after success or failure,
+            allows better naming for folders under logs directory
 
     """
     if not (
@@ -804,12 +806,17 @@ def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False):
             "skipping log collection"
         )
         return
-
-    log_dir_path = os.path.join(
-        os.path.expanduser(ocsci_config.RUN['log_dir']),
-        f"failed_testcase_ocs_logs_{ocsci_config.RUN['run_id']}",
-        f"{dir_name}_ocs_logs"
-    )
+    if status_failure:
+        log_dir_path = os.path.join(
+            os.path.expanduser(ocsci_config.RUN['log_dir']),
+            f"failed_testcase_ocs_logs_{ocsci_config.RUN['run_id']}",
+            f"{dir_name}_ocs_logs"
+        )
+    else:
+        log_dir_path = os.path.join(
+            os.path.expanduser(ocsci_config.RUN['log_dir']),
+            f"{dir_name}_{ocsci_config.RUN['run_id']}"
+        )
 
     if ocs:
         latest_tag = ocsci_config.REPORTING.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ from ocs_ci.ocs.mcg_workload import (
 )
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.utils import setup_ceph_toolbox
+from ocs_ci.ocs.utils import setup_ceph_toolbox, collect_ocs_logs
 from ocs_ci.ocs.resources.backingstore import (
     backingstore_factory as backingstore_factory_implementation
 )
@@ -2892,3 +2892,20 @@ def snapshot_restore_factory(request):
 
     request.addfinalizer(finalizer)
     return factory
+
+
+@pytest.fixture(scope="session", autouse=True)
+def collect_logs_fixture(request):
+    """
+    This fixture collects ocs logs after tier execution and this will allow
+    to see the cluster's status after the execution on all execution status options.
+    """
+    def finalizer():
+        """
+        Tracking both logs separately reduce changes of collision
+        """
+        if not config.RUN['cli_params'].get('deploy') and not config.RUN['cli_params'].get('teardown'):
+            collect_ocs_logs('testcases', ocs=False, status_failure=False)
+            collect_ocs_logs('testcases', ocp=False, status_failure=False)
+
+    request.addfinalizer(finalizer)


### PR DESCRIPTION
Allows to collect logs as well as if the OCS deployment succeeds.
That way we will have information about the cluster as well as if the deployment succeeded.