### PR TITLE
Improve internal ElasticSearch module

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2800,7 +2800,7 @@ def get_full_test_logs_path(cname):
     this function use the inspect module to find the name of the caller function, so it need
     to be call once from the main test function.
     the output is in the form of :
-      ocsci_log_path/<full test file path>/<test filename>/<test class name>/<test function name>
+        ocsci_log_path/<full test file path>/<test filename>/<test class name>/<test function name>
 
     Args:
         cname (obj): the Class object which was run and called this function

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2799,8 +2799,8 @@ def get_full_test_logs_path(cname):
 
     this function use the inspect module to find the name of the caller function, so it need
     to be call once from the main test function.
-    the output is in the form of :
-        ocsci_log_path/<full test file path>/<test filename>/<test class name>/<test function name>
+    the output is in the form of
+    ocsci_log_path/<full test file path>/<test filename>/<test class name>/<test function name>
 
     Args:
         cname (obj): the Class object which was run and called this function

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -12,6 +12,7 @@ import statistics
 import tempfile
 import threading
 import time
+import inspect
 from concurrent.futures import ThreadPoolExecutor
 from subprocess import PIPE, TimeoutExpired, run
 from uuid import uuid4
@@ -2790,3 +2791,27 @@ def fetch_used_size(cbp_name, exp_val=None):
             f"matching. Retrying"
         )
     return used_in_gb
+
+
+def get_full_logs_path(cname):
+    """
+    Getting the full path of the logs file for particular test
+
+    Args:
+        cname (obj): the Class object which was run and call this function
+
+    Return:
+        str : full path of the logs relative to the ocs-ci base path
+
+    """
+
+    # the module path relative to ocs-ci base path
+    log_file_name = (inspect.stack()[1][1]).replace(f"{os.getcwd()}/", "")
+
+    # The name of the class
+    mname = type(cname).__name__
+
+    # the full log path (relative to ocs-ci base path)
+    full_log = f"{ocsci_log_path()}/{log_file_name}/{mname}/{inspect.stack()[1][3]}"
+
+    return full_log

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2793,15 +2793,20 @@ def fetch_used_size(cbp_name, exp_val=None):
     return used_in_gb
 
 
-def get_full_logs_path(cname):
+def get_full_test_logs_path(cname):
     """
     Getting the full path of the logs file for particular test
 
+    this function use the inspect module to find the name of the caller function, so it need
+    to be call once from the main test function.
+    the output is in the form of :
+      ocsci_log_path/<full test file path>/<test filename>/<test class name>/<test function name>
+
     Args:
-        cname (obj): the Class object which was run and call this function
+        cname (obj): the Class object which was run and called this function
 
     Return:
-        str : full path of the logs relative to the ocs-ci base path
+        str : full path of the test logs relative to the ocs-ci base logs path
 
     """
 
@@ -2812,6 +2817,8 @@ def get_full_logs_path(cname):
     mname = type(cname).__name__
 
     # the full log path (relative to ocs-ci base path)
-    full_log = f"{ocsci_log_path()}/{log_file_name}/{mname}/{inspect.stack()[1][3]}"
+    full_log_path = (
+        f"{ocsci_log_path()}/{log_file_name}/{mname}/{inspect.stack()[1][3]}"
+    )
 
-    return full_log
+    return full_log_path

--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -1,5 +1,5 @@
 """
-Deploying en Elasticsearch server for collecting logs from ripsaw benchmarks.
+Deploying an Elasticsearch server for collecting logs from ripsaw benchmarks.
 Interface for the Performance ElasticSearch server
 
 """
@@ -51,7 +51,7 @@ def elasticsearch_load(connection, target_path):
             log.error(f"Can not connect to the main ES server on {connection}")
             return False
         for ind in all_files:
-            if ".data." in ind:  # load only data files and noy mapping info
+            if ".data." in ind:  # load only data files and not mapping info
                 file_name = f"{target_path}/results/{ind}"
                 ind_name = ind.split(".")[0]
                 log.info(f"Loading the {ind} data into the ES server")
@@ -240,11 +240,11 @@ class ElasticSearch(object):
         """
         log.info("Teardown the Elasticsearch environment")
         log.info("Deleting all resources")
-        log.info("deleting the dumper client pod")
+        log.info("Deleting the dumper client pod")
         self.ocp.delete(yaml_file=self.dumper_file)
-        log.info("deleting the es resource")
+        log.info("Deleting the es resource")
         self.ocp.delete(yaml_file=self.crd)
-        log.info("deleting the es project")
+        log.info("Deleting the es project")
         self.ns_obj.delete_project(project_name=self.namespace)
         self.ns_obj.wait_for_delete(resource_name=self.namespace, timeout=180)
 

--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -1,13 +1,12 @@
 """
