### PR TITLE
Print OBC YAML and `oc describe` if it fails to bind on creation

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -251,3 +251,7 @@ class PoolNotCompressedAsExpected(Exception):
 
 class PoolNotReplicatedAsNeeded(Exception):
     pass
+
+
+class UnhealthyBucket(Exception):
+    pass

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -213,6 +213,7 @@ class ObjectBucket(ABC):
             ):
                 if health_check:
                     logger.info(f"{self.name} is healthy")
+                    break
                 else:
                     logger.info(f"{self.name} is unhealthy. Rechecking.")
         except TimeoutExpiredError:

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -226,12 +226,10 @@ class ObjectBucket(ABC):
             obc_obj = OCP(kind="obc", namespace=self.namespace, resource_name=self.name)
             obc_yaml = obc_obj.get()
             obc_description = obc_obj.describe(resource_name=self.name)
-            assert (
-                False
-            ), (
+            assert False, (
                 f"{self.name} did not reach a healthy state within {timeout} seconds.\n"
                 f"OBC YAML:\n{json.dumps(obc_yaml, indent=2)}\n\n"
-                f"OBC description:\n{obc_description}"               
+                f"OBC description:\n{obc_description}"
             )
 
     """

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -195,7 +195,7 @@ class ObjectBucket(ABC):
             logger.error(f"{self.name} was not deleted within {timeout} seconds.")
             assert False, f"{self.name} was not deleted within {timeout} seconds."
 
-    def verify_health(self, timeout=1, interval=1):
+    def verify_health(self, timeout=60, interval=15):
         """
         Health verification function that tries to verify
         the a bucket's health by using its appropriate internal_verify_health
@@ -420,7 +420,7 @@ class MCGOCBucket(OCBucket):
             self.name = create_unique_resource_name("oc", "obc")
         obc_data["metadata"]["name"] = self.name
         obc_data["spec"]["bucketName"] = self.name
-        obc_data["spec"]["storageClassName"] = "nope.noobaa.io"
+        obc_data["spec"]["storageClassName"] = f"{self.namespace}.noobaa.io"
         obc_data["metadata"]["namespace"] = self.namespace
         if kwargs.get("bucketclass"):
             obc_data.setdefault("spec", {}).setdefault(

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -195,7 +195,7 @@ class ObjectBucket(ABC):
             logger.error(f"{self.name} was not deleted within {timeout} seconds.")
             assert False, f"{self.name} was not deleted within {timeout} seconds."
 
-    def verify_health(self, timeout=60, interval=15):
+    def verify_health(self, timeout=60, interval=5):
         """
         Health verification function that tries to verify
         the a bucket's health by using its appropriate internal_verify_health

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1961,9 +1961,8 @@ def bucket_factory_fixture(request, mcg_obj=None, rgw_obj=None):
             )
             created_buckets.append(created_bucket)
             if verify_health:
-                assert (
-                    created_bucket.verify_health()
-                ), f"{bucket_name} did not reach a healthy state in time."
+                created_bucket.verify_health()
+
         return created_buckets
 
     def bucket_cleanup():


### PR DESCRIPTION
Seems like OBCs are not always included in the `must-gather`, so this change allows us to have a better idea of what was their state at the time of the failure