### PR TITLE
Optional parameter to gather logs when deployment runs successfully

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,6 +102,8 @@ to the pytest.
   bugzilla_password = yourPassword
   ```
 * `--collect-logs` - to collect OCS logs for failed test cases.
+* `--collect-logs-on-success-run` - Collect must gather logs at the end of the 
+   execution (also when no failure in the tests)
 * `--io-in-bg` - If passed, IO will be running in the test background.
 * `--io-load` - IOs throughput target percentage. The value should be
    between 0 to 100. If not provided, the default is 30 (30%)
@@ -110,8 +112,6 @@ to the pytest.
 * `--csv-change` - Allows changes in the OCS CSV. For example, usage of custom image,
    like MCG or RHCS. The format should be:
    <pattern_to_replace_from::pattern_to_replace_to>, while '::' is the delimiter
-* `--collect-logs-on-success-run` - Allows to have the option of gathering logs even,
-   when the cluster deployment executed successfully
 
 ## Examples
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,6 +110,8 @@ to the pytest.
 * `--csv-change` - Allows changes in the OCS CSV. For example, usage of custom image,
    like MCG or RHCS. The format should be:
    <pattern_to_replace_from::pattern_to_replace_to>, while '::' is the delimiter
+* `--collect-logs-on-success-run` - Allows to have the option of gathering logs even,
+   when the cluster deployment executed successfully
 
 ## Examples
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -32,6 +32,7 @@ RUN:
   # This config file disables scale app pods to use OCS workers
   use_ocs_worker_for_scale: False
   load_status: None
+  collect_logs_on_success_run: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -32,7 +32,6 @@ RUN:
   # This config file disables scale app pods to use OCS workers
   use_ocs_worker_for_scale: False
   load_status: None
-  collect_logs_on_success_run: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.
@@ -93,6 +92,7 @@ REPORTING:
   default_ocs_must_gather_latest_tag: 'latest-4.6'
   gather_on_deploy_failure: true
   gather_on_deploy_success: true
+  collect_logs_on_success_run: False
 
 # This is the default information about environment.
 ENV_DATA:

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -422,6 +422,7 @@ def process_cluster_cli_params(config):
     if collect_logs_on_success_run:
         ocsci_config.REPORTING['collect_logs_on_success_run'] = True
 
+
 def pytest_collection_modifyitems(session, config, items):
     """
     Add Polarion ID property to test cases that are marked with one.

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -99,6 +99,13 @@ def pytest_addoption(parser):
         help="Collect OCS logs when test case failed",
     )
     parser.addoption(
+        '--collect-logs-on-success-run',
+        dest='collect_logs_on_success_run',
+        action="store_true",
+        default=False,
+        help="Collect must gather logs at the end of the execution (also when no failure in the tests)"
+    )
+    parser.addoption(
         '--io-in-bg',
         dest='io_in_bg',
         action="store_true",
@@ -181,13 +188,6 @@ def pytest_addoption(parser):
             "Pattern or string to change in the CSV. Should contain the value to replace "
             "from and the value to replace to, separated by '::'"
         )
-    )
-    parser.addoption(
-        '--collect-logs-on-success-run',
-        dest='collect_logs_on_success_run',
-        action="store_true",
-        default=False,
-        help="Collect OCS logs on successful cluster deployment case as well"
     )
 
 
@@ -420,7 +420,7 @@ def process_cluster_cli_params(config):
         ocsci_config.DEPLOYMENT['csv_change_to'] = csv_change[1]
     collect_logs_on_success_run = get_cli_param(config, 'collect_logs_on_success_run')
     if collect_logs_on_success_run:
-        ocsci_config.RUN['collect_logs_on_success_run'] = True
+        ocsci_config.REPORTING['collect_logs_on_success_run'] = True
 
 def pytest_collection_modifyitems(session, config, items):
     """

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -182,6 +182,13 @@ def pytest_addoption(parser):
             "from and the value to replace to, separated by '::'"
         )
     )
+    parser.addoption(
+        '--collect-logs-on-success-run',
+        dest='collect_logs_on_success_run',
+        action="store_true",
+        default=False,
+        help="Collect OCS logs on successful test cases as well"
+    )
 
 
 def pytest_configure(config):
@@ -411,7 +418,9 @@ def process_cluster_cli_params(config):
         csv_change = csv_change.split("::")
         ocsci_config.DEPLOYMENT['csv_change_from'] = csv_change[0]
         ocsci_config.DEPLOYMENT['csv_change_to'] = csv_change[1]
-
+    collect_logs_on_success_run = get_cli_param(config, 'collect_logs_on_success_run')
+    if collect_logs_on_success_run:
+        ocsci_config.RUN['collect_logs_on_success_run'] = True
 
 def pytest_collection_modifyitems(session, config, items):
     """

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -187,7 +187,7 @@ def pytest_addoption(parser):
         dest='collect_logs_on_success_run',
         action="store_true",
         default=False,
-        help="Collect OCS logs on successful test cases as well"
+        help="Collect OCS logs on successful cluster deployment case as well"
     )
 
 

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -813,7 +813,7 @@ def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False, status_failure=Tru
             f"{dir_name}_ocs_logs"
         )
     else:
-        if ocsci_config.RUN['collect_logs_on_success_run']:
+        if ocsci_config.REPORTING['collect_logs_on_success_run']:
             log_dir_path = os.path.join(
                 os.path.expanduser(ocsci_config.RUN['log_dir']),
                 f"{dir_name}_{ocsci_config.RUN['run_id']}"

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -813,10 +813,11 @@ def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False, status_failure=Tru
             f"{dir_name}_ocs_logs"
         )
     else:
-        log_dir_path = os.path.join(
-            os.path.expanduser(ocsci_config.RUN['log_dir']),
-            f"{dir_name}_{ocsci_config.RUN['run_id']}"
-        )
+        if ocsci_config.RUN['collect_logs_on_success_run']:
+            log_dir_path = os.path.join(
+                os.path.expanduser(ocsci_config.RUN['log_dir']),
+                f"{dir_name}_{ocsci_config.RUN['run_id']}"
+            )
 
     if ocs:
         latest_tag = ocsci_config.REPORTING.get(


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/3001

We wanted to provide an option to gather logs on successful deployments, since we don't want to cause over waiting after successful deployments.