### PR TITLE
Check rook ceph pods status after a node failure event

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1609,3 +1609,35 @@ def get_nodes_in_statuses(statuses):
     """
     nodes = get_node_objs()
     return [n for n in nodes if n.ocp.get_resource_status(n.name) in statuses]
+
+
+def get_node_osd_ids(node_name):
+    """
+    Get the node osd ids
+
+    Args:
+        node_name (str): The node name to get the osd ids
+
+    Returns:
+        list: The list of the osd ids
+
+    """
+    osd_pods = pod.get_osd_pods()
+    node_osd_pods = get_node_pods(node_name, pods_to_search=osd_pods)
+    return [pod.get_osd_pod_id(osd_pod) for osd_pod in node_osd_pods]
+
+
+def get_node_mon_ids(node_name):
+    """
+    Get the node mon ids
+
+    Args:
+        node_name (str): The node name to get the mon ids
+
+    Returns:
+        list: The list of the mon ids
+
+    """
+    mon_pods = pod.get_mon_pods()
+    node_mon_pods = get_node_pods(node_name, pods_to_search=mon_pods)
+    return [pod.get_mon_pod_id(mon_pod) for mon_pod in node_mon_pods]

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1594,3 +1594,18 @@ def add_new_nodes_and_label_upi_lso(
             add_node_to_lvd_and_lvs(node_obj.name)
 
     return new_node_names
+
+
+def get_nodes_in_statuses(statuses):
+    """
+    Get all nodes in specific statuses
+
+    Args:
+        statuses (list): List of the statuses to search for the nodes
+
+    Returns:
+        list: OCP objects representing the nodes in the specific statuses
+
+    """
+    nodes = get_node_objs()
+    return [n for n in nodes if n.ocp.get_resource_status(n.name) in statuses]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1563,16 +1563,23 @@ def get_pod_restarts_count(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
     return restart_dict
 
 
-def check_pods_in_running_state(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
+def check_pods_in_running_state(
+    namespace=defaults.ROOK_CLUSTER_NAMESPACE, pods_to_check=None
+):
     """
     checks whether all the pods in a given namespace are in Running state or not
+
+    Args:
+        namespace (str): Name of cluster namespace(default: defaults.ROOK_CLUSTER_NAMESPACE)
+        pods_to_check (list): List of the Pod objects to check.
+            If not provided, it will check all the pods in the given namespace
 
     Returns:
         Boolean: True, if all pods in Running state. False, otherwise
 
     """
     ret_val = True
-    list_of_pods = get_all_pods(namespace)
+    list_of_pods = pods_to_check or get_all_pods(namespace)
     ocp_pod_obj = OCP(kind=constants.POD, namespace=namespace)
     for p in list_of_pods:
         # we don't want to compare osd-prepare and canary pods as they get created freshly when an osd need to be added.
@@ -1615,13 +1622,15 @@ def get_running_state_pods(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
 
 
 def wait_for_pods_to_be_running(
-    namespace=defaults.ROOK_CLUSTER_NAMESPACE, timeout=200, sleep=10
+    namespace=defaults.ROOK_CLUSTER_NAMESPACE, pods_to_check=None, timeout=200, sleep=10
 ):
     """
     Wait for all the pods in a specific namespace to be running.
 
     Args:
         namespace (str): the namespace ot the pods
+        pods_to_check (list): List of the Pod objects to check.
+            If not provided, it will check all the pods in the given namespace
         timeout (int): time to wait for pods to be running
         sleep (int): Time in seconds to sleep between attempts
 
@@ -1635,6 +1644,7 @@ def wait_for_pods_to_be_running(
             sleep=sleep,
             func=check_pods_in_running_state,
             namespace=namespace,
+            pods_to_check=pods_to_check,
         ):
             # Check if all the pods in running state
             if pods_running:

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2016,3 +2016,22 @@ def get_osd_pods_having_ids(osd_ids):
             osd_pods_having_ids.append(osd_pod)
 
     return osd_pods_having_ids
