### PR TITLE
Save Noobaa DB migration pods logs during OCS upgrade

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -56,6 +56,7 @@ run it belongs here.
 * `log_utilization` - Enable logging of cluster utilization metrics every 10 seconds. Set via --log-cluster-utilization
 * `use_ocs_worker_for_scale` - Use OCS workers for scale testing (Default: false)
 * `load_status` - Current status of IO load
+* `save_live_pod_logs` - This config parameter is not supposed to be changed by the user but by the test fixture itself. It is used for saving the pods' logs during the test execution
 
 #### DEPLOYMENT
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -32,6 +32,8 @@ RUN:
   # This config file disables scale app pods to use OCS workers
   use_ocs_worker_for_scale: False
   load_status: None
+  # This config parameter is not supposed to be changed by the user but by the test fixture itself. It is used for saving the pods' logs during the test execution
+  save_live_pod_logs: False
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1070,7 +1070,6 @@ def save_live_logs(request, pods_containers_dict, patterns_to_log=None):
 
     def save_logs():
         while ocsci_config.RUN.get("save_live_pod_logs"):
-            time.sleep(10)
             if ocsci_config.RUN.get("save_live_pod_logs"):
                 try:
                     save_pods_logs_to_file(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,10 @@ from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implement
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pvc
-from ocs_ci.ocs.utils import setup_ceph_toolbox, collect_ocs_logs
+from ocs_ci.ocs.utils import (
+    setup_ceph_toolbox,
+    collect_ocs_logs,
+)
 from ocs_ci.ocs.resources.backingstore import (
     backingstore_factory as backingstore_factory_implementation,
 )


### PR DESCRIPTION
Noobaa DB replacement takes place as part of the OCS upgrade from 4.6 to 4.7.
The DB migration job, done as part of the upgrade has a few retries so it can fail up to 5 times and the upgrade will still be considered a success.
Currently, there is no way to know if there were such failed attempts, as the DB migration job pods get deleted once the DB migration is done. 

For that, this PR adds the capability to save the pods logs, from those DB migration job pods

In addition to that, there is a pattern to look for in the logs, which indicates a failed attempt. I added a search for that in the logs and we will be notified in the console log where to look for

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>