### PR TITLE
Add minimum size of '256' GB for test purpose (non production use)

### DIFF
--- a/conf/ocsci/minimum_test_device_size.yaml
+++ b/conf/ocsci/minimum_test_device_size.yaml
@@ -1,0 +1,5 @@
+---
+#This config file holds the disk size in GB for minimum test environments.
+ENV_DATA:
+  device_size: '256'
+


### PR DESCRIPTION
This is basically to use in DC-CP for test purpose( the total size provided by vSAN is bottleneck and using reduced disk size will allow us to create more clusters in DC-CP)

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>