### PR TITLE
Fix `get_ocs_version()`

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1027,7 +1027,6 @@ def get_ocs_version():
     for item in ocp_cluster.get()["items"]:
         if item["metadata"]["name"].startswith("ocs-operator"):
             return item["spec"]["version"]
-    return ocp_cluster.get()["items"][0]["spec"]["version"]
 
 
 def get_ocs_parsed_version():

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1024,10 +1024,9 @@ def get_ocs_version():
     ocp_cluster = OCP(
         namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
     )
-    if config.ENV_DATA["platform"].lower() == constants.OPENSHIFT_DEDICATED_PLATFORM:
-        for item in ocp_cluster.get()["items"]:
-            if item["metadata"]["name"].startswith("ocs-operator"):
-                return item["spec"]["version"]
+    for item in ocp_cluster.get()["items"]:
+        if item["metadata"]["name"].startswith("ocs-operator"):
+            return item["spec"]["version"]
     return ocp_cluster.get()["items"][0]["spec"]["version"]
 
 


### PR DESCRIPTION
By default, `get_ocs_version` checks for the version of the first CSV it can find.
However, the first CSV is now ElasticSearch operator, which means the function returns its version, instead of the OCS one.