### PR TITLE
Verify ceph health is HEALTH_WARN after ceph daemon killing

### DIFF
--- a/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -168,3 +168,21 @@ class TestKillCephDaemon(ManageTest):
             raise Exception(
                 f"coredump not getting generated for {daemon_types} daemons crash"
             )
+
+        log.info(
+            "Verify ceph status moved to HEALTH_WARN state with the relevant "
+            "information (daemons have recently crashed)"
+        )
+        sample = TimeoutSampler(
+            timeout=20,
+            sleep=5,
+            func=run_cmd_verify_cli_output,
+            cmd="ceph health detail",
+            expected_output_lst=daemon_types
+            + ["HEALTH_WARN", "daemons have recently crashed"],
+            cephtool_cmd=True,
+        )
+        if not sample.wait_for_func_status(True):
+            raise Exception(
+                "The output of command ceph health detail is invalid (ceph status or warnings)"
+            )

--- a/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -184,5 +184,6 @@ class TestKillCephDaemon(ManageTest):
         )
         if not sample.wait_for_func_status(True):
             raise Exception(
-                "The output of command ceph health detail is invalid (ceph status or warnings)"
+                "The output of command ceph health detail did not show "
+                "warning 'daemons have recently crashed'"
             )


### PR DESCRIPTION
Output:
```
sh-4.4# ceph health detail
HEALTH_WARN 3 daemons have recently crashed
RECENT_CRASH 3 daemons have recently crashed
    mgr.a crashed on host rook-ceph-mgr-a-56fdcbb6-nv54h at 2021-07-06 12:08:04.659384Z
    osd.2 crashed on host rook-ceph-osd-2-74cc6b5fd9-t5wr4 at 2021-07-06 12:08:10.811095Z
    mon.g crashed on host rook-ceph-mon-g-649bd4589d-6tp7j at 2021-07-06 12:08:16.709094Z
```
Signed-off-by: Oded Viner <oviner@redhat.com>