### PR TITLE
dev workflow updates for black

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format repository using black
+ee4dc48b7f9f5ce54fab47a3c3d9b3dea12c52f1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 repos:
 
+- repo: https://github.com/psf/black
+  rev: 20.8b1
+  hooks:
+    - id: black
+      language_version: python3.7
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.5.0
   hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ script:
 
 matrix:
   include:
+    - python: 3.7
+      env: TOXENV=black
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pre-commit==2.5.1
+black==20.8b1
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,flake8
+envlist = black,py36,py37,flake8
 
 [testenv]
 deps =
@@ -42,3 +42,8 @@ deps =
 changedir = docs
 skipsdist = true
 commands = /usr/bin/make -f Makefile.tox html
+
+[testenv:black]
+deps =
+    black==20.8b1
+commands = black . --check


### PR DESCRIPTION
Addresses a few of the outstanding tasks in #2952 by adding `black` to our developer requirements, pre-commit hooks, tox, and travis-ci. Also adds a file that can be used to clean up `git blame` output by ignoring changes done in the reformatting commit.