### PR TITLE
Don't fail deployment if we have more PV's

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1241,9 +1241,15 @@ def verify_pvs_created(expected_pvs):
 
     # check number of PVs created
     num_pvs = len(pv_json["items"])
-    assert (
-        num_pvs == expected_pvs
-    ), f"{num_pvs} PVs created but we are expecting {expected_pvs}"
+    ocp_version = float(get_ocp_version())
+    if ocp_version >= 4.6:
+        assert (
+            num_pvs >= expected_pvs
+        ), f"{num_pvs} PVs created but we are expecting {expected_pvs}"
+    else:
+        assert (
+            num_pvs == expected_pvs
+        ), f"{num_pvs} PVs created but we are expecting {expected_pvs}"
 
     # checks the state of PV
     for pv in pv_json["items"]:


### PR DESCRIPTION
 The reason for the PR is we are using localvolumeset it will create PV on all the disk and in some case, we might have more disk and ocs-ci was failing. This will not fail the deployment if we have more PV create at the time of deployment.


fixes #3217 

Signed-off-by: Pratik Surve <prsurve@redhat.com>