### PR TITLE
Skip configuring chrony in vSphere for OCP version 4.7

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -571,14 +571,17 @@ class VSPHEREUPI(VSPHEREBASE):
             remove_nodes(rhcos_nodes)
 
         # get datastore type and configure chrony for all nodes ONLY if
-        # datstore type is vsan
-        datastore_type = self.vsphere.get_datastore_type_by_name(
-            self.datastore, self.datacenter
-        )
-        if datastore_type != constants.VMFS:
-            configure_chrony_and_wait_for_machineconfig_status(
-                node_type="all", timeout=1800
+        # datastore type is vsan
+        # skip configuring chrony for OCP version 4.7, more details in
+        # bug 1910738
+        if Version.coerce(get_ocp_version()) < Version.coerce("4.7"):
+            datastore_type = self.vsphere.get_datastore_type_by_name(
+                self.datastore, self.datacenter
             )
+            if datastore_type != constants.VMFS:
+                configure_chrony_and_wait_for_machineconfig_status(
+                    node_type="all", timeout=1800
+                )
 
     def destroy_cluster(self, log_level="DEBUG"):
         """


### PR DESCRIPTION
Skipping configuring chrony in vSphere environment due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1910738

Signed-off-by: vavuthu <vavuthu@redhat.com>