### PR TITLE
Test to verify snapshot when PVC usage is at different levels

### DIFF
--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -3,6 +3,7 @@ General PVC object
 """
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnavailableResourceException
@@ -126,6 +127,12 @@ class PVC(OCS):
             'persistentVolumeReclaimPolicy'
         )
 
+    @property
+    def provisioner(self):
+        return self.get()['metadata']['annotations'][
+            'volume.beta.kubernetes.io/storage-provisioner'
+        ]
+
     def resize_pvc(self, new_size, verify=False):
         """
         Modify the capacity of PVC
@@ -180,6 +187,31 @@ class PVC(OCS):
             if pvc == self.name:
                 attached_pods.append(pod_obj)
         return attached_pods
+
+    def create_snapshot(self, snapshot_name=None, wait=False):
+        """
+        Take snapshot of the PVC
+
+        Args:
+            snapshot_name (str): Name to be provided for snapshot
+            wait (bool): True to wait for snapshot to be ready, False otherwise
+
+        Returns:
+            OCS: Kind Snapshot
+
+        """
+        assert self.provisioner in constants.OCS_PROVISIONERS, (
+            "Unknown provisioner"
+        )
+        if self.provisioner == 'openshift-storage.rbd.csi.ceph.com':
+            snap_yaml = constants.CSI_RBD_SNAPSHOT_YAML
+        elif self.provisioner == 'openshift-storage.cephfs.csi.ceph.com':
+            snap_yaml = constants.CSI_CEPHFS_SNAPSHOT_YAML
+        snapshot_name = snapshot_name or f"{self.name}-snapshot-{uuid4().hex}"
+        return create_pvc_snapshot(
+            pvc_name=self.name, snap_yaml=snap_yaml, snap_name=snapshot_name,
+            wait=wait
+        )
 
 
 def delete_pvcs(pvc_objs, concurrent=False):
@@ -305,7 +337,9 @@ def get_deviceset_pvs():
     return [pvc.backed_pv_obj for pvc in deviceset_pvcs]
 
 
-def create_pvc_snapshot(pvc_name, snap_yaml, snap_name, sc_name):
+def create_pvc_snapshot(
+    pvc_name, snap_yaml, snap_name, sc_name=None, wait=False
+):
     """
     Create snapshot of a PVC
 
@@ -314,17 +348,24 @@ def create_pvc_snapshot(pvc_name, snap_yaml, snap_name, sc_name):
         snap_yaml (str): The path of snapshot yaml
         snap_name (str): The name of the snapshot to be created
         sc_name (str): The name of the snapshot class
+        wait (bool): True to wait for snapshot to be ready, False otherwise
 
     Returns:
         OCS object
     """
     snapshot_data = templating.load_yaml(snap_yaml)
     snapshot_data['metadata']['name'] = snap_name
-    snapshot_data['spec']['volumeSnapshotClassName'] = sc_name
+    if sc_name:
+        snapshot_data['spec']['volumeSnapshotClassName'] = sc_name
     snapshot_data['spec']['source']['persistentVolumeClaimName'] = pvc_name
     ocs_obj = OCS(**snapshot_data)
     created_snap = ocs_obj.create(do_reload=True)
     assert created_snap, f"Failed to create snapshot {snap_name}"
+    if wait:
+        ocs_obj.ocp.wait_for_resource(
+            condition='true', resource_name=ocs_obj.name,
+            column=constants.STATUS_READYTOUSE, timeout=60
+        )
     return ocs_obj
 
 

--- a/ocs_ci/templates/CSI/cephfs/pvc-restore.yaml
+++ b/ocs_ci/templates/CSI/cephfs/pvc-restore.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: cephfs-pvc-restore
 spec:
-  storageClassName: csi-cephfs-sc
+  storageClassName: ocs-storagecluster-cephfs
   dataSource:
     name: cephfs-pvc-snapshot
     kind: VolumeSnapshot

