### PR TITLE
WIP: testing changes required for PR #4192 - Add ovirt sdk python package in virtual env of ocs-ci execution

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install ovirt-engine-sdk-python dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libcurl4-openssl-dev
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         # greenlet 1.0.0 is broken on ppc64le
         # https://github.com/python-greenlet/greenlet/issues/230
         "greenlet<1.0.0",
+        "ovirt-engine-sdk-python==4.4.11",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This is just testing PR - to check how to install dependencies for Github actions for PR https://github.com/red-hat-storage/ocs-ci/pull/4192.