### PR TITLE
Fio fill up functionality

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -611,6 +611,9 @@ FIO_IO_PARAMS_YAML = os.path.join(
 FIO_IO_RW_PARAMS_YAML = os.path.join(
     TEMPLATE_FIO_DIR, "workload_io_rw.yaml"
 )
+FIO_IO_FILLUP_PARAMS_YAML = os.path.join(
+    TEMPLATE_FIO_DIR, "workload_io_fillup.yaml"
+)
 FIO_DC_YAML = os.path.join(
     TEMPLATE_FIO_DIR, "fio_dc.yaml"
 )

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -304,6 +304,33 @@ class Pod(OCS):
         self.io_params['bs'] = bs
         self.fio_thread = self.wl_obj.run(**self.io_params)
 
+    def fillup_fs(self, size, fio_filename=None):
+        """
+        Execute FIO on a pod to fillup a file
+        This will run sequantial IO of 1MB block size to fill up the fill with data
+        This operation will run in background and will store the results in
+        'self.thread.result()'.
+        In order to wait for the output and not continue with the test until
+        FIO is done, call self.thread.result() right after calling run_io.
+        See tests/manage/test_pvc_deletion_during_io.py::test_run_io
+        for usage of FIO
+
+        Args:
+            size (str): Size in MB, e.g. '200M'
+            fio_filename(str): Name of fio file created on app pod's mount point
+
+        """
+
+        if not self.wl_setup_done:
+            self.workload_setup(storage_type='fs', jobs=1)
+
+        self.io_params = templating.load_yaml(constants.FIO_IO_FILLUP_PARAMS_YAML)
+        size = size if isinstance(size, str) else f"{size}M"
+        self.io_params['size'] = size
+        if fio_filename:
+            self.io_params['filename'] = fio_filename
+        self.fio_thread = self.wl_obj.run(**self.io_params)
+
     def run_git_clone(self):
         """
         Execute git clone on a pod to simulate a Jenkins user

--- a/ocs_ci/templates/workloads/fio/workload_io_fillup.yaml
+++ b/ocs_ci/templates/workloads/fio/workload_io_fillup.yaml
@@ -1,0 +1,10 @@
+name: fio-fillup
+filename: fio-fill-up
+rw: write
+bs: 1m
+direct: 1
+numjobs: 1
+time_based: 0
+runtime: 36000
+size: 100M
+ioengine: libaio

--- a/tests/internal/test_fio_fillup.py
+++ b/tests/internal/test_fio_fillup.py
@@ -1,0 +1,62 @@
+"""
+Module to perform IOs with several weights
+"""
+import pytest
+import logging
+
+from ocs_ci.framework.testlib import BaseTest
+from ocs_ci.ocs import constants
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestPVCFillup(BaseTest):
+    """
+    Test PVC Fillup
+
+    """
+
+    @pytest.mark.parametrize(
+        argnames=["size", "percentage"],
+        argvalues=[pytest.param(*['10', '50'])]
+    )
+    def test_fillup_fs(self, size, percentage,
+                       teardown_factory, storageclass_factory, interface_iterate,
+                       pod_factory, pvc_factory):
+        """
+        Test Fill up the filesystem
+        """
+        pvc_size = int(size)
+        self.interface = interface_iterate
+        self.sc_obj = storageclass_factory(self.interface)
+
+        # Creating PVC
+        self.pvc_obj = pvc_factory(
+            interface=self.interface,
+            size=size,
+            status=constants.STATUS_BOUND
+        )
+        self.pvc_obj.reload()
+        teardown_factory(self.pvc_obj)
+
+        # Creating POD which will connect to the PVC
+        self.pod_obj = pod_factory(
+            interface=self.interface,
+            pvc=self.pvc_obj,
+            status=constants.STATUS_RUNNING
+        )
+
+        # Calculation the amount of data to write
+        filesize = int(pvc_size * 1024 * (int(percentage) / 100))
+
+        logging.info(f'Going to run on PVC of {pvc_size} GB and will fill up {percentage} %')
+        logging.info(f'the filesize will be {filesize} MB')
+        self.pod_obj.fillup_fs(size=filesize,)
+        logging.info("Waiting for results")
+
+        # Getting the FIO output and verify all data was written
+        fio_result = self.pod_obj.get_fio_results()
+        writes = int(fio_result.get('jobs')[0].get('write').get('io_kbytes') / 1024)
+        logging.info(f"Total Write: {writes} MB")
+        assert (filesize <= writes), "Not all required data was written"

--- a/tests/internal/test_fio_fillup.py
+++ b/tests/internal/test_fio_fillup.py
@@ -59,4 +59,4 @@ class TestPVCFillup(BaseTest):
         fio_result = self.pod_obj.get_fio_results()
         writes = int(fio_result.get('jobs')[0].get('write').get('io_kbytes') / 1024)
         logging.info(f"Total Write: {writes} MB")
-        assert (filesize <= writes), "Not all required data was written"
+        assert filesize <= writes, "Not all required data was written"


### PR DESCRIPTION
This PR add the functionality to fill up file on PVC.
It create a file on the PVC, and run 1MB Sequential IO up to the desire size (given as parameter)
this PR contain :
* template YAML file for the FIO parameters
* function that actually do the work
* simple test to test this function 