### PR TITLE
Add patterns to must-gather test

### DIFF
--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -145,14 +145,16 @@ class MustGather(object):
         """
         regular_ex_list = [
             "must-gather-.*.-helper",
-            r"compute-*",
-            r"ip-*",
-            r"j-*",
-            r"argo-*",
-            r"vmware-*",
+            r"^compute-*",
+            r"^ip-*",
+            r"^j-*",
+            r"^argo-*",
+            r"^vmware-*",
+            "^must-gather",
+            r"-debug$",
         ]
         for regular_ex in regular_ex_list:
-            if re.match(regular_ex, pod_name) is not None:
+            if re.search(regular_ex, pod_name) is not None:
                 return True
         return False
 


### PR DESCRIPTION
Add patterns to `compare_running_pods` function
this function compare running pods list on openshift-storage project to "/pods" subdirectories
#4375

Signed-off-by: Oded Viner <oviner@redhat.com>