### PR TITLE
Enable Flexible Scaling on LSO cluster

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -73,6 +73,7 @@ from ocs_ci.utility.vsphere_nodes import update_ntp_compute_nodes
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.ui.base_ui import login_ui, close_browser
 from ocs_ci.ocs.ui.deployment_ui import DeploymentUI
+from ocs_ci.utility.utils import get_az_count
 
 logger = logging.getLogger(__name__)
 
@@ -578,6 +579,21 @@ class Deployment(object):
 
         deviceset_data = cluster_data["spec"]["storageDeviceSets"][0]
         device_size = int(config.ENV_DATA.get("device_size", defaults.DEVICE_SIZE))
+
+        logger.info(
+            "Flexible scaling is available from version 4.7 on LSO cluster with less than 3 zones"
+        )
+        ocs_version = float(config.ENV_DATA["ocs_version"])
+        zone_num = get_az_count()
+        if (
+            config.DEPLOYMENT.get("local_storage")
+            and ocs_version >= 4.7
+            and zone_num < 3
+        ):
+            cluster_data["spec"]["flexibleScaling"] = True
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1921023
+            cluster_data["spec"]["storageDeviceSets"][0]["count"] = 3
+            cluster_data["spec"]["storageDeviceSets"][0]["replica"] = 1
 
         # set size of request for storage
         if self.platform.lower() == constants.BAREMETAL_PLATFORM:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -4,6 +4,7 @@ platforms like AWS, VMWare, Baremetal etc.
 """
 
 from copy import deepcopy
+from semantic_version import Version
 import json
 import logging
 import tempfile
@@ -583,11 +584,11 @@ class Deployment(object):
         logger.info(
             "Flexible scaling is available from version 4.7 on LSO cluster with less than 3 zones"
         )
-        ocs_version = float(config.ENV_DATA["ocs_version"])
+        ocs_version = config.ENV_DATA["ocs_version"]
         zone_num = get_az_count()
         if (
             config.DEPLOYMENT.get("local_storage")
-            and ocs_version >= 4.7
+            and Version.coerce(ocs_version) >= Version.coerce("4.7")
             and zone_num < 3
         ):
             cluster_data["spec"]["flexibleScaling"] = True

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -6,6 +6,7 @@ import logging
 import tempfile
 
 from jsonschema import validate
+from semantic_version import Version
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults, ocp
@@ -383,9 +384,13 @@ def ocs_install_verification(
             kms = KMS.get_kms_deployment()
             kms.post_deploy_verification()
 
-    ocs_version = float(config.ENV_DATA["ocs_version"])
+    ocs_version = config.ENV_DATA["ocs_version"]
     zone_num = utils.get_az_count()
-    if config.DEPLOYMENT.get("local_storage") and ocs_version >= 4.7 and zone_num < 3:
+    if (
+        config.DEPLOYMENT.get("local_storage")
+        and Version.coerce(ocs_version) >= Version.coerce("4.7")
+        and zone_num < 3
+    ):
         storage_cluster_obj = get_storage_cluster()
         failure_domain = storage_cluster_obj.data["items"][0]["status"]["failureDomain"]
         assert failure_domain == "host", (

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -383,6 +383,16 @@ def ocs_install_verification(
             kms = KMS.get_kms_deployment()
             kms.post_deploy_verification()
 
+    ocs_version = float(config.ENV_DATA["ocs_version"])
+    zone_num = utils.get_az_count()
+    if config.DEPLOYMENT.get("local_storage") and ocs_version >= 4.7 and zone_num < 3:
+        storage_cluster_obj = get_storage_cluster()
+        failure_domain = storage_cluster_obj.data["items"][0]["status"]["failureDomain"]
+        assert failure_domain == "host", (
+            f"The failure domain type on LSO cluster with {zone_num} zones should be "
+            f"'host' and not {failure_domain}."
+        )
+
 
 def osd_encryption_verification():
     """


### PR DESCRIPTION
Enable Flexible scaling parameter on lso cluster with less than 3 zones, on OCS 4.7 and above
Verify failure domain is "host"
Signed-off-by: Oded Viner <oviner@redhat.com>