### PR TITLE
Add new j-ddd prefix

### DIFF
--- a/ocs_ci/cleanup/aws/defaults.py
+++ b/ocs_ci/cleanup/aws/defaults.py
@@ -6,6 +6,7 @@ CLUSTER_PREFIXES_SPECIAL_RULES = {
     "jnk-pr": 16,  # keep it as first item before jnk prefix for fist match
     "jnk": 36,
     "j\\d\\d\\d": 36,
+    "j-\\d\\d\\d": 36,
     "dnd": "never",
     "lr1": 24,
     "lr2": 48,


### PR DESCRIPTION
I think this MR:
https://gitlab.cee.redhat.com/ocs/ocs4-jenkins/-/merge_requests/694/diffs

Changed the logic and cluster names is now like j-ddd .
So we would like to include both.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>