### PR TITLE
Adding retries to get Catalog Source for OCS Internal Operator

### DIFF
--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -56,7 +56,7 @@ class PackageManifest(OCP):
             kind="packagemanifest",
             **kwargs,
         )
-
+    @retry(ResourceNotFoundError, tries=100, delay=5, backoff=1)
     def get(self, **kwargs):
         """
         Overloaded get method from OCP class.

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -56,6 +56,7 @@ class PackageManifest(OCP):
             kind="packagemanifest",
             **kwargs,
         )
+
     @retry(ResourceNotFoundError, tries=100, delay=5, backoff=1)
     def get(self, **kwargs):
         """

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -57,7 +57,7 @@ class PackageManifest(OCP):
             **kwargs,
         )
 
-    @retry(ResourceNotFoundError, tries=100, delay=5, backoff=1)
+    @retry(ResourceNotFoundError, tries=10, delay=10, backoff=1)
     def get(self, **kwargs):
         """
         Overloaded get method from OCP class.


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/3285

Verification: https://ocs4-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/qe-deploy-ocs-cluster/15944/consoleFull
(You can ctrl+f `kind: CatalogSource` to see results)
