### PR TITLE
Implement methods of disruptive operations for External mode cluster

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -1,7 +1,10 @@
 import logging
+import random
+import re
+import time
 
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs import constants, ocp, utils
 from ocs_ci.framework import config
 from ocs_ci.utility.utils import TimeoutSampler, run_async, run_cmd
 from ocs_ci.utility.retry import retry
@@ -14,18 +17,58 @@ POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
 
 class Disruptions:
     """
-    This class contains methods of disrupt operations
+    A factory class to get specific object based on deployment mode
     """
 
-    resource = None
-    resource_obj = None
-    resource_count = 0
-    selector = None
-    daemon_pid = None
+    def __init__(self):
+        self.cls_map = {
+            "internal": DisruptionsInternal,
+            "external": DisruptionsExternal,
+        }
+
+    def get_disruptor(self):
+        if config.DEPLOYMENT["external_mode"]:
+            return self.cls_map["external"]()
+        else:
+            return self.cls_map["internal"]()
+
+
+class DisruptionsBase(object):
+    """
+    A base class for disrupt operations
+    """
+
+    def __init__(self):
+        self.resource = None
+        self.resource_count = 0
+        self.resource_obj = None
+        self.selector = None
+
+    def set_resource(self, resource, leader_type="provisioner"):
+        raise NotImplementedError("Set resource functionality is not implemented")
+
+    def delete_resource(self, resource_id=0):
+        raise NotImplementedError("Delete resource functionality is not implemented")
+
+    def select_daemon(self):
+        raise NotImplementedError("Select daemon functionality is not implemented")
+
+    def kill_daemon(self):
+        raise NotImplementedError("Kill daemon functionality is not implemented")
+
+
+class DisruptionsInternal(DisruptionsBase):
+    """
+    This class contains methods of disrupt operations for Internal mode
+    """
+
+    def __init__(self):
+        super(DisruptionsInternal, self).__init__()
+        self.daemon_pid = None
 
     def set_resource(self, resource, leader_type="provisioner"):
         self.resource = resource
-        resource_count = 0
+        self.resource_count = 0
         if self.resource == "mgr":
             self.resource_obj = pod.get_mgr_pods()
             self.selector = constants.MGR_APP_LABEL
@@ -51,7 +94,7 @@ class Disruptions:
                 )
             ]
             self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
-            resource_count = len(pod.get_cephfsplugin_provisioner_pods())
+            self.resource_count = len(pod.get_cephfsplugin_provisioner_pods())
         if self.resource == "rbdplugin_provisioner":
             self.resource_obj = [
                 pod.get_plugin_provisioner_leader(
@@ -59,12 +102,12 @@ class Disruptions:
                 )
             ]
             self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
-            resource_count = len(pod.get_rbdfsplugin_provisioner_pods())
+            self.resource_count = len(pod.get_rbdfsplugin_provisioner_pods())
         if self.resource == "operator":
             self.resource_obj = pod.get_operator_pods()
             self.selector = constants.OPERATOR_LABEL
 
-        self.resource_count = resource_count or len(self.resource_obj)
+        self.resource_count = self.resource_count or len(self.resource_obj)
 
     def delete_resource(self, resource_id=0):
         self.resource_obj[resource_id].delete(force=True)
@@ -168,3 +211,137 @@ class Disruptions:
                 raise TimeoutExpiredError(
                     f"Waiting for pid of ceph-{self.resource} in {node_name}"
                 )
