### PR TITLE
Add tier 1 CRD namespace tests to test_namespace

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -300,6 +300,8 @@ MCG_BACKINGSTORE_SECRET_YAML = os.path.join(TEMPLATE_MCG_DIR, "BackingStoreSecre
 
 MCG_BACKINGSTORE_YAML = os.path.join(TEMPLATE_MCG_DIR, "BackingStore.yaml")
 
+MCG_NAMESPACESTORE_YAML = os.path.join(TEMPLATE_MCG_DIR, "NamespaceStore.yaml")
+
 PV_BACKINGSTORE_YAML = os.path.join(TEMPLATE_MCG_DIR, "PVBackingStore.yaml")
 
 MCG_BUCKETCLASS_YAML = os.path.join(TEMPLATE_MCG_DIR, "BucketClass.yaml")
@@ -1076,8 +1078,12 @@ BM_STATUS_RESPONSE_UPDATED = "UPDATED"
 MCG_NS_AWS_ENDPOINT = "https://s3.amazonaws.com"
 MCG_NS_AZURE_ENDPOINT = "https://blob.core.windows.net"
 MCG_NS_RESOURCE = "ns_resource"
+MCG_NSS = "ns-store"
 MCG_NS_BUCKET = "ns-bucket"
 MCG_CONNECTION = "connection"
+NAMESPACE_POLICY_TYPE_SINGLE = "Single"
+NAMESPACE_POLICY_TYPE_MULTI = "Multi"
+NAMESPACE_POLICY_TYPE_CACHE = "Cache"
 
 # Cloud provider default endpoints
 # Upon use, utilize .format() to replace the curly braces where necessary

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -83,6 +83,7 @@ class CloudManager(ABC):
             endpoint, access_key, secret_key = rgw_conn.get_credentials()
             cred_dict["RGW"] = {
                 "SECRET_PREFIX": "RGW",
+                "DATA_PREFIX": "AWS",
                 "ENDPOINT": endpoint,
                 "RGW_ACCESS_KEY_ID": access_key,
                 "RGW_SECRET_ACCESS_KEY": secret_key,
@@ -153,6 +154,7 @@ class S3Client(CloudClient):
         super().__init__(*args, **kwargs)
 
         secret_prefix = auth_dict.get("SECRET_PREFIX", "AWS")
+        data_prefix = auth_dict.get("DATA_PREFIX", "AWS")
         key_id = auth_dict.get(f"{secret_prefix}_ACCESS_KEY_ID")
         access_key = auth_dict.get(f"{secret_prefix}_SECRET_ACCESS_KEY")
         self.endpoint = auth_dict.get("ENDPOINT") or endpoint
@@ -167,8 +169,7 @@ class S3Client(CloudClient):
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
         )
-
-        self.secret = self.create_s3_secret(secret_prefix)
+        self.secret = self.create_s3_secret(secret_prefix, data_prefix)
 
     def internal_create_uls(self, name, region=None):
         """
@@ -313,7 +314,7 @@ class S3Client(CloudClient):
         else:
             self.client.meta.client.delete_bucket_policy(Bucket=aws_bucket_name)
 
-    def create_s3_secret(self, secret_prefix):
+    def create_s3_secret(self, secret_prefix, data_prefix):
         """
         Create a Kubernetes secret to allow NooBaa to create AWS-based backingstores
 
@@ -326,10 +327,10 @@ class S3Client(CloudClient):
         )
         bs_secret_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
         bs_secret_data["data"][
-            f"{secret_prefix}_ACCESS_KEY_ID"
+            f"{data_prefix}_ACCESS_KEY_ID"
         ] = base64.urlsafe_b64encode(self.access_key.encode("UTF-8")).decode("ascii")
         bs_secret_data["data"][
-            f"{secret_prefix}_SECRET_ACCESS_KEY"
+            f"{data_prefix}_SECRET_ACCESS_KEY"
         ] = base64.urlsafe_b64encode(self.secret_key.encode("UTF-8")).decode("ascii")
 
         return create_resource(**bs_secret_data)

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -593,7 +593,60 @@ class MCG:
             },
         )
         logger.info(f"result from RPC call: {result}")
