### PR TITLE
Allow z-stream upgrade from live content

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -405,9 +405,13 @@ class Deployment(object):
             self.create_ocs_operator_source()
         self.subscribe_ocs()
         operator_selector = get_selector_for_ocs_operator()
+        subscription_plan_approval = config.DEPLOYMENT.get(
+            'subscription_plan_approval'
+        )
         package_manifest = PackageManifest(
             resource_name=defaults.OCS_OPERATOR_NAME,
             selector=operator_selector,
+            subscription_plan_approval=subscription_plan_approval
         )
         package_manifest.wait_for_resource(timeout=300)
         channel = config.DEPLOYMENT.get('ocs_csv_channel')
@@ -628,9 +632,13 @@ class Deployment(object):
             self.create_ocs_operator_source()
         self.subscribe_ocs()
         operator_selector = get_selector_for_ocs_operator()
+        subscription_plan_approval = config.DEPLOYMENT.get(
+            'subscription_plan_approval'
+        )
         package_manifest = PackageManifest(
             resource_name=defaults.OCS_OPERATOR_NAME,
             selector=operator_selector,
+            subscription_plan_approval=subscription_plan_approval,
         )
         package_manifest.wait_for_resource(timeout=300)
         channel = config.DEPLOYMENT.get('ocs_csv_channel')

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -146,6 +146,10 @@ class ChannelNotFound(Exception):
     pass
 
 
+class CSVNotFound(Exception):
+    pass
+
+
 class UnsupportedPlatformError(Exception):
     pass
 

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -145,6 +145,9 @@ class OCSUpgrade(object):
         self._version_before_upgrade = version_before_upgrade
         self._ocs_registry_image = ocs_registry_image
         self.upgrade_in_current_source = upgrade_in_current_source
+        self.subscription_plan_approval = config.DEPLOYMENT.get(
+            'subscription_plan_approval'
+        )
 
     @property
     def version_before_upgrade(self):
@@ -216,6 +219,7 @@ class OCSUpgrade(object):
         operator_selector = get_selector_for_ocs_operator()
         package_manifest = PackageManifest(
             resource_name=OCS_OPERATOR_NAME, selector=operator_selector,
+            subscription_plan_approval=self.subscription_plan_approval,
         )
         channel = config.DEPLOYMENT.get('ocs_csv_channel')
 
@@ -309,6 +313,7 @@ class OCSUpgrade(object):
         operator_selector = get_selector_for_ocs_operator()
         package_manifest = PackageManifest(
             resource_name=OCS_OPERATOR_NAME, selector=operator_selector,
+            subscription_plan_approval=self.subscription_plan_approval,
         )
         csv_name_post_upgrade = package_manifest.get_current_csv(channel)
         if csv_name_post_upgrade == csv_name_pre_upgrade:
@@ -335,6 +340,7 @@ class OCSUpgrade(object):
         operator_selector = get_selector_for_ocs_operator()
         package_manifest = PackageManifest(
             resource_name=OCS_OPERATOR_NAME, selector=operator_selector,
+            subscription_plan_approval=self.subscription_plan_approval,
         )
         csv_name_post_upgrade = package_manifest.get_current_csv(channel)
         csv_post_upgrade = CSV(

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -183,8 +183,12 @@ class OCS(object):
 
 def get_version_info(namespace=None):
     operator_selector = get_selector_for_ocs_operator()
+    subscription_plan_approval = config.DEPLOYMENT.get(
+        'subscription_plan_approval'
+    )
     package_manifest = PackageManifest(
         resource_name=defaults.OCS_OPERATOR_NAME, selector=operator_selector,
+        subscription_plan_approval=subscription_plan_approval,
     )
     channel = config.DEPLOYMENT.get('ocs_csv_channel')
     csv_name = package_manifest.get_current_csv(channel)
@@ -222,8 +226,12 @@ def get_ocs_csv():
     """
     namespace = config.ENV_DATA['cluster_namespace']
     operator_selector = get_selector_for_ocs_operator()
+    subscription_plan_approval = config.DEPLOYMENT.get(
+        'subscription_plan_approval'
+    )
     ocs_package_manifest = PackageManifest(
         resource_name=defaults.OCS_OPERATOR_NAME, selector=operator_selector,
+        subscription_plan_approval=subscription_plan_approval,
     )
     channel = config.DEPLOYMENT.get('ocs_csv_channel')
     ocs_csv_name = ocs_package_manifest.get_current_csv(channel=channel)


### PR DESCRIPTION
In order to live upgrade for z-streams we need to load CSV name
different way out of latest approved install plan.

Fixes: #2653

Signed-off-by: Petr Balogh <pbalogh@redhat.com>