### PR TITLE
bug 1873938, Unexpected PV is created after node reboot

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2616,10 +2616,9 @@ def get_pv_names():
         list: list of pv names
 
     """
-
     ocp_obj = ocp.OCP(kind=constants.PV)
-    pv_objs = ocp_obj.get()['items']
-    return [pv_obj['metadata']['name'] for pv_obj in pv_objs]
+    pv_objs = ocp_obj.get()["items"]
+    return [pv_obj["metadata"]["name"] for pv_obj in pv_objs]
 
 
 def get_cluster_proxies():

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2608,6 +2608,20 @@ def get_pv_size(storageclass=None):
     return return_list
 
 
+def get_pv_names():
+    """
+    Get Pv names
+
+    Returns:
+        list: list of pv names
+
+    """
+
+    ocp_obj = ocp.OCP(kind=constants.PV)
+    pv_objs = ocp_obj.get()['items']
+    return [pv_obj['metadata']['name'] for pv_obj in pv_objs]
+
+
 def get_cluster_proxies():
     """
     Get http and https proxy configuration:

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -336,18 +336,19 @@ class TestNodesRestart(ManageTest):
 
         """
         pv_before_reset = get_pv_names()
-        worker_node = get_typed_nodes(
-            node_type=constants.WORKER_MACHINE, num_of_nodes=1
+        worker_nodes = get_typed_nodes(
+            node_type=constants.WORKER_MACHINE, num_of_nodes=3
         )
-        nodes.restart_nodes(nodes=worker_node, wait=False)
-        pv_after_reset = get_pv_names()
-        pv_diff = set(pv_after_reset) - set(pv_before_reset)
-        pv_new = []
         ocp_obj = OCP(kind=constants.PV)
-        for pv in pv_diff:
-            pv_obj = ocp_obj.get(resource_name=pv)
-            if pv_obj['spec']['storageClassName'] == 'localblock':
-                pv_new.append(pv)
-        assert not pv_new, (
-            f"Unexpected PV {pv_new} is created after node reboot"
-        )
+        for worker_node in worker_nodes:
+            nodes.restart_nodes(nodes=[worker_node], wait=True)
+            pv_after_reset = get_pv_names()
+            pv_diff = set(pv_after_reset) - set(pv_before_reset)
+            pv_new = []
+            for pv in pv_diff:
+                pv_obj = ocp_obj.get(resource_name=pv)
+                if pv_obj['spec']['storageClassName'] == 'localblock':
+                    pv_new.append(pv)
+            assert not pv_new, (
+                f"Unexpected PV {pv_new} is created after node reboot"
+            )

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -341,8 +341,16 @@ class TestNodesRestart(ManageTest):
         )
         ocp_obj = OCP(kind=constants.PV)
         for worker_node in worker_nodes:
+            # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
+
+            # Checking cluster and Ceph health
+            self.sanity_helpers.health_check()
+
+            # Get pv names
             pv_after_reset = get_pv_names()
+
+            logger.info(f'Verify PV after reboot {worker_node}')
             pv_diff = set(pv_after_reset) - set(pv_before_reset)
             pv_new = []
             for pv in pv_diff:
@@ -350,5 +358,5 @@ class TestNodesRestart(ManageTest):
                 if pv_obj['spec']['storageClassName'] == 'localblock':
                     pv_new.append(pv)
             assert not pv_new, (
-                f"Unexpected PV {pv_new} is created after node reboot"
+                f"Unexpected PV {pv_new} is created after reboot {worker_node}"
             )

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -2,17 +2,13 @@ import logging
 import pytest
 
 from ocs_ci.framework.testlib import (
-<<<<<<< HEAD
     tier4,
     tier4a,
     ignore_leftovers,
     ManageTest,
     aws_platform_required,
     bugzilla,
-=======
-    tier4, tier4a, ignore_leftovers, ManageTest,
-    aws_platform_required, bugzilla, skipif_no_lso
->>>>>>> Create new test to verify unexpected PV is not created after node reboot on LSO cluster
+    skipif_no_lso,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs, get_typed_nodes
@@ -73,13 +69,8 @@ class TestNodesRestart(ManageTest):
         self.sanity_helpers.health_check()
         self.sanity_helpers.create_resources(pvc_factory, pod_factory)
 
-    @bugzilla('1754287')
-<<<<<<< HEAD
-    @bugzilla('1873938')
-    @pytest.mark.polarion_id('OCS-2015')
-=======
+    @bugzilla("1754287")
     @pytest.mark.polarion_id("OCS-2015")
->>>>>>> Create new test to verify unexpected PV is not created after node reboot on LSO cluster
     def test_rolling_nodes_restart(self, nodes, pvc_factory, pod_factory):
         """
         Test restart nodes one after the other and check health status in between
