### PR TITLE
Name ocs subscription the same like done by UI

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -838,7 +838,7 @@ LATEST_TAGS = (
 )
 INTERNAL_MIRROR_PEM_FILE = "ops-mirror.pem"
 EC2_USER = "ec2-user"
-OCS_SUBSCRIPTION = "ocs-subscription"
+OCS_SUBSCRIPTION = "ocs-operator"
 
 # UI Deployment constants
 HTPASSWD_SECRET_NAME = "htpass-secret"

--- a/ocs_ci/templates/ocs-deployment/subscription.yaml
+++ b/ocs_ci/templates/ocs-deployment/subscription.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ocs-subscription
+  name: ocs-operator
   namespace: openshift-storage
 spec:
   channel: CHANNEL_PLACEHOLDER


### PR DESCRIPTION
In UI deployment the subscription is called ocs-operator,
so we should follow the same naming convention.

Fixes: #2478

Signed-off-by: Petr Balogh <pbalogh@redhat.com>