### PR TITLE
Use dc pod in test_worker_node_restart_during_pvc_expansion

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1742,7 +1742,7 @@ class AZURENodes(NodesBase):
                 node_names=node_names, status=constants.NODE_READY, timeout=timeout
             )
 
-    def restart_nodes(self, nodes, timeout=540, wait=True):
+    def restart_nodes(self, nodes, timeout=900, wait=True):
         """
         Restart Azure vm instances
 

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -43,8 +43,8 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
         self.pvcs, self.pods = create_pvcs_and_pods(
             pvc_size=4,
             pods_for_rwx=2,
-            num_of_rbd_pvc=15,
-            num_of_cephfs_pvc=10,
+            num_of_rbd_pvc=9,
+            num_of_cephfs_pvc=6,
             deployment_config=True,
         )
 

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -137,6 +137,7 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
                 size="6G",
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_file",
+                end_fsync=1,
             )
 
         log.info("Wait for IO to complete on all pods")

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -99,7 +99,7 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
         new_pods_list = []
         for pod_obj in self.pods:
             new_pods = get_all_pods(
-                namespace=self.namespace,
+                namespace=pod_obj.namespace,
                 selector=[pod_obj.labels.get("deploymentconfig")],
                 selector_label="deploymentconfig",
                 wait=True,

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -96,16 +96,20 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
 
         # Find respun pods
         new_pods_list = []
+        wait_to_stabilize = True
         for pod_obj in self.pods:
             new_pods = get_all_pods(
                 namespace=pod_obj.namespace,
                 selector=[pod_obj.labels.get("deploymentconfig")],
                 selector_label="deploymentconfig",
-                wait=False,
+                wait=wait_to_stabilize,
             )
             for pod_ob in new_pods:
                 pod_ob.pvc = pod_obj.pvc
             new_pods_list.extend(new_pods)
+            # Given enough time for pods to respin. So wait time
+            # is not needed for further iterations
+            wait_to_stabilize = False
         assert len(new_pods_list) == len(
             self.pods
         ), "Couldn't find all pods after node reboot"

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -122,7 +122,7 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
             capacity = pvc_obj.get().get("status").get("capacity").get("storage")
             assert capacity == f"{pvc_size_expanded}Gi", (
                 f"Capacity of PVC {pvc_obj.name} is not {pvc_size_expanded}Gi as "
-                f"expected, but {capacity}. Retrying."
+                f"expected, but {capacity}."
             )
         log.info("PVC expansion was successful on all PVCs")
 

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -42,9 +42,8 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
         """
         self.pvcs, self.pods = create_pvcs_and_pods(
             pvc_size=4,
-            pods_for_rwx=2,
-            num_of_rbd_pvc=9,
-            num_of_cephfs_pvc=6,
+            num_of_rbd_pvc=12,
+            num_of_cephfs_pvc=8,
             deployment_config=True,
         )
 
@@ -102,7 +101,7 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
                 namespace=pod_obj.namespace,
                 selector=[pod_obj.labels.get("deploymentconfig")],
                 selector_label="deploymentconfig",
-                wait=True,
+                wait=False,
             )
             for pod_ob in new_pods:
                 pod_ob.pvc = pod_obj.pvc


### PR DESCRIPTION
This PR Fixes #3709

Use dc pod in test_worker_node_restart_during_pvc_expansion because pods might respin on different node after a node reboot. The verification of PVC capacity after expansion should be done after identifying the re-spun pods. This will ensure thet the filesystem resize is completed.


Signed-off-by: Jilju Joy <jijoy@redhat.com>