### PR TITLE
GSS-BUG: Generate heap profile dump file for OSD

### DIFF
--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -3,13 +3,14 @@ import pytest
 import time
 import random
 
-from ocs_ci.framework.testlib import ManageTest, tier2, skipif_ocs_version
+from ocs_ci.framework.testlib import ManageTest, tier2, skipif_ocs_version, bugzilla
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 
 log = logging.getLogger(__name__)
 
 
 @tier2
+@bugzilla("1938049")
 @skipif_ocs_version("<4.7")
 @pytest.mark.polarion_id("OCS-2512")
 class TestOSDHeapProfile(ManageTest):

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -45,8 +45,9 @@ class TestOSDHeapProfile(ManageTest):
         )
         logging.info(out)
         for string_err in strings_err:
-            if string_err in out.lower():
-                assert f"error on the output command {out}"
+            assert (
+                string_err not in out.lower()
+            ), f"{string_err} on the output command {out}"
 
         time.sleep(10)
 
@@ -54,8 +55,9 @@ class TestOSDHeapProfile(ManageTest):
         out = pod_tool.exec_sh_cmd_on_pod(command=f"ceph tell osd.{osd_id} heap dump")
         logging.info(out)
         for string_err in strings_err:
-            if string_err in out.lower():
-                assert f"error on the output command {out}"
+            assert (
+                string_err not in out.lower()
+            ), f"{string_err} on the output command {out}"
 
         log.info(f"Get osd-{osd_id} pod object")
         for osd_pod in osd_pods:
@@ -65,5 +67,6 @@ class TestOSDHeapProfile(ManageTest):
         log.info(f"Verify osd.{osd_id}.profile log exist on /var/log/ceph/")
         out = osd_pod_profile.exec_cmd_on_pod(command="ls -ltr /var/log/ceph/")
         log.info(out)
-        if f"osd.{osd_id}.profile" not in out:
-            assert f"osd.{osd_id}.profile log does not exist on /var/log/ceph/\n{out}"
+        assert (
+            f"osd.{osd_id}.profile" in out
+        ), f"osd.{osd_id}.profile log does not exist on /var/log/ceph/\n{out}"

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -1,9 +1,9 @@
 import logging
 import pytest
 import time
+import random
 
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_ocs_version
-from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 
 log = logging.getLogger(__name__)
@@ -17,26 +17,6 @@ class TestOSDHeapProfile(ManageTest):
     Test osd heap profile created on '/var/log/ceph/'.
 
     """
-
-    @pytest.fixture(scope="function", autouse=True)
-    def teardown(self, request):
-        """
-        Archive a crash report so that it is no longer considered for the
-        RECENT_CRASH health check and does not appear in the
-        crash ls-new output
-
-        """
-
-        def finalizer():
-            logging.info("Silence the ceph warnings by “archiving” the crash")
-            tool_pod = get_ceph_tools_pod()
-            tool_pod.exec_ceph_cmd(ceph_cmd="ceph crash archive-all", format=None)
-            logging.info(
-                "Perform Ceph and cluster health checks after silencing the ceph warnings"
-            )
-            ceph_health_check()
-
-        request.addfinalizer(finalizer)
 
     def test_osd_heap_profile(self):
         """
