### PR TITLE
aws: update delete_cluster_buckets

### DIFF
--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1783,6 +1783,7 @@ def delete_cluster_buckets(cluster_name):
         f"{cluster_name}-(\\w+)-image-registry-{region}-(\\w+)",
         f"{cluster_name}-(\\d{{4}})-(\\d{{2}})-(\\d{{2}})-(\\d{{2}})-(\\d{{2}})-(\\d{{2}})",
         f"{cluster_name}-(\\w+)-oidc",
+        f"{cluster_name}-(\\d{{8}})",
     ]
     for pattern in patterns:
         r = re.compile(pattern)


### PR DESCRIPTION
Remove s3 bucket with name like `CLUSTER_NAME-XXXXXXXX` (e.g. `jnk-pr4435-b893-06150613`).

Signed-off-by: Daniel Horak <dahorak@redhat.com>