### PR TITLE
GSS bug,Verify the num of mon pods is 3 when drain node

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3019,6 +3019,25 @@ def get_mon_pdb():
     return disruptions_allowed, min_available_mon, max_unavailable_mon
 
 
+def verify_pdb_mon(disruptions_allowed, max_unavailable_mon):
+    """
+    Verify PDB mon
+
+    Args:
+        disruptions_allowed (int): the expected number of disruptions_allowed
+        max_unavailable_mon (int): the expected number of max_unavailable_mon
+
+    """
+    logging.info("Check mon pdb status")
+    mon_pdb = get_mon_pdb()
+    assert (
+        disruptions_allowed == mon_pdb[0]
+    ), f"disruptions_allowed expected is {disruptions_allowed} actual is {mon_pdb[0]}"
+    assert (
+        max_unavailable_mon == mon_pdb[2]
+    ), f"disruptions_allowed expected is {max_unavailable_mon} actual is {mon_pdb[2]}"
+
+
 @retry(CommandFailed, tries=10, delay=30, backoff=1)
 def run_cmd_verify_cli_output(
     cmd=None, expected_output_lst=(), cephtool_cmd=False, debug_node=None

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3027,15 +3027,24 @@ def verify_pdb_mon(disruptions_allowed, max_unavailable_mon):
         disruptions_allowed (int): the expected number of disruptions_allowed
         max_unavailable_mon (int): the expected number of max_unavailable_mon
 
+    return:
+        bool: True if the expected pdb state equal to actual pdb state, False otherwise
+
     """
     logging.info("Check mon pdb status")
     mon_pdb = get_mon_pdb()
-    assert (
-        disruptions_allowed == mon_pdb[0]
-    ), f"The expected disruptions_allowed is: {disruptions_allowed}.The actual one is {mon_pdb[0]}"
-    assert (
-        max_unavailable_mon == mon_pdb[2]
-    ), f"The expected max_unavailable_mon is {max_unavailable_mon}.The actual one is {mon_pdb[2]}"
+    result = True
+    if disruptions_allowed != mon_pdb[0]:
+        result = False
+        logger.error(
+            f"The expected disruptions_allowed is: {disruptions_allowed}.The actual one is {mon_pdb[0]}"
+        )
+    if max_unavailable_mon != mon_pdb[2]:
+        result = False
+        logger.error(
+            f"The expected max_unavailable_mon is {max_unavailable_mon}.The actual one is {mon_pdb[2]}"
+        )
+    return result
 
 
 @retry(CommandFailed, tries=10, delay=30, backoff=1)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3021,7 +3021,7 @@ def get_mon_pdb():
 
 def verify_pdb_mon(disruptions_allowed, max_unavailable_mon):
     """
-    Verify PDB mon
+    Compare between the PDB status and the expected PDB status
 
     Args:
         disruptions_allowed (int): the expected number of disruptions_allowed
@@ -3032,10 +3032,10 @@ def verify_pdb_mon(disruptions_allowed, max_unavailable_mon):
     mon_pdb = get_mon_pdb()
     assert (
         disruptions_allowed == mon_pdb[0]
-    ), f"disruptions_allowed expected is {disruptions_allowed} actual is {mon_pdb[0]}"
+    ), f"The expected disruptions_allowed is: {disruptions_allowed}.The actual one is {mon_pdb[0]}"
     assert (
         max_unavailable_mon == mon_pdb[2]
-    ), f"disruptions_allowed expected is {max_unavailable_mon} actual is {mon_pdb[2]}"
+    ), f"The expected max_unavailable_mon is {max_unavailable_mon}.The actual one is {mon_pdb[2]}"
 
 
 @retry(CommandFailed, tries=10, delay=30, backoff=1)

--- a/tests/manage/z_cluster/test_drain_node_mon.py
+++ b/tests/manage/z_cluster/test_drain_node_mon.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.6")
 @bugzilla("1959983")
 @ignore_leftovers