+
+
+class DisruptionsExternal(DisruptionsBase):
+    """
+    This class contains methods of disrupt operations for External mode
+    """
+
+    def __init__(self):
+        super(DisruptionsExternal, self).__init__()
+        self.resource_id = None
+        self.ceph_cluster = utils.get_external_mode_rhcs()
+
+    def set_resource(self, resource, leader_type="provisioner"):
+        self.resource = resource
+        self.resource_count = 0
+        ceph_resources = ["mgr", "mon", "osd", "mds"]
+        if self.resource in ceph_resources:
+            self.resource_count = len(self.ceph_cluster.get_metadata_list(resource))
+        else:
+            if self.resource == "cephfsplugin":
+                self.resource_obj = pod.get_plugin_pods(
+                    interface=constants.CEPHFILESYSTEM
+                )
+                self.selector = constants.CSI_CEPHFSPLUGIN_LABEL
+            if self.resource == "rbdplugin":
+                self.resource_obj = pod.get_plugin_pods(
+                    interface=constants.CEPHBLOCKPOOL
+                )
+                self.selector = constants.CSI_RBDPLUGIN_LABEL
+            if self.resource == "cephfsplugin_provisioner":
+                self.resource_obj = [
+                    pod.get_plugin_provisioner_leader(
+                        interface=constants.CEPHFILESYSTEM,
+                        leader_type=leader_type,
+                    )
+                ]
+                self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+                self.resource_count = len(pod.get_cephfsplugin_provisioner_pods())
+            if self.resource == "rbdplugin_provisioner":
+                self.resource_obj = [
+                    pod.get_plugin_provisioner_leader(
+                        interface=constants.CEPHBLOCKPOOL,
+                        leader_type=leader_type,
+                    )
+                ]
+                self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+                self.resource_count = len(pod.get_rbdfsplugin_provisioner_pods())
+            if self.resource == "operator":
+                self.resource_obj = pod.get_operator_pods()
+                self.selector = constants.OPERATOR_LABEL
+
+            self.resource_count = self.resource_count or len(self.resource_obj)
+
+    def delete_resource(self, resource_id=0, wait_time=60):
+        """
+        Stop and start Ceph daemon, which is the equivalent of pod deletion in
+        internal mode
+
+        Args:
+            wait_time (int): Seconds to wait before starting the Ceph daemon
+
+        """
+        ceph_resources = ["mgr", "mon", "osd", "mds"]
+        if self.resource not in ceph_resources:
+            self.resource_obj[resource_id].delete(force=True)
+            assert POD.wait_for_resource(
+                condition="Running",
+                selector=self.selector,
+                resource_count=self.resource_count,
+                timeout=300,
+            )
+        else:
+            if not self.resource_id:
+                self.select_daemon()
+
+            utils.manage_systemd_unit_external(
+                self.ceph_cluster, self.resource, self.resource_id, command="stop"
+            )
+            log.info(f"Waiting for {wait_time} seconds before starting the Ceph daemon")
+            time.sleep(wait_time)
+            utils.manage_systemd_unit_external(
+                self.ceph_cluster, self.resource, self.resource_id, command="start"
+            )
+
+    def select_daemon(self):
+        """
+        Select id of leader/active self.resource daemon
+
+        """
+        ct_pod = pod.get_ceph_tools_pod()
+        if self.resource == "mgr":
+            self.resource_id = ct_pod.exec_ceph_cmd("ceph mgr dump").get("active_name")
+        elif self.resource == "mon":
+            self.resource_id = ct_pod.exec_ceph_cmd("ceph quorum_status").get(
+                "quorum_leader_name"
+            )
+        elif self.resource == "mds":
+            mds_stat = ct_pod.exec_ceph_cmd("ceph mds stat", format="plain")
+            self.resource_id = re.search(r"(?<=0=).*?(?==up:active)", mds_stat).group(0)
+        else:
+            self.resource_id = random.randint(0, self.resource_count)
+
+        log.info(f"Selected daemon: {self.resource_id}")
+
+    def kill_daemon(self, kill_signal="SIGTERM", restart_daemon=True, wait_time=60):
+        """
+        Kill Ceph daemon with given signal
+
+        Args:
+            kill_signal (str): kill signal type to be sent (default: SIGTERM)
+            restart_daemon (bool): True to restart the Ceph daemon after killing it.
+                False to skip restart.
+            wait_time (int): Seconds to wait before restarting the Ceph daemon
+
+        """
+        if not self.resource_id:
+            self.select_daemon()
+
+        utils.manage_systemd_unit_external(
+            self.ceph_cluster,
+            self.resource,
+            self.resource_id,
+            command="kill",
+            options=f"-s {kill_signal}",
+        )
+
+        if restart_daemon:
+            log.info(
+                f"Waiting for {wait_time} seconds before restarting the Ceph daemon"
+            )
+            time.sleep(wait_time)
+            utils.manage_systemd_unit_external(
+                self.ceph_cluster, self.resource, self.resource_id, command="restart"
+            )

