### PR TITLE
Increase CLUSTER_NAME_MAX_CHARACTERS value

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -812,7 +812,7 @@ ZONE_LABEL_NEW = "topology.kubernetes.io/zone"
 
 # Cluster name limits
 CLUSTER_NAME_MIN_CHARACTERS = 5
-CLUSTER_NAME_MAX_CHARACTERS = 17
+CLUSTER_NAME_MAX_CHARACTERS = 18
 
 STAGE_CA_FILE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "stage-ca.crt")
 


### PR DESCRIPTION
OCP deployment fails with ClusterNameLengthError when cluster name
, for instance is 'dkhandel-ocsci-371' which is 18 characters long
while 5-17 characters long is expected

Signed-off-by: Deepshikha Khandelwal <dkhandel@redhat.com>