+@pytest.mark.polarion_id("OCS-2572")
 class TestDrainNodeMon(ManageTest):
     """
     1.Get worker node name where monitoring pod run
@@ -33,13 +35,13 @@ class TestDrainNodeMon(ManageTest):
     4.Verify pdb status, disruptions_allowed=0, max_unavailable_mon=1
     5.Verify the number of mon pods is 3 for (1400 seconds)
     6.Respin  rook-ceph operator pod
-    7.Change node to be scheduled
+    7.Uncordon the node or schedule the node
     8.Wait for mon and osd pods to be on running state
     9.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
 
     """
 
-    def test_drain_node_mon(self, node_drain_teardown):
+    def test_rook_operator_restart_during_mon_failover(self, node_drain_teardown):
         """
         Verify the number of monitoring pod is three when drain node
 

--- a/tests/manage/z_cluster/test_drain_node_mon.py
+++ b/tests/manage/z_cluster/test_drain_node_mon.py
@@ -27,10 +27,10 @@ class TestDrainNodeMon(ManageTest):
     3.Drain node where monitoring pod run
     4.Verify pdb status, disruptions_allowed=0, max_unavailable_mon=1
     5.Verify the number of mon pods is 3 for (1400 seconds)
-    6.Change node to be scheduled
-    7.Wait for mon pods to be on running state
-    8.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
-    9.Check ceph status
+    6.Respin  rook-ceph operator pod
+    7.Change node to be scheduled
+    8.Wait for mon pods to be on running state
+    9.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
 
     """
 

--- a/tests/manage/z_cluster/test_drain_node_mon.py
+++ b/tests/manage/z_cluster/test_drain_node_mon.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_ocs_version,
     skipif_external_mode,
+    ignore_leftovers,
 )
 
 log = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_ocs_version("<4.6")
 @bugzilla("1959983")
+@ignore_leftovers
 class TestDrainNodeMon(ManageTest):
     """
     1.Get worker node name where monitoring pod run

--- a/tests/manage/z_cluster/test_drain_node_mon.py
+++ b/tests/manage/z_cluster/test_drain_node_mon.py
@@ -1,0 +1,121 @@
+import logging
+import pytest
+
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
+from ocs_ci.ocs.resources.pod import get_mon_pods
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.node import drain_nodes, schedule_nodes, get_node_objs
+from ocs_ci.helpers.helpers import get_mon_pdb
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    bugzilla,
+    skipif_ocs_version,
+    skipif_external_mode,
+)
+
+log = logging.getLogger(__name__)
+
+
+@tier2
+@skipif_external_mode
+@skipif_ocs_version("<4.6")
+@bugzilla("1959983")
+class TestDrainNodeMon(ManageTest):
+    """
+    1.Get worker node name where monitoring pod run
+    2.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
+    3.Drain node where monitoring pod run
+    4.Verify pdb status, disruptions_allowed=0, max_unavailable_mon=1
+    5.Verify the number of mon pods is 3 for (1400 seconds)
+    6.Change node to be scheduled
+    7.Wait for mon pods to be on running state
+    8.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
+    9.Check ceph status
+
+    """
+
+    @pytest.fixture(scope="function", autouse=True)
+    def teardown(self, request):
+        def finalizer():
+            """
+            Make sure that all cluster's nodes are in 'Ready' state and if not,
+            change them back to 'Ready' state by marking them as schedulable
+
+            """
+            scheduling_disabled_nodes = [
+                n.name
+                for n in get_node_objs()
+                if n.ocp.get_resource_status(n.name)
+                == constants.NODE_READY_SCHEDULING_DISABLED
+            ]
+            if scheduling_disabled_nodes:
+                schedule_nodes(scheduling_disabled_nodes)
+            ceph_health_check(tries=60)
+
+        request.addfinalizer(finalizer)
+
+    def test_drain_node_mon(self):
+        """
+        Verify the number of monitoring pod is three when drain node
+
+        """
+        self.verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+
+        log.info("Get worker node name where monitoring pod run")
+        mon_pod_objs = get_mon_pods()
+        node_name = mon_pod_objs[0].data["spec"]["nodeName"]
+
+        drain_nodes([node_name])
+
+        self.verify_pdb_mon(disruptions_allowed=0, max_unavailable_mon=1)
+
+        log.info("Verify the number of mon pods is 3")
+        sample = TimeoutSampler(timeout=1400, sleep=30, func=self.get_num_mon_pods)
+        if sample.wait_for_func_status(result=True):
+            assert "There are more than 3 mon pods."
+
+        schedule_nodes([node_name])
+
+        logging.info("Wait for mon pods to be on running state")
+        pod = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
+        assert pod.wait_for_resource(
+            condition="Running",
+            selector=constants.MON_APP_LABEL,
+            resource_count=3,
+            timeout=100,
+        )
+        self.verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+
+    def get_num_mon_pods(self):
+        """
+        Get number of monitoring pods
+
+        """
+        mon_pod_list = get_mon_pods()
+        if len(mon_pod_list) == 3:
+            return False
+        else:
+            for mon_pod in mon_pod_list:
+                log.info(f"{mon_pod.name}")
+            return True
+
+    def verify_pdb_mon(self, disruptions_allowed, max_unavailable_mon):
+        """
+        Verify PDB mon
+
+        Args:
+            disruptions_allowed (int): the expected number of disruptions_allowed
+            max_unavailable_mon (int): the expected number of max_unavailable_mon
+
+        """
+        logging.info("Check mon pdb status")
+        mon_pdb = get_mon_pdb()
+        assert (
+            disruptions_allowed == mon_pdb[0]
+        ), f"disruptions_allowed expected is {disruptions_allowed} actual is {mon_pdb[0]}"
+        assert (
+            max_unavailable_mon == mon_pdb[2]
+        ), f"disruptions_allowed expected is {max_unavailable_mon} actual is {mon_pdb[2]}"

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -36,7 +36,7 @@ class TestDrainNodeMon(ManageTest):
     5.Verify the number of mon pods is 3 for (1400 seconds)
     6.Respin  rook-ceph operator pod
     7.Uncordon the node
-    8.Wait for mon and osd pods to be on running state
+    8.Wait for all the pods in openshift-storage to be running
     9.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
 
     """
