### PR TITLE
Pod reattach | adding sync after writing data

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1235,3 +1235,5 @@ MAX_NB_ENDPOINT_COUNT = 2
 
 OCS_TAINT = "node.ocs.openshift.io/storage"
 VOLUMESNAPSHOT = "volumesnapshot"
+
+PERF_IMAGE = "quay.io/ocsci/perf:latest"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -431,6 +431,8 @@ AMQ_SIMPLE_WORKLOAD_YAML = os.path.join(TEMPLATE_AMQ_DIR, "amq_simple_workload.y
 
 NGINX_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "nginx.yaml")
 
+PERF_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "performance.yaml")
+
 HSBENCH_OBJ_YAML = os.path.join(TEMPLATE_HSBENCH_DIR, "hsbench_obj.yaml")
 
 AWSCLI_SERVICE_CA_YAML = os.path.join(

--- a/ocs_ci/templates/app-pods/performance.yaml
+++ b/ocs_ci/templates/app-pods/performance.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: perf-pod
+  namespace: default
+spec:
+  containers:
+   - name: performance
+     image: quay.io/ocsci/perf:latest
+     command: ['/bin/sh']
+     stdin: true
+     tty: true
+     volumeMounts:
+       - name: mypvc
+         mountPath: /mnt
+  volumes:
+   - name: mypvc
+     persistentVolumeClaim:
+       claimName: pvc
+       readOnly: false

--- a/tests/e2e/performance/test_pod_reattachtime.py
+++ b/tests/e2e/performance/test_pod_reattachtime.py
@@ -19,13 +19,12 @@ class TestPVCCreationPerformance(E2ETest):
     """
 
     @pytest.fixture()
-    def base_setup(self, request, interface_iterate, storageclass_factory):
+    def base_setup(self, request, interface_iterate):
         """
         A setup phase for the test
         Args:
             interface_iterate: A fixture to iterate over ceph interfaces
-            storageclass_factory: A fixture to create everything needed for a
-                storageclass
+
         """
         self.interface = interface_iterate
 

--- a/tests/e2e/performance/test_pod_reattachtime.py
+++ b/tests/e2e/performance/test_pod_reattachtime.py
@@ -112,6 +112,8 @@ class TestPVCCreationPerformance(E2ETest):
             _ocp.exec_oc_cmd(rsh_cmd)
             rsh_cmd = f"exec {pod_name} -- cp -r {pod_path}/tmp {pod_path}/folder{x}"
             _ocp.exec_oc_cmd(rsh_cmd)
+            rsh_cmd = f"exec {pod_name} -- sync"
+            _ocp.exec_oc_cmd(rsh_cmd)
 
         rsh_cmd = f"delete pod {pod_name}"
         _ocp.exec_oc_cmd(rsh_cmd)

--- a/tests/e2e/performance/test_pod_reattachtime.py
+++ b/tests/e2e/performance/test_pod_reattachtime.py
@@ -31,9 +31,10 @@ class TestPVCCreationPerformance(E2ETest):
 
         if self.interface.lower() == "cephfs":
             self.interface = constants.CEPHFILESYSTEM
+            self.sc_obj = constants.DEFAULT_STORAGECLASS_CEPHFS
         if self.interface.lower() == "rbd":
             self.interface = constants.CEPHBLOCKPOOL
-        self.sc_obj = storageclass_factory(self.interface)
+            self.sc_obj = constants.DEFAULT_STORAGECLASS_RBD
 
     @pytest.mark.usefixtures(base_setup.__name__)
     def test_pvc_reattach_time_performance(self, pvc_factory, teardown_factory):

--- a/tests/e2e/performance/test_pod_reattachtime.py
+++ b/tests/e2e/performance/test_pod_reattachtime.py
@@ -76,7 +76,7 @@ class TestPVCCreationPerformance(E2ETest):
         # Create a pod on one node
         logging.info(f"Creating Pod with pvc {pvc_obj.name} on node {node_one}")
 
-        helpers.pull_images("quay.io/ocsci/perf:latest")
+        helpers.pull_images(constants.PERF_IMAGE)
         pod_obj1 = helpers.create_pod(
             interface_type=self.interface,
             pvc_name=pvc_obj.name,


### PR DESCRIPTION
The main issue that this PR is fixing is, adding 'sync' command after we are writing data, so all data will be actually will be written to the PVC and not stay in the cache.

also, it replace the 'nginx' image (for the pod) with pre-loaded image with the rsync command, so we do not need to install the rsync on the pod during the test.

the test was create new SC and now it use the default SC 