--- a/ocs_ci/templates/CSI/cephfs/snapshot.yaml
+++ b/ocs_ci/templates/CSI/cephfs/snapshot.yaml
@@ -4,6 +4,6 @@ kind: VolumeSnapshot
 metadata:
   name: cephfs-pvc-snapshot
 spec:
-  volumeSnapshotClassName: csi-cephfsplugin-snapclass
+  volumeSnapshotClassName: ocs-storagecluster-cephfsplugin-snapclass
   source:
     persistentVolumeClaimName: csi-cephfs-pvc

--- a/ocs_ci/templates/CSI/rbd/pvc-restore.yaml
+++ b/ocs_ci/templates/CSI/rbd/pvc-restore.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: rbd-pvc-restore
 spec:
-  storageClassName: csi-rbd
+  storageClassName: ocs-storagecluster-ceph-rbd
   dataSource:
     name: rbd-pvc-snapshot
     kind: VolumeSnapshot

--- a/ocs_ci/templates/CSI/rbd/snapshot.yaml
+++ b/ocs_ci/templates/CSI/rbd/snapshot.yaml
@@ -4,6 +4,6 @@ kind: VolumeSnapshot
 metadata:
   name: rbd-pvc-snapshot
 spec:
-  volumeSnapshotClassName: csi-rbdplugin-snapclass
+  volumeSnapshotClassName: ocs-storagecluster-rbdplugin-snapclass
   source:
     persistentVolumeClaimName: rbd-pvc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2564,18 +2564,18 @@ def multi_dc_pod(multi_pvc_factory, dc_pod_factory, service_account_factory):
         dc_pods_res = []
         sa_obj = service_account_factory(project=project)
         with ThreadPoolExecutor() as p:
-            for pvc in pvc_objs:
+            for pvc_obj in pvc_objs:
                 if create_rbd_block_rwx_pod:
                     dc_pods_res.append(
                         p.submit(
                             dc_pod_factory, interface=constants.CEPHBLOCKPOOL,
-                            pvc=pvc, raw_block_pv=True, sa_obj=sa_obj
+                            pvc=pvc_obj, raw_block_pv=True, sa_obj=sa_obj
                         ))
                 else:
                     dc_pods_res.append(
                         p.submit(
                             dc_pod_factory, interface=dict_types[pool_type],
-                            pvc=pvc, sa_obj=sa_obj
+                            pvc=pvc_obj, sa_obj=sa_obj
                         ))
 
         for dc in dc_pods_res:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,6 @@ from ocs_ci.ocs.resources.rgw import RGW
 from ocs_ci.ocs.jenkins import Jenkins
 from ocs_ci.ocs.couchbase import CouchBase
 from ocs_ci.ocs.amq import AMQ
-from ocs_ci.ocs.resources import pvc
 
 log = logging.getLogger(__name__)
 
@@ -2808,6 +2807,7 @@ def snapshot_restore_factory(request):
             OCS: OCS instance of kind VolumeSnapshot
 
         """
+        from ocs_ci.ocs.resources import pvc
         snapshot_info = snapshot_obj.get()
         size = size or snapshot_info['status']['restoreSize']
         restore_pvc_name = helpers.create_unique_resource_name(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2811,7 +2811,7 @@ def snapshot_restore_factory(request):
         snapshot_info = snapshot_obj.get()
         size = size or snapshot_info['status']['restoreSize']
         restore_pvc_name = helpers.create_unique_resource_name(
-            snapshot_obj.name, 'snapshot'
+            snapshot_obj.name, 'restore'
         )
 
         if snapshot_info['spec']['volumeSnapshotClassName'] == (
@@ -2829,7 +2829,7 @@ def snapshot_restore_factory(request):
             )
             restore_pvc_yaml = restore_pvc_yaml or constants.CSI_CEPHFS_PVC_RESTORE_YAML
         restored_pvc = pvc.create_restore_pvc(
-            sc_name=storageclass, snap_name=snapshot_obj.name,
+            sc_name=storageclass.name, snap_name=snapshot_obj.name,
             namespace=snapshot_obj.namespace, size=size,
             pvc_name=restore_pvc_name, volume_mode=volume_mode,
             restore_pvc_yaml=restore_pvc_yaml, access_mode=access_mode

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -18,7 +18,9 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
     Tests to take snapshot when PVC usage is at different levels
     """
     @pytest.fixture(autouse=True)
