### PR TITLE
Instantiate all cloud clients as None by default

### DIFF
--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -202,7 +202,11 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                     backingstore_name = backingstore_name[:-16]
                     created_backingstores.append(
                         BackingStore(
-                            name=backingstore_name, vol_num=vol_num, vol_size=size
+                            name=backingstore_name,
+                            method=method.lower(),
+                            mcg_obj=mcg_obj,
+                            vol_num=vol_num,
+                            vol_size=size
                         )
                     )
                     if method.lower() == "cli":

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -237,7 +237,6 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                         )
                 else:
                     _, region = uls_tup
-                    # TODO: Verify that the given cloud has an initialized client
                     uls_dict = cloud_uls_factory({cloud: [uls_tup]})
                     for uls_name in uls_dict[cloud.lower()]:
                         backingstore_name = create_unique_resource_name(

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -57,6 +57,7 @@ class BackingStore:
                 kind="backingstore", namespace=config.ENV_DATA["cluster_namespace"]
             ).delete(resource_name=self.name)
         elif self.method == "cli":
+
             def _cli_deletion_flow():
                 try:
                     self.mcg_obj.exec_mcg_cmd(f"backingstore delete {self.name}")
@@ -68,6 +69,7 @@ class BackingStore:
                             "Retrying..."
                         )
                         return False
+
             sample = TimeoutSampler(
                 timeout=120,
                 sleep=20,
@@ -224,7 +226,7 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                             method=method.lower(),
                             mcg_obj=mcg_obj,
                             vol_num=vol_num,
-                            vol_size=size
+                            vol_size=size,
                         )
                     )
                     if method.lower() == "cli":

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -56,21 +56,20 @@ class CloudManager(ABC):
         if not cred_dict:
             logger.warning(
                 "Local auth.yaml not found, or failed to load. "
-                "Instantiating default clients as None."
+                "All cloud clients will be instantiated as None."
             )
-            for cloud_name in constants.CLOUD_MNGR_PLATFORMS:
-                setattr(self, f"{cloud_name.lower()}_client", None)
+
+        # Instantiate all needed cloud clients as None by default
+        for cloud_name in constants.CLOUD_MNGR_PLATFORMS:
+            setattr(self, f"{cloud_name.lower()}_client", None)
 
         else:
+            # Override None clients with actual ones if found
             for cloud_name in cred_dict:
                 if cloud_name in cloud_map:
-                    if any(value is None for value in cred_dict[cloud_name].values()):
-                        logger.warning(
-                            f"{cloud_name} credentials not found "
-                            "no client will be instantiated"
-                        )
-                        setattr(self, f"{cloud_name.lower()}_client", None)
-                    else:
+                    # If all the values of the client are filled in auth.yaml,
+                    # instantiate an actual client
+                    if not any(value is None for value in cred_dict[cloud_name].values()):
                         setattr(
                             self,
                             f"{cloud_name.lower()}_client",

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -69,7 +69,9 @@ class CloudManager(ABC):
                 if cloud_name in cloud_map:
                     # If all the values of the client are filled in auth.yaml,
                     # instantiate an actual client
-                    if not any(value is None for value in cred_dict[cloud_name].values()):
+                    if not any(
+                        value is None for value in cred_dict[cloud_name].values()
+                    ):
                         setattr(
                             self,
                             f"{cloud_name.lower()}_client",


### PR DESCRIPTION
Should fix failures that stem from a misconfigured/outdated `auth.yaml`
Also:
- hotfix CLI PV backingstore creation bug
- Add CLI BS deletion retry