### PR TITLE
Fix 3453 in tests/e2e/scale/test_cephfs_many_files.py

### DIFF
--- a/tests/e2e/scale/test_cephfs_many_files.py
+++ b/tests/e2e/scale/test_cephfs_many_files.py
@@ -88,7 +88,6 @@ class MillionFilesOnCephfs(object):
             interface_type=constants.CEPHFILESYSTEM,
             namespace=config.ENV_DATA["cluster_namespace"],
             pvc_name=pvc_name,
-            node_name="compute-0",
             pod_name=self.pod_name,
         )
         helpers.wait_for_resource_state(


### PR DESCRIPTION
Log error if Exception is generated by rsync.
When creating new cephfs pod, use template values for namespace and node_name.

Signed-off-by: Warren Usui <wusui@redhat.com>