### PR TITLE
Force delete storage when destroy IBM Cloud cluster

### DIFF
--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -210,7 +210,7 @@ def destroy_cluster(cluster):
         cluster (str): Cluster name or ID.
 
     """
-    cmd = f"ibmcloud ks cluster rm -c {cluster} -f"
+    cmd = f"ibmcloud ks cluster rm -c {cluster} -f --force-delete-storage"
     out = run_ibmcloud_cmd(cmd)
     logger.info(f"Destroy command output: {out}")
 


### PR DESCRIPTION
This commit should fix the issue of volume leftovers in
IBM Cloud.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>