### PR TITLE
Configure proxy server for Chrome browser if required

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1379,3 +1379,13 @@ SHA_SEPARATOR = "@sha256:"
 
 # ibmcloud related constants
 IBMCLOUD_VOLUME_NAME = "ibmvolume"
+
+# manifest.json and background.js files used for Chrome extention configuring
+# authenticated proxy, see also:
+# https://botproxy.net/docs/how-to/setting-chromedriver-proxy-auth-with-selenium-using-python/
+CHROME_PROXY_EXTENSION_MANIFEST_JSON_TEMPLATE = os.path.join(
+    "ui", "chrome-proxy-extension-manifest.json.j2"
+)
+CHROME_PROXY_EXTENSION_BACKGROUND_JS_TEMPLATE = os.path.join(
+    "ui", "chrome-proxy-extension-background.js.j2"
+)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1383,9 +1383,9 @@ IBMCLOUD_VOLUME_NAME = "ibmvolume"
 # manifest.json and background.js files used for Chrome extention configuring
 # authenticated proxy, see also:
 # https://botproxy.net/docs/how-to/setting-chromedriver-proxy-auth-with-selenium-using-python/
-CHROME_PROXY_EXTENSION_MANIFEST_JSON_TEMPLATE = os.path.join(
+CHROME_PROXY_EXTENSION_MANIFEST_TEMPLATE = os.path.join(
     "ui", "chrome-proxy-extension-manifest.json.j2"
 )
-CHROME_PROXY_EXTENSION_BACKGROUND_JS_TEMPLATE = os.path.join(
+CHROME_PROXY_EXTENSION_BACKGROUND_TEMPLATE = os.path.join(
     "ui", "chrome-proxy-extension-background.js.j2"
 )

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -350,3 +350,7 @@ class IPAMAssignUpdateFailed(Exception):
 
 class NodeHasNoAttachedVolume(Exception):
     pass
+
+
+class NotSupportedProxyConfiguration(Exception):
+    pass

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -592,6 +592,14 @@ def login_ui():
             chrome_options.add_argument("--headless")
             chrome_options.add_argument("window-size=1920,1400")
 
+        # use proxy, if required
+        if (
+            config.DEPLOYMENT.get("proxy") or config.DEPLOYMENT.get("disconnected")
+        ) and config.ENV_DATA.get("client_http_proxy"):
+            chrome_options.add_argument(
+                f"--proxy-server={config.ENV_DATA.get('client_http_proxy')}"
+            )
+
         chrome_browser_type = ocsci_config.UI_SELENIUM.get("chrome_type")
         driver = webdriver.Chrome(
             ChromeDriverManager(chrome_type=chrome_browser_type).install(),

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -607,7 +607,7 @@ def login_ui():
             # and authenticated proxy server for Chrome:
             # * not authenticated proxy can be configured via --proxy-server
             #   command line parameter
-            # * authenticated proxy have to be provided throught customly
+            # * authenticated proxy have to be provided through customly
             #   created Extension and it doesn't work in headless mode!
             if not client_proxy.username:
                 # not authenticated proxy
@@ -623,10 +623,10 @@ def login_ui():
                 )
                 _templating = Templating()
                 manifest_json = _templating.render_template(
-                    constants.CHROME_PROXY_EXTENSION_MANIFEST_JSON_TEMPLATE, {}
+                    constants.CHROME_PROXY_EXTENSION_MANIFEST_TEMPLATE, {}
                 )
                 background_js = _templating.render_template(
-                    constants.CHROME_PROXY_EXTENSION_BACKGROUND_JS_TEMPLATE,
+                    constants.CHROME_PROXY_EXTENSION_BACKGROUND_TEMPLATE,
                     {"proxy": client_proxy},
                 )
                 pluginfile = "/tmp/proxy_auth_plugin.zip"

--- a/ocs_ci/templates/ui/chrome-proxy-extension-background.js.j2
+++ b/ocs_ci/templates/ui/chrome-proxy-extension-background.js.j2
@@ -1,0 +1,28 @@
+var config = {
+        mode: "fixed_servers",
+        rules: {
+        singleProxy: {
+            scheme: "http",
+            host: "{{proxy.hostname}}",
+            port: parseInt({{proxy.port}})
+        },
+        bypassList: ["localhost"]
+        }
+    };
+
+chrome.proxy.settings.set({value: config, scope: "regular"}, function() {});
+
+function callbackFn(details) {
+    return {
+        authCredentials: {
+            username: "{{proxy.username}}",
+            password: "{{proxy.password}}"
+        }
+    };
+}
+
+chrome.webRequest.onAuthRequired.addListener(
+            callbackFn,
+            {urls: ["<all_urls>"]},
+            ['blocking']
+);

--- a/ocs_ci/templates/ui/chrome-proxy-extension-manifest.json.j2
+++ b/ocs_ci/templates/ui/chrome-proxy-extension-manifest.json.j2
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "manifest_version": 2,
+    "name": "Chrome Authenticated Proxy",
+    "permissions": [
+        "proxy",
+        "tabs",
+        "unlimitedStorage",
+        "storage",
+        "<all_urls>",
+        "webRequest",
+        "webRequestBlocking"
+    ],
+    "background": {
+        "scripts": ["background.js"]
+    },
+    "minimum_chrome_version":"22.0.0"
+}

--- a/ocs_ci/utility/flexy.py
+++ b/ocs_ci/utility/flexy.py
@@ -58,9 +58,11 @@ def load_cluster_info():
         if cluster_info.get("INSTALLER", {}).get("CLIENT_PROXY"):
             client_proxy = cluster_info.get("INSTALLER", {}).get("CLIENT_PROXY")
             logging.info(f"Configuring client proxy: {client_proxy}")
-            config.ENV_DATA["client_http_proxy"] = client_proxy
-            os.environ["http_proxy"] = client_proxy
-            os.environ["https_proxy"] = client_proxy
+            config.ENV_DATA["client_http_proxy"] = config.ENV_DATA.get(
+                "client_http_proxy", client_proxy
+            )
+            os.environ["http_proxy"] = config.ENV_DATA["client_http_proxy"]
+            os.environ["https_proxy"] = config.ENV_DATA["client_http_proxy"]
 
 
 def configure_allowed_domains_in_proxy():


### PR DESCRIPTION
If `ENV_DATA["client_http_proxy"]` parameter is defined, configure proxy server for the Chrome/Chromium browser.

There is a big difference between configuring **not authenticated** and **authenticated** proxy server for Chrome:
* **not authenticated** proxy can be configured via `--proxy-server` command line parameter
* there is no easy way, to configure **authenticated** proxy in Chrome browser via Selenium, the only found solution is creating custom Extension ([see also this page](https://botproxy.net/docs/how-to/setting-chromedriver-proxy-auth-with-selenium-using-python/)). This doesn't work in headless mode!

This PR depends on PR https://github.com/red-hat-storage/ocs-ci/pull/4747.
