### PR TITLE
Add PR checks on Fedora34

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+          - 3.7.10
+          - 3.8.10
+          - 3.9.5
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   pr_checks:
-    runs-on: [fedora34, ubuntu-latest]
+    runs-on: fedora34
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   pr_checks:
-    runs-on: [quay.io/centos/centos:8, ubuntu-latest]
+    runs-on: [ "quay.io/centos/centos:8" , ubuntu-latest]
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   pr_checks:
-    runs-on: [ "quay.io/centos/centos:8" , ubuntu-latest]
+    runs-on: [fedora34, ubuntu-latest]
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   pr_checks:
-    runs-on: [quay.io/centos/centos8:latest, ubuntu-latest]
+    runs-on: [quay.io/centos/centos:8, ubuntu-latest]
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   pr_checks:
-    runs-on: ubuntu-latest
+    runs-on: [quay.io/centos/centos8:latest, ubuntu-latest]
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -5,26 +5,10 @@ on: pull_request
 jobs:
   pr_checks:
     runs-on: fedora34
-    strategy:
-      matrix:
-        python-version:
-          - 3.7.10
-          - 3.8.10
-          - 3.9.5
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install ovirt-engine-sdk-python dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y libcurl4-openssl-dev
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Add PR checks on Fedora34 to avoid any dependency breakage in CentOS/Fedora

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>