### PR TITLE
Change scale TC fixture scope to "Class"

### DIFF
--- a/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
+++ b/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
@@ -13,7 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='class')
 def fioscale(request):
     """
     FIO Scale fixture to create expected number of POD+PVC


### PR DESCRIPTION
This is partial fix for https://github.com/red-hat-storage/ocs-ci/issues/2758
1. Change TC fixture scope to class, this is creating problem for other test executions
2. Planning to re-work on the entire TC to implement using kube jobs #2758 will have complete fix there.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>