### PR TITLE
Move RPLogHandler import to prevent PytestAssertRewriteWarning

### DIFF
--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -3,7 +3,6 @@ import pytest
 import logging
 from py.xml import html
 from ocs_ci.utility.utils import email_reports
-from pytest_reportportal import RPLogHandler
 from ocs_ci.framework import config as ocsci_config
 
 
@@ -43,6 +42,7 @@ def pytest_runtest_makereport(item, call):
     """
     Add extra column( Log File) and link the log file location
     """
+    from pytest_reportportal import RPLogHandler
     pytest_html = item.config.pluginmanager.getplugin("html")
     outcome = yield
     report = outcome.get_result()

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -43,6 +43,7 @@ def pytest_runtest_makereport(item, call):
     Add extra column( Log File) and link the log file location
     """
     from pytest_reportportal import RPLogHandler
+
     pytest_html = item.config.pluginmanager.getplugin("html")
     outcome = yield
     report = outcome.get_result()


### PR DESCRIPTION
Closes #1862
Checked locally and the warning does not appear anymore after moving the import.
Needs more thorough verification.