### PR TITLE
Fix MCG CLI bucketclass creation in 4.7

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1078,6 +1078,9 @@ BM_STATUS_ABSENT = "ABSENT"
 BM_STATUS_PRESENT = "PRESENT"
 BM_STATUS_RESPONSE_UPDATED = "UPDATED"
 
+# MCG constants
+PLACEMENT_BUCKETCLASS = "placement-bucketclass"
+
 # MCG namespace constants
 MCG_NS_AWS_ENDPOINT = "https://s3.amazonaws.com"
 MCG_NS_AZURE_ENDPOINT = "https://blob.core.windows.net"

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -694,7 +694,7 @@ class MCG:
         backingstore_name_list = [backingstore.name for backingstore in backingstores]
         bc = f" --backingstores={','.join(backingstore_name_list)} --placement={placement}"
         placement_parameter = (
-            "placement-bucketclass "
+            f"{constants.PLACEMENT_BUCKETCLASS} "
             if float(config.ENV_DATA["ocs_version"]) < 4.7
             else ""
         )

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -693,7 +693,12 @@ class MCG:
         """
         backingstore_name_list = [backingstore.name for backingstore in backingstores]
         bc = f" --backingstores={','.join(backingstore_name_list)} --placement={placement}"
-        self.exec_mcg_cmd(f"bucketclass create {name}{bc}")
+        placement_parameter = (
+            "placement-bucketclass"
+            if float(config.ENV_DATA["ocs_version"]) < 4.7
+            else ""
+        )
+        self.exec_mcg_cmd(f"bucketclass create {placement_parameter} {name}{bc}")
 
     def check_if_mirroring_is_done(self, bucket_name, timeout=140):
         """

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -694,11 +694,11 @@ class MCG:
         backingstore_name_list = [backingstore.name for backingstore in backingstores]
         bc = f" --backingstores={','.join(backingstore_name_list)} --placement={placement}"
         placement_parameter = (
-            "placement-bucketclass"
+            "placement-bucketclass "
             if float(config.ENV_DATA["ocs_version"]) < 4.7
             else ""
         )
-        self.exec_mcg_cmd(f"bucketclass create {placement_parameter} {name}{bc}")
+        self.exec_mcg_cmd(f"bucketclass create {placement_parameter}{name}{bc}")
 
     def check_if_mirroring_is_done(self, bucket_name, timeout=140):
         """

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -695,7 +695,7 @@ class MCG:
         bc = f" --backingstores={','.join(backingstore_name_list)} --placement={placement}"
         placement_parameter = (
             f"{constants.PLACEMENT_BUCKETCLASS} "
-            if float(config.ENV_DATA["ocs_version"]) < 4.7
+            if float(config.ENV_DATA["ocs_version"]) >= 4.7
             else ""
         )
         self.exec_mcg_cmd(f"bucketclass create {placement_parameter}{name}{bc}")


### PR DESCRIPTION
The CLI commands were changed in 4.7 (CLI 5.7.0) in order to support creation of bucketclasses that contain namespace stores.
This PR aims to fix placement-policy-based BC creation via CLI on 4.7