### PR TITLE
Add RBD thick provision verification in test

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3069,8 +3069,7 @@ def check_rbd_image_used_size(
                     f"Expected the used size to be diferent than {usage_to_compare}. "
                     f"Actual used size: {used_size}. Rbd du out: {du_out}"
                 )
-
-            no_match_list.append(pvc_obj.name)
+                no_match_list.append(pvc_obj.name)
 
     if no_match_list:
         logger.error(

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3026,3 +3026,55 @@ def run_cmd_verify_cli_output(
         if expected_output not in out:
             return False
     return True
+
+
+def check_rbd_image_used_size(
+    pvc_objs, usage_to_compare, rbd_pool=constants.DEFAULT_BLOCKPOOL, expect_match=True
+):
+    """
+    Check if RBD image used size of the PVCs are matching with the given value
+
+    Args:
+        pvc_objs (list): List of PVC objects
+        usage_to_compare (str): Value of image used size to be compared with actual value. eg: "5GiB"
+        rbd_pool (str): Name of the pool
+        expect_match (bool): True to verify the used size is equal to 'usage_to_compare' value.
+            False to verify the used size is not equal to 'usage_to_compare' value.
+
+    Returns:
+        bool: True if the verification is success for all the PVCs, False otherwise
+
+    """
+    ct_pod = pod.get_ceph_tools_pod()
+    no_match_list = []
+    for pvc_obj in pvc_objs:
+        rbd_image_name = pvc_obj.get_rbd_image_name
+        du_out = ct_pod.exec_ceph_cmd(
+            ceph_cmd=f"rbd du -p {rbd_pool} {rbd_image_name}",
+            format="",
+        )
+        used_size = "".join(du_out.strip().split()[-2:])
+        if expect_match:
+            if usage_to_compare != used_size:
+                logger.error(
+                    f"Rbd image {rbd_image_name} of PVC {pvc_obj.name} did not meet the expectation."
+                    f" Expected used size: {usage_to_compare}. Actual used size: {used_size}. "
+                    f"Rbd du out: {du_out}"
+                )
+                no_match_list.append(pvc_obj.name)
+        else:
+            if usage_to_compare == used_size:
+                logger.error(
+                    f"Rbd image {rbd_image_name} of PVC {pvc_obj.name} did not meet the expectation. "
+                    f"Expected the used size to be diferent than {usage_to_compare}. "
+                    f"Actual used size: {used_size}. Rbd du out: {du_out}"
+                )
+
+            no_match_list.append(pvc_obj.name)
+
+    if no_match_list:
+        logger.error(
+            f"RBD image used size of these PVCs did not meet the expectation - {no_match_list}"
+        )
+        return False
+    return True

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -131,6 +131,16 @@ class PVC(OCS):
             "volume.beta.kubernetes.io/storage-provisioner"
         ]
 
+    @property
+    def get_rbd_image_name(self):
+        """
+        Fetch image name associated with the RBD PVC
+
+        Returns:
+            str: Image name associated with the RBD PVC
+        """
+        return self.backed_pv_obj.get()["spec"]["csi"]["volumeAttributes"]["imageName"]
+
     def resize_pvc(self, new_size, verify=False):
         """
         Modify the capacity of PVC

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -106,12 +106,12 @@ class TestExpansionSnapshotClone(ManageTest):
 
         self.ct_pod = pod.get_ceph_tools_pod()
         if pvc_create_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=self.pvcs,
                 usage_to_compare=f"{self.pvc_size}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more PVCs are not thick provisioned."
 
     def test_expansion_snapshot_clone(
         self,
@@ -173,12 +173,12 @@ class TestExpansionSnapshotClone(ManageTest):
 
         # Verify thick provision by checking the image used size
         if pvc_create_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=self.pvcs,
                 usage_to_compare=f"{pvc_size_expand_1}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more PVCs are not thick provisioned after expansion"
             log.info(
                 f"Verified thick provision after expanding the PVCs to {pvc_size_expand_1}GiB"
             )
@@ -214,12 +214,12 @@ class TestExpansionSnapshotClone(ManageTest):
 
         # Verify thick provision by checking the image used size
         if pvc_create_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=self.pvcs,
                 usage_to_compare=f"{pvc_size_expand_2}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more PVCs are not thick provisioned after expansion"
             log.info(
                 f"Verified thick provision after expanding the PVCs to {pvc_size_expand_2}GiB"
             )
@@ -283,42 +283,42 @@ class TestExpansionSnapshotClone(ManageTest):
 
         # Verify restored PVCs are thick provision or not by checking the image used size
         if restore_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs,
                 usage_to_compare=f"{pvc_size_expand_1}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more restored PVCs are not thick provisioned"
             log.info("Verified thick provision on restored PVCs")
         elif restore_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs,
                 usage_to_compare=f"{pvc_size_expand_1}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
-            )
+            ), "One or more restored PVCs are not thin provisioned"
             log.info("Verified: Restored PVCs are not thick provisioned.")
 
         # Verify clones are thick provision or not by checking the image used size
         if pvc_create_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=clone_objs,
                 usage_to_compare=f"{pvc_size_expand_2}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more cloned PVCs are not thick provisioned"
             log.info("Verified thick provision on cloned PVCs.")
         elif pvc_create_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=clone_objs,
                 usage_to_compare=f"{pvc_size_expand_2}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
-            )
+            ), "One or more cloned PVCs are not thin provisioned"
             log.info("Verified: Cloned PVCs are not thick provisioned.")
 
         # Attach the restored and cloned PVCs to pods
@@ -357,11 +357,14 @@ class TestExpansionSnapshotClone(ManageTest):
 
         # Verify thick provision or not by checking the image used size
         if pvc_create_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=clone_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
+            ), (
+                "One or more cloned PVCs are not thick provisioned after expanding "
+                f"to {pvc_size_expand_3}GiB"
             )
             log.info(
                 f"Verified thick provision after expanding cloned PVCs to {pvc_size_expand_3}GiB"
@@ -369,36 +372,48 @@ class TestExpansionSnapshotClone(ManageTest):
         elif pvc_create_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=clone_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
+            ), (
+                "One or more cloned PVCs are not thin provisioned after expanding "
+                f"to {pvc_size_expand_3}GiB"
             )
             log.info(
-                f"Verified: PVCs are not thick provisioned after expanding cloned PVCs to {pvc_size_expand_3}GiB"
+                "Verified: PVCs are not thick provisioned after expanding cloned "
+                f"PVCs to {pvc_size_expand_3}GiB"
             )
         if restore_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
+            ), (
+                "One or more restored PVCs are not thick provisioned after"
+                f" expanding to {pvc_size_expand_3}GiB"
             )
             log.info(
-                f"Verified thick provision after expanding restored PVCs to {pvc_size_expand_3}GiB"
+                "Verified thick provision after expanding restored PVCs "
+                f"to {pvc_size_expand_3}GiB"
             )
         elif restore_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
+            ), (
+                "One or more restored PVCs are not thin provisioned after "
+                f"expanding to {pvc_size_expand_3}GiB"
             )
             log.info(
-                f"Verified: PVCs are not thick provisioned after expanding restored PVCs to {pvc_size_expand_3}GiB"
+                "Verified: PVCs are not thick provisioned after expanding "
+                f"restored PVCs to {pvc_size_expand_3}GiB"
             )
 
         # Run IO on pods attached with cloned and restored PVCs
@@ -472,24 +487,24 @@ class TestExpansionSnapshotClone(ManageTest):
         # Verify PVCs cloned from restored PVCs are thick provisioned or not
         # by checking the image used size
         if restore_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restored_clone_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more PVCs cloned from restored PVCs are not thick provisioned"
             log.info(
                 "Verified that the PVCs cloned from restored PVCs are thick provisioned"
             )
         if restore_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restored_clone_objs,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
-            )
+            ), "One or more PVCs cloned from restored PVCs are not thin provisioned"
             log.info(
                 "Verified that the PVCs cloned from restored PVCs are not thick provisioned"
             )
@@ -539,22 +554,22 @@ class TestExpansionSnapshotClone(ManageTest):
 
         # Verify thick provision or not by checking the image used size
         if restore_sc_type == "thick":
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs_new,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=True,
-            )
+            ), "One or more restored PVCs are not thick provisioned"
             log.info("Verified thick provision on PVCs restored from the snapshots.")
         if restore_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):
-            check_rbd_image_used_size(
+            assert check_rbd_image_used_size(
                 pvc_objs=restore_objs_new,
                 usage_to_compare=f"{pvc_size_expand_3}GiB",
                 rbd_pool=constants.DEFAULT_BLOCKPOOL,
                 expect_match=False,
-            )
+            ), "One or more restored PVCs are not thin provisioned"
             log.info(
                 "Verified that the PVCs restored from the snapshots are not thick provisioned."
             )

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -44,7 +44,11 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *["thick", "thin"],
-            marks=[polarion_id("OCS-2508"), skipif_ocs_version("<4.8")],
+            marks=[
+                polarion_id("OCS-2508"),
+                skipif_ocs_version("<4.8"),
+                bugzilla("1959793"),
+            ],
         ),
     ],
 )

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -276,7 +276,9 @@ class TestExpansionSnapshotClone(ManageTest):
                 pvc_objs=clone_objs, expected_usage=f"{pvc_size_expand_2}GiB"
             )
             log.info("Verified thick provision on cloned PVCs.")
-        elif pvc_create_sc_type == "thin":
+        elif pvc_create_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=clone_objs,
                 expected_usage=f"{pvc_size_expand_2}GiB",
@@ -320,7 +322,9 @@ class TestExpansionSnapshotClone(ManageTest):
                 pvc_objs=restore_objs, expected_usage=f"{pvc_size_expand_1}GiB"
             )
             log.info(f"Verified thick provision on restored PVCs")
-        elif restore_sc_type == "thin":
+        elif restore_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=restore_objs,
                 expected_usage=f"{pvc_size_expand_1}GiB",
@@ -370,7 +374,9 @@ class TestExpansionSnapshotClone(ManageTest):
             log.info(
                 f"Verified thick provision after expanding cloned PVCs to {pvc_size_expand_3}GiB"
             )
-        elif pvc_create_sc_type == "thin":
+        elif pvc_create_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=clone_objs,
                 expected_usage=f"{pvc_size_expand_3}GiB",
@@ -386,7 +392,9 @@ class TestExpansionSnapshotClone(ManageTest):
             log.info(
                 f"Verified thick provision after expanding restored PVCs to {pvc_size_expand_3}GiB"
             )
-        elif restore_sc_type == "thin":
+        elif restore_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=restore_objs,
                 expected_usage=f"{pvc_size_expand_3}GiB",
@@ -472,7 +480,9 @@ class TestExpansionSnapshotClone(ManageTest):
             log.info(
                 "Verified that the PVCs cloned from restored PVCs are thick provisioned"
             )
-        if restore_sc_type == "thin":
+        if restore_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=restored_clone_objs,
                 expected_usage=f"{pvc_size_expand_3}GiB",
@@ -531,7 +541,9 @@ class TestExpansionSnapshotClone(ManageTest):
                 pvc_objs=restore_objs_new, expected_usage=f"{pvc_size_expand_3}GiB"
             )
             log.info("Verified thick provision on PVCs restored from the snapshots.")
-        if restore_sc_type == "thin":
+        if restore_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
             self.verify_thick_provision(
                 pvc_objs=restore_objs_new,
                 expected_usage=f"{pvc_size_expand_3}GiB",

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -270,22 +270,6 @@ class TestExpansionSnapshotClone(ManageTest):
             f"as {pvc_size_expand_2}Gi"
         )
 
-        # Verify thick provision or not
-        if pvc_create_sc_type == "thick":
-            self.verify_thick_provision(
-                pvc_objs=clone_objs, expected_usage=f"{pvc_size_expand_2}GiB"
-            )
-            log.info("Verified thick provision on cloned PVCs.")
-        elif pvc_create_sc_type == "thin" and (
-            "thick" in (pvc_create_sc_type, restore_sc_type)
-        ):
-            self.verify_thick_provision(
-                pvc_objs=clone_objs,
-                expected_usage=f"{pvc_size_expand_2}GiB",
-                expect_thick=False,
-            )
-            log.info("Verified: Cloned PVCs are not thick provisioned.")
-
         # Ensure restore size is not impacted by parent PVC expansion
         log.info("Verify restore size of snapshots")
         for snapshot_obj in snapshots:
@@ -316,7 +300,7 @@ class TestExpansionSnapshotClone(ManageTest):
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound.")
 
-        # Verify thick provision or not
+        # Verify restored PVCs are thick provision or not
         if restore_sc_type == "thick":
             self.verify_thick_provision(
                 pvc_objs=restore_objs, expected_usage=f"{pvc_size_expand_1}GiB"
@@ -331,6 +315,22 @@ class TestExpansionSnapshotClone(ManageTest):
                 expect_thick=False,
             )
             log.info("Verified: Restored PVCs are not thick provisioned.")
+
+        # Verify clones are thick provision or not
+        if pvc_create_sc_type == "thick":
+            self.verify_thick_provision(
+                pvc_objs=clone_objs, expected_usage=f"{pvc_size_expand_2}GiB"
+            )
+            log.info("Verified thick provision on cloned PVCs.")
+        elif pvc_create_sc_type == "thin" and (
+            "thick" in (pvc_create_sc_type, restore_sc_type)
+        ):
+            self.verify_thick_provision(
+                pvc_objs=clone_objs,
+                expected_usage=f"{pvc_size_expand_2}GiB",
+                expect_thick=False,
+            )
+            log.info("Verified: Cloned PVCs are not thick provisioned.")
 
         # Attach the restored and cloned PVCs to pods
         log.info("Attach the restored and cloned PVCs to pods")

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -321,7 +321,7 @@ class TestExpansionSnapshotClone(ManageTest):
             self.verify_thick_provision(
                 pvc_objs=restore_objs, expected_usage=f"{pvc_size_expand_1}GiB"
             )
-            log.info(f"Verified thick provision on restored PVCs")
+            log.info("Verified thick provision on restored PVCs")
         elif restore_sc_type == "thin" and (
             "thick" in (pvc_create_sc_type, restore_sc_type)
         ):


### PR DESCRIPTION
Added RBD thick provision verification in the test test_expansion_snapshot_clone. This is done by verifying the used size of rbd image.
Added a function to get default thick provision storage class.
Added thick provision storage class name as constants.
Added a function to get image name.
Added bugzilla marker to relevant tests.
Signed-off-by: Jilju Joy <jijoy@redhat.com>