### PR TITLE
Enhance pvc creations scale using kube_job

### DIFF
--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -709,3 +709,84 @@ def increase_pods_per_worker_node_count(pods_per_node=500, pods_per_core=10):
     # During manual execution observed each node took 240+ sec for update
     timeout = machine_count * 300
     utils.wait_for_machineconfigpool_status(node_type=constants.WORKER_MACHINE, timeout=timeout)
+
+
+def construct_pvc_creation_yaml_bulk_for_kube_job(no_of_pvc, access_mode, sc_name):
+    """
+    Function to construct pvc.yaml to create bulk of pvc's using kube_job
+
+    Args:
+        no_of_pvc(int): Bulk PVC count
+        access_mode (str): PVC access_mode
+        sc_name (str): SC name for pvc creation
+
+    Returns:
+         pvc_dict_list (list): List of all PVC.yaml dicts
+
+    """
+    if access_mode == 'ReadWriteMany' and 'rbd' in sc_name:
+        volume_mode_block_flag = 1
+    else:
+        volume_mode_block_flag = 0
+
+    pvc_dict_list = list()
+    for i in range(no_of_pvc):
+        pvc_name = helpers.create_unique_resource_name('test', 'pvc')
+        size = f"{random.randrange(5, 105, 5)}Gi"
+        pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
+        pvc_data['metadata']['name'] = pvc_name
+        del pvc_data['metadata']['namespace']
+        pvc_data['spec']['accessModes'] = [access_mode]
+        pvc_data['spec']['storageClassName'] = sc_name
+        pvc_data['spec']['resources']['requests']['storage'] = size
+        if volume_mode_block_flag:
+            pvc_data['spec']['volumeMode'] = 'Block'
+        else:
+            pvc_data['spec']['volumeMode'] = None
+        pvc_dict_list.append(pvc_data)
+
+    return pvc_dict_list
+
+
+def check_all_pvc_reached_bound_state_in_kube_job(kube_job_obj, namespace, no_of_pvc):
+    """
+    Function to check either bulk created PVCs reached Bound state using kube_job
+
+    Args:
+        kube_job_obj (obj): Kube Job Object
+        namespace (str): Namespace of PVC's created
+        no_of_pvc (int): Bulk PVC count
+
+    Returns:
+        pvc_bound_list (list): List of all PVCs which is in Bound state.
+
+    Asserts:
+        If not all PVC reached to Bound state.
+
+    """
+    # Check all the PVC reached Bound state
+    pvc_bound_list, pvc_not_bound_list = ([] for i in range(2))
+    while_iteration_count = 0
+    while True:
+        job_get_output = kube_job_obj.get(namespace=namespace)
+        for i in range(no_of_pvc):
+            status = job_get_output['items'][i]['status']['phase']
+            logging.info(f"pvc {job_get_output['items'][i]['metadata']['name']} status {status}")
+            if status != 'Bound':
+                pvc_not_bound_list.append(job_get_output['items'][i]['metadata']['name'])
+        if len(pvc_not_bound_list):
+            time.sleep(30)
+            while_iteration_count += 1
+            if while_iteration_count >= 11:
+                assert logging.error(
+                    f" Listed PVCs took more than 600secs to bound {pvc_not_bound_list}"
+                )
+                break
+            pvc_not_bound_list.clear()
+            continue
+        elif not len(pvc_not_bound_list):
+            for i in range(no_of_pvc):
+                pvc_bound_list.append(job_get_output['items'][i]['metadata']['name'])
+            logging.info("All PVCs in Bound state")
+            break
+    return pvc_bound_list

