### PR TITLE
fix-3371 -- Add 5mins waittime after PVC deletion.

### DIFF
--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -4,6 +4,7 @@ Test to measure pvc scale creation & deletion time. Total pvc count would be 150
 import logging
 import csv
 import pytest
+import time
 
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources import pvc
@@ -132,6 +133,11 @@ class TestPVCCreationDeletionScale(E2ETest):
         job_file1.delete(namespace=self.namespace)
         job_file2.delete(namespace=self.namespace)
 
+        # Adding 5min wait time for PVC deletion logs to be updated
+        # Observed failure when we immediately check the logs for pvc delete time
+        # https://github.com/red-hat-storage/ocs-ci/issues/3371
+        time.sleep(300)
+
         # Get PVC deletion time
         pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(
             interface=interface, pv_name_list=pv_name_list
@@ -247,6 +253,11 @@ class TestPVCCreationDeletionScale(E2ETest):
         # Delete kube_job
         job_file_rbd.delete(namespace=self.namespace)
         job_file_cephfs.delete(namespace=self.namespace)
+
+        # Adding 5min wait time for PVC deletion logs to be updated
+        # Observed failure when we immediately check the logs for pvc delete time
+        # https://github.com/red-hat-storage/ocs-ci/issues/3371
+        time.sleep(300)
 
         # Get PV deletion time
         fs_pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -133,10 +133,10 @@ class TestPVCCreationDeletionScale(E2ETest):
         job_file1.delete(namespace=self.namespace)
         job_file2.delete(namespace=self.namespace)
 
-        # Adding 5min wait time for PVC deletion logs to be updated
+        # Adding 1min wait time for PVC deletion logs to be updated
         # Observed failure when we immediately check the logs for pvc delete time
         # https://github.com/red-hat-storage/ocs-ci/issues/3371
-        time.sleep(300)
+        time.sleep(60)
 
         # Get PVC deletion time
         pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(
@@ -254,10 +254,10 @@ class TestPVCCreationDeletionScale(E2ETest):
         job_file_rbd.delete(namespace=self.namespace)
         job_file_cephfs.delete(namespace=self.namespace)
 
-        # Adding 5min wait time for PVC deletion logs to be updated
+        # Adding 1min wait time for PVC deletion logs to be updated
         # Observed failure when we immediately check the logs for pvc delete time
         # https://github.com/red-hat-storage/ocs-ci/issues/3371
-        time.sleep(300)
+        time.sleep(60)
 
         # Get PV deletion time
         fs_pvc_deletion_time = helpers.measure_pv_deletion_time_bulk(


### PR DESCRIPTION
The problem is in code should provide ample time for log generation to complete
During PVC deletion process, immediately after kube_job deletion we are collecting
CSI logs to capture PVC delete data.

With 10 or 100 no of PVCs logs are getting generated faster but when we perform delete
of 500/1000/2000 PVCs in bulk, immediately collecting logs missing PVC delete data.
Due to this reason in code list is getting empty data i.e. no respective PVC data in logs.
Fixing the problem by adding 5min wait time

Note: This is just a quick fix, better to have separate function to get the required timeout value based on PVC count.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>