### PR TITLE
Allow only pausing and only resuming cluster load

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1284,7 +1284,7 @@ def reduce_cluster_load_implementation(request, pause, resume=True):
 @pytest.fixture()
 def pause_cluster_load(request):
     """
-    Pause the background cluster load
+    Pause the background cluster load without resuming it
 
     """
     reduce_cluster_load_implementation(request=request, pause=True, resume=False)
@@ -1293,7 +1293,7 @@ def pause_cluster_load(request):
 @pytest.fixture()
 def resume_cluster_load(request):
     """
-    Pause the background cluster load
+    Resume the background cluster load
 
     """
     if config.RUN.get('io_in_bg'):
@@ -1311,7 +1311,7 @@ def resume_cluster_load(request):
 @pytest.fixture()
 def pause_resume_cluster_load(request):
     """
-    Pause the background cluster load
+    Pause the background cluster load and resume it in teardown
 
     """
     reduce_cluster_load_implementation(request=request, pause=True)
@@ -1320,7 +1320,7 @@ def pause_resume_cluster_load(request):
 @pytest.fixture()
 def reduce_resume_cluster_load(request):
     """
-    Reduce the background cluster load to be 50% of what it is
+    Reduce the background cluster load to be 50% of what it is and resume the load in teardown
 
     """
     reduce_cluster_load_implementation(request=request, pause=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1260,6 +1260,10 @@ def reduce_cluster_load_implementation(request, pause, resume=True):
     """
     Pause/reduce the background cluster load
 
+    Args:
+        pause (bool): True for completely pausing the cluster load, False for reducing it by 50%
+        resume (bool): True for resuming the cluster load upon teardown, False for not resuming
+
     """
     if config.RUN.get('io_in_bg'):
 
@@ -1309,18 +1313,19 @@ def resume_cluster_load(request):
 
 
 @pytest.fixture()
-def pause_resume_cluster_load(request):
+def pause_and_resume_cluster_load(request):
     """
-    Pause the background cluster load and resume it in teardown
+    Pause the background cluster load and resume it in teardown to the original load value
 
     """
     reduce_cluster_load_implementation(request=request, pause=True)
 
 
 @pytest.fixture()
-def reduce_resume_cluster_load(request):
+def reduce_and_resume_cluster_load(request):
     """
     Reduce the background cluster load to be 50% of what it is and resume the load in teardown
+    to the original load value
 
     """
     reduce_cluster_load_implementation(request=request, pause=False)

--- a/tests/ecosystem/upgrade/test_resources.py
+++ b/tests/ecosystem/upgrade/test_resources.py
@@ -36,7 +36,7 @@ def test_storage_pods_running(multiregion_mirror_setup_session):
 )
 @pre_upgrade
 @ignore_leftovers
-def test_start_pre_upgrade_pod_io(pre_upgrade_pods_running_io, pause_cluster_load):
+def test_start_pre_upgrade_pod_io(pause_cluster_load, pre_upgrade_pods_running_io):
     """
     Confirm that there are pods created before upgrade.
     """

--- a/tests/ecosystem/upgrade/test_resources.py
+++ b/tests/ecosystem/upgrade/test_resources.py
@@ -36,7 +36,7 @@ def test_storage_pods_running(multiregion_mirror_setup_session):
 )
 @pre_upgrade
 @ignore_leftovers
-def test_start_pre_upgrade_pod_io(pre_upgrade_pods_running_io):
+def test_start_pre_upgrade_pod_io(pre_upgrade_pods_running_io, pause_cluster_load):
     """
     Confirm that there are pods created before upgrade.
     """
@@ -59,7 +59,8 @@ def test_pod_io(
     post_upgrade_filesystem_pods,
     pre_upgrade_block_pods,
     post_upgrade_block_pods,
-    fio_project
+    fio_project,
+    resume_cluster_load
 ):
     """
     Test IO on multiple pods at the same time and finish IO on pods that were

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -26,7 +26,7 @@ class TestUpgradeOCP(ManageTest):
     5. monitor cluster health
     """
 