-Deploying en Elasticsearch server for collecting logs from ripsaw benchmarks
+Deploying en Elasticsearch server for collecting logs from ripsaw benchmarks.
+Interface for the Performance ElasticSearch server
 
 """
-import os
 import logging
 import base64
-import signal
-import subprocess
 import time
+import json
 
 from elasticsearch import Elasticsearch, exceptions as esexp
 
@@ -15,8 +14,59 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.helpers.performance_lib import run_command
 
 log = logging.getLogger(__name__)
+
+# mute the elasticsearch logging
+es_log = logging.getLogger("elasticsearch")
+es_log.setLevel(logging.CRITICAL)
+
+
+def elasticsearch_load(connection, target_path):
+    """
+    Load all data from target_path/results into an elasticsearch (es) server.
+
+    Args:
+        connection (dict): a dictionary with the main elasticsearch server information
+          {host: the server ip address, port: the port to connect}
+        target_path (str): the path where data was dumped into
+
+    Returns:
+        bool: True if loading data succeed, False otherwise
+
+    """
+
+    all_files = run_command(f"ls {target_path}/results/", out_format="list")
+    if "Error in command" in all_files:
+        log.error("There is No data to load into ES server")
+        return False
+    else:
+        log.info(f"Loading data from {target_path} to ES server at {connection}")
+        try:
+            log.info(f"Creating new ES connection to {connection}")
+            main_es = Elasticsearch([connection])
+            log.debug(f"Connection info : {main_es}")
+        except esexp.ConnectionError:
+            log.error(f"Can not connect to the main ES server on {connection}")
+            return False
+        for ind in all_files:
+            if ".data." in ind:  # load only data files and noy mapping info
+                file_name = f"{target_path}/results/{ind}"
+                ind_name = ind.split(".")[0]
+                log.info(f"Loading the {ind} data into the ES server")
+                with open(file_name) as json_file:
+                    while True:
+                        line = json_file.readline()
+                        if line:
+                            full_data = json.loads(line)
+                            log.debug(f"Loading {full_data} into the ES")
+                            main_es.index(
+                                index=ind_name, doc_type="_doc", body=full_data
+                            )
+                        else:
+                            break
+        return True
 
 
 class ElasticSearch(object):
@@ -32,9 +82,9 @@ class ElasticSearch(object):
         log.info("Initializing the Elastic-Search environment object")
         self.namespace = "elastic-system"
         self.eck_file = "ocs_ci/templates/app-pods/eck.1.3.1-all-in-one.yaml"
+        self.dumper_file = "ocs_ci/templates/app-pods/esclient.yaml"
         self.pvc = "ocs_ci/templates/app-pods/es-pvc.yaml"
         self.crd = "ocs_ci/templates/app-pods/esq.yaml"
-        self.lspid = None
 
         # Creating some different types of OCP objects
         self.ocp = OCP(
@@ -66,8 +116,7 @@ class ElasticSearch(object):
                 time.sleep(30)
                 timeout -= 30
 
-        # Starting LocalServer process - port forwarding
-        self.local_server()
+        self._deploy_dump_client()
 
         # Connect to the server
         self.con = self._es_connect()
@@ -92,6 +141,27 @@ class ElasticSearch(object):
                     break
             except IndexError:
                 log.info("ECK operator pod not ready yet")
+
+    def _deploy_dump_client(self):
+        """
+        Deploying elastic search client pod with utility which dump all the data
+        from the server to .tgz file
+
+        """
+
+        log.info("Deploying the es client for dumping all data")
+        self.ocp.apply(self.dumper_file)
+
+        for dmp_pod in TimeoutSampler(
+            300, 10, get_pod_name_by_pattern, "es-dumper", self.namespace
+        ):
+            try:
+                if dmp_pod[0] is not None:
+                    self.dump_pod = dmp_pod[0]
+                    log.info(f"The dumper client pod {self.dump_pod} is ready !")
+                    break
+            except IndexError:
+                log.info("Dumper pod not ready yet")
 
     def get_ip(self):
         """
