### PR TITLE
Fix the RGW test_bucket_delete flow

### DIFF
--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -33,7 +33,7 @@ class TestBucketDeletion:
         """
         for bucket in rgw_bucket_factory(amount, interface):
             logger.info(f"Deleting bucket: {bucket.name}")
-            assert bucket.delete()
+            bucket.delete(verify=True)
 
     @pytest.mark.parametrize(
         argnames="interface",


### PR DESCRIPTION
[The OB deletion flow was changed](https://github.com/red-hat-storage/ocs-ci/pull/3623/files#diff-182979f19c5a44501b1e65af59e1067af0e96e8b479ca0eb150e208459b16934), and doesn't return a value anymore.
The return value was unneeded because the deletion assertion is performed internally as part of the delete function.
This should fix a test that relied on a return value.

`verify` is True by default, but I felt it'd be good to explicitly state it so people reading the test can know that the verification is performed internally.