### PR TITLE
Check if new alerts are raised during test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ from ocs_ci.utility.environment_check import (
     get_status_before_execution,
     get_status_after_execution,
 )
+from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.uninstall_openshift_logging import uninstall_cluster_logging
 from ocs_ci.utility.utils import (
     ceph_health_check,
@@ -2717,6 +2718,58 @@ def user_factory(request, htpasswd_identity_provider, htpasswd_path):
 @pytest.fixture(scope="session")
 def user_factory_session(request, htpasswd_identity_provider, htpasswd_path):
     return users.user_factory(request, htpasswd_path)
+
+
+@pytest.fixture(autouse=True)
+def log_alerts(request):
+    """
+    Log alerts at the beginning and end of each test case. At the end of test
+    case print a difference: what new alerts are in place after the test is
+    complete.
+
+    """
+    alerts_before = []
+    alerts_after = []
+    prometheus = None
+
+    try:
+        prometheus = PrometheusAPI()
+    except Exception as e:
+        log.warning("There was a problem with connecting to Promeheus: {e.message}")
+
+    def _collect_alerts():
+        try:
+            alerts_response = prometheus.get(
+                "alerts", payload={"silenced": False, "inhibited": False}
+            )
+            if alerts_response.ok:
+                alerts = alerts_response.json().get("data").get("alerts")
+                log.debug(f"Found alerts: {alerts}")
+                return alerts
+            else:
+                log.warning(
+                    f"There was a problem with collecting alerts for analysis: {alerts_response.text}"
+                )
+                return False
+        except Exception as e:
+            log.warning(
+                "There was a problem with collecting alerts for analysis: {e.message}"
+            )
+            return False
+
+    def _print_diff():
+        if alerts_before:
+            alerts_after = _collect_alerts()
+            if alerts_after:
+                alerts_new = [
+                    alert for alert in alerts_after if alert not in alerts_before
+                ]
+                if alerts_new:
+                    log.warning("During test were raised new alerts")
+                    log.warning(alerts_new)
+
+    alerts_before = _collect_alerts()
+    request.addfinalizer(_print_diff)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2729,13 +2729,12 @@ def log_alerts(request):
 
     """
     alerts_before = []
-    alerts_after = []
     prometheus = None
 
     try:
         prometheus = PrometheusAPI()
     except Exception as e:
-        log.warning("There was a problem with connecting to Promeheus: {e.message}")
+        log.warning(f"There was a problem with connecting to Promeheus: {e.message}")
 
     def _collect_alerts():
         try:
@@ -2753,7 +2752,7 @@ def log_alerts(request):
                 return False
         except Exception as e:
             log.warning(
-                "There was a problem with collecting alerts for analysis: {e.message}"
+                f"There was a problem with collecting alerts for analysis: {e.message}"
             )
             return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2733,8 +2733,8 @@ def log_alerts(request):
 
     try:
         prometheus = PrometheusAPI()
-    except Exception as e:
-        log.warning(f"There was a problem with connecting to Promeheus: {e.message}")
+    except Exception:
+        log.exception("There was a problem with connecting to Promeheus")
 
     def _collect_alerts():
         try:
@@ -2750,10 +2750,8 @@ def log_alerts(request):
                     f"There was a problem with collecting alerts for analysis: {alerts_response.text}"
                 )
                 return False
-        except Exception as e:
-            log.warning(
-                f"There was a problem with collecting alerts for analysis: {e.message}"
-            )
+        except Exception:
+            log.exception("There was a problem with collecting alerts for analysis")
             return False
 
     def _print_diff():


### PR DESCRIPTION
- Print warning if new alerts are raised during test to help with test analysis.
- Most of the code is in try, except blocks to prevent fails if Prometheus is not available.

Signed-off-by: Filip Balak <fbalak@redhat.com>