### PR TITLE
Enable rotational disks for LSO PSI deployment

### DIFF
--- a/conf/ocsci/flexy_baremetalpsi_upi.yaml
+++ b/conf/ocsci/flexy_baremetalpsi_upi.yaml
@@ -4,6 +4,7 @@ ENV_DATA:
   platform: 'baremetalpsi'
   deployment_type: 'upi'
   flexy_deployment: true
+  local_storage_allow_rotational_disks: true
 
 FLEXY:
   LAUNCHER_VARS: {"num_workers":"3", "openstack_network":"provider_net_cci_9","rhel_vm_template":"ql-rhel-7.6","qe_additional_repos":"[{'id': 'rhel7', 'name': 'rhel7', 'baseurl': 'http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os', 'enabled': 1, 'gpgcheck': 0}]","vm_type_masters":"m1.large","vm_type_workers":"m1.large","ssh_key_name":"openshift-dev","rhel_ansible_user":"cloud-user","installer_payload_image":"registry.svc.ci.openshift.org/ocp/release:4.5","num_nodes": 1}

--- a/conf/ocsci/lso_enable_rotational_disks.yaml
+++ b/conf/ocsci/lso_enable_rotational_disks.yaml
@@ -1,0 +1,7 @@
+# This configuration file is to enable rotational disk devices for LSO
+# deployment
+---
+DEPLOYMENT:
+  local_storage: true
+ENV_DATA:
+  local_storage_allow_rotational_disks: true

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1106,7 +1106,10 @@ def setup_local_storage(storageclass):
         # Since we don't have datastore with SSD on our current VMware machines, localvolumeset doesn't detect
         # NonRotational disk. As a workaround we are setting Rotational to device MechanicalProperties to detect
         # HDD disk
-        if platform == constants.VSPHERE_PLATFORM:
+        if (
+            platform == constants.VSPHERE_PLATFORM
+            or config.ENV_DATA.get("local_storage_allow_rotational_disks")
+        ):
             logger.info("Adding Rotational for deviceMechanicalProperties spec to detect HDD disk")
             lvs_data['spec']['deviceInclusionSpec']['deviceMechanicalProperties'].append("Rotational")
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -134,6 +134,9 @@ ENV_DATA:
   # use Flexy for OCP installation (not available for all platforms and
   # deployment types)
   flexy_deployment: False
+  # To enable rotational disk devices for LSO deployment we can set
+  # local_storage_allow_rotational_disks to true
+  local_storage_allow_rotational_disks: false
 
 # This section is related to upgrade
 UPGRADE:


### PR DESCRIPTION
Fixes: #3230

Enable rotational disk devices for LSO deployment over PSI +
adding configuration file for enable this option.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>