+
+
+def get_pod_objs(pod_names, namespace=defaults.ROOK_CLUSTER_NAMESPACE):
+    """
+    Get the pod objects of the specified pod names
+
+    Args:
+        pod_names (list): The list of the pod names to get their pod objects
+        namespace (str): Name of cluster namespace(default: defaults.ROOK_CLUSTER_NAMESPACE)
+
+    Returns:
+        list: The pod objects of the specified pod names
+
+    """
+    # Convert it to set to reduce complexity
+    pod_names = set(pod_names)
+    pods = get_all_pods(namespace=namespace)
+
+    return [p for p in pods if p.name in pod_names]

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -9,14 +9,18 @@ from ocs_ci.ocs.node import (
     get_ocs_nodes,
     get_nodes_in_statuses,
     get_node_pods,
+    get_node_osd_ids,
+    get_node_mon_ids,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
-    get_pod_name_by_pattern,
     get_osd_pods,
     get_osd_pod_id,
     wait_for_change_in_pods_statuses,
+    get_rook_ceph_pod_names,
+    get_mon_pods,
+    get_mon_pod_id,
 )
 
 log = logging.getLogger(__name__)
@@ -33,34 +37,12 @@ def get_rook_ceph_pod_names_not_in_node(node_name):
         list: List of the rook ceph pod names that are not running on the node 'node_name'
 
     """
-    rook_ceph_pod_names = get_pod_name_by_pattern("rook-ceph-")
-    # Exclude the rook ceph pod tools because it creates by OCS and not rook ceph operator
-    rook_ceph_pod_names_set = {
-        pod_name
-        for pod_name in rook_ceph_pod_names
-        if not pod_name.startswith("rook-ceph-tools-")
-    }
+    rook_ceph_pod_names_set = set(get_rook_ceph_pod_names())
     node_pods = get_node_pods(node_name)
     node_pod_names_set = set([p.name for p in node_pods])
     rook_ceph_pod_names_not_in_node = list(rook_ceph_pod_names_set - node_pod_names_set)
 
     return rook_ceph_pod_names_not_in_node
-
-
-def get_node_osd_ids(node_name):
-    """
-    Get the node osd ids
-
-    Args:
-        node_name (str): The node name to get the osd ids
-
-    Returns:
-        list: The list of the osd ids
-
-    """
-    osd_pods = get_osd_pods()
-    node_osd_pods = get_node_pods(node_name, pods_to_search=osd_pods)
-    return [get_osd_pod_id(osd_pod) for osd_pod in node_osd_pods]
 
 
 def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
@@ -137,16 +119,18 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
         ocs_node = random.choice(ocs_nodes)
         node_name = ocs_node.name
         log.info(f"Selected node is '{node_name}'")
-        # Save the rook ceph pods and osd ids before shutting down the node
+        # Save the rook ceph pods, the osd ids, and the mon ids before shutting down the node
         rook_ceph_pod_names_not_in_node = get_rook_ceph_pod_names_not_in_node(node_name)
         node_osd_ids = get_node_osd_ids(node_name)
+        node_mon_ids = get_node_mon_ids(node_name)
 
         log.info(f"Shutting down node '{node_name}'")
         nodes.stop_nodes([ocs_node])
         wait_for_nodes_status(node_names=[node_name], status=constants.NODE_NOT_READY)
         log.info(f"The node '{node_name}' reached '{constants.NODE_NOT_READY}' status")
 
-        timeout = 300
+        log.info("Wait for a change in the rook ceph pod statuses...")
+        timeout = 360
         is_rook_ceph_pods_status_changed = wait_for_change_in_rook_ceph_pods(
             node_name, timeout=timeout
         )
@@ -161,17 +145,23 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
         )
         assert are_pods_running, f"The pods are not 'Running' after {timeout} seconds"
 
-        # Get the rook ceph pods without the osd pods have the old node ids
+        # Get the rook ceph pods without the osd, and mon pods have the old node ids
         osd_pods = get_osd_pods()
-        new_node_osd_id_names = [
+        new_node_osd_id_names_set = {
             p.name for p in osd_pods if get_osd_pod_id(p) in node_osd_ids
-        ]
-        rook_ceph_pod_names_not_in_node = get_rook_ceph_pod_names_not_in_node(node_name)
-        new_rook_ceph_pod_names = [
-            pod_name
-            for pod_name in rook_ceph_pod_names_not_in_node
-            if pod_name not in new_node_osd_id_names
-        ]
+        }
+        mon_pods = get_mon_pods()
+        new_node_mon_id_names_set = {
+            p.name for p in mon_pods if get_mon_pod_id(p) in node_mon_ids
+        }
+
+        new_node_osd_mon_id_names_set = new_node_osd_id_names_set.union(
+            new_node_mon_id_names_set
+        )
+        rook_ceph_pod_names_set = set(get_rook_ceph_pod_names())
+        new_rook_ceph_pod_names = list(
+            rook_ceph_pod_names_set - new_node_osd_mon_id_names_set
+        )
 
         log.info(
             "Verify that the new rook ceph pods are in 'Running' or 'Completed' state"

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -85,6 +85,7 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 
 @ignore_leftovers
 @tier4a
+@pytest.mark.polarion_id("OCS-2552")
 class TestCheckPodsAfterNodeFailure(ManageTest):
     """
     Test check pods status after a node failure event.

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -130,7 +130,7 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
         log.info(f"The node '{node_name}' reached '{constants.NODE_NOT_READY}' status")
 
         log.info("Wait for a change in the rook ceph pod statuses...")
