### PR TITLE
Decrease the number of pools created to two 

### DIFF
--- a/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -33,7 +33,7 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
         *. Run IO on each app pod
         """
 
-        # Create 3 storageclasses, each with different pool name
+        # Create 2 storageclasses, each with different pool name
         cbp_list = []
         sc_list = []
         for i in range(2):

--- a/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -36,7 +36,7 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
         # Create 3 storageclasses, each with different pool name
         cbp_list = []
         sc_list = []
-        for i in range(3):
+        for i in range(2):
             log.info("Creating cephblockpool")
             cbp_obj = helpers.create_ceph_block_pool()
             log.info(
@@ -62,7 +62,7 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
 
         # Create PVCs using each SC
         pvc_list = []
-        for i in range(3):
+        for i in range(2):
             log.info(f"Creating a PVC using {sc_list[i].name}")
             pvc_obj = helpers.create_pvc(sc_list[i].name)
             log.info(
@@ -76,7 +76,7 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
 
         # Create app pod and mount each PVC
         pod_list = []
-        for i in range(3):
+        for i in range(2):
             log.info(f"Creating an app pod and mount {pvc_list[i].name}")
             pod_obj = helpers.create_pod(
                 interface_type=constants.CEPHBLOCKPOOL,


### PR DESCRIPTION
Fixes: #2867 

While creating 3 pools for this test, the number of PGs exceeded the limit for PGs (750) for a 3 OSD cluster and hence failed on a VMware cluster.Hence reducing the pool count to two.
More details in the issue.

Signed-off-by: rachael-george <rgeorge@redhat.com>