### PR TITLE
Look for the right ObjectBucketName field dependent on version

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1093,6 +1093,10 @@ MCG_NS_RESOURCE = "ns_resource"
 MCG_NS_BUCKET = "ns-bucket"
 MCG_CONNECTION = "connection"
 
+# MCG version-dependent constants
+OBJECTBUCKETNAME_46ANDBELOW = "ObjectBucketName"
+OBJECTBUCKETNAME_47ANDABOVE = "objectBucketName"
+
 # Cloud provider default endpoints
 # Upon use, utilize .format() to replace the curly braces where necessary
 AZURE_BLOB_ENDPOINT_TEMPLATE = "https://{}.blob.core.windows.net"

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -53,7 +53,12 @@ class OBC(object):
             kind="ObjectBucketClaim",
             resource_name=self.obc_name,
         ).get()
-        self.ob_name = obc_resource.get("spec").get("ObjectBucketName")
+        obn_str = (
+            "ObjectBucketName"
+            if float(config.ENV_DATA["ocs_version"]) < 4.7
+            else "objectBucketName"
+        )
+        self.ob_name = obc_resource.get("spec").get(obn_str)
         self.bucket_name = obc_resource.get("spec").get("bucketName")
         ob_obj = OCP(
             namespace=self.namespace, kind="ObjectBucket", resource_name=self.ob_name

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -54,9 +54,9 @@ class OBC(object):
             resource_name=self.obc_name,
         ).get()
         obn_str = (
-            "ObjectBucketName"
+            constants.OBJECTBUCKETNAME_46ANDBELOW
             if float(config.ENV_DATA["ocs_version"]) < 4.7
-            else "objectBucketName"
+            else constants.OBJECTBUCKETNAME_47ANDABOVE
         )
         self.ob_name = obc_resource.get("spec").get(obn_str)
         self.bucket_name = obc_resource.get("spec").get("bucketName")


### PR DESCRIPTION
In OCS 4.7, the field name was changed from *O*bjectBucketName, to *o*bjectBucketName