### PR TITLE
Enhancements for pv_services/test_rwo_pvc_fencing_unfencing.py

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -230,6 +230,12 @@ skipif_vsphere_ipi = pytest.mark.skipif(
     reason="Test will not run on vSphere IPI cluster",
 )
 
+skipif_tainted_nodes = pytest.mark.skipif(
+    config.DEPLOYMENT.get("infra_nodes") is True
+    or config.DEPLOYMENT.get("ocs_operator_nodes_to_taint") > 0,
+    reason="Test will not run if nodes are tainted",
+)
+
 metrics_for_external_mode_required = pytest.mark.skipif(
     float(config.ENV_DATA["ocs_version"]) < 4.6
     and config.DEPLOYMENT.get("external_mode") is True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2979,9 +2979,9 @@ def node_drain_teardown(request):
 @pytest.fixture(scope="function")
 def node_restart_teardown(request, nodes):
     """
-    Make sure all nodes are up again
-    Make sure that all cluster's nodes are in 'Ready' state and if not,
-    change them back to 'Ready' state by restarting the nodes
+    Make sure all nodes are up and in 'Ready' state and if not,
+    try to make them 'Ready' by restarting the nodes.
+
     """
 
     def finalizer():
@@ -3000,7 +3000,7 @@ def node_restart_teardown(request, nodes):
                 log.info(
                     f"Nodes in NotReady status found: {[n.name for n in not_ready_nodes]}"
                 )
-                nodes.restart_nodes(not_ready_nodes)
+                nodes.restart_nodes_by_stop_and_start(not_ready_nodes)
                 node.wait_for_nodes_status(status=constants.NODE_READY)
 
     request.addfinalizer(finalizer)

--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -5,24 +5,24 @@ from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import (
-    skipif_aws_i3,
-    skipif_bm,
-    skipif_ibm_cloud,
-    skipif_lso,
-    skipif_vsphere_ipi,
-)
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
+    skipif_aws_i3,
+    skipif_bm,
+    skipif_external_mode,
+    skipif_ibm_cloud,
+    skipif_lso,
+    skipif_vsphere_ipi,
+    skipif_tainted_nodes,
     tier4,
     tier4a,
     tier4b,
     tier4c,
 )
 from ocs_ci.ocs import constants, machine, node, ocp
