### PR TITLE
Invalid node name - compute-0

### DIFF
--- a/tests/e2e/scale/test_cephfs_many_files.py
+++ b/tests/e2e/scale/test_cephfs_many_files.py
@@ -88,7 +88,6 @@ class MillionFilesOnCephfs(object):
             interface_type=constants.CEPHFILESYSTEM,
             namespace=config.ENV_DATA["cluster_namespace"],
             pvc_name=pvc_name,
-            node_name="compute-0",
             pod_name=self.pod_name,
         )
         helpers.wait_for_resource_state(


### PR DESCRIPTION
Node name does not have to be specified for the testcase.  It doesn't matter which worker node is used to run the pod, so don't specify a node name.  Tested on a power server running the ocs-ci scale testsuite.

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>