### PR TITLE
Skip rbd-thick storage class verification in external mode

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -220,9 +220,10 @@ def ocs_install_verification(
         f"{storage_cluster_name}-ceph-rbd",
     }
     if Version.coerce(ocs_version) >= Version.coerce("4.8"):
-        # TODO: Add rbd-thick storage class verification in external mode once the bug 1964426 is fixed
-        # Skip rbd-thick storage class verification in external mode. This is blocked by bug 1964426
-        if not config.DEPLOYMENT["external_mode"]:
+        # TODO: Add rbd-thick storage class verification in external mode cluster upgraded
+        # to OCS 4.8 when the bug 1978542 is fixed
+        # Skip rbd-thick storage class verification in external mode upgraded cluster. This is blocked by bug 1978542
+        if not (config.DEPLOYMENT["external_mode"] and post_upgrade_verification):
             required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
     skip_storage_classes = set()
     if disable_cephfs:

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -220,7 +220,10 @@ def ocs_install_verification(
         f"{storage_cluster_name}-ceph-rbd",
     }
     if Version.coerce(ocs_version) >= Version.coerce("4.8"):
-        required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
+        # TODO: Add rbd-thick storage class verification in external mode once the bug 1964426 is fixed
+        # Skip rbd-thick storage class verification in external mode. This is blocked by bug 1964426
+        if not config.DEPLOYMENT["external_mode"]:
+            required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
     skip_storage_classes = set()
     if disable_cephfs:
         skip_storage_classes.update(


### PR DESCRIPTION
Skip rbd-thick storage class verification in external mode until the bug [1978542](https://bugzilla.redhat.com/show_bug.cgi?id=1978542) gets fixed
Signed-off-by: Jilju Joy <jijoy@redhat.com>