### PR TITLE
increased waiting for rebalance timeout when io in background

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1700,7 +1700,7 @@ def check_ceph_health_after_add_capacity(
         additional_ceph_health_tries = int(config.RUN.get("io_load") * 1.3)
         ceph_health_tries += additional_ceph_health_tries
 
-        additional_ceph_rebalance_timeout = int(config.RUN.get("io_load") * 40)
+        additional_ceph_rebalance_timeout = int(config.RUN.get("io_load") * 80)
         ceph_rebalance_timeout += additional_ceph_rebalance_timeout
 
     ceph_health_check(


### PR DESCRIPTION
current time out cause "test add capacity" to fail, as timeout is too short

Signed-off-by: aviadp <apolak@redhat.com>