### PR TITLE
Added ipi_deployment_required marker in scale tests where node scaling is done for app pods.

### DIFF
--- a/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
+++ b/tests/e2e/scale/test_ceph_pod_respin_in_scaled_cluster.py
@@ -6,7 +6,10 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import utils
 from ocs_ci.ocs.scale_lib import FioPodScale
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
-from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode,
+    ipi_deployment_required,
+)
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +36,7 @@ def fioscale(request):
 @scale
 @ignore_leftovers
 @skipif_external_mode
+@ipi_deployment_required
 @pytest.mark.parametrize(
     argnames="resource_to_delete",
     argvalues=[

--- a/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
+++ b/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
@@ -22,6 +22,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_cloud,
     skipif_ibm_power,
     skipif_lso,
+    ipi_deployment_required,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
@@ -39,6 +40,7 @@ SCALE_DATA_FILE = f"{log_path}/scale_data_file.yaml"
 @skipif_ibm_cloud
 @skipif_ibm_power
 @skipif_external_mode
+@ipi_deployment_required
 @ignore_leftovers
 class TestAddNode(E2ETest):
     """

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     post_upgrade,
     skipif_bm,
     skipif_external_mode,
+    ipi_deployment_required,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
@@ -29,6 +30,7 @@ SCALE_DATA_FILE = f"{log_path}/scale_data_file.yaml"
 @skipif_external_mode
 @skipif_bm
 @pre_upgrade
+@ipi_deployment_required
 @pytest.mark.polarion_id("OCS-755")
 def test_scale_pvcs_pods_pre_upgrade():
     """


### PR DESCRIPTION
In scale tests like creation of 1000+ PVC's and PODs we need more worker nodes(other than OCS nodes)
for running app pods and all the relevant tests supports only IPI platform.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>