### PR TITLE
[WIP] Remove CI testing on python 3.6 to reduce travis-ci credit use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,10 @@ script:
 
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-    - python: 3.6
-      env: TOXENV=flake8
     - python: 3.7
       env: TOXENV=flake8
-    - python: 3.6
-      env: TOXENV=collectonly
     - python: 3.7
       env: TOXENV=collectonly
     - python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,flake8
+envlist = py37,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
This is to help reduce credit use from the new travis-ci.org

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>