### PR TITLE
Add --re-trigger-failed-tests parameter

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,6 +145,11 @@ to the pytest.
 * `--dev-mode` - Runs in development mode. Skip the checks like collecting
    cluster versions, collection ocs versions, health checks etc.
 * `--ceph-debug` - Deploy with Ceph in debug log level. This option is available starting OCS 4.7
+* `--re-trigger-failed-tests` - Path to the xunit file for xml junit report from the
+    previous execution. If the file is provided, the execution will remove all the test cases
+    which passed and will run only those test cases which were skipped / failed / or had error
+    in the provided report.
+
 ## Examples
 
 Deployment and teardown of the test cluster can be done automatically with

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 import pytest
+from junitparser import JUnitXml
 
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework.exceptions import (
@@ -254,6 +255,16 @@ def pytest_addoption(parser):
         action="append",
         choices=["rgw", "cephfs", "noobaa", "blockpools"],
         help=("disable deployment of ocs component:rgw, cephfs, noobaa, blockpools."),
+    )
+    parser.addoption(
+        "--re-trigger-failed-tests",
+        dest="re_trigger_failed_tests",
+        help="""
+        Path to the xunit file for xml junit report from the previous execution.
+        If the file is provided, the execution will remove all the test cases
+        which passed and will run only those test cases which were skipped /
+        failed / or had error in the provided report.
+        """,
     )
 
 
@@ -513,13 +524,32 @@ def process_cluster_cli_params(config):
     skip_download_client = get_cli_param(config, "skip_download_client")
     if skip_download_client:
         ocsci_config.DEPLOYMENT["skip_download_client"] = True
+    re_trigger_failed_tests = get_cli_param(config, "--re-trigger-failed-tests")
+    if re_trigger_failed_tests:
+        ocsci_config.RUN["re_trigger_failed_tests"] = os.path.expanduser(
+            re_trigger_failed_tests
+        )
 
 
 def pytest_collection_modifyitems(session, config, items):
     """
     Add Polarion ID property to test cases that are marked with one.
     """
-    for item in items:
+
+    re_trigger_failed_tests = ocsci_config.RUN.get("re_trigger_failed_tests")
+    if re_trigger_failed_tests:
+        junit_report = JUnitXml.fromfile(re_trigger_failed_tests)
+        cases_to_re_trigger = []
+        for suite in junit_report:
+            cases_to_re_trigger += [_case.name for _case in suite if _case.result]
+    for item in items[:]:
+        if re_trigger_failed_tests and item.name not in cases_to_re_trigger:
+            log.info(
+                f"Test case: {item.name} will be removed from execution, "
+                "because of you provided --re-trigger-failed-tests parameter "
+                "and this test passed in previous execution from the report!"
+            )
+            items.remove(item)
         try:
             marker = item.get_closest_marker(name="polarion_id")
             if marker:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         # https://github.com/python-greenlet/greenlet/issues/230
         "greenlet<1.0.0",
         "ovirt-engine-sdk-python==4.4.11",
+        "junitparser",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This new parameter allows to re-trigger only failed tests from the
previous execution provided as path to junit xml file.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>