### PR TITLE
Bump version to 4.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name="ocs-ci",
-    version="4.5.0",
+    version="4.6.0",
     description="OCS CI tests that run in jenkins and standalone mode using aws provider",
     author="OCS QE",
     author_email="ocs-ci@redhat.com",


### PR DESCRIPTION
OCS 4.6 GA is 17.12. so we should move the version here to 4.6.0.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>