### PR TITLE
downstream ci: use python3.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,14 +39,16 @@ pipeline {
           fi
           sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
           sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+          sudo yum install -y python38-devel
           python3 -V
           pip3 install --user virtualenv
-          python3 -m virtualenv venv
+          python3 -m virtualenv -p python3.8 venv
           source ./venv/bin/activate
+          python -V
           pip3 install tox
           pip3 install -r requirements.txt
-          python3 setup.py develop
-          python3 ./.functional_ci_setup.py --skip-aws
+          python setup.py develop
+          python ./.functional_ci_setup.py --skip-aws
           """
       }
     }
@@ -64,7 +66,7 @@ pipeline {
         script { LAST_STAGE=env.STAGE_NAME }
         sh """
           source ./venv/bin/activate
-          tox -e py36
+          tox -e py38
           """
       }
     }


### PR DESCRIPTION
I've tested this and python3.8 is installed and used: https://storage-jenkins-csb-ceph.cloud.paas.psi.redhat.com/job/ocs-ci/215/console