### PR TITLE
Use stable 4.8 tag

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-4.8.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.8.yaml
@@ -1,7 +1,7 @@
 ---
 DEPLOYMENT:
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.8"
-  default_latest_tag: 'latest-4.8'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-stable-4.8"
+  default_latest_tag: 'latest-stable-4.8'
   ocs_csv_channel: "stable-4.8"
   default_ocp_version: '4.8'
 ENV_DATA:


### PR DESCRIPTION
Cause we already have stable tag and we have deployment blocker
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1941448
which block 4.8 deployment with latest tag only we should
start consuming stable tagged builds from now on.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>