@@ -328,7 +319,7 @@ class TestNodesRestart(ManageTest):
         # Checking cluster and Ceph health
         self.sanity_helpers.health_check()
 
-    @bugzilla('1873938')
+    @bugzilla("1873938")
     @skipif_no_lso
     def test_pv_after_reboot_node(self, nodes):
         """
@@ -344,15 +335,15 @@ class TestNodesRestart(ManageTest):
             # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
             pod.wait_for_storage_pods()
-            logger.info(f'Verify PV after reboot {worker_node}')
+            logger.info(f"Verify PV after reboot {worker_node}")
             pv_after_reset = get_pv_names()
             pv_diff = set(pv_after_reset) - set(pv_before_reset)
             pv_new = []
             for pv in pv_diff:
                 pv_obj = ocp_obj.get(resource_name=pv)
-                if pv_obj['spec']['storageClassName'] == 'localblock':
+                if pv_obj["spec"]["storageClassName"] == "localblock":
                     pv_new.append(pv)
-            assert not pv_new, (
-                f"Unexpected PV {pv_new} is created after reboot {worker_node}"
-            )
-        logger.info('SUCCESS - No new PV was created.')
+            assert (
+                not pv_new
+            ), f"Unexpected PV {pv_new} is created after reboot {worker_node}"
+        logger.info("SUCCESS - No new PV was created.")

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -345,5 +345,5 @@ class TestNodesRestart(ManageTest):
                     pv_new.append(pv)
             assert (
                 not pv_new
-            ), f"Unexpected PV {pv_new} is created after reboot {worker_node}"
+            ), f"Unexpected PV {pv_new} created after reboot {worker_node}"
         logger.info("SUCCESS - No new PV was created.")

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -332,8 +332,7 @@ class TestNodesRestart(ManageTest):
         for worker_node in worker_nodes:
             # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
-            self.sanity_helpers.health_check(tries=40)
-            pod.wait_for_storage_pods()
+            self.sanity_helpers.health_check(cluster_check=False, tries=60)
             logger.info(f"Verify PV after reboot {worker_node}")
             pv_after_reset = get_pv_names()
             pv_diff = set(pv_after_reset) - set(pv_before_reset)

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -332,6 +332,7 @@ class TestNodesRestart(ManageTest):
         for worker_node in worker_nodes:
             # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
+            self.sanity_helpers.health_check(tries=40)
             pod.wait_for_storage_pods()
             logger.info(f"Verify PV after reboot {worker_node}")
             pv_after_reset = get_pv_names()

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -343,14 +343,8 @@ class TestNodesRestart(ManageTest):
         for worker_node in worker_nodes:
             # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
-
-            # Checking cluster and Ceph health
-            self.sanity_helpers.health_check()
-
-            # Get pv names
-            pv_after_reset = get_pv_names()
-
             logger.info(f'Verify PV after reboot {worker_node}')
+            pv_after_reset = get_pv_names()
             pv_diff = set(pv_after_reset) - set(pv_before_reset)
             pv_new = []
             for pv in pv_diff:
@@ -360,3 +354,4 @@ class TestNodesRestart(ManageTest):
             assert not pv_new, (
                 f"Unexpected PV {pv_new} is created after reboot {worker_node}"
             )
+        pod.wait_for_storage_pods()

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -348,6 +348,6 @@ class TestNodesRestart(ManageTest):
             pv_obj = ocp_obj.get(resource_name=pv)
             if pv_obj['spec']['storageClassName'] == 'localblock':
                 pv_new.append(pv)
-        assert pv_new == [], (
+        assert not pv_new, (
             f"Unexpected PV {pv_new} is created after node reboot"
         )

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -11,7 +11,7 @@ from ocs_ci.framework.testlib import (
     skipif_no_lso,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.node import get_node_objs, get_typed_nodes
+from ocs_ci.ocs.node import get_node_objs, get_nodes
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import wait_for_ct_pod_recovery, get_pv_names
@@ -327,9 +327,7 @@ class TestNodesRestart(ManageTest):
 
         """
         pv_before_reset = get_pv_names()
