### PR TITLE
Modify NSS_MAPPING's get_attr_chain usage to be safer

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -614,7 +614,7 @@ class MCG:
                 "awsS3": {
                     "targetBucket": target_bucket_name,
                     "secret": {
-                        "name": get_attr_chain(cld_mgr.aws_client, "secret.name")
+                        "name": get_attr_chain(cld_mgr, "aws_client.secret.name")
                     },
                 },
             },
@@ -623,7 +623,7 @@ class MCG:
                 "azureBlob": {
                     "targetBlobContainer": target_bucket_name,
                     "secret": {
-                        "name": get_attr_chain(cld_mgr.azure_client, "secret.name")
+                        "name": get_attr_chain(cld_mgr, "azure_client.secret.name")
                     },
                 },
             },
@@ -631,10 +631,10 @@ class MCG:
                 "type": "s3-compatible",
                 "s3Compatible": {
                     "targetBucket": target_bucket_name,
-                    "endpoint": get_attr_chain(cld_mgr.rgw_client, "endpoint"),
+                    "endpoint": get_attr_chain(cld_mgr, "rgw_client.endpoint"),
                     "signatureVersion": "v2",
                     "secret": {
-                        "name": get_attr_chain(cld_mgr.rgw_client, "secret.name")
+                        "name": get_attr_chain(cld_mgr, "rgw_client.secret.name")
                     },
                 },
             },


### PR DESCRIPTION
Although all cloud clients should be initialized as None by default, this change makes the code more robust by not having to rely on them being initialized at all