### PR TITLE
Added RGW restart count fixture into first running Tier1 test

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @tier1
 @pytest.mark.post_ocp_upgrade
-@pytest.mark.first
+@pytest.mark.run(order=2)
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_openshift_dedicated
 def test_monitoring_enabled():

--- a/tests/manage/monitoring/prometheusmetrics/test_rgw.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_rgw.py
@@ -8,7 +8,7 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.testlib import skipif_ocs_version, tier4, tier4a
+from ocs_ci.framework.testlib import skipif_ocs_version, tier1, tier4, tier4a
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.ocs import metrics
 from ocs_ci.ocs.resources.ocs import OCS
@@ -56,3 +56,14 @@ def test_ceph_rgw_metrics_after_metrics_exporter_respin(rgw_deployments):
         "so that the list of metrics without results is empty."
     )
     assert list_of_metrics_without_results == [], msg
+
+
+@tier1
+@pytest.mark.post_ocp_upgrade
+@pytest.mark.run(order=1)
+@pytest.mark.polarion_id("OCS-2584")
+def verify_rgw_pods_restart_count(verify_rgw_restart_count_session):
+    """
+    This test starting session scope fixture, that verify RGW pod restarts count
+    """
+    logger.info("Starting RGW pod restart counts")


### PR DESCRIPTION
Automated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1784255
As part of Tier1 tests (where RGW pod count should remain 0), verify that no unwanted restart accrued

Signed-off-by: aviadp <apolak@redhat.com>