### PR TITLE
Fixed how we determine method for retrieving compute node names based on platform

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -657,17 +657,17 @@ def get_compute_node_names(no_replace=False):
     """
     platform = config.ENV_DATA.get('platform').lower()
     compute_node_objs = get_typed_nodes()
-    if platform == (constants.VSPHERE_PLATFORM or constants.AWS_PLATFORM):
+    if platform in [constants.VSPHERE_PLATFORM, constants.AWS_PLATFORM]:
         return [
             compute_obj.get()['metadata']['labels'][constants.HOSTNAME_LABEL]
             for compute_obj in compute_node_objs
         ]
     elif (
-        platform == (
-            constants.BAREMETAL_PLATFORM
-            or constants.BAREMETALPSI_PLATFORM
-            or constants.IBM_POWER_PLATFORM
-        )
+        platform in [
+            constants.BAREMETAL_PLATFORM,
+            constants.BAREMETALPSI_PLATFORM,
+            constants.IBM_POWER_PLATFORM
+        ]
     ):
         if no_replace:
             return [


### PR DESCRIPTION
#3187 introduced some faulty logic in how we match the platform to how we retrieve the compute node names. This change aims to fix that logic and ensure that we are using the right method for each platform.

Signed-off-by: Coady LaCroix <clacroix@redhat.com>