### PR TITLE
increase the timeout for collection must-gather on OCS4.6

### DIFF
--- a/conf/ocsci/scale.yaml
+++ b/conf/ocsci/scale.yaml
@@ -1,2 +1,2 @@
 REPORTING:
-  must_gather_timeout: 1200
+  must_gather_timeout: 1500

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -733,7 +733,7 @@ def run_must_gather(log_dir_path, image, command=None):
         image (str): must-gather image registry path
         command (str): optional command to execute within the must-gather image
     """
-    # Must-gather has many changes in 4.6 which add more time to the collection.
+    # Must-gather has many changes on 4.6 which add more time to the collection.
     # https://github.com/red-hat-storage/ocs-ci/issues/3240
     ocs_version = float(ocsci_config.ENV_DATA['ocs_version'])
     timeout = 1500 if ocs_version >= 4.6 else 600

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -736,7 +736,7 @@ def run_must_gather(log_dir_path, image, command=None):
     # Must-gather has many changes in 4.6 which add more time to the collection.
     # https://github.com/red-hat-storage/ocs-ci/issues/3240
     ocs_version = float(ocsci_config.ENV_DATA['ocs_version'])
-    timeout = 1500 if ocs_version == 4.6 else 600
+    timeout = 1500 if ocs_version >= 4.6 else 600
     must_gather_timeout = ocsci_config.REPORTING.get(
         'must_gather_timeout', timeout
     )

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -736,14 +736,10 @@ def run_must_gather(log_dir_path, image, command=None):
     # Must-gather has many changes in 4.6 which add more time to the collection.
     # https://github.com/red-hat-storage/ocs-ci/issues/3240
     ocs_version = float(ocsci_config.ENV_DATA['ocs_version'])
-    if ocs_version == 4.6:
-        must_gather_timeout = ocsci_config.REPORTING.get(
-            'must_gather_timeout', 1500
-        )
-    else:
-        must_gather_timeout = ocsci_config.REPORTING.get(
-            'must_gather_timeout', 600
-        )
+    timeout = 1500 if ocs_version == 4.6 else 600
+    must_gather_timeout = ocsci_config.REPORTING.get(
+        'must_gather_timeout', timeout
+    )
 
     log.info(f"Must gather image: {image} will be used.")
     create_directory_path(log_dir_path)

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -733,9 +733,17 @@ def run_must_gather(log_dir_path, image, command=None):
         image (str): must-gather image registry path
         command (str): optional command to execute within the must-gather image
     """
-    must_gather_timeout = ocsci_config.REPORTING.get(
-        'must_gather_timeout', 600
-    )
+    # Must-gather has many changes in 4.6 which add more time to the collection.
+    # https://github.com/red-hat-storage/ocs-ci/issues/3240
+    ocs_version = float(ocsci_config.ENV_DATA['ocs_version'])
+    if ocs_version == 4.6:
+        must_gather_timeout = ocsci_config.REPORTING.get(
+            'must_gather_timeout', 1500
+        )
+    else:
+        must_gather_timeout = ocsci_config.REPORTING.get(
+            'must_gather_timeout', 600
+        )
 
     log.info(f"Must gather image: {image} will be used.")
     create_directory_path(log_dir_path)


### PR DESCRIPTION
Signed-off-by: Oded Viner <oviner@redhat.com>

OCS4.6 must_gather failed to complete in 600sec

oc adm must-gather --image=quay.io/rhceph-dev/ocs-must-gather:latest-4.6

`image=quay.io/rhceph-dev/ocs-must-gather:latest-4.6 --dest-dir=/home/jenkins/current-cluster-dir/logs/deployment_1603639721/ocs_must_gather 17:07:50 - MainThread - ocs_ci.ocs.utils - ERROR - Timeout 600s for must-gather reached, command exited with error: Command '['oc', '--kubeconfig', '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig', 'adm', 'must-gather', '--image=quay.io/rhceph-dev/ocs-must-gather:latest-4.6', '--dest-dir=/home/jenkins/current-cluster-dir/logs/deployment_1603639721/ocs_must_gather']' timed out after 600 seconds`


Must-gather has many changes in 4.6 which add more time to the collection.
Added crash information from nodes which can be a large file so there is sleep of 15 mins
Increased the timeout for OCS4.6 to 1500sec (25min) 