### PR TITLE
Check RBD thick storage class in install verification

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -201,7 +201,7 @@ def ocs_install_verification(
         f"{storage_cluster_name}-cephfs",
         f"{storage_cluster_name}-ceph-rbd",
     }
-    if float(config.ENV_DATA["ocs_version"]) >= 4.8:
+    if Version.coerce(ocs_version) >= Version.coerce("4.8"):
         required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
     if config.DEPLOYMENT["external_mode"]:
         required_storage_classes.update(

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -201,6 +201,8 @@ def ocs_install_verification(
         f"{storage_cluster_name}-cephfs",
         f"{storage_cluster_name}-ceph-rbd",
     }
+    if float(config.ENV_DATA["ocs_version"]) >= 4.8:
+        required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
     if config.DEPLOYMENT["external_mode"]:
         required_storage_classes.update(
             {

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -6,6 +6,7 @@ import logging
 import tempfile
 
 from jsonschema import validate
+from semantic_version import Version
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults, ocp


### PR DESCRIPTION
With OCS 4.8 there will be a new storage class ```ocs-storagecluster-ceph-rbd-thick``` created during installation. Adding this to the list of the storage class to be verified after installation.

Signed-off-by: Jilju Joy <jijoy@redhat.com>