### PR TITLE
deployment: Don't run vsphere code on all nodes

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -817,7 +817,8 @@ class Deployment(object):
                     f"Changing NTP on compute nodes to"
                     f" {constants.RH_NTP_CLOCK}"
                 )
-                update_ntp_compute_nodes()
+                if self.platform == constants.VSPHERE_PLATFORM:
+                    update_ntp_compute_nodes()
                 assert ceph_health_check(
                     namespace=self.namespace, tries=60, delay=10
                 )


### PR DESCRIPTION
When a clock skew was detected, we were running vsphere-specific code on
all deployments, causing premature failures.

Signed-off-by: Zack Cerza <zack@redhat.com>