### PR TITLE
Define MCG code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
+/tests/manage/mcg/ @red-hat-storage/mcg-reviewers
 
 # The `docs/*` pattern will match files like
 # `docs/getting-started.md` but not further nested files like
@@ -42,4 +43,3 @@
 # In this example, @doctocat owns any file in the `/docs`
 # directory in the root of your repository.
 #/docs/ @doctocat
-


### PR DESCRIPTION
This change allows us to more granularly control the approval and merge procedures of MCG-related PRs by requiring reviews from specific members