### PR TITLE
OCS disconnected installation from live content

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -181,6 +181,20 @@ To enable ocs-ci to use this token, add the following to your `auth.yaml`:
 quay:
   access_token: 'YOUR_TOKEN'
 ```
+#### GitHub
+
+For disconnected cluster installation, we need to access github api (during
+downloading opm tool) which have very strict rate limit for unauthenticated
+requests ([60 requests per hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)).
+To avoid API rate limit exceeded errors, you can provide github authentication
+credentials (username and token) obtained on [Personal access tokens](https://github.com/settings/tokens)
+page (Settings -> Developer settings -> Personal access tokens).
+
+```yaml
+github:
+  username: "GITHUB_USERNAME"
+  token: "GITHUB_TOKEN"
+```
 
 ## Tests
 

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -60,6 +60,11 @@ def prepare_disconnected_ocs_deployment():
     - mirror related images to mirror registry
     - create imageContentSourcePolicy for the mirrored images
     - disable the default OperatorSources
+
+    Returns:
+        str: OCS registry image prepared for disconnected installation (with
+            sha256 digest)
+
     """
 
     logger.info("Prepare for disconnected OCS installation")

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -4,15 +4,21 @@ This module contains functionality required for disconnected installation.
 
 import logging
 import os
+import tempfile
+
 import yaml
 
 from ocs_ci.framework import config
+from ocs_ci.helpers.disconnected import get_opm_tool
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.utility import templating
 from ocs_ci.utility.utils import (
     create_directory_path,
     exec_cmd,
     get_image_with_digest,
     get_latest_ds_olm_tag,
+    get_ocp_version,
     login_to_mirror_registry,
     prepare_customized_pull_secret,
     wait_for_machineconfigpool_status,
@@ -63,15 +69,90 @@ def prepare_disconnected_ocs_deployment():
 
     Returns:
         str: OCS registry image prepared for disconnected installation (with
-            sha256 digest)
+            sha256 digest) or None (for live deployment)
 
     """
 
     logger.info("Prepare for disconnected OCS installation")
     if config.DEPLOYMENT.get("live_deployment"):
-        raise NotImplementedError(
-            "Disconnected installation from live is not implemented!"
+        get_opm_tool()
+
+        pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        ocp_version = get_ocp_version()
+        index_image = f"{config.DEPLOYMENT['cs_redhat_operators_image']}:v{ocp_version}"
+        mirrored_index_image = (
+            f"{config.DEPLOYMENT['mirror_registry']}/{constants.MIRRORED_INDEX_IMAGE_NAMESPACE}/"
+            f"{constants.MIRRORED_INDEX_IMAGE_NAME}:v{ocp_version}"
         )
+        # prune an index image
+        logger.info(
+            f"Prune index image {index_image} -> {mirrored_index_image} "
+            f"(packages: {', '.join(constants.DISCON_CL_REQUIRED_PACKAGES)})"
+        )
+        cmd = (
+            f"opm index prune -f {index_image} "
+            f"-p {','.join(constants.DISCON_CL_REQUIRED_PACKAGES)} "
+            f"-t {mirrored_index_image}"
+        )
+        # opm tool doesn't have --atuhfile parameter, we have to suply auth
+        # file through env variable
+        os.environ["REGISTRY_AUTH_FILE"] = pull_secret_path
+        exec_cmd(cmd)
+
+        # login to mirror registry
+        login_to_mirror_registry(pull_secret_path)
+
+        # push pruned index image to mirror registry
+        logger.info(
+            f"Push pruned index image to mirror registry: {mirrored_index_image}"
+        )
+        cmd = f"podman push --authfile {pull_secret_path} --tls-verify=false {mirrored_index_image}"
+        exec_cmd(cmd)
+
+        # mirror related images (this might take very long time)
+        logger.info(f"Mirror images related to index image: {mirrored_index_image}")
+        cmd = (
+            f"oc adm catalog mirror {mirrored_index_image} -a {pull_secret_path} --insecure "
+            f"{config.DEPLOYMENT['mirror_registry']} --filter-by-os='.*'"
+        )
+        exec_cmd(cmd, timeout=7200)
+
+        # create ImageContentSourcePolicy
+        icsp_file = os.path.join(
+            f"{constants.MIRRORED_INDEX_IMAGE_NAME}-manifests",
+            "imageContentSourcePolicy.yaml",
+        )
+        exec_cmd(f"oc apply -f {icsp_file}")
+
+        # Disable the default OperatorSources
+        exec_cmd(
+            """oc patch OperatorHub cluster --type json """
+            """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
+        )
+
+        # create redhat-operators CatalogSource
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+
+        catalog_source_manifest = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="catalog_source_manifest", delete=False
+        )
+        catalog_source_data["spec"]["image"] = f"{mirrored_index_image}"
+        catalog_source_data["metadata"]["name"] = "redhat-operators"
+        catalog_source_data["spec"]["displayName"] = "Red Hat Operators - Mirrored"
+
+        templating.dump_data_to_temp_yaml(
+            catalog_source_data, catalog_source_manifest.name
+        )
+        exec_cmd(f"oc apply -f {catalog_source_manifest.name}")
+        catalog_source = CatalogSource(
+            resource_name="redhat-operators",
+            namespace=constants.MARKETPLACE_NAMESPACE,
+        )
+        # Wait for catalog source is ready
+        catalog_source.wait_for_state("READY")
+
+        return
+
     if config.DEPLOYMENT.get("stage_rh_osbs"):
         raise NotImplementedError(
             "Disconnected installation from stage is not implemented!"

--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -325,7 +325,7 @@ class FlexyBase(object):
 
     def flexy_post_processing(self):
         """
-        Pefrom few actions required after flexy execution:
+        Perform a few actions required after flexy execution:
         - update global pull-secret
         - login to mirror registry (disconected cluster)
         - configure proxy server (disconnected cluster)

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -146,6 +146,10 @@ ENV_DATA:
   disk_enable_uuid: 'TRUE'
   # Encoding type for the ignition config
   ignition_data_encoding: base64
+  # opm tool github owner and repository (used in api url for downloading opm tool)
+  opm_owner_repo: "operator-framework/operator-registry"
+  # opm tool release tag (particular version or "latest") to be downloaded
+  opm_release_tag: "latest"
 
 # This section is related to upgrade
 UPGRADE:

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -78,6 +78,8 @@ DEPLOYMENT:
   infra_nodes: False
   # How long should ocs-ci wait for `openshift-install create cluster` run?
   openshift_install_timeout: 3600
+  # redhat-operators CatalogSource image (used for disconnected installation)
+  cs_redhat_operators_image: "registry.redhat.io/redhat/redhat-operator-index"
 
 # Section for reporting configuration
 REPORTING:

--- a/ocs_ci/helpers/disconnected.py
+++ b/ocs_ci/helpers/disconnected.py
@@ -1,0 +1,79 @@
+import json
+import logging
+import os
+import platform
+
+from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    NotFoundError,
+    UnsupportedOSType,
+)
+from ocs_ci.utility.utils import (
+    download_file,
+    exec_cmd,
+    get_url_content,
+    prepare_bin_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_opm_tool():
+    """
+    Download and install opm tool.
+
+    """
+    try:
+        opm_version = exec_cmd("opm version")
+    except (CommandFailed, FileNotFoundError):
+        logger.info("opm tool is not available, installing it")
+        opm_release_tag = config.ENV_DATA.get("opm_release_tag", "latest")
+        if opm_release_tag != "latest":
+            opm_release_tag = f"tags/{opm_release_tag}"
+        opm_releases_api_url = (
+            f"https://api.github.com/repos/{config.ENV_DATA.get('opm_owner_repo')}/"
+            f"releases/{opm_release_tag}"
+        )
+        if config.AUTH.get("github"):
+            github_auth = (
+                config.AUTH["github"].get("username"),
+                config.AUTH["github"].get("token"),
+            )
+            logger.debug(f"Using github authentication (user: {github_auth[0]})")
+        else:
+            github_auth = None
+            logger.warning(
+                "Github credentials are not provided in data/auth.yaml file. "
+                "You might encounter issues with accessing github api as it "
+                "have very strict rate limit for unauthenticated requests "
+                "(60 requests per hour). Please check docs/getting_started.md "
+                "file to find how to configure github authentication."
+            )
+        release_data = json.loads(
+            get_url_content(opm_releases_api_url, auth=github_auth)
+        )
+
+        if platform.system() == "Darwin":
+            opm_asset_name = "darwin-amd64-opm"
+        elif platform.system() == "Linux":
+            opm_asset_name = "linux-amd64-opm"
+        else:
+            raise UnsupportedOSType
+
+        for asset in release_data["assets"]:
+            if asset["name"] == opm_asset_name:
+                opm_download_url = asset["browser_download_url"]
+                break
+        else:
+            raise NotFoundError(
+                f"opm binary for selected type {opm_asset_name} was not found"
+            )
+        prepare_bin_dir()
+        bin_dir = os.path.expanduser(config.RUN["bin_dir"])
+        logger.info(f"Downloading opm tool from '{opm_download_url}' to '{bin_dir}'")
+        download_file(opm_download_url, os.path.join(bin_dir, "opm"))
+        cmd = f"chmod +x {os.path.join(bin_dir, 'opm')}"
+        exec_cmd(cmd)
+        opm_version = exec_cmd("opm version")
+    logger.info(f"opm tool is available: {opm_version.stdout.decode('utf-8')}")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1023,6 +1023,17 @@ DISCON_CL_PROXY_ALLOWED_DOMAINS = (
     "mirrorlist.centos.org",
     "mirror.centos.org",
 )
+# mirrored redhat-operators index image for catalog source namespace and name
+MIRRORED_INDEX_IMAGE_NAMESPACE = "olm-mirror"
+MIRRORED_INDEX_IMAGE_NAME = "redhat-operator-index"
+# following packages are required for live disconnected cluster installation
+# (all images related to those packages will be mirrored to the mirror registry)
+DISCON_CL_REQUIRED_PACKAGES = [
+    # "elasticsearch-operator",
+    "local-storage-operator",
+    "ocs-operator",
+]
+
 
 # PSI-openstack constants
 NOVA_CLNT_VERSION = "2.0"

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -259,3 +259,7 @@ class ImageIsNotDeletedOrNotFound(Exception):
 
 class UnhealthyBucket(Exception):
     pass
+
+
+class NotFoundError(Exception):
+    pass

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -511,28 +511,30 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     return completed_process
 
 
-def download_file(url, filename):
+def download_file(url, filename, **kwargs):
     """
     Download a file from a specified url
 
     Args:
         url (str): URL of the file to download
         filename (str): Name of the file to write the download to
+        kwargs (dict): additional keyword arguments passed to requests.get(...)
 
     """
     log.debug(f"Download '{url}' to '{filename}'.")
     with open(filename, "wb") as f:
-        r = requests.get(url)
+        r = requests.get(url, **kwargs)
         assert r.ok, f"The URL {url} is not available! Status: {r.status_code}."
         f.write(r.content)
 
 
-def get_url_content(url):
+def get_url_content(url, **kwargs):
     """
     Return URL content
 
     Args:
         url (str): URL address to return
+        kwargs (dict): additional keyword arguments passed to requests.get(...)
     Returns:
         str: Content of URL
 
@@ -541,7 +543,7 @@ def get_url_content(url):
 
     """
     log.debug(f"Download '{url}' content.")
-    r = requests.get(url)
+    r = requests.get(url, **kwargs)
     assert r.ok, f"Couldn't load URL: {url} content! Status: {r.status_code}."
     return r.content
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2457,7 +2457,7 @@ def prepare_customized_pull_secret(images=None):
     use whole content of pull-secret.
 
     Args:
-        images (str or list): image (or images) to match with auth section
+        images (str, list): image (or images) to match with auth section
 
     Returns:
         NamedTemporaryFile: prepared pull-secret


### PR DESCRIPTION
This patch is implementing installation of live (released) OCS in disconnected OCP environment.

It mostly follows steps from official OCP documentation [3.8. Using Operator Lifecycle Manager on restricted networks](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html-single/operators/index#olm-restricted-networks).

Additionally it contains few small doc string fixes for issues from previous PR.