### PR TITLE
Skip snapshot tests if OCP version is below 4.6

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier1
+    skipif_ocs_version, ManageTest, tier1, skipif_ocp_version
 )
 from ocs_ci.ocs.resources import pod, pvc
 from ocs_ci.helpers import helpers
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[

--- a/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
@@ -2,7 +2,9 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, tier1
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version, ManageTest, tier1, skipif_ocp_version
+)
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers.helpers import wait_for_resource_state, create_pods
 
@@ -11,6 +13,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @pytest.mark.polarion_id('OCS-2361')
 class TestRbdBlockPvcSnapshot(ManageTest):
     """

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -4,7 +4,9 @@ from copy import deepcopy
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, tier1
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version, ManageTest, tier1, skipif_ocp_version
+)
 from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
 from ocs_ci.helpers.helpers import wait_for_resource_state
 
@@ -13,6 +15,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @pytest.mark.polarion_id('OCS-2318')
 class TestSnapshotAtDifferentPvcUsageLevel(ManageTest):
     """


### PR DESCRIPTION
Add skipif_ocp_version marker in PVC snapshot tests. Tests should be skipped if OCP version < 4.6

Signed-off-by: Jilju Joy <jijoy@redhat.com>