### PR TITLE
Adding the url parameter to the CRD file for the FIO workload

### DIFF
--- a/tests/e2e/performance/test_fio_benchmark.py
+++ b/tests/e2e/performance/test_fio_benchmark.py
@@ -188,9 +188,14 @@ class TestFIOBenchmark(E2ETest):
                 self.fio_cr["spec"]["elasticsearch"] = {
                     "server": defaults.ELASTICSEARCH_DEV_IP,
                     "port": defaults.ELASTICSEARCE_PORT,
+                    "url": f"http://{defaults.ELASTICSEARCH_DEV_IP}:{defaults.ELASTICSEARCE_PORT}",
                 }
 
         if "elasticsearch" in self.fio_cr["spec"]:
+            self.fio_cr["spec"]["elasticsearch"]["url"] = (
+                f"http://{self.fio_cr['spec']['elasticsearch']['server']}:"
+                f"{self.fio_cr['spec']['elasticsearch']['port']}"
+            )
             self.backup_es = self.fio_cr["spec"]["elasticsearch"]
         else:
             log.warning("Elastic Search information does not exists in YAML file")
@@ -201,6 +206,7 @@ class TestFIOBenchmark(E2ETest):
             self.fio_cr["spec"]["elasticsearch"] = {
                 "server": elasticsearch.get_ip(),
                 "port": elasticsearch.get_port(),
+                "url": f"http://{elasticsearch.get_ip()}:{elasticsearch.get_port()}",
             }
 
     def setting_storage_usage(self):


### PR DESCRIPTION
In the Ripsaw repository the server + port parameters replaced with the url parameter.

i just added the url parameter and not replaced the server+port to prevent more changes in the code that use thous parameters

This PR along with PR #3647 will fix #3645

Signed-off-by: Avi Liani <alayani@redhat.com>