### PR TITLE
Log MCG RPC token retrieval calls

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -230,6 +230,8 @@ class MCG:
                         "password": self.noobaa_password,
                     },
                 )
+                # Should be removed ASAP
+                # For more info: https://github.com/red-hat-storage/ocs-ci/issues/3673
                 logger.info(f"RPC_RESPONSE_JSON: {str(rpc_response.json())}")
                 return rpc_response.json().get("reply").get("token")
 

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -230,7 +230,7 @@ class MCG:
                         "password": self.noobaa_password,
                     },
                 )
-                logger.error(f"RPC_RESPONSE_JSON: {str(rpc_response.json())}")
+                logger.info(f"RPC_RESPONSE_JSON: {str(rpc_response.json())}")
                 return rpc_response.json().get("reply").get("token")
 
             except json.JSONDecodeError:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -230,6 +230,7 @@ class MCG:
                         "password": self.noobaa_password,
                     },
                 )
+                logger.error(f"RPC_RESPONSE_JSON: {str(rpc_response.json())}")
                 return rpc_response.json().get("reply").get("token")
 
             except json.JSONDecodeError:


### PR DESCRIPTION
We started seeing a pattern in recent OCS 4.7 runs where the NB token retrieval RPC call would fail.
We do not log it, and thus, can't know what is the issue.