### PR TITLE
Abandoned - WIP : Add interface and implementation for adding nodes and storage

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -14,6 +14,7 @@ from ocs_ci.deployment.vmware import (
     clone_openshift_installer,
     update_machine_conf,
 )
+from ocs_ci.utility.nodemgmt import NodeManagement
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.framework import config, merge_dict
 from ocs_ci.utility import aws, vsphere, templating, baremetal, azure_utils, powernodes
@@ -1796,6 +1797,19 @@ class IBMPowerNodes(NodesBase):
     def __init__(self):
         super(IBMPowerNodes, self).__init__()
         self.powernodes = powernodes.PowerNodes()
+
+    def create_and_attach_nodes_to_cluster(self, node_conf, node_type, num_nodes):
+        """
+        Create and Attach nodes to cluster
+
+        Args:
+            node_conf: Node configuration
+            node_type: Node type RHCOS or RHEL. For Power platform, this will be
+                       ignored, as the type will always be RHCOS
+            num_nodes: Number of nodes to be added to the cluster
+        """
+        node = NodeManagement.get_nodemanagement_platform()
+        node.addNodes(num_nodes)
 
     def stop_nodes(self, nodes, force=True):
         """

--- a/ocs_ci/utility/nodemgmt.py
+++ b/ocs_ci/utility/nodemgmt.py
@@ -1,0 +1,106 @@
+from ocs_ci.framework import config
+from ocs_ci.utility import powernodes
+
+
+class NodeManagement(object):
+    """
+    This is a class to define node management functionality. This can
+    be used to implement adding and removing nodes dynamically and driven
+    via test-case code. If a specific deployer of OCS reqires dynamic addition
+    of nodes, this class needs to be sub-classed and required platform specific
+    functionlity needs to be implemented and consumed.
+    """
+
+    def __init__(self, consumer):
+        """
+        Class Initialization.
+
+        Initialize the class. Maintain the consumer who initialized this class for
+        logging purposes. Also, maintain a dictionary of node management objects
+        with platform string as key. This key should match the platform entry in the
+        ocs-ci configuration.
+        """
+
+        self.cls_map = {
+            "powervs": IBMPowerNodeManagement,
+        }
+        self.consumer = consumer
+
+    def get_nodemanagement_platform(self):
+        """
+        Retrieve the node management object for a given platform from config
+
+        Args: None
+        Returns: Platform specific nodemanagement object from the class map.
+        """
+
+        platform = config.ENV_DATA["platform"]
+        return self.cls_map[platform]()
+
+    def addNodes(self, num_nodes):
+        """
+        Add nodes to the cluster
+        """
+
+        raise NotImplementedError("Add node functionality is not implemented")
+
+    def deleteNodes(self, num_nodes):
+        """
+        Delete nodes from the cluster
+        """
+
+        raise NotImplementedError("Delete node functionality is not implemented")
+
+    def addStorage(self, node, num_disks):
+        """
+        Add additional storage to worker/storage node
+        """
+
+        raise NotImplementedError("Add storage functionality is not implemented")
+
+    def deleteStorage(self, node, num_disks):
+        """
+        Delete storage disks from worker/storage node
+        """
+
+        raise NotImplementedError("Delete storage functionality is not implemented")
+
+
+class IBMPowerNodeManagement(NodeManagement):
+    """
+    This is an implementation of NodeManagement class for IBM Power PowerVS platform.
+    """
+
+    def __init__(self):
+        """
+        Class Initialization.
+
+        Initialize the class.
+        """
+
+        super(IBMPowerNodeManagement, self).__init__("PowerVS")
+        self.powernodes = powernodes.PowerNodes()
+
+    def addNodes(self, num_nodes):
+        """
+        Add nodes to cluster. Use powernodes utility
+
+        Args:
+            num_nodes: Number of nodes to be added to the cluster
+
+        Returns: None
+        """
+
+        self.powernodes.addNodes(num_nodes)
+
+    def deleteNodes(self, num_nodes):
+        """
+        Delete nodes from the cluster. Use powernodes utility
+
+        Args:
+            num_nodes: Number of nodes to be removed from the cluster
+
+        Returns: None
+        """
+
+        self.powernodes.deleteNodes(num_nodes)

--- a/ocs_ci/utility/powernodes.py
+++ b/ocs_ci/utility/powernodes.py
@@ -42,6 +42,40 @@ class PowerNodes(object):
         """
         return self.isKVM
 
+    def addNodes(self, num_nodes):
+        """
+        Add nodes to the powervs cluster
+        An utility called ocpdr will be used to perform the node addition. This
+        utility ocpdr should already be present in the PATH.
+
+        Args:
+            num_nodes: Number of nodes to be added to the cluster
+
+        Returns: None
+        """
+
+        if self.iskvm():
+            logger.info("Adding nodes to cluster is not implemented on Libvirt.")
+        else:
+            result = exec_cmd("sudo ocpdr " + "addnode " + num_nodes)
+            logger.info(f"Result of add node: {result}")
+
+    def deleteNodes(self, num_nodes):
+        """
+        Delete nodes from powervs cluster
+        An utility called ocpdr will be used to perform the node addition. This
+        utility ocpdr should already be present in the PATH.
+
+        Args:
+            num_nodes: Number of nodes to be deleted from the cluster
+        """
+
+        if self.iskvm():
+            logger.info("Deleting nodes to cluster is not implemented on Libvirt.")
+        else:
+            result = exec_cmd("sudo ocpdr " + "deletenode " + num_nodes)
+            logger.info(f"Result of delete node: {result}")
+
     def verify_machine_is_down(self, node):
         """
         Verify if PowerNode is completely powered off


### PR DESCRIPTION
This is an effort to standardize on an interface that can be used
by any component to implement add node and add storage to nodes to
an existing OCP/OCS cluster. This will work in conjunction with
the platform_nodes interface.

This PR introduces NodeManagement interface and also an implementation
of the same for IBM Power platform.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>