### PR TITLE
run load_cluster_info_file before cluster_load

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -42,6 +42,7 @@ from ocs_ci.ocs.exceptions import (
     UnexpectedImage,
     UnsupportedOSType,
 )
+from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility.retry import retry
 
 
@@ -2692,6 +2693,9 @@ def login_to_mirror_registry(authfile):
         authfile (str): authfile (pull-secret) path
 
     """
+    # load cluster info
+    load_cluster_info()
+
     mirror_registry = config.DEPLOYMENT["mirror_registry"]
     mirror_registry_user = config.DEPLOYMENT["mirror_registry_user"]
     mirror_registry_password = config.DEPLOYMENT["mirror_registry_password"]


### PR DESCRIPTION
- fixes https://github.com/red-hat-storage/ocs-ci/issues/4280

Signed-off-by: Daniel Horak <dahorak@redhat.com>