### PR TITLE
Use the correct NB DB pod label for 4.7

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -11,6 +11,8 @@ and with consideration of the entire project.
 
 import os
 
+from ocs_ci.framework import config
+
 # Logging
 LOG_FORMAT = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"
 
@@ -243,7 +245,11 @@ LOCAL_STORAGE_OPERATOR_LABEL = "name=local-storage-operator"
 NOOBAA_APP_LABEL = "app=noobaa"
 NOOBAA_CORE_POD_LABEL = "noobaa-core=noobaa"
 NOOBAA_OPERATOR_POD_LABEL = "noobaa-operator=deployment"
-NOOBAA_DB_LABEL = "noobaa-db=noobaa"
+NOOBAA_DB_LABEL = (
+    "noobaa-db=noobaa"
+    if float(config.ENV_DATA["ocs_version"]) < 4.7
+    else "noobaa-db=postgres"
+)
 NOOBAA_ENDPOINT_POD_LABEL = "noobaa-s3=noobaa"
 ROOK_CEPH_DETECT_VERSION_LABEL = "app=rook-ceph-detect-version"
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -11,8 +11,6 @@ and with consideration of the entire project.
 
 import os
 
-from ocs_ci.framework import config
-
 # Logging
 LOG_FORMAT = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -245,11 +245,8 @@ LOCAL_STORAGE_OPERATOR_LABEL = "name=local-storage-operator"
 NOOBAA_APP_LABEL = "app=noobaa"
 NOOBAA_CORE_POD_LABEL = "noobaa-core=noobaa"
 NOOBAA_OPERATOR_POD_LABEL = "noobaa-operator=deployment"
