### PR TITLE
Add ceph health check at the end of the test

### DIFF
--- a/conf/ocp_version/ocp-4.5-upgrade.yaml
+++ b/conf/ocp_version/ocp-4.5-upgrade.yaml
@@ -1,5 +1,6 @@
 ---
 # Use this config for upgrading of OCP 4.4 to 4.5 cluster
 UPGRADE:
+  ocp_channel: "stable-4.5"
   ocp_upgrade_version: "4.5.0-0.nightly"
   ocp_upgrade_path: "registry.svc.ci.openshift.org/ocp/release"

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -6,6 +6,7 @@ from ocs_ci.utility.utils import (
     TimeoutSampler,
     get_latest_ocp_version,
     expose_ocp_version,
+    ceph_health_check
 )
 from ocs_ci.framework.testlib import ManageTest, ocp_upgrade, ignore_leftovers
 from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
@@ -25,7 +26,7 @@ class TestUpgradeOCP(ManageTest):
     5. monitor cluster health
     """
 
-    def test_upgrade_ocp(self):
+    def test_upgrade_ocp(self, reduce_cluster_load):
         """
         Tests OCS stability when upgrading OCP
 
@@ -116,3 +117,7 @@ class TestUpgradeOCP(ManageTest):
                 if sampler:
                     logger.info("Upgrade Completed Successfully!")
                     break
+
+        new_ceph_cluster = CephCluster()
+        new_ceph_cluster.wait_for_rebalance(timeout=1800)
+        ceph_health_check(tries=90, delay=30)


### PR DESCRIPTION
When running ocp upgrade with IO, sometime teardown failed due to unclean PGs. adding this check should avoid this situation

fix issue [2602](https://github.com/red-hat-storage/ocs-ci/issues/2602)

Signed-off-by: aviadp <apolak@redhat.com>