### PR TITLE
must gather, delete 'rook-ceph-mon-a.yaml'

### DIFF
--- a/ocs_ci/ocs/must_gather/const_must_gather.py
+++ b/ocs_ci/ocs/must_gather/const_must_gather.py
@@ -155,7 +155,6 @@ GATHER_COMMANDS_OTHERS = [
     "registry-cephfs-rwx-pvc.yaml",
     "replicasets.yaml",
     "replicationcontrollers.yaml",
-    "rook-ceph-mon-a.yaml",
     "routes.yaml",
     "secrets.yaml",
     "services.yaml",


### PR DESCRIPTION
Delete 'rook-ceph-mon-a.yaml' because we don't create PVCs for MONs instead we use host path to save mon data.
Fixes #3479

Signed-off-by: Oded Viner <oviner@redhat.com>