### PR TITLE
pull nginx image from quay.io instead of docker to avoid rate limit issue

### DIFF
--- a/ocs_ci/templates/CSI/cephfs/pod.yaml
+++ b/ocs_ci/templates/CSI/cephfs/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: nginx
+     image: quay.io/ocsci/nginx:latest
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/CSI/rbd/pod.yaml
+++ b/ocs_ci/templates/CSI/rbd/pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: nginx
+     image: quay.io/ocsci/nginx:latest
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/app-pods/nginx.yaml
+++ b/ocs_ci/templates/app-pods/nginx.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: nginx
+     image: quay.io/ocsci/nginx:latest
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/app-pods/raw_block_pod.yaml
+++ b/ocs_ci/templates/app-pods/raw_block_pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: nginx
+      image: quay.io/ocsci/nginx:latest
       securityContext:
          capabilities:
            add: ["SYS_ADMIN"]


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/3320

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>