### PR TITLE
Use equality instead of identity checks 

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -434,7 +434,7 @@ class AMQ(object):
         cmd = f"oc logs -n {namespace} {pod} --since={since_time}s"
         msg = run_cmd(cmd)
         substring = f"Hello world - {int(value) - 1}"
-        if msg.find(substring) is -1:
+        if msg.find(substring) == -1:
             return False
         else:
             return True


### PR DESCRIPTION
Fixes: #4302 

Description:

From python 3.8, there is new warning added for using identity checks
for certain type of literals.

Use equality ( == and != ) instead of identity checks ( is and is not )

Signed-off-by: vavuthu <vavuthu@redhat.com>