### PR TITLE
Fix RGW tests to run on external-mode clusters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1739,7 +1739,16 @@ def rgw_obj_fixture(request):
     rgw_deployments = get_deployments_having_label(
         label=constants.RGW_APP_LABEL, namespace=config.ENV_DATA["cluster_namespace"]
     )
-    if rgw_deployments:
+    try:
+        storageclass = OCP(
+            kind=constants.STORAGECLASS,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_RGW,
+        )
+    except CommandFailed:
+        storageclass = None
+
+    if rgw_deployments or storageclass:
         return RGW()
     else:
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1744,7 +1744,7 @@ def rgw_obj_fixture(request):
             kind=constants.STORAGECLASS,
             namespace=config.ENV_DATA["cluster_namespace"],
             resource_name=constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_RGW,
-        )
+        ).get()
     except CommandFailed:
         storageclass = None
 


### PR DESCRIPTION
Currently, we only check for whether there are RGW deployments on the cluster. In external mode clusters, the deployments are not found on the same cluster, and thus another check for the external RGW storageclass was added, to let the tests run on external-mode clusters.