### PR TITLE
Changing network_adapter parameter

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1538,7 +1538,7 @@ class VSPHEREUPINode(VMWareNodes):
                     int(config.ENV_DATA["worker_num_cpus"]),
                     int(config.ENV_DATA["compute_memory"]),
                     125829120,
-                    config.ENV_DATA["network_adapter"],
+                    config.ENV_DATA["vm_network"],
                     power_on=True,
                     **data,
                 )


### PR DESCRIPTION
Since we already have "vm_network" parameter in the initial configuration, there is no need to add extra parameter
for adding nodes. Since all the nodes in the same cluster should share the same network.

Fixes: #3295 

Signed-off-by: vavuthu <vavuthu@redhat.com>