### PR TITLE
add new prefix for production clusters to cleanup script

### DIFF
--- a/ocs_ci/cleanup/aws/defaults.py
+++ b/ocs_ci/cleanup/aws/defaults.py
@@ -5,6 +5,7 @@ AWS_REGION = 'us-east-2'
 CLUSTER_PREFIXES_SPECIAL_RULES = {
     'jnk-pr': 16,  # keep it as first item before jnk prefix for fist match
     'jnk': 36,
+    'j\\d\\d\\d': 36,
     'dnd': 'never',
     'lr1': 24,
     'lr2': 48,


### PR DESCRIPTION
- prefix for production clusters will be changed from "jnk-" to "jXXX" where
  XXX is last three digits from build number, so adding respective regex
  to the defaults for aws cleanup script

Signed-off-by: Daniel Horak <dahorak@redhat.com>