-from ocs_ci.ocs.cluster import CephCluster
-from ocs_ci.ocs.exceptions import ResourceWrongStatusException, UnexpectedBehaviour
+from ocs_ci.ocs.cluster import CephCluster, CephClusterExternal
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check, get_az_count
@@ -39,13 +39,10 @@ class TestRwoPVCFencingUnfencing(ManageTest):
     KNIP-677 OCS support for Automated fencing/unfencing RWO PV
     """
 
+    expected_mon_count = 3  # Min. mon count for ceph health to be OK
+    num_of_app_pods_per_node = 2  # Pods of each interface type on nodes going to fail
     pvc_size = 10  # size in Gi
-
-    # Pods of each interface type to be run on nodes which are going to fail
-    num_of_app_pods_per_node = 2
-
     short_nw_fail_time = 300  # Duration in seconds for short network failure
-
     prolong_nw_fail_time = 900  # Duration in seconds for prolong network failure
 
     @pytest.fixture()
@@ -88,25 +85,33 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 node_list=test_nodes, label_key="nodetype"
             )
 
+            # Check ceph health
+            ceph_health_check(tries=40)
+
         request.addfinalizer(finalizer)
 
-        ceph_cluster = CephCluster()
         project = project_factory()
 
-        # Wait for mon pods to reach expected count
-        # Bug 1778273 - [RFE]: Configure 5 MONs for OCS cluster with 5 or more nodes
-        # This wait is required for some of the previous OCS versions (< 4.5)
-        current_mon_count = int(
-            ceph_cluster.CEPHCLUSTER.get_resource(resource_name="", column="MONCOUNT")
-        )
-        assert ceph_cluster.POD.wait_for_resource(
-            condition=constants.STATUS_RUNNING,
-            selector=constants.MON_APP_LABEL,
-            resource_count=current_mon_count,
-            timeout=900,
-        )
-        ceph_cluster.mons = []
-        ceph_cluster.scan_cluster()
+        if helpers.storagecluster_independent_check():
+            ceph_cluster = CephClusterExternal()
+        else:
+            ceph_cluster = CephCluster()
+            # Wait for mon pods to reach expected count
+            # Bug 1778273 - [RFE]: Configure 5 MONs for OCS cluster with 5 or more nodes
+            # This wait is required for some of the previous OCS versions (< 4.5)
+            current_mon_count = int(
+                ceph_cluster.CEPHCLUSTER.get_resource(
+                    resource_name="", column="MONCOUNT"
+                )
+            )
+            assert ceph_cluster.POD.wait_for_resource(
+                condition=constants.STATUS_RUNNING,
+                selector=constants.MON_APP_LABEL,
+                resource_count=current_mon_count,
+                timeout=900,
+            )
+            ceph_cluster.mons = []
+            ceph_cluster.scan_cluster()
 
         # Select nodes for running app pods and inducing network failure later
         app_pod_nodes = self.select_nodes_for_app_pods(
@@ -195,40 +200,6 @@ class TestRwoPVCFencingUnfencing(ManageTest):
 
         return ceph_cluster, dc_pods, ceph_pods, app_pod_nodes, test_nodes, disruptor
 
-    @pytest.fixture()
-    def teardown(self, request, nodes):
-        """
-        Make sure all nodes are up again
-        Make sure that all cluster's nodes are in 'Ready' state and if not,
-        change them back to 'Ready' state by restarting the nodes
-
-        """
-
-        def finalizer():
-            # Start the powered off nodes
-            nodes.restart_nodes_by_stop_and_start_teardown()
-            try:
-                node.wait_for_nodes_status(status=constants.NODE_READY)
-            except ResourceWrongStatusException:
-                # Restart the nodes if in NotReady state
-                not_ready_nodes = [
-                    n
-                    for n in node.get_node_objs()
-                    if n.ocp.get_resource_status(n.name) == constants.NODE_NOT_READY
-                ]
-                if not_ready_nodes:
-                    logger.info(
-                        f"Nodes in NotReady status found: {[n.name for n in not_ready_nodes]}"
-                    )
-                    nodes.restart_nodes_by_stop_and_start(not_ready_nodes)
-                    node.wait_for_nodes_status(status=constants.NODE_READY)
-
-            # Check ceph health
-            assert ceph_health_check(), "Ceph cluster health is not OK"
-            logger.info("Ceph cluster health is OK")
-
-        request.addfinalizer(finalizer)
-
     def identify_and_add_nodes(self, scenario, num_of_nodes):
         """
         Fetches info about the worker nodes and add nodes (if required)
@@ -259,24 +230,16 @@ class TestRwoPVCFencingUnfencing(ManageTest):
             logger.info(f"{nodes_to_add} extra workers nodes needed")
 
             if config.ENV_DATA["deployment_type"] == "ipi":
-                machine_name = machine.get_machine_from_node_name(
-                    random.choice(initial_worker_nodes)
-                )
+                machine_name = random.choice(
+                    machine.get_machines(machine_type=constants.WORKER_MACHINE)
+                ).name
                 machineset_name = machine.get_machineset_from_machine_name(machine_name)
