### PR TITLE
Remove elastic search usage from Scale tests

### DIFF
--- a/ocs_ci/ocs/small_file_workload.py
+++ b/ocs_ci/ocs/small_file_workload.py
@@ -69,6 +69,8 @@ def smallfile_workload(ripsaw, es, file_size, files, threads, samples, interface
             "server": es.get_ip(),
             "port": es.get_port(),
         }
+    else:
+        del sf_data["spec"]["elasticsearch"]
 
     log.info("Apply Operator CRD")
     ripsaw.apply_crd("resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml")

--- a/tests/e2e/scale/test_scale_small_file_workload.py
+++ b/tests/e2e/scale/test_scale_small_file_workload.py
@@ -116,9 +116,9 @@ class TestSmallFileWorkloadScale(E2ETest):
         argvalues=[pytest.param(*[16, 1000000, 4, constants.CEPHFILESYSTEM])] * 20,
     )
     def test_scale_smallfile_workload(
-        self, ripsaw, es, scale_leaks, file_size, files, threads, interface
+        self, ripsaw, scale_leaks, file_size, files, threads, interface
     ):
-        smallfile_workload(ripsaw, es, file_size, files, threads, 3, interface)
+        smallfile_workload(ripsaw, None, file_size, files, threads, 3, interface)
         cephfs_data.count += 1
         run_data = get_cephfs_data()
         for entry in run_data:


### PR DESCRIPTION
Remove elastic search usage from Scale test tests/e2e/scale/test_scale_small_file_workload.py

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>