### PR TITLE
Pass NSS list instead of object in `test_namespace_bucket_creation_with_many_resources_crd`

### DIFF
--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -519,7 +519,7 @@ class TestNamespace(MCGTest):
         bucketclass_dict = {
             "interface": "OC",
             "namespace_policy_dict": {
-                "type": "Mulsti",
+                "type": "Multi",
                 "namespacestores": ns_resources,
             },
         }

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -513,7 +513,7 @@ class TestNamespace(MCGTest):
         """
         logger.info("Create namespace resources and verify health")
         nss_tup = ("oc", {"aws": [(100, self.DEFAULT_REGION)]})
-        ns_resources = namespace_store_factory(*nss_tup)[0]
+        ns_resources = namespace_store_factory(*nss_tup)
 
         logger.info("Create the namespace bucket with many namespace resources")
         bucketclass_dict = {


### PR DESCRIPTION
The test failed because the bucketclass factory expects `namespacestores` to be a list of NamespaceStore objects, but the test passes an object instead