### PR TITLE
Skip test_upgrade_mcg_io due to BZ 1874243

### DIFF
--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -160,6 +160,7 @@ def test_start_upgrade_mcg_io(mcg_workload_job):
 
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2207")
+@bugzilla("1874243")
 def test_upgrade_mcg_io(mcg_workload_job):
     """
     Confirm that there is MCG workload job running after upgrade.


### PR DESCRIPTION
- mcg_workload_job fixture teardown is called after upgrade so that the IO is ran during upgrade even when the test is skipped.

Signed-off-by: Filip Balak <fbalak@redhat.com>