### PR TITLE
Handle GCP ULS deletion race condition

### DIFF
--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -410,6 +410,7 @@ class GoogleClient(CloudClient):
                 logger.warning(
                     "Failed to delete some of the bucket blobs. Retrying..."
                 )
+                sleep(10)
 
     def get_all_uls_names(self):
         """

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -406,11 +406,10 @@ class GoogleClient(CloudClient):
                 bucket.delete_blobs(bucket.list_blobs())
                 bucket.delete()
                 break
-            except ClientError:  # TODO: Find relevant exception
-                logger.info(
-                    f"Deletion of Underlying Storage {name} failed. Retrying..."
+            except GoogleExceptions.NotFound:
+                logger.warning(
+                    "Failed to delete some of the bucket blobs. Retrying..."
                 )
-                sleep(3)
 
     def get_all_uls_names(self):
         """

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -407,9 +407,7 @@ class GoogleClient(CloudClient):
                 bucket.delete()
                 break
             except GoogleExceptions.NotFound:
-                logger.warning(
-                    "Failed to delete some of the bucket blobs. Retrying..."
-                )
+                logger.warning("Failed to delete some of the bucket blobs. Retrying...")
                 sleep(10)
 
     def get_all_uls_names(self):


### PR DESCRIPTION
As part of `test_bucket_deletion`, we delete an OBC containing objects.
This means that NB has to delete all the objects by itself once the OBC is deleted.
However, we proceed to try and clean up + delete the ULS once the test is done, and it seems like we ran into a race condition where both we and NB try to delete the same blobs.
This PR should retry blob deletion until the bucket is completely empty and ready for removal.