### PR TITLE
Increase timeout in the test 'test_add_capacity'

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -71,7 +71,7 @@ def add_capacity_test():
     if config.ENV_DATA.get("encryption_at_rest"):
         osd_encryption_verification()
 
-    check_ceph_health_after_add_capacity()
+    check_ceph_health_after_add_capacity(ceph_rebalance_timeout=3600)
 
 
 @ignore_leftovers


### PR DESCRIPTION
We can see in the Jenkins job https://ocs4-jenkins-csb-ocsqe.apps.ocp4.prod.psi.redhat.com/job/qe-trigger-aws-ipi-3az-rhcos-3m-3w-acceptance/45/ that the test "test_add_capacity" failed on timeout when waiting for the Ceph rebalance to complete. 
So in this PR, I increased the Ceph rebalance timeout.