### PR TITLE
Fix typo and code duplication

### DIFF
--- a/ocs_ci/ocs/resources/bucketclass.py
+++ b/ocs_ci/ocs/resources/bucketclass.py
@@ -108,24 +108,15 @@ def bucket_class_factory(
                     "namespacestore_dict"
                 ]
                 namespacestores = namespace_store_factory(interface, nss_dict)
-                namespace_policy["type"] = bucket_class_dict["namespace_policy_dict"][
-                    "type"
-                ]
-                namespace_policy["read_resources"] = [
-                    nss.name for nss in namespacestores
-                ]
-                namespace_policy["write_resource"] = namespacestores[0].name
             elif "namespacestores" in bucket_class_dict["namespace_policy_dict"]:
                 namespacestores = bucket_class_dict["namespace_policy_dict"][
                     "namespacestores"
                 ]
-                namespace_policy["type"] = bucket_class_dict["namespace_policy_dict"][
-                    "type"
-                ]
-                namespace_policy["read_resources"] = [
-                    nss.name for nss in namespacestores
-                ]
-                namespace_policy["write_resource"] = namespacestores[0].name
+            namespace_policy["type"] = bucket_class_dict["namespace_policy_dict"][
+                "type"
+            ]
+            namespace_policy["read_resources"] = [nss.name for nss in namespacestores]
+            namespace_policy["write_resource"] = namespacestores[0].name
 
         elif "backingstore_dict" in bucket_class_dict:
             backingstores = [

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -519,7 +519,7 @@ class TestNamespace(MCGTest):
         bucketclass_dict = {
             "interface": "OC",
             "namespace_policy_dict": {
-                "type": "Mulsti",
+                "type": "Multi",
                 "namespacestores": ns_resources,
             },
         }


### PR DESCRIPTION
Partial fix for https://github.com/red-hat-storage/ocs-ci/issues/4118.

Fixes:
- Under test_namespace_bucket_creation_with_many_resources_crd there is a typo (Mulsti instead of Multi)
- Code duplication in the bucketclass resource the if should only include which namespaces to use (create new or use existing)

Signed-off-by: Filip Balak <fbalak@redhat.com>