### PR TITLE
Fix test_create_storageclass_with_same_name to initiate SC delete only if it is created

### DIFF
--- a/tests/manage/storageclass/test_create_storageclass_with_same_name.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_same_name.py
@@ -26,9 +26,10 @@ def teardown():
     Tearing down the environment
 
     """
-    log.info(f"Deleting created storage class: {SC_OBJ.name}")
-    SC_OBJ.delete()
-    log.info(f"Storage class: {SC_OBJ.name} deleted successfully")
+    if SC_OBJ:
+        log.info(f"Deleting created storage class: {SC_OBJ.name}")
+        SC_OBJ.delete()
+        log.info(f"Storage class: {SC_OBJ.name} deleted successfully")
 
 
 def create_storageclass(sc_name, expect_fail=False):


### PR DESCRIPTION
Fix test_create_storageclass_with_same_name to initiate storage class delete process only if it is actually created.The value of SC_OBJ will be None if the storage class is not created.
Fixes #4404 
Signed-off-by: Jilju Joy <jijoy@redhat.com>