-        timeout = 360
+        timeout = 480
         is_rook_ceph_pods_status_changed = wait_for_change_in_rook_ceph_pods(
             node_name, timeout=timeout
         )

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -14,21 +14,20 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
     get_pod_name_by_pattern,
-    get_pod_objs,
 )
 
 log = logging.getLogger(__name__)
 
 
-def get_rook_ceph_pods_not_in_node(node_name):
+def get_rook_ceph_pod_names_not_in_node(node_name):
     """
-    Get all the rook ceph pods that are not running on the node
+    Get all the rook ceph pod names that are not running on the node
 
     Args:
         node_name (str): The node name
 
     Returns:
-        list: List of the rook ceph pod objects that are not running on the node 'node_name'
+        list: List of the rook ceph pod names that are not running on the node 'node_name'
 
     """
     rook_ceph_pod_names_set = set(get_pod_name_by_pattern("rook-ceph-"))
@@ -36,7 +35,7 @@ def get_rook_ceph_pods_not_in_node(node_name):
     node_pod_names_set = set([p.name for p in node_pods])
     rook_ceph_pod_names_not_in_node = list(rook_ceph_pod_names_set - node_pod_names_set)
 
-    return get_pod_objs(pod_names=rook_ceph_pod_names_not_in_node)
+    return rook_ceph_pod_names_not_in_node
 
 
 @ignore_leftovers
@@ -93,7 +92,7 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
         node_name = ocs_node.name
         log.info(f"Selected node is '{node_name}'")
         # Save the rook ceph pods before shutting down the node
-        rook_ceph_pods_not_in_node = get_rook_ceph_pods_not_in_node(node_name)
+        rook_ceph_pod_names_not_in_node = get_rook_ceph_pod_names_not_in_node(node_name)
 
         log.info(f"Shutting down node '{node_name}'")
         nodes.stop_nodes([ocs_node])
