### PR TITLE
[4.8 feature] vSphere deployment with thick storageclass

### DIFF
--- a/conf/deployment/vsphere/eagerzeroedthick_storage_class.yaml
+++ b/conf/deployment/vsphere/eagerzeroedthick_storage_class.yaml
@@ -1,0 +1,5 @@
+---
+# This config is for vSphere deployment with eagerzeroedthick storageclass provisioning
+DEPLOYMENT:
+  thick_sc: True
+  eager_zeroed_thick_sc: True

--- a/conf/deployment/vsphere/thick_storage_class.yaml
+++ b/conf/deployment/vsphere/thick_storage_class.yaml
@@ -1,4 +1,0 @@
----
-# This config is for vSphere deployment with thick provisioning
-DEPLOYMENT:
-  thick_sc_ocs_deploy: True

--- a/conf/deployment/vsphere/thick_storage_class.yaml
+++ b/conf/deployment/vsphere/thick_storage_class.yaml
@@ -1,0 +1,4 @@
+---
+# This config is for vSphere deployment with thick provisioning
+DEPLOYMENT:
+  thick_sc_ocs_deploy: True

--- a/conf/deployment/vsphere/zeroedthick_storage_class.yaml
+++ b/conf/deployment/vsphere/zeroedthick_storage_class.yaml
@@ -1,0 +1,5 @@
+---
+# This config is for vSphere deployment with zeroedthick_storageclass provisioning
+DEPLOYMENT:
+  thick_sc: True
+  eager_zeroed_thick_sc: False

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -9,6 +9,7 @@ import os
 from shutil import rmtree
 import time
 
+import tempfile
 import hcl
 import yaml
 
@@ -26,6 +27,7 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     wait_for_nodes_status,
 )
+from ocs_ci.utility import templating
 from ocs_ci.ocs.openshift_ops import OCP
 from ocs_ci.utility.bootstrap import gather_bootstrap
 from ocs_ci.utility.csr import approve_pending_csr, wait_for_all_nodes_csr_and_approve
@@ -618,6 +620,14 @@ class VSPHEREUPI(VSPHEREBASE):
             configure_chrony_and_wait_for_machineconfig_status(
                 node_type="all", timeout=1800
             )
+        if config.DEPLOYMENT["thick_sc_ocs_deploy"]:
+            sc_data = templating.load_yaml(constants.VSPHERE_THICK_STORAGECLASS_YAML)
+            sc_data_yaml = tempfile.NamedTemporaryFile(
+                mode="w+", prefix="storageclass", delete=False
+            )
+            templating.dump_data_to_temp_yaml(sc_data, sc_data_yaml.name)
+            run_cmd(f"oc create -f {sc_data_yaml.name}")
+            self.DEFAULT_STORAGECLASS = "thick"
 
     def destroy_cluster(self, log_level="DEBUG"):
         """

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -620,11 +620,15 @@ class VSPHEREUPI(VSPHEREBASE):
             configure_chrony_and_wait_for_machineconfig_status(
                 node_type="all", timeout=1800
             )
-        if config.DEPLOYMENT["thick_sc_ocs_deploy"]:
+        if config.DEPLOYMENT["thick_sc"]:
             sc_data = templating.load_yaml(constants.VSPHERE_THICK_STORAGECLASS_YAML)
             sc_data_yaml = tempfile.NamedTemporaryFile(
                 mode="w+", prefix="storageclass", delete=False
             )
+            if config.DEPLOYMENT["eager_zeroed_thick_sc"]:
+                sc_data["parameters"]["diskformat"] = "eagerzeroedthick"
+            else:
+                sc_data["parameters"]["diskformat"] = "zeroedthick"
             templating.dump_data_to_temp_yaml(sc_data, sc_data_yaml.name)
             run_cmd(f"oc create -f {sc_data_yaml.name}")
             self.DEFAULT_STORAGECLASS = "thick"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -284,6 +284,10 @@ CEPHFILESYSTEM_YAML = os.path.join(TEMPLATE_CSI_FS_DIR, "CephFileSystem.yaml")
 
 CEPHBLOCKPOOL_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "cephblockpool.yaml")
 
+VSPHERE_THICK_STORAGECLASS_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "vsphere_storageclass_thick.yaml"
+)
+
 CSI_RBD_STORAGECLASS_YAML = os.path.join(TEMPLATE_CSI_RBD_DIR, "storageclass.yaml")
 
 ROOK_CSI_RBD_STORAGECLASS_YAML = os.path.join(ROOK_CSI_RBD_DIR, "storageclass.yaml")

--- a/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
+++ b/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
@@ -1,12 +1,11 @@
 ---
-storage_class_yaml:
-  apiVersion: storage.k8s.io/v1
-  kind: StorageClass
-  metadata:
-    name: thick
-  parameters:
-    datastore: vsanDatastore
-    diskformat: thick
-  provisioner: kubernetes.io/vsphere-volume
-  reclaimPolicy: Delete
-  volumeBindingMode: Immediate
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: thick
+parameters:
+  datastore: vsanDatastore
+  diskformat: thick
+provisioner: kubernetes.io/vsphere-volume
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
+++ b/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
@@ -5,7 +5,7 @@ metadata:
   name: thick
 parameters:
   datastore: vsanDatastore
-  diskformat: thick
+  diskformat: zeroedthick
 provisioner: kubernetes.io/vsphere-volume
 reclaimPolicy: Delete
 volumeBindingMode: Immediate

--- a/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
+++ b/ocs_ci/templates/ocs-deployment/vsphere_storageclass_thick.yaml
@@ -1,0 +1,12 @@
+---
+storage_class_yaml:
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: thick
+  parameters:
+    datastore: vsanDatastore
+    diskformat: thick
+  provisioner: kubernetes.io/vsphere-volume
+  reclaimPolicy: Delete
+  volumeBindingMode: Immediate


### PR DESCRIPTION
https://issues.redhat.com/browse/KNIP-1610

According to https://bugzilla.redhat.com/show_bug.cgi?id=1932280#c10:

There is no "diskformat: thick" supported in OCP. There is only "thin", "zeroedthick" and "eagerzeroedthick" - see https://docs.openshift.com/container-platform/4.7/storage/dynamic-provisioning.html#vsphere-definition_dynamic-provisioning


Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>