@@ -169,29 +239,18 @@ class ElasticSearch(object):
 
         """
         log.info("Teardown the Elasticsearch environment")
-        log.info(f"Killing the local server process ({self.lspid})")
-        os.kill(self.lspid, signal.SIGKILL)
         log.info("Deleting all resources")
-        subprocess.run(f"oc delete -f {self.crd}", shell=True)
+        log.info("deleting the dumper client pod")
+        self.ocp.delete(yaml_file=self.dumper_file)
+        log.info("deleting the es resource")
+        self.ocp.delete(yaml_file=self.crd)
+        log.info("deleting the es project")
         self.ns_obj.delete_project(project_name=self.namespace)
         self.ns_obj.wait_for_delete(resource_name=self.namespace, timeout=180)
 
-    def local_server(self):
-        """
-        Starting sub-process that will do port-forwarding, to allow access from
-        outside the open-shift cluster into the Elasticsearch server.
-
-        """
-        cmd = f"oc -n {self.namespace } "
-        cmd += f"port-forward service/quickstart-es-http {self.get_port()}"
-        log.info(f"Going to run : {cmd}")
-        proc = subprocess.Popen(cmd, shell=True)
-        log.info(f"Starting LocalServer with PID of {proc.pid}")
-        self.lspid = proc.pid
-
     def _es_connect(self):
         """
-        Create a connection to the ES via the localhost port-fwd
+        Create a connection to the local ES
 
         Returns:
             Elasticsearch: elasticsearch connection object
@@ -201,7 +260,7 @@ class ElasticSearch(object):
 
         """
         try:
-            es = Elasticsearch([{"host": "localhost", "port": self.get_port()}])
+            es = Elasticsearch([{"host": self.get_ip(), "port": self.get_port()}])
         except esexp.ConnectionError:
             log.error("Can not connect to ES server in the LocalServer")
             raise
@@ -224,11 +283,13 @@ class ElasticSearch(object):
 
     def _copy(self, es):
         """
-        Copy All data from the internal ES server to the main ES
+        Copy All data from the internal ES server to the main ES.
+
+        **This is deprecated function** , use the dump function, and load
+        the data from the files for the main ES server
 
         Args:
             es (obj): elasticsearch object which connected to the main ES
-
         """
 
         query = {"size": 1000, "query": {"match_all": {}}}
@@ -245,3 +306,38 @@ class ElasticSearch(object):
             for doc in result["hits"]["hits"]:
                 log.debug(f"Going to write : {doc}")
                 es.index(index=ind, doc_type="_doc", body=doc["_source"])
+
+    def dump(self, target_path):
+        """
+        Dump All data from the internal ES server to .tgz file.
+
+        Args:
+            target_path (str): the path where the results file will be copy into
+
+        Return:
+            bool: True if the dump operation succeed and return the results data to the host
+                  otherwise False
+        """
+
+        log.info("dumping data from ES server to .tgz file")
+        rsh_cmd = f"rsh {self.dump_pod} /elasticsearch-dump/esdumper.py --ip {self.get_ip()} --port {self.get_port()}"
+        result = self.ocp.exec_oc_cmd(rsh_cmd, out_yaml_format=False, timeout=1200)
+        if "ES dump is done." not in result:
+            log.error("There is no data in the Elasticsearch server")
+            return False
+        else:
+            src_file = result.split()[-1]
+            log.info(f"Copy {src_file} from the client pod")
+
+            cp_command = f"cp {self.dump_pod}:{src_file} {target_path}/FullResults.tgz"
+            result = self.ocp.exec_oc_cmd(cp_command, timeout=120)
+            log.info(f"The output from the POD is {result}")
+            log.info("Extracting the FullResults.tgz file")
+            kwargs = {"cwd": target_path}
+            results = run_command(f"tar zxvf {target_path}/FullResults.tgz", **kwargs)
+            log.warning(f"The untar results is {results}")
+            if "Error in command" in results:
+                log.warning("Can not untar the dumped file")
+                return False
+
+        return True

--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -116,7 +116,7 @@ class ElasticSearch(object):
                 time.sleep(30)
                 timeout -= 30
 
-        self._deploy_dump_client()
+        self._deploy_data_dumper_client()
 
         # Connect to the server
         self.con = self._es_connect()
@@ -142,7 +142,7 @@ class ElasticSearch(object):
             except IndexError:
                 log.info("ECK operator pod not ready yet")
 
-    def _deploy_dump_client(self):
+    def _deploy_data_dumper_client(self):
         """
         Deploying elastic search client pod with utility which dump all the data
         from the server to .tgz file
