### PR TITLE
Skip deletion for PVC backingstores that couldn't be found

### DIFF
--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -70,6 +70,8 @@ class BackingStore:
                     f"Could not find the OCP object for {self.name}, proceeding without removal"
                 )
                 return True
+            except Exception as e:
+                raise e
             pv_name = backingstore_pvc["spec"]["volumeName"]
 
         if self.method == "oc":

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -59,11 +59,17 @@ class BackingStore:
         log.info(f"Cleaning up backingstore {self.name}")
         # If the backingstore utilizes a PV, save its PV name for deletion verification
         if self.type == "pv":
-            backingstore_pvc = OCP(
-                kind=constants.PVC,
-                selector=f"pool={self.name}",
-                namespace=config.ENV_DATA["cluster_namespace"],
-            ).get()["items"][0]
+            try:
+                backingstore_pvc = OCP(
+                    kind=constants.PVC,
+                    selector=f"pool={self.name}",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                ).get()["items"][0]
+            except IndexError:
+                log.error(
+                    f"Could not find the OCP object for {self.name}, proceeding without removal"
+                )
+                return
             pv_name = backingstore_pvc["spec"]["volumeName"]
 
         if self.method == "oc":

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -69,7 +69,7 @@ class BackingStore:
                 log.error(
                     f"Could not find the OCP object for {self.name}, proceeding without removal"
                 )
-                return
+                return True
             pv_name = backingstore_pvc["spec"]["volumeName"]
 
         if self.method == "oc":


### PR DESCRIPTION
Up until now, we tried to delete PVCs that weren't necessarily properly created before, leading to an exception when accessing the [0] index of the PVC list. This PR skips the deletion if no fitting backingstores are found.