### PR TITLE
Add end_fsync while running fio in test

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -164,6 +164,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
                 runtime=30,
                 rate="10M",
                 fio_filename=f"{pod_obj.name}_f2",
+                end_fsync=1,
             )
 
         log.info("Wait for IO to complete on all pods")


### PR DESCRIPTION
Add end_fsync=1 fio parameter in test test_resource_deletion_during_pvc_expansion.
According to this [comment](https://bugzilla.redhat.com/show_bug.cgi?id=1915706#c9)  it is advisable to add end_fsync if the volume will be deleted immediately after the IO. 
Signed-off-by: Jilju Joy <jijoy@redhat.com>