### PR TITLE
Give extra time for new nodes to reach Ready state

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -566,7 +566,7 @@ def add_node(machine_set, count):
     return True
 
 
-def wait_for_new_node_to_be_ready(machine_set, timeout=300):
+def wait_for_new_node_to_be_ready(machine_set, timeout=600):
     """
     Wait for the new node to reach ready state
 


### PR DESCRIPTION
Should Fix: #3695 
Increase timeout for `wait_for_new_node_to_be_ready()` in `machine.py`

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>