### PR TITLE
Ensure that email with test results is send even in case of failure in sessionfinish 

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1375,9 +1375,9 @@ def email_reports(session):
 
     try:
         build_id = get_ocs_build_number()
-    except Exception as e:
+    except Exception:
         build_id = ""
-        log.exception(e)
+        log.exception("Getting OCS operator build number failed!")
     build_str = f"BUILD ID: {build_id} " if build_id else ""
     mailids = config.RUN["cli_params"]["email"]
     recipients = []
@@ -1409,8 +1409,8 @@ def email_reports(session):
         s.sendmail(sender, recipients, msg.as_string())
         s.quit()
         log.info(f"Results have been emailed to {recipients}")
-    except Exception as e:
-        log.exception(e)
+    except Exception:
+        log.exception("Sending email with results failed!")
 
 
 def get_cluster_version_info():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1373,7 +1373,11 @@ def email_reports(session):
     # total = passed + failed + error
     # percentage_passed = (passed / total) * 100
 
-    build_id = get_ocs_build_number()
+    try:
+        build_id = get_ocs_build_number()
+    except Exception as e:
+        build_id = ""
+        log.exception(e)
     build_str = f"BUILD ID: {build_id} " if build_id else ""
     mailids = config.RUN["cli_params"]["email"]
     recipients = []


### PR DESCRIPTION
- this will ensure, that email with test results will be send even when
  the get_ocs_build_number() fails for example because some network
  issue or because the cluster was deleted

fixes https://github.com/red-hat-storage/ocs-ci/issues/4387

Signed-off-by: Daniel Horak <dahorak@redhat.com>