-    def setup(self, create_pvcs_and_pods):
+    def setup(
+        self, project_factory, snapshot_restore_factory, create_pvcs_and_pods
+    ):
         """
         Create PVCs and pods
 
@@ -31,13 +33,13 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
         )
 
     def test_snapshot_at_different_usage_level(
-        self, snapshot_factory, pod_factory, snapshot_restore_factory
+        self, snapshot_factory, snapshot_restore_factory, pod_factory
     ):
         """
         Test to take multiple snapshots of same PVC when the PVC usage is at
         0%, 20%, 40%, 60%, and 80%, then delete the parent PVC and restore the
         snapshots to create new PVCs. Delete snapshots and attach the restored
-        to pods to verify the data.
+        PVCs to pods to verify the data.
 
         """
         snapshots = []
@@ -175,6 +177,7 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
                 f"Attached the PVC {restore_pvc_obj.name} to pod "
                 f"{restore_pod_obj.name}"
             )
+            restore_pod_objs.append(restore_pod_obj)
 
         # Verify the new pods are running
         log.info("Verify the new pods are running")
@@ -187,7 +190,8 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
         for restore_pod_obj in restore_pod_objs:
             log.info(
                 f"Verifying md5sum of these files on pod "
-                f"{restore_pod_obj.name}:{restore_pod_obj.pvc.snapshot.md5_sum}"
+                f"{restore_pod_obj.name}:"
+                f"{restore_pod_obj.pvc.snapshot.md5_sum}"
             )
             for file_name, actual_md5_sum in (
                 restore_pod_obj.pvc.snapshot.md5_sum.items()
@@ -219,6 +223,7 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
                 )
             log.info(
                 f"Verified md5sum of these files on pod "
-                f"{restore_pod_obj.name}:{restore_pod_obj.pvc.snapshot.md5_sum}"
+                f"{restore_pod_obj.name}:"
+                f"{restore_pod_obj.pvc.snapshot.md5_sum}"
             )
         log.info("md5sum verified")

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -3,9 +3,8 @@ import pytest
 from copy import deepcopy
 
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources import pod, pvc
+from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, tier1
-from tests import helpers
 
 log = logging.getLogger(__name__)
 

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -1,0 +1,184 @@
+import logging
+import pytest
+from copy import deepcopy
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources import pod, pvc
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, tier1
+from tests import helpers
+
+log = logging.getLogger(__name__)
+
+
+@tier1
+@skipif_ocs_version('<4.6')
+@pytest.mark.polarion_id('OCS-2318')
+class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
+    """
+    Tests to take snapshot when PVC usage is at different levels
+    """
+    @pytest.fixture(autouse=True)
+    def setup(self, create_pvcs_and_pods):
+        """
+        Create PVCs and pods
+
+        """
+        self.pvc_size = 10
+        self.pvcs, self.pods = create_pvcs_and_pods(
+            pvc_size=self.pvc_size,
+            access_modes_rbd=[constants.ACCESS_MODE_RWO],
+            access_modes_cephfs=[constants.ACCESS_MODE_RWO]
+        )
+
+    def test_snapshot_at_different_usage_level(
+        self, pod_factory, teardown_factory
+    ):
+        """
+        Test to take multiple snapshots of same PVC when the PVC usage is at
+        0% 20% 40% 60% and 80%, delete the parent PVC and restore the
+        snapshots to create new PVCs
+
+        """
+        snapshots = []
+        for usage in [0, 20, 40, 60, 80]:
+            if usage != 0:
+                for pod_obj in self.pods:
+                    log.info(
+                        f"Running IO on pod {pod_obj.name} to utilize {usage}%"
+                    )
+                    pod_obj.pvc.filename = f'{pod_obj.name}_{usage}'
+                    pod_obj.run_io(
+                        storage_type='fs', size='2G', runtime=20,
+                        fio_filename=pod_obj.pvc.filename
+                    )
+                log.info(f"IO started on all pods to utilize {usage}%")
+
+                for pod_obj in self.pods:
+                    # Wait for fio to finish
+                    pod_obj.get_fio_results()
+                    log.info(
+                        f"IO to utilize {usage}% finished on pod "
+                        f"{pod_obj.name}"
+                    )
+                    # Calculate md5sum
+                    md5_sum = pod.cal_md5sum(pod_obj, pod_obj.pvc.filename)
+                    if not getattr(pod_obj.pvc, 'md5_sum', None):
+                        setattr(pod_obj.pvc, 'md5_sum', {})
+                    pod_obj.pvc.md5_sum[pod_obj.pvc.filename] = md5_sum
+
+            # Take snapshot of all PVCs
+            log.info(f"Creating snapshot of all PVCs at {usage}%")
+            for pvc_obj in self.pvcs:
+                log.info(
+                    f"Creating snapshot of PVC {pvc_obj.name} at {usage}%"
+                )
+                snap_obj = pvc_obj.create_snapshot(wait=True)
+                teardown_factory(snap_obj)
+                # Set a dict containing filename:md5sum for later verification
+                setattr(
+                    snap_obj, 'md5_sum',
+                    deepcopy(getattr(pvc_obj, 'md5_sum', {}))
+                )
+                if constants.CEPHFS_INTERFACE in pvc_obj.storageclass.name:
+                    snap_obj.interface = constants.CEPHFILESYSTEM
+                else:
+                    snap_obj.interface = constants.CEPHBLOCKPOOL
+                snap_obj.volume_mode = pvc_obj.volume_mode
+                snapshots.append(snap_obj)
+                log.info(f"Created snapshot of PVC {pvc_obj.name} at {usage}%")
+            log.info(f"Created snapshot of all PVCs at {usage}%")
+
+        # Delete pods
+        log.info("Deleting the pods")
+        for pod_obj in self.pods:
+            pod_obj.delete()
+            pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+        log.info("Deleted all the pods")
+
+        # Delete parent PVCs
+        log.info("Deleting parent PVCs")
+        for pvc_obj in self.pvcs:
+            pv_obj = pvc_obj.backed_pv_obj
+            pvc_obj.delete()
+            pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
+            log.info(
+                f"Deleted PVC {pvc_obj.name}. Verifying whether PV "
+                f"{pv_obj.name} is deleted."
+            )
+            pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name)
+        log.info(
+            "Deleted parent PVCs before restoring snapshot. "
+            "PVs are also deleted."
+        )
+
+        # Create PVCs out of the snapshots and attach to pods
+        log.info("Creating new PVCs from snapshots")
+        for snapshot in snapshots:
+            log.info(f"Creating a PVC from snapshot {snapshot.name}")
+            if snapshot.interface == constants.CEPHFILESYSTEM:
+                restore_pvc_yaml = constants.CSI_CEPHFS_PVC_RESTORE_YAML
+            else:
+                restore_pvc_yaml = constants.CSI_RBD_PVC_RESTORE_YAML
+            storageclass = helpers.default_storage_class(snapshot.interface)
+            restore_pvc_obj = pvc.create_restore_pvc(
+                sc_name=storageclass.name, snap_name=snapshot.name,
+                namespace=snapshot.namespace, size=f'{self.pvc_size}Gi',
+                pvc_name=f'{snapshot.name}-restore',
+                volume_mode=snapshot.volume_mode,
+                restore_pvc_yaml=restore_pvc_yaml
+            )
+            teardown_factory(restore_pvc_obj)
+            helpers.wait_for_resource_state(
+                restore_pvc_obj, constants.STATUS_BOUND
+            )
+            restore_pvc_obj.reload()
+            log.info(
+                f"Created PVC {restore_pvc_obj.name} from snapshot "
+                f"{snapshot.name}"
+            )
+
+            # Attach the restored PVC to a pod
+            restore_pod_obj = pod_factory(
+                interface=snapshot.interface, pvc=restore_pvc_obj,
+                status=constants.STATUS_RUNNING
+            )
+            log.info(
+                f"Attached the PVC {restore_pvc_obj.name} to pod "
+                f"{restore_pod_obj.name}"
+            )
+
+            # Verify md5sum of files on the new pod
+            log.info(
+                f"Verifying md5sum of these files on pod "
+                f"{restore_pod_obj.name}:{snapshot.md5_sum}"
+            )
+            for file_name, actual_md5_sum in snapshot.md5_sum.items():
+                file_path = pod.get_file_path(restore_pod_obj, file_name)
+                log.info(
+                    f"Checking the existence of file {file_name} on pod "
+                    f"{restore_pod_obj.name}"
+                )
+                assert pod.check_file_existence(restore_pod_obj, file_path), (
+                    f"File {file_name} does not exist on pod "
+                    f"{restore_pod_obj.name}"
+                )
+                log.info(
+                    f"File {file_name} exists on pod {restore_pod_obj.name}"
+                )
+
+                # Verify that the md5sum matches
+                log.info(
+                    f"Verifying md5sum of file {file_name} on pod "
+                    f"{restore_pod_obj.name}"
+                )
+                pod.verify_data_integrity(
+                    restore_pod_obj, file_name, actual_md5_sum
+                )
+                log.info(
+                    f"Verified md5sum of file {file_name} on pod "
+                    f"{restore_pod_obj.name}"
+                )
+            log.info(
+                f"Verified md5sum of these files on pod "
+                f"{restore_pod_obj.name}:{snapshot.md5_sum}"
+            )

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -41,7 +41,8 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
 
         """
         snapshots = []
