### PR TITLE
get proxies: logging and performance improvement

### DIFF
--- a/ocs_ci/helpers/proxy.py
+++ b/ocs_ci/helpers/proxy.py
@@ -33,9 +33,12 @@ def get_cluster_proxies():
         http_proxy = proxy_obj.get("spec", {}).get("httpProxy", "")
         https_proxy = proxy_obj.get("spec", {}).get("httpsProxy", "")
         no_proxy = proxy_obj.get("status", {}).get("noProxy", "")
-    logger.info("Using http_proxy: '%s'", http_proxy)
-    logger.info("Using https_proxy: '%s'", https_proxy)
-    logger.info("Using no_proxy: '%s'", no_proxy)
+        config.ENV_DATA["http_proxy"] = http_proxy
+        config.ENV_DATA["https_proxy"] = https_proxy
+        config.ENV_DATA["no_proxy"] = no_proxy
+    logger.debug("Using http_proxy: '%s'", http_proxy)
+    logger.debug("Using https_proxy: '%s'", https_proxy)
+    logger.debug("Using no_proxy: '%s'", no_proxy)
     return http_proxy, https_proxy, no_proxy
 
 


### PR DESCRIPTION
Improve logging and performace of get_cluster_proxies function:
- change log level from info to debug
- save loaded proxy configuration to config object
- related to https://github.com/red-hat-storage/ocs-ci/issues/3800

Signed-off-by: Daniel Horak <dahorak@redhat.com>