### PR TITLE
Skip PVC clone test cases if OCP version is below 4.6

### DIFF
--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -3,7 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier2, polarion_id
+    skipif_ocs_version, ManageTest, tier2, polarion_id, skipif_ocp_version
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.prometheus import PrometheusAPI, check_alert_list
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 @tier2
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @polarion_id('OCS-2353')
 class TestCloneWhenFull(ManageTest):
     """

--- a/tests/manage/pv_services/pvc_clone/test_clone_with_different_access_mode.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_with_different_access_mode.py
@@ -4,7 +4,7 @@ from itertools import cycle
 
 from ocs_ci.ocs import constants, node
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier1, polarion_id
+    skipif_ocs_version, ManageTest, tier1, polarion_id, skipif_ocp_version
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers import helpers
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @polarion_id('OCS-2368')
 class TestCloneWithDifferentAccessMode(ManageTest):
     """

--- a/tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py
@@ -3,7 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version, ManageTest, tier1
+    skipif_ocs_version, ManageTest, tier1, skipif_ocp_version
 )
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs.resources import pod
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version('<4.6')
+@skipif_ocp_version('<4.6')
 @pytest.mark.parametrize(
     argnames=["interface_type"],
     argvalues=[


### PR DESCRIPTION
Add skipif_ocp_version marker in PVC clone test cases to skips the tests if OCP version is below 4.6

Signed-off-by: Jilju Joy <jijoy@redhat.com>