### PR TITLE
Use api key in Prometheus API communication on IBM Cloud

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.utility.utils import run_cmd, update_container_with_mirrored_image
+from ocs_ci.utility.utils import exec_cmd, run_cmd, update_container_with_mirrored_image
 from ocs_ci.utility.templating import dump_data_to_temp_yaml, load_yaml
 from ocs_ci.ocs import defaults, constants
 from ocs_ci.framework import config
@@ -421,9 +421,10 @@ class OCP(object):
 
         Returns:
             str: output of login command
+
         """
-        command = f"oc login -u {user} -p {password}"
-        status = run_cmd(command)
+        command = ['oc', 'login', '-u', user, '-p', password]
+        status = exec_cmd(command, secrets=[password])
         return status
 
     def login_as_sa(self):

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -312,7 +312,7 @@ class PrometheusAPI(object):
         """
         if config.ENV_DATA['platform'].lower() == 'ibm_cloud':
             self._user = user or 'apikey'
-            self._password = password or config.AUTH.get('ibm_apikey')
+            self._password = password or config.AUTH["ibmcloud"]['api_key']
         else:
             self._user = user or config.RUN['username']
             if not password:


### PR DESCRIPTION
 - For successful Prometheus API communication on IBM Cloud needs to be set `ibm_apikey` in `AUTH` configuration.

Signed-off-by: Filip Balak <fbalak@redhat.com>