### PR TITLE
Increase PVC provisioning timeout in test test_rbd_thick_provisioning 

### DIFF
--- a/tests/manage/pv_services/test_rbd_thick_provisioning.py
+++ b/tests/manage/pv_services/test_rbd_thick_provisioning.py
@@ -65,7 +65,7 @@ class TestRbdThickProvisioning(ManageTest):
                 access_modes=access_modes_rbd,
                 status=constants.STATUS_BOUND,
                 num_of_pvc=3,
-                timeout=120,
+                timeout=150,
             )
             for pvc_obj in pvc_objs:
                 pvc_obj.io_file_size = pvc_and_file_sizes[pvc_size]


### PR DESCRIPTION
PVC provisioning is taking more than the given timeout of 120 seconds. Increasing timeout.
Fixes #4136 
Signed-off-by: Jilju Joy <jijoy@redhat.com>