### PR TITLE
Change Node replacement proactive test to run on vSphere and cloud platforms

### DIFF
--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -20,8 +20,6 @@ from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_openshift_dedicated,
     skipif_bmpsi,
-    cloud_platform_required,
-    vsphere_platform_required,
 )
 
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -200,8 +198,6 @@ class TestNodeReplacementWithIO(ManageTest):
 @tier4a
 @acceptance
 @ignore_leftovers
-@cloud_platform_required
-@vsphere_platform_required
 @skipif_openshift_dedicated
 @skipif_bmpsi
 class TestNodeReplacement(ManageTest):


### PR DESCRIPTION
Currently, the Node replacement proactive test can work on vSphere and cloud platforms. 
So we don't need to add the annotations of `cloud_platform_required` and `vsphere_platform_required`.