@@ -87,7 +87,7 @@ class TestDrainNodeMon(ManageTest):
         schedule_nodes([node_name])
 
         logging.info("Wait for all the pods in openshift-storage to be running.")
-        wait_for_pods_to_be_running()
+        assert wait_for_pods_to_be_running(timeout=300)
 
         sample = TimeoutSampler(
             timeout=100,

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.resources.pod import get_mon_pods, get_pod_obj
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes
@@ -46,7 +46,16 @@ class TestDrainNodeMon(ManageTest):
         Verify the number of monitoring pod is three when drain node
 
         """
-        verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+        # verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+        sample = TimeoutSampler(
+            timeout=100,
+            sleep=10,
+            func=verify_pdb_mon,
+            disruptions_allowed=1,
+            max_unavailable_mon=1,
+        )
+        if sample.wait_for_func_status(result=True):
+            assert "the expected pdb state is not equal to actual pdb state"
 
         log.info("Get worker node name where monitoring pod run")
         mon_pod_objs = get_mon_pods()
@@ -54,7 +63,16 @@ class TestDrainNodeMon(ManageTest):
 
         drain_nodes([node_name])
 
-        verify_pdb_mon(disruptions_allowed=0, max_unavailable_mon=1)
+        # verify_pdb_mon(disruptions_allowed=0, max_unavailable_mon=1)
+        sample = TimeoutSampler(
+            timeout=100,
+            sleep=10,
+            func=verify_pdb_mon,
+            disruptions_allowed=0,
+            max_unavailable_mon=1,
+        )
+        if sample.wait_for_func_status(result=True):
+            assert "the expected pdb state is not equal to actual pdb state"
 
         log.info("Verify the number of mon pods is 3")
         sample = TimeoutSampler(timeout=1400, sleep=10, func=self.check_mon_pods_eq_3)
@@ -82,7 +100,18 @@ class TestDrainNodeMon(ManageTest):
             resource_count=3,
             timeout=100,
         )
-        verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+        # verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+        sample = TimeoutSampler(
+            timeout=100,
+            sleep=10,
+            func=verify_pdb_mon,
+            disruptions_allowed=1,
+            max_unavailable_mon=1,
+        )
+        if sample.wait_for_func_status(result=True):
+            assert "the expected pdb state is not equal to actual pdb state"
+
+        ceph_health_check()
 
     def check_mon_pods_eq_3(self):
         """

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -1,10 +1,8 @@
 import logging
 import pytest
-import time
 
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
-from ocs_ci.ocs.utils import get_pod_name_by_pattern
-from ocs_ci.ocs.resources.pod import get_mon_pods, get_pod_obj
+from ocs_ci.ocs.resources.pod import get_mon_pods, get_operator_pods
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes
 from ocs_ci.helpers.helpers import verify_pdb_mon
 from ocs_ci.ocs.ocp import OCP
@@ -79,10 +77,8 @@ class TestDrainNodeMon(ManageTest):
             assert "There are more than 3 mon pods."
 
         log.info("Respin pod rook-ceph operator pod")
-        time.sleep(30)
-        rook_ceph_operator_name = get_pod_name_by_pattern("rook-ceph-operator")
-        rook_ceph_operator_obj = get_pod_obj(name=rook_ceph_operator_name[0])
-        rook_ceph_operator_obj.delete()
+        rook_ceph_operator_pod_obj = get_operator_pods()
+        rook_ceph_operator_pod_obj[0].delete()
 
         schedule_nodes([node_name])
 

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -113,6 +113,9 @@ class TestDrainNodeMon(ManageTest):
         """
         Get number of monitoring pods
 
+        return:
+            bool: False if number of mon pods is 3, True otherwise
+
         """
         mon_pod_list = get_mon_pods()
         if len(mon_pod_list) == 3:

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
@@ -46,7 +47,6 @@ class TestDrainNodeMon(ManageTest):
         Verify the number of monitoring pod is three when drain node
 
         """
-        # verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
         sample = TimeoutSampler(
             timeout=100,
             sleep=10,
@@ -63,7 +63,6 @@ class TestDrainNodeMon(ManageTest):
 
         drain_nodes([node_name])
 
-        # verify_pdb_mon(disruptions_allowed=0, max_unavailable_mon=1)
         sample = TimeoutSampler(
             timeout=100,
             sleep=10,
@@ -80,6 +79,7 @@ class TestDrainNodeMon(ManageTest):
             assert "There are more than 3 mon pods."
 
         log.info("Respin pod rook-ceph operator pod")
+        time.sleep(30)
         rook_ceph_operator_name = get_pod_name_by_pattern("rook-ceph-operator")
         rook_ceph_operator_obj = get_pod_obj(name=rook_ceph_operator_name[0])
         rook_ceph_operator_obj.delete()
@@ -100,7 +100,7 @@ class TestDrainNodeMon(ManageTest):
             resource_count=3,
             timeout=100,
         )
-        # verify_pdb_mon(disruptions_allowed=1, max_unavailable_mon=1)
+
         sample = TimeoutSampler(
             timeout=100,
             sleep=10,

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -113,7 +113,7 @@ class TestDrainNodeMon(ManageTest):
         """
         Get number of monitoring pods
 
-        return:
+        Returns:
             bool: False if number of mon pods is 3, True otherwise
 
         """

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -35,7 +35,7 @@ class TestDrainNodeMon(ManageTest):
     4.Verify pdb status, disruptions_allowed=0, max_unavailable_mon=1
     5.Verify the number of mon pods is 3 for (1400 seconds)
     6.Respin  rook-ceph operator pod
-    7.Uncordon the node or schedule the node
+    7.Uncordon the node
     8.Wait for mon and osd pods to be on running state
     9.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1959983
Test Process:
    1.Get worker node name where monitoring pod run
    2.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
    3.Drain node where monitoring pod run
    4.Verify pdb status, disruptions_allowed=0, max_unavailable_mon=1
    5.Verify the number of mon pods is 3 for (1400 seconds)
    6.Change node to be scheduled
    7.Wait for mon pods to be on running state
    8.Verify pdb status, disruptions_allowed=1, max_unavailable_mon=1
    9.Check ceph status

Signed-off-by: Oded Viner <oviner@redhat.com>