### PR TITLE
Create configs for OCP 4.6 GA

### DIFF
--- a/conf/ocp_version/ocp-4.6-ga-config.yaml
+++ b/conf/ocp_version/ocp-4.6-ga-config.yaml
@@ -1,19 +1,18 @@
 ---
-# Config file for OCP GA 4.5 stable channel
+# Config file for OCP GA 4.6 stable channel
 
 RUN:
-  client_version: '4.5-ga'
+  client_version: '4.6-ga'
 
 DEPLOYMENT:
   ocp_url_template: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{version}/{file_name}-{os_type}-{version}.tar.gz"
-  installer_version: "4.5-ga"
+  installer_version: "4.6-ga"
   terraform_version: "0.12.26"
   ocp_channel: "stable"
-  # No promoted content to stable-4.5 channel yet
-  # Once the build promoted to stable, we can revert back
-  # http://post-office.corp.redhat.com/archives/aos-devel/2020-May/msg00071.html
+  # No promoted content to stable-4.6 channel yet
+  # Once the build promoted to stable, we can move to stable channel
 ENV_DATA:
-  vm_template: 'rhcos-4.5.6-x86_64-vmware.x86_64'
+  vm_template: 'rhcos-46.82.202010011740-0-vmware.x86_64'
   # rhcos_ami: 'ami-06c85f9d106577272'
   # If rhcos_ami is not specified the ID for aws upi deployments will be fetched from
   # https://raw.githubusercontent.com/openshift/installer/release-4.5/data/data/rhcos.json

--- a/conf/ocp_version/ocp-4.6-ga-minus1-config.yaml
+++ b/conf/ocp_version/ocp-4.6-ga-minus1-config.yaml
@@ -1,0 +1,14 @@
+---
+# Config file for OCP GA 4.6 stable channel minus 1 version
+
+RUN:
+  client_version: '4.6-ga'
+
+DEPLOYMENT:
+  ocp_url_template: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{version}/{file_name}-{os_type}-{version}.tar.gz"
+  installer_version: "4.6-ga"
+  terraform_version: "0.12.26"
+  ocp_channel: "stable"
+  ocp_version_index: -2
+ENV_DATA:
+  vm_template: 'rhcos-46.82.202010011740-0-vmware.x86_64'

--- a/conf/ocp_version/ocp-4.6-ga-upgrade.yaml
+++ b/conf/ocp_version/ocp-4.6-ga-upgrade.yaml
@@ -1,0 +1,5 @@
+---
+# Use this config for upgrading of OCP 4.6 GA cluster
+UPGRADE:
+  ocp_channel: "stable-4.6"
+  ocp_upgrade_path: "quay.io/openshift-release-dev/ocp-release"


### PR DESCRIPTION
As OCP 4.6 is GAed, we need to add the GA config for OCP 4.6.
This is done in this commit.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>