### PR TITLE
Verify thorough PV backingstore deletion

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -930,15 +930,21 @@ def run_io_with_rados_bench(**kw):
     return ret
 
 
-def get_all_pvs():
+def get_all_pvs(namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=None):
     """
-    Gets all pv in openshift-storage namespace
+    Gets all persistent volumes in a given namespace
+
+    Args:
+        namespace (str): Name of namespace  ('all-namespaces' to get all namespaces)
+        selector (str): The label selector to look for
 
     Returns:
-         dict: Dict of all pv in openshift-storage namespace
+         dict: Dict of all persistent volumes in the given namespace
     """
-    ocp_pv_obj = ocp.OCP(kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
-    return ocp_pv_obj.get()
+    all_ns = True if namespace == "all-namespaces" else False
+    ocp_pv_obj = ocp.OCP(kind=constants.PV, namespace=namespace)
+
+    return ocp_pv_obj.get(selector=selector, all_namespaces=all_ns)
 
 
 # TODO: revert counts of tries and delay,BZ 1726266

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -930,21 +930,15 @@ def run_io_with_rados_bench(**kw):
     return ret
 
 
-def get_all_pvs(namespace=defaults.ROOK_CLUSTER_NAMESPACE, selector=None):
+def get_all_pvs():
     """
-    Gets all persistent volumes in a given namespace
-
-    Args:
-        namespace (str): Name of namespace  ('all-namespaces' to get all namespaces)
-        selector (str): The label selector to look for
+    Gets all pv in openshift-storage namespace
 
     Returns:
-         dict: Dict of all persistent volumes in the given namespace
+         dict: Dict of all pv in openshift-storage namespace
     """
-    all_ns = True if namespace == "all-namespaces" else False
-    ocp_pv_obj = ocp.OCP(kind=constants.PV, namespace=namespace)
-
-    return ocp_pv_obj.get(selector=selector, all_namespaces=all_ns)
+    ocp_pv_obj = ocp.OCP(kind=constants.PV, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    return ocp_pv_obj.get()
 
 
 # TODO: revert counts of tries and delay,BZ 1726266

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -17,7 +17,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.helpers.helpers import create_unique_resource_name, get_all_pvs
 from ocs_ci.ocs.resources.pod import get_pods_having_label
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
 from ocs_ci.utility.utils import TimeoutSampler
@@ -141,9 +141,10 @@ def check_resources_deleted(backingstore_name, namespace=None):
         bool: True if pvc(s) were deleted
 
     """
+    pvs = get_all_pvs(namespace=namespace, selector=f"pool={backingstore_name}")
     pvcs = get_all_pvcs(namespace=namespace, selector=f"pool={backingstore_name}")
     pods = get_pods_having_label(namespace=namespace, label=f"pool={backingstore_name}")
-    return True if len(pvcs["items"]) == 0 and len(pods) == 0 else False
+    return len(pvcs["items"]) == 0 and len(pvs["items"]) == 0 and len(pods) == 0
 
 
 def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -1,4 +1,5 @@
 import logging
+
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed
 
@@ -17,7 +18,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import create_unique_resource_name, get_all_pvs
+from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.resources.pod import get_pods_having_label
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
 from ocs_ci.utility.utils import TimeoutSampler
@@ -48,9 +49,16 @@ class BackingStore:
         self.mcg_obj = mcg_obj
         self.vol_num = vol_num
         self.vol_size = vol_size
+        self.pv_name = None
 
     def delete(self):
         log.info(f"Cleaning up backingstore {self.name}")
+        # If the backingstore utilizes a PV, save its PV name for deletion verification
+        if "pv-backingstore" in self.name.lower():
+            backingstore_pvc = OCP(
+                kind=constants.PVC, selector=f"pool={self.name}"
+            ).get()["items"][0]
+            self.pv_name = backingstore_pvc["spec"]["volumeName"]
 
         if self.method == "oc":
             OCP(
@@ -79,6 +87,7 @@ class BackingStore:
                 log.error(f"Failed to {self.name}")
                 raise TimeoutExpiredError
 
+        # Verify deletion was successful
         log.info(f"Verifying whether backingstore {self.name} exists after deletion")
         bs_deleted_successfully = False
 
@@ -104,47 +113,51 @@ class BackingStore:
 
         if "pv-backingstore" in self.name.lower():
             log.info(f"Waiting for backingstore {self.name} resources to be deleted")
-            wait_for_pv_backingstore_resource_deleted(self.name)
+            self.wait_for_pv_backingstore_resource_deleted()
 
+    def wait_for_pv_backingstore_resource_deleted(self, namespace=None):
+        """
+        wait for pv backing store resources to be deleted at the end of test teardown
 
-def wait_for_pv_backingstore_resource_deleted(backingstore_name, namespace=None):
-    """
-    wait for pv backing store resources to be deleted at the end of test teardown
+        Args:
+            backingstore_name (str): backingstore name
+            namespace (str): backing store's namespace
 
-    Args:
-        backingstore_name (str): backingstore name
-        namespace (str): backing store's namespace
+        """
+        namespace = namespace or config.ENV_DATA["cluster_namespace"]
+        sample = TimeoutSampler(
+            timeout=120,
+            sleep=15,
+            func=self.check_resources_deleted,
+            namespace=namespace,
+        )
+        if not sample.wait_for_func_status(result=True):
+            log.error(f"{self.name} was not deleted properly, leftovers were found")
+            raise TimeoutExpiredError
 
-    """
-    namespace = namespace or config.ENV_DATA["cluster_namespace"]
-    sample = TimeoutSampler(
-        timeout=120,
-        sleep=15,
-        func=check_resources_deleted,
-        backingstore_name=backingstore_name,
-        namespace=namespace,
-    )
-    if not sample.wait_for_func_status(result=True):
-        log.error(f"Unable to delete resources of {backingstore_name}")
-        raise TimeoutExpiredError
+    def check_resources_deleted(self, namespace=None):
+        """
+        check if resources of the pv pool backingstore deleted properly
 
+        Args:
+            namespace (str): backing store's namespace
 
-def check_resources_deleted(backingstore_name, namespace=None):
-    """
-    check if resources of the pv pool backingstore deleted properly
+        Returns:
+            bool: True if pvc(s) were deleted
 
-    Args:
-        backingstore_name (str): backingstore name
-        namespace (str): backing store's namespace
-
-    Returns:
-        bool: True if pvc(s) were deleted
-
-    """
-    pvs = get_all_pvs(namespace=namespace, selector=f"pool={backingstore_name}")
-    pvcs = get_all_pvcs(namespace=namespace, selector=f"pool={backingstore_name}")
-    pods = get_pods_having_label(namespace=namespace, label=f"pool={backingstore_name}")
-    return len(pvcs["items"]) == 0 and len(pvs["items"]) == 0 and len(pods) == 0
+        """
+        try:
+            OCP(kind=constants.PV, resource_name=self.pv_name).get()
+            log.warning(f"Found PV leftovers belonging to {self.name}")
+            return False
+        except CommandFailed as e:
+            if "not found" in str(e):
+                pass
+            else:
+                raise
+        pvcs = get_all_pvcs(namespace=namespace, selector=f"pool={self.name}")
+        pods = get_pods_having_label(namespace=namespace, label=f"pool={self.name}")
+        return len(pvcs["items"]) == 0 and len(pods) == 0
 
 
 def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):


### PR DESCRIPTION
Up until now, we did not verify that the PV was deleted after a PV backingstore was deleted.
We did confirm that the related pod and PVC were deleted, but sometimes, a PV is left for a few seconds after the PVC is gone, which has caused false failures in teardowns.
This PR verifies that the PV is also deleted thoroughly, before moving on to the rest of the teardown.