### PR TITLE
Increase timeout value in restart_nodes() for Azure platform

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1766,7 +1766,7 @@ class AZURENodes(NodesBase):
                 node_names=node_names, status=constants.NODE_READY, timeout=timeout
             )
 
-    def restart_nodes(self, nodes, timeout=540, wait=True):
+    def restart_nodes(self, nodes, timeout=900, wait=True):
         """
         Restart Azure vm instances
 


### PR DESCRIPTION
Fixes: #3735 

In Azure platform, node(s) takes longer time to reach Ready state (takes around 12 minutes sometimes) after node restart. Hence, increased the timeout to 900 seconds.

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>