-        worker_nodes = get_typed_nodes(
-            node_type=constants.WORKER_MACHINE, num_of_nodes=3
-        )
+        worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE, num_of_nodes=3)
         ocp_obj = OCP(kind=constants.PV)
         for worker_node in worker_nodes:
             # Restart one worker node

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs, get_typed_nodes
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import Sanity
-from ocs_ci.helpers.helpers import wait_for_ct_pod_recovery
+from ocs_ci.helpers.helpers import wait_for_ct_pod_recovery, get_pv_names
 from ocs_ci.ocs.ocp import OCP
 
 

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -355,4 +355,4 @@ class TestNodesRestart(ManageTest):
             assert not pv_new, (
                 f"Unexpected PV {pv_new} is created after reboot {worker_node}"
             )
-        logger.info('No new PV was created.')
+        logger.info('SUCCESS - No new PV was created.')

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -343,6 +343,7 @@ class TestNodesRestart(ManageTest):
         for worker_node in worker_nodes:
             # Restart one worker node
             nodes.restart_nodes(nodes=[worker_node], wait=True)
+            pod.wait_for_storage_pods()
             logger.info(f'Verify PV after reboot {worker_node}')
             pv_after_reset = get_pv_names()
             pv_diff = set(pv_after_reset) - set(pv_before_reset)
@@ -354,4 +355,4 @@ class TestNodesRestart(ManageTest):
             assert not pv_new, (
                 f"Unexpected PV {pv_new} is created after reboot {worker_node}"
             )
-        pod.wait_for_storage_pods()
+        logger.info('No new PV was created.')

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -67,18 +67,26 @@ class TestNodesRestart(ManageTest):
         self.sanity_helpers.health_check()
         self.sanity_helpers.create_resources(pvc_factory, pod_factory)
 
-    @bugzilla("1754287")
-    @pytest.mark.polarion_id("OCS-2015")
+    @bugzilla('1754287')
+    @bugzilla('1873938')
+    @pytest.mark.polarion_id('OCS-2015')
     def test_rolling_nodes_restart(self, nodes, pvc_factory, pod_factory):
         """
         Test restart nodes one after the other and check health status in between
 
         """
         ocp_nodes = get_node_objs()
+        pv_current = get_pv_names()
+        pv_list = []
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
+            pv_list.append(get_pv_names())
         self.sanity_helpers.create_resources(pvc_factory, pod_factory)
+        for pv in pv_list:
+            assert pv.sort() == pv_current.sort(), (
+                "After reset a node, new PV was created."
+            )
 
     @pytest.mark.parametrize(
         argnames=["interface", "operation"],


### PR DESCRIPTION
Signed-off-by: Oded Viner <oviner@redhat.com>

- Get pv names and then restart a node.
- After a node-reboot, verify there is not additional unexpected PV.

https://bugzilla.redhat.com/show_bug.cgi?id=1873938


** I used `test_rolling_nodes_restart` to save running time.