-        for usage in [0, 20, 40, 60, 80]:
+        usage_percent = [0, 20, 40, 60, 80]
+        for usage in usage_percent:
             if usage != 0:
                 for pod_obj in self.pods:
                     log.info(
@@ -49,8 +50,9 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
                     )
                     pod_obj.pvc.filename = f'{pod_obj.name}_{usage}'
                     pod_obj.run_io(
-                        storage_type='fs', size='2G', runtime=20,
-                        fio_filename=pod_obj.pvc.filename
+                        storage_type='fs',
+                        size=f'{int(self.pvc_size/len(usage_percent))}G',
+                        runtime=20, fio_filename=pod_obj.pvc.filename
                     )
                 log.info(f"IO started on all pods to utilize {usage}%")
 

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -92,14 +92,16 @@ class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
         # Delete parent PVCs
         log.info("Deleting parent PVCs")
         for pvc_obj in self.pvcs:
-            pv_obj = pvc_obj.backed_pv_obj
-            pvc_obj.delete()
-            pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
-            log.info(
-                f"Deleted PVC {pvc_obj.name}. Verifying whether PV "
-                f"{pv_obj.name} is deleted."
-            )
-            pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name)
+            # TODO: Unblock parent PVC deletion for cephfs PVC when the bug 1854501 is fixed
+            if constants.RBD_INTERFACE in pvc_obj.backed_sc:
+                pv_obj = pvc_obj.backed_pv_obj
+                pvc_obj.delete()
+                pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
+                log.info(
+                    f"Deleted PVC {pvc_obj.name}. Verifying whether PV "
+                    f"{pv_obj.name} is deleted."
+                )
+                pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name)
         log.info(
             "Deleted parent PVCs before restoring snapshot. "
             "PVs are also deleted."


### PR DESCRIPTION
Test to take multiple snapshots of same PVC when the PVC usage is at 0% 20% 40% 60% and 80%, delete the parent PVC and restore the snapshots to create new PVCs.

Test case: OCS-2318 - Snapshot at different PVC usage levels and verify parent PVC deletion when snapshots present

Signed-off-by: Jilju Joy <jijoy@redhat.com>