### PR TITLE
Skip RBD thick test if OCS version is below 4.8

### DIFF
--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -2,7 +2,14 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 import pytest
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, polarion_id, bugzilla
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier4,
+    tier4a,
+    polarion_id,
+    bugzilla,
+    skipif_ocs_version,
+)
 from ocs_ci.helpers.helpers import (
     verify_volume_deleted_in_backend,
     default_thick_storage_class,
@@ -20,6 +27,7 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 @tier4
 @tier4a
+@skipif_ocs_version("<4.8")
 class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
     Test to delete rbd provisioner leader pod while thick provisioning is progressing


### PR DESCRIPTION
Skip the test test_delete_provisioner_pod_while_thick_provisioning if OCS version is below 4.8. RBD thick provision feature is not present in OCS versions below 4.8.
Signed-off-by: Jilju Joy <jijoy@redhat.com>