### PR TITLE
Change awscli pod to random naming and fix awscli_pod_session teardown issue

### DIFF
--- a/ocs_ci/templates/mcg/aws-cli-service-ca-configmap.yaml
+++ b/ocs_ci/templates/mcg/aws-cli-service-ca-configmap.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: awscli-service-ca
-  namespace: default
+  namespace: openshift-storage
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1758,7 +1758,9 @@ def awscli_pod_fixture(request, scope_name):
     )
 
     awscli_pod_obj = helpers.create_resource(**awscli_pod_dict)
-    OCP(namespace=constants.DEFAULT_NAMESPACE, kind='ConfigMap').wait_for_resource(
+    OCP(
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE, kind='ConfigMap'
+    ).wait_for_resource(
         resource_name=service_ca_configmap.name,
         column='DATA',
         condition='1'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,8 +50,10 @@ from ocs_ci.ocs.node import check_nodes_specs
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import get_rgw_pods, delete_deploymentconfig_pods, \
+from ocs_ci.ocs.resources.pod import (
+    get_rgw_pods, delete_deploymentconfig_pods,
     get_pods_having_label
+)
 from ocs_ci.ocs.resources.pvc import PVC, create_restore_pvc
 from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
 from ocs_ci.ocs.cluster_load import ClusterLoad, wrap_msg
@@ -1714,35 +1716,35 @@ def mcg_obj_fixture(request, *args, **kwargs):
 
 @pytest.fixture()
 def awscli_pod(request):
-    return awscli_pod_fixture(request, 'function')
+    return awscli_pod_fixture(request, scope_name='function')
 
 
 @pytest.fixture(scope='session')
 def awscli_pod_session(request):
-    return awscli_pod_fixture(request, 'session')
+    return awscli_pod_fixture(request, scope_name='session')
 
 
-def awscli_pod_fixture(request, scope):
+def awscli_pod_fixture(request, scope_name):
     """
     Creates a new AWSCLI pod for relaying commands
+    Args:
+        scope_name (str): The name of the fixture's scope,
+        used for giving a descriptive name to the pod and configmap
 
     Returns:
         pod: A pod running the AWS CLI
 
     """
     # Create the service-ca configmap to be mounted upon pod creation
-    try:
-        service_ca_data = templating.load_yaml(constants.AWSCLI_SERVICE_CA_YAML)
-        service_ca_data['metadata']['name'] = create_unique_resource_name(
-            constants.AWSCLI_SERVICE_CA_CONFIGMAP_NAME,
-            scope
-        )
-        log.info('Trying to create the AWS CLI service CA')
-        service_ca_configmap = helpers.create_resource(
-            **service_ca_data
-        )
-    except CommandFailed:
-        raise
+    service_ca_data = templating.load_yaml(constants.AWSCLI_SERVICE_CA_YAML)
+    service_ca_data['metadata']['name'] = create_unique_resource_name(
+        constants.AWSCLI_SERVICE_CA_CONFIGMAP_NAME,
+        scope_name
+    )
+    log.info('Trying to create the AWS CLI service CA')
+    service_ca_configmap = helpers.create_resource(
+        **service_ca_data
+    )
 
     arch = get_system_architecture()
     if arch.startswith('x86'):
@@ -1752,7 +1754,7 @@ def awscli_pod_fixture(request, scope):
     awscli_pod_obj = helpers.create_pod(
         namespace=constants.DEFAULT_NAMESPACE,
         pod_dict_path=pod_dict_path,
-        pod_name=create_unique_resource_name(constants.AWSCLI_RELAY_POD_NAME, scope)
+        pod_name=create_unique_resource_name(constants.AWSCLI_RELAY_POD_NAME, scope_name)
     )
     OCP(namespace=constants.DEFAULT_NAMESPACE, kind='ConfigMap').wait_for_resource(
         resource_name=service_ca_configmap.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1752,7 +1752,7 @@ def awscli_pod_fixture(request, scope_name):
         pod_dict_path = constants.AWSCLI_MULTIARCH_POD_YAML
 
     awscli_pod_dict = templating.load_yaml(pod_dict_path)
-    awscli_pod_dict['spec']['volumes']['configMap']['name'] = service_ca_configmap_name
+    awscli_pod_dict['spec']['volumes'][0]['configMap']['name'] = service_ca_configmap_name
     awscli_pod_dict['metadata']['name'] = create_unique_resource_name(
         constants.AWSCLI_RELAY_POD_NAME, scope_name
     )

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -71,29 +71,29 @@ class TestBucketIO(MCGTest):
     @pytest.mark.polarion_id("OCS-1949")
     @tier1
     @acceptance
-    def test_mcg_data_deduplication(self, mcg_obj, awscli_pod_session, bucket_factory):
+    def test_mcg_data_deduplication(self, mcg_obj, awscli_pod, bucket_factory):
         """
         Test data deduplication mechanics
         Args:
             mcg_obj (obj): An object representing the current state of the MCG in the cluster
-            awscli_pod_session (pod): A pod running the AWSCLI tools
+            awscli_pod (pod): A pod running the AWSCLI tools
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
         download_dir = '/aws/deduplication/'
-        awscli_pod_session.exec_cmd_on_pod(
+        awscli_pod.exec_cmd_on_pod(
             command=craft_s3_command(
                 f'cp s3://{constants.TEST_FILES_BUCKET}/danny.webm {download_dir}danny.webm'
             ),
             out_yaml_format=False
         )
-        file_size = int(awscli_pod_session.exec_cmd_on_pod(
+        file_size = int(awscli_pod.exec_cmd_on_pod(
             command=f'stat -c %s {download_dir}danny.webm',
             out_yaml_format=False
         ))
         bucket = bucket_factory(amount=1)[0]
         bucketname = bucket.name
         for i in range(3):
-            awscli_pod_session.exec_cmd_on_pod(
+            awscli_pod.exec_cmd_on_pod(
                 command=craft_s3_command(
                     f'cp {download_dir}danny.webm s3://{bucketname}/danny{i}.webm',
                     mcg_obj=mcg_obj
@@ -105,16 +105,16 @@ class TestBucketIO(MCGTest):
     @pytest.mark.polarion_id("OCS-1949")
     @tier1
     @acceptance
-    def test_mcg_data_compression(self, mcg_obj, awscli_pod_session, bucket_factory):
+    def test_mcg_data_compression(self, mcg_obj, awscli_pod, bucket_factory):
         """
         Test data reduction mechanics
         Args:
             mcg_obj (obj): An object representing the current state of the MCG in the cluster
-            awscli_pod_session (pod): A pod running the AWSCLI tools
+            awscli_pod (pod): A pod running the AWSCLI tools
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
         download_dir = '/aws/compression/'
-        awscli_pod_session.exec_cmd_on_pod(
+        awscli_pod.exec_cmd_on_pod(
             command=craft_s3_command(
                 f'cp s3://{constants.TEST_FILES_BUCKET}/enwik8 {download_dir}'
             ),
@@ -124,7 +124,7 @@ class TestBucketIO(MCGTest):
         bucketname = bucket.name
         full_object_path = f"s3://{bucketname}"
         sync_object_directory(
-            awscli_pod_session, download_dir, full_object_path, mcg_obj
+            awscli_pod, download_dir, full_object_path, mcg_obj
         )
         # For this test, enwik8 is used in conjunction with Snappy compression
         # utilized by NooBaa. Snappy consistently compresses 35MB of the file.


### PR DESCRIPTION
awscli fixture wasnt assigning different name for each awscli pod created, which causes an issue when trying to create multiple pods (for example session and function scopes).
For now to resolve issue #3255 we'll also use the function scope awscli pod in the compression and deduplication tests