### PR TITLE
Initialize RGW cloud client as None in case regular init failed

### DIFF
--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -95,7 +95,7 @@ class CloudManager(ABC):
             }
             setattr(self, "rgw_client", cloud_map["RGW"](auth_dict=cred_dict["RGW"]))
         except CommandFailed:
-            pass
+            setattr(self, "rgw_client", None)
 
 
 class CloudClient(ABC):


### PR DESCRIPTION
The default behavior of the cloud manager is to initialize any clients with missing credentials as None.
This fixes the RGW client to follow suit, instead of not being initialized at all