### PR TITLE
Increase timeout for tar creation in

### DIFF
--- a/tests/e2e/scale/test_cephfs_many_files.py
+++ b/tests/e2e/scale/test_cephfs_many_files.py
@@ -48,7 +48,7 @@ def add_million_files(pod_name, ocp_obj):
             logging.info(f"{dispv} local files created")
             test_file_list.append(fname.split(os.sep)[-1])
     tmploc = ntar_loc.split("/")[-1]
-    run_cmd(f"tar cfz {tarfile} -C {new_dir} .")
+    run_cmd(f"tar cfz {tarfile} -C {new_dir} .", timeout=1800)
     ocp_obj.exec_oc_cmd(
         f"rsync {ntar_loc} {pod_name}:{constants.MOUNT_POINT}", timeout=300
     )


### PR DESCRIPTION
tests/e2e/scale/test_cephfs_many_files.py
This fixes issue #4589

Signed-off-by: wusui <wusui@redhat.com>