### PR TITLE
exec_oc_cmd: use kubeconfig from cluster dir if env. variable KUBECONFIG not set

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -115,16 +115,14 @@ class OCP(object):
 
         """
         oc_cmd = "oc "
-        if os.getenv('KUBECONFIG'):
-            kubeconfig = os.getenv('KUBECONFIG')
-        elif os.path.exists(os.path.join(
+        cluster_dir_kubeconfig = os.path.join(
             config.ENV_DATA['cluster_path'],
             config.RUN.get('kubeconfig_location')
-        )):
-            kubeconfig = os.path.join(
-                config.ENV_DATA['cluster_path'],
-                config.RUN.get('kubeconfig_location')
-            )
+        )
+        if os.getenv('KUBECONFIG'):
+            kubeconfig = os.getenv('KUBECONFIG')
+        elif os.path.exists(cluster_dir_kubeconfig):
+            kubeconfig = cluster_dir_kubeconfig
         else:
             kubeconfig = None
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -115,7 +115,19 @@ class OCP(object):
 
         """
         oc_cmd = "oc "
-        kubeconfig = os.getenv('KUBECONFIG')
+        if os.getenv('KUBECONFIG'):
+            kubeconfig = os.getenv('KUBECONFIG')
+        elif os.path.exists(os.path.join(
+            config.ENV_DATA['cluster_path'],
+            config.RUN.get('kubeconfig_location')
+        )):
+            kubeconfig = os.path.join(
+                config.ENV_DATA['cluster_path'],
+                config.RUN.get('kubeconfig_location')
+            )
+        else:
+            kubeconfig = None
+
         if self.namespace:
             oc_cmd += f"-n {self.namespace} "
 


### PR DESCRIPTION
Use kubeconfig from cluster dir for `oc` command executed via `exec_oc_cmd` method (if evn. variable `KUBECONFIG` not set).

When OCP cluster is installed via Flexy, `KUBECONFIG` env. variable is not directly set, but `kubeconfig` file is available in `auth` directory in cluster dir, so it make sense to check if it exists and use it from there. 

Signed-off-by: Daniel Horak <dahorak@redhat.com>