### PR TITLE
WIP: cli: Add support for env variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
     AWS_SECRET_ACCESS_KEY = credentials("openshift-dev-aws-secret-access-key-${env.CLUSTER_USER}")
     PULL_SECRET = credentials('openshift-pull-secret')
     BUGZILLA_CFG = credentials('ocs-bugzilla-cfg')
+    OCS_CI_OCP_VERSION = "${env.OCP_VERSION}"
   }
   stages {
     stage("Setup") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,13 @@ pipeline {
       steps {
         script { LAST_STAGE=env.STAGE_NAME }
         sh """
+        echo "ENV1"
+        env
+        echo "1VNE"
         source ./venv/bin/activate
+        echo "ENV2"
+        env
+        echo "2VNE"
         run-ci -m deployment --deploy --ocsci-conf=ocs-ci-ocp.yaml --ocsci-conf=conf/ocsci/production-aws-ipi.yaml --ocsci-conf=conf/ocsci/production_device_size.yaml --cluster-name=${env.CLUSTER_USER}-ocsci-${env.BUILD_ID} --cluster-path=cluster --collect-logs
         """
       }

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -365,7 +365,7 @@ def get_cli_param(config, name_of_param, default=None):
     """
 
     # Override the default value from environmental variables
-    env_var_name = name_of_param.lstrip("-").replace("-", "_").upper()
+    env_var_name = "OCS_CI_" + name_of_param.lstrip("-").replace("-", "_").upper()
     print("ENV: %s" % env_var_name)
     if env_var_name in os.environ:
         default = os.environ.get(env_var_name)

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -363,6 +363,12 @@ def get_cli_param(config, name_of_param, default=None):
         any: value of cli parameter or default value
 
     """
+
+    # Override the default value from environmental variables
+    env_var_name = name_of_param.lstrip("-").replace("-", "_").upper()
+    if env_var_name in os.environ:
+        default = os.environ.get(env_var_name)
+
     cli_param = config.getoption(name_of_param, default=default)
     ocsci_config.RUN["cli_params"][name_of_param] = cli_param
     return cli_param

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -366,10 +366,13 @@ def get_cli_param(config, name_of_param, default=None):
 
     # Override the default value from environmental variables
     env_var_name = name_of_param.lstrip("-").replace("-", "_").upper()
+    print("ENV: %s" % env_var_name)
     if env_var_name in os.environ:
         default = os.environ.get(env_var_name)
 
+    print("default: %s" % str(default))
     cli_param = config.getoption(name_of_param, default=default)
+    print("cli_param: %s" % str(cli_param))
     ocsci_config.RUN["cli_params"][name_of_param] = cli_param
     return cli_param
 
@@ -454,6 +457,7 @@ def process_cluster_cli_params(config):
     ocp_version = get_cli_param(config, "--ocp-version")
     if ocp_version:
         version_config_file = f"ocp-{ocp_version}-config.yaml"
+        print("Loading config '%s'" % version_config_file)
         version_config_file_path = os.path.join(
             OCP_VERSION_CONF_DIR, version_config_file
         )

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -371,7 +371,7 @@ def get_cli_param(config, name_of_param, default=None):
         default = os.environ.get(env_var_name)
 
     print("default: %s" % str(default))
-    cli_param = config.getoption(name_of_param, default=default)
+    cli_param = config.getoption(name_of_param, default=default) or default
     print("cli_param: %s" % str(cli_param))
     ocsci_config.RUN["cli_params"][name_of_param] = cli_param
     return cli_param


### PR DESCRIPTION
This commit will look for an env variable with a matching name in upper case with '-' replaced by '_' for the cli params with `OCS_CSI_` prefix.

This adds support for overriding e.g. ocp version with an `OCS_CI_OCP_VERSION` env variable.

Signed-off-by: Boris Ranto <branto@redhat.com>