### PR TITLE
Check whether the df output is empty before processing the value in test_resource_deletion_during_pvc_expansion

### DIFF
--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -131,6 +131,8 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
             for df_out in TimeoutSampler(
                 240, 3, pod_obj.exec_cmd_on_pod, command="df -kh"
             ):
+                if not df_out:
+                    continue
                 df_out = df_out.split()
                 new_size_mount = df_out[df_out.index(pod_obj.get_storage_path()) - 4]
                 if new_size_mount in [


### PR DESCRIPTION
Closes: #3846 
This PR is for fixing the issue in test mentioned in [comment](https://github.com/red-hat-storage/ocs-ci/issues/3846#issuecomment-883906599)

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>