### PR TITLE
FIO | use the new algorithm for environment without elasticsearch server

### DIFF
--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -42,14 +42,22 @@ def elasticsearch_load(connection, target_path):
         log.error("There is No data to load into ES server")
         return False
     else:
+        if connection is None:
+            log.warning("There is no elasticsearch server to load data into")
+            return False
+        """
         log.info(f"Loading data from {target_path} to ES server at {connection}")
+        log.info(f"Creating new ES connection to {connection}")
         try:
-            log.info(f"Creating new ES connection to {connection}")
-            main_es = Elasticsearch([connection])
-            log.debug(f"Connection info : {main_es}")
-        except esexp.ConnectionError:
+            main_es = Elasticsearch([connection], verify_certs=True)
+        except esexp.ConnectionError as ex:
+            log.error(f"Can not connect to the main ES server on {connection} - ({ex})")
+            return False
+        if not main_es.ping():
             log.error(f"Can not connect to the main ES server on {connection}")
             return False
+        """
+        log.info(f"The ES connection is {connection}")
         for ind in all_files:
             if ".data." in ind:  # load only data files and not mapping info
                 file_name = f"{target_path}/results/{ind}"
@@ -61,7 +69,7 @@ def elasticsearch_load(connection, target_path):
                         if line:
                             full_data = json.loads(line)
                             log.debug(f"Loading {full_data} into the ES")
-                            main_es.index(
+                            connection.index(
                                 index=ind_name, doc_type="_doc", body=full_data
                             )
                         else:
@@ -253,17 +261,14 @@ class ElasticSearch(object):
         Create a connection to the local ES
 
         Returns:
-            Elasticsearch: elasticsearch connection object
-
-        Raise:
-            ConnectionError: if can not connect to the server
+            Elasticsearch: elasticsearch connection object, None if can not connect to ES
 
         """
         try:
             es = Elasticsearch([{"host": self.get_ip(), "port": self.get_port()}])
         except esexp.ConnectionError:
-            log.error("Can not connect to ES server in the LocalServer")
-            raise
+            log.warning("Can not connect to ES server in the LocalServer")
+            es = None
         return es
 
     def get_indices(self):

--- a/ocs_ci/ocs/elasticsearch.py
+++ b/ocs_ci/ocs/elasticsearch.py
@@ -45,18 +45,6 @@ def elasticsearch_load(connection, target_path):
         if connection is None:
             log.warning("There is no elasticsearch server to load data into")
             return False
-        """
-        log.info(f"Loading data from {target_path} to ES server at {connection}")
-        log.info(f"Creating new ES connection to {connection}")
-        try:
-            main_es = Elasticsearch([connection], verify_certs=True)
-        except esexp.ConnectionError as ex:
-            log.error(f"Can not connect to the main ES server on {connection} - ({ex})")
-            return False
-        if not main_es.ping():
-            log.error(f"Can not connect to the main ES server on {connection}")
-            return False
-        """
         log.info(f"The ES connection is {connection}")
         for ind in all_files:
             if ".data." in ind:  # load only data files and not mapping info
@@ -261,13 +249,13 @@ class ElasticSearch(object):
         Create a connection to the local ES
 
         Returns:
-            Elasticsearch: elasticsearch connection object, None if can not connect to ES
+            Elasticsearch: elasticsearch connection object, None if Cannot connect to ES
 
         """
         try:
             es = Elasticsearch([{"host": self.get_ip(), "port": self.get_port()}])
         except esexp.ConnectionError:
-            log.warning("Can not connect to ES server in the LocalServer")
+            log.warning("Cannot connect to ES server in the LocalServer")
             es = None
         return es
 
@@ -342,7 +330,7 @@ class ElasticSearch(object):
             results = run_command(f"tar zxvf {target_path}/FullResults.tgz", **kwargs)
             log.debug(f"The untar results is {results}")
             if "Error in command" in results:
-                log.warning("Can not untar the dumped file")
+                log.warning("Cannot untar the dumped file")
                 return False
 
         return True

--- a/ocs_ci/ocs/perfresult.py
+++ b/ocs_ci/ocs/perfresult.py
@@ -54,13 +54,13 @@ class PerfResult:
             self.es = Elasticsearch([{"host": self.server, "port": self.port}])
         except ESExp.ConnectionError:
             log.warning(
-                "can not connect to ES server {}:{}".format(self.server, self.port)
+                "Cannot connect to ES server {}:{}".format(self.server, self.port)
             )
 
         # Testing the connection to the elastic-search
         if not self.es.ping():
             log.warning(
-                "can not connect to ES server {}:{}".format(self.server, self.port)
+                "Cannot connect to ES server {}:{}".format(self.server, self.port)
             )
 
     def es_read(self):

--- a/tests/e2e/performance/test_fio_benchmark.py
+++ b/tests/e2e/performance/test_fio_benchmark.py
@@ -216,7 +216,7 @@ class TestFIOBenchmark(E2ETest):
             )
             self.main_es = Elasticsearch([self.backup_es["url"]], verify_certs=True)
             if not self.main_es.ping():
-                log.warning("Can not connect to Main elasticsearch server")
+                log.warning("Cannot connect to Main elasticsearch server")
                 self.main_es = None
 
         else:
@@ -431,7 +431,7 @@ class TestFIOBenchmark(E2ETest):
                 time.sleep(10)
                 return True
             else:
-                log.warning("Can not upload data into the Main ES server")
+                log.warning("Cannot upload data into the Main ES server")
                 return False
 
     def cleanup(self):


### PR DESCRIPTION
With this PR the FIO test will be able to run and collect data at environment without an elasticsearch server to push the results into (e.g. IBM)
If Elasticsearch server does not exist, the test will not failed.

Also some more changes :

   * do not push results of dev-mode run to codespeed
   * use the global ES fixture
   * do not raise excaption if no connection to elasticsearch

Signed-off-by: Avi Liani <alayani@redhat.com>