### PR TITLE
[Multus] Add namespace reference along with NAD name in the StorageCluster network spec

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -750,7 +750,9 @@ class Deployment(object):
         if config.ENV_DATA.get("is_multus_enabled"):
             cluster_data["spec"]["network"] = {
                 "provider": "multus",
-                "selectors": {"public": "ocs-public"},
+                "selectors": {
+                    "public": f"{defaults.ROOK_CLUSTER_NAMESPACE}/ocs-public"
+                },
             }
 
         cluster_data_yaml = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
When deployment is done via UI, the NAD is referenced along with the namespace in which it is present.
The format is as follows:
```
public: <namespace>/<name of NAD>
```

Updating the code to follow the same format.

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>