### PR TITLE
add without_presistent_monitoring.yam conf file

### DIFF
--- a/conf/examples/without_presistent_monitoring.yaml
+++ b/conf/examples/without_presistent_monitoring.yaml
@@ -3,5 +3,4 @@ ENV_DATA:
   # disable persistent monitoring (reconfiguration of OCP Prometheus and alert
   # manager to use OCS backed PVs) but make sure monitoring is enabled
   monitoring_enabled: true
-  cluster_namespace: 'openshift-storage'
   persistent-monitoring: false

--- a/conf/examples/without_presistent_monitoring.yaml
+++ b/conf/examples/without_presistent_monitoring.yaml
@@ -1,0 +1,7 @@
+---
+ENV_DATA:
+  # disable persistent monitoring (reconfiguration of OCP Prometheus and alert
+  # manager to use OCS backed PVs) but make sure monitoring is enabled
+  monitoring_enabled: true
+  cluster_namespace: 'openshift-storage'
+  persistent-monitoring: false


### PR DESCRIPTION
New example config file disables ocs persistent monitoring reconfiguration, while keeping monitoring enabled.

This is useful to disable such setup easily from deployment job if necessary.