### PR TITLE
Fixes for IBM Power

### DIFF
--- a/conf/ocsci/production_powervs_upi.yaml
+++ b/conf/ocsci/production_powervs_upi.yaml
@@ -1,6 +1,3 @@
-RUN:
-  bin_dir: '/usr/local/bin'
-
 DEPLOYMENT:
   local_storage: True
   force_download_installer: False

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1257,9 +1257,12 @@ def get_ocp_version(seperator=None):
 
     """
     char = seperator if seperator else '.'
-    version = Version.coerce(
-        config.DEPLOYMENT['installer_version']
-    )
+    if config.ENV_DATA.get('skip_ocp_deployment'):
+        raw_version = json.loads(
+            run_cmd("oc version -o json"))['openshiftVersion']
+    else:
+        raw_version = config.DEPLOYMENT['installer_version']
+    version = Version.coerce(raw_version)
     return char.join(
         [str(version.major), str(version.minor)]
     )


### PR DESCRIPTION
This PR fixes:
* _Some_ of the issues destroying OCS while leaving OCP intact on IBM Power
* An issue with ocs-ci assuming the wrong OCP version (it's trivial to detect it)
* The improper setting of `bin_dir` in one of the stock config files