### PR TITLE
remove base_domain from azure configs

### DIFF
--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
@@ -7,7 +7,6 @@ ENV_DATA:
   deployment_type: 'ipi'
   region: 'eastus'
   azure_base_domain_resource_group_name: 'ocsqe'
-  base_domain: 'azure.qe.rh-ocs.com'
   worker_availability_zones:
     - '1'
   master_availability_zones:

--- a/conf/deployment/azure/ipi_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_3az_rhcos_3m_3w.yaml
@@ -7,7 +7,6 @@ ENV_DATA:
   deployment_type: 'ipi'
   region: 'eastus'
   azure_base_domain_resource_group_name: 'ocsqe'
-  base_domain: 'azure.qe.rh-ocs.com'
   worker_availability_zones:
     - '1'
     - '2'

--- a/conf/ocsci/azure2_qe_rh_ocs_com_domain.yaml
+++ b/conf/ocsci/azure2_qe_rh_ocs_com_domain.yaml
@@ -1,0 +1,3 @@
+---
+ENV_DATA:
+  base_domain: 'azure2.qe.rh-ocs.com'

--- a/conf/ocsci/azure_qe_rh_ocs_com_domain.yaml
+++ b/conf/ocsci/azure_qe_rh_ocs_com_domain.yaml
@@ -1,0 +1,3 @@
+---
+ENV_DATA:
+  base_domain: 'azure.qe.rh-ocs.com'

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -20,10 +20,25 @@ TODO document this platform
 
 ## Azure
 
-TODO document this platform
+File `osServicePrincipal.json` in `~/.azure/` directory with proper credentials
+is required. The file looks like this:
 
-* `base_domain` in `ENV_DATA` section have to be properly configured for
-  particular deployment (see for example `conf/ocsci/azure_qe_rh_ocs_com_domain.yaml` file)
+```json
+{
+  "subscriptionId": "...",
+  "clientId": "...",
+  "clientSecret": "...",
+  "tenantId": "..."
+}
+```
+
+To deploy ocs-ci cluster on Azure platform using one of OCS QE subscriptions,
+you need to specify one deployment config file from `conf/deployment/azure/`
+directory (which one to use depends on the type of deployment one needs to
+use) and also one config file with azure `base_domain` value (either
+`conf/ocsci/azure_qe_rh_ocs_com_domain.yaml` or
+`conf/ocsci/azure2_qe_rh_ocs_com_domain.yaml` file), because each azure
+subscription has it's own domain name.
 
 ### Deployment types
 

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -37,8 +37,9 @@ you need to specify one deployment config file from `conf/deployment/azure/`
 directory (which one to use depends on the type of deployment one needs to
 use) and also one config file with azure `base_domain` value (either
 `conf/ocsci/azure_qe_rh_ocs_com_domain.yaml` or
-`conf/ocsci/azure2_qe_rh_ocs_com_domain.yaml` file), because each azure
-subscription has it's own domain name.
+`conf/ocsci/azure2_qe_rh_ocs_com_domain.yaml` or similar newly created with
+proper `base_domain` configuration), because each azure subscription has it's
+own domain name.
 
 ### Deployment types
 

--- a/docs/supported_platforms.md
+++ b/docs/supported_platforms.md
@@ -22,6 +22,9 @@ TODO document this platform
 
 TODO document this platform
 
+* `base_domain` in `ENV_DATA` section have to be properly configured for
+  particular deployment (see for example `conf/ocsci/azure_qe_rh_ocs_com_domain.yaml` file)
+
 ### Deployment types
 
 #### UPI


### PR DESCRIPTION
- remove `base_domain` from azure config, to support more azure Accounts with different `base_domain`
- create new config files defining `base_domain` for the two available Azure accounts (usable for manual execution, in Jenkins this is handled as Credential files)
- related to https://projects.engineering.redhat.com/browse/OCSQE-596
- the merge should be coordinated with [MR!545](https://gitlab.cee.redhat.com/ocs/ocs4-jenkins/-/merge_requests/545)

Signed-off-by: Daniel Horak <dahorak@redhat.com>