### PR TITLE
Dynamic installation of vSphere IPI cluster

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -326,3 +326,11 @@ class NotAllNodesCreated(Exception):
 
 class TemplateNotFound(Exception):
     pass
+
+
+class IPAMReleaseUpdateFailed(Exception):
+    pass
+
+
+class IPAMAssignUpdateFailed(Exception):
+    pass

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1403,16 +1403,8 @@ class AWS(object):
         """
         base_domain = base_domain or config.ENV_DATA["base_domain"]
         record_name = f"{cluster_name}.{base_domain}."
-        hosted_zones = self.route53_client.list_hosted_zones_by_name(
-            DNSName=base_domain, MaxItems="1"
-        )["HostedZones"]
-        hosted_zone_ids = [
-            zone["Id"] for zone in hosted_zones if zone["Name"] == f"{base_domain}."
-        ]
-        hosted_zone_id = hosted_zone_ids[0]
-        record_sets_in_base_domain = self.route53_client.list_resource_record_sets(
-            HostedZoneId=hosted_zone_id
-        )["ResourceRecordSets"]
+        hosted_zone_id = self.get_hosted_zone_id_for_domain(domain=base_domain)
+        record_sets_in_base_domain = self.get_record_sets(domain=base_domain)
 
         for record in record_sets_in_base_domain:
             if record["Name"] == record_name:
@@ -1421,6 +1413,24 @@ class AWS(object):
                 # breaking here since we will have single record in
                 # base domain and deleting is destructive action
                 break
+
+    def get_record_sets(self, domain=None):
+        """
+        Get all the record sets in domain
+
+        Args:
+            domain (str): Domain name to fetch the records
+
+        Returns:
+            list: list of record sets
+
+        """
+        domain = domain or config.ENV_DATA["base_domain"]
+        hosted_zone_id = self.get_hosted_zone_id_for_domain(domain=domain)
+        record_sets = self.route53_client.list_resource_record_sets(
+            HostedZoneId=hosted_zone_id
+        )["ResourceRecordSets"]
+        return record_sets
 
     def delete_record(self, record, hosted_zone_id):
         """
@@ -1561,6 +1571,26 @@ class AWS(object):
                 Id=response["ChangeInfo"]["Id"],
                 WaiterConfig={"MaxAttempts": max_attempts},
             )
+
+    def get_hosted_zone_id_for_domain(self, domain=None):
+        """
+        Get Zone id for domain
+
+        Args:
+            domain (str): Name of the domain.
+
+        Returns:
+            str: Zone id
+
+        """
+        domain = domain or config.ENV_DATA["base_domain"]
+        hosted_zones = self.route53_client.list_hosted_zones_by_name(
+            DNSName=domain, MaxItems="1"
+        )["HostedZones"]
+        hosted_zone_ids = [
+            zone["Id"] for zone in hosted_zones if zone["Name"] == f"{domain}."
+        ]
+        return hosted_zone_ids[0]
 
 
 def get_instances_ids_and_names(instances):

--- a/ocs_ci/utility/ipam.py
+++ b/ocs_ci/utility/ipam.py
@@ -7,6 +7,8 @@ import os
 import requests
 
 from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import IPAMReleaseUpdateFailed, IPAMAssignUpdateFailed
+from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,7 @@ class IPAM(object):
             ConnectionError: in case of Connection Error
             Timeout: in case of Timeout
             RequestException: Any Exception from requests
+            IPAMAssignUpdateFailed: if it fails to assign IP
 
         """
         endpoint = os.path.join("http://", self.ipam, "api/getFreeIP.php?")
@@ -74,7 +77,7 @@ class IPAM(object):
 
         if "Error" in res.text:
             logger.error(f"Error in assigning IP to host. Error: {res.text}")
-            raise
+            raise IPAMAssignUpdateFailed(f"Failed to assign IP to {host}")
         else:
             logger.info(f"Successfully assigned IP to {host}")
             return res.text
@@ -93,12 +96,16 @@ class IPAM(object):
         """
         return [self.assign_ip(host, subnet) for host in hosts]
 
+    @retry(IPAMReleaseUpdateFailed, tries=5, delay=3, backoff=1)
     def release_ip(self, hostname):
         """
         Release IP from IPAM server
 
         Args:
             hostname (str): Hostname to release IP
+
+        Raises:
+            IPAMReleaseUpdateFailed: If it fails to release IP from IPAM server
 
         """
         # release the IP
@@ -107,6 +114,10 @@ class IPAM(object):
         res = requests.post(endpoint, data=payload)
         if res.status_code == "200":
             logger.info(f"Successfully released {hostname} IP from IPAM server")
