### PR TITLE
Increase wait_time of measure_pvc_creation_time_bulk call

### DIFF
--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -107,7 +107,9 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # Get PVC creation time
         pvc_create_time = helpers.measure_pvc_creation_time_bulk(
-            interface=interface, pvc_name_list=pvc_bound_list
+            interface=interface,
+            pvc_name_list=pvc_bound_list,
+            wait_time=300,
         )
 
         # TODO: Update below code with google API, to record value in spreadsheet


### PR DESCRIPTION
in test_multiple_pvc_creaation_deletion_scale().

This results in a full test no longer throwing an UnexpectedBehaviour
exception.  The elapsed time of the full test increases by about 5%

Signed-off-by: wusui <wusui@redhat.com>