### PR TITLE
device replacement, verify new device is encrypted

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import re
 from prettytable import PrettyTable
+from collections import defaultdict
 
 from subprocess import TimeoutExpired
 
@@ -561,6 +562,20 @@ def get_osd_running_nodes():
 
     """
     return [pod.get_pod_node(osd_node).name for osd_node in pod.get_osd_pods()]
+
+
+def get_osds_per_node():
+    """
+    Gets the osd running pod names per node name
+
+    Returns:
+        dict: {"Node name":["osd running pod name running on the node",..,]}
+
+    """
+    dic_node_osd = defaultdict(list)
+    for osd_pod in pod.get_osd_pods():
+        dic_node_osd[pod.get_pod_node(osd_pod).name].append(osd_pod.name)
+    return dic_node_osd
 
 
 def get_app_pod_running_nodes(pod_obj):

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -30,6 +30,7 @@ from ocs_ci.ocs.resources.pod import (
 from ocs_ci.ocs.resources.ocs import get_job_obj, OCS
 from ocs_ci.utility.aws import AWSTimeoutException
 from ocs_ci.utility.utils import get_ocp_version
+from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,10 @@ class TestDiskFailures(ManageTest):
                     node_obj = get_pod_node(pod)
                     nodes.restart_nodes([node_obj])
                     node.wait_for_nodes_status([node_obj.name])
+
+            # Verify OSD encrypted
+            if config.ENV_DATA.get("encryption_at_rest"):
+                osd_encryption_verification()
 
         request.addfinalizer(finalizer)
 


### PR DESCRIPTION
Signed-off-by: Oded Viner <oviner@redhat.com>

- Add support for multiple OSDs verification per node on function `osd_encryption_verification`
for example:
```
ocs-deviceset-OSD1-block-dmcrypt
                              253:1      0   512G  0 crypt
ocs-deviceset-OSD2-block-dmcrypt
                              253:1      0   512G  0 crypt
```

Device replacement procredure:
- Scale down the OSD deployment for the OSD to be replaced
- Remove the old OSD from the cluster so that a new OSD can be added.
- Create a new OSD for a new device.
- Verify new OSD encrypted