### PR TITLE
WIP: Update the "add_capacity" tests

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1556,11 +1556,11 @@ def check_ceph_health_after_add_capacity():
     ceph_health_tries = 80
     ceph_rebalance_timeout = 1800
     if config.RUN.get("io_in_bg") and config.RUN.get("io_load"):
-        addtional_ceph_health_tries = int(config.RUN.get("io_load") * 0.3)
-        ceph_health_tries += addtional_ceph_health_tries
+        additional_ceph_health_tries = int(config.RUN.get("io_load") * 1.3)
+        ceph_health_tries += additional_ceph_health_tries
 
-        addtional_ceph_rebalance_timeout = config.RUN.get("io_load") * 20
-        ceph_rebalance_timeout += addtional_ceph_rebalance_timeout
+        additional_ceph_rebalance_timeout = config.RUN.get("io_load") * 20
+        ceph_rebalance_timeout += additional_ceph_rebalance_timeout
 
     ceph_health_check(
         namespace=config.ENV_DATA["cluster_namespace"], tries=ceph_health_tries

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -23,8 +23,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_osd_pods
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.cluster import check_ceph_health_after_add_capacity
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
 
@@ -72,11 +71,7 @@ def add_capacity_test():
     if config.ENV_DATA.get("encryption_at_rest"):
         osd_encryption_verification()
 
-    ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=80)
-    ceph_cluster_obj = CephCluster()
-    assert ceph_cluster_obj.wait_for_rebalance(
-        timeout=5400
-    ), "Data re-balance failed to complete"
+    check_ceph_health_after_add_capacity()
 
 
 @ignore_leftovers

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -7,9 +7,9 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.ocs.node import get_ocs_nodes
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
+from ocs_ci.ocs.cluster import check_ceph_health_after_add_capacity
 
 
 @pytest.mark.parametrize(
@@ -87,4 +87,4 @@ class TestAddCapacityNodeRestart(ManageTest):
 
         logging.info("Finished verifying add capacity osd storage with node restart")
         logging.info("Waiting for ceph health check to finished...")
-        ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=180)
+        check_ceph_health_after_add_capacity()

--- a/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
@@ -9,8 +9,10 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.ocs.cluster import get_percent_used_capacity, CephCluster
-from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.ocs.cluster import (
+    get_percent_used_capacity,
+    check_ceph_health_after_add_capacity,
+)
 from ocs_ci.helpers.disruption_helpers import Disruptions
 
 
@@ -151,8 +153,4 @@ class TestAddCapacityWithResourceDelete:
             "Finished verifying add capacity when one of the pods gets deleted"
         )
         logging.info("Waiting for ceph health check to finished...")
-        ceph_health_check(namespace=config.ENV_DATA["cluster_namespace"], tries=90)
-        ceph_cluster_obj = CephCluster()
-        assert ceph_cluster_obj.wait_for_rebalance(
-            timeout=1800
-        ), "Data re-balance failed to complete"
+        check_ceph_health_after_add_capacity()


### PR DESCRIPTION
According to the last failures of the "add_capacity" tests, we need to perform some changes in the test:

1. Increase timeout when running IO in the background in the "add_capacity" test.
2. Label the OCS worker nodes before the "add_capacity" the test `test_add_capacity_with_resource_delete` starts.
3. If we use the vSphere platform, we might need to add 3 extra worker nodes and label them before the test `test_add_capacity_with_resource_delete` starts.