### PR TITLE
Increase PVC creation timeout in test test_rbd_thick_provisioning

### DIFF
--- a/tests/manage/pv_services/test_rbd_thick_provisioning.py
+++ b/tests/manage/pv_services/test_rbd_thick_provisioning.py
@@ -65,7 +65,7 @@ class TestRbdThickProvisioning(ManageTest):
                 access_modes=access_modes_rbd,
                 status=constants.STATUS_BOUND,
                 num_of_pvc=3,
-                timeout=150,
+                timeout=300,
             )
             for pvc_obj in pvc_objs:
                 pvc_obj.io_file_size = pvc_and_file_sizes[pvc_size]


### PR DESCRIPTION
The test case
tests/manage/pv_services/test_rbd_thick_provisioning.py::TestRbdThickProvisioning::test_rbd_thick_provisioning
is failing due to timeout while creating the PVC.

The PVC is not reaching Bound state within the given time of 150 seconds. This error is also seen in another test run.
From csi-provisioner logs of csi-rbdplugin-provisioner pod it is observed that the provisioning took more than 150 seconds. So the timeout is increased to 300 seconds. 

Fixes #4426 

Signed-off-by: Jilju Joy <jijoy@redhat.com>