### PR TITLE
Github actions: install libcurl4-openssl-dev package

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install ovirt-engine-sdk-python dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libcurl4-openssl-dev
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This package provides `curl-config`, which is dependency for `ovirt-engine-sdk-python` on Github actions
This change is required by following two PRs: https://github.com/red-hat-storage/ocs-ci/pull/4192, https://github.com/red-hat-storage/ocs-ci/pull/4159

Signed-off-by: Daniel Horak <dahorak@redhat.com>