### PR TITLE
Add chaos_runner in test_ocs_monkey

### DIFF
--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -17,9 +17,7 @@ def test_ocs_monkey():
     # ocs-monkey run time in seconds
     run_time = 3200
     clone_repo(constants.OCS_MONKEY_REPOSITORY, ocs_monkety_dir)
-    run_cmd(
-        f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}"
-    )
+    run_cmd(f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}")
     workload_run_cmd = f"python workload_runner.py -t {run_time}"
     chaos_runner_cmd = "python chaos_runner.py"
 

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -52,6 +52,7 @@ def test_ocs_monkey():
 
         if ret_workload is not None:
             log.info("Workload runner completed.")
+            log.debug(popen_workload.stdout.read())
             # Terminate chaos_runner if workload_runner is completed
             log.info("Terminating chaos runner")
             popen_chaos.terminate()
@@ -73,6 +74,7 @@ def test_ocs_monkey():
 
         if ret_chaos is not None:
             log.info("Chaos runner completed.")
+            log.debug(popen_chaos.stdout.read())
             # Terminate workload_runner if chaos_runner is completed
             log.info("Terminating workload runner")
             popen_workload.terminate()
@@ -84,9 +86,9 @@ def test_ocs_monkey():
             break
 
         # Terminate the process if it is not completed within the specified
-        # time. Give grace period of 600 seconds considering the time
+        # time. Give grace period of 900 seconds considering the time
         # taken for setup
-        if time.time() - start_time > run_time + 600:
+        if time.time() - start_time > run_time + 900:
             log.error(
                 f"ocs-monkey did not complete with in the specified run time"
                 f" {run_time} seconds. Killing the process now."
@@ -96,7 +98,7 @@ def test_ocs_monkey():
             raise TimeoutError(
                 f"ocs-monkey did not complete with in the specified run time "
                 f"{run_time} seconds. Killed the process after providing "
-                f"grace period of 600 seconds."
+                f"grace period of 900 seconds."
             )
 
     assert ceph_health_check(tries=40, delay=30), "Ceph cluster health is not OK"

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -17,12 +17,15 @@ def test_ocs_monkey():
     # ocs-monkey run time in seconds
     run_time = 3200
     clone_repo(constants.OCS_MONKEY_REPOSITORY, ocs_monkety_dir)
-    run_cmd(f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}")
+    run_cmd(
+        f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}"
+    )
     workload_run_cmd = f"python workload_runner.py -t {run_time}"
+    chaos_runner_cmd = f"python chaos_runner.py"
 
     start_time = time.time()
