### PR TITLE
fix-3370 -- Exclude compute-o-debug pod in Validation

### DIFF
--- a/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
+++ b/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
@@ -77,8 +77,10 @@ class TestPodAreNotOomkilledWhileRunningIO(E2ETest):
         pod_objs = get_all_pods(
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
             selector=[
-                "noobaa", "rook-ceph-osd-prepare",
-                "rook-ceph-drain-canary", "compute-0-debug"
+                "noobaa",
+                "rook-ceph-osd-prepare",
+                "rook-ceph-drain-canary",
+                "compute-0-debug",
             ],
             exclude_selector=True,
         )

--- a/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
+++ b/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
@@ -76,12 +76,7 @@ class TestPodAreNotOomkilledWhileRunningIO(E2ETest):
 
         pod_objs = get_all_pods(
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
-            selector=[
-                "noobaa",
-                "rook-ceph-osd-prepare",
-                "rook-ceph-drain-canary",
-                "compute-0-debug",
-            ],
+            selector=["noobaa", "rook-ceph-osd-prepare", "rook-ceph-drain-canary"],
             exclude_selector=True,
         )
 
@@ -117,6 +112,9 @@ class TestPodAreNotOomkilledWhileRunningIO(E2ETest):
 
         for pod in pod_objs:
             pod_name = pod.get().get("metadata").get("name")
+            if "debug" in pod_name:
+                logging.info(f"Skipping {pod_name} pod from validation")
+                continue
             restart_count = (
                 pod.get().get("status").get("containerStatuses")[0].get("restartCount")
             )

--- a/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
+++ b/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
@@ -76,7 +76,10 @@ class TestPodAreNotOomkilledWhileRunningIO(E2ETest):
 
         pod_objs = get_all_pods(
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
-            selector=["noobaa", "rook-ceph-osd-prepare", "rook-ceph-drain-canary"],
+            selector=[
+                "noobaa", "rook-ceph-osd-prepare",
+                "rook-ceph-drain-canary", "compute-0-debug"
+            ],
             exclude_selector=True,
         )
 


### PR DESCRIPTION
Failure is due to compute-0-debug not in running state, which is expected
i.e. compute-0-debug pod used to be created for running some OC commands and
it will be destroyed after that, it's better to avoid validation of debug pod

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>