### PR TITLE
consider `force_deploy_multiple_clusters` for VMware

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -579,7 +579,10 @@ class VSPHEREUPI(VSPHEREBASE):
         """
         cluster_name_parts = config.ENV_DATA.get("cluster_name").split("-")
         prefix = cluster_name_parts[0]
-        if not prefix.startswith(tuple(constants.PRODUCTION_JOBS_PREFIX)):
+        if (
+                not prefix.startswith(tuple(constants.PRODUCTION_JOBS_PREFIX))
+                or not config.DEPLOYMENT.get('force_deploy_multiple_clusters')
+        ):
             if self.check_cluster_existence(prefix):
                 raise exceptions.SameNamePrefixClusterAlreadyExistsException(
                     f"Cluster with name prefix {prefix} already exists. "


### PR DESCRIPTION
consider `DEPLOYMENT["force_deploy_multiple_clusters"]` for VMware cluster prefix existence check

Signed-off-by: Daniel Horak <dahorak@redhat.com>