### PR TITLE
Download terraform ignition provider for destroy job.

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -36,7 +36,7 @@ from ocs_ci.utility.utils import (
     replace_content_in_file, run_cmd, upload_file, wait_for_co,
     get_ocp_version, get_terraform, set_aws_region,
     configure_chrony_and_wait_for_machineconfig_status,
-    get_terraform_ignition_provider,
+    get_terraform_ignition_provider, get_ocp_upgrade_history,
 )
 from ocs_ci.utility.vsphere import VSPHERE as VSPHEREUtil
 from semantic_version import Version
@@ -666,7 +666,32 @@ class VSPHEREUPI(VSPHEREBASE):
                 terraform_plugins_path,
                 "terraform-provider-ignition"
             )
-            if not os.path.exists(terraform_ignition_provider_path):
+
+            # check the upgrade history of cluster and checkout to the
+            # original installer release. This is due to the issue of not
+            # supporting terraform state of OCP 4.5 in installer
+            # release of 4.6 branch. More details in
+            # https://github.com/red-hat-storage/ocs-ci/issues/2941
+            is_cluster_upgraded = False
+            try:
+                upgrade_history = get_ocp_upgrade_history()
+                if len(upgrade_history) > 1:
+                    is_cluster_upgraded = True
+                    original_installed_ocp_version = upgrade_history[-1]
+                    installer_release_branch = (
+                        f"release-{original_installed_ocp_version[0:3]}"
+                    )
+                    clone_repo(
+                        constants.VSPHERE_INSTALLER_REPO, upi_repo_path,
+                        installer_release_branch
+                    )
+            except Exception as ex:
+                logger.error(ex)
+
+            if not (
+                os.path.exists(terraform_ignition_provider_path)
+                or is_cluster_upgraded
+            ):
                 get_terraform_ignition_provider(terraform_data_dir)
             terraform.initialize()
         else:

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -657,6 +657,17 @@ class VSPHEREUPI(VSPHEREBASE):
         terraform = Terraform(os.path.join(upi_repo_path, "upi/vsphere/"))
         os.chdir(terraform_data_dir)
         if Version.coerce(ocp_version) >= Version.coerce('4.6'):
+            # Download terraform ignition provider. For OCP upgrade clusters,
+            # ignition provider doesn't exist, so downloading in destroy job
+            # as well
+            terraform_plugins_path = ".terraform/plugins/linux_amd64/"
+            terraform_ignition_provider_path = os.path.join(
+                terraform_data_dir,
+                terraform_plugins_path,
+                "terraform-provider-ignition"
+            )
+            if not os.path.exists(terraform_ignition_provider_path):
+                get_terraform_ignition_provider(terraform_data_dir)
             terraform.initialize()
         else:
             terraform.initialize(upgrade=True)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2643,3 +2643,22 @@ def get_cluster_id(cluster_path):
     with open(metadata_file) as f:
         metadata = json.load(f)
     return metadata["clusterID"]
+
+
+def get_ocp_upgrade_history():
+    """
+    Gets the OCP upgrade history for the cluster
+
+    Returns:
+        list: List of OCP upgrade paths. Latest version in the
+            beginning of the list
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+    ocp = OCP(kind="clusterversion")
+    cluster_version_info = ocp.get("version")
+    upgrade_history_info = cluster_version_info['status']['history']
+    upgrade_history = [
+        each_upgrade['version'] for each_upgrade in upgrade_history_info
+    ]
+    return upgrade_history

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2654,6 +2654,7 @@ def get_ocp_upgrade_history():
             beginning of the list
 
     """
+    # importing here to avoid circular imports
     from ocs_ci.ocs.ocp import OCP
     ocp = OCP(kind="clusterversion")
     cluster_version_info = ocp.get("version")


### PR DESCRIPTION
Fixes: #2941 

Download terraform ignition provider for destroy job.
usecase: OCP 4.5 to OCP 4.6 upgrade

Signed-off-by: vavuthu <vavuthu@redhat.com>