### PR TITLE
 "test_multiple_pvc_deletion_measurement_performance" test case impro…

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -700,7 +700,7 @@ def create_multiple_pvcs(
         ocs_objs.append(pvc.PVC(**pvc_data))
 
     logger.info("Creating all PVCs as bulk")
-    oc = OCP(kind="pod", namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    oc = OCP(kind="pod", namespace=namespace)
     cmd = f"create -f {tmpdir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
 

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -11,7 +11,6 @@ import threading
 import statistics
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
-from timeit import default_timer
 
 from ocs_ci.framework.testlib import performance
 from ocs_ci.ocs.perftests import PASTest
@@ -111,7 +110,6 @@ class TestPVCCreationDeletionPerformance(PASTest):
         """
         Create a new project
         """
-        self.start_time = default_timer()
         proj_obj = project_factory()
         self.namespace = proj_obj.namespace
 

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -11,11 +11,12 @@ import threading
 import statistics
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
+from timeit import default_timer
 
 from ocs_ci.framework.testlib import performance
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.helpers import helpers, performance_lib
-from ocs_ci.ocs import defaults, constants
+from ocs_ci.ocs import constants
 from ocs_ci.utility.performance_dashboard import push_to_pvc_time_dashboard
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs.perfresult import PerfResult
@@ -104,6 +105,15 @@ class TestPVCCreationDeletionPerformance(PASTest):
         else:
             self.sc_obj = storageclass_factory(self.interface)
         self.pod_factory = pod_factory
+
+    @pytest.fixture()
+    def namespace(self, project_factory):
+        """
+        Create a new project
+        """
+        self.start_time = default_timer()
+        proj_obj = project_factory()
+        self.namespace = proj_obj.namespace
 
     def init_full_results(self, full_results):
         """
@@ -389,6 +399,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
         ],
     )
     @pytest.mark.usefixtures(base_setup.__name__)
+    @pytest.mark.usefixtures(namespace.__name__)
     @pytest.mark.polarion_id("OCS-2618")
     def test_multiple_pvc_deletion_measurement_performance(self, teardown_factory):
         """
@@ -408,7 +419,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
 
         pvc_objs = helpers.create_multiple_pvcs(
             sc_name=self.sc_obj.name,
-            namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+            namespace=self.namespace,
             number_of_pvc=number_of_pvcs,
             size=pvc_size,
             burst=True,


### PR DESCRIPTION
"test_multiple_pvc_deletion_measurement_performance" test case improvement to create multiple PVCs in seperate namespace instead of openshift-storage namespace.

This will create a new namespace, create 120PVCs in the new name space and once test is completed newly created namespace would be deleted.