### PR TITLE
get_openshift_client: Avoid removing unnecessarily

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -710,6 +710,11 @@ def get_openshift_client(
                 f"Existing client version ({current_client_version}) does not match "
                 f"configured version ({version})."
             )
+            if config.ENV_DATA.get("skip_ocp_deployment"):
+                log.info(
+                    "ENV_DATA.skip_ocp_deployment is set; leaving client in place."
+                )
+                download_client = False
         else:
             log.debug(
                 f"Client exists ({client_binary_path}) and matches configured version, "


### PR DESCRIPTION
On some platforms (e.g. ppc64le), we deploy OCS on top of an OCP that
was deployed with a very different toolchain from ocs-ci. We don't have
quite the same level of control over the exact OCP version.
get_openshift_client's current behavior is problematic here, especially
since it only knows how to find amd64 binaries. If skip_ocp_deployment
is set, we ought to assume that the oc binary is safe to use.

Signed-off-by: Zack Cerza <zack@redhat.com>