### PR TITLE
build and push ocs-ci container image to quay

### DIFF
--- a/.github/workflows/build_quay.yml
+++ b/.github/workflows/build_quay.yml
@@ -1,0 +1,27 @@
+name: "Build Quay image"
+on:
+  push:
+    branches:
+      - 'stable*'
+
+jobs:
+  quay_build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.QUAY_URI }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: Build and push
+        id: quay_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: quay.io/ocsci/ocs-ci:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# set base image (host OS)
+FROM centos:latest
+
+RUN dnf install -y git openssl-devel python38 python3-devel python3-pip
+
+# copy the project files to the working directory
+#RUN git clone http://github.com/red-hat-storage/ocs-ci
+COPY . /ocs-ci
+
+# run setup
+WORKDIR ocs-ci
+RUN pip3 install --upgrade setuptools pip
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["run-ci"]
+
+
+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -63,6 +63,14 @@ necessary dependencies
    * `pip install -r requirements-dev.txt`
    * `pre-commit install --hook-type pre-commit --hook-type commit-msg`
 
+
+## OCS-CI Container Image
+  We also have ocs-ci container image available at quay.io/ocsci/ocs-ci, the image
+  is build using the latest branch. It is still experimental as the ci requires
+  configuration files that needs to be available for it to work properly.
+
+  The image is provided so that users can use it for development purpose.
+
 ## Initial Setup
 
 ### OCS-CI config


### PR DESCRIPTION
Partial Fixes one of the item in: https://github.com/red-hat-storage/ocs-ci/issues/3641

This builds the ocs-ci container image and pushes to quay.io/ocsci/ocs-ci based on push to latest branch.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>