### PR TITLE
Smallfiles - use the new ES method to retrieve data from internal ES

### DIFF
--- a/ocs_ci/ocs/perfresult.py
+++ b/ocs_ci/ocs/perfresult.py
@@ -95,7 +95,7 @@ class PerfResult:
 
         log.info(f"Writing all data to ES server {self.es}")
         self.add_key("all_results", self.all_results)
-        log.info(
+        log.debug(
             f"Params : index={self.new_index}, "
             f"doc_type=_doc, body={self.results}, id={self.uuid}"
         )

--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -1,0 +1,224 @@
+# import pytest
+import time
+import logging
+
+from elasticsearch import Elasticsearch
+
+from ocs_ci.framework.testlib import BaseTest
+
+from ocs_ci.ocs import defaults, constants
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import *  # noqa: F403
+from ocs_ci.ocs.version import get_environment_info
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.utils import get_pod_name_by_pattern
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.elasticsearch import elasticsearch_load
+
+log = logging.getLogger(__name__)
+
+
+@scale  # noqa: F405
+@performance  # noqa: F405
+class PASTest(BaseTest):
+    """
+    Base class for QPAS team - Performance and Scale tests
+
+    This class contain functions which used by performance and scale test,
+    and also can be used by E2E test which used the benchmark-operator (ripsaw)
+    """
+
+    def setup(self):
+        """
+        Setting up the environment for each performance and scale test
+
+        """
+        log.info("Setting up test environment")
+        self.crd_data = None  # place holder for Benchmark CDR data
+        self.es_backup = None  # place holder for the elasticsearch backup
+        self.main_es = None  # place holder for the main elasticsearch object
+        self.benchmark_obj = None  # place holder for the benchmark object
+        self.client_pod = None  # Place holder for the client pod object
+        self.dev_mode = config.RUN["cli_params"].get("dev_mode")
+        self.environment = get_environment_info()
+        self.pod_obj = OCP(kind="pod")
+
+    def ripsaw_deploy(self, ripsaw):
+        """
+        Deploy the benchmark operator (formally ripsaw) CRD
+
+        Args:
+            ripsaw (obj): benchmark operator object
+
+        """
+        log.info("Deploying benchmark operator (ripsaw)")
+        ripsaw.apply_crd("resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml")
+
+    def es_info_backup(self, elasticsearch):
+        """
+        Saving the Original elastic-search IP and PORT - if defined in yaml
+
+        Args:
+            elasticsearch (obj): elasticsearch object
+
+        """
+
+        # for development mode use the Dev ES server
+        if self.dev_mode:
+            if "elasticsearch" in self.crd_data["spec"]:
+                log.info("Using the development ES server")
+                self.crd_data["spec"]["elasticsearch"] = {
+                    "server": defaults.ELASTICSEARCH_DEV_IP,
+                    "port": defaults.ELASTICSEARCE_PORT,
+                }
+
+        if "elasticsearch" in self.crd_data["spec"]:
+            self.crd_data["spec"]["elasticsearch"]["url"] = (
+                f"http://{self.crd_data['spec']['elasticsearch']['server']}:"
+                f"{self.crd_data['spec']['elasticsearch']['port']}"
+            )
+            self.backup_es = self.crd_data["spec"]["elasticsearch"]
+            log.info(
+                f"Creating object for the Main ES server on {self.backup_es['url']}"
+            )
+            self.main_es = Elasticsearch([self.backup_es["url"]], verify_certs=True)
+        else:
+            log.warning("Elastic Search information does not exists in YAML file")
+            self.crd_data["spec"]["elasticsearch"] = {}
+
+        # Use the internal define elastic-search server in the test - if exist
+        if elasticsearch:
+            ip = elasticsearch.get_ip()
+            port = elasticsearch.get_port()
+            self.crd_data["spec"]["elasticsearch"] = {
+                "server": ip,
+                "port": port,
+                "url": f"http://{ip}:{port}",
+            }
+            log.info(f"Going to use the ES : {self.crd_data['spec']['elasticsearch']}")
+
+    def set_storageclass(self, interface):
+        """
+        Setting the benchmark CDR storageclass
+
+        Args:
+            interface (str): The interface which will used in the test
+
+        """
+        if interface == constants.CEPHBLOCKPOOL:
+            storageclass = constants.DEFAULT_STORAGECLASS_RBD
+        else:
+            storageclass = constants.DEFAULT_STORAGECLASS_CEPHFS
+        log.info(f"Using [{storageclass}] Storageclass")
+        self.crd_data["spec"]["workload"]["args"]["storageclass"] = storageclass
+
+    def get_env_info(self):
+        """
+        Getting the environment information and update the workload RC if
+        necessary.
+
+        """
+        if not self.environment["user"] == "":
+            self.crd_data["spec"]["test_user"] = self.environment["user"]
+        else:
+            # since full results object need this parameter, initialize it from CR file
+            self.environment["user"] = self.crd_data["spec"]["test_user"]
+        self.crd_data["spec"]["clustername"] = self.environment["clustername"]
+
+        log.debug(f"Environment information is : {self.environment}")
+
+    def deploy_and_wait_for_wl_to_start(self, timeout=300, sleep=20):
+        """
+        Deploy the workload and wait until it start working
+
+        Args:
+            timeout (int): time in second to wait until the benchmark start
+            sleep (int): Sleep interval seconds
+
+        """
+        log.debug(f"The {self.benchmark_name} CR file is {self.crd_data}")
+        self.benchmark_obj = OCS(**self.crd_data)
+        self.benchmark_obj.create()
+
+        # This time is only for reporting - when the benchmark started.
+        self.start_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
+
+        # Wait for benchmark client pod to be created
+        log.info(f"Waiting for {self.client_pod_name} to Start")
+        for bm_pod in TimeoutSampler(
+            timeout,
+            sleep,
+            get_pod_name_by_pattern,
+            self.client_pod_name,
+            constants.RIPSAW_NAMESPACE,
+        ):
+            try:
+                if bm_pod[0] is not None:
+                    self.client_pod = bm_pod[0]
+                    break
+            except IndexError:
+                log.info("Bench pod is not ready yet")
+        # Sleeping for 15 sec for the client pod to be fully accessible
+        time.sleep(15)
+        log.info(f"The benchmark pod {self.client_pod_name} is Running")
+
+    def wait_for_wl_to_finish(self, timeout=18000, sleep=300):
+        """
+        Waiting until the workload is finished and get the test log
+
+        Args:
+            timeout (int): time in second to wait until the benchmark start
+            sleep (int): Sleep interval seconds
+
+        """
+        log.info(f"Waiting for {self.client_pod_name} to complete")
+        self.pod_obj.wait_for_resource(
+            condition=constants.STATUS_COMPLETED,
+            resource_name=self.client_pod,
+            timeout=timeout,
+            sleep=sleep,
+        )
+
+        # Getting the end time of the benchmark - for reporting.
+        self.end_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
+        self.test_logs = self.pod_obj.exec_oc_cmd(
+            f"logs {self.client_pod}", out_yaml_format=False
+        )
+        # Saving the benchmark internal log into a file at the logs directory
+        log_file_name = f"{self.full_log_path}/test-pod.log"
+        try:
+            with open(log_file_name, "w") as f:
+                f.write(self.test_logs)
+            log.info(f"The Test log can be found at : {log_file_name}")
+        except Exception:
+            log.warning(f"Cannot write the log to the file {log_file_name}")
+        log.info(f"The {self.benchmark_name} benchmark complete")
+
+    def copy_es_data(self, elasticsearch):
+        """
+        Copy data from Internal ES (if exists) to the main ES
+
+        Args:
+            elasticsearch (obj): elasticsearch object (if exits)
+
+        """
+        log.info(f"In copy_es_data Function - {elasticsearch}")
+        if elasticsearch:
+            log.info("Copy all data from Internal ES to Main ES")
+            log.info("Dumping data from the Internal ES to tar ball file")
+            elasticsearch.dumping_all_data(self.full_log_path)
+            es_connection = self.backup_es
+            es_connection["host"] = es_connection.pop("server")
+            es_connection.pop("url")
+            if elasticsearch_load(self.main_es, self.full_log_path):
+                # Adding this sleep between the copy and the analyzing of the results
+                # since sometimes the results of the read (just after write) are empty
+                time.sleep(10)
+                log.info(
+                    f"All raw data for tests results can be found at : {self.full_log_path}"
+                )
+                return True
+            else:
+                log.warning("Cannot upload data into the Main ES server")
+                return False

--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -100,7 +100,7 @@ class PASTest(BaseTest):
 
     def set_storageclass(self, interface):
         """
-        Setting the benchmark CDR storageclass
+        Setting the benchmark CRD storageclass
 
         Args:
             interface (str): The interface which will used in the test

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -19,18 +19,13 @@ import numpy as np
 from elasticsearch import exceptions as ESExp
 
 # Local modules
-from ocs_ci.ocs.ocp import OCP
-from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
-from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.ripsaw import RipSaw
-from ocs_ci.ocs import constants, node
-from ocs_ci.framework.testlib import E2ETest, performance
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import performance
 from ocs_ci.ocs.perfresult import PerfResult
-from ocs_ci.helpers.helpers import get_logs_with_errors
-from ocs_ci.ocs.elasticsearch import ElasticSearch
-from ocs_ci.ocs.version import get_environment_info
+from ocs_ci.helpers.helpers import get_full_test_logs_path
+from ocs_ci.ocs.perftests import PASTest
 
 log = logging.getLogger(__name__)
 
@@ -104,7 +99,7 @@ class SmallFileResultsAnalyse(PerfResult):
             self.all_results = self.es.search(
                 index=self.index, body=query, size=self.records
             )
-            log.info(self.all_results)
+            log.debug(self.all_results)
 
             if not self.all_results["hits"]["hits"]:
                 log.warning("No data in ES server, disabling results calculation")
@@ -190,7 +185,7 @@ class SmallFileResultsAnalyse(PerfResult):
         """
 
         res = {}
-        log.info(f"The results to combine {results}")
+        log.debug(f"The results to combine {results}")
         for rec in results.keys():
             record = results[rec]
             for key in self.managed_keys.keys():
@@ -234,13 +229,13 @@ class SmallFileResultsAnalyse(PerfResult):
 
         Returns:
             bool: True if results deviation (between samples) is les or equal
-                       to 5%, otherwise False
+                       to 20%, otherwise False
 
         """
 
         test_pass = True
         for op in self.results["operations"]:
-            log.info(f'Aggregating {op} - {self.results["full-res"][op]}')
+            log.debug(f'Aggregating {op} - {self.results["full-res"][op]}')
             results = self.combine_results(self.results["full-res"][op], False)
 
             log.info(f"Check IOPS {op} samples deviation")
@@ -305,24 +300,6 @@ class SmallFileResultsAnalyse(PerfResult):
 
 
 @pytest.fixture(scope="function")
-def es(request):
-
-    # Create internal ES only if Cloud platform is tested
-    if node.get_provider().lower() in constants.CLOUD_PLATFORMS:
-        es = ElasticSearch()
-    else:
-        es = None
-
-    def teardown():
-        if es is not None:
-            es.cleanup()
-            time.sleep(10)
-
-    request.addfinalizer(teardown)
-    return es
-
-
-@pytest.fixture(scope="function")
 def ripsaw(request, storageclass_factory):
     def teardown():
         ripsaw.cleanup()
@@ -336,7 +313,7 @@ def ripsaw(request, storageclass_factory):
 
 
 @performance
-class TestSmallFileWorkload(E2ETest):
+class TestSmallFileWorkload(PASTest):
     """
     Deploy Ripsaw operator and run SmallFile workload
     SmallFile workload using https://github.com/distributed-system-analysis/smallfile
@@ -344,6 +321,11 @@ class TestSmallFileWorkload(E2ETest):
     used to quickly measure performance for a variety of metadata-intensive
     workloads
     """
+
+    def setup(self):
+        super(TestSmallFileWorkload, self).setup()
+        self.benchmark_name = "SmallFiles"
+        self.client_pod_name = "smallfile-client"
 
     @pytest.mark.parametrize(
         argnames=["file_size", "files", "threads", "samples", "interface"],
@@ -377,45 +359,26 @@ class TestSmallFileWorkload(E2ETest):
         """
         Run SmallFile Workload
         """
+        self.full_log_path = get_full_test_logs_path(cname=self)
+        self.full_log_path += f"-{file_size}-{files}-{threads}-{samples}-{interface}"
+        log.info(f"Logs file path name is : {self.full_log_path}")
 
         # Loading the main template yaml file for the benchmark
-        sf_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
+        self.crd_data = templating.load_yaml(constants.SMALLFILE_BENCHMARK_YAML)
 
-        # Saving the Original elastic-search IP and PORT - if defined in yaml
-        if "elasticsearch" in sf_data["spec"]:
-            sf_data["spec"]["elasticsearch"][
-                "url"
-            ] = f"http://{sf_data['spec']['elasticsearch']['server']}:{sf_data['spec']['elasticsearch']['port']}"
-            backup_es = sf_data["spec"]["elasticsearch"]
-        else:
-            log.warning("Elastic Search information does not exists in YAML file")
-            sf_data["spec"]["elasticsearch"] = {}
+        self.es_info_backup(es)
 
-        # Use the internal define elastic-search server in the test - if exist
-        if es:
-            sf_data["spec"]["elasticsearch"] = {
-                "url": f"http://{es.get_ip()}:{es.get_port()}",
-                "server": es.get_ip(),
-                "port": es.get_port(),
-            }
-
-        log.info("Apply Operator CRD")
-        ripsaw.apply_crd("resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml")
-        if interface == constants.CEPHBLOCKPOOL:
-            storageclass = constants.DEFAULT_STORAGECLASS_RBD
-        else:
-            storageclass = constants.DEFAULT_STORAGECLASS_CEPHFS
-        log.info(f"Using {storageclass} Storageclass")
-        sf_data["spec"]["workload"]["args"]["storageclass"] = storageclass
+        self.ripsaw_deploy(ripsaw)
+        self.set_storageclass(interface=interface)
         log.info("Running SmallFile bench")
 
         """
             Setting up the parameters for this test
         """
-        sf_data["spec"]["workload"]["args"]["file_size"] = file_size
-        sf_data["spec"]["workload"]["args"]["files"] = files
-        sf_data["spec"]["workload"]["args"]["threads"] = threads
-        sf_data["spec"]["workload"]["args"]["samples"] = samples
+        self.crd_data["spec"]["workload"]["args"]["file_size"] = file_size
+        self.crd_data["spec"]["workload"]["args"]["files"] = files
+        self.crd_data["spec"]["workload"]["args"]["threads"] = threads
+        self.crd_data["spec"]["workload"]["args"]["samples"] = samples
         """
         Calculating the size of the volume that need to be test, it should
         be at least twice in the size then the size of the files, and at
@@ -428,62 +391,23 @@ class TestSmallFileWorkload(E2ETest):
         vol_size = int(vol_size / constants.GB2KB)
         if vol_size < 100:
             vol_size = 100
-        sf_data["spec"]["workload"]["args"]["storagesize"] = f"{vol_size}Gi"
-        environment = get_environment_info()
-        if not environment["user"] == "":
-            sf_data["spec"]["test_user"] = environment["user"]
-        else:
-            # since full results object need this parameter, initialize it from CR file
-            environment["user"] = sf_data["spec"]["test_user"]
+        self.crd_data["spec"]["workload"]["args"]["storagesize"] = f"{vol_size}Gi"
+        self.get_env_info()
 
-        sf_data["spec"]["clustername"] = environment["clustername"]
-
-        sf_obj = OCS(**sf_data)
-        sf_obj.create()
-        log.info(f"The smallfile yaml file is {sf_data}")
-
-        # wait for benchmark pods to get created - takes a while
-        for bench_pod in TimeoutSampler(
-            240,
-            10,
-            get_pod_name_by_pattern,
-            "smallfile-client",
-            constants.RIPSAW_NAMESPACE,
-        ):
-            try:
-                if bench_pod[0] is not None:
-                    small_file_client_pod = bench_pod[0]
-                    break
-            except IndexError:
-                log.info("Bench pod not ready yet")
-
-        bench_pod = OCP(kind="pod", namespace=constants.RIPSAW_NAMESPACE)
-        log.info("Waiting for SmallFile benchmark to Run")
-        assert bench_pod.wait_for_resource(
-            condition=constants.STATUS_RUNNING,
-            resource_name=small_file_client_pod,
-            sleep=30,
-            timeout=600,
-        )
-        # Getting the start time of the test
-        start_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
-
-        test_start_time = time.time()
-
-        # After testing manually, changing the timeout
-        timeout = 3600
+        self.deploy_and_wait_for_wl_to_start(timeout=240, sleep=10)
 
         # Getting the UUID from inside the benchmark pod
-        uuid = ripsaw.get_uuid(small_file_client_pod)
-        # Setting back the original elastic-search information
-        if backup_es:
-            sf_data["spec"]["elasticsearch"] = backup_es
+        uuid = ripsaw.get_uuid(self.client_pod)
 
-        full_results = SmallFileResultsAnalyse(uuid, sf_data)
+        # Setting back the original elastic-search information
+        if self.backup_es:
+            self.crd_data["spec"]["elasticsearch"] = self.backup_es
+
+        full_results = SmallFileResultsAnalyse(uuid, self.crd_data)
 
         # Initialize the results doc file.
-        for key in environment:
-            full_results.add_key(key, environment[key])
+        for key in self.environment:
+            full_results.add_key(key, self.environment[key])
 
         # Calculating the total size of the working data set - in GB
         full_results.add_key(
@@ -500,43 +424,33 @@ class TestSmallFileWorkload(E2ETest):
             {
                 "files": files,
                 "file_size": file_size,
-                "storageclass": sf_data["spec"]["workload"]["args"]["storageclass"],
-                "vol_size": sf_data["spec"]["workload"]["args"]["storagesize"],
+                "storageclass": self.crd_data["spec"]["workload"]["args"][
+                    "storageclass"
+                ],
+                "vol_size": self.crd_data["spec"]["workload"]["args"]["storagesize"],
             },
         )
 
-        while True:
-            logs = bench_pod.exec_oc_cmd(
-                f"logs {small_file_client_pod}", out_yaml_format=False
+        self.wait_for_wl_to_finish(timeout=3600, sleep=30)
+
+        if "RUN STATUS DONE" in self.test_logs:
+            # Getting the end time of the test
+            full_results.add_key(
+                "test_time", {"start": self.start_time, "end": self.end_time}
             )
-            if "RUN STATUS DONE" in logs:
-                # Getting the end time of the test
-                end_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
-                full_results.add_key(
-                    "test_time", {"start": start_time, "end": end_time}
-                )
-                # if Internal ES is exists, Copy all data from the Internal to main ES
-                if es:
-                    log.info("Copy all data from Internal ES to Main ES")
-                    es._copy(full_results.es)
-                full_results.read()
-                if not full_results.dont_check:
-                    full_results.add_key("hosts", full_results.get_clients_list())
-                    full_results.init_full_results()
-                    full_results.aggregate_host_results()
-                    test_status = full_results.aggregate_samples_results()
-                    full_results.es_write()
+            # if Internal ES is exists, Copy all data from the Internal to main ES
+            self.copy_es_data(es)
+            full_results.read()
+            if not full_results.dont_check:
+                full_results.add_key("hosts", full_results.get_clients_list())
+                full_results.init_full_results()
+                full_results.aggregate_host_results()
+                test_status = full_results.aggregate_samples_results()
+                full_results.es_write()
 
-                    # Creating full link to the results on the ES server
-                    log.info(
-                        f"The Result can be found at ; {full_results.results_link()}"
-                    )
-                else:
-                    test_status = True
+                # Creating full link to the results on the ES server
+                log.info(f"The Result can be found at : {full_results.results_link()}")
+            else:
+                test_status = True
 
-                break
-
-            if timeout < (time.time() - test_start_time):
-                raise TimeoutError("Timed out waiting for benchmark to complete")
-            time.sleep(30)
-        assert not get_logs_with_errors() and test_status, "Test Failed"
+        assert test_status, "Test Failed !"


### PR DESCRIPTION
This PR is implementing the new way of using internal elastic-search server within the cluster and retrieving data from it to the main elastic-search server.

without this fix the test will not work properly, since we saw that the old method did not work all the time.

it also implement new Library for the Performance & Scale tests to prevent code duplication.