+        return target_bucket_name
 
+    def create_namespace_store(
+        self, nss_name, region, cld_mgr, cloud_uls_factory, platform
+    ):
+        """
+        Creates a new namespace store
+
+        Args:
+            nss_name (str): The name to be given to the new namespace store
+            region (str): The region name to be used
+            cld_mgr: A cloud manager instance
+            cloud_uls_factory: The cloud uls factory
+            platform (str): The platform resource name
+
+        Returns:
+            str: The name of the created target_bucket_name (cloud uls)
+        """
+        # Create the actual target bucket on AWS
+        uls_dict = cloud_uls_factory({platform: [(1, region)]})
+        target_bucket_name = list(uls_dict[platform])[0]
+
+        nss_data = templating.load_yaml(constants.MCG_NAMESPACESTORE_YAML)
+        nss_data["metadata"]["name"] = nss_name
+        nss_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+
+        NSS_MAPPING = {
+            constants.AWS_PLATFORM: {
+                "type": "aws-s3",
+                "awsS3": {
+                    "targetBucket": target_bucket_name,
+                    "secret": {"name": cld_mgr.aws_client.secret.name},
+                },
+            },
+            constants.AZURE_PLATFORM: {
+                "type": "azure-blob",
+                "azureBlob": {
+                    "targetBlobContainer": target_bucket_name,
+                    "secret": {"name": cld_mgr.azure_client.secret.name},
+                },
+            },
+            constants.RGW_PLATFORM: {
+                "type": "s3-compatible",
+                "s3Compatible": {
+                    "targetBucket": target_bucket_name,
+                    "endpoint": cld_mgr.rgw_client.endpoint,
+                    "signatureVersion": "v4",
+                    "secret": {"name": cld_mgr.rgw_client.secret.name},
+                },
+            },
+        }
+
+        nss_data["spec"] = NSS_MAPPING[platform]
+        create_resource(**nss_data)
         return target_bucket_name
 
     def check_ns_resource_validity(
@@ -628,6 +681,7 @@ class MCG:
             f"The NS resource named {ns_resource_name} got wrong endpoint "
             f"{actual_endpoint} ≠ {endpoint}"
         )
+        return True
 
     def delete_ns_connection(self, ns_connection_name):
         """
@@ -653,13 +707,14 @@ class MCG:
             "pool_api", "delete_namespace_resource", {"name": ns_resource_name}
         )
 
-    def oc_create_bucketclass(self, name, backingstores, placement):
+    def oc_create_bucketclass(self, name, backingstores, placement, namespace_policy):
         """
         Creates a new NooBaa bucket class using a template YAML
         Args:
             name (str): The name to be given to the bucket class
             backingstores (list): The backing stores to use as part of the policy
             placement (str): The placement policy to be used - Mirror | Spread
+            namespace_policy (dict): The namespace policy to be used
 
         Returns:
             OCS: The bucket class resource
@@ -668,9 +723,37 @@ class MCG:
         bc_data = templating.load_yaml(constants.MCG_BUCKETCLASS_YAML)
         bc_data["metadata"]["name"] = name
         bc_data["metadata"]["namespace"] = self.namespace
