### PR TITLE
Adding skip for some of tier4 tests for power

### DIFF
--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_bm,
     skipif_ibm_cloud,
     skipif_lso,
+    skipif_ibm_power,
     skipif_vsphere_ipi,
 )
 from ocs_ci.framework.testlib import (
@@ -562,6 +563,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
 
     @skipif_bm
     @skipif_ibm_cloud
+    @skipif_ibm_power
     @tier4a
     @pytest.mark.parametrize(
         argnames=[
@@ -699,6 +701,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
 
     @skipif_bm
     @skipif_ibm_cloud
+    @skipif_ibm_power
     @tier4b
     @pytest.mark.parametrize(
         argnames=[
@@ -849,6 +852,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
 
     @skipif_bm
     @skipif_ibm_cloud
+    @skipif_ibm_power
     @tier4c
     @pytest.mark.parametrize(
         argnames=[

--- a/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -7,6 +7,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_i3,
     skipif_vsphere_ipi,
+    skipif_ibm_power,
 )
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier4, tier4c
 from ocs_ci.ocs import constants, machine, node
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 @tier4c
 @skipif_aws_i3
 @skipif_vsphere_ipi
+@skipif_ibm_power
 @ignore_leftovers
 class TestWorkerNodesFailure(ManageTest):
     """


### PR DESCRIPTION
Fixes:  Some of the failing tests in tier4 as these tests are shutting down the network interface which in turn causes the worker nodes to be in NotReady state as kubelet.service can't talk outside. Then our environment tries to restart the node by SSHing into the worker node which is also not possible as network interface is down. 

Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>