### PR TITLE
Add rerun markers for flaky tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "greenlet<1.0.0",
         "ovirt-engine-sdk-python==4.4.11",
         "junitparser",
+        "flaky==3.7.0",
     ],
     entry_points={
         "console_scripts": [

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -3,6 +3,7 @@ import timeit
 
 import botocore
 import pytest
+from flaky import flaky
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
@@ -175,6 +176,7 @@ class TestBucketDeletion(MCGTest):
         ],
         ids=["S3", "CLI", "OC", "OC-AWS", "OC-AZURE", "OC-GCP"],
     )
+    @flaky
     def test_bucket_delete_with_objects(
         self, mcg_obj, awscli_pod, bucket_factory, interface, bucketclass_dict
     ):

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from flaky import flaky
 
 from ocs_ci.framework.testlib import MCGTest, tier1, tier2, tier3
 from ocs_ci.ocs import constants
@@ -24,6 +25,7 @@ FILESIZE_SKIP = pytest.mark.skip("Current test filesize is too large.")
 RUNTIME_SKIP = pytest.mark.skip("Runtime is too long; Code needs to be parallelized")
 
 
+@flaky
 @skipif_openshift_dedicated
 class TestObjectIntegrity(MCGTest):
     """

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -2,6 +2,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from flaky import flaky
 
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
@@ -88,6 +89,7 @@ class TestBucketIO(MCGTest):
             "GCP-OC-1",
         ],
     )
+    @flaky
     def test_write_file_to_bucket(
         self,
         mcg_obj,

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -2,8 +2,9 @@ import logging
 
 import botocore
 import pytest
-from ocs_ci.ocs.bucket_utils import retrieve_test_objects_to_pod, sync_object_directory
+from flaky import flaky
 
+from ocs_ci.ocs.bucket_utils import retrieve_test_objects_to_pod, sync_object_directory
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import acceptance, tier1, tier3
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -43,6 +44,7 @@ class TestBucketDeletion:
             ),
         ],
     )
+    @flaky
     def test_bucket_delete_with_objects(
         self, rgw_bucket_factory, interface, awscli_pod
     ):

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from flaky import flaky
 
 from ocs_ci.ocs.bucket_utils import (
     retrieve_test_objects_to_pod,
@@ -19,6 +20,7 @@ class TestObjectIntegrity(ManageTest):
     """
 
     @tier1
+    @flaky
     @pytest.mark.polarion_id("OCS-2246")
     def test_check_object_integrity(self, awscli_pod, rgw_bucket_factory):
         """


### PR DESCRIPTION
Some of our tests rely on the retrieval of test objects from AWS. Because of transient connection errors, those tests sometimes fail.
These new markers should rerun each test in case it fails, which should hopefully reduce the number of failures overall.