### PR TITLE
Restore snapshot to different pool

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -95,35 +95,43 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
                 timeout=180,
             )
 
-        # Create storage classes
+        # Create storage classes. Create two RBD storage class.
+        # One storage class will use new pool to verify the bug 1901954
         sc_objs = {
-            constants.CEPHBLOCKPOOL: storageclass_factory(
-                interface=constants.CEPHBLOCKPOOL
-            ).name,
-            constants.CEPHFILESYSTEM: storageclass_factory(
-                interface=constants.CEPHFILESYSTEM
-            ).name,
+            constants.CEPHBLOCKPOOL: [
+                storageclass_factory(
+                    interface=constants.CEPHBLOCKPOOL,
+                ).name,
+                storageclass_factory(
+                    interface=constants.CEPHBLOCKPOOL, new_rbd_pool=True
+                ).name,
+            ],
+            constants.CEPHFILESYSTEM: [
+                storageclass_factory(interface=constants.CEPHFILESYSTEM).name
+            ],
         }
 
         # Create PVCs out of the snapshots
         restore_pvc_objs = []
         log.info("Creating new PVCs from snapshots")
         for snap_obj in snap_objs:
-            log.info(f"Creating a PVC from snapshot {snap_obj.name}")
-            restore_pvc_obj = snapshot_restore_factory(
-                snapshot_obj=snap_obj,
-                storageclass=sc_objs[snap_obj.interface],
-                size=f"{self.pvc_size}Gi",
-                volume_mode=snap_obj.parent_volume_mode,
-                access_mode=snap_obj.parent_access_mode,
-                status="",
-            )
+            for storageclass in sc_objs[snap_obj.interface]:
+                log.info(f"Creating a PVC from snapshot {snap_obj.name}")
+                restore_pvc_obj = snapshot_restore_factory(
+                    snapshot_obj=snap_obj,
+                    storageclass=storageclass,
+                    size=f"{self.pvc_size}Gi",
+                    volume_mode=snap_obj.parent_volume_mode,
+                    access_mode=snap_obj.parent_access_mode,
+                    status="",
+                )
 
-            log.info(
-                f"Created PVC {restore_pvc_obj.name} from snapshot {snap_obj.name}"
-            )
-            restore_pvc_obj.md5sum = snap_obj.md5sum
-            restore_pvc_objs.append(restore_pvc_obj)
+                log.info(
+                    f"Created PVC {restore_pvc_obj.name} from snapshot {snap_obj.name}."
+                    f"Used the storage class {storageclass}"
+                )
+                restore_pvc_obj.md5sum = snap_obj.md5sum
+                restore_pvc_objs.append(restore_pvc_obj)
         log.info("Created new PVCs from all the snapshots")
 
         # Confirm that the restored PVCs are Bound


### PR DESCRIPTION
Test case test_snapshot_restore_using_different_sc is updated to use a storage class using different pool. This will verify the bug 1901954.
Signed-off-by: Jilju Joy <jijoy@redhat.com>