### PR TITLE
Implement node stop/start/restart for Power

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -278,6 +278,30 @@ def get_node_ips(node_type="worker"):
         raise NotImplementedError
 
 
+def get_node_ip_addresses(ipkind):
+    """
+    Gets a dictionary of required IP addresses for all nodes
+
+    Args:
+        ipkind: ExternalIP or InternalIP or Hostname
+
+    Returns:
+        dict: Internal or Exteranl IP addresses keyed off of node name
+
+    """
+    ocp = OCP(kind=constants.NODE)
+    masternodes = ocp.get(selector=constants.MASTER_LABEL).get("items")
+    workernodes = ocp.get(selector=constants.WORKER_LABEL).get("items")
+    nodes = masternodes + workernodes
+
+    return {
+        node["metadata"]["name"]: each["address"]
+        for node in nodes
+        for each in node["status"]["addresses"]
+        if each["type"] == ipkind
+    }
+
+
 def add_new_node_and_label_it(machineset_name, num_nodes=1, mark_for_ocs_label=True):
     """
     Add a new node for ipi and label it

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1720,7 +1720,7 @@ class IBMPowerNodes(NodesBase):
 
     def __init__(self):
         super(IBMPowerNodes, self).__init__()
-        self.powernodes = powernodes.POWERNodes()
+        self.powernodes = powernodes.PowerNodes()
 
     def stop_nodes(self, nodes, force=True):
         """
@@ -1736,8 +1736,8 @@ class IBMPowerNodes(NodesBase):
                 nodes, timeout=900, wait=True, force=force
             )
         else:
-            raise NotImplementedError(
-                "This is not libvirt environment. Stop nodes not implemented"
+            self.powernodes.stop_powernodes_machines_powervs(
+                nodes, timeout=900, wait=True
             )
 
     def start_nodes(self, nodes, force=True):
@@ -1754,8 +1754,8 @@ class IBMPowerNodes(NodesBase):
                 nodes, timeout=900, wait=True, force=force
             )
         else:
-            raise NotImplementedError(
-                "This is not libvirt environment. Start nodes not implemented"
+            self.powernodes.start_powernodes_machines_powervs(
+                nodes, timeout=900, wait=True
             )
 
     def restart_nodes(self, nodes, timeout=540, wait=True, force=True):
@@ -1775,8 +1775,8 @@ class IBMPowerNodes(NodesBase):
                 nodes, timeout=900, wait=True, force=force
             )
         else:
-            raise NotImplementedError(
-                "This is not libvirt environment. Restart nodes not implemented"
+            self.powernodes.restart_powernodes_machines_powervs(
+                nodes, timeout=900, wait=True
             )
 
     def restart_nodes_by_stop_and_start(self, nodes, force=True):
@@ -1793,31 +1793,37 @@ class IBMPowerNodes(NodesBase):
                 nodes, timeout=900, wait=True, force=force
             )
         else:
