### PR TITLE
Increase PV deletion wait time if platform is azure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,7 +639,13 @@ def pvc_factory_fixture(request, project_factory):
                 pv_obj.delete()
                 pv_obj.ocp.wait_for_delete(pv_obj.name)
             else:
-                pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
+                # Workaround for bug 1915706, increasing timeout from 180 to 720
+                timeout = (
+                    720
+                    if config.ENV_DATA["platform"].lower() == constants.AZURE_PLATFORM
+                    else 180
+                )
+                pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=timeout)
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
Test cases are failing in tear down due to timeout error while waiting for PV to get deleted after deleting the PVC.
eg: tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py::TestResourceDeletionDuringPvcExpansion::test_resource_deletion_during_pvc_expansion[mgr]
Test result.
Bug - https://bugzilla.redhat.com/show_bug.cgi?id=1915706
Increased the PV deletion wait time to 720 seconds in pvc_factory_fixture fixture.

Fixes #3678
Signed-off-by: Jilju Joy <jijoy@redhat.com>