### PR TITLE
use fedora and postgres images from quay.io to avoid docker rate limits

### DIFF
--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -20,7 +20,7 @@ spec:
           claimName: tet-2
       containers:
       - name: fedora
-        image: fedora
+        image: quay.io/ocsci/fedora
         resources:
           limits:
             memory: "2048Mi"

--- a/ocs_ci/templates/workloads/pgsql/server/StatefulSet.yaml
+++ b/ocs_ci/templates/workloads/pgsql/server/StatefulSet.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:10.4
+          image: quay.io/ocsci/postgres:10.4
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/3367
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/3368

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>