### PR TITLE
Revert "Skip relevant pv_services test cases on IBM cloud due to Bug 1871314 and 1871315"

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     skipif_ocs_version, ManageTest, tier1, acceptance, skipif_upgraded_from
 )
@@ -16,13 +15,6 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_ocs_version('<4.5')
 @skipif_upgraded_from(['4.4'])
-@pytest.mark.skipif(
-    config.ENV_DATA['platform'].lower() == 'ibm_cloud',
-    reason=(
-        "Skipping tests on IBM Cloud due to bug 1871314 "
-        "https://bugzilla.redhat.com/show_bug.cgi?id=1871314"
-    )
-)
 class TestPvcExpand(ManageTest):
     """
     Tests to verify PVC expansion

--- a/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from ocs_ci.framework.testlib import ManageTest, tier1, acceptance
-from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources import pod
@@ -75,13 +74,6 @@ class TestDynamicPvc(ManageTest):
 
     @acceptance
     @tier1
-    @pytest.mark.skipif(
-        config.ENV_DATA['platform'].lower() == 'ibm_cloud',
-        reason=(
-            "Skipping tests on IBM Cloud due to bug 1871315 "
-            "https://bugzilla.redhat.com/show_bug.cgi?id=1871315"
-        )
-    )
     @pytest.mark.parametrize(
         argnames=["interface_type", "reclaim_policy"],
         argvalues=[

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -3,7 +3,6 @@ import pytest
 import random
 
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier1, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
@@ -79,13 +78,6 @@ class TestPvcAssignPodNode(ManageTest):
 
     @acceptance
     @tier1
-    @pytest.mark.skipif(
-        config.ENV_DATA['platform'].lower() == 'ibm_cloud',
-        reason=(
-            "Skipping tests on IBM Cloud due to bug 1871314 "
-            "https://bugzilla.redhat.com/show_bug.cgi?id=1871314"
-        )
-    )
     @pytest.mark.parametrize(
         argnames=["interface"],
         argvalues=[

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs import constants
 from tests import helpers
@@ -13,13 +12,6 @@ log = logging.getLogger(__name__)
 
 
 @tier1
-@pytest.mark.skipif(
-    config.ENV_DATA['platform'].lower() == 'ibm_cloud',
-    reason=(
-        "Skipping tests on IBM Cloud due to bug 1871314 "
-        "https://bugzilla.redhat.com/show_bug.cgi?id=1871314"
-    )
-)
 @pytest.mark.parametrize(
     argnames=["reclaim_policy"],
     argvalues=[

--- a/tests/manage/pv_services/test_verify_rwo_using_multiple_pods.py
+++ b/tests/manage/pv_services/test_verify_rwo_using_multiple_pods.py
@@ -3,7 +3,6 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier1
 from tests.helpers import wait_for_resource_state
 
@@ -11,13 +10,6 @@ log = logging.getLogger(__name__)
 
 
 @tier1
-@pytest.mark.skipif(
-    config.ENV_DATA['platform'].lower() == 'ibm_cloud',
-    reason=(
-        "Skipping tests on IBM Cloud due to bug 1871315 "
-        "https://bugzilla.redhat.com/show_bug.cgi?id=1871315"
-    )
-)
 @pytest.mark.parametrize(
     argnames='interface',
     argvalues=[


### PR DESCRIPTION
Fixes: #2800 
Revert: #2793 

The related bug [1871314](https://bugzilla.redhat.com/show_bug.cgi?id=1871314) and [1871315](https://bugzilla.redhat.com/show_bug.cgi?id=1871315) have been `CLOSED NOTABUG` due to setup/configuration issue. Reverting the skips so that test cases will be executed in next run after fixing those issues.
