### PR TITLE
Skip RBD thick test cases in OCS 4.9

### DIFF
--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -28,7 +28,7 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 @tier4
 @tier4a
-@skipif_ocs_version("<4.9")
+@skipif_ocs_version("<=4.9")
 class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
     Test to delete rbd provisioner leader pod while thick provisioning is progressing

--- a/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
+++ b/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
@@ -60,7 +60,7 @@ class TestDeletePvcWhileProvisioning(ManageTest):
         """
         self.proj_obj = project_factory()
 
-    @skipif_ocs_version("<4.9")
+    @skipif_ocs_version("<=4.9")
     def test_delete_rbd_pvc_while_thick_provisioning(
         self,
         resource_to_delete,

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
             *["thick", "thick"],
             marks=[
                 polarion_id("OCS-2502"),
-                skipif_ocs_version("<4.9"),
+                skipif_ocs_version("<=4.9"),
                 bugzilla("1959793"),
             ],
         ),
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
             *["thin", "thick"],
             marks=[
                 polarion_id("OCS-2507"),
-                skipif_ocs_version("<4.9"),
+                skipif_ocs_version("<=4.9"),
                 bugzilla("1959793"),
             ],
         ),
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
             *["thick", "thin"],
             marks=[
                 polarion_id("OCS-2508"),
-                skipif_ocs_version("<4.9"),
+                skipif_ocs_version("<=4.9"),
                 bugzilla("1959793"),
             ],
         ),

--- a/tests/manage/pv_services/test_rbd_thick_provisioning.py
+++ b/tests/manage/pv_services/test_rbd_thick_provisioning.py
@@ -16,7 +16,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
-@skipif_ocs_version("<4.9")
+@skipif_ocs_version("<=4.9")
 class TestRbdThickProvisioning(ManageTest):
     """
     Tests to verify PVC creation and consumption using RBD thick provisioning enabled storage class

--- a/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
+++ b/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
@@ -19,7 +19,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
-@skipif_ocs_version("<4.9")
+@skipif_ocs_version("<=4.9")
 class TestVerifyRbdThickPvcUtilization(ManageTest):
     """
     Tests to verify storage utilization of RBD thick provisioned PVC


### PR DESCRIPTION
Skip RBD thick test cases because the feature will not be fully supported in OCS4.9
Signed-off-by: Jilju Joy <jijoy@redhat.com>