### PR TITLE
replace object deletion check with timeout sampler

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1082,6 +1082,11 @@ def wait_for_cache(mcg_obj, bucket_name, expected_objects_names=None):
         expected_objects_names (list): Expected objects to be cached
 
     """
+    if expected_objects_names:
+        error_msg = "Objects were not able to cache properly"
+    else:
+        error_msg = "Objects were not deleted from cache properly"
+
     sample = TimeoutSampler(
         timeout=60,
         sleep=10,
@@ -1091,7 +1096,7 @@ def wait_for_cache(mcg_obj, bucket_name, expected_objects_names=None):
         expected_objects_names=expected_objects_names,
     )
     if not sample.wait_for_func_status(result=True):
-        logger.error("Objects were not able to cache properly")
+        logger.error(error_msg)
         raise UnexpectedBehaviour
 
 

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -788,7 +788,7 @@ class TestNamespace(MCGTest):
                     "interface": "OC",
                     "namespace_policy_dict": {
                         "type": "Cache",
-                        "ttl": 1000,
+                        "ttl": 600000,
                         "namespacestore_dict": {
                             "aws": [(1, "eu-central-1")],
                         },
@@ -835,9 +835,8 @@ class TestNamespace(MCGTest):
 
         # Delete the object from mcg interface
         s3_delete_object(mcg_obj, bucket_obj.name, writen_objs_names[0])
-        sleep(1)
-        if not check_cached_objects_by_name(mcg_obj, bucket_obj.name):
-            raise UnexpectedBehaviour("Object was not deleted from cache properly")
+        # Wait for object to be deleted from cache
+        wait_for_cache(mcg_obj, bucket_obj.name)
 
         # Check deletion in the cloud provider
         aws_target_bucket = bucket_obj.bucketclass.namespacestores[0].uls_name


### PR DESCRIPTION
In our recent automation runs `test_delete_cached_object` has been failing over the deletion check performed right after the query to delete the object, from my analysis it looks like we need to give a bit of extra time for the deletion to occur and so i think it would be best to use our existing `wait_for_cache` function to verify the deletion over a period of one minute before failing the test.