### PR TITLE
Prepare optional-operators for installation on disconnected cluster

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -84,6 +84,7 @@ anywhere else.
 * `infra_nodes` - Add infrastructure nodes to the cluster
 * `openshift_install_timeout` - Time (in seconds) to wait before timing out during OCP installation
 * `local_storage` - Deploy OCS with the local storage operator (Default: false)
+* `optional_operators_image` - If provided, it is used for LSO installation on unreleased OCP version
 * `disconnected` - Set if the cluster is deployed in a disconnected environment
 * `mirror_registry` - Hostname of the mirror registry
 * `mirror_registry_user` - Username for disconnected cluster mirror registry

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -160,7 +160,7 @@ def prune_and_mirror_index_image(
         exec_cmd(
             f"oc image mirror --filter-by-os='.*' -f {mapping_file_updated} "
             f"--insecure --registry-config={pull_secret_path} "
-            "--max-per-registry=2",
+            "--max-per-registry=2 --continue-on-error=true --skip-missing=true",
             timeout=3600,
             ignore_error=True,
         )

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -61,56 +61,31 @@ def get_csv_from_image(bundle_image):
         raise
 
 
-def prepare_disconnected_ocs_deployment(upgrade=False):
+def prune_and_mirror_index_image(index_image, mirrored_index_image, packages):
     """
-    Prepare disconnected ocs deployment:
-    - get related images from OCS operator bundle csv
-    - mirror related images to mirror registry
-    - create imageContentSourcePolicy for the mirrored images
-    - disable the default OperatorSources
+    Prune given index image and push it to mirror registry, mirror all related
+    images to mirror registry and create relevant imageContentSourcePolicy
 
     Args:
-        upgrade (bool): is this fresh installation or upgrade process
-            (default: False)
+        index_image(str): index image which will be pruned and mirrored
+        mirrored_index_image(str): mirrored index image which will be pushed to
+            mirror registry
 
     Returns:
-        str: mirrored OCS registry image prepared for disconnected installation
-            or None (for live deployment)
+        str: path to generated catalogSource.yaml file
 
     """
-
-    if config.DEPLOYMENT.get("stage_rh_osbs"):
-        raise NotImplementedError(
-            "Disconnected installation from stage is not implemented!"
-        )
-
-    logger.info(
-        f"Prepare for disconnected OCS {'upgrade' if upgrade else 'installation'}"
-    )
-    # Disable the default OperatorSources
-    exec_cmd(
-        """oc patch OperatorHub cluster --type json """
-        """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
-    )
-
     get_opm_tool()
-
     pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
-    ocp_version = get_ocp_version()
-    index_image = f"{config.DEPLOYMENT['cs_redhat_operators_image']}:v{ocp_version}"
-    mirrored_index_image = (
-        f"{config.DEPLOYMENT['mirror_registry']}/{constants.MIRRORED_INDEX_IMAGE_NAMESPACE}/"
-        f"{constants.MIRRORED_INDEX_IMAGE_NAME}:v{ocp_version}"
-    )
 
     # prune an index image
     logger.info(
         f"Prune index image {index_image} -> {mirrored_index_image} "
-        f"(packages: {', '.join(constants.DISCON_CL_REQUIRED_PACKAGES)})"
+        f"(packages: {', '.join(packages)})"
     )
     cmd = (
         f"opm index prune -f {index_image} "
-        f"-p {','.join(constants.DISCON_CL_REQUIRED_PACKAGES)} "
+        f"-p {','.join(packages)} "
         f"-t {mirrored_index_image}"
     )
     # opm tool doesn't have --authfile parameter, we have to supply auth
@@ -153,6 +128,64 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
     logger.info("Sleeping for 60 sec to start update machineconfigpool status")
     time.sleep(60)
     wait_for_machineconfigpool_status("all")
+
+    cs_file = os.path.join(
+        f"{mirroring_manifests_dir}",
+        "catalogSource.yaml",
+    )
+    return cs_file
+
+
+def prepare_disconnected_ocs_deployment(upgrade=False):
+    """
+    Prepare disconnected ocs deployment:
+    - mirror required images from redhat-operators
+    - get related images from OCS operator bundle csv
+    - mirror related images to mirror registry
+    - create imageContentSourcePolicy for the mirrored images
+    - disable the default OperatorSources
+
+    Args:
+        upgrade (bool): is this fresh installation or upgrade process
+            (default: False)
+
+    Returns:
+        str: mirrored OCS registry image prepared for disconnected installation
+            or None (for live deployment)
+
+    """
+
+    if config.DEPLOYMENT.get("stage_rh_osbs"):
+        raise NotImplementedError(
+            "Disconnected installation from stage is not implemented!"
+        )
+
+    logger.info(
+        f"Prepare for disconnected OCS {'upgrade' if upgrade else 'installation'}"
+    )
+    # Disable the default OperatorSources
+    exec_cmd(
+        """oc patch OperatorHub cluster --type json """
+        """-p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'"""
+    )
+
+    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+
+    # login to mirror registry
+    login_to_mirror_registry(pull_secret_path)
+
+    ocp_version = get_ocp_version()
+    index_image = f"{config.DEPLOYMENT['cs_redhat_operators_image']}:v{ocp_version}"
+    mirrored_index_image = (
+        f"{config.DEPLOYMENT['mirror_registry']}/{constants.MIRRORED_INDEX_IMAGE_NAMESPACE}/"
+        f"{constants.MIRRORED_INDEX_IMAGE_NAME}:v{ocp_version}"
+    )
+
+    prune_and_mirror_index_image(
+        index_image,
+        mirrored_index_image,
+        constants.DISCON_CL_REQUIRED_PACKAGES,
+    )
 
     # create redhat-operators CatalogSource
     catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -44,12 +44,20 @@ def setup_local_storage(storageclass):
     ocs_version = config.ENV_DATA.get("ocs_version")
     ocp_ga_version = get_ocp_ga_version(ocp_version)
     if not ocp_ga_version:
-        optional_operators_data = templating.load_yaml(
-            constants.LOCAL_STORAGE_OPTIONAL_OPERATORS, multi_document=True
+        optional_operators_data = list(
+            templating.load_yaml(
+                constants.LOCAL_STORAGE_OPTIONAL_OPERATORS, multi_document=True
+            )
         )
         optional_operators_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="optional_operators", delete=False
         )
+        if config.DEPLOYMENT.get("optional_operators_image"):
+            for _dict in optional_operators_data:
+                if _dict.get("kind").lower() == "catalogsource":
+                    _dict["spec"]["image"] = config.DEPLOYMENT.get(
+                        "optional_operators_image"
+                    )
         templating.dump_data_to_temp_yaml(
             optional_operators_data, optional_operators_yaml.name
         )

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -8,6 +8,7 @@ import logging
 import tempfile
 import time
 
+from ocs_ci.deployment.disconnected import prune_and_mirror_index_image
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, ocp, defaults
 from ocs_ci.ocs.exceptions import CommandFailed, UnsupportedPlatformError
@@ -58,6 +59,22 @@ def setup_local_storage(storageclass):
                     _dict["spec"]["image"] = config.DEPLOYMENT.get(
                         "optional_operators_image"
                     )
+        if config.DEPLOYMENT.get("disconnected"):
+            # in case of disconnected environment, we have to mirror all the
+            # optional_operators images
+            for _dict in optional_operators_data:
+                if _dict.get("kind").lower() == "catalogsource":
+                    index_image = _dict["spec"]["image"]
+                    mirrored_index_image = (
+                        f"{config.DEPLOYMENT['mirror_registry']}/"
+                        f"{index_image.split('/', 1)[-1]}"
+                    )
+                    prune_and_mirror_index_image(
+                        index_image,
+                        mirrored_index_image,
+                        constants.DISCON_CL_REQUIRED_PACKAGES,
+                    )
+                    _dict["spec"]["image"] = mirrored_index_image
         templating.dump_data_to_temp_yaml(
             optional_operators_data, optional_operators_yaml.name
         )


### PR DESCRIPTION
When LSO is used on unreleased OCP version, we need to prepare optional-operators for the disconnected installation.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/4448