### PR TITLE
Fix issue with retrieving ocp channel

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1076,7 +1076,11 @@ def get_ocp_channel():
         kind="",
         resource_name="clusterversion",
     )
-    return ocp_cluster.get()["items"][0]["spec"]["channel"]
+    try:
+        cnl = ocp_cluster.get()["items"][0]["spec"]["channel"]
+    except Exception:
+        cnl = None
+    return cnl
 
 
 def switch_to_project(project_name):

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1079,7 +1079,7 @@ def get_ocp_channel():
     try:
         cnl = ocp_cluster.get()["items"][0]["spec"]["channel"]
     except Exception:
-        cnl = None
+        cnl = "None"
     return cnl
 
 


### PR DESCRIPTION
This PR fixing issue with IBM Cloud (or any other platform) which the OCP channel is not configure.

in this case instead of the the test will failed because the we do not found the OCP channel in the output of the command `oc get clusterversion -o json` it will return "None" - this is the string None and not None value since elastic-search an not index the None value
 
Signed-off-by: Avi Layani <alayani@redhat.com>