### PR TITLE
Test case: PVC clone when full

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -254,7 +254,7 @@ class Pod(OCS):
     def run_io(
         self, storage_type, size, io_direction='rw', rw_ratio=75,
         jobs=1, runtime=60, depth=4, rate='1m', rate_process='poisson',
-        fio_filename=None, bs='4K', end_fsync=None
+        fio_filename=None, bs='4K', end_fsync=0
     ):
         """
         Execute FIO on a pod
@@ -281,8 +281,8 @@ class Pod(OCS):
             rate_process (str): kind of rate process default poisson, e.g. poisson
             fio_filename(str): Name of fio file created on app pod's mount point
             bs (str): Block size, e.g. 4K
-            end_fsync (int): If 1, fsync file contents when a write stage has
-                completed. Fio default is 0
+            end_fsync (int): If 1, fio will sync file contents when a write
+                stage has completed. Fio default is 0
         """
         if not self.wl_setup_done:
             self.workload_setup(storage_type=storage_type, jobs=jobs)

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -253,7 +253,8 @@ class Pod(OCS):
 
     def run_io(
         self, storage_type, size, io_direction='rw', rw_ratio=75,
-        jobs=1, runtime=60, depth=4, rate='1m', rate_process='poisson', fio_filename=None, bs='4K'
+        jobs=1, runtime=60, depth=4, rate='1m', rate_process='poisson',
+        fio_filename=None, bs='4K', end_fsync=None
     ):
         """
         Execute FIO on a pod
@@ -280,6 +281,8 @@ class Pod(OCS):
             rate_process (str): kind of rate process default poisson, e.g. poisson
             fio_filename(str): Name of fio file created on app pod's mount point
             bs (str): Block size, e.g. 4K
+            end_fsync (int): If 1, fsync file contents when a write stage has
+                completed. Fio default is 0
         """
         if not self.wl_setup_done:
             self.workload_setup(storage_type=storage_type, jobs=jobs)
@@ -302,6 +305,8 @@ class Pod(OCS):
         self.io_params['rate'] = rate
         self.io_params['rate_process'] = rate_process
         self.io_params['bs'] = bs
+        if end_fsync:
+            self.io_params['end_fsync'] = end_fsync
         self.fio_thread = self.wl_obj.run(**self.io_params)
 
     def fillup_fs(self, size, fio_filename=None):

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -452,4 +452,5 @@ def create_pvc_clone(
     ocs_obj = PVC(**pvc_data)
     created_pvc = ocs_obj.create(do_reload=do_reload)
     assert created_pvc, f"Failed to create resource {pvc_name}"
+    ocs_obj.reload()
     return ocs_obj

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -133,10 +133,6 @@ class PVC(OCS):
             'volume.beta.kubernetes.io/storage-provisioner'
         ]
 
-    @property
-    def volume_mode(self):
-        return self.get()['spec']['volumeMode']
-
     def resize_pvc(self, new_size, verify=False):
         """
         Modify the capacity of PVC

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -133,6 +133,10 @@ class PVC(OCS):
             'volume.beta.kubernetes.io/storage-provisioner'
         ]
 
+    @property
+    def volume_mode(self):
+        return self.get()['spec']['volumeMode']
+
     def resize_pvc(self, new_size, verify=False):
         """
         Modify the capacity of PVC
@@ -413,18 +417,24 @@ def create_restore_pvc(
 
 
 def create_pvc_clone(
-    sc_name, parent_pvc, clone_yaml, pvc_name=None, do_reload=True, storage_size=None
+    sc_name, parent_pvc, clone_yaml, pvc_name=None, do_reload=True,
+    storage_size=None, access_mode=None, volume_mode=None
 ):
     """
     Create a cloned pvc from existing pvc
 
     Args:
-        sc_name (str): The name of storage class (same for both parent and cloned pvc).
+        sc_name (str): The name of storage class.
         parent_pvc (str): Name of the parent pvc, whose clone is to be created.
         pvc_name (str): The name of the PVC being created
-        do_reload (bool): True for wait for reloading PVC after its creation, False otherwise
-        storage_size (str): Size of the clone, if not passed will use the default "storage" value from pvc-clone.yaml
-
+        do_reload (bool): True for wait for reloading PVC after its creation,
+            False otherwise
+        storage_size (str): Size of the clone, if not passed will use the
+            default "storage" value from pvc-clone.yaml. eg: '5Gi'
+        access_mode (str): This decides the access mode to be used for
+                the cloned PVC. eg: ReadWriteOnce, ReadOnlyMany, ReadWriteMany
+        volume_mode (str): Volume mode for PVC. This should match the
+            volume mode of parent PVC
     Returns:
         PVC: PVC instance
 
@@ -432,13 +442,17 @@ def create_pvc_clone(
     pvc_data = templating.load_yaml(clone_yaml)
     pvc_data['metadata']['name'] = (
         pvc_name if pvc_name else helpers.create_unique_resource_name(
-            'cloned', 'pvc'
+            parent_pvc, 'clone'
         )
     )
     pvc_data['spec']['storageClassName'] = sc_name
     pvc_data['spec']['dataSource']['name'] = parent_pvc
     if storage_size:
         pvc_data['spec']['resources']['requests']['storage'] = storage_size
+    if volume_mode:
+        pvc_data['spec']['volumeMode'] = volume_mode
+    if access_mode:
+        pvc_data['spec']['accessModes'] = [access_mode]
     ocs_obj = PVC(**pvc_data)
     created_pvc = ocs_obj.create(do_reload=do_reload)
     assert created_pvc, f"Failed to create resource {pvc_name}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2578,18 +2578,18 @@ def multi_dc_pod(multi_pvc_factory, dc_pod_factory, service_account_factory):
         dc_pods_res = []
         sa_obj = service_account_factory(project=project)
         with ThreadPoolExecutor() as p:
-            for pvc in pvc_objs:
+            for pvc_obj in pvc_objs:
                 if create_rbd_block_rwx_pod:
                     dc_pods_res.append(
                         p.submit(
                             dc_pod_factory, interface=constants.CEPHBLOCKPOOL,
-                            pvc=pvc, raw_block_pv=True, sa_obj=sa_obj
+                            pvc=pvc_obj, raw_block_pv=True, sa_obj=sa_obj
                         ))
                 else:
                     dc_pods_res.append(
                         p.submit(
                             dc_pod_factory, interface=dict_types[pool_type],
-                            pvc=pvc, sa_obj=sa_obj
+                            pvc=pvc_obj, sa_obj=sa_obj
                         ))
 
         for dc in dc_pods_res:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3077,4 +3077,3 @@ def pvc_clone_factory(request):
 
     request.addfinalizer(finalizer)
     return factory
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ from ocs_ci.ocs.mcg_workload import (
 )
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs.utils import setup_ceph_toolbox, collect_ocs_logs
 from ocs_ci.ocs.resources.backingstore import (
     backingstore_factory as backingstore_factory_implementation
@@ -3001,3 +3002,79 @@ def nb_ensure_endpoint_count(request):
     # Assert that we have the desired number of endpoints
     ready_count = get_ready_noobaa_endpoint_count(namespace)
     assert min_ep_count <= ready_count and ready_count <= max_ep_count
+
+
+@pytest.fixture()
+def pvc_clone_factory(request):
+    """
+    Calling this fixture creates a clone from the specified PVC
+
+    """
+    instances = []
+
+    def factory(
+        pvc_obj,
+        status=constants.STATUS_BOUND,
+        clone_name=None,
+        storageclass=None,
+        size=None,
+        access_mode=None,
+        volume_mode=None
+    ):
+        """
+        Args:
+            pvc_obj (PVC): PVC object from which clone has to be created
+            status (str): If provided then factory waits for cloned PVC to
+                reach the desired state
+            clone_name (str): Name to be provided for cloned PVC
+            storageclass (str): storage class to be used for cloned PVC
+            size (int): The requested size for the cloned PVC. This should
+                be same as the size of parent PVC for a successful clone
+            access_mode (str): This decides the access mode to be used for
+                the cloned PVC. eg: ReadWriteOnce, ReadOnlyMany, ReadWriteMany
+            volume_mode (str): Volume mode for PVC. This should match the
+                volume mode of parent PVC
+
+        Returns:
+            PVC: PVC instance
+
+        """
+        assert pvc_obj.provisioner in constants.OCS_PROVISIONERS, (
+            f"Unknown provisioner in PVC {pvc_obj.name}"
+        )
+        if pvc_obj.provisioner == 'openshift-storage.rbd.csi.ceph.com':
+            clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
+        elif pvc_obj.provisioner == 'openshift-storage.cephfs.csi.ceph.com':
+            clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
+
+        size = size or pvc_obj.get().get('spec').get('resources').get('requests').get('storage')
+        storageclass = storageclass or pvc_obj.backed_sc
+        access_mode = access_mode or pvc_obj.get_pvc_access_mode
+        volume_mode = volume_mode or pvc_obj.volume_mode
+
+        # Create clone
+        clone_pvc_obj = pvc.create_pvc_clone(
+            sc_name=storageclass, parent_pvc=pvc_obj.name,
+            clone_yaml=clone_yaml, pvc_name=clone_name, storage_size=size,
+            access_mode=access_mode, volume_mode=volume_mode
+        )
+        instances.append(clone_pvc_obj)
+        clone_pvc_obj.parent = pvc_obj
+
+        if status:
+            helpers.wait_for_resource_state(pvc_obj, status)
+        return clone_pvc_obj
+
+    def finalizer():
+        """
+        Delete the cloned PVCs
+
+        """
+        for instance in instances:
+            if not instance.is_deleted:
+                instance.delete()
+                instance.ocp.wait_for_delete(instance.name)
+
+    request.addfinalizer(finalizer)
+    return factory
+

--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -57,8 +57,8 @@ class TestCloneWhenFull(ManageTest):
             # Get the numeral value of available space. eg: 3070 from '3070M'
             available_size = int(df_avail_size.strip().split()[1][0:-1])
             pod_obj.run_io(
-                'fs', size=f'{available_size-2}M', io_direction='write',
-                runtime=20, rate='100M', fio_filename=file_name
+                'fs', size=f'{available_size-2}M', runtime=20, rate='100M',
+                fio_filename=file_name, end_fsync=1
             )
         log.info("Started IO on all pods to utilise 100% of PVCs")
 
@@ -67,6 +67,7 @@ class TestCloneWhenFull(ManageTest):
         for pod_obj in self.pods:
             pod_obj.get_fio_results()
             log.info(f"IO finished on pod {pod_obj.name}")
+
             # Verify used space on pod is 100%
             used_space = pod.get_used_space_on_mount_point(pod_obj)
             assert used_space == '100%', (
@@ -74,7 +75,6 @@ class TestCloneWhenFull(ManageTest):
                 f"but {used_space}"
             )
             log.info(f"Verified: Used space on pod {pod_obj.name} is 100%")
-
             # Calculate md5sum of the file
             pod_obj.pvc.md5sum = pod.cal_md5sum(pod_obj, file_name)
 

--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -1,0 +1,300 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version, ManageTest, tier2, polarion_id
+)
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.prometheus import PrometheusAPI, check_alert_list
+from ocs_ci.utility.utils import TimeoutSampler
+from tests.helpers import wait_for_resource_state
+
+log = logging.getLogger(__name__)
+
+
+@tier2
+@skipif_ocs_version('<4.6')
+@polarion_id('OCS-2353')
+class TestCloneWhenFull(ManageTest):
+    """
+    Tests to verify PVC clone when PVC is full
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, project_factory, pvc_clone_factory, create_pvcs_and_pods):
+        """
+        Create PVCs and pods
+
+        """
+        self.pvc_size_gi = 3
+        self.pvcs, self.pods = create_pvcs_and_pods(
+            pvc_size=self.pvc_size_gi,
+            access_modes_rbd=[constants.ACCESS_MODE_RWO],
+            access_modes_cephfs=[constants.ACCESS_MODE_RWO]
+        )
+
+    def test_clone_when_full(self, pvc_clone_factory, pod_factory):
+        """
+        Create a clone from an existing PVC when the PVC is 100% utilized.
+        Verify utilization alert in cloned PVC.
+        Expand cloned PVC and ensure utilization alerts are stopped firing.
+        Verify data integrity.
+
+        """
+        pvc_size_expanded = 3
+        file_name = 'fio_full'
+        prometheus_api = PrometheusAPI()
+
+        # Run IO to utilize 100% of volume
+        log.info("Run IO on all to utilise 100% of PVCs")
+        for pod_obj in self.pods:
+            pod_obj.run_io(
+                'fs', size=f'{self.pvc_size_gi}G', io_direction='write',
+                runtime=20, rate='100M', fio_filename=file_name
+            )
+        log.info("Started IO on all pods to utilise 100% of PVCs")
+
+        # Wait for IO to finish
+        log.info("Wait for IO to finish on pods")
+        for pod_obj in self.pods:
+            try:
+                pod_obj.get_fio_results()
+            except CommandFailed as cfe:
+                if "No space left on device" not in str(cfe):
+                    raise
+            log.info(f"IO finished on pod {pod_obj.name}")
+            # Verify used space on pod is 100%
+            used_space = pod.get_used_space_on_mount_point(pod_obj)
+            assert used_space == '100%', (
+                f"The used space on pod {pod_obj.name} is not 100% "
+                f"but {used_space}"
+            )
+            log.info(f"Verified: Used space on pod {pod_obj.name} is 100%")
+
+            # Calculate md5sum of the file
+            pod_obj.pvc.md5sum = pod.cal_md5sum(self.pod_obj, file_name)
+
+        log.info("Creating clone of the PVCs")
+        cloned_pvcs = [pvc_clone_factory(pvc_obj) for pvc_obj in self.pvcs]
+        log.info("Created clone of the PVCs. Cloned PVCs are Bound")
+
+        # Wait till utilization alerts starts
+        for response in TimeoutSampler(140, 5, prometheus_api.get, 'alerts'):
+            alerts = response.json()['data']['alerts']
+            for pvc_obj in cloned_pvcs:
+                alerts_pvc = [
+                    alert for alert in alerts if alert.get('labels', {}).get(
+                        'persistentvolumeclaim'
+                    ) == pvc_obj.name
+                ]
+                # At least 2 alerts should be present
+                if len(alerts_pvc) < 2:
+                    break
+
+                # Verify 'PersistentVolumeUsageNearFull' alert is firing
+                if not getattr(pvc_obj, 'near_full_alert', False):
+                    try:
+                        log.info(
+                            f"Checking 'PersistentVolumeUsageNearFull' alert "
+                            f"for PVC {pvc_obj.name}"
+                        )
+                        near_full_msg = (
+                            f"PVC {pvc_obj.name} is nearing full. Data "
+                            f"deletion or PVC expansion is required."
+                        )
+                        check_alert_list(
+                            label='PersistentVolumeUsageNearFull',
+                            msg=near_full_msg, alerts=alerts_pvc,
+                            states=['firing'], severity='warning'
+                        )
+                        pvc_obj.near_full_alert = True
+                    except AssertionError:
+                        log.info(
+                            f"'PersistentVolumeUsageNearFull' alert not "
+                            f"started firing for PVC {pvc_obj.name}"
+                        )
+
+                # Verify 'PersistentVolumeUsageCritical' alert is firing
+                if not getattr(pvc_obj, 'critical_alert', False):
+                    try:
+                        log.info(
+                            f"Checking 'PersistentVolumeUsageCritical' alert "
+                            f"for PVC {pvc_obj.name}"
+                        )
+                        critical_msg = (
+                            f"PVC {pvc_obj.name} is critically full. Data "
+                            f"deletion or PVC expansion is required."
+                        )
+                        check_alert_list(
+                            label='PersistentVolumeUsageCritical',
+                            msg=critical_msg, alerts=alerts_pvc,
+                            states=['firing'], severity='error'
+                        )
+                        pvc_obj.critical_alert = True
+                    except AssertionError:
+                        log.info(
+                            f"'PersistentVolumeUsageCritical' alert not "
+                            f"started firing for PVC {pvc_obj.name}"
+                        )
+
+            # Collect list of PVCs for which alerts are not firing
+            not_near_full_pvc = [
+                pvc_ob.name for pvc_ob in cloned_pvcs if not getattr(
+                    pvc_ob, 'near_full_alert', False
+                )
+            ]
+            not_critical_pvc = [
+                pvc_ob.name for pvc_ob in cloned_pvcs if not getattr(
+                    pvc_ob, 'critical_alert', False
+                )
+            ]
+
+            if (not not_near_full_pvc) and (not not_critical_pvc):
+                log.info(
+                    "'PersistentVolumeUsageNearFull' and "
+                    "'PersistentVolumeUsageCritical' alerts are firing "
+                    "for all cloned PVCs."
+                )
+                break
+        log.info("Verified: Utilization alerts are firing")
+
+        log.info("Expanding cloned PVCs.")
+        for pvc_obj in cloned_pvcs:
+            log.info(
+                f"Expanding size of PVC {pvc_obj.name} to "
+                f"{pvc_size_expanded}Gi"
+            )
+            # Resize PVC. Skip verification
+            pvc_obj.resize_pvc(pvc_size_expanded, False)
+
+        # Attach the cloned PVCs to pods
+        log.info("Attach the cloned PVCs to pods")
+        clone_pod_objs = []
+        for clone_pvc_obj in cloned_pvcs:
+            interface = constants.CEPHFILESYSTEM if (
+                constants.CEPHFS_INTERFACE in clone_pvc_obj.backed_sc
+            ) else constants.CEPHBLOCKPOOL
+            clone_pod_obj = pod_factory(
+                interface=interface, pvc=clone_pvc_obj,
+                status=''
+            )
+            log.info(
+                f"Attached the PVC {clone_pvc_obj.name} to pod "
+                f"{clone_pvc_obj.name}"
+            )
+            clone_pod_objs.append(clone_pod_obj)
+
+        # Verify the new pods are running
+        log.info("Verify the new pods are running")
+        for pod_obj in clone_pod_objs:
+            wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+        log.info("Verified: New pods are running")
+
+        # Verify that the md5sum matches
+        for pod_obj in clone_pod_objs:
+            log.info(
+                f"Verifying md5sum of {file_name} "
+                f"on pod {pod_obj.name}"
+            )
+            pod.verify_data_integrity(
+                pod_obj,
+                file_name,
+                pod_obj.pvc.parent.md5sum
+            )
+            log.info(
+                f"Verified: md5sum of {file_name} on pod {pod_obj} "
+                f"matches with the original md5sum"
+            )
+
+        # Verify utilization alerts are stopped
+        for response in TimeoutSampler(140, 5, prometheus_api.get, 'alerts'):
+            alerts = response.json()['data']['alerts']
+            for pvc_obj in clone_pod_objs:
+                alerts_pvc = [
+                    alert for alert in alerts if alert.get('labels', {}).get(
+                        'persistentvolumeclaim'
+                    ) == pvc_obj.name
+                ]
+                if not alerts_pvc:
+                    pvc_obj.near_full_alert = False
+                    pvc_obj.critical_alert = False
+                    continue
+
+                # Verify 'PersistentVolumeUsageNearFull' alert stopped firing
+                if getattr(pvc_obj, 'near_full_alert'):
+                    try:
+                        log.info(
+                            f"Checking 'PrsistentVolumeUsageNearFull' alert "
+                            f"is cleared for PVC {pvc_obj.name}"
+                        )
+                        near_full_msg = (
+                            f"PVC {pvc_obj.name} is nearing full. Data "
+                            f"deletion or PVC expansion is required."
+                        )
+                        check_alert_list(
+                            label='PersistentVolumeUsageNearFull',
+                            msg=near_full_msg, alerts=alerts_pvc,
+                            states=['firing'], severity='warning'
+                        )
+                        log.info(
+                            f"'PersistentVolumeUsageNearFull' alert is not "
+                            f"stopped for PVC {pvc_obj.name}"
+                        )
+                    except AssertionError:
+                        pvc_obj.near_full_alert = False
+                        log.info(
+                            f"'PersistentVolumeUsageNearFull' alert stopped "
+                            f"firing for PVC {pvc_obj.name}"
+                        )
+
+                # Verify 'PersistentVolumeUsageCritical' alert stopped firing
+                if getattr(pvc_obj, 'critical_alert'):
+                    try:
+                        log.info(
+                            f"Checking 'PersistentVolumeUsageCritical' alert "
+                            f"is cleared for PVC {pvc_obj.name}"
+                        )
+                        critical_msg = (
+                            f"PVC {pvc_obj.name} is critically full. Data "
+                            f"deletion or PVC expansion is required."
+                        )
+                        check_alert_list(
+                            label='PersistentVolumeUsageCritical',
+                            msg=critical_msg, alerts=alerts_pvc,
+                            states=['firing'], severity='error'
+                        )
+                        log.info(
+                            f"'PersistentVolumeUsageCritical' alert is not "
+                            f"stopped for PVC {pvc_obj.name}"
+                        )
+                    except AssertionError:
+                        pvc_obj.critical_alert = False
+                        log.info(
+                            f"'PersistentVolumeUsageCritical' alert stopped "
+                            f"firing for PVC {pvc_obj.name}"
+                        )
+
+            # Collect list of PVCs for which alerts are still firing
+            near_full_pvcs = [
+                pvc_ob.name for pvc_ob in clone_pod_objs if getattr(
+                    pvc_ob, 'near_full_alert'
+                )
+            ]
+            critical_pvcs = [
+                pvc_ob.name for pvc_ob in clone_pod_objs if getattr(
+                    pvc_ob, 'critical_alert'
+                )
+            ]
+
+            if (not near_full_pvcs) and (not critical_pvcs):
+                log.info(
+                    "'PersistentVolumeUsageNearFull' and "
+                    "'PersistentVolumeUsageCritical' alerts are cleared for "
+                    "all cloned PVCs."
+                )
+                break
+
+        log.info("Verified: Utilization alerts stopped firing")

--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -75,7 +75,7 @@ class TestCloneWhenFull(ManageTest):
             log.info(f"Verified: Used space on pod {pod_obj.name} is 100%")
 
             # Calculate md5sum of the file
-            pod_obj.pvc.md5sum = pod.cal_md5sum(self.pod_obj, file_name)
+            pod_obj.pvc.md5sum = pod.cal_md5sum(pod_obj, file_name)
 
         log.info("Creating clone of the PVCs")
         cloned_pvcs = [pvc_clone_factory(pvc_obj) for pvc_obj in self.pvcs]


### PR DESCRIPTION
Test case: OCS-2353 - FT-Clone when PVC is 100% full
```
Create a clone from an existing PVC when the PVC is 100% utilized.
Verify data integrity.
Expand cloned PVC and ensure utilization alerts are stopped firing.
Verify utilization alert in cloned PVC.
```

Created pvc_clone_factory fixture.
Enhancement in ocs.resources.pvc.create_pvc_clone

Signed-off-by: Jilju Joy <jijoy@redhat.com>