### PR TITLE
fix delete_cluster_buckets function

### DIFF
--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1788,19 +1788,16 @@ def delete_cluster_buckets(cluster_name):
         r = re.compile(pattern)
         filtered_buckets = list(filter(r.search, bucket_names))
         logger.info(f"Found buckets: {filtered_buckets}")
-        if len(filtered_buckets):
-            s3_resource = boto3.resource("s3", region_name=region)
-            for bucket_name in filtered_buckets:
-                logger.info("Deleting all files in bucket %s", bucket_name)
-                try:
-                    bucket = s3_resource.Bucket(bucket_name)
-                    bucket.objects.delete()
-                    logger.info("Deleting bucket %s", bucket_name)
-                    bucket.delete()
-                except ClientError as e:
-                    logger.error(e)
-        else:
-            logger.info("No matches found for pattern %s", pattern)
+        s3_resource = boto3.resource("s3", region_name=region)
+        for bucket_name in filtered_buckets:
+            logger.info("Deleting all files in bucket %s", bucket_name)
+            try:
+                bucket = s3_resource.Bucket(bucket_name)
+                bucket.objects.delete()
+                logger.info("Deleting bucket %s", bucket_name)
+                bucket.delete()
+            except ClientError as e:
+                logger.error(e)
 
 
 def get_stack_name_from_instance_dict(instance_dict):

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1788,17 +1788,17 @@ def delete_cluster_buckets(cluster_name):
         r = re.compile(pattern)
         filtered_buckets = list(filter(r.search, bucket_names))
         logger.info(f"Found buckets: {filtered_buckets}")
-        if len(filtered_buckets) == 1:
+        if len(filtered_buckets):
             s3_resource = boto3.resource("s3", region_name=region)
-            bucket_name = filtered_buckets[0]
-            logger.info("Deleting all files in bucket %s", bucket_name)
-            try:
-                bucket = s3_resource.Bucket(bucket_name)
-                bucket.objects.delete()
-                logger.info("Deleting bucket %s", bucket_name)
-                bucket.delete()
-            except ClientError as e:
-                logger.error(e)
+            for bucket_name in filtered_buckets:
+                logger.info("Deleting all files in bucket %s", bucket_name)
+                try:
+                    bucket = s3_resource.Bucket(bucket_name)
+                    bucket.objects.delete()
+                    logger.info("Deleting bucket %s", bucket_name)
+                    bucket.delete()
+                except ClientError as e:
+                    logger.error(e)
         else:
             logger.info("No matches found for pattern %s", pattern)
 


### PR DESCRIPTION
This PR should fix following issue, when there are multiple buckets for one cluster as visible from following log, but the deletion is skipped (because it expect only one bucket).
```
13:53:13 - MainThread - /home/jenkins/workspace/qe-destroy-ocs-cluster/ocs-ci/ocs_ci/utility/aws.py - INFO - Found buckets: ['nb.1618218687702.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1618225114521.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1618407891258.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1618474410587.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1618566480071.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1619699741758.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1619790281615.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1620213703129.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1620813394439.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1621850068402.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1622036643825.apps.fbalak-aws.qe.rh-ocs.com', 'nb.1622541308615.apps.fbalak-aws.qe.rh-ocs.com']
13:53:13 - MainThread - /home/jenkins/workspace/qe-destroy-ocs-cluster/ocs-ci/ocs_ci/utility/aws.py - INFO - No matches found for pattern nb.(\d+).apps.fbalak-aws.qe.rh-ocs.com
```