### PR TITLE
Fix OCP 4.6 installation on vSphere: use main.tf for updating gateway - branch release-4.6

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1083,7 +1083,7 @@ def update_machine_conf(folder_structure=True):
         change_mem_and_cpu()
 
     else:
-        if Version.coerce(get_ocp_version()) >= Version.coerce("4.7"):
+        if Version.coerce(get_ocp_version()) >= Version.coerce("4.6"):
             gw_string = "${cidrhost(var.machine_cidr, 1)}"
             gw_conf_file = constants.VM_MAIN
         else:


### PR DESCRIPTION
See also https://github.com/red-hat-storage/ocs-ci/pull/4506 and https://github.com/red-hat-storage/ocs-ci/issues/4503