### PR TITLE
Change channel for OCP 4.8-GA config to stable

### DIFF
--- a/ocs_ci/framework/conf/ocp_version/ocp-4.8-ga-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.8-ga-config.yaml
@@ -11,6 +11,6 @@ DEPLOYMENT:
   # ignition_version can be found here
   # https://docs.openshift.com/container-platform/4.8/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0"
-  ocp_channel: "fast"
+  ocp_channel: "stable"
 ENV_DATA:
   vm_template: "rhcos-4.8.2-x86_64-vmware.x86_64"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.8-ga-upgrade.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.8-ga-upgrade.yaml
@@ -1,5 +1,5 @@
 ---
 # Use this config for upgrading of OCP 4.8 GA cluster
 UPGRADE:
-  ocp_channel: "fast-4.8"
+  ocp_channel: "stable-4.8"
   ocp_upgrade_path: "quay.io/openshift-release-dev/ocp-release"


### PR DESCRIPTION
Command:

```
curl -sH 'Accept:application/json' \
  'https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.8' \
  | jq -r '.nodes[] | .version' | sort -V | tail -1
```
Returns:
4.8.2

So we are ready to move to the stable channel.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>