### PR TITLE
fix create_pod when raw block is used with no pod_dict_path

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -227,7 +227,10 @@ def create_pod(
                 "volumeDevices"
             ] = temp_dict
 
-        elif pod_dict_path == constants.NGINX_POD_YAML:
+        elif (
+            pod_dict_path == constants.NGINX_POD_YAML
+            or pod_dict == constants.CSI_RBD_POD_YAML
+        ):
             temp_dict = [
                 {
                     "devicePath": raw_block_device,


### PR DESCRIPTION
When using:
`pod_factory(pvc=pvc, raw_block_pv=True)`
I fails:
`>               pod_data["spec"]["containers"][0]["volumeDevices"][0][
                    "devicePath"
                ] = raw_block_device
E               KeyError: 'volumeDevices'
`
When no pod_dict_path is used the default is constants.CSI_RBD_POD_YAML with suitable for filesystem and the  conditions doesn't handle it and get to a part that only assign devicePath and it fails.
Before that part there is:
`        elif pod_dict_path == constants.NGINX_POD_YAML:
            temp_dict = [
                {
                    "devicePath": raw_block_device,
                    "name": pod_data.get("spec")
                    .get("containers")[0]
                    .get("volumeMounts")[0]
                    .get("name"),
                }
            ]
            del pod_data["spec"]["containers"][0]["volumeMounts"]
            pod_data["spec"]["containers"][0]["volumeDevices"] = temp_dict`
Which is suitable also for constants.CSI_RBD_POD_YAML which is assigned now to pod_dict and not pod_dict_path.
Tested with:
pod_dict_path=None
pod_dict_path=constants.NGINX_POD_YAML
pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML