### PR TITLE
Testcase-Verify rbd provisioner pod deletion will not break thick provisioning

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -46,13 +46,17 @@ class Disruptions:
             self.selector = constants.CSI_RBDPLUGIN_LABEL
         if self.resource == "cephfsplugin_provisioner":
             self.resource_obj = [
-                pod.get_plugin_provisioner_leader(interface=constants.CEPHFILESYSTEM, leader_type=leader_type)
+                pod.get_plugin_provisioner_leader(
+                    interface=constants.CEPHFILESYSTEM, leader_type=leader_type
+                )
             ]
             self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
             resource_count = len(pod.get_cephfsplugin_provisioner_pods())
         if self.resource == "rbdplugin_provisioner":
             self.resource_obj = [
-                pod.get_plugin_provisioner_leader(interface=constants.CEPHBLOCKPOOL, leader_type=leader_type)
+                pod.get_plugin_provisioner_leader(
+                    interface=constants.CEPHBLOCKPOOL, leader_type=leader_type
+                )
             ]
             self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
             resource_count = len(pod.get_rbdfsplugin_provisioner_pods())

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -46,13 +46,13 @@ class Disruptions:
             self.selector = constants.CSI_RBDPLUGIN_LABEL
         if self.resource == "cephfsplugin_provisioner":
             self.resource_obj = [
-                pod.get_plugin_provisioner_leader(interface=constants.CEPHFILESYSTEM)
+                pod.get_plugin_provisioner_leader(interface=constants.CEPHFILESYSTEM, leader_type=leader_type)
             ]
             self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
             resource_count = len(pod.get_cephfsplugin_provisioner_pods())
         if self.resource == "rbdplugin_provisioner":
             self.resource_obj = [
-                pod.get_plugin_provisioner_leader(interface=constants.CEPHBLOCKPOOL)
+                pod.get_plugin_provisioner_leader(interface=constants.CEPHBLOCKPOOL, leader_type=leader_type)
             ]
             self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
             resource_count = len(pod.get_rbdfsplugin_provisioner_pods())

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3050,8 +3050,7 @@ def check_rbd_image_used_size(
     for pvc_obj in pvc_objs:
         rbd_image_name = pvc_obj.get_rbd_image_name
         du_out = ct_pod.exec_ceph_cmd(
-            ceph_cmd=f"rbd du -p {rbd_pool} {rbd_image_name}",
-            format="",
+            ceph_cmd=f"rbd du -p {rbd_pool} {rbd_image_name}", format="",
         )
         used_size = "".join(du_out.strip().split()[-2:])
         if expect_match:

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3050,7 +3050,8 @@ def check_rbd_image_used_size(
     for pvc_obj in pvc_objs:
         rbd_image_name = pvc_obj.get_rbd_image_name
         du_out = ct_pod.exec_ceph_cmd(
-            ceph_cmd=f"rbd du -p {rbd_pool} {rbd_image_name}", format="",
+            ceph_cmd=f"rbd du -p {rbd_pool} {rbd_image_name}",
+            format="",
         )
         used_size = "".join(du_out.strip().split()[-2:])
         if expect_match:

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -44,7 +44,7 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         Test to delete RBD provisioner leader pod while creating a PVC using thick provision enabled storage class
         """
         pvc_size = 5
-        executor = ThreadPoolExecutor()
+        executor = ThreadPoolExecutor(max_workers=1)
         DISRUPTION_OPS.set_resource(
             resource="rbdplugin_provisioner", leader_type="provisioner"
         )

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -1,21 +1,16 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
-from functools import partial
 
 from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id
-from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import verify_volume_deleted_in_backend
-from ocs_ci.ocs import constants, node
+from ocs_ci.helpers.helpers import verify_volume_deleted_in_backend, default_thick_storage_class
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
-from ocs_ci.ocs.resources import pod
-from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from ocs_ci.helpers import helpers, disruption_helpers
 
 
 logger = logging.getLogger(__name__)
-
 DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 
@@ -43,34 +38,31 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         pod_factory,
     ):
         """
-        Test to delete rbd provisioner leader pod while creating a PVC using thick provision enabled storage class
+        Test to delete RBD provisioner leader pod while creating a PVC using thick provision enabled storage class
         """
         pvc_size = 5
-
-        DISRUPTION_OPS.set_resource(resource="rbdplugin_provisioner", leader_type="provisioner")
-
-
         executor = ThreadPoolExecutor()
+        DISRUPTION_OPS.set_resource(resource="rbdplugin_provisioner", leader_type="provisioner")
 
         # Start creation of PVC
         pvc_create = executor.submit(
             pvc_factory,
             interface=constants.CEPHBLOCKPOOL,
             project=self.proj_obj,
-            storageclass=None,
+            storageclass=default_thick_storage_class,
             size=pvc_size,
             access_mode=constants.ACCESS_MODE_RWO,
             status="",
         )
 
-        # Ensure PVC is being created before deleting the resource
+        # Ensure that the PVC is being created before deleting the rbd provisioner pod
         ret = helpers.wait_for_resource_count_change(
             get_all_pvcs, 0, self.proj_obj.namespace, "increase"
         )
         assert ret, "Wait timeout: PVC is not being created."
         logger.info("PVC creation has started.")
         DISRUPTION_OPS.delete_resource()
-
+        logger.info("Deleted RBD provisioner leader pod.")
         pvc_obj = pvc_create.result()
 
         # Confirm that the PVC is Bound
@@ -80,38 +72,38 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         pvc_obj.reload()
         logger.info(f"Verified: PVC {pvc_obj.name} reached Bound state.")
 
-        image_uid = pvc_obj.image_uuid
-
-        # Create pod
+        # Create pod and run IO
         pod_obj = pod_factory(
             interface=constants.CEPHBLOCKPOOL,
             pvc=pvc_obj,
             status=constants.STATUS_RUNNING,
         )
-
         pod_obj.run_io(
             storage_type="fs", size=f"{pvc_size-1}G", fio_filename=f"{pod_obj.name}_io"
         )
 
+        # Get IO result
         get_fio_rw_iops(pod_obj)
 
+        logger.info(f"Deleting pod {pod_obj.name}")
         pod_obj.delete()
-
         pod_obj.ocp.wait_for_delete(
             pod_obj.name, 180
         ), f"Pod {pod_obj.name} is not deleted"
 
+        # Fetch image id for verification
+        image_uid = pvc_obj.image_uuid
+
+        logger.info(f"Deleting PVC {pvc_obj.name}")
         pvc_obj.delete()
         pvc_obj.ocp.wait_for_delete(
             pvc_obj.name
         ), f"PVC {pvc_obj.name} is not deleted"
         logger.info(f"Verified: PVC {pvc_obj.name} is deleted.")
 
+        # Verify the rbd image is deleted
         verify_volume_deleted_in_backend(
             interface=constants.CEPHBLOCKPOOL, image_uuid=image_uid, pool_name=constants.DEFAULT_BLOCKPOOL,
             timeout=300
         )
-
-
-
-
+        logger.info("Verified: RBD image is deleted")

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -59,7 +59,7 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
             access_mode=constants.ACCESS_MODE_RWO,
             status="",
         )
-
+        pvc_obj = pvc_create.result()
         # Ensure that the PVC is being created before deleting the rbd provisioner pod
         ret = helpers.wait_for_resource_count_change(
             get_all_pvcs, 0, self.proj_obj.namespace, "increase"
@@ -68,6 +68,7 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         logger.info("PVC creation has started.")
         DISRUPTION_OPS.delete_resource()
         logger.info("Deleted RBD provisioner leader pod.")
+
         pvc_obj = pvc_create.result()
 
         # Confirm that the PVC is Bound

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -54,12 +54,12 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
             pvc_factory,
             interface=constants.CEPHBLOCKPOOL,
             project=self.proj_obj,
-            storageclass=default_thick_storage_class,
+            storageclass=default_thick_storage_class(),
             size=pvc_size,
             access_mode=constants.ACCESS_MODE_RWO,
             status="",
         )
-        pvc_obj = pvc_create.result()
+
         # Ensure that the PVC is being created before deleting the rbd provisioner pod
         ret = helpers.wait_for_resource_count_change(
             get_all_pvcs, 0, self.proj_obj.namespace, "increase"

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -79,7 +79,9 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         logger.info(f"Verified: PVC {pvc_obj.name} reached Bound state.")
 
         # Verify thick provision
-        image_name = pvc_obj.backed_pv_obj.get()["spec"]["csi"]["volumeAttributes"]["imageName"]
+        image_name = pvc_obj.backed_pv_obj.get()["spec"]["csi"]["volumeAttributes"][
+            "imageName"
+        ]
         ct_pod = get_ceph_tools_pod()
         du_out = ct_pod.exec_ceph_cmd(
             ceph_cmd=f"rbd du -p {constants.DEFAULT_BLOCKPOOL} {image_name}",

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -79,10 +79,10 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         )
         pvc_obj.reload()
         logger.info(f"Verified: PVC {pvc_obj.name} reached Bound state.")
+        image_name = pvc_obj.get_rbd_image_name
+        pv_obj = pvc_obj.backed_pv_obj
 
         # Verify thick provision by checking the image used size
-        pv_obj = pvc_obj.backed_pv_obj
-        image_name = pv_obj.get()["spec"]["csi"]["volumeAttributes"]["imageName"]
         assert check_rbd_image_used_size(
             pvc_objs=[pvc_obj],
             usage_to_compare=f"{pvc_size}GiB",

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -73,14 +73,14 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
 
         pvc_obj = pvc_create.result()
 
-        image_uid = pvc_obj.image_uuid
-
         # Confirm that the PVC is Bound
         helpers.wait_for_resource_state(
             resource=pvc_obj, state=constants.STATUS_BOUND, timeout=600
         )
         pvc_obj.reload()
-        logger.info("Verified: PVCs are Bound.")
+        logger.info(f"Verified: PVC {pvc_obj.name} reached Bound state.")
+
+        image_uid = pvc_obj.image_uuid
 
         # Create pod
         pod_obj = pod_factory(

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -1,0 +1,117 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+import pytest
+from functools import partial
+
+from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id
+from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import verify_volume_deleted_in_backend
+from ocs_ci.ocs import constants, node
+from ocs_ci.ocs.resources.pod import get_fio_rw_iops
+from ocs_ci.ocs.resources.pvc import get_all_pvcs
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
+from ocs_ci.helpers import helpers, disruption_helpers
+
+
+logger = logging.getLogger(__name__)
+
+DISRUPTION_OPS = disruption_helpers.Disruptions()
+
+
+@tier4
+@tier4a
+@polarion_id("")
+class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
+    """
+    Test to delete rbd provisioner leader pod while thick provisioning is progressing
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, project_factory):
+        """
+        Create Project for the test
+
+        Returns:
+            OCP: An OCP instance of project
+        """
+        self.proj_obj = project_factory()
+
+    def test_delete_provisioner_pod_while_thick_provisioning(
+        self,
+        pvc_factory,
+        pod_factory,
+    ):
+        """
+        Test to delete rbd provisioner leader pod while creating a PVC using thick provision enabled storage class
+        """
+        pvc_size = 5
+
+        DISRUPTION_OPS.set_resource(resource="rbdplugin_provisioner", leader_type="provisioner")
+
+
+        executor = ThreadPoolExecutor()
+
+        # Start creation of PVC
+        pvc_create = executor.submit(
+            pvc_factory,
+            interface=constants.CEPHBLOCKPOOL,
+            project=self.proj_obj,
+            storageclass=None,
+            size=pvc_size,
+            access_mode=constants.ACCESS_MODE_RWO,
+            status="",
+        )
+
+        # Ensure PVC is being created before deleting the resource
+        ret = helpers.wait_for_resource_count_change(
+            get_all_pvcs, 0, self.proj_obj.namespace, "increase"
+        )
+        assert ret, "Wait timeout: PVC is not being created."
+        logger.info("PVC creation has started.")
+        DISRUPTION_OPS.delete_resource()
+
+        pvc_obj = pvc_create.result()
+
+        image_uid = pvc_obj.image_uuid
+
+        # Confirm that the PVC is Bound
+        helpers.wait_for_resource_state(
+            resource=pvc_obj, state=constants.STATUS_BOUND, timeout=600
+        )
+        pvc_obj.reload()
+        logger.info("Verified: PVCs are Bound.")
+
+        # Create pod
+        pod_obj = pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            pvc=pvc_obj,
+            status=constants.STATUS_RUNNING,
+        )
+
+        pod_obj.run_io(
+            storage_type="fs", size=f"{pvc_size-1}G", fio_filename=f"{pod_obj.name}_io"
+        )
+
+        get_fio_rw_iops(pod_obj)
+
+        pod_obj.delete()
+
+        pod_obj.ocp.wait_for_delete(
+            pod_obj.name, 180
+        ), f"Pod {pod_obj.name} is not deleted"
+
+        pvc_obj.delete()
+        pvc_obj.ocp.wait_for_delete(
+            pvc_obj.name
+        ), f"PVC {pvc_obj.name} is not deleted"
+        logger.info(f"Verified: PVC {pvc_obj.name} is deleted.")
+
+        verify_volume_deleted_in_backend(
+            interface=constants.CEPHBLOCKPOOL, image_uuid=image_uid, pool_name=constants.DEFAULT_BLOCKPOOL,
+            timeout=300
+        )
+
+
+
+

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -2,7 +2,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id
+from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id, bugzilla
 from ocs_ci.helpers.helpers import (
     verify_volume_deleted_in_backend,
     default_thick_storage_class,
@@ -19,7 +19,6 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 @tier4
 @tier4a
-@polarion_id("OCS-2531")
 class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
     Test to delete rbd provisioner leader pod while thick provisioning is progressing
@@ -35,6 +34,8 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         """
         self.proj_obj = project_factory()
 
+    @polarion_id("OCS-2531")
+    @bugzilla("1961647")
     def test_delete_provisioner_pod_while_thick_provisioning(
         self,
         pvc_factory,

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -3,7 +3,10 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id
-from ocs_ci.helpers.helpers import verify_volume_deleted_in_backend, default_thick_storage_class
+from ocs_ci.helpers.helpers import (
+    verify_volume_deleted_in_backend,
+    default_thick_storage_class,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
@@ -42,7 +45,9 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         """
         pvc_size = 5
         executor = ThreadPoolExecutor()
-        DISRUPTION_OPS.set_resource(resource="rbdplugin_provisioner", leader_type="provisioner")
+        DISRUPTION_OPS.set_resource(
+            resource="rbdplugin_provisioner", leader_type="provisioner"
+        )
 
         # Start creation of PVC
         pvc_create = executor.submit(
@@ -96,14 +101,14 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
 
         logger.info(f"Deleting PVC {pvc_obj.name}")
         pvc_obj.delete()
-        pvc_obj.ocp.wait_for_delete(
-            pvc_obj.name
-        ), f"PVC {pvc_obj.name} is not deleted"
+        pvc_obj.ocp.wait_for_delete(pvc_obj.name), f"PVC {pvc_obj.name} is not deleted"
         logger.info(f"Verified: PVC {pvc_obj.name} is deleted.")
 
         # Verify the rbd image is deleted
         verify_volume_deleted_in_backend(
-            interface=constants.CEPHBLOCKPOOL, image_uuid=image_uid, pool_name=constants.DEFAULT_BLOCKPOOL,
-            timeout=300
+            interface=constants.CEPHBLOCKPOOL,
+            image_uuid=image_uid,
+            pool_name=constants.DEFAULT_BLOCKPOOL,
+            timeout=300,
         )
         logger.info("Verified: RBD image is deleted")

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -123,6 +123,8 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
         pvc_obj.delete()
         pvc_obj.ocp.wait_for_delete(pvc_obj.name), f"PVC {pvc_obj.name} is not deleted"
         logger.info(f"Verified: PVC {pvc_obj.name} is deleted.")
+        pv_obj.ocp.wait_for_delete(pv_obj.name), f"PV {pv_obj.name} is not deleted"
+        logger.info(f"Verified: PV {pv_obj.name} is deleted.")
 
         # Verify the rbd image is deleted
         logger.info(f"Wait for the RBD image {image_name} to get deleted")


### PR DESCRIPTION
Test case to verify that rbd provisioner leader pod deletion will not break thick provisioning. This test case will delete RBD provisioner leader pod while creating a PVC using thick provision enabled storage class and ensure that the provisioning will succeed.