### PR TITLE
fixing github issue #3569 - increasing multiple creation time by 5 secs

### DIFF
--- a/tests/e2e/performance/test_pvc_creation_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_performance.py
@@ -222,9 +222,11 @@ class TestPVCCreationPerformance(E2ETest):
         end_time = helpers.get_provision_time(self.interface, pvc_objs, status="end")
         total = end_time - start_time
         total_time = total.total_seconds()
+        logging.info(f"Deletion time of {number_of_pvcs} is {total_time} seconds.")
+
         if total_time > 50:
             raise ex.PerformanceException(
                 f"{number_of_pvcs} PVCs creation (after initial deletion of "
-                f"75%) time is {total_time} and greater than 50 seconds"
+                f"75% of PVCs) time is {total_time} and greater than 50 seconds."
             )
         logging.info(f"{number_of_pvcs} PVCs creation time took less than a 50 seconds")

--- a/tests/e2e/performance/test_pvc_creation_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_performance.py
@@ -222,9 +222,9 @@ class TestPVCCreationPerformance(E2ETest):
         end_time = helpers.get_provision_time(self.interface, pvc_objs, status="end")
         total = end_time - start_time
         total_time = total.total_seconds()
-        if total_time > 45:
+        if total_time > 50:
             raise ex.PerformanceException(
                 f"{number_of_pvcs} PVCs creation (after initial deletion of "
-                f"75%) time is {total_time} and greater than 45 seconds"
+                f"75%) time is {total_time} and greater than 50 seconds"
             )
-        logging.info(f"{number_of_pvcs} PVCs creation time took less than a 45 seconds")
+        logging.info(f"{number_of_pvcs} PVCs creation time took less than a 50 seconds")


### PR DESCRIPTION
Signed-off-by: Yulia Persky <ypersky@redhat.com>

The reason for increasing multiple creation time threshold by 5 secs ( from 45 to 50 secs) is the fact that the test was failing on Azure encrypted cluster- multiple creation time was 46.71secs ( and on number of different runs it was always 46 - 47 secs)  
See 4.6 Performance report for this measurement : 
https://docs.google.com/document/d/11q_DqV30XY7DG_AgwZWVvl3k0KI5PNjqLLFqjUs5tns/edit#

Therefore after consulting @Avilir we've agreed that it's ok to raise this threshold up to 50 secs. 
