### PR TITLE
Adding Osd cache drop for performance tests

### DIFF
--- a/Docker_files/osd_cache_dropping
+++ b/Docker_files/osd_cache_dropping
@@ -1,0 +1,7 @@
+ARG ARCH=
+FROM ${ARCH}quay.io/rhceph-dev/rook-ceph:latest-4.8
+
+USER root
+RUN yum install -y git
+RUN mkdir -p /opt/bohica/
+RUN cd /opt/bohica ; git clone https://github.com/cloud-bulldozer/bohica.git .

--- a/ocs_ci/ocs/resources/cache_drop.py
+++ b/ocs_ci/ocs/resources/cache_drop.py
@@ -16,12 +16,12 @@ class OSDCashDrop(OCP):
     Usage:
         import OSDCashDrop
 
-        cd = OSDCashDrop()                          # create new cache_drop object
-        cd.deploy()                                 # deploy the cache_drop pod
-        ....                                        # run test
-        cd.drop_cache()                             # drop the OSD's cache
-        ....                                        # run the test again
-        cd.delete(resource_name=cd.resource_name)   # delete the cache_drop pod
+        cd = OSDCashDrop()  # create new cache_drop object
+        cd.deploy()         # deploy the cache_drop pod
+        ....                # run test
+        cd.drop_cache()     # drop the OSD's cache
+        ....                # run the test again
+        cd.cleanup()        # delete the cache_drop pod
 
     """
 
@@ -44,6 +44,14 @@ class OSDCashDrop(OCP):
         """
         self.create(self.crd)
         self.wait_for_resource(condition=constants.STATUS_RUNNING, timeout=240)
+
+    def cleanup(self):
+        """
+        Delete the pod from the cluster
+
+        """
+        self.delete(resource_name=self.resource_name)
+        self.wait_for_delete(resource_name=self.resource_name)
 
     @property
     def ip(self):

--- a/ocs_ci/ocs/resources/cache_drop.py
+++ b/ocs_ci/ocs/resources/cache_drop.py
@@ -1,0 +1,76 @@
+# Builtin modules
+import logging
+import http.client
+
+# OCS-CI modules
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+
+log = logging.getLogger(__name__)
+
+
+class OSDCashDrop(OCP):
+    """
+    This module is for deploying pod which enable to drop the OSD's cache.
+
+    Usage:
+        import OSDCashDrop
+
+        cd = OSDCashDrop()                          # create new cache_drop object
+        cd.deploy()                                 # deploy the cache_drop pod
+        ....                                        # run test
+        cd.drop_cache()                             # drop the OSD's cache
+        ....                                        # run the test again
+        cd.delete(resource_name=cd.resource_name)   # delete the cache_drop pod
+
+    """
+
+    def __init__(self):
+        """
+        Initialize the object parameters
+        """
+        super(OSDCashDrop, self).__init__(
+            kind="POD",
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            resource_name="rook-ceph-osd-cache-drop",
+        )
+        self.crd = constants.RIPSAW_DROP_CACHE
+        self.port = 9432  # this port number is hard coded in the pod
+
+    def deploy(self):
+        """
+        Deploy the cache drop pod and wait until it is up
+
+        """
+        self.create(self.crd)
+        self.wait_for_resource(condition=constants.STATUS_RUNNING, timeout=240)
+
+    @property
+    def ip(self):
+        """
+        return the cache drop IP
+
+        """
+        return self.get()["status"]["podIP"]
+
+    def drop_cache(self):
+        """
+        Drop the OSD's cache by sending http request to the pod
+
+        Raises:
+            exaption : if the request to drop the cache failed
+
+        """
+        log.info(f"ceph OSD cache drop pod: {self.ip}")
+        conn = http.client.HTTPConnection(self.ip, port=self.port, timeout=30)
+        log.info(f"requesting ceph to drop cache via {self.ip}:{self.port}")
+        try:
+            conn.request("GET", "/drop_osd_caches")
+            rsp = conn.getresponse()
+            if rsp.status != http.client.OK:
+                log.error(f"HTTP ERROR {rsp.status}: {rsp.reason}")
+                raise Exception(f"Ceph OSD cache drop {self.ip}:{self.port} Failed")
+            else:
+                log.info("The OSD cache was successfully dropped")
+        except Exception as e:
+            log.error(f"Can not connect to pod : {e}")

--- a/ocs_ci/ocs/resources/cache_drop.py
+++ b/ocs_ci/ocs/resources/cache_drop.py
@@ -66,7 +66,7 @@ class OSDCashDrop(OCP):
         Drop the OSD's cache by sending http request to the pod
 
         Raises:
-            exaption : if the request to drop the cache failed
+            exception : if the request to drop the cache failed
 
         """
         log.info(f"ceph OSD cache drop pod: {self.ip}")

--- a/ocs_ci/templates/workloads/fio/drop_cache_pod.yaml
+++ b/ocs_ci/templates/workloads/fio/drop_cache_pod.yaml
@@ -6,17 +6,22 @@ metadata:
 spec:
   containers:
   - name: rook-ceph-osd-cache-drop
-    image: quay.io/cloud-bulldozer/ceph-cache-dropper:latest
+    image: quay.io/ocsci/osd_cache_drop:latest-4.8
     imagePullPolicy: Always
     command: [/bin/sh, -c]
     args:
-      - cd /opt/bohica/ceph-cache-dropper; python ./osd-cache-drop-websvc.py
+      - cd /opt/bohica/ceph-cache-dropper; python3 ./osd-cache-drop-websvc.py
     env:
-      - name: ROOK_ADMIN_SECRET
+      - name: ROOK_CEPH_USERNAME
         valueFrom:
           secretKeyRef:
-            key: admin-secret
             name: rook-ceph-mon
+            key: ceph-username
+      - name: ROOK_CEPH_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: rook-ceph-mon
+            key: ceph-secret
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
This PR update the yaml file for creating cache_drop_pod to use multi-arch image.

It also add the Dockerfile to build the multi-arch image for cache dropping

and it create an object to implement the use of this new pod.
the new object implement :

- pod Deployment
- pod deletion (in the end of the test - teardown)
- Drop the OSD cache