### PR TITLE
fix "skipif_ui" decorator

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2439,7 +2439,7 @@ def skipif_ui(ui_test):
 
     ocp_version = get_running_ocp_version()
     try:
-        locators.get(ocp_version).get(ui_test)
+        locators[ocp_version][ui_test]
     except KeyError:
         return True
     return False


### PR DESCRIPTION
Need to fix the "skipif_ui" decorator, return None if key does not exist [expected KeyError]
#4458
Signed-off-by: Oded Viner <oviner@redhat.com>