### PR TITLE
Skipping mcg related tests for openshift dedicated acceptance testing

### DIFF
--- a/conf/ocsci/openshift_dedicated.yaml
+++ b/conf/ocsci/openshift_dedicated.yaml
@@ -1,0 +1,7 @@
+---
+ENV_DATA:
+  platform: 'openshiftdedicated'
+  deployment_type: 'managed'
+
+DEPLOYMENT:
+  ocs_csv_channel: "alpha"

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -181,6 +181,11 @@ skipif_bm = pytest.mark.skipif(
     reason="Test will not run on Bare Metal",
 )
 
+skipif_openshift_dedicated = pytest.mark.skipif(
+    config.ENV_DATA["platform"].lower() == "openshiftdedicated",
+    reason="Test will not run on Openshift dedicated cluster",
+)
+
 skipif_external_mode = pytest.mark.skipif(
     config.DEPLOYMENT.get("external_mode") is True,
     reason="Test will not run on External Mode cluster",

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -14,10 +14,12 @@ from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.framework.testlib import MCGTest
+from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
 
 logger = logging.getLogger(__name__)
 
 
+@skipif_openshift_dedicated
 class TestBucketCreation(MCGTest):
     """
     Test creation of a bucket

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -21,11 +21,13 @@ from ocs_ci.ocs.bucket_utils import (
 )
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.framework.testlib import MCGTest
+from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
 
 logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
 
 
+@skipif_openshift_dedicated
 class TestBucketDeletion(MCGTest):
     """
     Test bucket Creation Deletion of buckets

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -22,6 +22,7 @@ from ocs_ci.ocs.bucket_utils import (
     retrieve_anon_s3_resource,
     craft_s3_command,
 )
+from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ def pod_io(pods):
             p.submit(pod.run_io, "fs", "1G")
 
 
+@skipif_openshift_dedicated
 class TestBucketIO(MCGTest):
     """
     Test IO of a bucket


### PR DESCRIPTION
**Description**

- This PR has the changes to skip the MCG related tests as part of openshift dedicated acceptance testing.
- `conf/ocsci/osd_cluster.yaml` will be passed as a value for `--ocsci-conf` parameter

Signed-off-by: kesavan <kvellalo@redhat.com>