### PR TITLE
io - Remove performance marker

### DIFF
--- a/tests/e2e/performance/test_io_performance.py
+++ b/tests/e2e/performance/test_io_performance.py
@@ -5,16 +5,12 @@ import pytest
 import logging
 
 from ocs_ci.utility.performance_dashboard import push_perf_dashboard
-from ocs_ci.framework.testlib import (
-    ManageTest,
-    performance,
-)
+from ocs_ci.framework.testlib import ManageTest
 
 
 logger = logging.getLogger(__name__)
 
 
-@performance
 class TestIOPerformance(ManageTest):
     """
     Test IO performance


### PR DESCRIPTION
Removing the performance marker from the basic IO test since it is not performance test, just an I/O functionality test