@@ -52,22 +32,38 @@ class TestOSDHeapProfile(ManageTest):
             -rw-r--r--. 1 ceph ceph 295891 Apr 11 14:33 osd.0.profile.0001.heap
 
         """
-        log.info("Start heap profiler for osd-0")
+        strings_err = ["error", "fail"]
+        osd_pods = get_osd_pods()
+        osd_id = str(random.randint(0, len(osd_pods) - 1))
+
+        log.info(f"Start heap profiler for osd-{osd_id}")
         pod_tool = get_ceph_tools_pod()
-        pod_tool.exec_sh_cmd_on_pod(command="ceph tell osd.0 heap start_profiler")
+        out = pod_tool.exec_sh_cmd_on_pod(
+            command=f"ceph tell osd.{osd_id} heap start_profiler"
+        )
+        logging.info(out)
+        for string_err in strings_err:
+            if string_err in out.lower():
+                raise (ValueError, f"{out}")
 
         time.sleep(10)
 
         log.info("Dump heap profile")
-        pod_tool.exec_sh_cmd_on_pod(command="ceph tell osd.0 heap dump")
+        out = pod_tool.exec_sh_cmd_on_pod(command=f"ceph tell osd.{osd_id} heap dump")
+        logging.info(out)
+        for string_err in strings_err:
+            if string_err in out.lower():
+                raise (ValueError, f"{out}")
 
-        log.info("Get osd-0 pod object")
-        osd_pods = get_osd_pods()
+        log.info(f"Get osd-{osd_id} pod object")
         for osd_pod in osd_pods:
-            if get_osd_pod_id(osd_pod) == "0":
-                osd_pod_0 = osd_pod
+            if get_osd_pod_id(osd_pod) == osd_id:
+                osd_pod_profile = osd_pod
 
-        log.info("Verify osd.0.profile log exist on /var/log/ceph/")
-        out = osd_pod_0.exec_cmd_on_pod(command="ls -ltr /var/log/ceph/")
-        if "osd.0.profile" not in out:
-            raise Exception("osd.0.profile log does not exist on /var/log/ceph/")
+        log.info(f"Verify osd.{osd_id}.profile log exist on /var/log/ceph/")
+        out = osd_pod_profile.exec_cmd_on_pod(command="ls -ltr /var/log/ceph/")
+        log.info(out)
+        if f"osd.{osd_id}.profile" not in out:
+            raise Exception(
+                f"osd.{osd_id}.profile log does not exist on /var/log/ceph/\n{out}"
+            )

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -70,3 +70,4 @@ class TestOSDHeapProfile(ManageTest):
         assert (
             f"osd.{osd_id}.profile" in out
         ), f"osd.{osd_id}.profile log does not exist on /var/log/ceph/\n{out}"
+        log.info(f"osd.{osd_id}.profile log exist on /var/log/ceph")

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -49,6 +49,7 @@ class TestOSDHeapProfile(ManageTest):
                 string_err not in out.lower()
             ), f"{string_err} on the output command {out}"
 
+        logging.info("Sleep 10 sec, for running heap profiler")
         time.sleep(10)
 
         log.info("Dump heap profile")

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -2,14 +2,14 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.testlib import ManageTest, tier1, skipif_ocs_version
+from ocs_ci.framework.testlib import ManageTest, tier2, skipif_ocs_version
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 
 log = logging.getLogger(__name__)
 
 
-@tier1
+@tier2
 @skipif_ocs_version("<4.7")
 @pytest.mark.polarion_id("OCS-2512")
 class TestOSDHeapProfile(ManageTest):
@@ -40,7 +40,16 @@ class TestOSDHeapProfile(ManageTest):
 
     def test_osd_heap_profile(self):
         """
