### PR TITLE
Update tests to use custom RBD thick SC and update OCS version in relevant tests

### DIFF
--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -12,7 +12,6 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.helpers.helpers import (
     verify_volume_deleted_in_backend,
-    default_thick_storage_class,
     check_rbd_image_used_size,
     default_ceph_block_pool,
 )

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -35,14 +35,19 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory):
+    def setup(self, project_factory, storageclass_factory):
         """
-        Create Project for the test
+        Create Project and storage class
 
-        Returns:
-            OCP: An OCP instance of project
         """
         self.proj_obj = project_factory()
+
+        self.sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            new_rbd_pool=False,
+            pool_name=default_ceph_block_pool(),
+            rbd_thick_provision=True,
+        )
 
     @polarion_id("OCS-2531")
     @bugzilla("1961647")
@@ -66,7 +71,7 @@ class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
             pvc_factory,
             interface=constants.CEPHBLOCKPOOL,
             project=self.proj_obj,
-            storageclass=default_thick_storage_class(),
+            storageclass=self.sc_obj,
             size=pvc_size,
             access_mode=constants.ACCESS_MODE_RWO,
             status="",

--- a/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
+++ b/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
@@ -60,7 +60,7 @@ class TestDeletePvcWhileProvisioning(ManageTest):
         """
         self.proj_obj = project_factory()
 
-    @skipif_ocs_version("<4.8")
+    @skipif_ocs_version("<4.9")
     def test_delete_rbd_pvc_while_thick_provisioning(
         self,
         resource_to_delete,

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
             *["thick", "thick"],
             marks=[
                 polarion_id("OCS-2502"),
-                skipif_ocs_version("<4.8"),
+                skipif_ocs_version("<4.9"),
                 bugzilla("1959793"),
             ],
         ),
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
             *["thin", "thick"],
             marks=[
                 polarion_id("OCS-2507"),
-                skipif_ocs_version("<4.8"),
+                skipif_ocs_version("<4.9"),
                 bugzilla("1959793"),
             ],
         ),
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
             *["thick", "thin"],
             marks=[
                 polarion_id("OCS-2508"),
-                skipif_ocs_version("<4.8"),
+                skipif_ocs_version("<4.9"),
                 bugzilla("1959793"),
             ],
         ),

--- a/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
+++ b/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
@@ -9,7 +9,6 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
 )
 from ocs_ci.helpers.helpers import (
-    default_thick_storage_class,
     fetch_used_size,
     default_ceph_block_pool,
 )

--- a/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
+++ b/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
@@ -27,12 +27,19 @@ class TestVerifyRbdThickPvcUtilization(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory):
+    def setup(self, project_factory, storageclass_factory):
         """
         Create project for the test
 
         """
         self.proj_obj = project_factory()
+
+        self.sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            new_rbd_pool=False,
+            pool_name=default_ceph_block_pool(),
+            rbd_thick_provision=True,
+        )
 
     @tier2
     @polarion_id("OCS-2537")
@@ -58,7 +65,7 @@ class TestVerifyRbdThickPvcUtilization(ManageTest):
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
             project=self.proj_obj,
-            storageclass=default_thick_storage_class(),
+            storageclass=self.sc_obj,
             size=pvc_size,
             access_mode=constants.ACCESS_MODE_RWO,
             status=constants.STATUS_BOUND,


### PR DESCRIPTION
Default RBD thick storage class will not be present in OCS 4.8 when the bug [1979263](https://bugzilla.redhat.com/show_bug.cgi?id=1979263) gets fixed.
Update tests to use custom RBD thick SC and update OCS version in relevant tests.

Signed-off-by: Jilju Joy <jijoy@redhat.com>