### PR TITLE
RBD thick provisioning - verify PVC expansion, snapshot and clone

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -497,7 +497,7 @@ def create_storage_class(
         reclaim_policy (str): Type of reclaim policy. Defaults to 'Delete'
             (eg., 'Delete', 'Retain')
         rbd_thick_provision (bool): True to enable RBD thick provisioning.
-                Applicable if interface_type is CephBlockPool
+            Applicable if interface_type is CephBlockPool
 
     Returns:
         OCS: An OCS instance for the storage class

--- a/tests/manage/pv_services/conftest.py
+++ b/tests/manage/pv_services/conftest.py
@@ -24,6 +24,8 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
         num_of_cephfs_pvc=None,
         replica_count=1,
         deployment_config=False,
+        sc_rbd=None,
+        sc_cephfs=None,
     ):
         """
         Args:
@@ -40,15 +42,20 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
                 Default is set as ['ReadWriteOnce', 'ReadWriteMany']
             num_of_rbd_pvc (int): Number of rbd PVCs to be created. Value
                 should be greater than or equal to the number of elements in
-                the list 'access_modes_rbd'
-            num_of_cephfs_pvc (int): Number of cephfs PVCs to be created.
+                the list 'access_modes_rbd'. Pass 0 for not creating RBD PVC.
+            num_of_cephfs_pvc (int): Number of cephfs PVCs to be created
                 Value should be greater than or equal to the number of
-                elements in the list 'access_modes_cephfs'
+                elements in the list 'access_modes_cephfs'. Pass 0 for not
+                creating CephFS PVC
             replica_count (int): The replica count for deployment config
             deployment_config (bool): True for DeploymentConfig creation,
                 False otherwise
+            sc_rbd (OCS): RBD storage class. ocs_ci.ocs.resources.ocs.OCS instance
+                of 'StorageClass' kind
+            sc_cephfs (OCS): Cephfs storage class. ocs_ci.ocs.resources.ocs.OCS instance
+                of 'StorageClass' kind
         Returns:
-            list: OCS instance of pods
+            tuple: List of pvcs and pods
         """
 
         access_modes_rbd = access_modes_rbd or [
@@ -62,11 +69,21 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
             constants.ACCESS_MODE_RWX,
         ]
 
+        num_of_rbd_pvc = (
+            num_of_rbd_pvc if num_of_rbd_pvc is not None else len(access_modes_rbd)
+        )
+        num_of_cephfs_pvc = (
+            num_of_cephfs_pvc
+            if num_of_cephfs_pvc is not None
+            else len(access_modes_cephfs)
+        )
+
         num_of_rbd_pvc = num_of_rbd_pvc or len(access_modes_rbd)
         num_of_cephfs_pvc = num_of_cephfs_pvc or len(access_modes_cephfs)
 
         pvcs_rbd = multi_pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
+            storageclass=sc_rbd,
             size=pvc_size,
             access_modes=access_modes_rbd,
             status=constants.STATUS_BOUND,
@@ -76,11 +93,12 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
         for pvc_obj in pvcs_rbd:
             pvc_obj.interface = constants.CEPHBLOCKPOOL
 
-        project = pvcs_rbd[0].project
+        project = pvcs_rbd[0].project if pvcs_rbd else None
 
         pvcs_cephfs = multi_pvc_factory(
             interface=constants.CEPHFILESYSTEM,
             project=project,
+            storageclass=sc_cephfs,
             size=pvc_size,
             access_modes=access_modes_cephfs,
             status=constants.STATUS_BOUND,
@@ -139,7 +157,7 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
         # pods_dc will be an empty list if deployment_config is False
         for pod_dc in pods_dc:
             pod_objs = pod.get_all_pods(
-                namespace=project.namespace,
+                namespace=pvcs[0].project.namespace,
                 selector=[pod_dc.name],
                 selector_label="name",
             )

--- a/tests/manage/pv_services/conftest.py
+++ b/tests/manage/pv_services/conftest.py
@@ -78,9 +78,6 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
             else len(access_modes_cephfs)
         )
 
