### PR TITLE
replace fedora image by quay.io/ocsci/fedora

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1025,7 +1025,7 @@ def create_build_from_docker_image(
     image_name,
     install_package,
     namespace,
-    source_image="fedora",
+    source_image="quay.io/ocsci/fedora",
     source_image_label="latest",
 ):
     """


### PR DESCRIPTION
change the default source_image in create_build_from_docker_image
function from `fedora` to `quay.io/ocsci/fedora` to avoid docker.io rate
limit issues

fixes: https://github.com/red-hat-storage/ocs-ci/issues/3495

Signed-off-by: Daniel Horak <dahorak@redhat.com>