-        tiers = bc_data["spec"]["placementPolicy"]["tiers"][0]
-        tiers["backingStores"] = [backingstore.name for backingstore in backingstores]
-        tiers["placement"] = placement
+        bc_data["spec"] = {}
+
+        if (backingstores is not None) and (placement is not None):
+            bc_data["spec"]["placementPolicy"] = {"tiers": [{}]}
+            tiers = bc_data["spec"]["placementPolicy"]["tiers"][0]
+            tiers["backingStores"] = [
+                backingstore.name for backingstore in backingstores
+            ]
+            tiers["placement"] = placement
+
+        if namespace_policy is not None:
+            bc_data["spec"]["namespacePolicy"] = {}
+            ns_policy = bc_data["spec"]["namespacePolicy"]
+            ns_policy_type = namespace_policy.get("type")
+            ns_policy["type"] = ns_policy_type
+
+            if ns_policy_type == constants.NAMESPACE_POLICY_TYPE_SINGLE:
+                ns_policy["single"] = {"resource": namespace_policy.get("resource")}
+
+            elif ns_policy_type == constants.NAMESPACE_POLICY_TYPE_MULTI:
+                ns_policy["multi"] = {
+                    "writeResource": namespace_policy.get("write_resource"),
+                    "readResources": namespace_policy.get("read_resources"),
+                }
+
+            elif ns_policy_type == constants.NAMESPACE_POLICY_TYPE_CACHE:
+                ns_policy["cache"] = {
+                    "hubResource": namespace_policy.get("hub_resource"),
+                    "ttl": namespace_policy.get("ttl"),
+                }
+
         return create_resource(**bc_data)
 
     def cli_create_bucketclass(self, name, backingstores, placement):

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -1,0 +1,162 @@
+import logging
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.exceptions import UnsupportedPlatformError
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.resources.rgw import RGW
+
+log = logging.getLogger(__name__)
+
+
+class NamespaceStore:
+    """
+    A class that represents NamespaceStore objects
+
+    """
+
+    def __init__(
+        self,
+        name,
+        method,
+        uls_name=None,
+        secret_name=None,
+        mcg_obj=None,
+    ):
+        self.name = name
+        self.method = method
+        self.uls_name = uls_name
+        self.secret_name = secret_name
+        self.mcg_obj = mcg_obj
+
+    def delete(self):
+        log.info(f"Cleaning up namespacestore {self.name}")
+
+        if self.method == "oc":
+            OCP(
+                kind="namespacestore", namespace=config.ENV_DATA["cluster_namespace"]
+            ).delete(resource_name=self.name)
+        elif self.method == "cli":
+
+            def _cli_deletion_flow():
+                try:
+                    self.mcg_obj.exec_mcg_cmd(f"namespacestore delete {self.name}")
+                    return True
+                except CommandFailed as e:
+                    if "being used by one or more buckets" in str(e).lower():
+                        log.warning(
+                            f"Deletion of {self.name} failed because it's being used by a bucket. "
+                            "Retrying..."
+                        )
+                        return False
+
+            sample = TimeoutSampler(
+                timeout=120,
+                sleep=20,
+                func=_cli_deletion_flow,
+            )
+            if not sample.wait_for_func_status(result=True):
+                log.error(f"Failed to {self.name}")
+                raise TimeoutExpiredError
+
+        log.info(f"Verifying whether namespacestore {self.name} exists after deletion")
+        ns_deleted_successfully = False
+
+        try:
+            if self.method == "oc":
+                OCP(
+                    kind="namespacestore",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    resource_name=self.name,
+                ).get()
+            elif self.method == "cli":
+                self.mcg_obj.exec_mcg_cmd(f"namespacestore status {self.name}")
+
+        except CommandFailed as e:
+            if "Not Found" in str(e) or "NotFound" in str(e):
+                ns_deleted_successfully = True
+            else:
+                raise
+
+        assert (
+            ns_deleted_successfully
+        ), f"Namespacestore {self.name} was not deleted successfully"
+
+
+def namespace_store_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
+    """
+    Create a namespace store factory. Calling this fixture creates a new namespace store.
+
+    """
+    created_nss = []
+
+    def _create_nss(platform=constants.AWS_PLATFORM):
+
+        # Create the actual namespace resource
+        rand_nss_name = create_unique_resource_name(constants.MCG_NSS, platform)
+        if platform == constants.RGW_PLATFORM:
+            region = None
+        else:
+            # TODO: fix this when https://github.com/red-hat-storage/ocs-ci/issues/3338
+            # is resolved
+            region = "us-east-2"
+
+        target_bucket_name = mcg_obj.create_namespace_store(
+            rand_nss_name,
+            region,
+            cld_mgr,
+            cloud_uls_factory,
+            platform,
+        )
+
+        log.info(f"Check validity of NS store {rand_nss_name}")
+        if platform == constants.AWS_PLATFORM:
+            endpoint = constants.MCG_NS_AWS_ENDPOINT
+        elif platform == constants.AZURE_PLATFORM:
+            endpoint = constants.MCG_NS_AZURE_ENDPOINT
+        elif platform == constants.RGW_PLATFORM:
+            rgw_conn = RGW()
+            endpoint, _, _ = rgw_conn.get_credentials()
+        else:
+            raise UnsupportedPlatformError(f"Unsupported Platform: {platform}")
+
+        sample = TimeoutSampler(
+            timeout=60,
+            sleep=5,
+            func=mcg_obj.check_ns_resource_validity,
+            ns_resource_name=rand_nss_name,
+            target_bucket_name=target_bucket_name,
+            endpoint=endpoint,
+        )
+        if not sample.wait_for_func_status(result=True):
+            log.error(f"Failed to check validty for ${rand_nss_name}")
+            raise TimeoutExpiredError
+
+        created_nss.append(
+            NamespaceStore(
+                name=rand_nss_name,
+                method="oc",
+                mcg_obj=mcg_obj,
+            )
+        )
+        return target_bucket_name, rand_nss_name
+
+    def nss_cleanup():
+        for nss in created_nss:
+            try:
+                nss.delete()
+            except CommandFailed as e:
+                if "not found" in str(e).lower():
+                    log.warning(
+                        f"Namespacestore {nss.name} could not be found in cleanup."
+                        "\nSkipping deletion."
+                    )
+                else:
+                    raise
+
+    request.addfinalizer(nss_cleanup)
+
+    return _create_nss

