### PR TITLE
Update Pull-secret link

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -103,7 +103,7 @@ All elasticsearch configuration done in the `ocs_ci/framework/conf/default_confi
 
 In order to deploy a cluster to AWS with the Openshift Installer,
 you will need to download the pull secret for your account.
-Download this file from [openshift.com](https://cloud.openshift.com/clusters/install)
+Download this file from [openshift.com](https://console.redhat.com/openshift/install/pull-secret)
 and place in the `data` directory at the root level of the project.
 If there is no `data` directory, create one.
 The name of the file should be `pull-secret`.


### PR DESCRIPTION
pull secret link was updated from cloud.openshift.com to https://console.redhat.com/openshift/install/pull-secret