### PR TITLE
Updating Snapshot creation time log parsing

### DIFF
--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -121,10 +121,14 @@ class TestPvcSnapshotPerformance(E2ETest):
 
         # Getting the snapshot content name
         self.snap_content = helpers.get_snapshot_content_obj(self.snap_obj)
+        self.snap_uid = (
+            self.snap_content.data.get("spec").get("volumeSnapshotRef").get("uid")
+        )
+        log.info(f"The snapshot UID is :{self.snap_uid}")
 
         # Measure the snapshot creation time
         c_time = helpers.measure_snapshot_creation_time(
-            interface, snap_name, self.snap_content.name
+            interface, snap_name, self.snap_content.name, self.snap_uid
         )
         return c_time
 


### PR DESCRIPTION
On OCS 4.8 the way that the snapshot creation report to the log was changed, and all performance test of snapshot creation was failed.

This PR is fixing this problem and in case the creation time did not found in the log in the previous format, it try to find it in the new format (for backward compatibility)