### PR TITLE
Adding fsync in the end to fio command

### DIFF
--- a/ocs_ci/templates/workloads/fio/workload_io_fillup.yaml
+++ b/ocs_ci/templates/workloads/fio/workload_io_fillup.yaml
@@ -8,3 +8,4 @@ time_based: 0
 runtime: 36000
 size: 100M
 ioengine: libaio
+end_fsync: 1


### PR DESCRIPTION
this is to resolve problem which cause to data not present in restored from snapshot PVC 