### PR TITLE
Update toolbox_pod.yaml and utils.py to use new creds format

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -721,6 +721,24 @@ def get_pod_name_by_pattern(
     return pod_list
 
 
+def get_rook_version():
+    """
+    Get the rook image information from rook-ceph-operator pod
+
+    Returns:
+        str: rook version
+
+    """
+    namespace = ocsci_config.ENV_DATA["cluster_namespace"]
+    rook_operator = get_pod_name_by_pattern("rook-ceph-operator", namespace)
+    out = run_cmd(
+        f"oc -n {namespace} get pods {rook_operator[0]} -o yaml",
+    )
+    version = yaml.safe_load(out)
+    rook_version = version["spec"]["containers"][0]["image"]
+    return rook_version
+
+
 def setup_ceph_toolbox(force_setup=False):
     """
     Setup ceph-toolbox - also checks if toolbox exists, if it exists it
@@ -743,24 +761,24 @@ def setup_ceph_toolbox(force_setup=False):
     external_mode = ocsci_config.DEPLOYMENT.get("external_mode")
 
     if ocsci_config.ENV_DATA.get("ocs_version") == "4.2":
-        rook_operator = get_pod_name_by_pattern("rook-ceph-operator", namespace)
-        out = run_cmd(
-            f"oc -n {namespace} get pods {rook_operator[0]} -o yaml",
-        )
-        version = yaml.safe_load(out)
-        rook_version = version["spec"]["containers"][0]["image"]
         tool_box_data = templating.load_yaml(constants.TOOL_POD_YAML)
         tool_box_data["spec"]["template"]["spec"]["containers"][0][
             "image"
-        ] = rook_version
+        ] = get_rook_version()
         rook_toolbox = OCS(**tool_box_data)
         rook_toolbox.create()
     else:
         if external_mode:
             toolbox = templating.load_yaml(constants.TOOL_POD_YAML)
+            toolbox["spec"]["template"]["spec"]["containers"][0][
+                "image"
+            ] = get_rook_version()
             toolbox["metadata"]["name"] += "-external"
             keyring_dict = ocsci_config.EXTERNAL_MODE.get("admin_keyring")
-            env = [{"name": "ROOK_ADMIN_SECRET", "value": keyring_dict["key"]}]
+            env = toolbox["spec"]["template"]["spec"]["containers"][0]["env"]
+            # replace secret
+            env = [item for item in env if not (item["name"] == "ROOK_CEPH_SECRET")]
+            env.append({"name": "ROOK_CEPH_SECRET", "value": keyring_dict["key"]})
             toolbox["spec"]["template"]["spec"]["containers"][0]["env"] = env
             # add ceph volumeMounts
             ceph_volume_mount_path = {"mountPath": "/etc/ceph", "name": "ceph-config"}

--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -19,16 +19,21 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.3.8
+        image: rook/ceph:v1.4.9
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent
         env:
-          - name: ROOK_ADMIN_SECRET
+          - name: ROOK_CEPH_USERNAME
             valueFrom:
               secretKeyRef:
                 name: rook-ceph-mon
-                key: admin-secret
+                key: ceph-username
+          - name: ROOK_CEPH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: ceph-secret
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
- Update the creds and image in toolbox_pod.yaml
- Update setup_ceph_toolbox() to use new cred format and by default use 
rook image present in rook-ceph-operator

Fixes: #4486 
Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>