--- a/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
+++ b/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
@@ -44,7 +44,7 @@ class TestPvcSnapshotAndCloneWithBaseOperation(E2ETest):
 
         flow_ops = flowtest.FlowOperations()
         log.info("Starting operation 1: Pod Restarts")
-        disruption = Disruptions()
+        disruption = Disruptions().get_disruptor()
         pod_obj_list = [
             "osd",
             "mon",

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -122,7 +122,7 @@ class TestScaleEndpointAutoScale(MCGTest):
         self._assert_endpoint_count(desired_count=self.MAX_ENDPOINT_COUNT)
 
         # Respin ceph pods
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         number_of_resource = disruption.resource_count
         for i in range(0, number_of_resource):

--- a/tests/e2e/scale/test_cephfs_many_files.py
+++ b/tests/e2e/scale/test_cephfs_many_files.py
@@ -157,7 +157,7 @@ class TestMillionCephfsFiles(E2ETest):
 
         """
         logging.info(f"Testing respin of {resource_to_delete}")
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         disruption.delete_resource()
         ocp_obj = million_file_cephfs.ocp_obj

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -107,7 +107,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
             resource_to_delete (str): Ceph resource type to be deleted.
             eg: mgr/mon/osd/mds/cephfsplugin/rbdplugin/cephfsplugin_provisioner/rbdplugin_provisioner
         """
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         no_of_resource = disruption.resource_count
         for i in range(0, no_of_resource):

--- a/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
+++ b/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
@@ -169,7 +169,7 @@ class TestAddNode(E2ETest):
             raise FileNotFoundError
 
         # perform disruption test
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         no_of_resource = disruption.resource_count
         for i in range(0, no_of_resource):

--- a/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
+++ b/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
@@ -92,7 +92,7 @@ class TestScaleRespinCephPods(E2ETest):
         else:
             raise FileNotFoundError
 
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         no_of_resource = disruption.resource_count
         for i in range(0, no_of_resource):

--- a/tests/e2e/workloads/app/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/app/amq/test_amq_pod_respin.py
@@ -96,7 +96,7 @@ class TestAMQPodRespin(E2ETest):
                 )
         else:
             log.info(f"Respin Ceph pod {pod_name}")
-            disruption = Disruptions()
+            disruption = Disruptions().get_disruptor()
             disruption.set_resource(resource=f"{pod_name}")
             disruption.delete_resource()
 

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_pod_respin.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_pod_respin.py
@@ -41,7 +41,7 @@ class TestCouchBasePodRespin(E2ETest):
         if pod_name == "couchbase":
             self.cb.respin_couchbase_app_pod()
         else:
-            disruption = Disruptions()
+            disruption = Disruptions().get_disruptor()
             disruption.set_resource(resource=f"{pod_name}")
             disruption.delete_resource()
 

--- a/tests/e2e/workloads/app/jenkins/test_jenkins_pod_respin.py
+++ b/tests/e2e/workloads/app/jenkins/test_jenkins_pod_respin.py
@@ -77,7 +77,7 @@ class TestJenkinsPodRespin(E2ETest):
 
         # Respin pod
         log.info(f"Respin pod {pod_name}")
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=f"{pod_name}")
         disruption.delete_resource()
 

--- a/tests/e2e/workloads/app/pgsql/test_pgsql_pod_respin.py
+++ b/tests/e2e/workloads/app/pgsql/test_pgsql_pod_respin.py
@@ -71,7 +71,7 @@ class TestPgSQLPodRespin(E2ETest):
             pgsql.respin_pgsql_app_pod()
         else:
             log.info(f"Respin Ceph pod {pod_name}")
