### PR TITLE
Revert #3928 and #4548

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1053,10 +1053,6 @@ NOOBAA_SERVICE_ACCOUNT = "system:serviceaccount:openshift-storage:noobaa"
 RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
 RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
 
-# Routes
-RGW_DEFAULT_ROUTE_NAME = "ocs-storagecluster-cephobjectstore"
-RGW_EXTERNAL_ROUTE_NAME = "ocs-external-storagecluster-cephobjectstore"
-
 # Miscellaneous
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"
 NOOBAA_OPERATOR_LOCAL_CLI_PATH = os.path.join(DATA_DIR, "mcg-cli")

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -36,8 +36,8 @@ class RGW(object):
     def get_credentials(self, secret_name=constants.NOOBAA_OBJECTSTOREUSER_SECRET):
         """
         Get Endpoint, Access key and Secret key from OCS secret. Endpoint is
-        taken from rgw exposed service. On 4.7 and above, the service is exposed by default.
-        Below 4.7, use the rgw_endpoint fixture in a test to expose it.
+        taken from rgw exposed service. Use rgw_endpoint fixture in test to get
+        it exposed.
 
         Args:
             secret_name (str): Name of secret to be used
@@ -57,28 +57,14 @@ class RGW(object):
             kind=constants.ROUTE, namespace=config.ENV_DATA["cluster_namespace"]
         )
         creds_secret_obj = secret_ocp_obj.get(secret_name)
-        # In 4.6 and prior, we manually expose the RGW service
-        # thus leading to different route names in 4.6 and 4.7
-        # in external and internal modes.
-        if float(config.ENV_DATA["ocs_version"]) < 4.6:
-            if config.DEPLOYMENT["external_mode"]:
-                endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_SERVICE_EXTERNAL_MODE
-                )
-            else:
-                endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_SERVICE_INTERNAL_MODE
-                )
+        if config.DEPLOYMENT["external_mode"]:
+            endpoint = route_ocp_obj.get(
+                resource_name=constants.RGW_SERVICE_EXTERNAL_MODE
+            )
         else:
-            if config.DEPLOYMENT["external_mode"]:
-                endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_EXTERNAL_ROUTE_NAME
-                )
-            else:
-                endpoint = route_ocp_obj.get(
-                    resource_name=constants.RGW_DEFAULT_ROUTE_NAME
-                )
-
+            endpoint = route_ocp_obj.get(
+                resource_name=constants.RGW_SERVICE_INTERNAL_MODE
+            )
         endpoint = f"http://{endpoint['status']['ingress'][0]['host']}"
         access_key = base64.b64decode(
             creds_secret_obj.get("data").get("AccessKey")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1783,18 +1783,6 @@ def rgw_endpoint(request):
     oc = ocp.OCP(kind=constants.SERVICE, namespace=config.ENV_DATA["cluster_namespace"])
     rgw_service = oc.get(selector=constants.RGW_APP_LABEL)["items"]
     if rgw_service:
-        if float(config.ENV_DATA["ocs_version"]) > 4.6:
-            log.info("RGW service should be exposed by default. Skipping exposure.")
-            if config.DEPLOYMENT["external_mode"]:
-                rgw_route = constants.RGW_EXTERNAL_ROUTE_NAME
-            else:
-                rgw_route = constants.RGW_DEFAULT_ROUTE_NAME
-            default_rgw_route = ocp.OCP(
-                kind=constants.ROUTE, namespace=config.ENV_DATA["cluster_namespace"]
-            ).get(resource_name=rgw_route)
-            default_rgw_host = default_rgw_route["status"]["ingress"][0]["host"]
-            return f"http://{default_rgw_host}"
-
         if config.DEPLOYMENT["external_mode"]:
             rgw_service = constants.RGW_SERVICE_EXTERNAL_MODE
         else:


### PR DESCRIPTION
Since the current implementation on external mode is problematic, it'd probably be best to return to the old flow for the time being.