+        else:
+            raise IPAMReleaseUpdateFailed(
+                f"Failed to release {hostname} IP from IPAM server"
+            )
 
     def release_ips(self, hosts):
         """

--- a/ocs_ci/utility/ipam.py
+++ b/ocs_ci/utility/ipam.py
@@ -1,0 +1,120 @@
+"""
+This module will interact with IPAM server
+"""
+
+import logging
+import os
+import requests
+
+from ocs_ci.framework import config
+
+logger = logging.getLogger(__name__)
+
+
+class IPAM(object):
+    """
+    IPAM class
+    """
+
+    def __init__(self, appiapp, ipam=None, token=None):
+        """
+        Initialize required variables
+
+        Args:
+            apiapp (str): App ID
+            ipam (str): IPAM server name or IP
+            token (str): Authentication token
+
+        """
+        self.apiapp = appiapp
+        self.ipam = ipam or config.ENV_DATA["ipam"]
+        self.token = token or config.ENV_DATA["ipam_token"]
+
+    def assign_ip(self, host, subnet):
+        """
+        Reserve IP in IPAM server for a given host
+
+        Args:
+            host (str): hostname to reserve IP in IPAM server
+            subnet (str): subnet to reserve IP
+
+        Returns:
+            str: Reserved IP
+
+        Raises:
+            HTTPError: in case of HTTP error
+            ConnectionError: in case of Connection Error
+            Timeout: in case of Timeout
+            RequestException: Any Exception from requests
+
+        """
+        endpoint = os.path.join("http://", self.ipam, "api/getFreeIP.php?")
+        payload = {
+            "apiapp": self.apiapp,
+            "apitoken": self.token,
+            "subnet": subnet,
+            "host": host,
+        }
+
+        try:
+            res = requests.post(endpoint, data=payload)
+            res.raise_for_status()
+        except requests.exceptions.HTTPError as http_err:
+            logger.error(f"HTTP Error: {http_err}")
+            raise
+        except requests.exceptions.ConnectionError as conn_err:
+            logger.error(f"Error Connecting: {conn_err}")
+            raise
+        except requests.exceptions.Timeout as timeout_err:
+            logger.error(f"Timeout Error: {timeout_err}")
+            raise
+        except requests.exceptions.RequestException as err:
+            logger.error(f"Unexpected Error: {err}")
+            raise
+
+        if "Error" in res.text:
+            logger.error(f"Error in assigning IP to host. Error: {res.text}")
+            raise
+        else:
+            logger.info(f"Successfully assigned IP to {host}")
+            return res.text
+
+    def assign_ips(self, hosts, subnet):
+        """
+        Assign IPs to the hosts
+
+        Args:
+            hosts (list): List of hosts to reserve IP in IPAM server
+            subnet (str): subnet to reserve IPs
+
+        Returns:
+            list: List of Reserved IP's
+
+        """
+        return [self.assign_ip(host, subnet) for host in hosts]
+
+    def release_ip(self, hostname):
+        """
+        Release IP from IPAM server
+
+        Args:
+            hostname (str): Hostname to release IP
+
+        """
+        # release the IP
+        endpoint = os.path.join("http://", self.ipam, "api/removeHost.php?")
+        payload = {"apiapp": self.apiapp, "apitoken": self.token, "host": hostname}
+        res = requests.post(endpoint, data=payload)
+        if res.status_code == "200":
+            logger.info(f"Successfully released {hostname} IP from IPAM server")
+
+    def release_ips(self, hosts):
+        """
+        Releases host IP's from IPAM server
+
+        Args:
+            hosts (list): List of host names to release IP's
+
+        """
+        for host in hosts:
+            self.release_ip(host)


### PR DESCRIPTION
This PR will lift the limitation of deploying single cluster in vSphere IPI. Below are important changes with this PR

1. Lifted the limitation of deploying 1 cluster, with this PR we can deploy n number of clusters based on our VMware resources
2. Dynamic creation and deletion of DNS records
3. Dynamic allocation and releasing of IP's
4. Changed base domain to qe.rh-ocs.com
5. vSphere IPI is deployed with the same cluster name as we passed as parameter to ocs-ci

Important commits with this PR:

d55e00e87fdf1abec4562ccd176051ef2ce39a79 : Adding IPAM module
ca65de0e4861a9084e7b7f8dd466dd82608ee339 : fetching hosted zone ID and record sets for domain in aws
b9bb4fb96c68b72704c9f031391b1dd4f3c45f05 : Assigning IPs in IPAM server and creating DNS records in aws
4e7ac5c8ba2709863ce658e5b5d1f2adcecdd272 : Delete DNS records and release IP's from IPAM server
a64d5e2704a3c51c97e8530c5e0a0dea4d7c306f : Changing base domain to qe.rh-ocs.com and cluster name to sync with ocs-ci cluster name parameter                                                              

Signed-off-by: vavuthu <vavuthu@redhat.com>