### PR TITLE
Adding marker for skip depend on OCP version

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -201,6 +201,9 @@ gather_metrics_on_fail = pytest.mark.gather_metrics_on_fail
 # here is the place to implement some plugins hooks which will process marks
 # if some operation needs to be done for some specific marked tests.
 
+# Marker for skipping tests based on OCP version
+skipif_ocp_version = pytest.mark.skipif_ocp_version
+
 # Marker for skipping tests based on OCS version
 skipif_ocs_version = pytest.mark.skipif_ocs_version
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2055,6 +2055,32 @@ def get_cluster_name(cluster_path):
     return metadata["clusterName"]
 
 
+def skipif_ocp_version(expressions):
+    """
+    This function evaluates the condition for test skip
+    based on expression
+
+    Args:
+        expressions (str OR list): condition for which we need to check,
+        eg: A single expression string '>=4.2' OR
+            A list of expressions like ['<4.3', '>4.2'], ['<=4.3', '>=4.2']
+
+    Return:
+        'True' if test needs to be skipped else 'False'
+
+    """
+    skip_this = True
+    ocp_version = ".".join(
+        config.DEPLOYMENT.get('installer_version').split('.')[:-2]
+    )
+    expr_list = [expressions] if isinstance(expressions, str) else expressions
+    for expr in expr_list:
+        comparision_str = ocp_version + expr
+        skip_this = skip_this and eval(comparision_str)
+    # skip_this will be either True or False after eval
+    return skip_this
+
+
 def skipif_ocs_version(expressions):
     """
     This function evaluates the condition for test skip


### PR DESCRIPTION
Since there are some features, like snapshot which cannot be run on all OCP versions, we need this functionality 

using it by adding the marker : @skipif_ocp_version(<expression>) 
for example : @skipif_ocp_version('<4.6') 

Signed-off-by: Avi Liani <alayani@redhat.com>