### PR TITLE
Define OCS-CI CODEOWNERS by squads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,21 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
-/tests/manage/mcg/ @red-hat-storage/mcg-reviewers
+/tests/manage/z_cluster/ @red-hat-storage/brown-squad
+/tests/manage/pv_services/ @red-hat-storage/green-squad
+/tests/manage/storageclass/ @red-hat-storage/green-squad
+/tests/manage/monitoring/ @red-hat-storage/blue-squad
+/tests/manage/mcg/ @red-hat-storage/red-squad
+/tests/manage/rgw/ @red-hat-storage/red-squad
+/tests/manage/z_cluster/test_must_gather.py @red-hat-storage/purple-squad
+/tests/ecosystem/upgrade/ @red-hat-storage/purple-squad
+/tests/e2e/flowtest/ @red-hat-storage/magenta-squad
+/tests/e2e/lifecycle/ @red-hat-storage/magenta-squad
+/tests/e2e/logging/ @red-hat-storage/magenta-squad
+/tests/e2e/registry/ @red-hat-storage/magenta-squad
+/tests/e2e/workloads/ @red-hat-storage/magenta-squad
+/tests/e2e/performance/ @red-hat-storage/grey-squad
+/tests/e2e/scale/ @red-hat-storage/orange-squad
 
 # The `docs/*` pattern will match files like
 # `docs/getting-started.md` but not further nested files like

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,6 @@
 /tests/manage/monitoring/ @red-hat-storage/blue-squad
 /tests/manage/mcg/ @red-hat-storage/red-squad
 /tests/manage/rgw/ @red-hat-storage/red-squad
-/tests/manage/z_cluster/test_must_gather.py @red-hat-storage/purple-squad
 /tests/ecosystem/upgrade/ @red-hat-storage/purple-squad
 /tests/e2e/flowtest/ @red-hat-storage/magenta-squad
 /tests/e2e/lifecycle/ @red-hat-storage/magenta-squad


### PR DESCRIPTION
On the Manage team call that was held yesterday, it was decided to add the test analysis squads as CODEOWNERS ("top level reviewers") for each squad's appropriate test directories. Once this PR is merged, particular sets of people will _have_ to review and approve certain PRs in order to merge them into `master`. This change is supposed to help improve code quality and accountability across the project.

The teams can be seen [here](https://github.com/orgs/red-hat-storage/teams/ocs-qe/teams)