### PR TITLE
Emergency fix for ripsaw operator

### DIFF
--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -42,9 +42,13 @@ class RipSaw(object):
         """
         self.args = kwargs
         self.repo = self.args.get(
-            "repo", "https://github.com/cloud-bulldozer/benchmark-operator"
+            # "repo", "https://github.com/cloud-bulldozer/benchmark-operator"
+            # This is emergency fix since the all benchmark-operator has changed
+            "repo",
+            "https://github.com/Avilir/ripsaw",
         )
-        self.branch = self.args.get("branch", "master")
+        self.branch = self.args.get("branch", "V0.1")
+        # self.branch = self.args.get("branch", "master")
         self.namespace = self.args.get("namespace", RIPSAW_NAMESPACE)
         self.pgsql_is_setup = False
         self.ocp = OCP()

--- a/ocs_ci/ocs/ripsaw.py
+++ b/ocs_ci/ocs/ripsaw.py
@@ -89,7 +89,8 @@ class RipSaw(object):
         Args:
             crd (str): Name of file to apply
         """
-        self.dir += "/benchmark-operator"
+        # self.dir += "/benchmark-operator"
+        self.dir += "/ripsaw"
         run("oc apply -f deploy", shell=True, check=True, cwd=self.dir)
         run(f"oc apply -f {crd}", shell=True, check=True, cwd=self.dir)
         run(f"oc apply -f {self.operator}", shell=True, check=True, cwd=self.dir)


### PR DESCRIPTION
Since the benchmark-operator (known as ripsaw) SDK was changed and now it is deployed in a different way and in a different namespace, all our test that use this operator are failing to run.

I forked from the benchmark-operator main branch and create new branch which is not contain the last SDK change, and OCS-CI will use **temporary** this fork/branch.

after understanding the changes and make ocs-ci comply with thous changes we will return to the main branch.

Signed-off-by: Avi Layani <alayani@redhat.com>