### PR TITLE
Include squad analysis into email results report

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,8 @@ to the pytest.
    necessary styles and scripts
 * `--email` - to send the email reports of the test run which was generated
    by --html option. MUST specify --html to send email reports.
+* `--squad-analysis` - Include Squad Analysis to email report. Applicable only
+    in combination with --email option.
 * `--bugzilla` - allows you to skip tests with unresolved bug (test case
   needs to be properly decorated as you can see in
   [documentation](./writing_tests.md)). You will also need to

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -85,6 +85,13 @@ def pytest_addoption(parser):
         help="Email ID to send results",
     )
     parser.addoption(
+        '--squad-analysis',
+        dest='squad_analysis',
+        action="store_true",
+        default=False,
+        help="Include Squad Analysis to email report.",
+    )
+    parser.addoption(
         '--collect-logs',
         dest='collect-logs',
         action="store_true",
@@ -383,6 +390,7 @@ def process_cluster_cli_params(config):
             raise ClusterNameNotProvidedError()
     if get_cli_param(config, 'email') and not get_cli_param(config, '--html'):
         pytest.exit("--html option must be provided to send email reports")
+    get_cli_param(config, 'squad_analysis')
     get_cli_param(config, '-m')
     osd_size = get_cli_param(config, '--osd-size')
     if osd_size:

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -43,6 +43,16 @@ def pytest_runtest_makereport(item, call):
             log_file = logging.getLogger().handlers[1].baseFilename
         extra.append(pytest_html.extras.url(log_file, name='Log File'))
         report.extra = extra
+        item.session.results[item] = report
+    if report.skipped:
+        item.session.results[item] = report
+
+
+def pytest_sessionstart(session):
+    """
+    Prepare results dict
+    """
+    session.results = dict()
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -50,4 +60,4 @@ def pytest_sessionfinish(session, exitstatus):
     send email report
     """
     if ocsci_config.RUN['cli_params'].get('email'):
-        email_reports()
+        email_reports(session)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1153,7 +1153,7 @@ SQUADS = {
     'Brown': ["/nodes/"],
     'Green': ["/pv_services/", "/storageclass/"],
     'Blue': ["/monitoring/"],
-    'Red': ["/mcg/"],
+    'Red': ["/mcg/", "/rgw/"],
     'Yellow': ["/cluster_expansion/"],
     'Purple': ["/test_must_gather", "/upgrade/"],
     'Magenta': ["/workloads/", "/registry/", "/logging/"],

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1143,11 +1143,12 @@ MCG_NS_RESOURCE = 'ns_resource'
 MCG_NS_BUCKET = 'ns-bucket'
 MCG_NS_AWS_CONNECTION = 'aws_connection'
 
-# Create your own squads.
-# Squads are separated by Python packages in your project so it is important to
-# put the squad name in '.' --> ".squad_name." For example: In case this test
-# fails - tests.e2e.registry.test_pod_from_registry.TestRegistryImage.test_run_pod_local_image
-# the squad is ".registry." as can be seen in the Magenta squad below
+# Squads assignment
+# Tests are assigned to Squads based on patterns matching test path.
+# For example: In case following test fails:
+# tests/e2e/registry/test_pod_from_registry.py::TestRegistryImage::test_run_pod_local_image
+# the pattern "/registry/" match the test path and so the test belongs to
+# Magenta squad.
 SQUADS = {
     'Brown': ["/nodes/"],
     'Green': ["/pv_services/", "/storageclass/"],

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1142,3 +1142,20 @@ MCG_NS_AWS_ENDPOINT = 'https://s3.amazonaws.com'
 MCG_NS_RESOURCE = 'ns_resource'
 MCG_NS_BUCKET = 'ns-bucket'
 MCG_NS_AWS_CONNECTION = 'aws_connection'
+
+# Create your own squads.
+# Squads are separated by Python packages in your project so it is important to
+# put the squad name in '.' --> ".squad_name." For example: In case this test
+# fails - tests.e2e.registry.test_pod_from_registry.TestRegistryImage.test_run_pod_local_image
+# the squad is ".registry." as can be seen in the Magenta squad below
+SQUADS = {
+    'Brown': ["/nodes/"],
+    'Green': ["/pv_services/", "/storageclass/"],
+    'Blue': ["/monitoring/"],
+    'Red': ["/mcg/"],
+    'Yellow': ["/cluster_expansion/"],
+    'Purple': ["/test_must_gather", "/upgrade/"],
+    'Magenta': ["/workloads/", "/registry/", "/logging/"],
+    'Grey': ["/performance/"],
+    'Orange': ["/scale/"],
+}

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -936,6 +936,7 @@ def parse_html_for_email(soup):
 
 def add_squad_analysis_to_email(session, soup):
     """
+    Add squad analysis to the html test results used in email reporting
 
     Args:
         session (obj): Pytest session object

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -940,7 +940,7 @@ def add_squad_analysis_to_email(session, soup):
 
     Args:
         session (obj): Pytest session object
-        soup (obj): BeautifulSoup object
+        soup (obj): BeautifulSoup object of HTML Report data
 
     """
     failed = {}


### PR DESCRIPTION
Controlled by `--squad-analysis` parameter.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/2920

Signed-off-by: Daniel Horak <dahorak@redhat.com>