### PR TITLE
change cluster-launcher repo to v4-scaleup

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -89,7 +89,7 @@ class VSPHEREBASE(Deployment):
             constants.EXTERNAL_DIR, "openshift-misc"
         )
         self.cluster_launcer_repo_path = os.path.join(
-            constants.EXTERNAL_DIR, "cluster-launcher"
+            constants.EXTERNAL_DIR, "v4-scaleup"
         )
         os.environ["TF_LOG"] = config.ENV_DATA.get("TF_LOG_LEVEL", "TRACE")
         os.environ["TF_LOG_PATH"] = os.path.join(
@@ -141,7 +141,7 @@ class VSPHEREBASE(Deployment):
         # git clone repo from openshift-misc
         clone_repo(constants.VSPHERE_SCALEUP_REPO, self.upi_scale_up_repo_path)
 
-        # git clone repo from cluster-launcher
+        # git clone repo from v4-scaleup
         clone_repo(constants.VSPHERE_CLUSTER_LAUNCHER, self.cluster_launcer_repo_path)
 
         helpers = VSPHEREHELPERS()
@@ -770,7 +770,7 @@ class VSPHEREUPI(VSPHEREBASE):
 
         """
         clone_repo(constants.VSPHERE_SCALEUP_REPO, self.upi_scale_up_repo_path)
-        # git clone repo from cluster-launcher
+        # git clone repo from v4-scaleup
         clone_repo(constants.VSPHERE_CLUSTER_LAUNCHER, self.cluster_launcer_repo_path)
 
         # modify scale-up repo

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -707,7 +707,7 @@ VSPHERE_NODE_USER = "core"
 VSPHERE_INSTALLER_BRANCH = "release-4.3"
 VSPHERE_INSTALLER_REPO = "https://github.com/openshift/installer.git"
 VSPHERE_SCALEUP_REPO = "https://code.engineering.redhat.com/gerrit/openshift-misc"
-VSPHERE_CLUSTER_LAUNCHER = "https://gitlab.cee.redhat.com/aosqe/cluster-launcher.git"
+VSPHERE_CLUSTER_LAUNCHER = "https://gitlab.cee.redhat.com/aosqe/v4-scaleup.git"
 VSPHERE_DIR = os.path.join(EXTERNAL_DIR, "installer/upi/vsphere/")
 INSTALLER_IGNITION = os.path.join(VSPHERE_DIR, "machine/ignition.tf")
 VM_IFCFG = os.path.join(VSPHERE_DIR, "vm/ifcfg.tmpl")
@@ -735,9 +735,9 @@ SCALEUP_VSPHERE_MACHINE_CONF = os.path.join(
     SCALEUP_VSPHERE_DIR, "machines/vsphere-rhel-machine.tf"
 )
 
-# cluster-launcher
+# v4-scaleup
 CLUSTER_LAUNCHER_VSPHERE_DIR = os.path.join(
-    EXTERNAL_DIR, "cluster-launcher/v4-scaleup/ocp4-rhel-scaleup/"
+    EXTERNAL_DIR, "v4-scaleup/ocp4-rhel-scaleup/"
 )
 CLUSTER_LAUNCHER_MACHINE_CONF = "vsphere/machines/vsphere-rhel-machine.tf"
 


### PR DESCRIPTION
- replace deprecated https://gitlab.cee.redhat.com/aosqe/cluster-launcher.git
  by https://gitlab.cee.redhat.com/aosqe/v4-scaleup.git
- fixes https://github.com/red-hat-storage/ocs-ci/issues/4343