-    log.info("Starting ocs-monkey")
-    popen_obj = subprocess.Popen(
+    log.info("Starting workload runner")
+    popen_workload = subprocess.Popen(
         shlex.split(workload_run_cmd),
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
@@ -30,20 +33,58 @@ def test_ocs_monkey():
         cwd=ocs_monkety_dir,
     )
 
+    log.info("Starting chaos runner")
+    popen_chaos = subprocess.Popen(
+        shlex.split(chaos_runner_cmd),
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+        cwd=ocs_monkety_dir,
+    )
+
     while True:
-        output = popen_obj.stdout.readline()
-        # Check whether the process is completed
-        ret = popen_obj.poll()
-        if len(output) == 0 and ret is not None:
-            log.info("ocs-monkey run completed.")
-            assert ret == 0, (
-                f"ocs-monkey exited with return value {ret}. "
+        output_workload = popen_workload.stdout.readline()
+
+        # Get the status of workload runner process
+        ret_workload = popen_workload.poll()
+
+        # Stream the workload runner output in console
+        if output_workload:
+            log.info(output_workload.strip())
+
+        if len(output_workload) == 0 and ret_workload is not None:
+            log.info("Workload runner completed.")
+            # Terminate chaos_runner if workload_runner is completed
+            log.info("Terminating chaos runner")
+            popen_chaos.terminate()
+            # Check return value of workload runner process
+            assert ret_workload == 0, (
+                f"Workload runner exited with return value {ret_workload}. "
                 f"Check logs for details."
             )
+            log.info("ocs-monkey run completed")
             break
-        # Stream the output in console
-        if output:
-            log.info(output.strip())
+
+        output_chaos = popen_chaos.stdout.readline()
+        # Get the status of chaos runner process
+        ret_chaos = popen_chaos.poll()
+
+        # Stream the chaos runner output in console
+        if output_chaos:
+            log.info(output_chaos.strip())
+
+        if len(output_chaos) == 0 and ret_chaos is not None:
+            log.info("Chaos runner completed.")
+            # Terminate workload_runner if chaos_runner is completed
+            log.info("Terminating workload runner")
+            popen_workload.terminate()
+            assert ret_chaos == 0, (
+                f"Chaos runner exited with return value {ret_chaos}. "
+                f"Check logs for details."
+            )
+            log.info("ocs-monkey run completed")
+            break
+
         # Terminate the process if it is not completed within the specified
         # time. Give grace period of 600 seconds considering the time
         # taken for setup
@@ -52,7 +93,8 @@ def test_ocs_monkey():
                 f"ocs-monkey did not complete with in the specified run time"
                 f" {run_time} seconds. Killing the process now."
             )
-            popen_obj.terminate()
+            popen_workload.terminate()
+            popen_chaos.terminate()
             raise TimeoutError(
                 f"ocs-monkey did not complete with in the specified run time "
                 f"{run_time} seconds. Killed the process after providing "

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -5,7 +5,7 @@ import os
 import time
 
 from ocs_ci.framework.testlib import ignore_leftovers
-from ocs_ci.utility.utils import clone_repo, run_cmd
+from ocs_ci.utility.utils import clone_repo, run_cmd, ceph_health_check
 from ocs_ci.ocs import constants
 
 log = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def test_ocs_monkey():
     ocs_monkety_dir = "/tmp/ocs-monkey"
     # ocs-monkey run time in seconds
-    run_time = 3200
+    run_time = 3600
     clone_repo(constants.OCS_MONKEY_REPOSITORY, ocs_monkety_dir)
     run_cmd(f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}")
     workload_run_cmd = f"python workload_runner.py -t {run_time}"
@@ -50,7 +50,7 @@ def test_ocs_monkey():
         if output_workload:
             log.info(output_workload.strip())
 
-        if len(output_workload) == 0 and ret_workload is not None:
+        if ret_workload is not None:
             log.info("Workload runner completed.")
             # Terminate chaos_runner if workload_runner is completed
             log.info("Terminating chaos runner")
@@ -71,7 +71,7 @@ def test_ocs_monkey():
         if output_chaos:
             log.info(output_chaos.strip())
 
-        if len(output_chaos) == 0 and ret_chaos is not None:
+        if ret_chaos is not None:
             log.info("Chaos runner completed.")
             # Terminate workload_runner if chaos_runner is completed
             log.info("Terminating workload runner")
@@ -98,3 +98,5 @@ def test_ocs_monkey():
                 f"{run_time} seconds. Killed the process after providing "
                 f"grace period of 600 seconds."
             )
+
+    assert ceph_health_check(tries=40, delay=30), "Ceph cluster health is not OK"

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -21,7 +21,7 @@ def test_ocs_monkey():
         f"pip install -r {os.path.join(ocs_monkety_dir, 'requirements.txt')}"
     )
     workload_run_cmd = f"python workload_runner.py -t {run_time}"
-    chaos_runner_cmd = f"python chaos_runner.py"
+    chaos_runner_cmd = "python chaos_runner.py"
 
     start_time = time.time()
     log.info("Starting workload runner")


### PR DESCRIPTION
[Chaos_runner](https://github.com/red-hat-storage/ocs-monkey/blob/master/chaos_runner.py) is a randomized fault injector which will run pod delete operations - rbdplugin, rbdplugin-provisioner, mon, osd, operator pods. Chaos_runner will be triggered along with workload_runner.

Closes #3132 

Signed-off-by: Jilju Joy <jijoy@redhat.com>