@@ -307,7 +307,7 @@ class ElasticSearch(object):
                 log.debug(f"Going to write : {doc}")
                 es.index(index=ind, doc_type="_doc", body=doc["_source"])
 
-    def dump(self, target_path):
+    def dumping_all_data(self, target_path):
         """
         Dump All data from the internal ES server to .tgz file.
 

--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -335,7 +335,7 @@ class ElasticSearch(object):
             log.info("Extracting the FullResults.tgz file")
             kwargs = {"cwd": target_path}
             results = run_command(f"tar zxvf {target_path}/FullResults.tgz", **kwargs)
-            log.warning(f"The untar results is {results}")
+            log.debug(f"The untar results is {results}")
             if "Error in command" in results:
                 log.warning("Can not untar the dumped file")
                 return False

--- a/ocs_ci/templates/app-pods/esclient.yaml
+++ b/ocs_ci/templates/app-pods/esclient.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
    - name: esdumpper
-     image: quay.io/avili/esdump:v0.1
+     image: quay.io/ocsci/esdump:latest
      imagePullPolicy: Always
      command: ['/bin/bash']
      stdin: true

--- a/ocs_ci/templates/app-pods/esclient.yaml
+++ b/ocs_ci/templates/app-pods/esclient.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: es-dumper
+  namespace: elastic-system
+spec:
+  containers:
+   - name: esdumpper
+     image: quay.io/avili/esdump:v0.1
+     imagePullPolicy: Always
+     command: ['/bin/bash']
+     stdin: true
+     tty: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ from ocs_ci.ocs.resources.rgw import RGW
 from ocs_ci.ocs.jenkins import Jenkins
 from ocs_ci.ocs.couchbase import CouchBase
 from ocs_ci.ocs.amq import AMQ
+from ocs_ci.ocs.elasticsearch import ElasticSearch
 
 log = logging.getLogger(__name__)
 
@@ -3523,3 +3524,21 @@ def multiple_snapshot_and_clone_of_postgres_pvc_factory(
 
     request.addfinalizer(finalizer)
     return factory
+
+
+@pytest.fixture()
+def es(request):
+    """
+    Create In-cluster elastic-search deployment for benchmark-operator tests.
+
+    using the name es - as shortcut for elastic-search for simplicity
+    """
+
+    def teardown():
+        es.cleanup()
+
+    request.addfinalizer(teardown)
+
+    es = ElasticSearch()
+
+    return es

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,6 @@ import pytest
 from ocs_ci.ocs.resources.pod import delete_deploymentconfig_pods
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.ocs.elasticsearch import ElasticSearch
 
 
 @pytest.fixture()
@@ -340,21 +339,3 @@ def create_serviceaccount(request):
         namespace=class_instance.project_obj.namespace,
     )
     assert class_instance.sa_obj, "Failed to create serviceaccount"
-
-
-@pytest.fixture()
-def es(request):
-    """
-    Create In-cluster elastic-search deployment for benchmark-operator tests.
-
-    using the name es - as shortcut for elastcsearch for simplicity
-    """
-
-    def teardown():
-        es.cleanup()
-
-    request.addfinalizer(teardown)
-
-    es = ElasticSearch()
-
-    return es

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,6 +3,7 @@ import pytest
 from ocs_ci.ocs.resources.pod import delete_deploymentconfig_pods
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.elasticsearch import ElasticSearch
 
 
 @pytest.fixture()
@@ -339,3 +340,21 @@ def create_serviceaccount(request):
         namespace=class_instance.project_obj.namespace,
     )
     assert class_instance.sa_obj, "Failed to create serviceaccount"
+
+
+@pytest.fixture()
+def es(request):
+    """
+    Create In-cluster elastic-search deployment for benchmark-operator tests.
+
+    using the name es - as shortcut for elastcsearch for simplicity
+    """
+
+    def teardown():
+        es.cleanup()
+
+    request.addfinalizer(teardown)
+
+    es = ElasticSearch()
+
+    return es

--- a/tests/libtest/test_elasticsearch.py
+++ b/tests/libtest/test_elasticsearch.py
@@ -7,59 +7,106 @@ import time
 
 import pytest
 
-from ocs_ci.ocs.elasticsearch import ElasticSearch
-from elasticsearch import Elasticsearch, exceptions as esexp
-from subprocess import run
+from ocs_ci.ocs import defaults
+from tests.fixtures import es
+from ocs_ci.helpers.helpers import get_full_logs_path
+from ocs_ci.helpers.performance_lib import run_command
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.utils import get_pod_name_by_pattern
+from ocs_ci.ocs.ripsaw import RipSaw
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.elasticsearch import elasticsearch_load
 
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function")
-def es(request):
-    def teardown():
-        es.cleanup()
+@pytest.mark.usefixtures(
+    es.__name__,
+)
+class TestElasticsearch:
+    def smallfile_run(self, es):
+        """
+        Run the smallfiles workload so the elasticsearch server will have some data
+        in it for copy
 
