### PR TITLE
Changing default osd size to 100

### DIFF
--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -31,7 +31,7 @@ TEMP_YAML = os.path.join(constants.TEMPLATE_DIR, "temp.yaml")
 PROMETHEUS_ROUTE = 'prometheus-k8s'
 
 # Default device size in Gigs
-DEVICE_SIZE = 512
+DEVICE_SIZE = 100
 
 OCS_OPERATOR_NAME = "ocs-operator"
 LOCAL_STORAGE_OPERATOR_NAME = "local-storage-operator"


### PR DESCRIPTION
This will allow us to run more clusters in vSphere Common pool, Current restriction is due to datastore (storage) rather than CPU/Memory.

Signed-off-by: vavuthu <vavuthu@redhat.com>