### PR TITLE
Squad analysis: highlight yellow title

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1020,6 +1020,11 @@ def add_squad_analysis_to_email(session, soup):
     .squad-unassigned {
         background-color: #FFBA88;
     }
+    h4.squad-yellow {
+        color: black;
+        background-color: yellow;
+        display: inline;
+    }
     """
     # prepare place for the Squad Analysis in the email
     squad_analysis_div = soup.new_tag("div")


### PR DESCRIPTION
Make "yellow squad" title font black on yellow background for better readability:

![email-results-squad-analysis-example4b](https://user-images.githubusercontent.com/4759779/93880785-4d6ab700-fcde-11ea-88d1-caea263008a1.png)

Signed-off-by: Daniel Horak <dahorak@redhat.com>