### PR TITLE
Changing default_latest_tag to stable for OCS 4.9

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-4.9.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.9.yaml
@@ -1,7 +1,7 @@
 ---
 DEPLOYMENT:
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.9"
-  default_latest_tag: 'latest-4.9'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-stable-4.9"
+  default_latest_tag: 'latest-stable-4.9'
   ocs_csv_channel: "stable-4.9"
   default_ocp_version: '4.9'
 ENV_DATA:


### PR DESCRIPTION
Signed-off-by: vavuthu <vavuthu@redhat.com>