### PR TITLE
skipif_ocp get the version from running cluster and not from config file

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1283,9 +1283,15 @@ def get_running_ocp_version(separator=None):
     """
     char = separator if separator else '.'
     namespace = config.ENV_DATA['cluster_namespace']
-    results = run_cmd(f'oc get clusterversion -n {namespace} -o yaml')
-    build = yaml.safe_load(results)['items'][0]['status']['desired']['version']
-    return char.join(build.split('.')[0:2])
+    try:
+        # if the cluster exist, this part will be run
+        results = run_cmd(f'oc get clusterversion -n {namespace} -o yaml')
+        build = yaml.safe_load(results)['items'][0]['status']['desired']['version']
+        return char.join(build.split('.')[0:2])
+    except Exception:
+        # this part will return version from the config file in case
+        # cluster is not exists.
+        return get_ocp_version(separator=char)
 
 
 def get_ocp_repo():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1291,7 +1291,7 @@ def get_running_ocp_version(separator=None):
     except Exception:
         # this part will return version from the config file in case
         # cluster is not exists.
-        return get_ocp_version(separator=char)
+        return get_ocp_version(seperator=char)
 
 
 def get_ocp_repo():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1265,6 +1265,29 @@ def get_ocp_version(seperator=None):
     )
 
 
+def get_running_ocp_version(separator=None):
+    """
+    Get current running ocp version
+
+    Args:
+        separator (str): String that would separate major and
+            minor version numbers
+
+    Returns:
+        string : If separator is 'None', version string will be returned as is
+            eg: '4.2', '4.3'.
+            If separator is provided then '.' in the version string would be
+            replaced by separator and resulting string will be returned.
+            eg: If separator is '_' then string returned would be '4_2'
+
+    """
+    char = separator if separator else '.'
+    namespace = config.ENV_DATA['cluster_namespace']
+    results = run_cmd(f'oc get clusterversion -n {namespace} -o yaml')
+    build = yaml.safe_load(results)['items'][0]['status']['desired']['version']
+    return char.join(build.split('.')[0:2])
+
+
 def get_ocp_repo():
     """
     Get ocp repo file, name will be generated dynamically based on
@@ -2070,7 +2093,7 @@ def skipif_ocp_version(expressions):
 
     """
     skip_this = True
-    ocp_version = get_ocp_version()
+    ocp_version = get_running_ocp_version()
     expr_list = [expressions] if isinstance(expressions, str) else expressions
     for expr in expr_list:
         comparision_str = ocp_version + expr

--- a/tests/internal/test_skipif_ocp.py
+++ b/tests/internal/test_skipif_ocp.py
@@ -1,0 +1,27 @@
+import logging
+
+from ocs_ci.framework.testlib import BaseTest, skipif_ocp_version
+
+log = logging.getLogger(__name__)
+
+
+class TestSkipifOCP(BaseTest):
+    """
+    Tests to check the skipif_ocp marker
+    """
+
+    @skipif_ocp_version('<4.7')
+    def test_skipif_ocp(self):
+        """
+        Simple test to verify that skipif_ocp marker is working
+        """
+
+        log.error('Test did not skipped')
+
+    @skipif_ocp_version('<4.5')
+    def test_skipif_ocp_need2run(self):
+        """
+        Simple test to verify that skipif_ocp marker is working
+        """
+
+        log.info('Test did not skipped and is running')


### PR DESCRIPTION
The purpose of this PR is the get the OCP version from the running cluster and not from the configuration file at the deployment section.

for backward compatibility, and since in the deployment phase we do need the information from the configuration file, i created another function and did not modify the existing one.

I also add a simple test that will used as unit-test for this functionality

This should solve #3115 

Signed-off-by: Avi Liani <alayani@redhat.com>