### PR TITLE
Check whether the df output is empty before processing the value in test test_pvc_expand_expanded_pvc

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
@@ -107,6 +107,8 @@ class TestPvcExpand(ManageTest):
             for df_out in TimeoutSampler(
                 240, 3, pod_obj.exec_cmd_on_pod, command="df -kh"
             ):
+                if not df_out:
+                    continue
                 df_out = df_out.split()
                 new_size_mount = df_out[df_out.index(pod_obj.get_storage_path()) - 4]
                 if new_size_mount in [


### PR DESCRIPTION
The test case tests/manage/pv_services/pvc_resize/test_pvc_expansion.py::TestPvcExpand::test_pvc_expand_expanded_pvc is failing with the below error.
```
for df_out in TimeoutSampler( 240, 3, pod_obj.exec_cmd_on_pod, command="df -kh" ):> df_out = df_out.split()E AttributeError: 'NoneType' object has no attribute 'split'tests/manage/pv_services/pvc_resize/test_pvc_expansion.py:110: AttributeError
```
The output of df command on the app pod did not return any value. As a solution, check whether the df output is empty before processing the value
Issue #3846 
Signed-off-by: Jilju Joy <jijoy@redhat.com>