### PR TITLE
Couchbase teardown failure fix

### DIFF
--- a/ocs_ci/ocs/couchbase.py
+++ b/ocs_ci/ocs/couchbase.py
@@ -35,6 +35,7 @@ class CouchBase(PillowFight):
         constants.COUCHBASE_VALIDATING_WEBHOOK_YAML
     ]
     pod_obj = OCP(kind='pod')
+    ns_obj = OCP(kind='namespace')
     couchbase_pod = OCP(kind='pod')
     secretsadder = OCP(kind='pod')
     admission_pod = []
@@ -106,7 +107,7 @@ class CouchBase(PillowFight):
             timeout=self.WAIT_FOR_TIME,
             sleep=10,
         )
-        self.pod_obj.new_project(constants.COUCHBASE_OPERATOR)
+        self.ns_obj.new_project(constants.COUCHBASE_OPERATOR)
         couchbase_data = templating.load_yaml(
             constants.COUCHBASE_CRD_YAML
         )
@@ -297,7 +298,8 @@ class CouchBase(PillowFight):
         self.operator_role.delete()
         self.couchbase_obj.delete()
         switch_to_project('default')
-        self.pod_obj.delete_project(constants.COUCHBASE_OPERATOR)
+        self.ns_obj.delete_project(constants.COUCHBASE_OPERATOR)
+        self.ns_obj.wait_for_delete(resource_name=constants.COUCHBASE_OPERATOR)
         for adm_yaml in self.admission_parts:
             adm_data = templating.load_yaml(adm_yaml)
             adm_obj = OCS(**adm_data)

--- a/ocs_ci/ocs/pillowfight.py
+++ b/ocs_ci/ocs/pillowfight.py
@@ -56,8 +56,6 @@ class PillowFight(object):
         self.namespace = self.args.get(
             'namespace', 'couchbase-operator-namespace')
         self.ocp = OCP()
-        self.ns_obj = OCP(kind='namespace')
-        self.pod_obj = OCP(kind='pod')
         self.up_check = OCP(namespace=constants.COUCHBASE_OPERATOR)
         self.logs = tempfile.mkdtemp(prefix='pf_logs_')
 
@@ -268,9 +266,3 @@ class PillowFight(object):
 
         """
         rmtree(self.logs)
-        nsinfo = self.pod_obj.exec_oc_cmd(command="get namespace")
-        if constants.COUCHBASE_OPERATOR in nsinfo:
-            self.pod_obj.exec_oc_cmd(
-                command=f"delete namespace {constants.COUCHBASE_OPERATOR}"
-            )
-            self.ns_obj.wait_for_delete(resource_name=constants.COUCHBASE_OPERATOR)


### PR DESCRIPTION
In couchbase teardown method, added validation for project deletion. 
Fixes https://github.com/red-hat-storage/ocs-ci/issues/3229