### PR TITLE
optional operators selector

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -576,6 +576,7 @@ OPERATOR_CS_QUAY_API_QUERY = (
     "https://quay.io/api/v1/repository/rhceph-dev/{image}/"
     "tag/?onlyActiveTags=true&limit={tag_limit}"
 )
+OPTIONAL_OPERATORS_SELECTOR = "catalog=optional-operators"
 
 # OCP related constants
 OPENSHIFT_UPGRADE_INFO_API = (

--- a/ocs_ci/utility/localstorage.py
+++ b/ocs_ci/utility/localstorage.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.node import get_nodes
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import csv
 from ocs_ci.ocs.resources.packagemanifest import PackageManifest
+from ocs_ci.utility.deployment import get_ocp_ga_version
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import clone_repo, get_ocp_version, run_cmd
 
@@ -179,8 +180,15 @@ def get_lso_channel():
 
     """
     ocp_version = get_ocp_version()
+    # If OCP version is not GA, we will be using the Optional Operators CatalogSource
+    # This means there are two PackageManifests with the name local-storage-operator
+    # so we need to also use a selector to ensure we retrieve the correct one
+    ocp_ga_version = get_ocp_ga_version(ocp_version)
+    selector = constants.OPTIONAL_OPERATORS_SELECTOR if not ocp_ga_version else None
     # Retrieve available channels for LSO
-    package_manifest = PackageManifest(resource_name=constants.LOCAL_STORAGE_CSV_PREFIX)
+    package_manifest = PackageManifest(
+        resource_name=constants.LOCAL_STORAGE_CSV_PREFIX, selector=selector
+    )
     channels = package_manifest.get_channels()
     channel_names = [channel["name"] for channel in channels]
 


### PR DESCRIPTION
Use selector to ensure optional operators packagemanifest is selected for LSO when OCP is not GA

Signed-off-by: Coady LaCroix <clacroix@redhat.com>