### PR TITLE
Disconnected cluster: prepare installation of cluster-logging operator

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -5,6 +5,7 @@ This module contains functionality required for disconnected installation.
 import logging
 import os
 import tempfile
+import time
 
 import yaml
 
@@ -78,107 +79,108 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
 
     """
 
-    logger.info(
-        f"Prepare for disconnected OCS {'upgrade' if upgrade else 'installation'}"
-    )
-    if config.DEPLOYMENT.get("live_deployment"):
-        get_opm_tool()
-
-        pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
-        ocp_version = get_ocp_version()
-        index_image = f"{config.DEPLOYMENT['cs_redhat_operators_image']}:v{ocp_version}"
-        mirrored_index_image = (
-            f"{config.DEPLOYMENT['mirror_registry']}/{constants.MIRRORED_INDEX_IMAGE_NAMESPACE}/"
-            f"{constants.MIRRORED_INDEX_IMAGE_NAME}:v{ocp_version}"
-        )
-        # prune an index image
-        logger.info(
-            f"Prune index image {index_image} -> {mirrored_index_image} "
-            f"(packages: {', '.join(constants.DISCON_CL_REQUIRED_PACKAGES)})"
-        )
-        cmd = (
-            f"opm index prune -f {index_image} "
-            f"-p {','.join(constants.DISCON_CL_REQUIRED_PACKAGES)} "
-            f"-t {mirrored_index_image}"
-        )
-        # opm tool doesn't have --authfile parameter, we have to supply auth
-        # file through env variable
-        os.environ["REGISTRY_AUTH_FILE"] = pull_secret_path
-        exec_cmd(cmd)
-
-        # login to mirror registry
-        login_to_mirror_registry(pull_secret_path)
-
-        # push pruned index image to mirror registry
-        logger.info(
-            f"Push pruned index image to mirror registry: {mirrored_index_image}"
-        )
-        cmd = f"podman push --authfile {pull_secret_path} --tls-verify=false {mirrored_index_image}"
-        exec_cmd(cmd)
-
-        # mirror related images (this might take very long time)
-        logger.info(f"Mirror images related to index image: {mirrored_index_image}")
-        cmd = (
-            f"oc adm catalog mirror {mirrored_index_image} -a {pull_secret_path} --insecure "
-            f"{config.DEPLOYMENT['mirror_registry']} --index-filter-by-os='.*'"
-        )
-        oc_acm_result = exec_cmd(cmd, timeout=7200)
-
-        for line in oc_acm_result.stdout.decode("utf-8").splitlines():
-            if "wrote mirroring manifests to" in line:
-                break
-        else:
-            raise NotFoundError(
-                "Manifests directory not printed to stdout of 'oc adm catalog mirror ...' command."
-            )
-        mirroring_manifests_dir = line.replace("wrote mirroring manifests to ", "")
-        logger.debug(f"Mirrored manifests directory: {mirroring_manifests_dir}")
-
-        # create ImageContentSourcePolicy
-        icsp_file = os.path.join(
-            f"{mirroring_manifests_dir}",
-            "imageContentSourcePolicy.yaml",
-        )
-        exec_cmd(f"oc apply -f {icsp_file}")
-
-        # Disable the default OperatorSources
-        exec_cmd(
-            """oc patch OperatorHub cluster --type json """
-            """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
-        )
-
-        # create redhat-operators CatalogSource
-        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
-
-        catalog_source_manifest = tempfile.NamedTemporaryFile(
-            mode="w+", prefix="catalog_source_manifest", delete=False
-        )
-        catalog_source_data["spec"]["image"] = f"{mirrored_index_image}"
-        catalog_source_data["metadata"]["name"] = "redhat-operators"
-        catalog_source_data["spec"]["displayName"] = "Red Hat Operators - Mirrored"
-        # remove ocs-operator-internal label
-        catalog_source_data["metadata"]["labels"].pop("ocs-operator-internal", None)
-
-        templating.dump_data_to_temp_yaml(
-            catalog_source_data, catalog_source_manifest.name
-        )
-        exec_cmd(f"oc apply -f {catalog_source_manifest.name}")
-        catalog_source = CatalogSource(
-            resource_name="redhat-operators",
-            namespace=constants.MARKETPLACE_NAMESPACE,
-        )
-        # Wait for catalog source is ready
-        catalog_source.wait_for_state("READY")
-
-        # ensure that newly created imageContentSourcePolicy is applied on all nodes
-        wait_for_machineconfigpool_status("all")
-
-        return
-
     if config.DEPLOYMENT.get("stage_rh_osbs"):
         raise NotImplementedError(
             "Disconnected installation from stage is not implemented!"
         )
