### PR TITLE
Skip namespace tests when unsupported OCS version is installed

### DIFF
--- a/tests/manage/mcg/test_namespace.py
+++ b/tests/manage/mcg/test_namespace.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from ocs_ci.framework.testlib import (
     MCGTest,
+    skipif_ocs_version,
     tier1,
     tier2,
     tier3,
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 @skipif_openshift_dedicated
 @skipif_aws_creds_are_missing
+@skipif_ocs_version("<4.6")
 class TestNamespace(MCGTest):
     """
     Test creation of a namespace resource
@@ -354,6 +356,7 @@ class TestNamespace(MCGTest):
 
     @pytest.mark.polarion_id("OCS-2280")
     @pytest.mark.bugzilla("1900760")
+    @skipif_ocs_version("<4.7")
     @tier3
     def test_create_resource_with_invalid_target_bucket(
         self, mcg_obj, mcg_connection_factory


### PR DESCRIPTION
Signed-off-by: Filip Balak <fbalak@redhat.com>