### PR TITLE
azure deployment config update

### DIFF
--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
@@ -7,10 +7,10 @@ ENV_DATA:
   deployment_type: 'ipi'
   region: 'eastus'
   azure_base_domain_resource_group_name: 'ocsqe'
-  base_domain: 'azure.qe.rh-ocs.com'
+  base_domain: 'azure2.qe.rh-ocs.com'
   worker_replicas: 3
   master_replicas: 3
-  master_instance_type: 'Standard_D8s_v3'
+  master_instance_type: 'Standard_D16s_v3'
   worker_instance_type: 'Standard_D16s_v3'
 REPORTING:
   polarion:

--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
@@ -10,7 +10,7 @@ ENV_DATA:
   base_domain: 'azure2.qe.rh-ocs.com'
   worker_replicas: 3
   master_replicas: 3
-  master_instance_type: 'Standard_D16s_v3'
+  master_instance_type: 'Standard_D8s_v3'
   worker_instance_type: 'Standard_D16s_v3'
 REPORTING:
   polarion:


### PR DESCRIPTION
To use new azure subscription, the following details are changed:

- base_domain to new azure2.qe.rh-ocs.com (new domain is necessary to
  allow for a brief transition period without removing deployments in
  the old subscription)
- ~master instance type to match worker instance type, as suggested for
  production configuration (previously, we were limited by quotas)~

fixes https://github.com/red-hat-storage/ocs-ci/issues/3539