### PR TITLE
deployment: Optionally allow rotational storage

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1106,7 +1106,8 @@ def setup_local_storage(storageclass):
         # Since we don't have datastore with SSD on our current VMware machines, localvolumeset doesn't detect
         # NonRotational disk. As a workaround we are setting Rotational to device MechanicalProperties to detect
         # HDD disk
-        if platform == constants.VSPHERE_PLATFORM:
+        if (platform == constants.VSPHERE_PLATFORM
+                or config.ENV_DATA.get('allow_rotational_storage', False)):
             logger.info("Adding Rotational for deviceMechanicalProperties spec to detect HDD disk")
             lvs_data['spec']['deviceInclusionSpec']['deviceMechanicalProperties'].append("Rotational")
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -99,6 +99,7 @@ ENV_DATA:
   storage_device_sets_name: "storageDeviceSets"
   cluster_namespace: 'openshift-storage'
   local_storage_namespace: 'openshift-local-storage'
+  allow_rotational_storage: false
   monitoring_enabled: true
   persistent-monitoring: true
   platform: 'AWS'


### PR DESCRIPTION
I found that the behavior I needed for a particular Power system was already invoked automatically on vsphere. Let's just make it configurable. The existing behavior is unchanged, though.