### PR TITLE
disable test_ceph_rbd_metrics_available test

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -102,6 +102,7 @@ def test_ceph_mgr_dashboard_not_deployed():
         assert "ceph-mgr-dashboard" not in route_name, msg
 
 
+@pytest.mark.skip(reason="BZ 1779336 was closed as NOTABUG")
 @skipif_ocs_version('<4.6')
 @metrics_for_external_mode_required
 @tier1


### PR DESCRIPTION
Since BZ 1779336 was closed with NOTABUG resolution:

https://bugzilla.redhat.com/show_bug.cgi?id=1779336#c34

The test case covering affected feature will be now disabled until rbd
metrics are evaluated as necessary for OCS Monitoring again.