### PR TITLE
Fix restart node timeout error in test

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -67,7 +67,7 @@ class TestAddCapacityNodeRestart(ManageTest):
         # Restart nodes while additional storage is being added
         logging.info("Restart nodes:")
         logging.info([n.name for n in node_list])
-        nodes.restart_nodes(nodes=node_list, wait=True, timeout=420)
+        nodes.restart_nodes(nodes=node_list, wait=True)
         logging.info("Finished restarting the node list")
 
         # The exit criteria verification conditions here are not complete. When the branch


### PR DESCRIPTION
Fixes #3744 
Test case ```test_add_capacity_node_restart``` is updated to use the default value of platform specific restart node timeout which is given in ```restart_nodes``` function.
Signed-off-by: Jilju Joy <jijoy@redhat.com>