-        num_of_rbd_pvc = num_of_rbd_pvc or len(access_modes_rbd)
-        num_of_cephfs_pvc = num_of_cephfs_pvc or len(access_modes_cephfs)
-
         pvcs_rbd = multi_pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
             storageclass=sc_rbd,

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -26,13 +26,16 @@ log = logging.getLogger(__name__)
             marks=[polarion_id("OCS-2408"), skipif_ocs_version("<4.6")],
         ),
         pytest.param(
-            *["thick", "thick"], marks=[polarion_id("OCS-2502"), skipif_ocs_version("<4.8")]
+            *["thick", "thick"],
+            marks=[polarion_id("OCS-2502"), skipif_ocs_version("<4.8")],
         ),
         pytest.param(
-            *["thin", "thick"], marks=[polarion_id("2507"), skipif_ocs_version("<4.8")]
+            *["thin", "thick"],
+            marks=[polarion_id("OCS-2507"), skipif_ocs_version("<4.8")],
         ),
         pytest.param(
-            *["thick", "thin"], marks=[polarion_id("OCS-2508"), skipif_ocs_version("<4.8")]
+            *["thick", "thin"],
+            marks=[polarion_id("OCS-2508"), skipif_ocs_version("<4.8")],
         ),
     ],
 )

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -217,7 +217,7 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Verify restored PVCs are Bound")
         for pvc_obj in restore_objs:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=420
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
             )
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound.")
@@ -362,7 +362,7 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Verify restored PVCs are Bound")
         for pvc_obj in restore_objs_new:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=420
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
             )
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound.")

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -217,7 +217,7 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Verify restored PVCs are Bound")
         for pvc_obj in restore_objs:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=420
             )
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound.")
@@ -362,7 +362,7 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Verify restored PVCs are Bound")
         for pvc_obj in restore_objs_new:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=180
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=420
             )
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound.")

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -26,13 +26,13 @@ log = logging.getLogger(__name__)
             marks=[polarion_id("OCS-2408"), skipif_ocs_version("<4.6")],
         ),
         pytest.param(
-            *["thick", "thick"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+            *["thick", "thick"], marks=[polarion_id("OCS-2502"), skipif_ocs_version("<4.8")]
         ),
         pytest.param(
-            *["thick", "thin"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+            *["thin", "thick"], marks=[polarion_id("2507"), skipif_ocs_version("<4.8")]
         ),
         pytest.param(
-            *["thin", "thick"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+            *["thick", "thin"], marks=[polarion_id("OCS-2508"), skipif_ocs_version("<4.8")]
         ),
     ],
 )
@@ -102,6 +102,10 @@ class TestExpansionSnapshotClone(ManageTest):
         Data integrity will be checked in each stage as required.
         This test verifies that the clone, snapshot and parent PVCs are
         independent and any operation in one will not impact the other.
+
+        Use of thin or think provision storage class for PVC creation and snapshot restore
+        will be based on value of the parameters 'pvc_create_sc_type' and 'restore_sc_type'
+        respectively.
 
         """
         filename = "fio_file"

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.helpers import helpers
+from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.testlib import (
@@ -9,15 +10,32 @@ from ocs_ci.framework.testlib import (
     tier2,
     skipif_ocs_version,
     skipif_ocp_version,
+    polarion_id,
 )
 
 log = logging.getLogger(__name__)
 
 
 @tier2
-@skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
-@pytest.mark.polarion_id("OCS-2408")
+@pytest.mark.parametrize(
+    argnames=["pvc_create_sc_type", "restore_sc_type"],
+    argvalues=[
+        pytest.param(
+            *["thin", "thin"],
+            marks=[polarion_id("OCS-2408"), skipif_ocs_version("<4.6")],
+        ),
+        pytest.param(
+            *["thick", "thick"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+        ),
+        pytest.param(
+            *["thick", "thin"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+        ),
+        pytest.param(
+            *["thin", "thick"], marks=[polarion_id(""), skipif_ocs_version("<4.8")]
+        ),
+    ],
+)
 class TestExpansionSnapshotClone(ManageTest):
     """
     Tests to verify snapshot, clone and expansion
@@ -27,20 +45,47 @@ class TestExpansionSnapshotClone(ManageTest):
     @pytest.fixture(autouse=True)
     def setup(
         self,
+        storageclass_factory,
         project_factory,
         snapshot_restore_factory,
         pvc_clone_factory,
         create_pvcs_and_pods,
+        pvc_create_sc_type,
+        restore_sc_type,
     ):
         """
-        Create PVCs and pods
+        Create Storage Class, PVCs and pods
 
         """
         self.pvc_size = 2
+
+        if "thick" in (pvc_create_sc_type, restore_sc_type):
+            # Thick provisioning is applicable only for RBD
+            thick_sc = storageclass_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                new_rbd_pool=False,
+                rbd_thick_provision=True,
+            )
+            access_modes_cephfs = None
+            num_of_cephfs_pvc = 0
+            thin_sc = default_storage_class(constants.CEPHBLOCKPOOL)
+        else:
+            thick_sc = None
+            access_modes_cephfs = [constants.ACCESS_MODE_RWO]
+            num_of_cephfs_pvc = 1
+            thin_sc = default_storage_class(constants.CEPHFILESYSTEM)
+
+        sc_dict = {"thin": thin_sc, "thick": thick_sc}
+        self.pvc_create_sc = sc_dict[pvc_create_sc_type]
+        self.restore_sc = sc_dict[restore_sc_type]
+
         self.pvcs, self.pods = create_pvcs_and_pods(
             pvc_size=self.pvc_size,
             access_modes_rbd=[constants.ACCESS_MODE_RWO],
-            access_modes_cephfs=[constants.ACCESS_MODE_RWO],
+            access_modes_cephfs=access_modes_cephfs,
+            num_of_rbd_pvc=1,
+            num_of_cephfs_pvc=num_of_cephfs_pvc,
+            sc_rbd=self.pvc_create_sc,
         )
 
     def test_expansion_snapshot_clone(
@@ -163,7 +208,9 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Restore snapshots")
         restore_objs = []
         for snap_obj in snapshots:
-            restore_obj = snapshot_restore_factory(snapshot_obj=snap_obj, status="")
+            restore_obj = snapshot_restore_factory(
+                snapshot_obj=snap_obj, status="", storageclass=self.restore_sc.name
+            )
             restore_obj.md5sum = snap_obj.md5sum
             restore_objs.append(restore_obj)
 
@@ -305,7 +352,9 @@ class TestExpansionSnapshotClone(ManageTest):
         log.info("Restoring snapshots of cloned PVCs")
         restore_objs_new = []
         for snap_obj in snapshots_new:
-            restore_obj = snapshot_restore_factory(snap_obj, status="")
+            restore_obj = snapshot_restore_factory(
+                snap_obj, status="", storageclass=self.restore_sc.name
+            )
             restore_obj.md5sum = snap_obj.md5sum
             restore_obj.md5sum_new = snap_obj.md5sum_new
             restore_objs_new.append(restore_obj)


### PR DESCRIPTION
This PR covers the following test cases:
1. PVC snapshot restore, clone and expansion using think provision storage class.
OCS-2502 - FT-ThickProvisioning-PVC snapshot, clone, expansion test

2. Use thick provision storage class while restoring the snapshot of a thin provisioned PVC. Perform  expansion and clone operations on the restored PVC.
OCS-2507 - FT-Thick provision storage class to restore the snapshot of a thin provisioned PVC

3. Use thin provision storage class while restoring the snapshot of a thick provisioned PVC. Perform  expansion and clone operations on the restored PVC.
OCS-2508 - FT- Thin provision storage class to restore snapshot of a thick provisioned PVC

Updated create_pvcs_and_pods fixture to enable the capability to create CephFS or RBD PVC alone with the storage class specified.

Signed-off-by: Jilju Joy jijoy@redhat.com