### PR TITLE
PR to fix scale pvc expand test

### DIFF
--- a/ocs_ci/ocs/resources/objectconfigfile.py
+++ b/ocs_ci/ocs/resources/objectconfigfile.py
@@ -113,6 +113,17 @@ class ObjectConfFile:
         """
         return self._run_command("delete", namespace)
 
+    def apply(self, namespace=None):
+        """
+        Run ``oc apply`` on in this object file.
+
+        Args:
+            namespace (str): Name of the namespace where to deploy, overriding
+            self.project.namespace value (in a similar way how you can specify
+            any value to ``-n`` option of ``oc apply``.
+        """
+        return self._run_command("apply", namespace)
+
     def get(self, namespace=None):
         """
         Run ``oc get`` on in this object file.

--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -344,7 +344,7 @@ class FioPodScale(object):
             validate_all_expanded_pvc_size_in_kube_job(
                 kube_job_obj=objs,
                 namespace=self.namespace,
-                no_of_pvc=int(len(pvc_objs) / 2),
+                no_of_pvc=int(len(pvc_objs) / len(kube_job_objs)),
                 resize_value=pvc_new_size,
             )
 
@@ -1658,14 +1658,14 @@ def validate_all_expanded_pvc_size_in_kube_job(
         If not all PVC has the extended size.
 
     """
-    # Check all the PVC reached Bound state
+    # Check all the PVC extended size
     pvc_extended_list, pvc_not_extended_list = ([] for i in range(2))
     while_iteration_count = 0
     while True:
         # Get kube_job obj and fetch either all PVC size are extended
         # If not extended adding those PVCs to pvc_not_extended_list
         job_get_output = kube_job_obj.get(namespace=namespace)
-        for i in range(no_of_pvc):
+        for i in range(0, no_of_pvc):
             pvc_size = job_get_output["items"][i]["status"]["capacity"]["storage"]
             logging.info(
                 f"pvc {job_get_output['items'][i]['metadata']['name']} size {pvc_size}"

--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -1649,10 +1649,10 @@ def validate_all_expanded_pvc_size_in_kube_job(
         namespace (str): Namespace of PVC's created
         no_of_pvc (int): Bulk PVC count
         resize_value (int): Updated/extended PVC size
-        timeout: a timeout for all the pvc in kube job to reach bound status
+        timeout: a timeout for all the pvc in kube job to get extended size
 
     Returns:
-        pvc_extended_list (list): List of all PVCs which is in Bound state.
+        pvc_extended_list (list): List of all PVCs which have extended size.
 
     Asserts:
         If not all PVC has the extended size.
@@ -1663,7 +1663,7 @@ def validate_all_expanded_pvc_size_in_kube_job(
     while_iteration_count = 0
     while True:
         # Get kube_job obj and fetch either all PVC size are extended
-        # If not bound adding those PVCs to pvc_not_bound_list
+        # If not extended adding those PVCs to pvc_not_extended_list
         job_get_output = kube_job_obj.get(namespace=namespace)
         for i in range(no_of_pvc):
             pvc_size = job_get_output["items"][i]["status"]["capacity"]["storage"]
@@ -1675,8 +1675,8 @@ def validate_all_expanded_pvc_size_in_kube_job(
                     job_get_output["items"][i]["metadata"]["name"]
                 )
 
-        # Check the length of pvc_not_bound_list to decide either all PVCs size extended
-        # If not then wait for timeout secs and re-iterate while loop
+        # Check the length of pvc_not_extended_list to decide either all PVCs
+        # size extended If not then wait for timeout secs and re-iterate while loop
         if len(pvc_not_extended_list):
             time.sleep(timeout)
             while_iteration_count += 1

--- a/tests/e2e/scale/test_scale_pvc_expand.py
+++ b/tests/e2e/scale/test_scale_pvc_expand.py
@@ -15,7 +15,7 @@ from ocs_ci.utility import utils
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def resize_pvc(request):
     # Setup scale environment in the cluster
     resize_pvc = FioPodScale(

--- a/tests/e2e/scale/test_scale_pvc_expand.py
+++ b/tests/e2e/scale/test_scale_pvc_expand.py
@@ -56,11 +56,12 @@ class TestPVCExpand(E2ETest):
         Test case to scale pvc size expansion
         with and without IO running on the pods
         """
+
         # Create pvcs and scale pods
         logging.info("Create pvcs and scale pods")
         resize_pvc.create_scale_pods(
             scale_count=1500,
-            pods_per_iter=10,
+            pvc_per_pod_count=20,
             io_runtime=3600,
             start_io=start_io,
             pvc_size=pvc_size,

--- a/tests/e2e/scale/test_scale_pvc_expand.py
+++ b/tests/e2e/scale/test_scale_pvc_expand.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.testlib import (
     scale,
     ignore_leftovers,
     skipif_ocs_version,
+    skipif_external_mode,
+    ipi_deployment_required,
 )
 from ocs_ci.ocs.scale_lib import FioPodScale
 from ocs_ci.utility import utils
@@ -18,7 +20,6 @@ def resize_pvc(request):
     # Setup scale environment in the cluster
     resize_pvc = FioPodScale(
         kind=constants.POD,
-        pod_dict_path=constants.NGINX_POD_YAML,
         node_selector=constants.SCALE_NODE_SELECTOR,
     )
 
@@ -32,10 +33,8 @@ def resize_pvc(request):
 @scale
 @skipif_ocs_version("<4.5")
 @ignore_leftovers
-@pytest.mark.skip(
-    reason="Skipped due to scale_lib pod creations are "
-    "enhanced to use kube_job, TC needs update"
-)
+@skipif_external_mode
+@ipi_deployment_required
 @pytest.mark.parametrize(
     argnames=[
         "start_io",


### PR DESCRIPTION
Existing Scale Pvc expand test is skipped due to changes in scale_lib function for memory issue.
with the changes/enhancements in this PR code will support pvc_expand tests and other tests
we should not observe any memory failures since code is using kube_job for creating PVCs and PODs

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>