### PR TITLE
Fix-3371 - More fix to github issue

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1381,7 +1381,8 @@ def measure_pvc_creation_time_bulk(interface, pvc_name_list, wait_time=60):
         for name in pvc_name_list:
             # check if PV data present in CSI logs
             start = [i for i in logs if re.search(f"provision.*{name}.*started", i)]
-            if not start:
+            end = [i for i in logs if re.search(f"provision.*{name}.*succeeded", i)]
+            if not start or not end:
                 no_data_list.append(name)
 
         if no_data_list:
@@ -1447,7 +1448,8 @@ def measure_pv_deletion_time_bulk(interface, pv_name_list, wait_time=60):
         for pv in pv_name_list:
             # check if PV data present in CSI logs
             start = [i for i in logs if re.search(f'delete "{pv}": started', i)]
-            if not start:
+            end = [i for i in logs if re.search(f'delete "{pv}": succeeded', i)]
+            if not start or not end:
                 no_data_list.append(pv)
 
         if no_data_list:


### PR DESCRIPTION
Enhanced the code to check for end succeed data
Observed this failure in recent Jenkins run

```
            # Extract the deletion end time for the PV
            end = [i for i in logs if re.search(f'delete "{pv_name}": succeeded', i)]
>           end = end[0].split(" ")[1]
E           IndexError: list index out of range
```

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>