--- a/ocs_ci/templates/mcg/NamespaceStore.yaml
+++ b/ocs_ci/templates/mcg/NamespaceStore.yaml
@@ -1,8 +1,10 @@
+---
 apiVersion: noobaa.io/v1alpha1
-kind: BucketClass
+kind: NamespaceStore
 metadata:
-  name: default
+  name: namespace-store
   namespace: openshift-storage
   labels:
     app: noobaa
-spec:
+  finalizers:
+    - noobaa.io/finalizer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,11 @@ from ocs_ci.ocs.utils import setup_ceph_toolbox, collect_ocs_logs
 from ocs_ci.ocs.resources.backingstore import (
     backingstore_factory as backingstore_factory_implementation,
 )
+
+from ocs_ci.ocs.resources.namespacestore import (
+    namespace_store_factory as namespacestore_factory_implementation,
+)
+
 from ocs_ci.ocs.resources.bucketclass import (
     bucket_class_factory as bucketclass_factory_implementation,
 )
@@ -2882,6 +2887,40 @@ def ns_resource_factory(
     request.addfinalizer(ns_resources_cleanup)
 
     return _create_ns_resources
+
+
+@pytest.fixture()
+def namespace_store_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
+    """
+    Create a Namespace Store factory.
+    Calling this fixture creates a new Namespace Store(s).
+
+    Returns:
+        func: Factory method - each call to this function creates
+            a namespacestore
+
+    """
+    return namespacestore_factory_implementation(
+        request, cld_mgr, mcg_obj, cloud_uls_factory
+    )
+
+
+@pytest.fixture(scope="session")
+def namespace_store_factory_session(
+    request, cld_mgr, mcg_obj_session, cloud_uls_factory_session
+):
+    """
+    Create a Namespace Store factory.
+    Calling this fixture creates a new Namespace Store(s).
+
+    Returns:
+        func: Factory method - each call to this function creates
+            a namespacestore
+
+    """
+    return namespacestore_factory_implementation(
+        request, cld_mgr, mcg_obj_session, cloud_uls_factory_session
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
Signed-off-by: Romy <romy2232@gmail.com>

1. Added ns_store factory.
2. Added NamespaceStore template and updated the bucketclass template.
2. Added namespace policy for bucketclass creation (used for the creation of namespace buckets)
3. Updated tier1 tests in test_namespace.py
4. Fixed a bug when creating a secret for s3_client of type RGW - noobaa expects for "AWS_ACCESS_KEY_ID"
and "AWS_SECRET_ACCESS_KEY" and not RGW prefix.