### PR TITLE
Mirror the AWSCLI image to Quay

### DIFF
--- a/ocs_ci/templates/app-pods/awscli.yaml
+++ b/ocs_ci/templates/app-pods/awscli.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: awscli
-      image: amazon/aws-cli:2.0.13
+      image: quay.io/ocsci/aws-cli:2.0.13
       # Override the default `aws` entrypoint in order to 
       # allow the pod to run continuously and act as a relay
       command: ['/bin/sh']


### PR DESCRIPTION
Recently, we've begun to hit the Dockerhub image pull rate limit. Thus, I mirrored the AWSCLI image to Quay.