-            disruption = disruption_helpers.Disruptions()
+            disruption = disruption_helpers.Disruptions().get_disruptor()
             disruption.set_resource(resource=f"{pod_name}")
             disruption.delete_resource()
 

--- a/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
@@ -195,7 +195,7 @@ class Testopenshiftloggingonocs(E2ETest):
         project1 = dc_pvc_obj.project.namespace
 
         # Delete the OSD pod
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource="osd")
         disruption.delete_resource()
 

--- a/tests/e2e/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/e2e/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
@@ -315,7 +315,7 @@ class TestMonitoringBackedByOCS(E2ETest):
 
         # Re-spin the ceph pods(i.e mgr, mon, osd, mds) one by one
         resource_to_delete = ["mgr", "mon", "osd"]
-        disruption = Disruptions()
+        disruption = Disruptions().get_disruptor()
         for res_to_del in resource_to_delete:
             disruption.set_resource(resource=res_to_del)
             disruption.delete_resource()

--- a/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
@@ -66,7 +66,7 @@ class TestRegistryPodRespin(E2ETest):
 
         # Respin relevant pod
         log.info(f"Respin Ceph pod {pod_name}")
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=f"{pod_name}")
         disruption.delete_resource()
 

--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -57,7 +57,9 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
             "mgr",
         ]
         executor = ThreadPoolExecutor(max_workers=len(self.pvcs) + len(pods_to_delete))
-        disruption_ops = [disruption_helpers.Disruptions() for _ in pods_to_delete]
+        disruption_ops = [
+            disruption_helpers.Disruptions().get_disruptor() for _ in pods_to_delete
+        ]
         file_name = "file_clone"
 
         # Run IO

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -73,7 +73,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
         """
         pvc_size_expanded = 30
         executor = ThreadPoolExecutor(max_workers=len(self.pvcs))
-        disruption_ops = disruption_helpers.Disruptions()
+        disruption_ops = disruption_helpers.Disruptions().get_disruptor()
 
         # Run IO to fill some data
         log.info("Running IO on all pods to fill some data before PVC expansion.")

--- a/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -60,7 +60,9 @@ class TestResourceDeletionDuringSnapshotRestore(ManageTest):
             "mgr",
         ]
         executor = ThreadPoolExecutor(max_workers=len(self.pvcs) + len(pods_to_delete))
-        disruption_ops = [disruption_helpers.Disruptions() for _ in pods_to_delete]
+        disruption_ops = [
+            disruption_helpers.Disruptions().get_disruptor() for _ in pods_to_delete
+        ]
         file_name = "file_snap"
 
         # Run IO

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -135,7 +135,7 @@ class TestDaemonKillDuringResourceCreation(ManageTest):
         Deletion of 'resource_to_delete' daemon will be introduced while
         'operation_to_disrupt' is progressing.
         """
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         pod_functions = {
             "mds": partial(pod.get_mds_pods),
             "mon": partial(pod.get_mon_pods),

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -184,7 +184,7 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
             "rbdplugin_provisioner": partial(get_rbdfsplugin_provisioner_pods),
             "operator": partial(get_operator_pods),
         }
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_name)
         executor = ThreadPoolExecutor(max_workers=1)
 

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
@@ -171,7 +171,7 @@ class TestDaemonKillDuringCreationOperations(ManageTest):
 
         executor = ThreadPoolExecutor(max_workers=len(io_pods))
 
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_name)
 
         # Get number of pods of type 'resource_name'

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
@@ -266,7 +266,7 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
             "operator": partial(get_operator_pods),
         }
 
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_name)
         executor = ThreadPoolExecutor(max_workers=len(pod_objs) + len(rwx_pod_objs))
 

