### PR TITLE
Jenkins: Drop postfix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,13 +33,6 @@ pipeline {
       steps {
         script { LAST_STAGE=env.STAGE_NAME }
         sh """
-          sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
-          sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
-          if [ ! -z '${env.EMAIL}' ]; then
-            sudo yum install -y /usr/sbin/postfix
-            sudo sed -i -e "s|inet_protocols = .*|inet_protocols = ipv4|" /etc/postfix/main.cf
-            sudo systemctl start postfix
-          fi
           sudo yum install -y python38-devel
           python3 -V
           pip3 install --user virtualenv


### PR DESCRIPTION
We don't need it, and it has caused some problems lately when using
non-ephemeral nodes. Since this is all we needed the ipv6 stuff for,
drop it as well.

Signed-off-by: Zack Cerza <zack@redhat.com>