### PR TITLE
GSS, test the mechanism to enable and disable debug logs

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3152,8 +3152,6 @@ def check_osd_log_exist_on_rook_ceph_operator_pod(
         contain the unexpected strings, False otherwise
 
     """
-    from datetime import datetime
-
     logger.info("Respin OSD pod")
     osd_pod_objs = pod.get_osd_pods()
     osd_pod_obj = random.choice(osd_pod_objs)
@@ -3162,7 +3160,9 @@ def check_osd_log_exist_on_rook_ceph_operator_pod(
     rook_ceph_operator_logs = get_logs_rook_ceph_operator()
     for line in rook_ceph_operator_logs.splitlines():
         if re.search(r"\d{4}-\d{2}-\d{2}", line):
-            log_date_time_obj = datetime.strptime(line[:26], "%Y-%m-%d %H:%M:%S.%f")
+            log_date_time_obj = datetime.datetime.strptime(
+                line[:26], "%Y-%m-%d %H:%M:%S.%f"
+            )
             if log_date_time_obj > last_log_date_time_obj:
                 new_logs.append(line)
     res_expected = False
@@ -3194,13 +3194,11 @@ def get_last_log_time_date():
         last_log_date_time_obj (datetime obj): type of log
 
     """
-    from datetime import datetime
-
     logger.info("Get last log time")
     rook_ceph_operator_logs = get_logs_rook_ceph_operator()
     for line in rook_ceph_operator_logs.splitlines():
         if re.search(r"\d{4}-\d{2}-\d{2}", line):
-            last_log_date_time_obj = datetime.strptime(
+            last_log_date_time_obj = datetime.datetime.strptime(
                 line[:26], "%Y-%m-%d %H:%M:%S.%f"
             )
     return last_log_date_time_obj

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3119,3 +3119,16 @@ def set_configmap_log_level_rook_ceph_operator(value):
         resource_name=constants.ROOK_OPERATOR_CONFIGMAP,
     )
     configmap_obj.patch(params=params, format_type="json")
+
+
+def get_logs_rook_ceph_operator():
+    """
+    Get logs from a rook_ceph_operator pod
+
+    Returns:
+        str: Output from 'oc get logs rook-ceph-operator command
+
+    """
+    logger.info("Get logs from rook_ceph_operator pod")
+    rook_ceph_operator_objs = pod.get_operator_pods()
+    return pod.get_pod_logs(pod_name=rook_ceph_operator_objs[0].name)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3101,3 +3101,21 @@ def check_rbd_image_used_size(
         )
         return False
     return True
+
+
+def set_configmap_log_level_rook_ceph_operator(value):
+    """
+    Set ROOK_LOG_LEVEL on configmap of rook-ceph-operator
+
+    Args:
+        value (str): type of log
+
+    """
+    path = "/data/ROOK_LOG_LEVEL"
+    params = f"""[{{"op": "add", "path": "{path}", "value": "{value}"}}]"""
+    configmap_obj = OCP(
+        kind=constants.CONFIGMAP,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        resource_name=constants.ROOK_OPERATOR_CONFIGMAP,
+    )
+    configmap_obj.patch(params=params, format_type="json")

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2,6 +2,7 @@
 Helper functions file for OCS QE
 """
 import base64
+import random
 import datetime
 import hashlib
 import json
@@ -3132,3 +3133,74 @@ def get_logs_rook_ceph_operator():
     logger.info("Get logs from rook_ceph_operator pod")
     rook_ceph_operator_objs = pod.get_operator_pods()
     return pod.get_pod_logs(pod_name=rook_ceph_operator_objs[0].name)
+
+
+def check_osd_log_exist_on_rook_ceph_operator_pod(
+    last_log_date_time_obj, expected_strings=(), unexpected_strings=()
+):
+    """
+    Verify logs contain the expected strings and the logs do not
+        contain the unexpected strings
+
+    Args:
+        last_log_date_time_obj (datetime obj): type of log
+        expected_strings (list): verify the logs contain the expected strings
+        unexpected_strings (list): verify the logs do not contain the strings
+
+    Returns:
+        bool: True if logs contain the expected strings and the logs do not
+        contain the unexpected strings, False otherwise
+
+    """
+    from datetime import datetime
+
+    logger.info("Respin OSD pod")
+    osd_pod_objs = pod.get_osd_pods()
+    osd_pod_obj = random.choice(osd_pod_objs)
+    osd_pod_obj.delete()
+    new_logs = list()
+    rook_ceph_operator_logs = get_logs_rook_ceph_operator()
+    for line in rook_ceph_operator_logs.splitlines():
+        if re.search(r"\d{4}-\d{2}-\d{2}", line):
+            log_date_time_obj = datetime.strptime(line[:26], "%Y-%m-%d %H:%M:%S.%f")
+            if log_date_time_obj > last_log_date_time_obj:
+                new_logs.append(line)
+    res_expected = False
+    res_unexpected = True
+    for new_log in new_logs:
+        if all(
+            expected_string.lower() in new_log.lower()
+            for expected_string in expected_strings
+        ):
+            res_expected = True
+            logger.info(f"{new_log} contain expected strings {expected_strings}")
+            break
+    for new_log in new_logs:
+        if any(
+            unexpected_string.lower() in new_log.lower()
+            for unexpected_string in unexpected_strings
+        ):
+            logger.error(f"{new_log} contain unexpected strings {unexpected_strings}")
+            res_unexpected = False
+            break
+    return res_expected & res_unexpected
+
+
+def get_last_log_time_date():
+    """
+    Get last log time
+
+    Returns:
+        last_log_date_time_obj (datetime obj): type of log
+
+    """
+    from datetime import datetime
+
+    logger.info("Get last log time")
+    rook_ceph_operator_logs = get_logs_rook_ceph_operator()
+    for line in rook_ceph_operator_logs.splitlines():
+        if re.search(r"\d{4}-\d{2}-\d{2}", line):
+            last_log_date_time_obj = datetime.strptime(
+                line[:26], "%Y-%m-%d %H:%M:%S.%f"
+            )
+    return last_log_date_time_obj

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -2,12 +2,12 @@ from datetime import datetime
 import logging
 import re
 import pytest
+import random
 
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.resources.pod import (
     get_pod_logs,
     get_osd_pods,
-    get_ceph_tools_pod,
     get_operator_pods,
 )
 from ocs_ci.helpers.helpers import set_configmap_log_level_rook_ceph_operator
@@ -45,11 +45,6 @@ class TestRookCephOperatorLogType(ManageTest):
 
     def teardown(self):
         set_configmap_log_level_rook_ceph_operator(value="INFO")
-        tool_pod = get_ceph_tools_pod()
-        tool_pod.exec_ceph_cmd(ceph_cmd="ceph crash archive-all", format=None)
-        logging.info(
-            "Perform Ceph and cluster health checks after silencing the ceph warnings"
-        )
 
     def test_rook_ceph_operator_log_type(self):
         """
@@ -61,8 +56,9 @@ class TestRookCephOperatorLogType(ManageTest):
         last_log_date_time_obj = self.get_last_log_time_date()
 
         log.info("Respin OSD pod")
-        osd_pods_objs = get_osd_pods()
-        osd_pods_objs[0].delete()
+        osd_pod_objs = get_osd_pods()
+        osd_pod_obj = random.choice(osd_pod_objs)
+        osd_pod_obj.delete()
 
         sample = TimeoutSampler(
             timeout=400,
@@ -78,8 +74,9 @@ class TestRookCephOperatorLogType(ManageTest):
         last_log_date_time_obj = self.get_last_log_time_date()
 
         log.info("Respin OSD pod")
-        osd_pods_objs = get_osd_pods()
-        osd_pods_objs[0].delete()
+        osd_pod_objs = get_osd_pods()
+        osd_pod_obj = random.choice(osd_pod_objs)
+        osd_pod_obj.delete()
 
         sample = TimeoutSampler(
             timeout=400,
@@ -124,8 +121,9 @@ class TestRookCephOperatorLogType(ManageTest):
 
         """
         log.info("Respin OSD pod")
-        osd_pods_objs = get_osd_pods()
-        osd_pods_objs[0].delete()
+        osd_pod_objs = get_osd_pods()
+        osd_pod_obj = random.choice(osd_pod_objs)
+        osd_pod_obj.delete()
         new_logs = list()
         rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
         for line in rook_ceph_operator_logs.splitlines():

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -3,7 +3,7 @@ import logging
 import re
 import pytest
 
-from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
+from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.resources.pod import (
     get_pod_logs,
     get_osd_pods,
@@ -50,7 +50,6 @@ class TestRookCephOperatorLogType(ManageTest):
         logging.info(
             "Perform Ceph and cluster health checks after silencing the ceph warnings"
         )
-        ceph_health_check()
 
     def test_rook_ceph_operator_log_type(self):
         """

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -2,12 +2,14 @@ from datetime import datetime
 import logging
 import re
 
-from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs import constants
-from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
-from ocs_ci.ocs.utils import get_pod_name_by_pattern
-from ocs_ci.ocs.resources.pod import get_pod_logs, get_osd_pods
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
+from ocs_ci.ocs.resources.pod import (
+    get_pod_logs,
+    get_osd_pods,
+    get_ceph_tools_pod,
+    get_operator_pods,
+)
+from ocs_ci.helpers.helpers import set_configmap_log_level_rook_ceph_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -26,12 +28,12 @@ class TestRookCephOperatorLogType(ManageTest):
     Test Process:
     1.Set ROOK_LOG_LEVEL param to "DEBUG"
     2.Respin OSD pod
-    3.Set ROOK_LOG_LEVEL param to "INFO"
-    4.Find the last log (according to the time)
-    5.Respin OSD pod
-    6.Find 'osd' string on log
-    7.Find all new logs (after switching to INFO mode)
-    8.Verify there are no DEBUG logs 'D |'
+    3.Verify logs contain the expected strings
+    4.Verify logs do not contain the unexpected strings
+    5.Set ROOK_LOG_LEVEL param to "INFO"
+    6.Respin OSD pod
+    7.Verify logs contain the expected strings
+    8.Verify logs do not contain the unexpected strings
 
     Comment:
     On INFO mode,  expected log type [I],[E]
@@ -40,26 +42,24 @@ class TestRookCephOperatorLogType(ManageTest):
     """
 
     def teardown(self):
-        self.set_configmap_log_level(value="DEBUG")
+        set_configmap_log_level_rook_ceph_operator(value="INFO")
+        tool_pod = get_ceph_tools_pod()
+        tool_pod.exec_ceph_cmd(ceph_cmd="ceph crash archive-all", format=None)
+        logging.info(
+            "Perform Ceph and cluster health checks after silencing the ceph warnings"
+        )
+        ceph_health_check()
 
     def test_rook_ceph_operator_log_type(self):
         """
-        test the mechanism to enable and disable debug logs in rook-ceph operator
+        Test the ability to change the log level in rook-ceph operator dynamically
+        without rook-ceph operator pod restart.
 
         """
-        self.set_configmap_log_level(value="DEBUG")
-        osd_pods_objs = get_osd_pods()
-        osd_pods_objs[0].delete()
+        set_configmap_log_level_rook_ceph_operator(value="DEBUG")
+        last_log_date_time_obj = self.get_last_log_time_date()
 
-        self.set_configmap_log_level(value="INFO")
-
-        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
-        for line in rook_ceph_operator_logs.splitlines():
-            if re.search(r"\d{4}-\d{2}-\d{2}", line):
-                last_log_date_time_obj = datetime.strptime(
-                    line[:26], "%Y-%m-%d %H:%M:%S.%f"
-                )
-
+        log.info("Respin OSD pod")
         osd_pods_objs = get_osd_pods()
         osd_pods_objs[0].delete()
 
@@ -68,54 +68,63 @@ class TestRookCephOperatorLogType(ManageTest):
             sleep=20,
             func=self.check_osd_log_exist_on_rook_ceph_operator_pod,
             last_log_date_time_obj=last_log_date_time_obj,
+            expected_strings=["D |", "osd"],
         )
         if not sample.wait_for_func_status(result=True):
-            log.error(
-                "osd log does not exist on rook_ceph_operator pod after 100 seconds"
-            )
-            raise TimeoutExpiredError
+            raise ValueError("OSD DEBUG Log does not exist")
 
-        for new_log in self.new_logs:
-            if "D |" in new_log:
-                assert f"DEBUG log appeared in INFO state. {self.new_logs}"
+        set_configmap_log_level_rook_ceph_operator(value="INFO")
+        last_log_date_time_obj = self.get_last_log_time_date()
+
+        log.info("Respin OSD pod")
+        osd_pods_objs = get_osd_pods()
+        osd_pods_objs[0].delete()
+
+        sample = TimeoutSampler(
+            timeout=400,
+            sleep=20,
+            func=self.check_osd_log_exist_on_rook_ceph_operator_pod,
+            last_log_date_time_obj=last_log_date_time_obj,
+            expected_strings=["I |", "osd"],
+            unexpected_strings=["D |"],
+        )
+        if not sample.wait_for_func_status(result=True):
+            raise ValueError(
+                "OSD INFO Log does not exist or DEBUG Log exist on INFO mode"
+            )
 
     def get_logs_rook_ceph_operator(self):
         """
         Get logs from a rook_ceph_operator pod
 
+        Returns:
+            str: Output from 'oc get logs rook-ceph-operator command
+
         """
         log.info("Get logs from rook_ceph_operator pod")
-        rook_ceph_operator_name = get_pod_name_by_pattern("rook-ceph-operator")
-        return get_pod_logs(pod_name=rook_ceph_operator_name[0])
+        rook_ceph_operator_objs = get_operator_pods()
+        return get_pod_logs(pod_name=rook_ceph_operator_objs[0].name)
 
-    def set_configmap_log_level(self, value):
+    def check_osd_log_exist_on_rook_ceph_operator_pod(
+        self, last_log_date_time_obj, expected_strings=(), unexpected_strings=()
+    ):
         """
-        Set ROOK_LOG_LEVEL on configmap of rook-ceph-operator
-
-        Args:
-            value (str): type of log
-
-        """
-        path = "/data/ROOK_LOG_LEVEL"
-        params = f"""[{{"op": "add", "path": "{path}", "value": "{value}"}}]"""
-        configmap_obj = OCP(
-            kind=constants.CONFIGMAP,
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
-            resource_name=constants.ROOK_OPERATOR_CONFIGMAP,
-        )
-        configmap_obj.patch(params=params, format_type="json")
-
-    def check_osd_log_exist_on_rook_ceph_operator_pod(self, last_log_date_time_obj):
-        """
-        Check 'osd' string exist on rook_ceph_operator log
+        Verify logs contain the expected strings and the logs do not
+            contain the unexpected strings
 
         Args:
             last_log_date_time_obj (datetime obj): type of log
+            expected_strings (list): verify the logs contain the expected strings
+            unexpected_strings (list): verify the logs do not contain the strings
 
-        return:
-            bool: True if 'osd' string exist on logs, False otherwise
+        Returns:
+            bool: True if logs contain the expected strings and the logs do not
+            contain the unexpected strings, False otherwise
 
         """
+        log.info("Respin OSD pod")
+        osd_pods_objs = get_osd_pods()
+        osd_pods_objs[0].delete()
         new_logs = list()
         rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
         for line in rook_ceph_operator_logs.splitlines():
@@ -123,11 +132,39 @@ class TestRookCephOperatorLogType(ManageTest):
                 log_date_time_obj = datetime.strptime(line[:26], "%Y-%m-%d %H:%M:%S.%f")
                 if log_date_time_obj > last_log_date_time_obj:
                     new_logs.append(line)
+        res_expected = False
+        res_unexpected = True
         for new_log in new_logs:
-            if "osd" in new_log:
-                self.new_logs = new_logs
-                return True
-        osd_pods_objs = get_osd_pods()
-        osd_pods_objs[0].delete()
-        log.error(f"osd log does not exist on rook_ceph_operator pod {new_logs}")
-        return False
+            if all(
+                expected_string.lower() in new_log.lower()
+                for expected_string in expected_strings
+            ):
+                res_expected = True
+                log.info(f"{new_log} contain expected strings {expected_strings}")
+                break
+        for new_log in new_logs:
+            if any(
+                unexpected_string.lower() in new_log.lower()
+                for unexpected_string in unexpected_strings
+            ):
+                log.error(f"{new_log} contain unexpected strings {unexpected_strings}")
+                res_unexpected = False
+                break
+        return res_expected & res_unexpected
+
+    def get_last_log_time_date(self):
+        """
+        Get last log time
+
+        Returns:
+            last_log_date_time_obj (datetime obj): type of log
+
+        """
+        log.info("Get last log time")
+        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
+        for line in rook_ceph_operator_logs.splitlines():
+            if re.search(r"\d{4}-\d{2}-\d{2}", line):
+                last_log_date_time_obj = datetime.strptime(
+                    line[:26], "%Y-%m-%d %H:%M:%S.%f"
+                )
+        return last_log_date_time_obj

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+import logging
+import re
+
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.utils import get_pod_name_by_pattern
+from ocs_ci.ocs.resources.pod import get_pod_logs, get_osd_pods
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    skipif_ocs_version,
+    bugzilla,
+)
+
+log = logging.getLogger(__name__)
+
+
+@tier2
+@bugzilla("1962821")
+@skipif_ocs_version("<4.8")
+class TestRookCephOperatorLogType(ManageTest):
+    """
+    Test Process:
+    1.Set ROOK_LOG_LEVEL param to "DEBUG"
+    2.Respin OSD pod
+    3.Set ROOK_LOG_LEVEL param to "INFO"
+    4.Find the last log (according to the time)
+    5.Respin OSD pod
+    6.Find 'osd' string on log
+    7.Find all new logs (after switching to INFO mode)
+    8.Verify there are no DEBUG logs 'D |'
+
+    Comment:
+    On INFO mode,  expected log type [I],[E]
+    On DEBUG mode, expected log type [I],[D],[E]
+
+    """
+
+    def teardown(self):
+        self.set_configmap_log_level(value="DEBUG")
+
+    def test_rook_ceph_operator_log_type(self):
+        """
+        test the mechanism to enable and disable debug logs in rook-ceph operator
+
+        """
+        self.set_configmap_log_level(value="DEBUG")
+        osd_pods_objs = get_osd_pods()
+        osd_pods_objs[0].delete()
+
+        self.set_configmap_log_level(value="INFO")
+
+        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
+        for line in rook_ceph_operator_logs.splitlines():
+            if re.search(r"\d{4}-\d{2}-\d{2}", line):
+                last_log_date_time_obj = datetime.strptime(
+                    line[:26], "%Y-%m-%d %H:%M:%S.%f"
+                )
+
+        osd_pods_objs = get_osd_pods()
+        osd_pods_objs[0].delete()
+
+        sample = TimeoutSampler(
+            timeout=400,
+            sleep=20,
+            func=self.check_osd_log_exist_on_rook_ceph_operator_pod,
+            last_log_date_time_obj=last_log_date_time_obj,
+        )
+        if not sample.wait_for_func_status(result=True):
+            log.error(
+                "osd log does not exist on rook_ceph_operator pod after 100 seconds"
+            )
+            raise TimeoutExpiredError
+
+        for new_log in self.new_logs:
+            if "D |" in new_log:
+                assert f"DEBUG log appeared in INFO state. {self.new_logs}"
+
+    def get_logs_rook_ceph_operator(self):
+        """
+        Get logs from a rook_ceph_operator pod
+
+        """
+        log.info("Get logs from rook_ceph_operator pod")
+        rook_ceph_operator_name = get_pod_name_by_pattern("rook-ceph-operator")
+        return get_pod_logs(pod_name=rook_ceph_operator_name[0])
+
+    def set_configmap_log_level(self, value):
+        """
+        Set ROOK_LOG_LEVEL on configmap of rook-ceph-operator
+
+        Args:
+            value (str): type of log
+
+        """
+        path = "/data/ROOK_LOG_LEVEL"
+        params = f"""[{{"op": "add", "path": "{path}", "value": "{value}"}}]"""
+        configmap_obj = OCP(
+            kind=constants.CONFIGMAP,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            resource_name=constants.ROOK_OPERATOR_CONFIGMAP,
+        )
+        configmap_obj.patch(params=params, format_type="json")
+
+    def check_osd_log_exist_on_rook_ceph_operator_pod(self, last_log_date_time_obj):
+        """
+        Check 'osd' string exist on rook_ceph_operator log
+
+        Args:
+            last_log_date_time_obj (datetime obj): type of log
+
+        return:
+            bool: True if 'osd' string exist on logs, False otherwise
+
+        """
+        new_logs = list()
+        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
+        for line in rook_ceph_operator_logs.splitlines():
+            if re.search(r"\d{4}-\d{2}-\d{2}", line):
+                log_date_time_obj = datetime.strptime(line[:26], "%Y-%m-%d %H:%M:%S.%f")
+                if log_date_time_obj > last_log_date_time_obj:
+                    new_logs.append(line)
+        for new_log in new_logs:
+            if "osd" in new_log:
+                self.new_logs = new_logs
+                return True
+        osd_pods_objs = get_osd_pods()
+        osd_pods_objs[0].delete()
+        log.error(f"osd log does not exist on rook_ceph_operator pod {new_logs}")
+        return False

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -5,12 +5,11 @@ import pytest
 import random
 
 from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.ocs.resources.pod import (
-    get_pod_logs,
-    get_osd_pods,
-    get_operator_pods,
+from ocs_ci.ocs.resources.pod import get_osd_pods
+from ocs_ci.helpers.helpers import (
+    set_configmap_log_level_rook_ceph_operator,
+    get_logs_rook_ceph_operator,
 )
-from ocs_ci.helpers.helpers import set_configmap_log_level_rook_ceph_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -91,18 +90,6 @@ class TestRookCephOperatorLogType(ManageTest):
                 "OSD INFO Log does not exist or DEBUG Log exist on INFO mode"
             )
 
-    def get_logs_rook_ceph_operator(self):
-        """
-        Get logs from a rook_ceph_operator pod
-
-        Returns:
-            str: Output from 'oc get logs rook-ceph-operator command
-
-        """
-        log.info("Get logs from rook_ceph_operator pod")
-        rook_ceph_operator_objs = get_operator_pods()
-        return get_pod_logs(pod_name=rook_ceph_operator_objs[0].name)
-
     def check_osd_log_exist_on_rook_ceph_operator_pod(
         self, last_log_date_time_obj, expected_strings=(), unexpected_strings=()
     ):
@@ -125,7 +112,7 @@ class TestRookCephOperatorLogType(ManageTest):
         osd_pod_obj = random.choice(osd_pod_objs)
         osd_pod_obj.delete()
         new_logs = list()
-        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
+        rook_ceph_operator_logs = get_logs_rook_ceph_operator()
         for line in rook_ceph_operator_logs.splitlines():
             if re.search(r"\d{4}-\d{2}-\d{2}", line):
                 log_date_time_obj = datetime.strptime(line[:26], "%Y-%m-%d %H:%M:%S.%f")
@@ -160,7 +147,7 @@ class TestRookCephOperatorLogType(ManageTest):
 
         """
         log.info("Get last log time")
-        rook_ceph_operator_logs = self.get_logs_rook_ceph_operator()
+        rook_ceph_operator_logs = get_logs_rook_ceph_operator()
         for line in rook_ceph_operator_logs.splitlines():
             if re.search(r"\d{4}-\d{2}-\d{2}", line):
                 last_log_date_time_obj = datetime.strptime(

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
 import re
+import pytest
 
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from ocs_ci.ocs.resources.pod import (
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 @tier2
 @bugzilla("1962821")
 @skipif_ocs_version("<4.8")
+@pytest.mark.polarion_id("OCS-2581")
 class TestRookCephOperatorLogType(ManageTest):
     """
     Test Process:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=19628

  Test Process:
  1.Set ROOK_LOG_LEVEL param to "DEBUG"
  2.Respin OSD pod
  3.Verify logs contain the expected strings
  4.Verify logs do not contain the unexpected strings
  5.Set ROOK_LOG_LEVEL param to "INFO"
  6.Respin OSD pod
  7.Verify logs contain the expected strings
  8.Verify logs do not contain the unexpected strings

  Comment:
  On INFO mode,  expected log type [I],[E]
  On DEBUG mode, expected log type [I],[D],[E]
Signed-off-by: Oded Viner <oviner@redhat.com>