### PR TITLE
Remove manual exposure of RGW service on OCS 4.7+

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -984,8 +984,8 @@ RHEL_WORKERS_CONF = os.path.join(CONF_DIR, "ocsci/aws_upi_rhel_workers.yaml")
 NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 
 # Services
-RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
-RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
+RGW_SERVICE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
+RGW_SERVICE_EXTERNAL_MODE = "ocs-external-storagecluster-cephobjectstore"
 
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -984,8 +984,11 @@ RHEL_WORKERS_CONF = os.path.join(CONF_DIR, "ocsci/aws_upi_rhel_workers.yaml")
 NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 
 # Services
-RGW_SERVICE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
-RGW_SERVICE_EXTERNAL_MODE = "ocs-external-storagecluster-cephobjectstore"
+RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
+RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
+
+# Routes
+RGW_DEFAULT_ROUTE_NAME = "ocs-storagecluster-cephobjectstore"
 
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -989,6 +989,7 @@ RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjec
 
 # Routes
 RGW_DEFAULT_ROUTE_NAME = "ocs-storagecluster-cephobjectstore"
+RGW_EXTERNAL_ROUTE_NAME = "ocs-external-storagecluster-cephobjectstore"
 
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -72,11 +72,11 @@ class RGW(object):
         else:
             if config.DEPLOYMENT["external_mode"]:
                 endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_DEFAULT_ROUTE_NAME
+                    resource_name=constants.RGW_EXTERNAL_ROUTE_NAME
                 )
             else:
                 endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_EXTERNAL_ROUTE_NAME
+                    resource_name=constants.RGW_DEFAULT_ROUTE_NAME
                 )
 
         endpoint = f"http://{endpoint['status']['ingress'][0]['host']}"

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -36,8 +36,8 @@ class RGW(object):
     def get_credentials(self, secret_name=constants.NOOBAA_OBJECTSTOREUSER_SECRET):
         """
         Get Endpoint, Access key and Secret key from OCS secret. Endpoint is
-        taken from rgw exposed service. Use rgw_endpoint fixture in test to get
-        it exposed.
+        taken from rgw exposed service. On 4.7 and above, the service is exposed by default.
+        Below 4.7, use the rgw_endpoint fixture in a test to expose it.
 
         Args:
             secret_name (str): Name of secret to be used

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1739,6 +1739,9 @@ def rgw_endpoint(request):
         string: external RGW endpoint
 
     """
+    if float(config.ENV_DATA["ocs_version"]) > 4.6:
+        log.info("RGW service should be exposed by default. Skipping exposure.")
+        return
     log.info("Looking for RGW service to expose")
     oc = ocp.OCP(kind=constants.SERVICE, namespace=config.ENV_DATA["cluster_namespace"])
     rgw_service = oc.get(selector=constants.RGW_APP_LABEL)["items"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1764,7 +1764,11 @@ def rgw_endpoint(request):
         route = oc.get(resource_name="noobaa-mgmt")
         router_hostname = route["status"]["ingress"][0]["routerCanonicalHostname"]
         rgw_hostname = f"rgw.{router_hostname}"
-        oc.exec_oc_cmd(f"expose service/{rgw_service} --hostname {rgw_hostname}")
+        try:
+            oc.exec_oc_cmd(f"expose service/{rgw_service} --hostname {rgw_hostname}")
+        except CommandFailed as cmdfailed:
+            if "AlreadyExists" in str(cmdfailed):
+                log.warning("RGW route already exists.")
         # new route is named after service
         rgw_endpoint = oc.get(resource_name=rgw_service)
         endpoint_obj = OCS(**rgw_endpoint)


### PR DESCRIPTION
Manual exposure of the service is no longer needed thanks to [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1915730)