### PR TITLE
add Logs URL to html test report and email report

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -41,7 +41,7 @@ run it belongs here.
 * `username` - Kubeadmin username
 * `password_location` - Filepath (under the cluster path) where the kubeadmin password is located
 * `log_dir` - Directory where logs are placed
-* `logs_url` - URL where will be available logs for remote access, used for Jenkins runs and configured by Jenkins
+* `logs_url` - URL where the logs will be available for remote access, used for Jenkins runs and configured by Jenkins
 * `run_id` - Timestamp ID that is used for log directory naming
 * `kubeconfig_location` - Filepath (under the cluster path) where the kubeconfig is located
 * `cli_params` - Dict that holds onto all CLI parameters

--- a/conf/README.md
+++ b/conf/README.md
@@ -41,6 +41,7 @@ run it belongs here.
 * `username` - Kubeadmin username
 * `password_location` - Filepath (under the cluster path) where the kubeadmin password is located
 * `log_dir` - Directory where logs are placed
+* `logs_url` - URL where will be available logs for remote access, used for Jenkins runs
 * `run_id` - Timestamp ID that is used for log directory naming
 * `kubeconfig_location` - Filepath (under the cluster path) where the kubeconfig is located
 * `cli_params` - Dict that holds onto all CLI parameters

--- a/conf/README.md
+++ b/conf/README.md
@@ -41,7 +41,7 @@ run it belongs here.
 * `username` - Kubeadmin username
 * `password_location` - Filepath (under the cluster path) where the kubeadmin password is located
 * `log_dir` - Directory where logs are placed
-* `logs_url` - URL where will be available logs for remote access, used for Jenkins runs
+* `logs_url` - URL where will be available logs for remote access, used for Jenkins runs and configured by Jenkins
 * `run_id` - Timestamp ID that is used for log directory naming
 * `kubeconfig_location` - Filepath (under the cluster path) where the kubeconfig is located
 * `cli_params` - Dict that holds onto all CLI parameters

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -266,8 +266,9 @@ def pytest_configure(config):
         markers_arg = config.getoption("-m")
 
         # add logs url
-        if ocsci_config.RUN.get("logs_url"):
-            config._metadata["Logs URL"] = ocsci_config.RUN.get("logs_url")
+        logs_url = ocsci_config.RUN.get("logs_url")
+        if logs_url:
+            config._metadata["Logs URL"] = logs_url
 
         if ocsci_config.RUN["cli_params"].get("teardown") or (
             "deployment" in markers_arg and ocsci_config.RUN["cli_params"].get("deploy")

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -264,6 +264,11 @@ def pytest_configure(config):
         # Add OCS related versions to the html report and remove
         # extraneous metadata
         markers_arg = config.getoption("-m")
+
+        # add logs url
+        if ocsci_config.RUN.get("logs_url"):
+            config._metadata["Logs URL"] = ocsci_config.RUN.get("logs_url")
+
         if ocsci_config.RUN["cli_params"].get("teardown") or (
             "deployment" in markers_arg and ocsci_config.RUN["cli_params"].get("deploy")
         ):

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -23,6 +23,17 @@ def pytest_html_results_table_row(report, cells):
         cells.insert(2, html.td(report.description))
     except AttributeError:
         cells.insert(2, html.td("--- no description ---"))
+    # if logs_url is defined, replace local path Log File links to the logs_url
+    if ocsci_config.RUN.get("logs_url"):
+        for tag in cells[4][0]:
+            if (
+                hasattr(tag, "xmlname")
+                and tag.xmlname == "a"
+                and hasattr(tag.attr, "href")
+            ):
+                tag.attr.href = tag.attr.href.replace(
+                    ocsci_config.RUN.get("log_dir"), ocsci_config.RUN.get("logs_url")
+                )
 
 
 @pytest.mark.hookwrapper

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import logging
 from py.xml import html
@@ -32,7 +33,8 @@ def pytest_html_results_table_row(report, cells):
                 and hasattr(tag.attr, "href")
             ):
                 tag.attr.href = tag.attr.href.replace(
-                    ocsci_config.RUN.get("log_dir"), ocsci_config.RUN.get("logs_url")
+                    os.path.expanduser(ocsci_config.RUN.get("log_dir")),
+                    ocsci_config.RUN.get("logs_url"),
                 )
 
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -949,13 +949,17 @@ def parse_html_for_email(soup):
         soup (obj): BeautifulSoup object
 
     """
-    decompose_html_attributes(soup, ["extra", "col-links"])
+    attributes_to_decompose = ["extra"]
+    if not config.RUN.get("logs_url"):
+        attributes_to_decompose.append("col-links")
+    decompose_html_attributes(soup, attributes_to_decompose)
     soup.find(id="not-found-message").decompose()
 
-    for tr in soup.find_all("tr"):
-        for th in tr.find_all("th"):
-            if "Links" in th.text:
-                th.decompose()
+    if not config.RUN.get("logs_url"):
+        for tr in soup.find_all("tr"):
+            for th in tr.find_all("th"):
+                if "Links" in th.text:
+                    th.decompose()
 
     for p in soup.find_all("p"):
         if "(Un)check the boxes to filter the results." in p.text:


### PR DESCRIPTION
- if RUN["logs_url"] is defined, include it to the Environment part of html
  and email report and fix Log File links to point ot the logs_url
  instead of local log_dir
- fixes: https://github.com/red-hat-storage/ocs-ci/issues/3511

Signed-off-by: Daniel Horak <dahorak@redhat.com>