### PR TITLE
Fix test case test_pv_creation to skip PVC and yaml file deletion based on its existence

### DIFF
--- a/tests/manage/pv_services/test_pv_creation.py
+++ b/tests/manage/pv_services/test_pv_creation.py
@@ -40,9 +40,10 @@ def teardown(self):
     """
     Tearing down the environment
     """
-    assert delete_pv(self.pv_name)
-    assert not verify_pv_exist(self.pv_name)
-    utils.delete_file(TEMP_YAML_FILE)
+    if os.path.exists(TEMP_YAML_FILE):
+        assert delete_pv(self.pv_name)
+        assert not verify_pv_exist(self.pv_name)
+        utils.delete_file(TEMP_YAML_FILE)
 
 
 def create_pv(pv_data):


### PR DESCRIPTION
If the test case test_pv_creation is skipped due to degraded cluster, teardown will execute and try to delete the PVC and yaml file which is not actually present. Temporary yaml file will be present only if the test case is executed. 
Fixes #4403 

Signed-off-by: Jilju Joy <jijoy@redhat.com>