### PR TITLE
use delete reclaim policy for GCP storageclass

### DIFF
--- a/ocs_ci/templates/ocs-deployment/storageclass.gcp.yaml
+++ b/ocs_ci/templates/ocs-deployment/storageclass.gcp.yaml
@@ -6,3 +6,4 @@ provisioner: kubernetes.io/gce-pd
 parameters:
  type: pd-ssd
 volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/3396 based on [bz 1885692](https://bugzilla.redhat.com/show_bug.cgi?id=1885692).

We could wait for the BZ 1885692 to be fixed (which means the docs to be updated), but imho it's safe to merge this now wrt both testing and deployment stability.