### PR TITLE
Add VAULT_BACKEND parameter as a work around for BZ 1997624

### DIFF
--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -84,5 +84,6 @@ VAULT_CSI_CONNECTION_CONF = {
         "VAULT_CACERT_FILE": "fullchain.pem",
         "VAULT_CLIENT_CERT_FILE": "cert.pem",
         "VAULT_CLIENT_KEY_FILE": "privkey.pem",
+        "VAULT_BACKEND": "kv-v2",
     }
 }

--- a/ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml
+++ b/ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  1-vault: '{"KMS_PROVIDER":"vaulttokens","KMS_SERVICE_NAME":"vault","VAULT_ADDR":"https://vault.qe.rh-ocs.com:8200","VAULT_BACKEND_PATH":"kv-v2","VAULT_CACERT":"ocs-kms-ca-secret","VAULT_TLS_SERVER_NAME":"","VAULT_NAMESPACE":"","VAULT_TOKEN_NAME":"ocs-kms-token","VAULT_CACERT_FILE":"fullchain.pem","VAULT_CLIENT_CERT_FILE":"cert.pem","VAULT_CLIENT_KEY_FILE":"privkey.pem"}'
+  1-vault: '{"KMS_PROVIDER":"vaulttokens","KMS_SERVICE_NAME":"vault","VAULT_ADDR":"https://vault.qe.rh-ocs.com:8200","VAULT_BACKEND_PATH":"kv-v2","VAULT_CACERT":"ocs-kms-ca-secret","VAULT_TLS_SERVER_NAME":"","VAULT_NAMESPACE":"","VAULT_TOKEN_NAME":"ocs-kms-token","VAULT_CACERT_FILE":"fullchain.pem","VAULT_CLIENT_CERT_FILE":"cert.pem","VAULT_CLIENT_KEY_FILE":"privkey.pem","VAULT_BACKEND": "kv"}'
 kind: ConfigMap
 metadata:
   name: csi-kms-connection-details

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -751,7 +751,7 @@ class Vault(KMS):
         self.create_resource(csi_kms_token, prefix="csikmstoken")
 
     def create_vault_csi_kms_connection_details(
-        self, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        self, kv_version, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
     ):
         """
         Create vault specific csi kms connection details
@@ -772,6 +772,11 @@ class Vault(KMS):
         buf["VAULT_TOKEN_NAME"] = get_default_if_keyval_empty(
             config.ENV_DATA, "VAULT_TOKEN_NAME", constants.EXTERNAL_VAULT_CSI_KMS_TOKEN
         )
+        if kv_version == "v1":
+            buf["VAULT_BACKEND"] = "kv"
+        else:
+            buf["VAULT_BACKEND"] = "kv-v2"
+
         csi_kms_conn_details["data"]["1-vault"] = json.dumps(buf)
         csi_kms_conn_details["metadata"]["namespace"] = namespace
         self.create_resource(csi_kms_conn_details, prefix="csikmsconn")

--- a/tests/manage/pv_services/test_rbd_pv_encryption.py
+++ b/tests/manage/pv_services/test_rbd_pv_encryption.py
@@ -79,6 +79,13 @@ class TestRbdPvEncryption(ManageTest):
             vdict[self.new_kmsid] = vdict.pop(old_key)
             vdict[self.new_kmsid]["VAULT_BACKEND_PATH"] = self.vault_resource_name
             vdict[self.new_kmsid]["VAULT_NAMESPACE"] = self.vault_resource_name
+
+            # Workaround for BZ-1997624
+            if kv_version == "v1":
+                vdict[self.new_kmsid]["VAULT_BACKEND"] = "kv"
+            else:
+                vdict[self.new_kmsid]["VAULT_BACKEND"] = "kv-v2"
+
             kms.update_csi_kms_vault_connection_details(vdict)
 
         except CommandFailed as cfe:
@@ -86,7 +93,9 @@ class TestRbdPvEncryption(ManageTest):
                 raise
             else:
                 self.new_kmsid = "1-vault"
-                self.vault.create_vault_csi_kms_connection_details()
+                self.vault.create_vault_csi_kms_connection_details(
+                    kv_version=kv_version
+                )
 
         def finalizer():
             # Remove the vault config from csi-kms-connection-details configMap


### PR DESCRIPTION
Adding VAULT_BACKEND parameter to the csi-kms-connection-details to allow creation of encrypted PVs with the vault namespace functionality
Eng. Bug: [1997624](https://bugzilla.redhat.com/show_bug.cgi?id=1997624)
Signed-off-by: rachael-george <rgeorge@redhat.com>