### PR TITLE
Improve timeout/wrong-state reporting

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -27,7 +27,7 @@ from ocs_ci.ocs.exceptions import (
     CommandFailed,
     ResourceNotFoundError,
     ChannelNotFound,
-    ResourceInUnexpectedState,
+    ResourceWrongStatusException,
 )
 from ocs_ci.ocs.resources.ocs import get_ocs_csv, get_version_info
 from ocs_ci.ocs.utils import collect_ocs_logs, collect_prometheus_metrics
@@ -302,7 +302,7 @@ def pytest_configure(config):
             config.addinivalue_line(
                 "rp_launch_tags", f"ocs_csv_version:{ocs_csv_version}"
             )
-        except (ResourceNotFoundError, ChannelNotFound, ResourceInUnexpectedState):
+        except (ResourceNotFoundError, ChannelNotFound, ResourceWrongStatusException):
             # might be using exisitng cluster path using GUI installation
             log.warning("Unable to get CSV version for Reporting")
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -29,11 +29,16 @@ class ResourceLeftoversException(Exception):
 class TimeoutExpiredError(Exception):
     message = "Timed Out"
 
-    def __init__(self, value):
+    def __init__(self, value, custom_message=None):
         self.value = value
+        self.custom_message = custom_message
 
     def __str__(self):
-        return f"{self.message}: {self.value}"
+        if self.custom_message is None:
+            self.message = f"{self.__class__.message}: {self.value}"
+        else:
+            self.message = self.custom_message
+        return self.message
 
 
 class TimeoutException(Exception):

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -29,7 +29,7 @@ class ResourceLeftoversException(Exception):
 class TimeoutExpiredError(Exception):
     message = "Timed Out"
 
-    def __init__(self, *value):
+    def __init__(self, value):
         self.value = value
 
     def __str__(self):

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -66,12 +66,15 @@ class PerformanceException(Exception):
 
 
 class ResourceWrongStatusException(Exception):
-    def __init__(self, resource_name, describe_out):
+    def __init__(self, resource_name, describe_out=None):
         self.resource_name = resource_name
         self.describe_out = describe_out
 
     def __str__(self):
-        return f"Resource {self.resource_name} describe output: {self.describe_out}"
+        msg = f"Resource {self.resource_name}"
+        if self.describe_out:
+            msg += f" describe output: {self.describe_out}"
+        return msg
 
 
 class UnavailableResourceException(Exception):

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -105,10 +105,6 @@ class ResourceNameNotSpecifiedException(Exception):
     pass
 
 
-class ResourceInUnexpectedState(Exception):
-    pass
-
-
 class VMMaxDisksReachedException(Exception):
     pass
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -66,12 +66,28 @@ class PerformanceException(Exception):
 
 
 class ResourceWrongStatusException(Exception):
-    def __init__(self, resource_name, describe_out=None):
-        self.resource_name = resource_name
+    def __init__(
+        self, resource_or_name, describe_out=None, column=None, expected=None, got=None
+    ):
+        if isinstance(resource_or_name, str):
+            self.resource = None
+            self.resource_name = resource_or_name
+        else:
+            self.resource = resource_or_name
+            self.resource_name = self.resource.name
         self.describe_out = describe_out
 
     def __str__(self):
-        msg = f"Resource {self.resource_name}"
+        if self.resource:
+            msg = f"{self.resource.kind} resource {self.resource_name}"
+        else:
+            msg = f"Resource {self.resource_name}"
+        if self.column:
+            msg += f" in column {self.column}"
+        if self.got:
+            msg += f" was in state {self.got}"
+        if self.expected:
+            msg += f" but expected {self.expected}"
         if self.describe_out:
             msg += f" describe output: {self.describe_out}"
         return msg

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -563,8 +563,10 @@ class OCP(object):
                     actual_status = status
                     if error_condition is not None and status == error_condition:
                         raise ResourceInUnexpectedState(
-                            f"Status of '{resource_name}' at column {column}"
-                            f" is {status}."
+                            resource_name,
+                            column=column,
+                            expected=condition,
+                            got=status,
                         )
                 # More than 1 resources returned
                 elif sample.get("kind") == "List":
@@ -586,8 +588,10 @@ class OCP(object):
                                 and status == error_condition
                             ):
                                 raise ResourceInUnexpectedState(
-                                    f"Status of '{item_name}' "
-                                    f" at column {column} is {status}."
+                                    item_name,
+                                    column=column,
+                                    expected=condition,
+                                    got=status,
                                 )
                         except CommandFailed as ex:
                             log.info(

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.exceptions import (
     CommandFailed,
     NotSupportedFunctionError,
     NonUpgradedImagesFoundError,
-    ResourceInUnexpectedState,
+    ResourceWrongStatusException,
     ResourceNameNotSpecifiedException,
     TimeoutExpiredError,
 )
@@ -562,7 +562,7 @@ class OCP(object):
                     )
                     actual_status = status
                     if error_condition is not None and status == error_condition:
