### PR TITLE
Update tests to run IO on pods attached with PVCs having unique access mode and volume mode combination

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3302,7 +3302,7 @@ def select_unique_pvcs(pvcs):
     for pvc_obj in pvcs:
         pvc_data = pvc_obj.get()
         access_mode_volume_mode = (
-            pvc_data["spec"]["accessModes"],
+            pvc_data["spec"]["accessModes"][0],
             pvc_data["spec"].get("volumeMode"),
         )
         pvc_dict[access_mode_volume_mode] = pvc_dict.get(

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3285,3 +3285,27 @@ def get_noobaa_url():
     ocp_obj = OCP(kind=constants.ROUTE, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
     route_obj = ocp_obj.get(resource_name="noobaa-mgmt")
     return route_obj["spec"]["host"]
+
+
+def select_unique_pvcs(pvcs):
+    """
+    Get the PVCs with unique access mode and volume mode combination.
+
+    Args:
+        pvcs(list): List of PVC objects
+
+    Returns:
+        list: List of selected PVC objects
+
+    """
+    pvc_dict = {}
+    for pvc_obj in pvcs:
+        pvc_data = pvc_obj.get()
+        access_mode_volume_mode = (
+            pvc_data["spec"]["accessModes"],
+            pvc_data["spec"].get("volumeMode"),
+        )
+        pvc_dict[access_mode_volume_mode] = pvc_dict.get(
+            access_mode_volume_mode, pvc_obj
+        )
+    return pvc_dict.values()

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
@@ -354,9 +354,15 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
         disruption.select_daemon()
 
         # Start IO on pods to be deleted
-        log.info("Starting IO on pods to be deleted.")
-        self.run_io_on_pods(pods_to_delete)
-        log.info("IO started on pods to be deleted.")
+        pods_to_delete_io = [
+            pod_obj
+            for pod_obj in pods_to_delete
+            if pod_obj.pvc
+            in select_unique_pvcs([pod_obj.pvc for pod_obj in pods_to_delete])
+        ]
+        log.info("Starting IO on selected pods to be deleted.")
+        self.run_io_on_pods(pods_to_delete_io)
+        log.info("IO started on selected pods to be deleted.")
 
         # Start deleting PVCs
         pvc_bulk_delete = executor.submit(delete_pvcs, pvcs_to_delete)

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
@@ -28,6 +28,7 @@ from ocs_ci.helpers.helpers import (
     wait_for_resource_count_change,
     verify_pv_mounted_on_node,
     default_ceph_block_pool,
+    select_unique_pvcs,
 )
 from ocs_ci.helpers import disruption_helpers
 
@@ -231,15 +232,20 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
             ]
         )
 
+        io_pods = [
+            pod_obj
+            for pod_obj in io_pods
+            if pod_obj.pvc in select_unique_pvcs([pod_obj.pvc for pod_obj in io_pods])
+        ]
+
         log.info(
             f"{len(pods_to_delete)} pods selected for deletion in which "
             f"{len(pods_to_delete) - num_of_pods_to_delete} pairs of pod "
             f"share same RWX PVC"
         )
         log.info(
-            f"{len(io_pods)} pods selected for running IO in which "
-            f"{len(io_pods) - num_of_io_pods} pairs of pod share same "
-            f"RWX PVC"
+            f"{len(io_pods)} pods selected for running IO in which one "
+            f"pair of pod share same RWX PVC"
         )
         no_of_rwx_pvcs_delete = len(pods_for_pvc) - len(pvcs_to_delete)
         log.info(
@@ -321,12 +327,18 @@ class TestDaemonKillDuringMultipleDeleteOperations(ManageTest):
         log.info("Setup for running IO is completed on all pods.")
 
         # Start IO on pods having PVCs to delete to load data
+        pods_for_pvc_io = [
+            pod_obj
+            for pod_obj in pods_for_pvc
+            if pod_obj.pvc
+            in select_unique_pvcs([pod_obj.pvc for pod_obj in pods_for_pvc])
+        ]
         log.info("Starting IO on pods having PVCs to delete.")
-        self.run_io_on_pods(pods_for_pvc)
+        self.run_io_on_pods(pods_for_pvc_io)
         log.info("IO started on pods having PVCs to delete.")
 
         log.info("Fetching IO results from the pods having PVCs to delete.")
-        for pod_obj in pods_for_pvc:
+        for pod_obj in pods_for_pvc_io:
             get_fio_rw_iops(pod_obj)
         log.info("Verified IO result on pods having PVCs to delete.")
 

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -443,6 +443,15 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             "Verified: mount points are removed from nodes after deleting " "the pods"
         )
 
+        log.info("Fetching IO results from the pods.")
+        for pod_obj in io_pods:
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get("jobs")[0].get("error")
+            assert (
+                err_count == 0
+            ), f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
+        log.info("Verified IO result on pods.")
+
         pvcs_deleted = pvc_bulk_delete.result()
         assert pvcs_deleted, "Deletion of PVCs failed."
 
@@ -470,15 +479,6 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             assert ret, (
                 f"Volume associated with PVC {pvc_name} still exists " f"in backend"
             )
-
-        log.info("Fetching IO results from the pods.")
-        for pod_obj in io_pods:
-            fio_result = pod_obj.get_fio_results()
-            err_count = fio_result.get("jobs")[0].get("error")
-            assert (
-                err_count == 0
-            ), f"FIO error on pod {pod_obj.name}. FIO result: {fio_result}"
-        log.info("Verified IO result on pods.")
 
         # Verify number of pods of type 'resource_to_delete'
         final_num_resource_to_delete = len(pod_functions[resource_to_delete]())

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -370,9 +370,15 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
         log.info("Verified: Deleted pods which are having PVCs to delete.")
 
         # Start IO on pods to be deleted
-        log.info("Starting IO on pods to be deleted.")
-        self.run_io_on_pods(pods_to_delete)
-        log.info("IO started on pods to be deleted.")
+        pods_to_delete_io = [
+            pod_obj
+            for pod_obj in pods_to_delete
+            if pod_obj.pvc
+            in select_unique_pvcs([pod_obj.pvc for pod_obj in pods_to_delete])
+        ]
+        log.info("Starting IO on selected pods to be deleted.")
+        self.run_io_on_pods(pods_to_delete_io)
+        log.info("IO started on selected pods to be deleted.")
 
         # Start deleting PVCs
         pvc_bulk_delete = executor.submit(delete_pvcs, pvcs_to_delete)


### PR DESCRIPTION
Update tests to run IO on pods attached with PVCs having unique access mode and volume mode combination. This is to ensure that the IO will consume PVCs with all supported combination of of access mode and volume mode. The will also reduce the number of pods running IO simultaneously.

Tests updated:
tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py


Signed-off-by: Jilju Joy <jijoy@redhat.com>