### PR TITLE
Disconnected instalation from live: wait for machineconfig status

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -170,6 +170,9 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
         # Wait for catalog source is ready
         catalog_source.wait_for_state("READY")
 
+        # ensure that newly created imageContentSourcePolicy is applied on all nodes
+        wait_for_machineconfigpool_status("all")
+
         return
 
     if config.DEPLOYMENT.get("stage_rh_osbs"):


### PR DESCRIPTION
On disconnected installation from live, we didn't wait for machineconfigpool status to be updated after creation of imageContentSourcePolicy. This causes failures when creating StorageCluster when not all mon pods were running in time (or at all).
Related to [BZ1959935](https://bugzilla.redhat.com/show_bug.cgi?id=1959935).