### PR TITLE
Add options for FIO profile to generate S3 load for noobaa autoscale

### DIFF
--- a/ocs_ci/ocs/fio_artefacts.py
+++ b/ocs_ci/ocs/fio_artefacts.py
@@ -56,7 +56,7 @@ def get_mcg_conf(mcg_obj, workload_bucket, custom_options=None):
     # add or overwrite custom values
     if custom_options:
         for section in custom_options:
-            if section is not 'create':
+            if not config.has_section(section):
                 config.add_section(section)
             for configuration in custom_options[section]:
                 config.set(section, configuration[0], configuration[1])

--- a/ocs_ci/ocs/fio_artefacts.py
+++ b/ocs_ci/ocs/fio_artefacts.py
@@ -56,6 +56,8 @@ def get_mcg_conf(mcg_obj, workload_bucket, custom_options=None):
     # add or overwrite custom values
     if custom_options:
         for section in custom_options:
+            if section is not 'create':
+                config.add_section(section)
             for configuration in custom_options[section]:
                 config.set(section, configuration[0], configuration[1])
 

--- a/ocs_ci/templates/workloads/fio/config_s3.fio
+++ b/ocs_ci/templates/workloads/fio/config_s3.fio
@@ -32,3 +32,24 @@ size=64k
 # bs=4k
 # size=64k
 # io_size=4k
+
+[job1]
+iodepth=4
+rw=randrw
+bs=32k
+size=64m
+numjobs=4
+
+[job2]
+iodepth=16
+rw=randrw
+bs=64k
+size=512m
+numjobs=4
+
+[job3]
+iodepth=32
+rw=randrw
+bs=128k
+size=1024m
+numjobs=4

--- a/ocs_ci/templates/workloads/fio/config_s3.fio
+++ b/ocs_ci/templates/workloads/fio/config_s3.fio
@@ -32,24 +32,3 @@ size=64k
 # bs=4k
 # size=64k
 # io_size=4k
-
-[job1]
-iodepth=4
-rw=randrw
-bs=32k
-size=64m
-numjobs=4
-
-[job2]
-iodepth=16
-rw=randrw
-bs=64k
-size=512m
-numjobs=4
-
-[job3]
-iodepth=32
-rw=randrw
-bs=128k
-size=1024m
-numjobs=4

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -21,7 +21,8 @@ class TestEndpointAutoScale(MCGTest):
     def test_scaling_under_load(self, mcg_job_factory):
         self._assert_endpoint_count(1)
 
-        options = {}
+        options = {'create': [('name', 'job1'), ('name', 'job2'),
+                              ('name', 'job3'), ('runtime', '900')]}
         job = mcg_job_factory(custom_options=options)
         self._assert_endpoint_count(2)
 
@@ -37,5 +38,5 @@ class TestEndpointAutoScale(MCGTest):
             condition=constants.STATUS_RUNNING,
             selector=constants.NOOBAA_ENDPOINT_POD_LABEL,
             dont_allow_other_resources=True,
-            timeout=300,
+            timeout=500,
         )

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -21,8 +21,12 @@ class TestEndpointAutoScale(MCGTest):
     def test_scaling_under_load(self, mcg_job_factory):
         self._assert_endpoint_count(1)
 
-        options = {'create': [('name', 'job1'), ('name', 'job2'),
-                              ('name', 'job3'), ('runtime', '900')]}
+        options = {
+            'create': [('name', 'job1'), ('name', 'job2'), ('name', 'job3'), ('runtime', '900')],
+            'job1': [('iodepth', '4'), ('rw', 'randrw'), ('bs', '32k'), ('size', '64m'), ('numjobs', '4')],
+            'job2': [('iodepth', '16'), ('rw', 'randrw'), ('bs', '64k'), ('size', '512m'), ('numjobs', '4')],
+            'job3': [('iodepth', '32'), ('rw', 'randrw'), ('bs', '128k'), ('size', '1024m'), ('numjobs', '4')]
+        }
         job = mcg_job_factory(custom_options=options)
         self._assert_endpoint_count(2)
 


### PR DESCRIPTION
Add options for FIO profile to generate S3 load to >80% of CPU utilization.  This will trigger noobaa autoscale creating additional endpoint.
This will fix the issue: https://github.com/red-hat-storage/ocs-ci/issues/3282

Signed-off-by: Tiffany Nguyen <tunguyen@redhat.com>