### PR TITLE
Skip node_replacement_proactive test for IBM as the logic doesn't handle the IBM specific instance

### DIFF
--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -17,7 +17,11 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.cluster import CephCluster, is_lso_cluster
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_openshift_dedicated,
+    cloud_platform_required,
+    vsphere_platform_required,
+)
 
 from ocs_ci.helpers.sanity_helpers import Sanity
 
@@ -195,6 +199,8 @@ class TestNodeReplacementWithIO(ManageTest):
 @tier4a
 @acceptance
 @ignore_leftovers
+@cloud_platform_required
+@vsphere_platform_required
 @skipif_openshift_dedicated
 class TestNodeReplacement(ManageTest):
     """


### PR DESCRIPTION
delete_and_create_osd nodes only handle cloud and vsphere platforms, it does nothing for IBM and in the end verification fails, we should skip this test.  Seen during one of the dev failures https://storage-jenkins-csb-ceph.cloud.paas.psi.redhat.com/job/ocs-ci-kvm/152/testReport/

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>