### PR TITLE
Adding cache dropper pod to performance tests

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -209,3 +209,60 @@ def measure_pvc_creation_time(interface, pvc_name, start_time):
         f"Creation time (in seconds) for pvc {pvc_name} is {(et - st).total_seconds()}"
     )
     return (et - st).total_seconds()
+
+
+def diff_check(first, second, diffs=10):
+    """
+    Function to check the differance between 2 numbers, and return true if the
+    difference between them is more then expected
+
+    Args:
+        first (int) : the first number (usual the lowest)
+        second (int) : the second number (usual the highest)
+        diffs (int) : the acceptable difference between the number in percentage
+           the default is 10%
+
+    Return:
+        bool : True if the difference is more then the acceptable, other False
+
+    """
+    try:
+        # using the abs since the first number can be higher then the second
+        # one, and in this case the results can be negative
+        if abs((100 - (first * 100 / second))) > diffs:
+            return True
+    except ZeroDivisionError:
+        pass
+    return False
+
+
+def cleanup_results_numbers_from_spikes(data, spike=10):
+    """
+    Function to cleanup list of results number from the highest and lowes numbers,
+    usually, thous 2 numbers are 'noise' in the test.
+    if the list of the number have less then 5 numbers, it will not do any cleanup
+
+    Args:
+        data (list) : list of numbers - test results
+        spike (int) : the acceptable percentage, default is 10% (each side - total of 20%)
+
+    Returns:
+        list : the list of the numbers without the Highest & Lowest numbers
+
+    """
+
+    if len(data) < 5:
+        return data
+
+    # sorting the number list
+    data.sort()
+
+    logger.debug(f"The highest 2 numbers are {data[-1]}, {data[-2]}")
+    if diff_check(data[-1], data[-2], spike):
+        # remove the highest number from the list
+        data.remove(max(data))
+    logger.debug(f"The lowest 2 numbers are {data[0]}, {data[1]}")
+    if diff_check(data[1], data[0]):
+        # remove the lowest number from the list
+        data.remove(min(data))
+    return data

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -11,7 +11,8 @@ from ocs_ci.ocs.ocp import switch_to_default_rook_cluster_project
 from subprocess import run, CalledProcessError
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs.constants import RIPSAW_NAMESPACE
-
+from ocs_ci.ocs.node import get_nodes
+from ocs_ci.helpers import helpers
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +52,10 @@ class RipSaw(object):
         self.pod_obj = OCP(namespace=RIPSAW_NAMESPACE, kind="pod")
         self._create_namespace()
         self._clone_ripsaw()
+        self.worker_nodes = [node.name for node in get_nodes()]
+        helpers.label_worker_node(
+            self.worker_nodes, label_key="kernel-cache-dropper", label_value="yes"
+        )
 
     def _create_namespace(self):
         """
@@ -84,6 +89,12 @@ class RipSaw(object):
         run("oc apply -f deploy", shell=True, check=True, cwd=self.dir)
         run(f"oc apply -f {crd}", shell=True, check=True, cwd=self.dir)
         run(f"oc apply -f {self.operator}", shell=True, check=True, cwd=self.dir)
+        run(
+            "oc create -f resources/kernel-cache-drop-clusterrole.yaml",
+            shell=True,
+            check=True,
+            cwd=self.dir,
+        )
 
     def get_uuid(self, benchmark):
         """
@@ -122,7 +133,16 @@ class RipSaw(object):
         run(f"oc delete -f {self.crd}", shell=True, cwd=self.dir)
         run(f"oc delete -f {self.operator}", shell=True, cwd=self.dir)
         run("oc delete -f deploy", shell=True, cwd=self.dir)
+        run(
+            "oc delete -f resources/kernel-cache-drop-clusterrole.yaml",
+            shell=True,
+            check=True,
+            cwd=self.dir,
+        )
         run_cmd(f"oc delete project {self.namespace}")
         self.ns_obj.wait_for_delete(resource_name=self.namespace, timeout=180)
         # Reset namespace to default
         switch_to_default_rook_cluster_project()
+        helpers.remove_label_from_worker_node(
+            self.worker_nodes, label_key="kernel-cache-dropper"
+        )


### PR DESCRIPTION
This PR Add a cache dropper pod to the benchmark-operator based test, so the cache can be drop off between test samples for consistency results

this is supported and will be implemented in the FIO and SmallFiles tests