### PR TITLE
Skipping noobaa cache test on ocs 4.6

### DIFF
--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -11,7 +11,10 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     retrieve_anon_s3_resource,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_openshift_dedicated,
+    skipif_ocs_version,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +69,7 @@ class TestObjectIntegrity(MCGTest):
                         ]
                     },
                 },
-                marks=[tier1],
+                marks=[tier1, skipif_ocs_version("<4.7")],
             ),
         ],
         ids=[


### PR DESCRIPTION
Caching not supported in ocs 4.6
Signed-off-by: Parikshith Byregowda <pbyregow@redhat.com>