### PR TITLE
Fix delete pv when it is not bounded

### DIFF
--- a/tests/e2e/performance/test_fio_benchmark.py
+++ b/tests/e2e/performance/test_fio_benchmark.py
@@ -345,9 +345,12 @@ class TestFIOBenchmark(PASTest):
         for line in pvs_list:
             pv, ns = line.split(" ")
             pv = pv.replace("'", "")
-            if ns == constants.RIPSAW_NAMESPACE:
-                log.info(f"Going to delete {pv}")
-                run_command(f"oc delete pv {pv}")
+            try:
+                if ns == constants.RIPSAW_NAMESPACE:
+                    log.info(f"Going to delete {pv}")
+                    run_command(f"oc delete pv {pv}")
+            except Exception:
+                pass
 
     def run(self):
         """


### PR DESCRIPTION
When PV does not belong to any namespace the command will faild, so i just wrap it with 
try - except block. 