### PR TITLE
Deploying ocs if storage disks increases

### DIFF
--- a/conf/ocsci/production_powervs_upi.yaml
+++ b/conf/ocsci/production_powervs_upi.yaml
@@ -11,4 +11,4 @@ ENV_DATA:
   deployment_type: 'upi'
   monitoring_enabled: false
   number_of_storage_nodes: 3
-  number_of_storage_disks: 1
+

--- a/conf/ocsci/production_powervs_upi.yaml
+++ b/conf/ocsci/production_powervs_upi.yaml
@@ -11,3 +11,4 @@ ENV_DATA:
   deployment_type: 'upi'
   monitoring_enabled: false
   number_of_storage_nodes: 3
+  number_of_storage_disks: 1

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1127,6 +1127,9 @@ def setup_local_storage(storageclass):
     storage_class_device_count = 1
     if platform == constants.AWS_PLATFORM:
         storage_class_device_count = 2
+    if platform == constants.IBM_POWER_PLATFORM:
+        numberofstoragedisks = config.ENV_DATA["number_of_storage_disks"]
+        storage_class_device_count = numberofstoragedisks
     verify_pvs_created(len(worker_names) * storage_class_device_count)
 
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1128,7 +1128,7 @@ def setup_local_storage(storageclass):
     if platform == constants.AWS_PLATFORM:
         storage_class_device_count = 2
     if platform == constants.IBM_POWER_PLATFORM:
-        numberofstoragedisks = config.ENV_DATA["number_of_storage_disks"]
+        numberofstoragedisks = config.ENV_DATA.get("number_of_storage_disks", 1)
         storage_class_device_count = numberofstoragedisks
     verify_pvs_created(len(worker_names) * storage_class_device_count)
 


### PR DESCRIPTION
Deploying OCS using ocs-ci on IBM Power Systems if there are more than 1 storage disk available in an OCP cluster.