@@ -103,7 +102,7 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
         timeout = 1800
         log.info("Check the rook pods are in 'Running' or 'Completed' state")
         are_pods_running = wait_for_pods_to_be_running(
-            pods_to_check=rook_ceph_pods_not_in_node, timeout=timeout, sleep=30
+            pod_names=rook_ceph_pod_names_not_in_node, timeout=timeout, sleep=30
         )
         assert are_pods_running, f"The pods are not 'Running' after {timeout} seconds"
 

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -1,0 +1,116 @@
+import logging
+import pytest
+import random
+
+from ocs_ci.framework.testlib import ManageTest, tier4a, ignore_leftovers
+from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.ocs.node import (
+    wait_for_nodes_status,
+    get_ocs_nodes,
+    get_nodes_in_statuses,
+    get_node_pods,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import (
+    wait_for_pods_to_be_running,
+    get_pod_name_by_pattern,
+    get_pod_obj,
+)
+
+log = logging.getLogger(__name__)
+
+
+def get_rook_ceph_pods_not_in_node(node_name):
+    """
+    Get all the rook ceph pods that are not running on the node
+
+    Args:
+        node_name (str): The node name
+
+    Returns:
+        list: List of the rook ceph pod objects that are not running on the node 'node_name'
+
+    """
+    rook_ceph_pod_names_set = set(get_pod_name_by_pattern("rook-ceph-"))
+    node_pods = get_node_pods(node_name)
+    node_pod_names_set = set([p.name for p in node_pods])
+    rook_ceph_pod_names_not_in_node = list(rook_ceph_pod_names_set - node_pod_names_set)
+
+    return [get_pod_obj(pod_name) for pod_name in rook_ceph_pod_names_not_in_node]
+
+
+@ignore_leftovers
+@tier4a
+class TestCheckPodsAfterNodeFailure(ManageTest):
+    """
+    Test check pods status after a node failure event.
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_sanity(self):
+        """
+        Initialize Sanity instance
+
+        """
+
+        self.sanity_helpers = Sanity()
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request, nodes):
+        """
+        Make sure all nodes are up again
+
+        """
+
+        def finalizer():
+            not_ready_nodes = get_nodes_in_statuses([constants.NODE_NOT_READY])
+            not_ready_node_names = [n.name for n in not_ready_nodes]
+            log.warning(
+                f"We have nodes in not ready statuses: {not_ready_node_names}. "
+                f"Starting the nodes that are not ready..."
+            )
+            nodes.restart_nodes(not_ready_nodes)
+            wait_for_nodes_status(node_names=not_ready_node_names)
+
+        request.addfinalizer(finalizer)
+
+    def test_check_pods_status_after_node_failure(self, nodes, node_restart_teardown):
+        """
+        Test check pods status after a node failure event.
+        All the rook ceph pods should be in "Running" or "Completed"
+        state after a node failure event.
+
+        """
+        ocs_nodes = get_ocs_nodes()
+        if not ocs_nodes:
+            pytest.skip("We don't have ocs nodes in the cluster")
+
+        ocs_node = random.choice(ocs_nodes)
+        node_name = ocs_node.name
+        log.info(f"Selected node is '{node_name}'")
+        # Save the rook ceph pods before shutting down the node
+        rook_ceph_pods_not_in_node = get_rook_ceph_pods_not_in_node(node_name)
+
+        log.info(f"Shutting down node '{node_name}'")
+        nodes.stop_nodes([ocs_node])
+        wait_for_nodes_status(node_names=[node_name], status=constants.NODE_NOT_READY)
+        log.info(f"The node '{node_name}' reached '{constants.NODE_NOT_READY}' status")
+
+        timeout = 1800
+        log.info("Check the rook pods are in 'Running' or 'Completed' state")
+        are_pods_running = wait_for_pods_to_be_running(
+            pods_to_check=rook_ceph_pods_not_in_node, timeout=timeout, sleep=30
+        )
+        assert are_pods_running, f"The pods are not 'Running' after {timeout} seconds"
+
+        log.info("All the pods are in 'Running' or 'Completed' state")
+        log.info(f"Starting the node '{node_name}' again...")
+        nodes.start_nodes(nodes=[ocs_node])
+        wait_for_nodes_status(node_names=[node_name])
+
+        log.info(
+            "Waiting for all the pods to be running and cluster health to be OK..."
+        )
+        wait_for_pods_to_be_running(timeout=600)
+        self.sanity_helpers.health_check(tries=40)


### PR DESCRIPTION
Creating a new test to automate [BZ-1861021](https://bugzilla.redhat.com/show_bug.cgi?id=1861021). 
The test checks the rook ceph pods status after a node failure event - the pods should be in a "Running" or "Completed" state.
 