### PR TITLE
extend test_read_cached_object ttl

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1093,8 +1093,6 @@ def wait_for_cache(mcg_obj, bucket_name, expected_objects_names=None):
     if not sample.wait_for_func_status(result=True):
         logger.error("Objects were not able to cache properly")
         raise UnexpectedBehaviour
-    else:
-        logger.info("Objects were not cached yet, Retrying")
 
 
 def compare_directory(awscli_pod, original_dir, result_dir, amount=2):

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -442,7 +442,7 @@ class TestNamespace(MCGTest):
                     "interface": "OC",
                     "namespace_policy_dict": {
                         "type": "Cache",
-                        "ttl": 60000,
+                        "ttl": 300000,
                         "namespacestore_dict": {
                             "aws": [(1, "eu-central-1")],
                         },


### PR DESCRIPTION
test_read_cached_object have failed in recent automation runs due to slowness in execution, therefore I've adjusted the TTL of the test to 5 minutes instead of 1 to prevent slow execution time and latency from causing failures in the future.