### PR TITLE
deployment: Don't check for rbd-thick sc in OCS4.8

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -219,7 +219,7 @@ def ocs_install_verification(
         f"{storage_cluster_name}-cephfs",
         f"{storage_cluster_name}-ceph-rbd",
     }
-    if Version.coerce(ocs_version) >= Version.coerce("4.8"):
+    if Version.coerce(ocs_version) >= Version.coerce("4.9"):
         # TODO: Add rbd-thick storage class verification in external mode cluster upgraded
         # to OCS 4.8 when the bug 1978542 is fixed
         # Skip rbd-thick storage class verification in external mode upgraded cluster. This is blocked by bug 1978542

--- a/tests/ui/test_pvc_ui.py
+++ b/tests/ui/test_pvc_ui.py
@@ -46,7 +46,7 @@ class TestPvcUserInterface(object):
                 "ReadWriteMany",
                 "4",
                 "Block",
-                marks=[skipif_ocp_version("<4.8")],
+                marks=[skipif_ocp_version("<4.9")],
             ),
             pytest.param(
                 "ocs-storagecluster-cephfs",
@@ -68,7 +68,7 @@ class TestPvcUserInterface(object):
                 "ReadWriteOnce",
                 "12",
                 "Block",
-                marks=[skipif_ocp_version("<4.8")],
+                marks=[skipif_ocp_version("<4.9")],
             ),
             pytest.param(
                 "ocs-storagecluster-ceph-rbd",
@@ -83,7 +83,7 @@ class TestPvcUserInterface(object):
                 "ReadWriteOnce",
                 "4",
                 "Filesystem",
-                marks=[skipif_ocp_version("<4.8")],
+                marks=[skipif_ocp_version("<4.9")],
             ),
         ],
     )


### PR DESCRIPTION
Thick provisioning is disabled in OCS4.8 but deployment
is still checking and failing because of the same.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>