+
+    logger.info(
+        f"Prepare for disconnected OCS {'upgrade' if upgrade else 'installation'}"
+    )
+    # Disable the default OperatorSources
+    exec_cmd(
+        """oc patch OperatorHub cluster --type json """
+        """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
+    )
+
+    get_opm_tool()
+
+    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    ocp_version = get_ocp_version()
+    index_image = f"{config.DEPLOYMENT['cs_redhat_operators_image']}:v{ocp_version}"
+    mirrored_index_image = (
+        f"{config.DEPLOYMENT['mirror_registry']}/{constants.MIRRORED_INDEX_IMAGE_NAMESPACE}/"
+        f"{constants.MIRRORED_INDEX_IMAGE_NAME}:v{ocp_version}"
+    )
+
+    # prune an index image
+    logger.info(
+        f"Prune index image {index_image} -> {mirrored_index_image} "
+        f"(packages: {', '.join(constants.DISCON_CL_REQUIRED_PACKAGES)})"
+    )
+    cmd = (
+        f"opm index prune -f {index_image} "
+        f"-p {','.join(constants.DISCON_CL_REQUIRED_PACKAGES)} "
+        f"-t {mirrored_index_image}"
+    )
+    # opm tool doesn't have --authfile parameter, we have to supply auth
+    # file through env variable
+    os.environ["REGISTRY_AUTH_FILE"] = pull_secret_path
+    exec_cmd(cmd)
+
+    # login to mirror registry
+    login_to_mirror_registry(pull_secret_path)
+
+    # push pruned index image to mirror registry
+    logger.info(f"Push pruned index image to mirror registry: {mirrored_index_image}")
+    cmd = f"podman push --authfile {pull_secret_path} --tls-verify=false {mirrored_index_image}"
+    exec_cmd(cmd)
+
+    # mirror related images (this might take very long time)
+    logger.info(f"Mirror images related to index image: {mirrored_index_image}")
+    cmd = (
+        f"oc adm catalog mirror {mirrored_index_image} -a {pull_secret_path} --insecure "
+        f"{config.DEPLOYMENT['mirror_registry']} --index-filter-by-os='.*'"
+    )
+    oc_acm_result = exec_cmd(cmd, timeout=7200)
+
+    for line in oc_acm_result.stdout.decode("utf-8").splitlines():
+        if "wrote mirroring manifests to" in line:
+            break
+    else:
+        raise NotFoundError(
+            "Manifests directory not printed to stdout of 'oc adm catalog mirror ...' command."
+        )
+    mirroring_manifests_dir = line.replace("wrote mirroring manifests to ", "")
+    logger.debug(f"Mirrored manifests directory: {mirroring_manifests_dir}")
+
+    # create ImageContentSourcePolicy
+    icsp_file = os.path.join(
+        f"{mirroring_manifests_dir}",
+        "imageContentSourcePolicy.yaml",
+    )
+    exec_cmd(f"oc apply -f {icsp_file}")
+    logger.info("Sleeping for 60 sec to start update machineconfigpool status")
+    time.sleep(60)
+    wait_for_machineconfigpool_status("all")
+
+    # create redhat-operators CatalogSource
+    catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+
+    catalog_source_manifest = tempfile.NamedTemporaryFile(
+        mode="w+", prefix="catalog_source_manifest", delete=False
+    )
+    catalog_source_data["spec"]["image"] = f"{mirrored_index_image}"
+    catalog_source_data["metadata"]["name"] = "redhat-operators"
+    catalog_source_data["spec"]["displayName"] = "Red Hat Operators - Mirrored"
+    # remove ocs-operator-internal label
+    catalog_source_data["metadata"]["labels"].pop("ocs-operator-internal", None)
+
+    templating.dump_data_to_temp_yaml(catalog_source_data, catalog_source_manifest.name)
+    exec_cmd(
+        f"oc {'replace' if upgrade else 'apply'} -f {catalog_source_manifest.name}"
+    )
+    catalog_source = CatalogSource(
+        resource_name="redhat-operators",
+        namespace=constants.MARKETPLACE_NAMESPACE,
+    )
+    # Wait for catalog source is ready
+    catalog_source.wait_for_state("READY")
+
+    if config.DEPLOYMENT.get("live_deployment"):
+        # deployment from live can continue as normal now (ocs-operator images
+        # are already mirrored as part of redhat-operators)
+        return
 
     if upgrade:
         ocs_registry_image = config.UPGRADE.get("upgrade_ocs_registry_image", "")
@@ -283,13 +285,9 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
             f"{ocs_registry_image} {mirrored_ocs_registry_image}"
         )
 
-    # Disable the default OperatorSources
-    exec_cmd(
-        """oc patch OperatorHub cluster --type json """
-        """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
-    )
-
     # wait for newly created imageContentSourcePolicy is applied on all nodes
+    logger.info("Sleeping for 60 sec to start update machineconfigpool status")
+    time.sleep(60)
     wait_for_machineconfigpool_status("all")
 
     return mirrored_ocs_registry_image

--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -329,7 +329,7 @@ class FlexyBase(object):
         exec_cmd(chmod_cmd)
         # mirror flexy work dir to cluster path
         rsync_cmd = f"rsync -av {self.flexy_host_dir} {self.cluster_path}/"
-        exec_cmd(rsync_cmd)
+        exec_cmd(rsync_cmd, timeout=1200)
 
         # mirror install-dir to cluster path (auth directory, metadata.json
         # file and other files)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1105,7 +1105,8 @@ MIRRORED_INDEX_IMAGE_NAME = "redhat-operator-index"
 # following packages are required for live disconnected cluster installation
 # (all images related to those packages will be mirrored to the mirror registry)
 DISCON_CL_REQUIRED_PACKAGES = [
-    # "elasticsearch-operator",
+    "cluster-logging",
+    "elasticsearch-operator",
     "local-storage-operator",
     "ocs-operator",
 ]


### PR DESCRIPTION
* Prepare `cluster-logging` and `elasticsearch-operator` for installation on a disconnected cluster.
  * mirror required images from `redhat-operators` catalog
* Extend timeout for rsync flexy-dir command.

The patch looks like lot of changes, but there is not much new code - mostly it is restructuring and moving the existing functionality. Previously we were creating/mirroring `redhat-operators` only for Live installation, now we are mirroring the related images and creating `redhat-operators` catalog source also for OCS installation from internal builds - to be able to install also `cluster-logging`, `elasticsearch-operator` and `local-storage-operator`.