### PR TITLE
Remove cpu and memory limits for ceph pods

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -635,11 +635,6 @@ class Deployment(object):
                 and not lso_type == constants.AWS_EBS
             ):
                 deviceset_data["count"] = 2
-            if ocs_version >= 4.5:
-                deviceset_data["resources"] = {
-                    "limits": {"cpu": 2, "memory": "5Gi"},
-                    "requests": {"cpu": 1, "memory": "5Gi"},
-                }
             if (ocp_version >= 4.6) and (ocs_version >= 4.6):
                 cluster_data["metadata"]["annotations"] = {
                     "cluster.ocs.openshift.io/local-devices": "true"


### PR DESCRIPTION
vcpus are platform specific:
-  1 vcpu is 1/2 of a processor core for x86
-  1 vcpu is 1/8 of a processor core for power

The ocs-ci suite includes a performance test and limits seem contrary to the goal
of measuring performance.  These limits would have to be scaled to make sense for
power.  But, is it desirable to have limits on a storage resource?  A limit on
storage performance is an indirect limit on workload performance.

The UI deployment of ocs does not impose cpu and memory limits.  Shouldn't ocs-ci
emulate customer configuration?   I don't think it is needed or desirable.

By default, the linux scheduler and virtual memory management provide fairness.
The use of limits makes sense when a subsystem is cpu intensive or memory intensive,
but ceph is neither.

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>