### PR TITLE
[AZURE] Apply SSD tuning as a workaround for bug 1909793

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -64,6 +64,7 @@ from ocs_ci.utility.utils import (
     add_stage_cert,
     modify_csv,
     wait_for_machineconfigpool_status,
+    apply_ssd_tuning_azure,
 )
 from ocs_ci.utility.vsphere_nodes import update_ntp_compute_nodes
 from ocs_ci.helpers import helpers
@@ -134,6 +135,12 @@ class Deployment(object):
         if not config.ENV_DATA["skip_ocs_deployment"]:
             try:
                 self.deploy_ocs()
+
+                # WA for Bug 1909793
+                ocs_version = float(config.ENV_DATA["ocs_version"])
+                if self.platform == constants.AZURE_PLATFORM and ocs_version < 4.7:
+                    apply_ssd_tuning_azure()
+
                 if config.REPORTING["collect_logs_on_success_run"]:
                     collect_ocs_logs("deployment", ocp=False, status_failure=False)
             except Exception as e:


### PR DESCRIPTION
Fixes: #3764 

SSD tuning will be auto-applied after OCS deployment as a workaround for bug [1909793](https://bugzilla.redhat.com/show_bug.cgi?id=1909793)

For an existing cluster (without this tuning), follow the steps given in this doc: https://docs.google.com/document/d/1GVUazTDTmFKJ5budSuFPGWs3aYjzzxWpSaga22kXO9M/edit?usp=sharing

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>