### PR TITLE
Preventing call of collect ocs logs when status_failure=False is sent

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -97,7 +97,6 @@ def get_ocsci_conf():
         ),
         REPORTING=dict(
             gather_on_deploy_failure=True,
-            gather_on_deploy_success=True,
         )
     )
     if env.get("DOWNSTREAM") == "true":

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -137,7 +137,7 @@ class Deployment(object):
         if not config.ENV_DATA['skip_ocs_deployment']:
             try:
                 self.deploy_ocs()
-                if config.REPORTING['gather_on_deploy_success']:
+                if config.REPORTING['collect_logs_on_success_run']:
                     collect_ocs_logs('deployment', ocp=False, status_failure=False)
             except Exception as e:
                 logger.error(e)

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -91,7 +91,6 @@ REPORTING:
   ocs_must_gather_image: "quay.io/rhceph-dev/ocs-must-gather"
   default_ocs_must_gather_latest_tag: 'latest-4.6'
   gather_on_deploy_failure: true
-  gather_on_deploy_success: true
   collect_logs_on_success_run: False
 
 # This is the default information about environment.

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -813,11 +813,10 @@ def collect_ocs_logs(dir_name, ocp=True, ocs=True, mcg=False, status_failure=Tru
             f"{dir_name}_ocs_logs"
         )
     else:
-        if ocsci_config.REPORTING['collect_logs_on_success_run']:
-            log_dir_path = os.path.join(
-                os.path.expanduser(ocsci_config.RUN['log_dir']),
-                f"{dir_name}_{ocsci_config.RUN['run_id']}"
-            )
+        log_dir_path = os.path.join(
+            os.path.expanduser(ocsci_config.RUN['log_dir']),
+            f"{dir_name}_{ocsci_config.RUN['run_id']}"
+        )
 
     if ocs:
         latest_tag = ocsci_config.REPORTING.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2905,7 +2905,8 @@ def collect_logs_fixture(request):
         Tracking both logs separately reduce changes of collision
         """
         if not config.RUN['cli_params'].get('deploy') and not config.RUN['cli_params'].get('teardown'):
-            collect_ocs_logs('testcases', ocs=False, status_failure=False)
-            collect_ocs_logs('testcases', ocp=False, status_failure=False)
+            if config.REPORTING['collect_logs_on_success_run']:
+                collect_ocs_logs('testcases', ocs=False, status_failure=False)
+                collect_ocs_logs('testcases', ocp=False, status_failure=False)
 
     request.addfinalizer(finalizer)


### PR DESCRIPTION
Fixes: #3047
Follow-up discussion for this PR: #3056

In [pull-3025](https://github.com/red-hat-storage/ocs-ci/pull/3025), we were able to accept new ocs-ci parameter `collect_logs_on_success_run`, but the actions of it did not cover all the possible cases.

Besides checking where  `collect_ocs_logs` is being called, I assigned if statement before the variable creation `log_dir_path`, so when we deployed without sending `--collect-ocs-logs`, we received `Local variable is called without any assignment`.

This is reverted, and then this merge calls the `collect_ocs_logs` with status_failure=False, **only** if `--collect-logs-on-success-run` is sent on run-ci 