### PR TITLE
update doc with requirements for ovirt-engine-sdk

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,6 +12,9 @@
    Latest client can be downloaded from [oc-client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/).
 4. For vSphere based installations, [terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
    and [jq]( https://stedolan.github.io/jq/download/) should be installed ( terraform version should be 0.11.13  )
+5. Installation of ovirt-engine-sdk-python requires `curl-config` and
+   `libxml/xmlreader.h` (they are on Fedora, RHEL or CentOS provided by
+   packages `libcurl-devel` and `libxml2-devel` respectively).
 
 #### AWS UPI
 There are additional prerequisites if you plan to execute AWS UPI deployments


### PR DESCRIPTION
Add requied packages `libcurl-devel` and `libxml2-devel` to  getting_started doc.

Related to https://github.com/red-hat-storage/ocs-ci/pull/4192.