-        Test osd heap profile created on '/var/log/ceph/'.
+        1.Start heap profiler for osd
+          $ oc exec rook-ceph-tools-85ccf9f7c5-v7bgk ceph tell osd.0 heap start_profiler
+
+        2.Dump heap profile
+          $ oc exec rook-ceph-tools-85ccf9f7c5-v7bgk ceph tell osd.0 heap dump
+
+        3.Get heap profile in /var/log/ceph dir on osd node
+          $ oc rsh rook-ceph-osd-0-959dbdc6d-pddd4
+            sh-4.4# ls -ltr /var/log/ceph/
+            -rw-r--r--. 1 ceph ceph 295891 Apr 11 14:33 osd.0.profile.0001.heap
 
         """
         log.info("Start heap profiler for osd-0")

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -1,0 +1,65 @@
+import logging
+import pytest
+import time
+
+from ocs_ci.framework.testlib import ManageTest, tier1, bugzilla, skipif_ocs_version
+from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
+
+log = logging.getLogger(__name__)
+
+
+@tier1
+@skipif_ocs_version("<4.7")
+@bugzilla("1938049")
+@pytest.mark.polarion_id("OCS-2512")
+class TestOSDHeapProfile(ManageTest):
+    """
+    Test osd heap profile created on '/var/log/ceph/'.
+
+    """
+
+    @pytest.fixture(scope="function", autouse=True)
+    def teardown(self, request):
+        """
+        Archive a crash report so that it is no longer considered for the
+        RECENT_CRASH health check and does not appear in the
+        crash ls-new output
+
+        """
+
+        def finalizer():
+            logging.info("Silence the ceph warnings by “archiving” the crash")
+            tool_pod = get_ceph_tools_pod()
+            tool_pod.exec_ceph_cmd(ceph_cmd="ceph crash archive-all", format=None)
+            logging.info(
+                "Perform Ceph and cluster health checks after silencing the ceph warnings"
+            )
+            ceph_health_check()
+
+        request.addfinalizer(finalizer)
+
+    def test_osd_heap_profile(self):
+        """
+        Test osd heap profile created on '/var/log/ceph/'.
+
+        """
+        log.info("Start heap profiler for osd-0")
+        pod_tool = get_ceph_tools_pod()
+        pod_tool.exec_sh_cmd_on_pod(command="ceph tell osd.0 heap start_profiler")
+
+        time.sleep(10)
+
+        log.info("Dump heap profile")
+        pod_tool.exec_sh_cmd_on_pod(command="ceph tell osd.0 heap dump")
+
+        log.info("Get osd-0 pod object")
+        osd_pods = get_osd_pods()
+        for osd_pod in osd_pods:
+            if get_osd_pod_id(osd_pod) == "0":
+                osd_pod_0 = osd_pod
+
+        log.info("Verify osd.0.profile log exist on /var/log/ceph/")
+        out = osd_pod_0.exec_cmd_on_pod(command="ls -ltr /var/log/ceph/")
+        if "osd.0.profile" not in out:
+            raise Exception("osd.0.profile log does not exist on /var/log/ceph/")

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -45,7 +45,7 @@ class TestOSDHeapProfile(ManageTest):
         logging.info(out)
         for string_err in strings_err:
             if string_err in out.lower():
-                raise (ValueError, f"{out}")
+                raise Exception(f"{out}")
 
         time.sleep(10)
 
@@ -54,7 +54,7 @@ class TestOSDHeapProfile(ManageTest):
         logging.info(out)
         for string_err in strings_err:
             if string_err in out.lower():
-                raise (ValueError, f"{out}")
+                raise Exception(f"{out}")
 
         log.info(f"Get osd-{osd_id} pod object")
         for osd_pod in osd_pods:

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -40,7 +40,7 @@ class TestOSDHeapProfile(ManageTest):
 
         log.info(f"Start heap profiler for osd-{osd_id}")
         pod_tool = get_ceph_tools_pod()
-        out = pod_tool.exec_sh_cmd_on_pod(
+        out = pod_tool.exec_cmd_on_pod(
             command=f"ceph tell osd.{osd_id} heap start_profiler"
         )
         logging.info(out)

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -3,7 +3,13 @@ import pytest
 import time
 import random
 
-from ocs_ci.framework.testlib import ManageTest, tier2, skipif_ocs_version, bugzilla
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    skipif_ocs_version,
+    bugzilla,
+    skipif_external_mode,
+)
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 
 log = logging.getLogger(__name__)
@@ -13,6 +19,7 @@ log = logging.getLogger(__name__)
 @bugzilla("1938049")
 @skipif_ocs_version("<4.6")
 @pytest.mark.polarion_id("OCS-2512")
+@skipif_external_mode
 class TestOSDHeapProfile(ManageTest):
     """
     1.Start heap profiler for osd

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.testlib import ManageTest, tier1, bugzilla, skipif_ocs_version
+from ocs_ci.framework.testlib import ManageTest, tier1, skipif_ocs_version
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 
@@ -11,7 +11,6 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version("<4.7")
-@bugzilla("1938049")
 @pytest.mark.polarion_id("OCS-2512")
 class TestOSDHeapProfile(ManageTest):
     """

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 @tier2
 @bugzilla("1938049")
-@skipif_ocs_version("<4.7")
+@skipif_ocs_version("<4.6")
 @pytest.mark.polarion_id("OCS-2512")
 class TestOSDHeapProfile(ManageTest):
     """


### PR DESCRIPTION
gss bug: https://bugzilla.redhat.com/show_bug.cgi?id=1938049
Test Procedure:
1.Start heap profiler for osd
$ oc exec rook-ceph-tools-85ccf9f7c5-v7bgk ceph tell osd.0 heap start_profiler
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
osd.0 started profiler

2.Dump heap profile
$ oc exec rook-ceph-tools-85ccf9f7c5-v7bgk ceph tell osd.0 heap dump
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
osd.0 dumping heap profile now.

MALLOC:      439066216 (  418.7 MiB) Bytes in use by application
MALLOC: +            0 (    0.0 MiB) Bytes in page heap freelist
MALLOC: +     43649688 (   41.6 MiB) Bytes in central cache freelist
MALLOC: +     12115200 (   11.6 MiB) Bytes in transfer cache freelist
MALLOC: +     27081216 (   25.8 MiB) Bytes in thread cache freelists
MALLOC: +      6946816 (    6.6 MiB) Bytes in malloc metadata
MALLOC:   ------------
MALLOC: =    528859136 (  504.4 MiB) Actual memory used (physical + swap)
MALLOC: +    397721600 (  379.3 MiB) Bytes released to OS (aka unmapped)
MALLOC:   ------------
MALLOC: =    926580736 (  883.7 MiB) Virtual address space used
MALLOC:
MALLOC:          46898              Spans in use
MALLOC:             37              Thread heaps in use
MALLOC:           8192              Tcmalloc page size

Call ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).
Bytes released to the OS take up virtual address space but no physical memory.

3.Get heap profile in /var/log/ceph dir on osd node
$ oc rsh rook-ceph-osd-0-959dbdc6d-pddd4
sh-4.4# ls -ltr /var/log/ceph/
-rw-r--r--. 1 ceph ceph  295891 Apr 11 14:33 osd.0.profile.0001.heap

Signed-off-by: Oded Viner <oviner@redhat.com>