-    request.addfinalizer(teardown)
+        Args:
+            es (Elasticsearch): elastic search object
 
-    es = ElasticSearch()
+        Returns:
+            str: the UUID of the test
 
-    return es
+        """
 
+        ripsaw = RipSaw()
 
-class Test_Elasticsearch:
-    def curl_run(self, es, auth=True):
+        # Loading the main template yaml file for the benchmark and update some
+        # fields with new values
+        sf_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
 
-        if auth:
-            con_string = f"elastic:{es.get_password()}@"
-            msg = "with authentication"
-        else:
-            con_string = ""
-            msg = "without authentication"
+        # Setting up the parameters for this test
+        sf_data["spec"]["elasticsearch"]["server"] = es.get_ip()
+        sf_data["spec"]["elasticsearch"]["port"] = es.get_port()
 
-        log.info(f"\nTesting the Local server Connecting {msg}")
+        sf_data["spec"]["workload"]["args"]["samples"] = 1
+        sf_data["spec"]["workload"]["args"]["operation"] = ["create"]
+        sf_data["spec"]["workload"]["args"]["file_size"] = 4
+        sf_data["spec"]["workload"]["args"]["files"] = 500000
+        sf_data["spec"]["workload"]["args"]["threads"] = 4
+        sf_data["spec"]["workload"]["args"][
+            "storageclass"
+        ] = constants.DEFAULT_STORAGECLASS_RBD
+        sf_data["spec"]["workload"]["args"]["storagesize"] = "100Gi"
 
-        try:
-            if auth:
-                test_es = Elasticsearch(
-                    [{"host": "localhost", "port": es.get_port()}],
-                    http_auth=("elastic", es.get_password()),
-                )
-            else:
-                test_es = Elasticsearch([{"host": "localhost", "port": es.get_port()}])
-        except esexp.ConnectionError:
-            log.error(
-                "can not connect to ES server {}:{} {}".format(
-                    es.get_ip, es.get_port, msg
-                )
-            )
-            raise
+        # Deploy the ripsaw operator
+        log.info("Apply Operator CRD")
+        ripsaw.apply_crd("resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml")
 
-        log.info(f"testing ES object is {test_es}")
-        server_string = f'localhost:{es.get_port()}"'
-        curl_cmd = 'curl "http://'
+        # deploy the smallfile workload
+        log.info("Running SmallFile bench")
+        sf_obj = OCS(**sf_data)
+        sf_obj.create()
 
-        log.info(f"Going to run : {curl_cmd}{con_string}{server_string}")
-        log.info(run(f"{curl_cmd}{con_string}{server_string}", shell=True))
+        # wait for benchmark pods to get created - takes a while
+        for bench_pod in TimeoutSampler(
+            240,
+            10,
+            get_pod_name_by_pattern,
+            "smallfile-client",
+            constants.RIPSAW_NAMESPACE,
+        ):
+            try:
+                if bench_pod[0] is not None:
+                    small_file_client_pod = bench_pod[0]
+                    break
+            except IndexError:
+                log.info("Bench pod not ready yet")
+
+        bench_pod = OCP(kind="pod", namespace=constants.RIPSAW_NAMESPACE)
+        log.info("Waiting for SmallFile benchmark to Run")
+        bench_pod.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            resource_name=small_file_client_pod,
+            sleep=30,
+            timeout=600,
+        )
+        for item in bench_pod.get()["items"][1]["spec"]["volumes"]:
+            if "persistentVolumeClaim" in item:
+                break
+        uuid = ripsaw.get_uuid(small_file_client_pod)
+        timeout = 600
+        while timeout >= 0:
+            logs = bench_pod.get_logs(name=small_file_client_pod)
+            if "RUN STATUS DONE" in logs:
+                break
+            timeout -= 30
+            if timeout == 0:
+                raise TimeoutError("Timed out waiting for benchmark to complete")
+            time.sleep(30)
+        ripsaw.cleanup()
+        return uuid
 
     def test_elasticsearch(self, es):
         """
