### PR TITLE
Test to verify snapshot restore using a SC different than that of parent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2972,17 +2972,19 @@ def snapshot_restore_factory(request):
         if snapshot_info["spec"]["volumeSnapshotClassName"] == (
             helpers.default_volumesnapshotclass(constants.CEPHBLOCKPOOL).name
         ):
-            storageclass = storageclass or helpers.default_storage_class(
-                constants.CEPHBLOCKPOOL
-            ).name
+            storageclass = (
+                storageclass
+                or helpers.default_storage_class(constants.CEPHBLOCKPOOL).name
+            )
             restore_pvc_yaml = restore_pvc_yaml or constants.CSI_RBD_PVC_RESTORE_YAML
             interface = constants.CEPHBLOCKPOOL
         elif snapshot_info["spec"]["volumeSnapshotClassName"] == (
             helpers.default_volumesnapshotclass(constants.CEPHFILESYSTEM).name
         ):
-            storageclass = storageclass or helpers.default_storage_class(
-                constants.CEPHFILESYSTEM
-            ).name
+            storageclass = (
+                storageclass
+                or helpers.default_storage_class(constants.CEPHFILESYSTEM).name
+            )
             restore_pvc_yaml = restore_pvc_yaml or constants.CSI_CEPHFS_PVC_RESTORE_YAML
             interface = constants.CEPHFILESYSTEM
         restored_pvc = create_restore_pvc(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2974,7 +2974,7 @@ def snapshot_restore_factory(request):
         ):
             storageclass = storageclass or helpers.default_storage_class(
                 constants.CEPHBLOCKPOOL
-            )
+            ).name
             restore_pvc_yaml = restore_pvc_yaml or constants.CSI_RBD_PVC_RESTORE_YAML
             interface = constants.CEPHBLOCKPOOL
         elif snapshot_info["spec"]["volumeSnapshotClassName"] == (
@@ -2982,11 +2982,11 @@ def snapshot_restore_factory(request):
         ):
             storageclass = storageclass or helpers.default_storage_class(
                 constants.CEPHFILESYSTEM
-            )
+            ).name
             restore_pvc_yaml = restore_pvc_yaml or constants.CSI_CEPHFS_PVC_RESTORE_YAML
             interface = constants.CEPHFILESYSTEM
         restored_pvc = create_restore_pvc(
-            sc_name=storageclass.name,
+            sc_name=storageclass,
             snap_name=snapshot_obj.name,
             namespace=snapshot_obj.namespace,
             size=size,

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -52,7 +52,7 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
         file_name = "file_snapshot"
         # Run IO
         log.info("Start IO on all pods")
-        for pod_obj in self.pod_objs:
+        for pod_obj in self.pods:
             pod_obj.run_io(
                 storage_type="fs",
                 size=f"{self.pvc_size - 1}G",
@@ -62,12 +62,10 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
         log.info("IO started on all pods")
 
         # Wait for IO completion
-        for pod_obj in self.pod_objs:
+        for pod_obj in self.pods:
             pod_obj.get_fio_results()
             # Get md5sum of the file
-            pod_obj.pvc.md5sum = cal_md5sum(
-                pod_obj=pod_obj, file_name=file_name, block=True
-            )
+            pod_obj.pvc.md5sum = cal_md5sum(pod_obj=pod_obj, file_name=file_name)
         log.info("IO completed on all pods")
 
         # Create snapshots
@@ -150,6 +148,7 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
             wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
         log.info("Verified: New pods are running")
 
+        # Verify md5sum
         log.info("Verifying md5sum on new pods")
         for pod_obj in restore_pod_objs:
             log.info(f"Verifying md5sum on pod {pod_obj.name}")

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -25,7 +25,13 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory, snapshot_restore_factory, create_pvcs_and_pods):
+    def setup(
+        self,
+        project_factory,
+        secret_factory,
+        snapshot_restore_factory,
+        create_pvcs_and_pods,
+    ):
         """
         Create PVCs and pods
 

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -99,10 +99,10 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
         sc_objs = {
             constants.CEPHBLOCKPOOL: storageclass_factory(
                 interface=constants.CEPHBLOCKPOOL
-            ),
+            ).name,
             constants.CEPHFILESYSTEM: storageclass_factory(
                 interface=constants.CEPHFILESYSTEM
-            ),
+            ).name,
         }
 
         # Create PVCs out of the snapshots

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -29,6 +29,7 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
         self,
         project_factory,
         secret_factory,
+        storageclass_factory,
         snapshot_restore_factory,
         create_pvcs_and_pods,
     ):

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -1,0 +1,173 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version,
+    ManageTest,
+    tier1,
+    skipif_ocp_version,
+)
+from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
+from ocs_ci.helpers.helpers import wait_for_resource_state
+
+log = logging.getLogger(__name__)
+
+
+@tier1
+@skipif_ocs_version("<4.6")
+@skipif_ocp_version("<4.6")
+@pytest.mark.polarion_id("OCS-2424")
+class TestRestoreSnapshotUsingDifferentSc(ManageTest):
+    """
+    Tests to verify snapshot restore using an SC different than that of parent
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, project_factory, snapshot_restore_factory, create_pvcs_and_pods):
+        """
+        Create PVCs and pods
+
+        """
+        self.pvc_size = 3
+        self.pvcs, self.pods = create_pvcs_and_pods(
+            pvc_size=self.pvc_size,
+            access_modes_rbd=[constants.ACCESS_MODE_RWO],
+            access_modes_cephfs=[constants.ACCESS_MODE_RWO],
+        )
+
+    def test_snapshot_restore_using_different_sc(
+        self,
+        storageclass_factory,
+        snapshot_factory,
+        snapshot_restore_factory,
+        pod_factory,
+    ):
+        """
+        Test to verify snapshot restore using an SC different than that of parent
+
+        """
+        snap_objs = []
+        file_name = "file_snapshot"
+        # Run IO
+        log.info("Start IO on all pods")
+        for pod_obj in self.pod_objs:
+            pod_obj.run_io(
+                storage_type="fs",
+                size=f"{self.pvc_size - 1}G",
+                runtime=30,
+                fio_filename=file_name,
+            )
+        log.info("IO started on all pods")
+
+        # Wait for IO completion
+        for pod_obj in self.pod_objs:
+            pod_obj.get_fio_results()
+            # Get md5sum of the file
+            pod_obj.pvc.md5sum = cal_md5sum(
+                pod_obj=pod_obj, file_name=file_name, block=True
+            )
+        log.info("IO completed on all pods")
+
+        # Create snapshots
+        log.info("Create snapshots of all PVCs")
+        for pvc_obj in self.pvcs:
+            log.info(f"Creating snapshot of PVC {pvc_obj.name}")
+            snap_obj = snapshot_factory(pvc_obj, wait=False)
+            snap_obj.md5sum = pvc_obj.md5sum
+            snap_obj.interface = pvc_obj.interface
+            snap_objs.append(snap_obj)
+        log.info("Snapshots created")
+
+        # Verify snapshots are Ready
+        log.info("Verify snapshots are ready")
+        for snap_obj in snap_objs:
+            snap_obj.ocp.wait_for_resource(
+                condition="true",
+                resource_name=snap_obj.name,
+                column=constants.STATUS_READYTOUSE,
+                timeout=180,
+            )
+
+        # Create storage classes
+        sc_objs = {
+            constants.CEPHBLOCKPOOL: storageclass_factory(
+                interface=constants.CEPHBLOCKPOOL
+            ),
+            constants.CEPHFILESYSTEM: storageclass_factory(
+                interface=constants.CEPHFILESYSTEM
+            ),
+        }
+
+        # Create PVCs out of the snapshots
+        restore_pvc_objs = []
+        log.info("Creating new PVCs from snapshots")
+        for snap_obj in snap_objs:
+            log.info(f"Creating a PVC from snapshot {snap_obj.name}")
+            restore_pvc_obj = snapshot_restore_factory(
+                snapshot_obj=snap_obj,
+                storageclass=sc_objs[snap_obj.interface],
+                size=f"{self.pvc_size}Gi",
+                volume_mode=snap_obj.parent_volume_mode,
+                access_mode=snap_obj.parent_access_mode,
+                status="",
+            )
+
+            log.info(
+                f"Created PVC {restore_pvc_obj.name} from snapshot {snap_obj.name}"
+            )
+            restore_pvc_obj.md5sum = snap_obj.md5sum
+            restore_pvc_objs.append(restore_pvc_obj)
+        log.info("Created new PVCs from all the snapshots")
+
+        # Confirm that the restored PVCs are Bound
+        log.info("Verify the restored PVCs are Bound")
+        for pvc_obj in restore_pvc_objs:
+            wait_for_resource_state(
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
+            )
+            pvc_obj.reload()
+        log.info("Verified: Restored PVCs are Bound.")
+
+        # Attach the restored PVCs to pods
+        log.info("Attach the restored PVCs to pods")
+        restore_pod_objs = []
+        for restore_pvc_obj in restore_pvc_objs:
+            restore_pod_obj = pod_factory(
+                interface=restore_pvc_obj.snapshot.interface,
+                pvc=restore_pvc_obj,
+                status="",
+            )
+            log.info(
+                f"Attached the PVC {restore_pvc_obj.name} to pod {restore_pod_obj.name}"
+            )
+            restore_pod_objs.append(restore_pod_obj)
+
+        # Verify the new pods are running
+        log.info("Verify the new pods are running")
+        for pod_obj in restore_pod_objs:
+            wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+        log.info("Verified: New pods are running")
+
+        log.info("Verifying md5sum on new pods")
+        for pod_obj in restore_pod_objs:
+            log.info(f"Verifying md5sum on pod {pod_obj.name}")
+            verify_data_integrity(
+                pod_obj=pod_obj,
+                file_name=file_name,
+                original_md5sum=pod_obj.pvc.snapshot.md5sum,
+            )
+            log.info(f"Verified md5sum on pod {pod_obj.name}")
+        log.info("Verified md5sum on all pods")
+
+        # Run IO on new pods
+        log.info("Starting IO on new pods")
+        for pod_obj in restore_pod_objs:
+            pod_obj.run_io(storage_type="fs", size="500M", runtime=15)
+
+        # Wait for IO completion on new pods
+        log.info("Waiting for IO completion on new pods")
+        for pod_obj in restore_pod_objs:
+            pod_obj.get_fio_results()
+        log.info("IO completed on new pods.")


### PR DESCRIPTION
Test to verify snapshot restore using a storage class different than that of parent.
OCS-2424 - FT-Restore snapshot using an SC different than that of the parent

Signed-off-by: Jilju Joy <jijoy@redhat.com>