### PR TITLE
Fix `skipif_ocs_version` logic

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2410,13 +2410,8 @@ def skipif_ocs_version(expressions):
     Return:
         'True' if test needs to be skipped else 'False'
     """
-    skip_this = True
     expr_list = [expressions] if isinstance(expressions, str) else expressions
-    for expr in expr_list:
-        comparision_str = config.ENV_DATA["ocs_version"] + expr
-        skip_this = skip_this and eval(comparision_str)
-    # skip_this will be either True or False after eval
-    return skip_this
+    return any(eval(config.ENV_DATA["ocs_version"] + expr) for expr in expr_list)
 
 
 def get_ocs_version_from_image(image):


### PR DESCRIPTION
The original code would not work properly when given a list of expressions, and would always return `False` when more than one expression was given.
This PR aims to fix that while also shortening the code.