### PR TITLE
[Openshift-Dedicated] Exclude openshift-build-test namespace on teardown

### DIFF
--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -17,6 +17,7 @@ OPENSHIFT_REST_CLIENT_API_VERSION = "v1"
 
 INSTALLER_VERSION = "4.1.4"
 CLIENT_VERSION = INSTALLER_VERSION
+SRE_BUILD_TEST_NAMESPACE = "openshift-build-test"
 ROOK_CLUSTER_NAMESPACE = "openshift-storage"
 OCS_MONITORING_NAMESPACE = "openshift-monitoring"
 KUBECONFIG_LOCATION = "auth/kubeconfig"  # relative from cluster_dir

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -112,6 +112,11 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             if name == "openshift-must-gather-":
                 log.debug(f"ignoring item: {constants.NAMESPACE} with name {name}")
                 continue
+        if item.get("kind") == constants.NAMESPACE:
+            name = item.get("metadata").get("name")
+            if name.startswith(defaults.SRE_BUILD_TEST_NAMESPACE):
+                log.debug(f"ignoring item: {constants.NAMESPACE} with name {name}")
+                continue
         items_filtered.append(item)
 
     ignored = len(items) - len(items_filtered)


### PR DESCRIPTION
**Description**
This fixes the tear down failure on various tests in openshift-dedicated, by ignoring the openshift-build-test namespace. As multiple namespace of openshift-build-test* pattern gets created even after the successful cluster creation which then interferes with the OCS-CI tear down process.

Signed-off-by: kesavan <kvellalo@redhat.com>