### PR TITLE
Remove object bucket deletion assertion from test_bucket_delete

### DIFF
--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -33,7 +33,7 @@ class TestBucketDeletion:
         """
         for bucket in rgw_bucket_factory(amount, interface):
             logger.info(f"Deleting bucket: {bucket.name}")
-            assert bucket.delete()
+            bucket.delete()
 
     @pytest.mark.parametrize(
         argnames="interface",


### PR DESCRIPTION
Due to a change done in #3623, the OB deletion assertion is [no longer returning a value](https://github.com/red-hat-storage/ocs-ci/pull/3623/files#diff-182979f19c5a44501b1e65af59e1067af0e96e8b479ca0eb150e208459b16934L164-R164).
Thus, the test assertion would lead to an `assert None` case.