### PR TITLE
Fix PVC status check in pvc_clone_factory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3095,7 +3095,7 @@ def pvc_clone_factory(request):
         clone_pvc_obj.volume_mode = volume_mode
 
         if status:
-            helpers.wait_for_resource_state(pvc_obj, status)
+            helpers.wait_for_resource_state(clone_pvc_obj, status)
         return clone_pvc_obj
 
     def finalizer():


### PR DESCRIPTION
pvc_clone_factory is checking status of source PVC instead of cloned PVC. This PR will update pvc_clone_factory to check status of cloned PVC
Signed-off-by: Jilju Joy <jijoy@redhat.com>