-    def test_upgrade_ocp(self, reduce_resume_cluster_load):
+    def test_upgrade_ocp(self, reduce_and_resume_cluster_load):
         """
         Tests OCS stability when upgrading OCP
 

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -26,7 +26,7 @@ class TestUpgradeOCP(ManageTest):
     5. monitor cluster health
     """
 
-    def test_upgrade_ocp(self, reduce_cluster_load):
+    def test_upgrade_ocp(self, reduce_resume_cluster_load):
         """
         Tests OCS stability when upgrading OCP
 

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -122,7 +122,7 @@ class TestMCGResourcesDisruptions(MCGTest):
         ]
     )
     def test_drain_mcg_pod_node(
-        self, node_drain_teardown, reduce_cluster_load,
+        self, node_drain_teardown, reduce_resume_cluster_load,
         pod_to_drain
     ):
         """

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -122,7 +122,7 @@ class TestMCGResourcesDisruptions(MCGTest):
         ]
     )
     def test_drain_mcg_pod_node(
-        self, node_drain_teardown, reduce_resume_cluster_load,
+        self, node_drain_teardown, reduce_and_resume_cluster_load,
         pod_to_drain
     ):
         """

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -92,7 +92,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
     @acceptance
     @tier1
     def test_pvc_delete_and_verify_size_is_returned_to_backend_pool(
-        self, pause_resume_cluster_load, pvc_factory, pod_factory
+        self, pause_and_resume_cluster_load, pvc_factory, pod_factory
     ):
         """
         Test case to verify after delete pvc size returned to backend pools

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -92,7 +92,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
     @acceptance
     @tier1
     def test_pvc_delete_and_verify_size_is_returned_to_backend_pool(
-        self, pause_cluster_load, pvc_factory, pod_factory
+        self, pause_resume_cluster_load, pvc_factory, pod_factory
     ):
         """
         Test case to verify after delete pvc size returned to backend pools

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -59,7 +59,7 @@ class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
     """
-    def test_add_capacity(self, reduce_cluster_load):
+    def test_add_capacity(self, reduce_resume_cluster_load):
         """
         Test to add variable capacity to the OSD cluster while IOs running
         """
@@ -77,7 +77,7 @@ class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade
     """
-    def test_add_capacity_pre_upgrade(self, reduce_cluster_load):
+    def test_add_capacity_pre_upgrade(self, reduce_resume_cluster_load):
         """
         Test to add variable capacity to the OSD cluster while IOs running
         """

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -59,7 +59,7 @@ class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
     """
-    def test_add_capacity(self, reduce_resume_cluster_load):
+    def test_add_capacity(self, reduce_and_resume_cluster_load):
         """
         Test to add variable capacity to the OSD cluster while IOs running
         """
@@ -77,7 +77,7 @@ class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade
     """
-    def test_add_capacity_pre_upgrade(self, reduce_resume_cluster_load):
+    def test_add_capacity_pre_upgrade(self, reduce_and_resume_cluster_load):
         """
         Test to add variable capacity to the OSD cluster while IOs running
         """

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -96,7 +96,7 @@ class TestNodesMaintenance(ManageTest):
             pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1272"))
         ]
     )
-    def test_node_maintenance(self, reduce_resume_cluster_load, node_type, pvc_factory, pod_factory):
+    def test_node_maintenance(self, reduce_and_resume_cluster_load, node_type, pvc_factory, pod_factory):
         """
         OCS-1269/OCS-1272:
         - Maintenance (mark as unscheduable and drain) 1 worker/master node

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -96,7 +96,7 @@ class TestNodesMaintenance(ManageTest):
             pytest.param(*['master'], marks=pytest.mark.polarion_id("OCS-1272"))
         ]
     )
-    def test_node_maintenance(self, reduce_cluster_load, node_type, pvc_factory, pod_factory):
+    def test_node_maintenance(self, reduce_resume_cluster_load, node_type, pvc_factory, pod_factory):
         """
         OCS-1269/OCS-1272:
         - Maintenance (mark as unscheduable and drain) 1 worker/master node


### PR DESCRIPTION
We would like to re-enable pre and post upgrade test cases that run IOs. For that, we need to pause the cluster load while upgrade and while IO takes place from these tests.

This will partially address https://github.com/red-hat-storage/ocs-ci/issues/3165

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>