### PR TITLE
drop pip requires from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,4 @@
 [tox]
-# Use a new pip so we can use PEP 508 URL requirements
-requires = pip >= 19.1.1
 envlist = py36,py37,flake8
 
 [testenv]


### PR DESCRIPTION
fixes https://github.com/red-hat-storage/ocs-ci/issues/3037

Tested that tox run works on:
- [X] CentOS 8 (with python36 only, as I haven't python37 installed there)
- [X] Fedora 31
- [X] [Travis CI](https://travis-ci.org/github/red-hat-storage/ocs-ci/builds/732205228)