-            raise NotImplementedError(
-                "This is not libvirt environment. Restart nodes by stop and start not implemented"
+            self.powernodes.restart_powernodes_machines_powervs(
+                nodes, timeout=900, wait=True
             )
 
     def restart_nodes_by_stop_and_start_teardown(self):
         """
         Make sure all PowerNodes are up by the end of the test
         """
-        if not self.powernodes.iskvm():
-            raise NotImplementedError(
-                "This is not libvirt environment. Restart nodes by stop and start teardown not implemented"
-            )
-
         self.cluster_nodes = get_node_objs()
-        stopped_powernodes = [
-            powernode
-            for powernode in self.cluster_nodes
-            if self.powernodes.verify_machine_is_down(powernode) is True
-        ]
+        if self.powernodes.iskvm():
+            stopped_powernodes = [
+                powernode
+                for powernode in self.cluster_nodes
+                if self.powernodes.verify_machine_is_down(powernode) is True
+            ]
+        else:
+            stopped_powernodes = [
+                powernode
+                for powernode in self.cluster_nodes
+                if powernode.ocp.get_resource_status(powernode.name)
+                == constants.NODE_NOT_READY
+            ]
 
         if stopped_powernodes:
             logger.info(
                 f"The following PowerNodes are powered off: {stopped_powernodes}"
             )
-            self.powernodes.start_powernodes_machines(stopped_powernodes)
+            if self.powernodes.iskvm():
+                self.powernodes.start_powernodes_machines(stopped_powernodes)
+            else:
+                self.powernodes.start_powernodes_machines_powervs(stopped_powernodes)
 
 
 class AZURENodes(NodesBase):

--- a/ocs_ci/utility/service.py
+++ b/ocs_ci/utility/service.py
@@ -1,0 +1,242 @@
+import logging
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs import constants, node
+from ocs_ci.ocs.node import wait_for_nodes_status
+from ocs_ci.ocs.ocp import wait_for_cluster_connectivity
+from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
+
+logger = logging.getLogger(__name__)
+
+ACTIVE = b"active"
+INACTIVE = b"inactive"
+FAILED = b"failed"
+
+
+class Service(object):
+    """
+    Generic Service class
+
+    The purpose of this class is to provide a support to perform start/stop/restart and status
+    operations on a given service. The class is instantiated with required service name without
+    '.service extension. Refer to KubeletService class in this module for an example on how to
+    use these methods.
+    """
+
+    def __init__(self, service_name, force=False):
+        """
+        Class Initialization.
+
+        Initialize the service name local variable and collect a dictionary of Internel IP addresses
+        of nodes with node name as keys.
+        """
+        self.service_name = service_name
+        self.force = force
+
+        self.nodes = node.get_node_ip_addresses("InternalIP")
+
+    def verify_service(self, node, action):
+        """
+        Verify if PowerNode is completely powered off
+
+        Args:
+            node (object): Node objects
+            action (string): ACTIVE or INACTIVE or FAILED
+
+        Returns:
+            bool: True if service state is reqested action, False otherwise
+
+        """
+        nodeip = self.nodes[node.name]
+        result = exec_cmd(
+            f"ssh core@{nodeip} sudo systemctl is-active {self.service_name}.service"
+        )
+        if result.stdout.lower().rstrip() == action:
+            logger.info("Action succeeded.")
+            return True
+        else:
+            logger.info("Action pending.")
+            return False
+
+    def stop(self, node, timeout):
+        """
+        Stop the given service using systemctl.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to stop.
+
+        Raises:
+            UnexpectedBehaviour: If service on PowerNode machine is still up
+        """
+        nodeip = self.nodes[node.name]
+        cmd = f"ssh core@{nodeip} sudo systemctl stop {self.service_name}.service"
+        if self.force:
+            cmd += " -f"
+        result = exec_cmd(cmd)
+        logger.info(
+            f"Result of shutdown {result}. Checking if service {self.service_name} went down."
+        )
+        ret = TimeoutSampler(
+            timeout=timeout,
+            sleep=3,
+            func=self.verify_service,
+            node=node,
+            action=INACTIVE,
+        )
+        if not ret.wait_for_func_status(result=True):
+            raise UnexpectedBehaviour(
+                "Service {self.service_name} on Node {node.name} is still Running"
+            )
+
+    def start(self, node, timeout):
+        """
+        Start the given service using systemctl.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to start.
+
+        Raises:
+            UnexpectedBehaviour: If service on powerNode machine is still not up
+        """
+        nodeip = self.nodes[node.name]
+        cmd = f"ssh core@{nodeip} sudo systemctl start {self.service_name}.service"
+        result = exec_cmd(cmd)
+        logger.info(f"Result of start of service {self.service_name} is {result}")
+        ret = TimeoutSampler(
+            timeout=timeout,
+            sleep=3,
+            func=self.verify_service,
+            node=node,
+            action=ACTIVE,
+        )
+        if not ret.wait_for_func_status(result=True):
+            raise UnexpectedBehaviour(
+                "Service {self.service_name} on Node {node.name} is still not Running"
+            )
+
+    def kill(self, node, timeout):
+        """
+        Kill the given service using systemctl.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to be stopped.
+
+        """
+        nodeip = self.nodes[node.name]
+        cmd = f"ssh core@{nodeip} sudo systemctl kill {self.service_name}.service"
+        result = exec_cmd(cmd)
+        ret = TimeoutSampler(
+            timeout=timeout,
+            sleep=3,
+            func=self.verify_service,
+            node=node,
+            action=INACTIVE,
+        )
+        logger.info(f"Result of kill of service {self.service_name} is {result}-{ret}")
+
+    def restart(self, node, timeout):
+        """
+        Restart the given service using systemctl.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to be started.
+
+        """
+        nodeip = self.nodes[node.name]
+        cmd = f"ssh core@{nodeip} sudo systemctl restart {self.service_name}.service"
+        result = exec_cmd(cmd)
+        ret = TimeoutSampler(
+            timeout=timeout,
+            sleep=3,
+            func=self.verify_service,
+            node=node,
+            action=ACTIVE,
+        )
+        logger.info(
+            f"Result of restart of service {self.service_name} is {result}-{ret}"
+        )
+
+    def status(self, node, timeout):
+        """
+        Get the status of the given service using systemctl.
+
+        Args:
+            node (object): Node objects
+            timeout (int): Future use.
+
+        Returns:
+            (string): 'active' or 'inactive' or 'failed', etc.
+        """
+        nodeip = self.nodes[node.name]
+        cmd = f"ssh core@{nodeip} sudo systemctl status {self.service_name}.service"
+        result = exec_cmd(cmd)
+        logger.info(f"Result of status of service {self.service_name} is {result}")
+        return result.stdout.lower().rstrip()
+
+
+class KubeletService(Service):
+    """
+    Kubelet Service class
+
+    The purpose of this class is to extend Service class to provide stop/start/restart etc operations on
+    kubelet service. Since kubelet service stop and start operations involve changing status of OCP node
+    objects, this class verifies the same.
+    """
+
+    def __init__(self):
+        """
+        Class Initialization.
+
+        Initialize the service with kubelet service name.
+        """
+        super(KubeletService, self).__init__("kubelet")
+
+    def stop(self, node, timeout):
+        """
+        Stop the kubelet service using parent service class. After that, ensures the corresponding OCP node
+        moves to NotReady state.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to stop.
+
+        """
+        super().stop(node, timeout)
+        wait_for_nodes_status(
+            node_names=[node.name], status=constants.NODE_NOT_READY, timeout=timeout
+        )
+
+    def start(self, node, timeout):
+        """
+        Start the kubelet service using parent service class. After that, ensures the corresponding OCP node
+        is connectable and moves to Ready state.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to stop.
+
+        """
+        super().start(node, timeout)
+        wait_for_cluster_connectivity(tries=900)
+        wait_for_nodes_status(
+            node_names=[node.name], status=constants.NODE_READY, timeout=timeout
+        )
+
+    def restart(self, node, timeout):
+        """
+        Restart the kubelet service using parent service class. After that, ensures the corresponding OCP node
+        is connectable and moves to Ready state.
+
+        Args:
+            node (object): Node objects
+            timeout (int): time in seconds to wait for service to stop.
+
+        """
+        super().restart(node, timeout)
+        wait_for_cluster_connectivity(tries=900)
+        wait_for_nodes_status(
+            node_names=[node.name], status=constants.NODE_READY, timeout=timeout
+        )


### PR DESCRIPTION
This is an implementation of node stop/start/restart for
IBM Power environment other than libvirt. In libvirt
environment, the same is implemented using virsh stop/start etc.
For IBM Power environment other than Libvirt, the same is
attempted with stop/start of kubelet service inside the nodes.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>