### PR TITLE
Implement the OSD cache droping into the SmallFiles benchmark

### DIFF
--- a/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
+++ b/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
@@ -30,3 +30,8 @@ spec:
       files: 50000
       storageclass: ocs-storageclass-ceph-rbd
       storagesize: 100Gi
+      # un comment the next line when the  drop-cache-kernel will support multi-arch
+      # drop_cache_kernel: true
+      rook_ceph_drop_caches: True
+      # place holder for the pod ip - will be filled up in the test
+      rook_ceph_drop_cache_pod_ip:

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -445,6 +445,7 @@ class TestSmallFileWorkload(PASTest):
             self.ripsaw.cleanup()
         if isinstance(self.es, ElasticSearch):
             self.es.cleanup()
+        self.c_drop.cleanup()
 
         sleep_time = 5
         log.info(

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -452,11 +452,6 @@ class TestSmallFileWorkload(PASTest):
         self.c_drop = cache_drop.OSDCashDrop()
         self.c_drop.deploy()
 
-    def teardown(self):
-
-        # Deleting the OSD cache drop pod
-        self.c_drop.cleanup()
-
     @pytest.mark.parametrize(
         argnames=["file_size", "files", "threads", "samples", "interface"],
         argvalues=[

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -351,6 +351,10 @@ class TestSmallFileWorkload(PASTest):
         self.ripsaw = RipSaw()
         self.ripsaw_deploy(self.ripsaw)
 
+        # Deploying OSD cache drop pod
+        self.c_drop = cache_drop.OSDCashDrop()
+        self.c_drop.deploy()
+
     def setting_storage_usage(self, file_size, files, threads, samples):
         """
         Getting the storage capacity, calculate the usage of the storage and
@@ -447,10 +451,6 @@ class TestSmallFileWorkload(PASTest):
             f"Going to sleep for {sleep_time} Minute, for background cleanup to complete"
         )
         time.sleep(sleep_time * 60)
-
-        # Deploying OSD cache drop pod
-        self.c_drop = cache_drop.OSDCashDrop()
-        self.c_drop.deploy()
 
     @pytest.mark.parametrize(
         argnames=["file_size", "files", "threads", "samples", "interface"],


### PR DESCRIPTION
In this PR i am implementing the ability to drop the OSD cache between test samples for more consistency results