### PR TITLE
Extend the node replacement verification steps to work with more than 3 OSDs

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1109,7 +1109,7 @@ def get_worker_nodes_not_in_ocs():
 
 
 def node_replacement_verification_steps_user_side(
-    old_node_name, new_node_name, new_osd_node_name, old_osd_id
+    old_node_name, new_node_name, new_osd_node_name, old_osd_ids
 ):
     """
     Check the verification steps that the user should perform after the process
@@ -1119,7 +1119,7 @@ def node_replacement_verification_steps_user_side(
         old_node_name (str): The name of the old node that has been deleted
         new_node_name (str): The name of the new node that has been created
         new_osd_node_name (str): The name of the new node that has been added to osd nodes
-        old_osd_id (str): The old osd id
+        old_osd_ids (list): List of the old osd ids
 
     Returns:
         bool: True if all the verification steps passed. False otherwise
@@ -1147,18 +1147,31 @@ def node_replacement_verification_steps_user_side(
         log.warning("Not all the pods in running state")
         return False
 
-    new_osd_pod = get_node_pods(new_osd_node_name, pods_to_search=pod.get_osd_pods())[0]
-    if not new_osd_pod:
+    new_osd_node_pods = get_node_pods(
+        new_osd_node_name, pods_to_search=pod.get_osd_pods()
+    )
+    if not new_osd_node_pods:
         log.warning("Didn't find any osd pods running on the new node")
         return False
 
-    new_osd_id = pod.get_osd_pod_id(new_osd_pod)
-    if old_osd_id != new_osd_id:
-        log.warning(
-            f"The osd pod, that associated to the new node, has the id {new_osd_id} "
-            f"instead of the expected osd id {old_osd_id}"
-        )
+    log.info("Search for the old osd ids")
+    new_osd_pods = pod.get_osd_pods_having_ids(old_osd_ids)
+    if len(new_osd_pods) < len(old_osd_ids):
+        log.warning("Didn't find osd pods for all the osd ids")
         return False
+
+    for osd_pod in new_osd_pods:
+        osd_id = pod.get_osd_pod_id(osd_pod)
+        osd_pod_node = pod.get_pod_node(osd_pod)
+        if not osd_pod_node:
+            log.warning(
+                f"Didn't find osd node for the osd pod '{osd_pod}' with id '{osd_id}'"
+            )
+            return False
+
+        log.info(
+            f"Found new osd pod '{osd_pod}' with id '{osd_id}' on the node '{osd_pod_node.name}'"
+        )
 
     log.info("Verification steps from the user side finish successfully")
     return True

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1165,12 +1165,12 @@ def node_replacement_verification_steps_user_side(
         osd_pod_node = pod.get_pod_node(osd_pod)
         if not osd_pod_node:
             log.warning(
-                f"Didn't find osd node for the osd pod '{osd_pod}' with id '{osd_id}'"
+                f"Didn't find osd node for the osd pod '{osd_pod.name}' with id '{osd_id}'"
             )
             return False
 
         log.info(
-            f"Found new osd pod '{osd_pod}' with id '{osd_id}' on the node '{osd_pod_node.name}'"
+            f"Found new osd pod '{osd_pod.name}' with id '{osd_id}' on the node '{osd_pod_node.name}'"
         )
 
     log.info("Verification steps from the user side finish successfully")

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1983,3 +1983,26 @@ def check_pods_after_node_replacement():
     else:
         logger.warning(f"One of the '{pod_daemon_type}' pods is not running")
         return False
+
+
+def get_osd_pods_having_ids(osd_ids):
+    """
+    Get the osd pods having specific ids
+
+    Args:
+        osd_ids (list): The list of the osd ids
+
+    Returns:
+        list: The osd pods having the osd ids
+
+    """
+    # Convert it to set to reduce complexity
+    osd_ids_set = set(osd_ids)
+    osd_pods_having_ids = []
+
+    osd_pods = get_osd_pods()
+    for osd_pod in osd_pods:
+        if get_osd_pod_id(osd_pod) in osd_ids_set:
+            osd_pods_having_ids.append(osd_pod)
+
+    return osd_pods_having_ids

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -41,7 +41,7 @@ def select_osd_node_name():
 
 
 def check_node_replacement_verification_steps(
-    old_node_name, new_node_name, old_osd_node_names, old_osd_id
+    old_node_name, new_node_name, old_osd_node_names, old_osd_ids
 ):
     """
     Check if the node replacement verification steps finished successfully.
@@ -50,7 +50,7 @@ def check_node_replacement_verification_steps(
         old_node_name (str): The name of the old node that has been deleted
         new_node_name (str): The name of the new node that has been created
         old_osd_node_names (list): The name of the new node that has been added to osd nodes
-        old_osd_id (str): The old osd id
+        old_osd_ids (list): List of the old osd ids
 
     Raises:
         AssertionError: If the node replacement verification steps failed.
@@ -63,7 +63,7 @@ def check_node_replacement_verification_steps(
         old_node_name, new_node_name, new_osd_node_name
     )
     assert node.node_replacement_verification_steps_user_side(
-        old_node_name, new_node_name, new_osd_node_name, old_osd_id
+        old_node_name, new_node_name, new_osd_node_name, old_osd_ids
     )
 
 
@@ -76,8 +76,8 @@ def delete_and_create_osd_node(osd_node_name):
 
     """
     new_node_name = None
-    osd_pod = node.get_node_pods(osd_node_name, pods_to_search=pod.get_osd_pods())[0]
-    old_osd_id = pod.get_osd_pod_id(osd_pod)
+    osd_pods = node.get_node_pods(osd_node_name, pods_to_search=pod.get_osd_pods())
+    old_osd_ids = [pod.get_osd_pod_id(osd_pod) for osd_pod in osd_pods]
 
     old_osd_node_names = node.get_osd_running_nodes()
 
@@ -116,7 +116,7 @@ def delete_and_create_osd_node(osd_node_name):
 
     log.info("Start node replacement verification steps...")
     check_node_replacement_verification_steps(
-        osd_node_name, new_node_name, old_osd_node_names, old_osd_id
+        osd_node_name, new_node_name, old_osd_node_names, old_osd_ids
     )
 
 


### PR DESCRIPTION
Currently, the node replacement verification steps are working. Still, when we have many OSD's(for example, after adding capacity to the cluster), sometimes the verification steps can fail. So we need to extend the verification steps to work on any cluster - no matter the number of the OSD's and worker nodes. 