-                        raise ResourceInUnexpectedState(
+                        raise ResourceWrongStatusException(
                             resource_name,
                             column=column,
                             expected=condition,
@@ -587,7 +587,7 @@ class OCP(object):
                                 error_condition is not None
                                 and status == error_condition
                             ):
-                                raise ResourceInUnexpectedState(
+                                raise ResourceWrongStatusException(
                                     item_name,
                                     column=column,
                                     expected=condition,
@@ -646,7 +646,7 @@ class OCP(object):
                 )
             )
             raise (ex)
-        except ResourceInUnexpectedState:
+        except ResourceWrongStatusException:
             output = self.describe(resource_name, selector=selector)
             log.warning(
                 "Description of the resource(s) we were waiting for:\n%s", output
@@ -844,7 +844,7 @@ class OCP(object):
             )
         return False
 
-    @retry(ResourceInUnexpectedState, tries=4, delay=5, backoff=1)
+    @retry(ResourceWrongStatusException, tries=4, delay=5, backoff=1)
     def wait_for_phase(self, phase, timeout=300, sleep=5):
         """
         Wait till phase of resource is the same as required one passed in
@@ -856,7 +856,7 @@ class OCP(object):
             sleep (int): Time in seconds to sleep between attempts
 
         Raises:
-            ResourceInUnexpectedState: In case the resource is not in expected
+            ResourceWrongStatusException: In case the resource is not in expected
                 phase.
             NotSupportedFunctionError: If resource doesn't have phase!
             ResourceNameNotSpecifiedException: in case the name is not
@@ -867,7 +867,7 @@ class OCP(object):
         self.check_name_is_specified()
         sampler = TimeoutSampler(timeout, sleep, func=self.check_phase, phase=phase)
         if not sampler.wait_for_func_status(True):
-            raise ResourceInUnexpectedState(
+            raise ResourceWrongStatusException(
                 f"Resource: {self.resource_name} is not in expected phase: " f"{phase}"
             )
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -628,6 +628,12 @@ class OCP(object):
                     )
         except TimeoutExpiredError as ex:
             log.error(f"timeout expired: {ex}")
+            # run `oc describe` on the resources we were waiting for to provide
+            # evidence so that we can understand what was wrong
+            output = self.describe(resource_name, selector=selector)
+            log.warning(
+                "Description of the resource(s) we were waiting for:\n%s", output
+            )
             log.error(
                 (
                     f"Wait for {self._kind} resource {resource_name} at column {column}"
@@ -635,14 +641,12 @@ class OCP(object):
                     f" last actual status was {actual_status}"
                 )
             )
-            # run `oc describe` on the resources we were waiting for to provide
-            # evidence so that we can understand what was wrong
+            raise (ex)
+        except ResourceInUnexpectedState:
             output = self.describe(resource_name, selector=selector)
             log.warning(
                 "Description of the resource(s) we were waiting for:\n%s", output
             )
-            raise (ex)
-        except ResourceInUnexpectedState:
             log.error(
                 (
                     "Waiting for %s resource %s at column %s"
@@ -654,10 +658,6 @@ class OCP(object):
                 column,
                 condition,
                 error_condition,
-            )
-            output = self.describe(resource_name, selector=selector)
-            log.warning(
-                "Description of the resource(s) we were waiting for:\n%s", output
             )
             raise
 

--- a/ocs_ci/ocs/resources/catalog_source.py
+++ b/ocs_ci/ocs/resources/catalog_source.py
@@ -4,7 +4,7 @@ CatalogSource related functionalities
 import logging
 
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.exceptions import CommandFailed, ResourceInUnexpectedState
+from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility.retry import retry
 
@@ -99,7 +99,7 @@ class CatalogSource(OCP):
             )
         return False
 
-    @retry(ResourceInUnexpectedState, tries=4, delay=5, backoff=1)
+    @retry(ResourceWrongStatusException, tries=4, delay=5, backoff=1)
     def wait_for_state(self, state, timeout=480, sleep=5):
         """
         Wait till state of catalog source resource is the same as required one
@@ -111,14 +111,14 @@ class CatalogSource(OCP):
             sleep (int): Time in seconds to sleep between attempts
 
         Raises:
-            ResourceInUnexpectedState: In case the catalog source is not in
+            ResourceWrongStatusException: In case the catalog source is not in
                 expected state.
 
         """
         self.check_name_is_specified()
         sampler = TimeoutSampler(timeout, sleep, self.check_state, state=state)
         if not sampler.wait_for_func_status(True):
-            raise ResourceInUnexpectedState(
+            raise ResourceWrongStatusException(
                 f"Catalog source: {self.resource_name} is not in expected "
                 f"state: {state}"
             )

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -20,7 +20,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     TimeoutExpiredError,
-    ResourceInUnexpectedState,
+    ResourceWrongStatusException,
 )
 from ocs_ci.ocs.resources.rgw import RGW
 from ocs_ci.utility import templating
@@ -148,7 +148,7 @@ class CloudClient(ABC):
             )
         else:
             if is_available:
-                raise ResourceInUnexpectedState(
+                raise ResourceWrongStatusException(
                     f"{check_type[:-1]}ion of Underlying Storage {uls_name} timed out. "
                     f"Unable to {check_type.lower()} {uls_name}"
                 )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -882,33 +882,34 @@ class TimeoutSampler(object):
     Yielding the output allows you to handle every value as you wish.
 
     Feel free to set the instance variables.
+
+
+    Args:
+        timeout (int): Timeout in seconds
+        sleep (int): Sleep interval in seconds
+        func (function): The function to sample
+        func_args: Arguments for the function
+        func_kwargs: Keyword arguments for the function
     """
 
     def __init__(self, timeout, sleep, func, *func_args, **func_kwargs):
         self.timeout = timeout
-        """ Timeout in seconds. """
         self.sleep = sleep
-        """ Sleep interval seconds. """
         # check that given timeout and sleep values makes sense
         if self.timeout < self.sleep:
             raise ValueError("timeout should be larger than sleep time")
 
         self.func = func
-        """ A function to sample. """
         self.func_args = func_args
-        """ Args for func. """
         self.func_kwargs = func_kwargs
-        """ Kwargs for func. """
 
+        # Timestamps of the first and most recent samples
         self.start_time = None
-        """ Time of starting the sampling. """
         self.last_sample_time = None
-        """ Time of last sample. """
-
+        # The exception to raise
         self.timeout_exc_cls = TimeoutExpiredError
-        """ Class of exception to be raised.  """
+        # Arguments that will be passed to the exception
         self.timeout_exc_args = (self.timeout,)
-        """ An args for __init__ of the timeout exception. """
 
     def __iter__(self):
         if self.start_time is None:


### PR DESCRIPTION
This PR makes some improvements to ocs-ci's error reporting; specifically, it should save some time when triaging failures related to timeouts or wrong-state errors.

If you're like me, you typically review failures inside Jenkins, viewing the console log (either for the entire build or just one pipeline stage), starting from the bottom of the traceback and scrolling up from there.

The things I wanted to improve in this PR are:
1. The lack of information in `TimeoutExpiredError`
2. Having to scroll past hundreds or thousands of lines of `describe` output before seeing the "wait for _ resource at column _ to reach..." message
3. `ResourceWrongStatusException`: Instead of only reporting `Resource <name>`, can report as much as `<kind> resource <name> in column <col> was in state <actual> but expected <expected>`. Each value is independently added if present.
4. Also fixed a bug in `ResourceWrongStatusException` related to how it is often called.

A job timing out before these changes:
```
14:07:13 - MainThread - ocs_ci.ocs.ocp - ERROR - timeout expired: Timed Out: (600,)
14:07:13 - MainThread - ocs_ci.ocs.ocp - ERROR - Wait for Pod resource  at column STATUS to reach desired condition Running failed, last actual status was ['Running', 'Terminating', 'Running', 'Pending']
14:07:13 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc -n openshift-storage describe Pod  --selector=app=rook-ceph-mon
<describe output>
14:07:14 - MainThread - ocs_ci.deployment.deployment - ERROR - Timed Out: (600,)
<skip to the middle of the py.test ERRORS section>
E               ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed Out: (600,)
<skip to end of the py.test ERRORS section>
ocs_ci/utility/utils.py:926: TimeoutExpiredError
```

A job timing out with these changes:
```
16:50:20 - MainThread - ocs_ci.ocs.ocp - ERROR - timeout expired: Timed out after 900s running get("worker", True, None)
16:50:20 - MainThread - ocs_ci.utility.utils - INFO - Executing command: oc describe MachineConfigPool worker
<describe output>
16:50:20 - MainThread - ocs_ci.deployment.deployment - ERROR - Timed out after 900s running get("worker", True, None)
<skip to the middle of the py.test ERRORS section>
E               ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed out after 900s running get("worker", True, None)
<skip to end of the py.test ERRORS section>
ocs_ci/utility/utils.py:928: TimeoutExpiredError
```

These builds didn't fail for exactly the same reason so it's not a perfect comparison, but you can see how we at least get some information about the failure in the exception messages. This could be further improved, but I wanted to get some feedback before I spent much more time on it.
