### PR TITLE
add capacity, verify all relevant osds are encrypted

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -395,27 +395,29 @@ def osd_encryption_verification():
         raise UnsupportedFeatureError(error_message)
     osd_size = get_osd_size()
 
-    # Get "lsblk" command output on nodes where osd running
+    log.info("Get 'lsblk' command output on nodes where osd running")
     osd_node_names = get_osds_per_node()
     lsblk_output_list = []
     for worker_node in osd_node_names:
         lsblk_cmd = "oc debug node/" + worker_node + " -- chroot /host lsblk"
         out = run_cmd(lsblk_cmd)
         log.info(f"the output from lsblk command is {out}")
-        lsblk_output_list.append((out, len([worker_node])))
+        lsblk_output_list.append((out, len(osd_node_names[worker_node])))
 
-    # Verify "lsblk" command results are as expected
+    log.info("Verify 'lsblk' command results are as expected")
     for node_output_lsblk in lsblk_output_list:
         node_lsb = node_output_lsblk[0].split()
-        # Search 'crypt' in node_lsb list
+
+        log.info("Search 'crypt' in node_lsb list")
         all_occurrences_crypt = [
             index for index, element in enumerate(node_lsb) if element == "crypt"
         ]
-        # Verify all OSDs encrypted on node
+
+        log.info("Verify all OSDs encrypted on node")
         if len(all_occurrences_crypt) != node_output_lsblk[1]:
             raise EnvironmentError("OSD is not encrypted")
 
-        # Verify that OSD is encrypted, and not another component like sda
+        log.info("Verify that OSD is encrypted, and not another component like sda")
         for index_crypt in all_occurrences_crypt:
             encrypted_component_size = int(
                 (re.findall(r"\d+", node_lsb[index_crypt - 2]))[0]

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -42,7 +42,7 @@ def add_capacity_test():
     # )
     # Commented this lines as a workaround due to bug 1842500
 
-    # Verify OSDs are encrypted
+    # Verify OSDs are encrypted.
     if config.ENV_DATA.get("encryption_at_rest"):
         osd_encryption_verification()
 

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 
 
 def add_capacity_test():
@@ -40,6 +41,10 @@ def add_capacity_test():
     #     resource_count=result * 3
     # )
     # Commented this lines as a workaround due to bug 1842500
+
+    # Verify OSDs are encrypted
+    if config.ENV_DATA.get("encryption_at_rest"):
+        osd_encryption_verification()
 
     ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=80)
     ceph_cluster_obj = CephCluster()

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -15,6 +15,7 @@ from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.framework import config
 from ocs_ci.helpers.pvc_ops import test_create_delete_pvcs
+from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 
 logger = logging.getLogger(__name__)
 
@@ -343,10 +344,15 @@ class TestAddCapacity(ManageTest):
         for pod_io in cluster_io_pods:
             pod_helpers.get_fio_rw_iops(pod_io)
 
+        # Verify OSDs are encrypted
+        if config.ENV_DATA.get("encryption_at_rest"):
+            osd_encryption_verification()
+
         cluster_obj = cluster_helpers.CephCluster()
         assert (
             cluster_obj.get_ceph_health() != "HEALTH_ERR"
         ), "Ceph cluster health checking failed"
+
         logger.info("ALL Exit criteria verification successfully")
         logger.info(
             "********************** TEST PASSED *********************************"

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -9,6 +9,7 @@ from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.node import get_ocs_nodes
+from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 
 
 @pytest.mark.parametrize(
@@ -79,6 +80,10 @@ class TestAddCapacityNodeRestart(ManageTest):
             selector="app=rook-ceph-osd",
             resource_count=result * 3,
         )
+
+        # Verify OSDs are encrypted
+        if config.ENV_DATA.get("encryption_at_rest"):
+            osd_encryption_verification()
 
         logging.info("Finished verifying add capacity osd storage with node restart")
         logging.info("Waiting for ceph health check to finished...")


### PR DESCRIPTION
Signed-off-by: Oded Viner <oviner@redhat.com>

- Fix function `osd_encryption_verification()`,   (Worked until now because we used nodes with one osd.)

Add Capacity test procedure:
- there are 3 OSDs
- add 100G
- Three new OSDs were created (6 OSD)
- Verify all OSD encrypted

Expected results:
6 OSD Encrypted, 2 OSDs per Node
```
ocs-deviceset-OSD1-block-dmcrypt
                              253:1      0   512G  0 crypt
ocs-deviceset-OSD2-block-dmcrypt
                              253:1      0   512G  0 crypt
```

**There is an issue that ceph status stuck on `health_warn` after add capacity with encryption.
