### PR TITLE
Check all must-gather commads by versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ data/*
 external/
 apidoc/*
 _build/*
+infra-pods.txt
+jq
+report.html
+secret.json
+tests/e2e/logging/test_openshift-logging-forupgrade.py

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -946,7 +946,7 @@ OSD_TREE_ZONE = {
 GATHER_BOOTSTRAP_PATTERN = 'openshift-install gather bootstrap --help'
 
 # must-gather commands output files
-MUST_GATHER_COMMANDS = [
+BASE_MUST_GATHER_COMMANDS = [
     'ceph_versions', 'ceph_status', 'ceph_report', 'ceph_pg_dump',
     'ceph_osd_tree', 'ceph_osd_stat', 'ceph_osd_dump', 'ceph_osd_df_tree',
     'ceph_osd_crush_show-tunables', 'ceph_osd_crush_dump', 'ceph_mon_stat',
@@ -954,7 +954,83 @@ MUST_GATHER_COMMANDS = [
     'ceph_fs_ls', 'ceph_fs_dump', 'ceph_df', 'ceph_auth_list',
 ]
 
-MUST_GATHER_COMMANDS_JSON = [
+EXT_MUST_GATHER_COMMANDS = [
+    'ceph_versions', 'ceph_status', 'ceph_report', 'ceph_pg_dump',
+    'ceph_osd_tree', 'ceph_osd_stat', 'ceph_osd_dump', 'ceph_osd_df_tree',
+    'ceph_osd_crush_show-tunables', 'ceph_osd_crush_dump', 'ceph_mon_stat',
+    'ceph_mon_dump', 'ceph_mgr_dump', 'ceph_mds_stat', 'ceph_health_detail',
+    'ceph_fs_ls', 'ceph_fs_dump', 'ceph_df', 'ceph_auth_list',
+    'ceph_balancer_dump', 'ceph_balancer_pool_ls', 'ceph_balancer_status',
+    'ceph_config_dump', 'ceph_config-key_ls', 'ceph_crash_ls',
+    'ceph_crash_stat', 'ceph_device_ls', 'ceph_fs_status',
+    'ceph_fs_subvolumegroup_ls_ocs-storagecluster-cephfilesystem',
+    'ceph_fs_subvolume_ls_ocs-storagecluster-cephfilesystem_csi',
+    'ceph_mgr_module_ls', 'ceph_mgr_services', 'ceph_osd_utilization',
+    'ceph_osd_crush_weight-set_ls', 'ceph_osd_crush_weight-set_dump',
+    'ceph_osd_crush_rule_dump', 'ceph_osd_crush_rule_ls',
+    'ceph_osd_crush_class_ls', 'ceph_osd_perf',
+    'ceph_osd_numa-status', 'ceph_osd_getmaxosd', 'ceph_osd_drain_status',
+    'ceph_osd_pool_ls_detail', 'ceph_osd_lspools', 'ceph_osd_df',
+    'ceph_osd_blocked-by', 'ceph_osd_blacklist_ls', 'ceph_pg_stat',
+    'ceph_pool_autoscale-status', 'ceph_progress', 'ceph_progress_json',
+    'ceph_quorum_status', 'ceph_service_dump', 'ceph_time-sync-status'
+]
+
+
+BASE_MUST_GATHER_COMMANDS_JSON = [
+    'ceph_versions_--format_json-pretty', 'ceph_status_--format_json-pretty',
+    'ceph_report_--format_json-pretty', 'ceph_pg_dump_--format_json-pretty',
+    'ceph_osd_tree_--format_json-pretty',
+    'ceph_osd_stat_--format_json-pretty',
+    'ceph_osd_dump_--format_json-pretty',
+    'ceph_osd_df_tree_--format_json-pretty',
+    'ceph_osd_crush_show-tunables_--format_json-pretty',
+    'ceph_osd_crush_dump_--format_json-pretty',
+    'ceph_mon_stat_--format_json-pretty', 'ceph_mon_dump_--format_json-pretty',
+    'ceph_mgr_dump_--format_json-pretty', 'ceph_mds_stat_--format_json-pretty',
+    'ceph_health_detail_--format_json-pretty',
+    'ceph_fs_ls_--format_json-pretty', 'ceph_fs_dump_--format_json-pretty',
+    'ceph_df_--format_json-pretty', 'ceph_auth_list_--format_json-pretty',
+    'ceph_balancer_dump_--format_json-pretty',
+    'ceph_balancer_pool_ls_--format_json-pretty',
+    'ceph_balancer_status_--format_json-pretty',
+    'ceph_config_dump_--format_json-pretty',
+    'ceph_config-key_ls_--format_json-pretty',
+    'ceph_crash_ls_--format_json-pretty',
+    'ceph_crash_stat_--format_json-pretty',
+    'ceph_device_ls_--format_json-pretty',
+    'ceph_fs_status_--format_json-pretty',
+    'ceph_fs_subvolumegroup_ls_ocs-storagecluster-'
+    'cephfilesystem_--format_json-pretty',
+    'ceph_fs_subvolume_ls_ocs-storagecluster-'
+    'cephfilesystem_csi_--format_json-pretty',
+    'ceph_mgr_module_ls_--format_json-pretty',
+    'ceph_mgr_services_--format_json-pretty',
+    'ceph_osd_utilization_--format_json-pretty',
+    'ceph_osd_crush_weight-set_ls_--format_json-pretty',
+    'ceph_osd_crush_weight-set_dump_--format_json-pretty',
+    'ceph_osd_crush_rule_dump_--format_json-pretty',
+    'ceph_osd_crush_rule_ls_--format_json-pretty',
+    'ceph_osd_crush_class_ls_--format_json-pretty',
+    'ceph_osd_perf_--format_json-pretty',
+    'ceph_osd_numa-status_--format_json-pretty',
+    'ceph_osd_getmaxosd_--format_json-pretty',
+    'ceph_osd_drain_status_--format_json-pretty',
+    'ceph_osd_pool_ls_detail_--format_json-pretty',
+    'ceph_osd_lspools_--format_json-pretty',
+    'ceph_osd_df_--format_json-pretty',
+    'ceph_osd_blocked-by_--format_json-pretty',
+    'ceph_osd_blacklist_ls_--format_json-pretty',
+    'ceph_pg_stat_--format_json-pretty',
+    'ceph_pool_autoscale-status_--format_json-pretty',
+    'ceph_progress_--format_json-pretty',
+    'ceph_progress_json_--format_json-pretty',
+    'ceph_quorum_status_--format_json-pretty',
+    'ceph_service_dump_--format_json-pretty',
+    'ceph_time-sync-status_--format_json-pretty'
+]
+
+EXT_MUST_GATHER_COMMANDS_JSON = [
     'ceph_versions_--format_json-pretty', 'ceph_status_--format_json-pretty',
     'ceph_report_--format_json-pretty', 'ceph_pg_dump_--format_json-pretty',
     'ceph_osd_tree_--format_json-pretty', 'ceph_osd_stat_--format_json-pretty',

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -928,7 +928,7 @@ def get_ocs_version():
 
 def get_ocs_parsed_version():
     """
-    Get ocs version as float
+    Returns ocs version as float
 
     Returns:
         float: ocs version number as major.minor (for example: 4.5)

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -926,6 +926,22 @@ def get_ocs_version():
     return ocp_cluster.get()['items'][0]['spec']['version']
 
 
+def get_ocs_parsed_version():
+    """
+    Get ocs version as float
+
+    Returns:
+        float: ocs version number as major.minor (for example: 4.5)
+
+    """
+    ocs_ver = get_ocs_version().split("-")
+    major_minor = ocs_ver[0].split(".")
+    major = major_minor[0]
+    minor = major_minor[1]
+
+    return float(f"{major}.{minor}")
+
+
 def get_build():
     """
     Return the OCP Build Version

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -117,7 +117,7 @@ class TestMustGather(ManageTest):
                     f"Found must_gather_commands directory - {dir_root}"
                 )
                 assert 'json_output' in dirs, (
-                    "reduce_cluster_load "
+                    "json_output directory is not present in "
                     "must_gather_commands directory."
                 )
                 assert files, (

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -117,7 +117,7 @@ class TestMustGather(ManageTest):
                     f"Found must_gather_commands directory - {dir_root}"
                 )
                 assert 'json_output' in dirs, (
-                    "json_output directory is not present in "
+                    "reduce_cluster_load "
                     "must_gather_commands directory."
                 )
                 assert files, (
@@ -130,23 +130,31 @@ class TestMustGather(ManageTest):
                 break
 
         # Verify that command output files are present as expected
-        assert set(constants.MUST_GATHER_COMMANDS).issubset(files), (
+        current_ocs_version = ocp.get_ocs_parsed_version()
+        logger.info(f"Current OCS version: {current_ocs_version}")
+        must_gather_commands = constants.BASE_MUST_GATHER_COMMANDS
+        must_gather_commands_json = constants.BASE_MUST_GATHER_COMMANDS_JSON
+        if current_ocs_version > 4.4:
+            must_gather_commands = constants.EXT_MUST_GATHER_COMMANDS
+            must_gather_commands_json = constants.EXT_MUST_GATHER_COMMANDS_JSON
+
+        assert set(must_gather_commands).issubset(files), (
             f"Actual and expected commands output files are not matching.\n"
-            f"Actual: {files}\nExpected: {constants.MUST_GATHER_COMMANDS}"
+            f"Actual: {files}\nExpected: {must_gather_commands}"
         )
-        if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(files):
+        if sorted(must_gather_commands) != sorted(files):
             logger.warning(
                 "There are more actual must gather commands than expected"
             )
 
         # Verify that files for command output in json are present as expected
         commands_json = os.listdir(json_output_dir)
-        assert set(constants.MUST_GATHER_COMMANDS_JSON).issubset(commands_json), (
+        assert set(must_gather_commands_json).issubset(commands_json), (
             f"Actual and expected json output commands files are not "
             f"matching.\nActual: {commands_json}\n"
-            f"Expected: {constants.MUST_GATHER_COMMANDS_JSON}"
+            f"Expected: {must_gather_commands_json}"
         )
-        if sorted(constants.MUST_GATHER_COMMANDS_JSON) != sorted(commands_json):
+        if sorted(must_gather_commands_json) != sorted(commands_json):
             logger.warning(
                 "There are more actual must gather commands than expected"
             )

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -70,6 +70,7 @@ class TestMustGather(ManageTest):
 
         request.addfinalizer(finalizer)
 
+    @pytest.mark.bugzilla("1885640")
     def test_must_gather(self):
         """
         Tests functionality of: oc adm must-gather


### PR DESCRIPTION
- Added function that that return ocs version number as major.minor (float)
- Added new constant with list of must gather commands, base and extended
- Checks must-gather commands according to OCS current version
- Added bugzilla marker