### PR TITLE
Jenkinsfile: Set from to ocs-ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
           emailext (
             subject: "Job '${env.JOB_NAME}' build #${env.BUILD_ID} failed during stage '${LAST_STAGE}'",
             body: "Build failed : ${env.BUILD_URL}",
-            from: "${env.EMAIL}",
+            from: "ocs-ci@redhat.com",
             to: "${env.EMAIL}"
           )
         }


### PR DESCRIPTION
The pipeline shouldn't send the e-mail from the EMAIL env. We want to
support multiple comma-separated addresses in the EMAIL env and this
blocks us from doing that.

Using ocs-ci@redhat.com in `from` field instead of EMAIL env seems like
a reasonable value for this.

Signed-off-by: Boris Ranto <branto@redhat.com>