--- a/tests/manage/pv_services/test_delete_plugin_pod.py
+++ b/tests/manage/pv_services/test_delete_plugin_pod.py
@@ -9,7 +9,7 @@ from ocs_ci.helpers import disruption_helpers
 
 log = logging.getLogger(__name__)
 
-DISRUPTION_OPS = disruption_helpers.Disruptions()
+DISRUPTION_OPS = disruption_helpers.Disruptions().get_disruptor()
 
 
 @tier4

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -22,7 +22,7 @@ from ocs_ci.helpers import helpers, disruption_helpers
 
 
 logger = logging.getLogger(__name__)
-DISRUPTION_OPS = disruption_helpers.Disruptions()
+DISRUPTION_OPS = disruption_helpers.Disruptions().get_disruptor()
 
 
 @tier4

--- a/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
+++ b/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 
 log = logging.getLogger(__name__)
-DISRUPTION_OPS = disruption_helpers.Disruptions()
+DISRUPTION_OPS = disruption_helpers.Disruptions().get_disruptor()
 
 
 @pytest.mark.parametrize(

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -14,7 +14,7 @@ from ocs_ci.helpers import helpers, disruption_helpers
 
 logger = logging.getLogger(__name__)
 
-DISRUPTION_OPS = disruption_helpers.Disruptions()
+DISRUPTION_OPS = disruption_helpers.Disruptions().get_disruptor()
 
 
 @pytest.mark.skip(

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -54,7 +54,7 @@ class DisruptionBase(ManageTest):
             "rbdplugin_provisioner": partial(get_rbdfsplugin_provisioner_pods),
             "operator": partial(get_operator_pods),
         }
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         executor = ThreadPoolExecutor(max_workers=1)
 

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -195,7 +195,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         executor = ThreadPoolExecutor(max_workers=len(io_pods))
 
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
 
         # Get number of pods of type 'resource_to_delete'

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -287,7 +287,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             "operator": partial(get_operator_pods),
         }
 
-        disruption = disruption_helpers.Disruptions()
+        disruption = disruption_helpers.Disruptions().get_disruptor()
         disruption.set_resource(resource=resource_to_delete)
         executor = ThreadPoolExecutor(max_workers=len(pod_objs) + len(rwx_pod_objs))
 

--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -460,7 +460,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
 
         disruptor = []
         for resource in provisioner_resource:
-            disruption = disruption_helpers.Disruptions()
+            disruption = disruption_helpers.Disruptions().get_disruptor()
             disruption.set_resource(resource=resource)
             disruptor.append(disruption)
 

--- a/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
@@ -74,7 +74,7 @@ class TestAddCapacityWithResourceDelete:
             max_iterations (int): Maximum times of iterations to delete the given resource
 
         """
-        d = Disruptions()
+        d = Disruptions().get_disruptor()
 
         for i in range(max_iterations):
             logging.info(
@@ -160,7 +160,7 @@ class TestAddCapacityWithResourceDelete:
         osd_pods_before = pod_helpers.get_osd_pods()
         number_of_osd_pods_before = len(osd_pods_before)
 
-        d = Disruptions()
+        d = Disruptions().get_disruptor()
         d.set_resource(resource_name)
 
         self.new_pods_in_status_running = False

--- a/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -117,7 +117,7 @@ class TestKillCephDaemon(ManageTest):
                 raise Exception(f"The ceph-{daemon_type} process-id was not found.")
 
             log.info(f"Kill ceph-{daemon_type} process-id {pid}")
-            disruptions_obj = Disruptions()
+            disruptions_obj = Disruptions().get_disruptor()
             disruptions_obj.daemon_pid = pid
             disruptions_obj.kill_daemon(
                 node_name=node_name, check_new_pid=False, kill_signal="11"


### PR DESCRIPTION
This PR has the following changes related to disruptive operations utilities and tests:
    * Update disruption_helpers.py to use factory design and implement methods for external mode cluster
    * Update methods in utils.py to work with any Ceph daemon
    * Refactor code in existing tests to align with factory design of disruption_helpers.py