### PR TITLE
Rewriting OCS destroy on IBM Power

### DIFF
--- a/ocs_ci/deployment/ibm.py
+++ b/ocs_ci/deployment/ibm.py
@@ -3,13 +3,17 @@ This module implements the OCS deployment for IBM Power platform
 Base code in deployment.py contains the required changes to keep
 code duplication to minimum. Only destroy_ocs is retained here.
 """
+import json
 import logging
+import subprocess
+import time
 
 from ocs_ci.deployment.deployment import Deployment
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.utility.utils import run_cmd
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources import pvc
 
 logger = logging.getLogger(__name__)
 
@@ -26,206 +30,173 @@ class IBMDeployment(Deployment):
         worker-storage nodes, delete ocs CRDs, etc.
         """
         cluster_namespace = config.ENV_DATA["cluster_namespace"]
-        local_storage_namespace = config.ENV_DATA["local_storage_namespace"]
 
-        # STEP 2 & 3 not relevant. There are no PVCs using the storage class
-        # provisioners. other than noobaa.
+        # https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/deploying_openshift_container_storage_using_bare_metal_infrastructure/assembly_uninstalling-openshift-container-storage_rhocs
 
-        # STEP 1 & 4
-        # Get a list of storage classes
-        storage_classes = ocp.OCP(kind="StorageClass").get()
-        scnoprovisioner = []
-        scopenshiftprovisioner = []
-        for storage_class in storage_classes.get("items", []):
-            name = storage_class["metadata"]["name"]
-            if storage_class["provisioner"] == "kubernetes.io/no-provisioner":
-                scnoprovisioner.append(name)
-            else:
-                scopenshiftprovisioner.append(name)
-
-        storage_clusters = ocp.OCP(
-            kind="StorageCluster", namespace=cluster_namespace
-        ).get()
-        sclassindevicesets = []
-        for storage_cluster in storage_clusters.get("items", []):
-            device_sets = storage_cluster["spec"]["storageDeviceSets"]
-            sclassindevicesets.append(
-                [i["dataPVCTemplate"]["spec"]["storageClassName"] for i in device_sets]
+        # Section 3.1 Step 1
+        # Deleting PVCs
+        rbd_pvcs = [
+            p
+            for p in pvc.get_all_pvcs_in_storageclass(constants.CEPHBLOCKPOOL_SC)
+            if not (
+                p.data["metadata"]["namespace"] == cluster_namespace
+                and p.data["metadata"]["labels"]["app"] == "noobaa"
             )
-
-        # sclassindevicesets is a list of lists. Each outer list is for
-        # a specific storage cluster. All storage classes in the inner
-        # list are same (same storage class used across all devicesets
-        # in a storage cluster. So pick only the first one.
-
-        # for each storage class, get LocalVolume (owner).
-
-        if len(sclassindevicesets) == 0:
-            logger.warning("No storage class in device sets. Quitting.")
-            return
-
-        # compare scnoprovisioner and sclassindevicesets
-        tmplist = []
-        for sclist in sclassindevicesets:
-            for sc in sclist:
-                if sc in scnoprovisioner:
-                    if sc not in tmplist:
-                        tmplist.append(sc)
-
-        scandlvlist = []
-        for sc in tmplist:
-            storage_class = ocp.OCP(kind="StorageClass", resource_name=sc)
-            localvolumemeta = storage_class.get().get("metadata")
-            localvolume = localvolumemeta["labels"][
-                "local.storage.openshift.io/owner-name"
-            ]
-            scandlvlist.append((sc[0], localvolume))
-
-        alldevicepaths = []
-        for lv in scandlvlist:
-            # Get localvolume and corresponding devices
-            localvolume = (
-                ocp.OCP(
-                    kind="LocalVolume",
-                    namespace=local_storage_namespace,
-                    resource_name=lv[1],
-                )
-                .get()
-                .get("spec")
-            )
-            scdevices = localvolume["storageClassDevices"]
-            devicepaths = [sub["devicePaths"] for sub in scdevices]
-            alldevicepaths.append(devicepaths[0][0])
-
-        # STEP 5
-        # delete storage cluster - all of them.
-        scdelete = f"oc delete -n {cluster_namespace} storagecluster --all --wait=true"
-        logger.info(scdelete)
-        out = run_cmd(scdelete)
-        logger.info(out)
-
-        # STEP 6
-        spdelete = f"oc delete project {cluster_namespace} --wait=true --timeout=5m"
-        logger.info(spdelete)
-        out = run_cmd(spdelete)
-        logger.info(out)
-
-        default = "oc project default"
-        logger.info(default)
-        out = run_cmd(default)
-        logger.info(out)
-
-        # STEP 7 & 9
-        nodes = ocp.OCP(kind="node").get().get("items", [])
-        worker_nodes = [
-            node
-            for node in nodes
-            if "cluster.ocs.openshift.io/openshift-storage"
-            in node["metadata"]["labels"]
         ]
-        worker_node_names = [node["metadata"]["name"] for node in worker_nodes]
-        logger.warning(worker_node_names)
+        pvc.delete_pvcs(rbd_pvcs)
+        cephfs_pvcs = pvc.get_all_pvcs_in_storageclass(constants.CEPHFILESYSTEM_SC)
 
-        for worker_node in worker_node_names:
-            rookstring = (
-                "oc debug node/"
-                + worker_node
-                + " -- chroot /host rm -rfv /var/lib/rook"
+        # Section 3.1 Step 2
+        # Section 3.3 Step 1
+        # Removing OpenShift Container Platform registry from OpenShift Container Storage
+        registry_conf_name = "configs.imageregistry.operator.openshift.io"
+        registry_conf = ocp.OCP().exec_oc_cmd(f"get {registry_conf_name} -o yaml")
+        if registry_conf["items"][0]["spec"].get("storage", dict()).get("pvc"):
+            patch = dict(spec=dict(storage=dict(emptyDir=dict(), pvc=None)))
+            ocp.OCP().exec_oc_cmd(
+                f"patch {registry_conf_name} cluster --type merge "
+                f"-p '{json.dumps(patch)}'"
             )
-            logger.info(rookstring)
-            out = run_cmd(rookstring)
-            logger.info(out)
+        # Section 3.3 Step 2
+        pvc.delete_pvcs(cephfs_pvcs)
 
-            for devicepath in alldevicepaths:
-                sgdiskstring = (
-                    "oc debug node/"
-                    + worker_node
-                    + " -- chroot /host sgdisk --zap-all "
-                    + devicepath
-                )
-                logger.info(sgdiskstring)
-                # out = run_cmd(sgdiskstring)
-                # logger.info(out)
-
-        # STEP 8
-        for sc in scandlvlist:
-            lvdelete = f"oc delete localvolume -n {local_storage_namespace} --wait=true {sc[0]}"
-            logger.info(lvdelete)
-            out = run_cmd(lvdelete)
-            logger.info(out)
-            pvdelete = (
-                "oc delete pv -l \
-                storage.openshift.com/local-volume-owner-name="
-                + sc[0]
-                + " --wait --timeout=5m"
+        # Section 3.1 Step 3
+        try:
+            ocp.OCP().exec_oc_cmd(
+                f"delete -n {cluster_namespace} storagecluster --all --wait=true"
             )
-            logger.info(pvdelete)
-            out = run_cmd(pvdelete)
-            logger.info(out)
-            scdelete = "oc delete storageclass " + sc[1] + " --wait=true --timeout=5m"
-            logger.info(scdelete)
-            out = run_cmd(scdelete)
-            logger.info(out)
+        except (CommandFailed, subprocess.TimeoutExpired):
+            pass
 
-            for worker_node in worker_node_names:
-                rookstring = (
-                    "oc debug node/"
-                    + worker_node
-                    + " -- chroot /host rm -rfv /mnt/local-storage/ "
-                    + sc[1]
-                )
-                logger.info(rookstring)
-                out = run_cmd(rookstring)
-                logger.info(out)
-
-        # Delete all PV's for openshift provisioner storageclass
-        pvall = "oc delete pv --all"
-        logger.info(pvall)
-        out = run_cmd(pvall)
-        logger.info(out)
-
-        # STEP 10
-        for sc in scopenshiftprovisioner:
-            scdelete = "oc delete storageclass " + sc + " --wait=true --timeout=5m"
-            logger.info(scdelete)
-            out = run_cmd(scdelete)
-            logger.info(out)
-
-        # STEP 11
-        # Unlabel nodes
-        unlabel1 = "oc label nodes  --all cluster.ocs.openshift.io/openshift-storage="
-        logger.info(unlabel1)
-        # out = run_cmd(unlabel1)
-        logger.info(out)
-
-        unlabel2 = " oc label nodes  --all topology.rook.io/rack="
-        logger.info(unlabel2)
-        # out = run_cmd(unlabel2)
-        logger.info(out)
-
-        # STEP 12
-        # Remove local storage namespace
-        spdelete = (
-            f"oc delete project {local_storage_namespace} --wait=true --timeout=5m"
+        # Section 3.1 Step 4
+        ocp.OCP().exec_oc_cmd("project default")
+        ocp.OCP().exec_oc_cmd(
+            f"delete project {cluster_namespace} --wait=true --timeout=5m"
         )
-        logger.info(spdelete)
-        out = run_cmd(spdelete)
-        logger.info(out)
+        tried = 0
+        leftovers = True
+        while tried < 5:
+            # We need to loop here until the project can't be found
+            try:
+                ocp.OCP().exec_oc_cmd(
+                    f"get project {cluster_namespace}",
+                    out_yaml_format=False,
+                )
+            except CommandFailed:
+                leftovers = False
+                break
+            time.sleep(60)
+            tried += 1
+        if leftovers:
+            # https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/troubleshooting_openshift_container_storage/troubleshooting-and-deleting-remaining-resources-during-uninstall_rhocs
+            leftover_types = [
+                "cephfilesystem.ceph.rook.io",
+                "cephobjectstore.ceph.rook.io",
+                "cephobjectstoreuser.ceph.rook.io",
+                "storagecluster.ocs.openshift.io",
+            ]
+            patch = dict(metadata=dict(finalizers=None))
+            for obj_type in leftover_types:
+                try:
+                    objs = ocp.OCP(kind=obj_type).get()
+                except CommandFailed:
+                    continue
+                for obj in objs["items"]:
+                    name = obj["metadata"]["name"]
+                    ocp.OCP().exec_oc_cmd(
+                        f"oc patch -n {cluster_namespace} {obj_type} {name} --type=merge -p '{json.dumps(patch)}'"
+                    )
 
-        # STEP 13
-        catsource = f"oc delete catalogsource ocs-catalogsource -n {constants.MARKETPLACE_NAMESPACE}"
-        logger.info(catsource)
-        out = run_cmd(catsource)
-        logger.info(out)
+        # Section 3.1 Step 5
+        nodes = ocp.OCP().exec_oc_cmd(
+            "get node -l cluster.ocs.openshift.io/openshift-storage= -o yaml"
+        )
+        for node in nodes["items"]:
+            node_name = node["metadata"]["name"]
+            ocp.OCP().exec_oc_cmd(
+                f"debug node/{node_name} -- chroot /host rm -rfv /var/lib/rook"
+            )
 
-        # STEP 14
-        mondelete = f"oc delete configmap cluster-monitoring-config -n {constants.OPENSHIFT_MONITORING_NAMESPACE}"
-        logger.info(mondelete)
-        out = run_cmd(mondelete)
-        logger.info(out)
+        # Section 3.1 Step 6
+        ocp.OCP().exec_oc_cmd(
+            "delete storageclass  openshift-storage.noobaa.io --wait=true --timeout=5m"
+        )
 
-        # STEP 15
-        pvcdelete = f"oc delete pvc registry-cephfs-rwx-pvc -n {constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE}"
-        logger.info(pvcdelete)
-        out = run_cmd(pvcdelete)
-        logger.info(out)
+        # Section 3.1 Step 7
+        ocp.OCP().exec_oc_cmd(
+            "label nodes  --all cluster.ocs.openshift.io/openshift-storage-"
+        )
+        ocp.OCP().exec_oc_cmd("label nodes  --all topology.rook.io/rack-")
+
+        # Section 3.1 Step 8
+        pvs = ocp.OCP(kind="PersistentVolume").get()
+        for pv in pvs["items"]:
+            pv_name = pv["metadata"]["name"]
+            if pv_name.startswith("ocs-storagecluster-ceph"):
+                ocp.OCP().exec_oc_cmd(f"oc delete pv {pv_name}")
+
+        # Section 3.1 Step 9
+        try:
+            ocp.OCP().exec_oc_cmd(
+                "delete crd backingstores.noobaa.io bucketclasses.noobaa.io "
+                "cephblockpools.ceph.rook.io cephclusters.ceph.rook.io "
+                "cephfilesystems.ceph.rook.io cephnfses.ceph.rook.io "
+                "cephobjectstores.ceph.rook.io cephobjectstoreusers.ceph.rook.io "
+                "noobaas.noobaa.io ocsinitializations.ocs.openshift.io  "
+                "storageclusterinitializations.ocs.openshift.io "
+                "storageclusters.ocs.openshift.io cephclients.ceph.rook.io "
+                "--wait=true --timeout=5m"
+            )
+        except CommandFailed:
+            pass
+
+        # End sections from above documentation
+        ocp.OCP().exec_oc_cmd(
+            f"delete catalogsource {constants.OPERATOR_CATALOG_SOURCE_NAME} "
+            f"-n {constants.MARKETPLACE_NAMESPACE}"
+        )
+
+        storageclasses = ocp.OCP(kind="StorageClass").get(all_namespaces=True)
+        for sc in storageclasses["items"]:
+            if sc["provisioner"].startswith("openshift-storage."):
+                sc_name = sc["metadata"]["name"]
+                ocp.OCP().exec_oc_cmd(f"delete storageclass {sc_name}")
+        volumesnapclasses = ocp.OCP(kind="VolumeSnapshotClass").get(all_namespaces=True)
+        for vsc in volumesnapclasses["items"]:
+            if vsc["driver"].startswith("openshift-storage."):
+                vsc_name = vsc["metadata"]["name"]
+                ocp.OCP().exec_oc_cmd(f"delete volumesnapshotclass {vsc_name}")
+
+        self.destroy_lso()
+
+    def destroy_lso(self):
+        lso_namespace = config.ENV_DATA["local_storage_namespace"]
+        lso_name = constants.LOCAL_STORAGE_CSV_PREFIX
+        subscription = ocp.OCP(
+            kind="Subscription",
+            resource_name=lso_name,
+            namespace=lso_namespace,
+        ).get()
+        currentCSV = subscription["status"]["currentCSV"]
+        ocp.OCP().exec_oc_cmd(f"delete subscription {lso_name} -n {lso_namespace}")
+        ocp.OCP().exec_oc_cmd(
+            f"delete clusterserviceversion -n {lso_namespace} {currentCSV}"
+        )
+        ocp.OCP().exec_oc_cmd(
+            f"delete project {lso_namespace} --wait=true --timeout=5m"
+        )
+        ocp.OCP().exec_oc_cmd("delete storageclass localblock")
+        try:
+            ocp.OCP().exec_oc_cmd(
+                f"delete localvolumediscovery auto-discover-devices -n {lso_namespace}"
+            )
+            ocp.OCP().exec_oc_cmd(
+                f"delete localvolumeset localblock -n {lso_namespace}"
+            )
+        except CommandFailed:
+            pass
+        pvs = ocp.OCP(kind="PersistentVolume").get()
+        for pv in pvs["items"]:
+            pv_name = pv["metadata"]["name"]
+            if pv["spec"].get("storageClassName") == "localblock":
+                ocp.OCP().exec_oc_cmd(f"delete pv {pv_name}")

--- a/ocs_ci/deployment/ibm.py
+++ b/ocs_ci/deployment/ibm.py
@@ -140,7 +140,8 @@ class IBMDeployment(Deployment):
         # Instead of deleting all CRDs at once and calling the job done, we
         # iterate over a list of them, noting which ones don't delete fully and
         # applying the standard workaround of removing the finalizers from any
-        # CRs and also the CRD.
+        # CRs and also the CRD. Finally, the documentation leaves out a few
+        # CRDs that we've seen in deployed clusters.
         crd_types = [
             "backingstores.noobaa.io",
             "bucketclasses.noobaa.io",
@@ -149,8 +150,12 @@ class IBMDeployment(Deployment):
             "cephclusters.ceph.rook.io",
             "cephfilesystems.ceph.rook.io",
             "cephnfses.ceph.rook.io",
+            "cephobjectrealms.ceph.rook.io",  # not in doc
             "cephobjectstores.ceph.rook.io",
             "cephobjectstoreusers.ceph.rook.io",
+            "cephobjectzonegroups.ceph.rook.io",  # not in doc
+            "cephobjectzones.ceph.rook.io",  # not in doc
+            "cephrbdmirrors.ceph.rook.io",  # not in doc
             "noobaas.noobaa.io",
             "ocsinitializations.ocs.openshift.io",
             "storageclusterinitializations.ocs.openshift.io",

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -124,21 +124,16 @@ class OCP(object):
 
         """
         oc_cmd = "oc "
-        cluster_dir_kubeconfig = os.path.join(
-            config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
-        )
-        if os.getenv("KUBECONFIG"):
-            kubeconfig = os.getenv("KUBECONFIG")
-        elif os.path.exists(cluster_dir_kubeconfig):
-            kubeconfig = cluster_dir_kubeconfig
-        else:
-            kubeconfig = None
+        env_kubeconfig = os.getenv("KUBECONFIG")
+        if not env_kubeconfig or not os.path.exists(env_kubeconfig):
+            cluster_dir_kubeconfig = os.path.join(
+                config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
+            )
+            if os.path.exists(cluster_dir_kubeconfig):
+                oc_cmd += f"--kubeconfig {cluster_dir_kubeconfig} "
 
         if self.namespace:
             oc_cmd += f"-n {self.namespace} "
-
-        if kubeconfig:
-            oc_cmd += f"--kubeconfig {kubeconfig} "
 
         oc_cmd += command
         out = run_cmd(


### PR DESCRIPTION
With these changes, deploying OCS after it has already been deployed and destroyed works *usually*; I plan on continuing this work but want to get this in as it's more functional than before.

Proof it doesn't regress: https://storage-jenkins-csb-ceph.cloud.paas.psi.redhat.com/job/ocs-ci-kvm/120/testReport/