### PR TITLE
Return the MCG resources created for the current factory scope instead of all scopes

### DIFF
--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -220,6 +220,7 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
             list: A list of backingstore names.
 
         """
+        current_call_created_backingstores = []
         if method.lower() not in cmdMap:
             raise RuntimeError(
                 f"Invalid method type received: {method}. "
@@ -245,16 +246,16 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                     backingstore_name = create_unique_resource_name(
                         resource_description="backingstore", resource_type=cloud.lower()
                     )
-                    created_backingstores.append(
-                        BackingStore(
-                            name=backingstore_name,
-                            method=method.lower(),
-                            type="pv",
-                            mcg_obj=mcg_obj,
-                            vol_num=vol_num,
-                            vol_size=size,
-                        )
+                    backingstore_obj = BackingStore(
+                        name=backingstore_name,
+                        method=method.lower(),
+                        type="pv",
+                        mcg_obj=mcg_obj,
+                        vol_num=vol_num,
+                        vol_size=size,
                     )
+                    current_call_created_backingstores.append(backingstore_obj)
+                    created_backingstores.append(backingstore_obj)
                     if method.lower() == "cli":
                         cmdMap[method.lower()][cloud.lower()](
                             mcg_obj, backingstore_name, vol_num, size, storagecluster
@@ -271,15 +272,16 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                             resource_description="backingstore",
                             resource_type=cloud.lower(),
                         )
-                        created_backingstores.append(
-                            BackingStore(
-                                name=backingstore_name,
-                                method=method.lower(),
-                                type="cloud",
-                                uls_name=uls_name,
-                                mcg_obj=mcg_obj,
-                            )
+                        backingstore_obj = BackingStore(
+                            name=backingstore_name,
+                            method=method.lower(),
+                            type="pv",
+                            mcg_obj=mcg_obj,
+                            vol_num=vol_num,
+                            vol_size=size,
                         )
+                        current_call_created_backingstores.append(backingstore_obj)
+                        created_backingstores.append(backingstore_obj)
                         if method.lower() == "cli":
                             cmdMap[method.lower()][cloud.lower()](
                                 mcg_obj, cld_mgr, backingstore_name, uls_name, region
@@ -293,7 +295,7 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                         )
                         # TODO: Verify OC\CLI BS health by using the appropriate methods
 
-        return created_backingstores
+        return current_call_created_backingstores
 
     def backingstore_cleanup():
         for backingstore in created_backingstores:

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -275,10 +275,9 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                         backingstore_obj = BackingStore(
                             name=backingstore_name,
                             method=method.lower(),
-                            type="pv",
+                            type="cloud",
+                            uls_name=uls_name,
                             mcg_obj=mcg_obj,
-                            vol_num=vol_num,
-                            vol_size=size,
                         )
                         current_call_created_backingstores.append(backingstore_obj)
                         created_backingstores.append(backingstore_obj)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2058,6 +2058,7 @@ def bucket_factory_fixture(
         if bucketclass:
             interface = bucketclass["interface"]
 
+        current_call_created_buckets = []
         if interface.lower() not in BUCKET_MAP:
             raise RuntimeError(
                 f"Invalid interface type received: {interface}. "
@@ -2080,11 +2081,12 @@ def bucket_factory_fixture(
                 *args,
                 **kwargs,
             )
+            current_call_created_buckets.append(created_bucket)
             created_buckets.append(created_bucket)
             if verify_health:
                 created_bucket.verify_health()
 
-        return created_buckets
+        return current_call_created_buckets
 
     def bucket_cleanup():
         for bucket in created_buckets:


### PR DESCRIPTION
we currently return all created buckets and backingstores in these factories instead we should only return the currently requested objects.