### PR TITLE
Fix problem in create_pod volume mode block with no pod_dict_path

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -226,8 +226,7 @@ def create_pod(
             pod_data["spec"]["template"]["spec"]["containers"][0][
                 "volumeDevices"
             ] = temp_dict
-
-        elif pod_dict_path == constants.NGINX_POD_YAML:
+        else:
             temp_dict = [
                 {
                     "devicePath": raw_block_device,
@@ -239,13 +238,6 @@ def create_pod(
             ]
             del pod_data["spec"]["containers"][0]["volumeMounts"]
             pod_data["spec"]["containers"][0]["volumeDevices"] = temp_dict
-        else:
-            pod_data["spec"]["containers"][0]["volumeDevices"][0][
-                "devicePath"
-            ] = raw_block_device
-            pod_data["spec"]["containers"][0]["volumeDevices"][0]["name"] = (
-                pod_data.get("spec").get("volumes")[0].get("name")
-            )
 
     if command:
         if dc_deployment:


### PR DESCRIPTION
When calling:
pod_factory(pvc=pvc_obj, raw_block_pv=True)
It loads:
pod_dict = pod_dict_path if pod_dict_path else constants.CSI_RBD_POD_YAML
and the conditions leads to:
`        else:
            pod_data["spec"]["containers"][0]["volumeDevices"][0][
                "devicePath"
            ] = raw_block_device
            pod_data["spec"]["containers"][0]["volumeDevices"][0]["name"] = (
                pod_data.get("spec").get("volumes")[0].get("name")
            )
`
But constants.CSI_RBD_POD_YAML don't have volumeDevices and the assignment fails.

Above that it handles another option for         elif pod_dict_path == constants.NGINX_POD_YAML:
And the building the pod_data for raw_block_pv work also for the default pod_dict_path so I've change it to else instead of elseif.
It works for all option:
pod_dict_path = constants.NGINX_POD_YAML
pod_dict_path = None
No one else tried so far to use raw_block_pv=True with pod_dict_path = None.

