### PR TITLE
Increase ceph health check timeout in test test_add_capacity_node_restart

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -87,4 +87,4 @@ class TestAddCapacityNodeRestart(ManageTest):
 
         logging.info("Finished verifying add capacity osd storage with node restart")
         logging.info("Waiting for ceph health check to finished...")
-        ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=90)
+        ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=180)


### PR DESCRIPTION
The below test case is failing with CephHealthException while waiting for ceph health status to be HEALTH_OK.
tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py::TestAddCapacityNodeRestart::test_add_capacity_node_restart[1-workload_storageutilization_rbd0]

Add capacity succeeded. But recovery is taking more than the given wait time. Increasing the retries will resolve the issue.
Fixes #3832
Signed-off-by: Jilju Joy <jijoy@redhat.com>