### PR TITLE
Black formatting preparation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.5.0
   hooks:
-    - id: check-docstring-first
     - id: check-json
     - id: check-yaml
       args: [--multi]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 
-import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath('..'))
 
@@ -44,7 +43,10 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv', 'venv', 'tests', '.tox', 'data', '.pytest_cache', 'usecases/README.rst']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', '.venv', 'venv', 'tests', '.tox', 'data',
+    '.pytest_cache', 'usecases/README.rst'
+]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -65,9 +67,10 @@ master_doc = 'index'
 # Add support for MD files:
 # https://www.sphinx-doc.org/en/1.6/markdown.html
 source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
+    '.md': 'recommonmark.parser.CommonMarkParser',
 }
 source_suffix = ['.rst', '.md']
+
 
 # Based on this issue: https://github.com/readthedocs/readthedocs.org/issues/1139
 def run_apidoc(_):

--- a/docs/python-examples/fixtures/test_fixtures.py
+++ b/docs/python-examples/fixtures/test_fixtures.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 
 logger = logging.getLogger(__name__)
@@ -44,6 +43,8 @@ class TestPVC:
         pvc_2 = pvc_factory()
         # and so on - or use a loop
         # use the pvc
+        print(pvc_1.project.namespace)
+        print(pvc_2.project.namespace)
         # perform rest of the test
 
 

--- a/ocs_ci/ocs/pod_exec.py
+++ b/ocs_ci/ocs/pod_exec.py
@@ -29,14 +29,11 @@ from kubernetes.stream import stream
 
 logger = logging.getLogger(__name__)
 
-""" This dict holds a mapping of stringified class name to class
-
-Used by factory function to dynamically find the class to be instantiated
-
-"""
+# This dict holds a mapping of stringified class name to class
+# Used by factory function to dynamically find the class to be instantiated
 _clsmap = dict()
 
-"""Packing all elements required for execution """
+# Packing all elements required for execution
 CmdObj = namedtuple('CmdObj', [
     'cmd',
     'timeout',

--- a/tests/manage/monitoring/test_workload_example.py
+++ b/tests/manage/monitoring/test_workload_example.py
@@ -1,5 +1,10 @@
 # -*- coding: utf8 -*-
-
+"""
+This is a demonstration how to start k8s Job in one test, let it running, and
+then revisit it and stop in another one. Original simple draft was created by
+mbukatov based on discussion with fbalak, who is expected to tweak it further
+to fit into the upgrade scenario (as well as error checking adn logging).
+"""
 
 import logging
 import textwrap
@@ -14,14 +19,6 @@ from ocs_ci.utility.utils import run_cmd
 
 logger = logging.getLogger(__name__)
 TEST_NS = "namespace-test-fio-continuous-workload"
-
-
-"""
-This is a demonstration how to start k8s Job in one test, let it running, and
-then revisit it and stop in another one. Original simple draft was created by
-mbukatov based on discussion with fbalak, who is expected to tweak it further
-to fit into the upgrade scenario (as well as error checking adn logging).
-"""
 
 
 @pytest.mark.libtest

--- a/tests/manage/monitoring/test_workload_with_distruptions.py
+++ b/tests/manage/monitoring/test_workload_with_distruptions.py
@@ -1,18 +1,4 @@
 # -*- coding: utf8 -*-
-
-
-import logging
-
-from ocs_ci.framework import config
-from ocs_ci.framework.testlib import tier2, pre_upgrade, post_upgrade
-from ocs_ci.ocs import constants, ocp
-from ocs_ci.ocs import fiojob
-from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
-
-
-logger = logging.getLogger(__name__)
-
-
 """
 Test cases test_workload_with_checksum and test_workload_with_checksum_verify
 were originaly proposed for testing metrics and (partial) cluster shutdown, but
@@ -43,6 +29,17 @@ with the same parameters, and executes the checksum verification.
 The original idea was to use fio verification feature, but testing showed that
 when this fails for some reason or gets stuck, it's hard to debug.
 """
+
+import logging
+
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import tier2, pre_upgrade, post_upgrade
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs import fiojob
+from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
+
+
+logger = logging.getLogger(__name__)
 
 
 @pre_upgrade

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands = flake8 ocs_ci tests
 
 [flake8]
 basepython = python3
-ignore = E402, E741, W503
+ignore = E203, E402, E741, W503
 enable-extensions = M511
 exclude =
     venv,


### PR DESCRIPTION
This PR fixes various issues that were causing pre-commit to fail after formatting the repo with black. These failures were coming up now because pre-commit runs against files in your changeset and not against the entire repository. These problems existed before black formatting was being done.