### PR TITLE
Skip tests/e2e/scale/test_scale_amq.py TC due to issue #3372

### DIFF
--- a/tests/e2e/scale/test_scale_amq.py
+++ b/tests/e2e/scale/test_scale_amq.py
@@ -23,7 +23,10 @@ def test_fixture_amq(request):
 
 
 @scale
-@pytest.mark.polarion_id("OCS-424")
+@pytest.mark.skip(
+    reason="Skipped due to github issue #3372, TC is failing "
+    "in each test-run, priority to fix this issue is lower"
+)
 class TestAMQBasics(E2ETest):
     @pytest.mark.parametrize(
         argnames=["interface"],


### PR DESCRIPTION
Skip AMQ tests/e2e/scale/test_scale_amq.py TC due to issue #3372
This failure is observed in all the test run and the plan to fix this
issue is for now lower, so adding skip marker.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>