### PR TITLE
Introducing development mode option which skips the few checks like collecting version, collecting logs etc

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -198,6 +198,16 @@ def pytest_addoption(parser):
             "from and the value to replace to, separated by '::'"
         )
     )
+    parser.addoption(
+        '--dev-mode',
+        dest='dev_mode',
+        action="store_true",
+        default=False,
+        help=(
+            "Runs in development mode. It skips few checks like collecting "
+            "versions, collecting logs, etc"
+        )
+    )
 
 
 def pytest_configure(config):
@@ -245,6 +255,9 @@ def pytest_configure(config):
                 "Skipping version collection because we skipped "
                 "the OCS deployment"
             )
+            return
+        elif ocsci_config.RUN['cli_params'].get('dev_mode'):
+            log.info("Running in development mode")
             return
         print("Collecting Cluster versions")
         # remove extraneous metadata
@@ -435,6 +448,7 @@ def process_cluster_cli_params(config):
     collect_logs_on_success_run = get_cli_param(config, 'collect_logs_on_success_run')
     if collect_logs_on_success_run:
         ocsci_config.REPORTING['collect_logs_on_success_run'] = True
+    get_cli_param(config, 'dev_mode')
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,8 +256,12 @@ def log_ocs_version(cluster):
     """
     teardown = config.RUN['cli_params'].get('teardown')
     deploy = config.RUN['cli_params'].get('deploy')
+    dev_mode = config.RUN['cli_params'].get('dev_mode')
     if teardown and not deploy:
         log.info("Skipping version reporting for teardown.")
+        return
+    elif dev_mode:
+        log.info("Skipping version reporting for development mode.")
         return
     cluster_version, image_dict = get_ocs_version()
     file_name = os.path.join(
@@ -1036,6 +1040,10 @@ def tier_marks_name():
 @pytest.fixture(scope='function', autouse=True)
 def health_checker(request, tier_marks_name):
     skipped = False
+    dev_mode = config.RUN['cli_params'].get('dev_mode')
+    if dev_mode:
+        log.info("Skipping health checks for development mode")
+        return
 
     def finalizer():
         if not skipped:


### PR DESCRIPTION
Introducing development mode option which skips the few checks like collecting version,
collecting logs and health checks

Skips below checks:
1. Collecting cluster versions during initilization
2. Collecting OCS versions during live log setup
3. Health check during live log setup
4. Health check during teardown

Signed-off-by: vavuthu <vavuthu@redhat.com>