### PR TITLE
Skip tests if flexy deployment

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -262,6 +262,11 @@ skipif_tainted_nodes = pytest.mark.skipif(
     reason="Test will not run if nodes are tainted",
 )
 
+skipif_flexy_deployment = pytest.mark.skipif(
+    config.ENV_DATA.get("flexy_deployment"),
+    reason="This test doesn't work correctly on OCP cluster deployed via Flexy",
+)
+
 metrics_for_external_mode_required = pytest.mark.skipif(
     float(config.ENV_DATA["ocs_version"]) < 4.6
     and config.DEPLOYMENT.get("external_mode") is True,

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -2,11 +2,16 @@ import logging
 
 from ocs_ci.framework.testlib import tier1, ignore_leftovers, ManageTest
 from ocs_ci.ocs.cluster import CephCluster
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_openshift_dedicated,
+    skipif_flexy_deployment,
+)
 
 logger = logging.getLogger(__name__)
 
 
+# https://github.com/red-hat-storage/ocs-ci/issues/4802
+@skipif_flexy_deployment
 @skipif_openshift_dedicated
 @ignore_leftovers
 @tier1

--- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import skipif_flexy_deployment
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
 from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
@@ -9,6 +10,8 @@ from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
 logger = logging.getLogger(__name__)
 
 
+# https://github.com/red-hat-storage/ocs-ci/issues/4802
+@skipif_flexy_deployment
 @tier1
 @pytest.mark.polarion_id("OCS-2490")
 @pytest.mark.bugzilla("1794389")


### PR DESCRIPTION
Tests `test_add_ocs_node` and `test_ceph_csidriver_runs_on_non_ocs_nodes` are not compatible with OCP cluster installed via flexy, because of the way how terraform is used in Flexy for the OCP installation.

Created issue https://github.com/red-hat-storage/ocs-ci/issues/4802 for that, but the fix is not easy, so I would propose to skip those two tests for now.
