### PR TITLE
Adding reboot tests to scale script tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py

### DIFF
--- a/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
+++ b/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
@@ -1,10 +1,12 @@
 import logging
 import pytest
 
-from ocs_ci.helpers import disruption_helpers
-from ocs_ci.ocs import constants
 from ocs_ci.utility import utils
+from ocs_ci.ocs.node import get_nodes
 from ocs_ci.ocs.scale_lib import FioPodScale
+from ocs_ci.helpers import disruption_helpers
+from ocs_ci.ocs.resources.pod import wait_for_storage_pods
+from ocs_ci.ocs import constants, scale_lib, platform_nodes, machine
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
@@ -14,7 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def fioscale(request):
     """
     FIO Scale fixture to create expected number of POD+PVC
@@ -67,3 +69,55 @@ class TestScaleRespinCephPods(E2ETest):
             disruption.delete_resource(resource_id=i)
 
         utils.ceph_health_check()
+
+
+@scale
+@ignore_leftovers
+@skipif_external_mode
+@ipi_deployment_required
+@pytest.mark.parametrize(
+    argnames=["node_type"],
+    argvalues=[
+        pytest.param(
+            *[constants.MASTER_MACHINE], marks=pytest.mark.polarion_id("OCS-761")
+        ),
+        pytest.param(
+            *[constants.WORKER_MACHINE], marks=pytest.mark.polarion_id("OCS-762")
+        ),
+    ],
+)
+class TestRebootNodes(E2ETest):
+    """
+    Reboot nodes in scaled up cluster
+    """
+
+    def test_rolling_reboot_node(self, node_type):
+        """
+        Test to rolling reboot of nodes
+        """
+        node_list = list()
+
+        # Rolling reboot nodes
+        if node_type == constants.WORKER_MACHINE:
+            tmp_list = get_nodes(node_type=node_type)
+            ocs_node_list = machine.get_labeled_nodes(constants.OPERATOR_NODE_LABEL)
+            for tmp in tmp_list:
+                if tmp.name in ocs_node_list:
+                    node_list.append(tmp)
+        else:
+            node_list = get_nodes(node_type=node_type)
+
+        factory = platform_nodes.PlatformNodesFactory()
+        nodes = factory.get_nodes_platform()
+
+        for node in node_list:
+            nodes.restart_nodes(nodes=[node])
+            scale_lib.validate_node_and_oc_services_are_up_after_reboot()
+
+        # Validate storage pods are running
+        wait_for_storage_pods()
+
+        # Validate cluster health ok and all pods are running
+        assert utils.ceph_health_check(
+            delay=180
+        ), "Ceph health in bad state after node reboots"


### PR DESCRIPTION
renamed test_ceph_pod_respin_in_scaled_cluster.py to test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
Added reboot test to tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>