### PR TITLE
Change FIO timeout for long running test

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -109,7 +109,7 @@ class Pod(OCS):
         """
         self._roles.append(role)
 
-    def get_fio_results(self):
+    def get_fio_results(self, timeout=FIO_TIMEOUT):
         """
         Get FIO execution results
 
@@ -121,7 +121,7 @@ class Pod(OCS):
         """
         logger.info(f"Waiting for FIO results from pod {self.name}")
         try:
-            result = self.fio_thread.result(FIO_TIMEOUT)
+            result = self.fio_thread.result(timeout)
             if result:
                 return yaml.safe_load(result)
             raise CommandFailed(f"FIO execution results: {result}.")

--- a/ocs_ci/utility/workloads/fio.py
+++ b/ocs_ci/utility/workloads/fio.py
@@ -70,6 +70,7 @@ def run(**kwargs):
     io_pod = kwargs.pop('pod')
     st_type = kwargs.pop('type')
     path = kwargs.pop('path')
+    timeout = 600  # default timeout for the FIO test
 
     fio_cmd = "fio"
     args = ""
@@ -82,8 +83,12 @@ def run(**kwargs):
                 args = args + f" --{k}={path}"
         else:
             args = args + f" --{k}={v}"
+        if k == 'runtime' and v > timeout:
+            timeout = v  # for FIO with longer runtime, change the timeout
     fio_cmd = fio_cmd + args
     fio_cmd += " --output-format=json"
     log.info(f"Running cmd: {fio_cmd}")
 
-    return io_pod.exec_cmd_on_pod(fio_cmd, out_yaml_format=False)
+    return io_pod.exec_cmd_on_pod(
+        fio_cmd, out_yaml_format=False, timeout=timeout
+    )


### PR DESCRIPTION
Since we add a "long run" fill-up functionality using FIO, while trying to fill very large volume, the test can be take more then 10 Min. which is the default runtime for the FIO (and for any exec_cmd_on_pod() function).

This PR is taking the runtime for the fill-up functionality and set it as the timeout of the command.
 
This will fix #3126 

Signed-off-by: Avi Liani <alayani@redhat.com>