-NOOBAA_DB_LABEL = (
-    "noobaa-db=noobaa"
-    if float(config.ENV_DATA["ocs_version"]) < 4.7
-    else "noobaa-db=postgres"
-)
+NOOBAA_DB_LABEL_46_AND_UNDER = "noobaa-db=noobaa"
+NOOBAA_DB_LABEL_47_AND_ABOVE = "noobaa-db=postgres"
 NOOBAA_ENDPOINT_POD_LABEL = "noobaa-s3=noobaa"
 ROOK_CEPH_DETECT_VERSION_LABEL = "app=rook-ceph-detect-version"
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -156,10 +156,15 @@ def ocs_install_verification(
         min_eps = 1
         max_eps = 1
 
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     resources_dict = {
+        nb_db_label: 1,
         constants.OCS_OPERATOR_LABEL: 1,
         constants.OPERATOR_LABEL: 1,
-        constants.NOOBAA_DB_LABEL: 1,
         constants.NOOBAA_OPERATOR_POD_LABEL: 1,
         constants.NOOBAA_CORE_POD_LABEL: 1,
         constants.NOOBAA_ENDPOINT_POD_LABEL: min_eps,

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.resources.pod import get_pods_having_label
 from ocs_ci.utility import localstorage, utils
 from ocs_ci.ocs.node import get_osds_per_node
 from ocs_ci.ocs.exceptions import UnsupportedFeatureError
+from ocs_ci.ocs.utils import get_mcg_db_label
 from ocs_ci.utility.utils import run_cmd
 
 log = logging.getLogger(__name__)
@@ -156,13 +157,8 @@ def ocs_install_verification(
         min_eps = 1
         max_eps = 1
 
-    nb_db_label = (
-        constants.NOOBAA_DB_LABEL_46_AND_UNDER
-        if float(config.ENV_DATA["ocs_version"]) < 4.7
-        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
-    )
     resources_dict = {
-        nb_db_label: 1,
+        get_mcg_db_label(): 1,
         constants.OCS_OPERATOR_LABEL: 1,
         constants.OPERATOR_LABEL: 1,
         constants.NOOBAA_OPERATOR_POD_LABEL: 1,

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -16,7 +16,6 @@ from ocs_ci.ocs.resources.pod import get_pods_having_label
 from ocs_ci.utility import localstorage, utils
 from ocs_ci.ocs.node import get_osds_per_node
 from ocs_ci.ocs.exceptions import UnsupportedFeatureError
-from ocs_ci.ocs.utils import get_mcg_db_label
 from ocs_ci.utility.utils import run_cmd
 
 log = logging.getLogger(__name__)
@@ -157,8 +156,13 @@ def ocs_install_verification(
         min_eps = 1
         max_eps = 1
 
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     resources_dict = {
-        get_mcg_db_label(): 1,
+        nb_db_label: 1,
         constants.OCS_OPERATOR_LABEL: 1,
         constants.OPERATOR_LABEL: 1,
         constants.NOOBAA_OPERATOR_POD_LABEL: 1,

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -854,9 +854,14 @@ def collect_noobaa_db_dump(log_dir_path):
         Pod,
     )
 
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(ocsci_config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     nb_db_pod = Pod(
         **get_pods_having_label(
-            label=constants.NOOBAA_DB_LABEL, namespace=defaults.ROOK_CLUSTER_NAMESPACE
+            label=nb_db_label, namespace=defaults.ROOK_CLUSTER_NAMESPACE
         )[0]
     )
     ocs_log_dir_path = os.path.join(log_dir_path, "noobaa_db_dump")

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.external_ceph import RolesContainer, Ceph, CephNode
 from ocs_ci.ocs.clients import WinNode
 from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
-from ocs_ci.ocs.ocp import OCP, get_ocs_version
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.openstack import CephVMNode
 from ocs_ci.ocs.parallel import parallel
 from ocs_ci.ocs.resources.ocs import OCS
@@ -854,9 +854,14 @@ def collect_noobaa_db_dump(log_dir_path):
         Pod,
     )
 
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(ocsci_config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     nb_db_pod = Pod(
         **get_pods_having_label(
-            label=get_mcg_db_label(), namespace=defaults.ROOK_CLUSTER_NAMESPACE
+            label=nb_db_label, namespace=defaults.ROOK_CLUSTER_NAMESPACE
         )[0]
     )
     ocs_log_dir_path = os.path.join(log_dir_path, "noobaa_db_dump")
@@ -1113,9 +1118,3 @@ def reboot_node(ceph_node, timeout=300):
     except SSHException:
         log.exception(f"Failed to connect to node {ceph_node.hostname}")
         raise
-
-
-def get_mcg_db_label():
-    if float(".".join(get_ocs_version().split(".")[:2])) < 4.7:
-        return constants.NOOBAA_DB_LABEL_46_AND_UNDER
-    return constants.NOOBAA_DB_LABEL_47_AND_ABOVE

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.external_ceph import RolesContainer, Ceph, CephNode
 from ocs_ci.ocs.clients import WinNode
 from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
-from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.ocp import OCP, get_ocs_version
 from ocs_ci.ocs.openstack import CephVMNode
 from ocs_ci.ocs.parallel import parallel
 from ocs_ci.ocs.resources.ocs import OCS
@@ -854,14 +854,9 @@ def collect_noobaa_db_dump(log_dir_path):
         Pod,
     )
 
-    nb_db_label = (
-        constants.NOOBAA_DB_LABEL_46_AND_UNDER
-        if float(ocsci_config.ENV_DATA["ocs_version"]) < 4.7
-        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
-    )
     nb_db_pod = Pod(
         **get_pods_having_label(
-            label=nb_db_label, namespace=defaults.ROOK_CLUSTER_NAMESPACE
+            label=get_mcg_db_label(), namespace=defaults.ROOK_CLUSTER_NAMESPACE
         )[0]
     )
     ocs_log_dir_path = os.path.join(log_dir_path, "noobaa_db_dump")
@@ -1118,3 +1113,9 @@ def reboot_node(ceph_node, timeout=300):
     except SSHException:
         log.exception(f"Failed to connect to node {ceph_node.hostname}")
         raise
+
+
+def get_mcg_db_label():
+    if float(".".join(get_ocs_version().split(".")[:2])) < 4.7:
+        return constants.NOOBAA_DB_LABEL_46_AND_UNDER
+    return constants.NOOBAA_DB_LABEL_47_AND_ABOVE

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -1,8 +1,8 @@
 import logging
+from ocs_ci.framework import config
 
 import pytest
 
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     MCGTest,
     ignore_leftovers,
@@ -16,7 +16,6 @@ from ocs_ci.ocs import cluster, constants, defaults
 from ocs_ci.ocs.node import drain_nodes, wait_for_nodes_status
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.utils import get_mcg_db_label
 
 log = logging.getLogger(__name__)
 
@@ -36,9 +35,14 @@ class TestMCGResourcesDisruptions(MCGTest):
 
     """
 
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     labels_map = {
         "noobaa_core": constants.NOOBAA_CORE_POD_LABEL,
-        "noobaa_db": get_mcg_db_label(),
+        "noobaa_db": nb_db_label,
         "noobaa_endpoint": constants.NOOBAA_ENDPOINT_POD_LABEL,
         "noobaa_operator": constants.NOOBAA_OPERATOR_POD_LABEL,
     }

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -34,6 +34,7 @@ class TestMCGResourcesDisruptions(MCGTest):
     Test MCG resources disruptions
 
     """
+
     nb_db_label = (
         constants.NOOBAA_DB_LABEL_46_AND_UNDER
         if float(config.ENV_DATA["ocs_version"]) < 4.7

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -1,4 +1,5 @@
 import logging
+from ocs_ci.framework import config
 
 import pytest
 
@@ -33,10 +34,14 @@ class TestMCGResourcesDisruptions(MCGTest):
     Test MCG resources disruptions
 
     """
-
+    nb_db_label = (
+        constants.NOOBAA_DB_LABEL_46_AND_UNDER
+        if float(config.ENV_DATA["ocs_version"]) < 4.7
+        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
     labels_map = {
         "noobaa_core": constants.NOOBAA_CORE_POD_LABEL,
-        "noobaa_db": constants.NOOBAA_DB_LABEL,
+        "noobaa_db": nb_db_label,
         "noobaa_endpoint": constants.NOOBAA_ENDPOINT_POD_LABEL,
         "noobaa_operator": constants.NOOBAA_OPERATOR_POD_LABEL,
     }

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -1,8 +1,8 @@
 import logging
-from ocs_ci.framework import config
 
 import pytest
 
+from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     MCGTest,
     ignore_leftovers,
@@ -16,6 +16,7 @@ from ocs_ci.ocs import cluster, constants, defaults
 from ocs_ci.ocs.node import drain_nodes, wait_for_nodes_status
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.utils import get_mcg_db_label
 
 log = logging.getLogger(__name__)
 
@@ -35,14 +36,9 @@ class TestMCGResourcesDisruptions(MCGTest):
 
     """
 
-    nb_db_label = (
-        constants.NOOBAA_DB_LABEL_46_AND_UNDER
-        if float(config.ENV_DATA["ocs_version"]) < 4.7
-        else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
-    )
     labels_map = {
         "noobaa_core": constants.NOOBAA_CORE_POD_LABEL,
-        "noobaa_db": nb_db_label,
+        "noobaa_db": get_mcg_db_label(),
         "noobaa_endpoint": constants.NOOBAA_ENDPOINT_POD_LABEL,
         "noobaa_operator": constants.NOOBAA_OPERATOR_POD_LABEL,
     }


### PR DESCRIPTION
The pod label was changed in 4.7, and usage of the old label caused a cluster verification failure.
Closes #3551.