### PR TITLE
Flexy deployment: use common configuration parameters

### DIFF
--- a/conf/deployment/aws/upi_1az_rhcos_3m_3w_disconnected.yaml
+++ b/conf/deployment/aws/upi_1az_rhcos_3m_3w_disconnected.yaml
@@ -5,12 +5,14 @@ ENV_DATA:
   flexy_deployment: true
   flexy_template: 'upi-on-aws/versioned-installer-disconnected'
   skip_ntp_configuration: true
+  availability_zone_count: 1
+  master_replicas: 3
+  worker_replicas: 3
+  master_instance_type: 'm4.xlarge'
+  worker_instance_type: 'm5.4xlarge'
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"
-  AVAILABILITY_ZONE_COUNT: 1
 
 DEPLOYMENT:
   disconnected: true

--- a/conf/deployment/aws/upi_1az_rhcos_3m_3w_proxy.yaml
+++ b/conf/deployment/aws/upi_1az_rhcos_3m_3w_proxy.yaml
@@ -5,12 +5,14 @@ ENV_DATA:
   flexy_deployment: true
   flexy_template: 'upi-on-aws/versioned-installer-http_proxy'
   skip_ntp_configuration: true
+  availability_zone_count: 1
+  master_replicas: 3
+  worker_replicas: 3
+  master_instance_type: 'm4.xlarge'
+  worker_instance_type: 'm5.4xlarge'
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"
-  AVAILABILITY_ZONE_COUNT: 1
 
 REPORTING:
   polarion:

--- a/conf/deployment/aws/upi_3az_rhcos_3m_3w_disconnected.yaml
+++ b/conf/deployment/aws/upi_3az_rhcos_3m_3w_disconnected.yaml
@@ -5,12 +5,14 @@ ENV_DATA:
   flexy_deployment: true
   flexy_template: 'upi-on-aws/versioned-installer-disconnected'
   skip_ntp_configuration: true
+  availability_zone_count: 3
+  master_replicas: 3
+  worker_replicas: 3
+  master_instance_type: 'm4.xlarge'
+  worker_instance_type: 'm5.4xlarge'
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"
-  AVAILABILITY_ZONE_COUNT: 3
 
 DEPLOYMENT:
   disconnected: true

--- a/conf/deployment/aws/upi_3az_rhcos_3m_3w_proxy.yaml
+++ b/conf/deployment/aws/upi_3az_rhcos_3m_3w_proxy.yaml
@@ -5,12 +5,14 @@ ENV_DATA:
   flexy_deployment: true
   flexy_template: 'upi-on-aws/versioned-installer-http_proxy'
   skip_ntp_configuration: true
+  availability_zone_count: 3
+  master_replicas: 3
+  worker_replicas: 3
+  master_instance_type: 'm4.xlarge'
+  worker_instance_type: 'm5.4xlarge'
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"
-  AVAILABILITY_ZONE_COUNT: 3
 
 REPORTING:
   polarion:

--- a/conf/ocsci/aws_upi_flexy_rhcos_3m_3w_disconnected.yaml
+++ b/conf/ocsci/aws_upi_flexy_rhcos_3m_3w_disconnected.yaml
@@ -7,8 +7,6 @@ ENV_DATA:
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"
 
 DEPLOYMENT:
   disconnected: true

--- a/conf/ocsci/aws_upi_flexy_rhcos_3m_3w_proxy.yaml
+++ b/conf/ocsci/aws_upi_flexy_rhcos_3m_3w_proxy.yaml
@@ -7,5 +7,3 @@ ENV_DATA:
 
 # Override flexy params here
 FLEXY:
-  LAUNCHER_VARS: {"num_nodes": 3,"num_workers": 3,"vm_type_masters":"m4.xlarge","vm_type_workers":"m5.4xlarge","ssh_key_name":"openshift-dev"}
-  OPENSHIFT_SSHKEY_PATH: "~/.ssh/openshift-dev.pem"

--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -105,6 +105,19 @@ class FlexyBase(object):
             config.FLEXY["VARIABLES_LOCATION"] = self.template_file
         config.FLEXY["INSTANCE_NAME_PREFIX"] = self.cluster_name
         config.FLEXY["LAUNCHER_VARS"].update(self.get_installer_payload())
+        config.FLEXY["LAUNCHER_VARS"].update(
+            {
+                "vm_type_masters": config.ENV_DATA["master_instance_type"],
+                "vm_type_workers": config.ENV_DATA["worker_instance_type"],
+                "num_nodes": str(config.ENV_DATA["master_replicas"]),
+                "num_workers": str(config.ENV_DATA["worker_replicas"]),
+                "ssh_key_name": "openshift-dev",
+            }
+        )
+        config.FLEXY["AVAILABILITY_ZONE_COUNT"] = config.ENV_DATA.get(
+            "availability_zone_count", "1"
+        )
+        config.FLEXY["OPENSHIFT_SSHKEY_PATH"] = config.DEPLOYMENT["ssh_key_private"]
         self.merge_flexy_env()
 
     def get_installer_payload(self, version=None):

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -181,6 +181,7 @@ AUTH:
 # This section is for FLEXY, any variable in this section will be copied into
 # flexy env file
 FLEXY:
+  LAUNCHER_VARS: {}
 
 # Defines the configuration of external Ceph Cluster
 EXTERNAL_MODE:
@@ -221,4 +222,3 @@ COMPONENTS:
   disable_noobaa: False
   disable_cephfs: False
   disable_blockpools: False
-


### PR DESCRIPTION
Some of the existing parameters wasn't properly considered for flexy deployment (for example `master_instance_type`, `worker_instance_type`, `master_replicas`, `worker_replicas`, `availability_zone_count`) and they have to be specifically configured in `FLEXY` section.
