### PR TITLE
Change default instance type to m5.4xlarge

### DIFF
--- a/conf/ocsci/allow_lower_instance_requirements.yaml
+++ b/conf/ocsci/allow_lower_instance_requirements.yaml
@@ -1,0 +1,5 @@
+# This configuration file is for development purpose only and allow you to
+# install OCS on nodes with lower then required resources.
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: true

--- a/conf/ocsci/aws_ipi.yaml
+++ b/conf/ocsci/aws_ipi.yaml
@@ -1,7 +1,11 @@
 ---
+# This configuration file is for development purpose only and allow you to
+# install OCS on nodes with lower then required resources. This can lead to
+# some issues and should be used only for development purpose only.
+DEPLOYMENT:
+  allow_lower_instance_requirements: true
 ENV_DATA:
   platform: 'aws'
   deployment_type: 'ipi'
   region: 'us-east-2'
-  skip_ocp_deployment: false
-  skip_ocs_deployment: false
+  worker_instance_type: 'm4.xlarge'

--- a/conf/ocsci/aws_lower_resource_reqs.yaml
+++ b/conf/ocsci/aws_lower_resource_reqs.yaml
@@ -1,4 +1,6 @@
 ---
+DEPLOYMENT:
+  allow_lower_instance_requirements: true
 ENV_DATA:
   master_instance_type: 'm4.2xlarge'
   worker_instance_type: 'm4.2xlarge'

--- a/conf/ocsci/aws_upi.yaml
+++ b/conf/ocsci/aws_upi.yaml
@@ -1,6 +1,12 @@
 ---
+# This configuration file is for development purpose only and allow you to
+# install OCS on nodes with lower then required resources. This can lead to
+# some issues and should be used only for development purpose only.
+DEPLOYMENT:
+  allow_lower_instance_requirements: true
 ENV_DATA:
+  platform: 'aws'
   deployment_type: 'upi'
-  rhcos_ami: 'ami-06c85f9d106577272'
+  region: 'us-east-2'
   worker_instance_type: 'm4.xlarge'
   rhel_workers: false

--- a/conf/ocsci/vsphere_upi.yaml
+++ b/conf/ocsci/vsphere_upi.yaml
@@ -1,7 +1,15 @@
 ---
+# This configuration file is for development purpose only and allow you to
+# install OCS on nodes with lower then required resources. This can lead to
+# some issues and should be used only for development purpose only.
+DEPLOYMENT:
+  allow_lower_instance_requirements: true
 ENV_DATA:
   platform: 'vsphere'
   deployment_type: 'upi'
   worker_replicas: 3
   master_replicas: 3
   fio_storageutilization_min_mbps: 10.0
+  master_memory: '16384'
+  compute_memory: '32768'
+  worker_num_cpus: '12'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -60,7 +60,9 @@ DEPLOYMENT:
   ssh_key: "~/.ssh/openshift-dev.pub"
   ssh_key_private: "~/.ssh/openshift-dev.pem"
   force_deploy_multiple_clusters: False
-  allow_lower_instance_requirements: true
+  # If you deploy for development purpose on cluster with lower then minimum
+  # requirements, the value of option below needs to be set to true.
+  allow_lower_instance_requirements: false
   # For manual subscription plan (for manual approve of upgrade set bellow)
   # subscription_plan_approval: "Manual"
   # For UI deployment you have to set following parameter ui_deployment to True
@@ -106,7 +108,7 @@ ENV_DATA:
   region: 'us-east-2'
   base_domain: 'qe.rh-ocs.com'
   master_instance_type: 'm4.xlarge'
-  worker_instance_type: 'm4.xlarge'
+  worker_instance_type: 'm5.4xlarge'
   master_replicas: 3
   worker_replicas: 3
   skip_ocp_deployment: false

--- a/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
@@ -4,7 +4,7 @@ compute:
   - name: worker
     platform:
       aws:
-        type: {{ worker_instance_type | default('m4.xlarge') }}
+        type: {{ worker_instance_type | default('m5.4xlarge') }}
 {% if worker_availability_zones %}
         zones:
 {% for zone in worker_availability_zones %}

--- a/ocs_ci/templates/ocp-deployment/install-config-aws-upi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-aws-upi.yaml.j2
@@ -4,7 +4,7 @@ compute:
   - name: worker
     platform:
       aws:
-        type: {{ worker_instance_type | default('m4.large') }}
+        type: {{ worker_instance_type | default('m5.4xlarge') }}
 {% if worker_availability_zones %}
         zones:
 {% for zone in worker_availability_zones %}


### PR DESCRIPTION
Cause of we've seen a lot of issues like:
https://github.com/red-hat-storage/ocs-ci/issues/3449

Which caused issues in some of runs we decided to have this value as
default and create non production config files.

Fixes: #3463

Signed-off-by: Petr Balogh <pbalogh@redhat.com>