### PR TITLE
Verify VolumeSnapshotContent is deleted in testcase and fixture finalizer

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2636,6 +2636,7 @@ def get_snapshot_content_obj(snap_obj):
 
     Returns:
         OCS: OCS instance of kind VolumeSnapshotContent
+
     """
     data = dict()
     data['api_version'] = snap_obj.api_version

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2625,3 +2625,18 @@ def default_volumesnapshotclass(interface_type):
         resource_name=resource_name
     )
     return OCS(**base_snapshot_class.data)
+
+
+def get_snapshot_content_obj(snap_obj):
+    data = dict()
+    data['api_version'] = snap_obj.api_version
+    data['kind'] = constants.VOLUMESNAPSHOTCONTENT
+    snapcontent = snap_obj.ocp.get(
+        resource_name=snap_obj,out_yaml_format=True
+    )["status"]["boundVolumeSnapshotContentName"]
+    data['metadata'] = {
+        'name': snapcontent, 'namespace': snap_obj.namespace
+    }
+    snapcontent_obj = OCS(**data)
+    snapcontent_obj.reload()
+    return snapcontent_obj

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2632,7 +2632,7 @@ def get_snapshot_content_obj(snap_obj):
     data['api_version'] = snap_obj.api_version
     data['kind'] = constants.VOLUMESNAPSHOTCONTENT
     snapcontent = snap_obj.ocp.get(
-        resource_name=snap_obj, out_yaml_format=True
+        resource_name=snap_obj.name, out_yaml_format=True
     )["status"]["boundVolumeSnapshotContentName"]
     data['metadata'] = {
         'name': snapcontent, 'namespace': snap_obj.namespace

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2628,6 +2628,15 @@ def default_volumesnapshotclass(interface_type):
 
 
 def get_snapshot_content_obj(snap_obj):
+    """
+    Get volume snapshot content of a volume snapshot
+
+    Args:
+        snap_obj (OCS): OCS instance of kind VolumeSnapshot
+
+    Returns:
+        OCS: OCS instance of kind VolumeSnapshotContent
+    """
     data = dict()
     data['api_version'] = snap_obj.api_version
     data['kind'] = constants.VOLUMESNAPSHOTCONTENT

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2632,7 +2632,7 @@ def get_snapshot_content_obj(snap_obj):
     data['api_version'] = snap_obj.api_version
     data['kind'] = constants.VOLUMESNAPSHOTCONTENT
     snapcontent = snap_obj.ocp.get(
-        resource_name=snap_obj,out_yaml_format=True
+        resource_name=snap_obj, out_yaml_format=True
     )["status"]["boundVolumeSnapshotContentName"]
     data['metadata'] = {
         'name': snapcontent, 'namespace': snap_obj.namespace

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -117,6 +117,7 @@ PROXY = 'Proxy'
 MACHINECONFIGPOOL = "MachineConfigPool"
 VOLUMESNAPSHOTCLASS = "VolumeSnapshotClass"
 HPA = "horizontalpodautoscaler"
+VOLUMESNAPSHOTCONTENT = "VolumeSnapshotContent"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2863,10 +2863,23 @@ def snapshot_factory(request):
         Delete the snapshots
 
         """
+        snapcontent_objs = []
+
+        # Get VolumeSnapshotContent form VolumeSnapshots and delete
+        # VolumeSnapshots
         for instance in instances:
             if not instance.is_deleted:
+                snapcontent_objs.append(
+                    helpers.get_snapshot_content_obj(snap_obj=instance)
+                )
                 instance.delete()
                 instance.ocp.wait_for_delete(instance.name)
+
+        # Wait for VolumeSnapshotContents to be deleted
+        for snapcontent_obj in snapcontent_objs:
+            snapcontent_obj.ocp.wait_for_delete(
+                resource_name=snapcontent_obj.name, timeout=240
+            )
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
After deleting VolumeSnapShot , verify VolumeSnapShotContent is also deleted.
Added this check in test case test_snapshot_at_different_usage_level and snapshot_factory fixture finalizer

Signed-off-by: Jilju Joy <jijoy@redhat.com>