@@ -70,7 +117,8 @@ class Test_Elasticsearch:
             es (fixture) : fixture that deploy / teardown the elasticsearch
 
         """
-
+        full_log_path = get_full_logs_path(cname=self)
+        log.info(f"Log file name is {full_log_path}")
         log.info("The ElasticSearch deployment test started.")
         if es.get_health():
             log.info("The Status of the elasticsearch is OK")
@@ -88,11 +136,23 @@ class Test_Elasticsearch:
             log.info(f"The Elasticsearch IP is {es.get_ip()}")
             log.info(f"The Elasticsearch port is {es.get_port()}")
             log.info(f"The Password to connect is {es.get_password()}")
-            log.info(f"The local server PID is {es.lspid}")
-
-            self.curl_run(es, auth=True)
-
-            self.curl_run(es, auth=False)
 
         else:
             assert False, "The Elasticsearch module is not ready !"
+
+        log.info(f"Test UUDI is : {self.smallfile_run(es)}")
+
+        assert es.dump(full_log_path), "Can not Retrieve the test data"
+
+        assert run_command(
+            f"ls {full_log_path}/FullResults.tgz"
+        ), "Results file did not retrieve from pod"
+
+        # time.sleep(10)
+        main_es = {
+            "host": defaults.ELASTICSEARCH_DEV_IP,
+            "port": defaults.ELASTICSEARCE_PORT,
+        }
+        assert elasticsearch_load(
+            main_es, full_log_path
+        ), "Can not load data into Main ES server"

--- a/tests/libtest/test_elasticsearch.py
+++ b/tests/libtest/test_elasticsearch.py
@@ -142,7 +142,7 @@ class TestElasticsearch:
 
         log.info(f"Test UUDI is : {self.smallfile_run(es)}")
 
-        assert es.dump(full_log_path), "Can not Retrieve the test data"
+        assert es.dumping_all_data(full_log_path), "Can not Retrieve the test data"
 
         assert run_command(
             f"ls {full_log_path}/FullResults.tgz"

--- a/tests/libtest/test_elasticsearch.py
+++ b/tests/libtest/test_elasticsearch.py
@@ -9,7 +9,7 @@ import pytest
 
 from ocs_ci.ocs import defaults
 from tests.fixtures import es
-from ocs_ci.helpers.helpers import get_full_logs_path
+from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.helpers.performance_lib import run_command
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
@@ -117,8 +117,8 @@ class TestElasticsearch:
             es (fixture) : fixture that deploy / teardown the elasticsearch
 
         """
-        full_log_path = get_full_logs_path(cname=self)
-        log.info(f"Log file name is {full_log_path}")
+        full_log_path = get_full_test_logs_path(cname=self)
+        log.info(f"Logs file path name is : {full_log_path}")
         log.info("The ElasticSearch deployment test started.")
         if es.get_health():
             log.info("The Status of the elasticsearch is OK")

--- a/tests/libtest/test_elasticsearch.py
+++ b/tests/libtest/test_elasticsearch.py
@@ -5,10 +5,7 @@ Testing the Elasticsearch server deployment
 import logging
 import time
 
-import pytest
-
 from ocs_ci.ocs import defaults
-from tests.fixtures import es
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.helpers.performance_lib import run_command
 from ocs_ci.ocs.ocp import OCP
@@ -23,9 +20,6 @@ from ocs_ci.ocs.elasticsearch import elasticsearch_load
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures(
-    es.__name__,
-)
 class TestElasticsearch:
     def smallfile_run(self, es):
         """
@@ -148,7 +142,6 @@ class TestElasticsearch:
             f"ls {full_log_path}/FullResults.tgz"
         ), "Results file did not retrieve from pod"
 
-        # time.sleep(10)
         main_es = {
             "host": defaults.ELASTICSEARCH_DEV_IP,
             "port": defaults.ELASTICSEARCE_PORT,


### PR DESCRIPTION
In this PR, there is improvement of the Internal elasticsearch retrieving methodology.
I added a '**dumper**'  pod  in the elastic-system namespace which can dump all the data from the internal ES server to a .tgz file, and copy it outside of the cluster.
later one, the data from this file can be pushed to an ES server for reporting.

This will fix Issues: #3533 , #2901 and  #3492 