-                machineset_replica_count = machine.get_replica_count(machineset_name)
-                machine.add_node(
-                    machineset_name, count=machineset_replica_count + nodes_to_add
+                node.add_new_node_and_label_it(
+                    machineset_name=machineset_name,
+                    num_nodes=nodes_to_add,
+                    mark_for_ocs_label=False,
                 )
-                logger.info("Waiting for the new node(s) to be in ready state")
-                machine.wait_for_new_node_to_be_ready(machineset_name)
             else:
-                if (
-                    config.ENV_DATA.get("platform").lower()
-                    == constants.VSPHERE_PLATFORM
-                ):
-                    pytest.skip(
-                        "Skipping add node in VSPHERE due to https://bugzilla.redhat.com/show_bug.cgi?id=1844521"
-                    )
                 is_rhel = config.ENV_DATA.get("rhel_workers") or config.ENV_DATA.get(
                     "rhel_user"
                 )
@@ -573,7 +536,12 @@ class TestRwoPVCFencingUnfencing(ManageTest):
         argvalues=[
             pytest.param(
                 *["colocated", 3, 1, False],
-                marks=[pytest.mark.polarion_id("OCS-1423"), skipif_aws_i3],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1423"),
+                    skipif_aws_i3,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
             pytest.param(
                 *["dedicated", 2, 1, False], marks=pytest.mark.polarion_id("OCS-1428")
@@ -583,15 +551,27 @@ class TestRwoPVCFencingUnfencing(ManageTest):
             ),
             pytest.param(
                 *["colocated", 4, 1, False],
-                marks=[pytest.mark.polarion_id("OCS-1426"), skipif_aws_i3],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1426"),
+                    skipif_aws_i3,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
             pytest.param(
                 *["colocated", 5, 3, True],
-                marks=[pytest.mark.polarion_id("OCS-1424"), skipif_aws_i3],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1424"),
+                    skipif_aws_i3,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
         ],
     )
-    def test_rwo_pvc_fencing_node_short_network_failure(self, nodes, setup, teardown):
+    def test_rwo_pvc_fencing_node_short_network_failure(
+        self, nodes, setup, node_restart_teardown
+    ):
         """
         OCS-1423/OCS-1428/OCS-1426:
         - Start DeploymentConfig based app pods on 1 OCS/Non-OCS node
@@ -669,22 +649,23 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 sleep=30,
             ), (f"App pod with name {pod_obj.name} did not reach Running state")
 
-        # Wait for mon and osd pods to reach Running state
-        selectors_to_check = {
-            constants.MON_APP_LABEL: ceph_cluster.mon_count,
-            constants.OSD_APP_LABEL: ceph_cluster.osd_count,
-        }
-        for selector, count in selectors_to_check.items():
-            assert ceph_cluster.POD.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector=selector,
-                resource_count=count,
-                timeout=1800,
-                sleep=60,
-            ), f"{count} expected pods with selector {selector} are not in Running state"
+        if not helpers.storagecluster_independent_check():
+            # Wait for mon and osd pods to reach Running state
+            selectors_to_check = {
+                constants.MON_APP_LABEL: ceph_cluster.mon_count,
+                constants.OSD_APP_LABEL: ceph_cluster.osd_count,
+            }
+            for selector, count in selectors_to_check.items():
+                assert ceph_cluster.POD.wait_for_resource(
+                    condition=constants.STATUS_RUNNING,
+                    selector=selector,
+                    resource_count=count,
+                    timeout=1800,
+                    sleep=60,
+                ), f"{count} expected pods with selector {selector} are not in Running state"
 
-        assert ceph_health_check(), "Ceph cluster health is not OK"
-        logger.info("Ceph cluster health is OK")
+            assert ceph_health_check(), "Ceph cluster health is not OK"
+            logger.info("Ceph cluster health is OK")
 
         # Verify data integrity from new pods
         for num, pod_obj in enumerate(new_dc_pods):
@@ -716,16 +697,26 @@ class TestRwoPVCFencingUnfencing(ManageTest):
             ),
             pytest.param(
                 *["colocated", 4, 1, False],
-                marks=[pytest.mark.polarion_id("OCS-1427"), skipif_lso],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1427"),
+                    skipif_lso,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
             pytest.param(
                 *["colocated", 6, 3, True],
-                marks=[pytest.mark.polarion_id("OCS-1430"), skipif_lso],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1430"),
+                    skipif_lso,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
         ],
     )
     def test_rwo_pvc_fencing_node_prolonged_network_failure(
-        self, nodes, setup, teardown
+        self, nodes, setup, node_restart_teardown
     ):
         """
         OCS-1427/OCS-1429:
@@ -760,6 +751,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
         """
         ceph_cluster, dc_pods, ceph_pods, app_pod_nodes, test_nodes, disruptor = setup
 
+        external_mode = helpers.storagecluster_independent_check()
         # Run IO on pods
         md5sum_data = self.run_and_verify_io(
             pod_list=dc_pods, fio_filename="io_file1", run_io_in_bg=True
@@ -797,7 +789,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
         nodes.stop_nodes(node.get_node_objs(app_pod_nodes))
 
         # Force delete the app pods and/or mon,osd pods on the unresponsive node
-        if ceph_cluster.mon_count == 5 and float(config.ENV_DATA["ocs_version"]) < 4.4:
+        if float(config.ENV_DATA["ocs_version"]) < 4.4 and ceph_cluster.mon_count == 5:
             for pod_obj in ceph_cluster.mons:
                 if pod.get_pod_node(pod_obj).name in app_pod_nodes:
                     ceph_pods.append(pod_obj)
@@ -814,27 +806,31 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 sleep=30,
             ), (f"App pod with name {pod_obj.name} did not reach Running state")
 
-        # Wait for mon and osd pods to reach Running state
-        selectors_to_check = [constants.MON_APP_LABEL, constants.OSD_APP_LABEL]
-        for selector in selectors_to_check:
-            assert ceph_cluster.POD.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector=selector,
-                resource_count=3,
-                timeout=1800,
-                sleep=60,
-            ), f"3 expected pods with selector {selector} are not in Running state"
+        if not external_mode:
+            # Wait for mon and osd pods to reach Running state
+            selectors_to_check = {
+                constants.MON_APP_LABEL: self.expected_mon_count,
+                constants.OSD_APP_LABEL: ceph_cluster.osd_count,
+            }
+            for selector, count in selectors_to_check.items():
+                assert ceph_cluster.POD.wait_for_resource(
+                    condition=constants.STATUS_RUNNING,
+                    selector=selector,
+                    resource_count=count,
+                    timeout=1800,
+                    sleep=60,
+                ), f"{count} expected pods with selector {selector} are not in Running state"
 
-        if ceph_cluster.mon_count == 3:
-            # Check ceph health
-            toolbox_status = ceph_cluster.POD.get_resource_status(
-                ceph_cluster.toolbox.name
-            )
-            if toolbox_status == constants.STATUS_TERMINATING:
-                ceph_cluster.toolbox.delete(force=True)
+            if ceph_cluster.mon_count == self.expected_mon_count:
+                # Check ceph health
+                toolbox_status = ceph_cluster.POD.get_resource_status(
+                    ceph_cluster.toolbox.name
+                )
+                if toolbox_status == constants.STATUS_TERMINATING:
+                    ceph_cluster.toolbox.delete(force=True)
 
-            assert ceph_health_check(), "Ceph cluster health is not OK"
-            logger.info("Ceph cluster health is OK")
+                assert ceph_health_check(), "Ceph cluster health is not OK"
+                logger.info("Ceph cluster health is OK")
 
         # Verify data integrity from new pods
         for num, pod_obj in enumerate(new_dc_pods):
@@ -863,12 +859,17 @@ class TestRwoPVCFencingUnfencing(ManageTest):
             ),
             pytest.param(
                 *["colocated", 4, 1, True],
-                marks=[pytest.mark.polarion_id("OCS-1431"), skipif_lso],
+                marks=[
+                    pytest.mark.polarion_id("OCS-1431"),
+                    skipif_lso,
+                    skipif_external_mode,
+                    skipif_tainted_nodes,
+                ],
             ),
         ],
     )
     def test_rwo_pvc_fencing_node_prolonged_and_short_network_failure(
-        self, nodes, setup, teardown
+        self, nodes, setup, node_restart_teardown
     ):
         """
         OCS-1431/OCS-1436:
@@ -894,6 +895,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
         """
         ceph_cluster, dc_pods, ceph_pods, app_pod_nodes, test_nodes, disruptor = setup
 
+        external_mode = helpers.storagecluster_independent_check()
         extra_nodes = list(set(test_nodes) - set(app_pod_nodes))
         helpers.remove_label_from_worker_node(
             node_list=extra_nodes[:-1], label_key="nodetype"
@@ -948,27 +950,31 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 sleep=30,
             ), (f"App pod with name {pod_obj.name} did not reach Running state")
 
-        # Wait for mon and osd pods to reach Running state
-        selectors_to_check = [constants.MON_APP_LABEL, constants.OSD_APP_LABEL]
-        for selector in selectors_to_check:
-            assert ceph_cluster.POD.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector=selector,
-                resource_count=3,
-                timeout=1800,
-                sleep=60,
-            ), f"3 expected pods with selector {selector} are not in Running state"
+        if not external_mode:
+            # Wait for mon and osd pods to reach Running state
+            selectors_to_check = {
+                constants.MON_APP_LABEL: self.expected_mon_count,
+                constants.OSD_APP_LABEL: ceph_cluster.osd_count,
+            }
+            for selector, count in selectors_to_check.items():
+                assert ceph_cluster.POD.wait_for_resource(
+                    condition=constants.STATUS_RUNNING,
+                    selector=selector,
+                    resource_count=count,
+                    timeout=1800,
+                    sleep=60,
+                ), f"{count} expected pods with selector {selector} are not in Running state"
 
-        if ceph_cluster.mon_count == 3:
-            # Check ceph health
-            toolbox_status = ceph_cluster.POD.get_resource_status(
-                ceph_cluster.toolbox.name
-            )
-            if toolbox_status == constants.STATUS_TERMINATING:
-                ceph_cluster.toolbox.delete(force=True)
+            if ceph_cluster.mon_count == self.expected_mon_count:
+                # Check ceph health
+                toolbox_status = ceph_cluster.POD.get_resource_status(
+                    ceph_cluster.toolbox.name
+                )
+                if toolbox_status == constants.STATUS_TERMINATING:
+                    ceph_cluster.toolbox.delete(force=True)
 
-            assert ceph_health_check(), "Ceph cluster health is not OK"
-            logger.info("Ceph cluster health is OK")
+                assert ceph_health_check(), "Ceph cluster health is not OK"
+                logger.info("Ceph cluster health is OK")
 
         # Verify data integrity from new pods
         for num, pod_obj in enumerate(new_dc_pods):
@@ -1020,20 +1026,21 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 sleep=30,
             ), (f"App pod with name {pod_obj.name} did not reach Running state")
 
-        # Wait for mon and osd pods to reach Running state
-        for selector in selectors_to_check:
-            assert ceph_cluster.POD.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector=selector,
-                resource_count=3,
-                timeout=1800,
-                sleep=60,
-            ), f"3 expected pods with selector {selector} are not in Running state"
+        if not external_mode:
+            # Wait for mon and osd pods to reach Running state
+            for selector, count in selectors_to_check.items():
+                assert ceph_cluster.POD.wait_for_resource(
+                    condition=constants.STATUS_RUNNING,
+                    selector=selector,
+                    resource_count=count,
+                    timeout=1800,
+                    sleep=60,
+                ), f"{count} expected pods with selector {selector} are not in Running state"
 
-        if ceph_cluster.mon_count == 3:
-            # Check ceph health
-            assert ceph_health_check(), "Ceph cluster health is not OK"
-            logger.info("Ceph cluster health is OK")
+            if ceph_cluster.mon_count == 3:
+                # Check ceph health
+                assert ceph_health_check(), "Ceph cluster health is not OK"
+                logger.info("Ceph cluster health is OK")
 
         # Verify data integrity from new pods
         for num, pod_obj in enumerate(new_dc_pods2):


### PR DESCRIPTION
This PR resolves #2969, resolves #3981 and include following changes: 
 -  Update node_restart_teardown fixture in conftest.py
  - Enhance test_rwo_pvc_fencing_unfencing.py for internal and external mode
    - Support relevant and skip irrelevant tests in external mode
    - Skip irrelevant tests when nodes are tainted
    - Remove skip for add node in vSphere
    - Other minor updates

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>