### PR TITLE
Add additonal FIO workload to trigger Noobaa autoscale 

### DIFF
--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -99,8 +99,8 @@ class TestScaleEndpointAutoScale(MCGTest):
 
         # Delete mcg_job_factory
         for i in range(10):
-            f"job{i}".delete()
-            f"job{i}".ocp.wait_for_delete(resource_name=f"job{i}".name, timeout=60)
+            exec(f"job{i}.delete()")
+            exec(f"job{i}.ocp.wait_for_delete(resource_name=job{i}.name, timeout=60)")
 
         # Validate autoscale endpoint count
         self._assert_endpoint_count(desired_count=1)

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -67,7 +67,7 @@ class TestScaleEndpointAutoScale(MCGTest):
             condition=constants.STATUS_RUNNING,
             selector=constants.NOOBAA_ENDPOINT_POD_LABEL,
             dont_allow_other_resources=True,
-            timeout=500,
+            timeout=900,
         )
 
     def test_scale_endpoint_and_respin_ceph_pods(
@@ -84,7 +84,8 @@ class TestScaleEndpointAutoScale(MCGTest):
         self._assert_endpoint_count(desired_count=1)
 
         # Create s3 workload using mcg_job_factory
-        job = mcg_job_factory(custom_options=options)
+        for i in range(10):
+            exec(f"job{i} = mcg_job_factory(custom_options=options)")
 
         # Validate autoscale endpoint count
         self._assert_endpoint_count(desired_count=2)
@@ -97,8 +98,9 @@ class TestScaleEndpointAutoScale(MCGTest):
             disruption.delete_resource(resource_id=i)
 
         # Delete mcg_job_factory
-        job.delete()
-        job.ocp.wait_for_delete(resource_name=job.name, timeout=60)
+        for i in range(10):
+            f"job{i}".delete()
+            f"job{i}".ocp.wait_for_delete(resource_name=f"job{i}".name, timeout=60)
 
         # Validate autoscale endpoint count
         self._assert_endpoint_count(desired_count=1)

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -50,11 +50,12 @@ class TestEndpointAutoScale(MCGTest):
                 ("numjobs", "4"),
             ],
         }
-        job = mcg_job_factory(custom_options=options)
-        self._assert_endpoint_count(2)
+        for i in range(10):
+            exec(f"job{i} = mcg_job_factory(custom_options={options})")
 
-        job.delete()
-        job.ocp.wait_for_delete(resource_name=job.name, timeout=60)
+        for i in range(10):
+            exec(f"job{i}.delete()")
+            exec(f"job{i}.ocp.wait_for_delete(resource_name=job{i}.name, timeout=60)")
         self._assert_endpoint_count(1)
 
     def _assert_endpoint_count(self, desired_count):
@@ -65,5 +66,5 @@ class TestEndpointAutoScale(MCGTest):
             condition=constants.STATUS_RUNNING,
             selector=constants.NOOBAA_ENDPOINT_POD_LABEL,
             dont_allow_other_resources=True,
-            timeout=500,
+            timeout=900,
         )

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -52,6 +52,7 @@ class TestEndpointAutoScale(MCGTest):
         }
         for i in range(10):
             exec(f"job{i} = mcg_job_factory(custom_options={options})")
+        self._assert_endpoint_count(2)
 
         for i in range(10):
             exec(f"job{i}.delete()")


### PR DESCRIPTION
Creating 10 FIO pods running in parallel to generate enough load to trigger Noobaa autoscale feature.
Fixing issue: https://github.com/red-hat-storage/ocs-ci/issues/4129
