### PR TITLE
[WIP] : Remove skipif_upgraded_from marker from PVC expansion tests

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -7,7 +7,7 @@ from ocs_ci.utility.utils import ceph_health_check
 from tests.helpers import wait_for_resource_state
 from ocs_ci.framework.testlib import (
     skipif_ocs_version, ManageTest, tier4, tier4b, ignore_leftovers,
-    polarion_id, skipif_bm, skipif_upgraded_from
+    polarion_id, skipif_bm
 )
 
 log = logging.getLogger(__name__)
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_bm
 @skipif_ocs_version('<4.5')
-@skipif_upgraded_from(['4.4'])
 @polarion_id('OCS-2235')
 class TestNodeRestartDuringPvcExpansion(ManageTest):
     """

--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier1, acceptance, skipif_upgraded_from
+    skipif_ocs_version, ManageTest, tier1, acceptance
 )
 from tests import helpers
 
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.5')
-@skipif_upgraded_from(['4.4'])
 @pytest.mark.skipif(
     config.ENV_DATA['platform'].lower() == 'ibm_cloud',
     reason=(

--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier2, polarion_id, skipif_upgraded_from
+    skipif_ocs_version, ManageTest, tier2, polarion_id
 )
 from ocs_ci.utility.prometheus import PrometheusAPI, check_alert_list
 from ocs_ci.utility.utils import TimeoutSampler
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 @tier2
 @skipif_ocs_version('<4.5')
-@skipif_upgraded_from(['4.4'])
 @polarion_id('OCS-301')
 class TestPvcExpansionWhenFull(ManageTest):
     """

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -4,8 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier4, tier4b, ignore_leftover_label,
-    skipif_upgraded_from
+    skipif_ocs_version, ManageTest, tier4, tier4b, ignore_leftover_label
 )
 from ocs_ci.utility.utils import ceph_health_check
 from tests import disruption_helpers
@@ -16,7 +15,6 @@ log = logging.getLogger(__name__)
 @tier4
 @tier4b
 @skipif_ocs_version('<4.5')
-@skipif_upgraded_from(['4.4'])
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames='resource_to_delete',


### PR DESCRIPTION
With the fix of bug [1872119](https://bugzilla.redhat.com/show_bug.cgi?id=1872119) , expansion of new PVCs will be enabled on clusters upgraded from OCS 4.4.
Removing ```skipif_upgraded_from``` marker will enable these tests to run on upgraded clusters.

Signed-off-by: Jilju Joy <jijoy@redhat.com>