--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -724,10 +724,6 @@ def construct_pvc_creation_yaml_bulk_for_kube_job(no_of_pvc, access_mode, sc_nam
          pvc_dict_list (list): List of all PVC.yaml dicts
 
     """
-    if access_mode == 'ReadWriteMany' and 'rbd' in sc_name:
-        volume_mode_block_flag = 1
-    else:
-        volume_mode_block_flag = 0
 
     # Construct PVC.yaml for the no_of_required_pvc count
     # append all the pvc.yaml dict to pvc_dict_list and return the list
@@ -742,7 +738,7 @@ def construct_pvc_creation_yaml_bulk_for_kube_job(no_of_pvc, access_mode, sc_nam
         pvc_data['spec']['storageClassName'] = sc_name
         pvc_data['spec']['resources']['requests']['storage'] = size
         # Check to identify RBD_RWX PVC and add VolumeMode
-        if volume_mode_block_flag:
+        if access_mode == 'ReadWriteMany' and 'rbd' in sc_name:
             pvc_data['spec']['volumeMode'] = 'Block'
         else:
             pvc_data['spec']['volumeMode'] = None
@@ -789,7 +785,7 @@ def check_all_pvc_reached_bound_state_in_kube_job(kube_job_obj, namespace, no_of
             # And if PVCs still not in bound state then there will be assert.
             if while_iteration_count >= 10:
                 assert logging.error(
-                    f" Listed PVCs took more than 600secs to bound {pvc_not_bound_list}"
+                    f" Listed PVCs took more than 300secs to bound {pvc_not_bound_list}"
                 )
                 break
             pvc_not_bound_list.clear()

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -3,20 +3,20 @@ Test to measure pvc scale creation & deletion time. Total pvc count would be 150
 """
 import logging
 import csv
-import random
 import pytest
 import threading
 
 from tests import helpers
-from ocs_ci.framework.testlib import scale, E2ETest, polarion_id
-from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources import pvc
+from ocs_ci.ocs import constants, scale_lib
 from ocs_ci.utility.utils import ocsci_log_path
+from ocs_ci.framework.testlib import scale, E2ETest, polarion_id
+from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 
 log = logging.getLogger(__name__)
 
 
 @scale
-@pytest.mark.skip(reason="Skip this test due to Cannot allocate memory problem")
 class TestPVCCreationDeletionScale(E2ETest):
     """
     Base class for PVC scale creation and deletion
@@ -47,69 +47,59 @@ class TestPVCCreationDeletionScale(E2ETest):
         ]
     )
     @pytest.mark.usefixtures(namespace.__name__)
-    def test_multiple_pvc_creation_deletion_scale(self, namespace, access_mode, interface):
+    def test_multiple_pvc_creation_deletion_scale(self, namespace, tmp_path, access_mode, interface):
         """
         Measuring PVC creation time while scaling PVC
         Measure PVC deletion time after creation test
         """
-        number_of_pvc = 1500
+        number_of_pvc = 750
         log.info(f"Start creating {access_mode}-{interface} {number_of_pvc} PVC")
-
         if interface == constants.CEPHBLOCKPOOL:
-            self.sc_obj = constants.DEFAULT_STORAGECLASS_RBD
+            sc_name = constants.DEFAULT_STORAGECLASS_RBD
         elif interface == constants.CEPHFS_INTERFACE:
-            self.sc_obj = constants.DEFAULT_STORAGECLASS_CEPHFS
+            sc_name = constants.DEFAULT_STORAGECLASS_CEPHFS
 
-        # Create PVC
-        pvc_objs = helpers.create_multiple_pvcs(
-            sc_name=self.sc_obj,
-            namespace=self.namespace,
-            number_of_pvc=number_of_pvc,
-            size=f"{random.randrange(5, 105, 5)}Gi",
-            access_mode=access_mode
+        pvc_dict_list1 = scale_lib.construct_pvc_creation_yaml_bulk_for_kube_job(
+            no_of_pvc=number_of_pvc, access_mode=access_mode, sc_name=sc_name
+        )
+        pvc_dict_list2 = scale_lib.construct_pvc_creation_yaml_bulk_for_kube_job(
+            no_of_pvc=number_of_pvc, access_mode=access_mode, sc_name=sc_name
         )
 
-        # Check for PVC status using threads
-        threads = list()
-        for obj in pvc_objs:
-            process = threading.Thread(
-                target=helpers.wait_for_resource_state,
-                args=(obj, constants.STATUS_BOUND, )
+        # There is 2 kube_job to reduce the load, observed time_out problems
+        # during delete process of single kube_job and heavy load.
+        job_file1 = ObjectConfFile(
+            name='job_profile_1', obj_dict_list=pvc_dict_list1,
+            project=self.namespace, tmp_path=tmp_path
+        )
+        job_file2 = ObjectConfFile(
+            name='job_profile_2', obj_dict_list=pvc_dict_list2,
+            project=self.namespace, tmp_path=tmp_path
+        )
+
+        job_file1.create(namespace=self.namespace)
+        job_file2.create(namespace=self.namespace)
+
+        # Check all the PVC reached Bound state
+        pvc_bound_list = scale_lib.check_all_pvc_reached_bound_state_in_kube_job(
+            kube_job_obj=job_file1, namespace=self.namespace, no_of_pvc=number_of_pvc
+        )
+        pvc_bound_list.extend(
+            scale_lib.check_all_pvc_reached_bound_state_in_kube_job(
+                kube_job_obj=job_file2, namespace=self.namespace, no_of_pvc=number_of_pvc
             )
-            process.start()
-            threads.append(process)
-        for process in threads:
-            process.join()
+        )
 
-        # Get pvc_name, require pvc_name to fetch creation time data from log
-        threads = list()
-        for pvc_obj in pvc_objs:
-            process = threading.Thread(target=pvc_obj.reload)
-            process.start()
-            threads.append(process)
-        for process in threads:
-            process.join()
-
-        pvc_name_list, pv_name_list = ([] for i in range(2))
-        threads = list()
-        for pvc_obj in pvc_objs:
-            process1 = threading.Thread(target=pvc_name_list.append(pvc_obj.name))
-            process2 = threading.Thread(target=pv_name_list.append(pvc_obj.backed_pv))
-            process1.start()
-            process2.start()
-            threads.append(process1)
-            threads.append(process2)
-        for process in threads:
-            process.join()
+        logging.info(f"Length of pvc_bound_list {len(pvc_bound_list)}")
 
         # Get PVC creation time
         pvc_create_time = helpers.measure_pvc_creation_time_bulk(
-            interface=interface, pvc_name_list=pvc_name_list
+            interface=interface, pvc_name_list=pvc_bound_list
         )
 
         # TODO: Update below code with google API, to record value in spreadsheet
         # TODO: For now observing Google API limit to write more than 100 writes
-        log_path = f"{ocsci_log_path()}/{self.sc_obj}-{access_mode}"
+        log_path = f"{ocsci_log_path()}/{interface}-{access_mode}"
         with open(f"{log_path}-creation-time.csv", "w") as fd:
             csv_obj = csv.writer(fd)
             for k, v in pvc_create_time.items():
@@ -118,10 +108,23 @@ class TestPVCCreationDeletionScale(E2ETest):
             f"Create data present in {log_path}-creation-time.csv file"
         )
 
-        # Delete PVC
-        for obj in pvc_objs:
-            obj.delete()
-            obj.ocp.wait_for_delete(obj.name)
+        # Get pvc_name, require pvc_name to fetch creation time data from log
+        # TODO: Revisit on changing below code without threads, for now it looks good
+        # TODO: but run-ci memory growth is increasing ~0.4G with below threads
+        pvc_objs = pvc.get_all_pvc_objs(namespace=self.namespace)
+        threads, pv_name_list = ([] for i in range(2))
+        for pvc_obj in pvc_objs:
+            process1 = threading.Thread(target=pvc_obj.reload)
+            process2 = threading.Thread(target=pv_name_list.append(pvc_obj.backed_pv))
+            process1.start()
+            process2.start()
+            threads.append(process1)
+            threads.append(process2)
+        for process in threads:
+            process.join()
+
+        job_file1.delete(namespace=self.namespace)
+        job_file2.delete(namespace=self.namespace)
 
         # Get PVC deletion time
         pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(
@@ -141,79 +144,56 @@ class TestPVCCreationDeletionScale(E2ETest):
 
     @polarion_id('OCS-1885')
     @pytest.mark.usefixtures(namespace.__name__)
-    def test_all_4_type_pvc_creation_deletion_scale(self, namespace):
+    def test_all_4_type_pvc_creation_deletion_scale(self, namespace, tmp_path):
         """
         Measuring PVC creation time while scaling PVC of all 4 types, Total 1500 PVCs
         will be created, i.e. 375 each pvc type
         Measure PVC deletion time in scale env
         """
-        number_of_pvc = 375
-        log.info(f"Start creating {number_of_pvc} PVC of all 4 types")
-
+        log.info("Start creating 1500 PVC of all 4 types")
         cephfs_sc_obj = constants.DEFAULT_STORAGECLASS_CEPHFS
         rbd_sc_obj = constants.DEFAULT_STORAGECLASS_RBD
 
-        # Create all 4 types of PVC
-        fs_pvc_obj, rbd_pvc_obj = ([] for i in range(2))
+        rbd_pvc_dict_list, cephfs_pvc_dict_list = ([] for i in range(2))
         for mode in [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]:
-            fs_pvc_obj.extend(helpers.create_multiple_pvcs(
-                sc_name=cephfs_sc_obj, namespace=self.namespace, number_of_pvc=number_of_pvc,
-                size=f"{random.randrange(5, 105, 5)}Gi", access_mode=mode)
+            rbd_pvc_dict_list.extend(
+                scale_lib.construct_pvc_creation_yaml_bulk_for_kube_job(
+                    no_of_pvc=375, access_mode=mode, sc_name=rbd_sc_obj
+                )
             )
-            rbd_pvc_obj.extend(helpers.create_multiple_pvcs(
-                sc_name=rbd_sc_obj, namespace=self.namespace, number_of_pvc=number_of_pvc,
-                size=f"{random.randrange(5, 105, 5)}Gi", access_mode=mode)
+            cephfs_pvc_dict_list.extend(
+                scale_lib.construct_pvc_creation_yaml_bulk_for_kube_job(
+                    no_of_pvc=375, access_mode=mode, sc_name=cephfs_sc_obj
+                )
             )
 
-        # Check for PVC status using threads
-        threads = list()
-        for obj in fs_pvc_obj:
-            process = threading.Thread(
-                target=helpers.wait_for_resource_state,
-                args=(obj, constants.STATUS_BOUND, )
-            )
-            process.start()
-            threads.append(process)
-        for obj in rbd_pvc_obj:
-            process = threading.Thread(
-                target=helpers.wait_for_resource_state,
-                args=(obj, constants.STATUS_BOUND,)
-            )
-            process.start()
-            threads.append(process)
-        for process in threads:
-            process.join()
+        job_file_rbd = ObjectConfFile(
+            name='rbd_pvc_job', obj_dict_list=rbd_pvc_dict_list,
+            project=self.namespace, tmp_path=tmp_path
+        )
+        job_file_cephfs = ObjectConfFile(
+            name='cephfs_pvc_job', obj_dict_list=cephfs_pvc_dict_list,
+            project=self.namespace, tmp_path=tmp_path
+        )
 
-        # Get pvc_name, require pvc_name to fetch creation time data from log
-        threads = list()
-        for fs_obj, rbd_obj in zip(fs_pvc_obj, rbd_pvc_obj):
-            process1 = threading.Thread(target=fs_obj.reload)
-            process2 = threading.Thread(target=rbd_obj.reload)
-            process1.start()
-            process2.start()
-            threads.append(process1)
-            threads.append(process2)
-        for process in threads:
-            process.join()
+        job_file_rbd.create(namespace=self.namespace)
+        job_file_cephfs.create(namespace=self.namespace)
 
-        fs_pvc_name, rbd_pvc_name = ([] for i in range(2))
-        fs_pv_name, rbd_pv_name = ([] for i in range(2))
-        threads = list()
-        for fs_obj, rbd_obj in zip(fs_pvc_obj, rbd_pvc_obj):
-            process1 = threading.Thread(target=fs_pvc_name.append(fs_obj.name))
-            process2 = threading.Thread(target=rbd_pvc_name.append(rbd_obj.name))
-            process3 = threading.Thread(target=fs_pv_name.append(fs_obj.backed_pv))
-            process4 = threading.Thread(target=rbd_pv_name.append(rbd_obj.backed_pv))
-            process1.start()
-            process2.start()
-            process3.start()
-            process4.start()
-            threads.append(process1)
-            threads.append(process2)
-            threads.append(process3)
-            threads.append(process4)
-        for process in threads:
-            process.join()
+        # Check all the PVC reached Bound state
+        rbd_pvc_name = scale_lib.check_all_pvc_reached_bound_state_in_kube_job(
+            kube_job_obj=job_file_rbd, namespace=self.namespace, no_of_pvc=750
+        )
+        fs_pvc_name = scale_lib.check_all_pvc_reached_bound_state_in_kube_job(
+            kube_job_obj=job_file_cephfs, namespace=self.namespace, no_of_pvc=750
+        )
+
+        rbd_pvc_obj, cephfs_pvc_obj = ([] for i in range(2))
+        pvc_objs = pvc.get_all_pvc_objs(namespace=self.namespace)
+        for pvc_obj in pvc_objs:
+            if pvc_obj.backed_sc == constants.DEFAULT_STORAGECLASS_RBD:
+                rbd_pvc_obj.append(pvc_obj)
+            elif pvc_obj.backed_sc == constants.DEFAULT_STORAGECLASS_CEPHFS:
+                cephfs_pvc_obj.append(pvc_obj)
 
         # Get PVC creation time
         fs_pvc_create_time = helpers.measure_pvc_creation_time_bulk(
@@ -235,18 +215,37 @@ class TestPVCCreationDeletionScale(E2ETest):
             f"Create data present in {log_path}-creation-time.csv file"
         )
 
+        # Get pvc_name, require pvc_name to fetch creation time data from log
+        # TODO: Revisit on changing below code without threads, for now it looks good
+        # TODO: but run-ci memory growth is increasing ~0.4G with below threads
+        fs_pv_list, rbd_pv_list = ([] for i in range(2))
+        threads = list()
+        for fs_obj, rbd_obj in zip(cephfs_pvc_obj, rbd_pvc_obj):
+            process1 = threading.Thread(target=fs_obj.reload)
+            process2 = threading.Thread(target=rbd_obj.reload)
+            process3 = threading.Thread(target=fs_pv_list.append(fs_obj.backed_pv))
+            process4 = threading.Thread(target=rbd_pv_list.append(rbd_obj.backed_pv))
+            process1.start()
+            process2.start()
+            process3.start()
+            process4.start()
+            threads.append(process1)
+            threads.append(process2)
+            threads.append(process3)
+            threads.append(process4)
+        for process in threads:
+            process.join()
+
         # Delete PVC
-        pvc_objs = fs_pvc_obj + rbd_pvc_obj
-        for obj in pvc_objs:
-            obj.delete()
-            obj.ocp.wait_for_delete(obj.name)
+        job_file_rbd.delete(namespace=self.namespace)
+        job_file_cephfs.delete(namespace=self.namespace)
 
         # Get PVC deletion time
         fs_pvc_deletion_time = helpers. measure_pv_deletion_time_bulk(
-            interface=constants.CEPHFS_INTERFACE, pv_name_list=fs_pv_name
+            interface=constants.CEPHFS_INTERFACE, pv_name_list=fs_pv_list
         )
         rbd_pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(
-            interface=constants.CEPHBLOCKPOOL, pv_name_list=rbd_pv_name
+            interface=constants.CEPHBLOCKPOOL, pv_name_list=rbd_pv_list
         )
         fs_pvc_deletion_time.update(rbd_pvc_deletion_time)
 

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -59,6 +59,7 @@ class TestPVCCreationDeletionScale(E2ETest):
         elif interface == constants.CEPHFS_INTERFACE:
             sc_name = constants.DEFAULT_STORAGECLASS_CEPHFS
 
+        # Get pvc_dict_list, append all the pvc.yaml dict to pvc_dict_list
         pvc_dict_list1 = scale_lib.construct_pvc_creation_yaml_bulk_for_kube_job(
             no_of_pvc=number_of_pvc, access_mode=access_mode, sc_name=sc_name
         )
@@ -77,6 +78,7 @@ class TestPVCCreationDeletionScale(E2ETest):
             project=self.namespace, tmp_path=tmp_path
         )
 
+        # Create kube_job
         job_file1.create(namespace=self.namespace)
         job_file2.create(namespace=self.namespace)
 
@@ -108,7 +110,7 @@ class TestPVCCreationDeletionScale(E2ETest):
             f"Create data present in {log_path}-creation-time.csv file"
         )
 
-        # Get pvc_name, require pvc_name to fetch creation time data from log
+        # Get pv_name, require pv_name to fetch deletion time data from log
         # TODO: Revisit on changing below code without threads, for now it looks good
         # TODO: but run-ci memory growth is increasing ~0.4G with below threads
         pvc_objs = pvc.get_all_pvc_objs(namespace=self.namespace)
@@ -123,6 +125,7 @@ class TestPVCCreationDeletionScale(E2ETest):
         for process in threads:
             process.join()
 
+        # Delete kube_job
         job_file1.delete(namespace=self.namespace)
         job_file2.delete(namespace=self.namespace)
 
@@ -154,6 +157,7 @@ class TestPVCCreationDeletionScale(E2ETest):
         cephfs_sc_obj = constants.DEFAULT_STORAGECLASS_CEPHFS
         rbd_sc_obj = constants.DEFAULT_STORAGECLASS_RBD
 
+        # Get pvc_dict_list, append all the pvc.yaml dict to pvc_dict_list
         rbd_pvc_dict_list, cephfs_pvc_dict_list = ([] for i in range(2))
         for mode in [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]:
             rbd_pvc_dict_list.extend(
@@ -167,6 +171,7 @@ class TestPVCCreationDeletionScale(E2ETest):
                 )
             )
 
+        # There is 2 kube_job for cephfs and rbd PVCs
         job_file_rbd = ObjectConfFile(
             name='rbd_pvc_job', obj_dict_list=rbd_pvc_dict_list,
             project=self.namespace, tmp_path=tmp_path
@@ -176,6 +181,7 @@ class TestPVCCreationDeletionScale(E2ETest):
             project=self.namespace, tmp_path=tmp_path
         )
 
+        # Create kube_job
         job_file_rbd.create(namespace=self.namespace)
         job_file_cephfs.create(namespace=self.namespace)
 
@@ -187,6 +193,7 @@ class TestPVCCreationDeletionScale(E2ETest):
             kube_job_obj=job_file_cephfs, namespace=self.namespace, no_of_pvc=750
         )
 
+        # Get pvc objs from namespace, which is used to identify backend pv
         rbd_pvc_obj, cephfs_pvc_obj = ([] for i in range(2))
         pvc_objs = pvc.get_all_pvc_objs(namespace=self.namespace)
         for pvc_obj in pvc_objs:
@@ -215,7 +222,7 @@ class TestPVCCreationDeletionScale(E2ETest):
             f"Create data present in {log_path}-creation-time.csv file"
         )
 
-        # Get pvc_name, require pvc_name to fetch creation time data from log
+        # Get pv_name, require pv_name to fetch deletion time data from log
         # TODO: Revisit on changing below code without threads, for now it looks good
         # TODO: but run-ci memory growth is increasing ~0.4G with below threads
         fs_pv_list, rbd_pv_list = ([] for i in range(2))
@@ -236,11 +243,11 @@ class TestPVCCreationDeletionScale(E2ETest):
         for process in threads:
             process.join()
 
-        # Delete PVC
+        # Delete kube_job
         job_file_rbd.delete(namespace=self.namespace)
         job_file_cephfs.delete(namespace=self.namespace)
 
-        # Get PVC deletion time
+        # Get PV deletion time
         fs_pvc_deletion_time = helpers. measure_pv_deletion_time_bulk(
             interface=constants.CEPHFS_INTERFACE, pv_name_list=fs_pv_list
         )


### PR DESCRIPTION
With use of kube_job pvc creations were faster compared to old automated tests
Also memory usage of run-ci command is reduced below 1.5G
This also helped the test to complete the run within 30mins.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>