### PR TITLE
Raise an exception for get packagemanifest function

### DIFF
--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -80,6 +80,11 @@ class PackageManifest(OCP):
                 ]
                 if len(items_match_name) == 1:
                     return items_match_name[0]
+                if len(items_match_name) == 0:
+                    raise ResourceNotFoundError(
+                        f"Requested packageManifest: {resource_name} with "
+                        f"selector: {selector} not found!"
+                    )
                 else:
                     return items_match_name
         return data


### PR DESCRIPTION
We need to raise an exception for get function in packageManifest class
in the case we will not find the resource with proper name.

This case the wait_for_resource and timeout sampler will work properly.

Fixes: #3260

Signed-off-by: Petr Balogh <pbalogh@redhat.com>