### PR TITLE
Fix test_rgw_host_node_failure to look for the correct NB DB pod name

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -235,6 +235,10 @@ ACCESS_MODE_RWO = "ReadWriteOnce"
 ACCESS_MODE_ROX = "ReadOnlyMany"
 ACCESS_MODE_RWX = "ReadWriteMany"
 
+# Pod names
+NB_DB_NAME_46_AND_BELOW = "noobaa-db-0"
+NB_DB_NAME_47_AND_ABOVE = "noobaa-db-pg-0"
+
 # Pod label
 MON_APP_LABEL = "app=rook-ceph-mon"
 MDS_APP_LABEL = "app=rook-ceph-mds"

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -62,14 +62,15 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
         noobaa_pod_obj = get_noobaa_pods()
 
         # Get the node where noobaa-db hosted
+        noobaa_pod_node = None
         for noobaa_pod in noobaa_pod_obj:
             if noobaa_pod.name in [
                 constants.NB_DB_NAME_46_AND_BELOW,
                 constants.NB_DB_NAME_47_AND_ABOVE,
             ]:
                 noobaa_pod_node = get_pod_node(noobaa_pod)
-            else:
-                assert False, "Could not find the NooBaa DB pod"
+        if noobaa_pod_node is None:
+            assert False, "Could not find the NooBaa DB pod"
 
         for rgw_pod in rgw_pod_obj:
             pod_node = rgw_pod.get().get("spec").get("nodeName")

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -51,8 +51,8 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
         self, nodes, node_restart_teardown, mcg_obj, bucket_factory
     ):
         """
-        Test case to fail node where RGW and Noobaa-db-0 hosting
-        and verify new pod spuns on healthy node
+        Test case to fail node where RGW and the NooBaa DB are hosted
+        and verify the new pods spin on a healthy node
 
         """
         # Get rgw pods
@@ -63,8 +63,13 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
 
         # Get the node where noobaa-db hosted
         for noobaa_pod in noobaa_pod_obj:
-            if noobaa_pod.name == "noobaa-db-0":
+            if noobaa_pod.name in [
+                constants.NB_DB_NAME_46_AND_BELOW,
+                constants.NB_DB_NAME_47_AND_ABOVE,
+            ]:
                 noobaa_pod_node = get_pod_node(noobaa_pod)
+            else:
+                assert False, "Could not find the NooBaa DB pod"
 
         for rgw_pod in rgw_pod_obj:
             pod_node = rgw_pod.get().get("spec").get("nodeName")
@@ -72,7 +77,7 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
                 # Stop the node
                 log.info(
                     f"Stopping node {pod_node} where"
-                    f" rgw pod {rgw_pod.name} and noobaa-db-0 hosted"
+                    f" rgw pod {rgw_pod.name} and NooBaa DB are hosted"
                 )
                 node_obj = get_node_objs(node_names=[pod_node])
                 nodes.stop_nodes(node_obj)


### PR DESCRIPTION
The test currently only verifies the pod name in 4.6 and below.
I changed it to work with the new pod name. This should address, at least partially, #3926 