### PR TITLE
Fix error while checking node status

### DIFF
--- a/ocs_ci/utility/service.py
+++ b/ocs_ci/utility/service.py
@@ -48,7 +48,8 @@ class Service(object):
         """
         nodeip = self.nodes[node.name]
         result = exec_cmd(
-            f"ssh core@{nodeip} sudo systemctl is-active {self.service_name}.service"
+            f"ssh core@{nodeip} sudo systemctl is-active {self.service_name}.service",
+            ignore_error=True,
         )
         if result.stdout.lower().rstrip() == action:
             logger.info("Action succeeded.")


### PR DESCRIPTION
This PR will fix the errors that we are getting while restarting and stopping node in our powerVS environment. 
When systemctl status command is executed via ssh, it does not always return 0. It returns 3 if the service is in stopped state. So we need to ignore non-zero return code. 

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>

