### PR TITLE
Adding bulk deletion functions and functionality, adding parametrization of bulk size 

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -786,6 +786,7 @@ def delete_bulk_pvcs(pvc_yaml_dir):
     cmd = f"delete -f {pvc_yaml_dir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
 
+
 def verify_block_pool_exists(pool_name):
     """
     Verify if a Ceph block pool exist

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -778,10 +778,10 @@ def create_bulk_pvcs(
 
 def delete_bulk_pvcs(pvc_yaml_dir):
     """
-       Deletes all the pvcs created from yaml file in a provided dir
-       Args:
-           pvc_yaml_dir (str): Directory in which yaml file resides
-       """
+    Deletes all the pvcs created from yaml file in a provided dir
+    Args:
+        pvc_yaml_dir (str): Directory in which yaml file resides
+    """
     oc = OCP(kind="pod", namespace=defaults.ROOK_CLUSTER_NAMESPACE)
     cmd = f"delete -f {pvc_yaml_dir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -728,7 +728,7 @@ def delete_bulk_pvcs(pvc_yaml_dir, pv_names_list):
     cmd = f"delete -f {pvc_yaml_dir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
 
-    time.sleep(500)
+    time.sleep(len(pv_names_list) / 2)
 
     for pv_name in pv_names_list:
         validate_pv_delete(pv_name)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -716,6 +716,76 @@ def create_multiple_pvcs(
     return ocs_objs
 
 
+def create_bulk_pvcs(
+    sc_name,
+    namespace,
+    number_of_pvc=1,
+    size=None,
+    access_mode=constants.ACCESS_MODE_RWO,
+):
+    """
+    Create one or more PVC as a bulk or one by one
+    Args:
+        sc_name (str): The name of the storage class to provision the PVCs from
+        namespace (str): The namespace for the PVCs creation
+        number_of_pvc (int): Number of PVCs to be created
+        size (str): The size of the PVCs to create
+        do_reload (bool): True for wait for reloading PVC after its creation,
+            False otherwise
+        access_mode (str): The kind of access mode for PVC
+    Returns:
+         list: List of PVC objects and tmp dir where the yamls are created
+    """
+
+    pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
+    pvc_data["metadata"]["namespace"] = namespace
+    pvc_data["spec"]["accessModes"] = [access_mode]
+    pvc_data["spec"]["storageClassName"] = sc_name
+    if size:
+        pvc_data["spec"]["resources"]["requests"]["storage"] = size
+    if access_mode == "ReadWriteMany" and "rbd" in sc_name:
+        pvc_data["spec"]["volumeMode"] = "Block"
+    else:
+        pvc_data["spec"]["volumeMode"] = None
+
+    # Creating tem directory to hold the files for the PVC creation
+    tmpdir = tempfile.mkdtemp()
+    logger.info("Creating the PVC yaml files for creation in bulk")
+    ocs_objs = []
+    for _ in range(number_of_pvc):
+        name = create_unique_resource_name("test", "pvc")
+        logger.info(f"Adding PVC with name {name}")
+        pvc_data["metadata"]["name"] = name
+        templating.dump_data_to_temp_yaml(pvc_data, f"{tmpdir}/{name}.yaml")
+        ocs_objs.append(pvc.PVC(**pvc_data))
+
+    logger.info("Creating all PVCs as bulk")
+    oc = OCP(kind="pod", namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    cmd = f"create -f {tmpdir}/"
+    oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
+
+    # Letting the system 1 sec for each PVC to create.
+    # this will prevent any other command from running in the system in this
+    # period of time.
+    logger.info(
+        f"Going to sleep for {number_of_pvc} sec. "
+        "until starting verify that PVCs was created."
+    )
+    time.sleep(number_of_pvc)
+
+    return ocs_objs, tmpdir
+
+
+def delete_bulk_pvcs(pvc_yaml_dir):
+    """
+       Deletes all the pvcs created from yaml file in a provided dir
+       Args:
+           pvc_yaml_dir (str): Directory in which yaml file resides
+       """
+    oc = OCP(kind="pod", namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    cmd = f"delete -f {pvc_yaml_dir}/"
+    oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
+
 def verify_block_pool_exists(pool_name):
     """
     Verify if a Ceph block pool exist
@@ -1374,6 +1444,47 @@ def get_provision_time(interface, pvc_name, status="start"):
             stat = all_stats[-1]  # return the highest time
         elif status.lower() == "start":
             stat = all_stats[0]  # return the lowest time
+    return datetime.datetime.strptime(stat, DATE_TIME_FORMAT)
+
+
+def get_pvc_bulk_deletion_time(interface, pv_names, status="start"):
+    """
+    Get the deletion time of PVC bulk based on csi provisioner logs
+    Args:
+        interface (str): The interface backed the PVC
+        pv_names (list): Names of the PVs which are backend objects for PVCs deleted
+        status (str): the status that we want to get - start / end time of bulk deletion
+    Returns:
+        datetime object: The time of bulk pvc deletion
+    """
+
+    # Define the operation that need to retrieve
+    operation = "started"
+    if status.lower() == "end":
+        operation = "succeeded"
+
+    this_year = str(datetime.datetime.now().year)
+    # Get the correct provisioner pod based on the interface
+    pod_name = pod.get_csi_provisioner_pod(interface)
+    # get the logs from the csi-provisioner containers
+    logs = pod.get_pod_logs(pod_name[0], "csi-provisioner")
+    logs += pod.get_pod_logs(pod_name[1], "csi-provisioner")
+
+    logs = logs.split("\n")
+
+    all_stats = []
+    for pv_name in pv_names:
+        stat = [i for i in logs if re.search(f'delete "{pv_name}".*{operation}', i)]
+        mon_day = " ".join(stat[0].split(" ")[0:2])
+        stat = f"{this_year} {mon_day}"
+        all_stats.append(stat)
+
+    all_stats = sorted(all_stats)
+    if status.lower() == "end":
+        stat = all_stats[-1]  # return the latest time
+    elif status.lower() == "start":
+        stat = all_stats[0]  # return the earliest time
+
     return datetime.datetime.strptime(stat, DATE_TIME_FORMAT)
 
 

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -730,9 +730,8 @@ def create_bulk_pvcs(
         namespace (str): The namespace for the PVCs creation
         number_of_pvc (int): Number of PVCs to be created
         size (str): The size of the PVCs to create
-        do_reload (bool): True for wait for reloading PVC after its creation,
-            False otherwise
         access_mode (str): The kind of access mode for PVC
+
     Returns:
          list: List of PVC objects and tmp dir where the yamls are created
     """

--- a/tests/e2e/performance/test_pvc_bulk_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_bulk_creation_deletion_performance.py
@@ -39,19 +39,19 @@ class TestPVCCreationPerformance(E2ETest):
         argnames=["interface_type", "bulk_size"],
         argvalues=[
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 480],
+                *[constants.CEPHBLOCKPOOL, 60],
                 marks=[pytest.mark.performance],
             ),
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 720],
+                *[constants.CEPHBLOCKPOOL, 240],
                 marks=[pytest.mark.performance],
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 120],
+                *[constants.CEPHFILESYSTEM, 60],
                 marks=[pytest.mark.performance],
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 720],
+                *[constants.CEPHFILESYSTEM, 240],
                 marks=[pytest.mark.performance],
             ),
         ],
@@ -146,10 +146,10 @@ class TestPVCCreationPerformance(E2ETest):
     @pytest.mark.usefixtures(base_setup_creation_after_deletion.__name__)
     @polarion_id("OCS-1270")
     @bugzilla("1741612")
-    def test_multiple_pvc_creation_after_deletion_performance(self, teardown_factory):
+    def test_bulk_pvc_creation_after_deletion_performance(self, teardown_factory):
         """
-        Measuring PVC creation time of 75% of initial PVCs (120) in the same
-        rate after deleting 75% of the initial PVCs.
+        Measuring PVC creation time of bulk of 75% of initial PVC bulk (120) in the same
+        rate after deleting ( serial deletion) 75% of the initial PVCs.
 
         Args:
             teardown_factory: A fixture used when we want a new resource that was created during the tests
@@ -160,7 +160,7 @@ class TestPVCCreationPerformance(E2ETest):
         initial_number_of_pvcs = 120
         number_of_pvcs = math.ceil(initial_number_of_pvcs * 0.75)
 
-        log.info("Start creating new 120 PVCs")
+        log.info(f"Start creating new {initial_number_of_pvcs} PVCs in a bulk")
         pvc_objs = helpers.create_multiple_pvcs(
             sc_name=self.sc_obj.name,
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -415,7 +415,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
 
         log.info(f"{msg_prefix} Start creating new 120 PVCs")
 
-        pvc_objs,_ = helpers.create_multiple_pvcs(
+        pvc_objs, _ = helpers.create_multiple_pvcs(
             sc_name=self.sc_obj.name,
             namespace=self.namespace,
             number_of_pvc=number_of_pvcs,

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -421,7 +421,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
             number_of_pvc=number_of_pvcs,
             size=pvc_size,
             burst=True,
-        )
+        )[0]
 
         for pvc_obj in pvc_objs:
             pvc_obj.reload()

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -415,13 +415,13 @@ class TestPVCCreationDeletionPerformance(PASTest):
 
         log.info(f"{msg_prefix} Start creating new 120 PVCs")
 
-        pvc_objs = helpers.create_multiple_pvcs(
+        pvc_objs,_ = helpers.create_multiple_pvcs(
             sc_name=self.sc_obj.name,
             namespace=self.namespace,
             number_of_pvc=number_of_pvcs,
             size=pvc_size,
             burst=True,
-        )[0]
+        )
 
         for pvc_obj in pvc_objs:
             pvc_obj.reload()

--- a/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
@@ -4,7 +4,6 @@ Test to verify PVC creation performance
 import logging
 import pytest
 import math
-import time
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
 from concurrent.futures import ThreadPoolExecutor

--- a/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
@@ -40,7 +40,7 @@ class TestPVCCreationPerformance(E2ETest):
         argnames=["interface_type", "bulk_size"],
         argvalues=[
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 60],
+                *[constants.CEPHBLOCKPOOL, 120],
                 marks=[pytest.mark.performance],
             ),
             pytest.param(
@@ -48,7 +48,7 @@ class TestPVCCreationPerformance(E2ETest):
                 marks=[pytest.mark.performance],
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 60],
+                *[constants.CEPHFILESYSTEM, 120],
                 marks=[pytest.mark.performance],
             ),
             pytest.param(

--- a/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 @performance
 class TestPVCCreationPerformance(E2ETest):
     """
-    Test to verify PVC creation performance
+    Test to verify PVC creation and deletion performance
     """
 
     pvc_size = "1Gi"
@@ -63,7 +63,7 @@ class TestPVCCreationPerformance(E2ETest):
     ):
 
         """
-        Measuring PVC creation time of 120 PVCs in 180 seconds
+        Measuring PVC creation and deletion time of bulk_size (120/720) PVCs
 
         Args:
             teardown_factory: A fixture used when we want a new resource that was created during the tests
@@ -72,7 +72,7 @@ class TestPVCCreationPerformance(E2ETest):
         Returns:
 
         """
-        multi_creation_time_limit = bulk_size / 2
+        bulk_creation_time_limit = bulk_size / 2
         log.info(f"Start creating new {bulk_size} PVCs")
 
         pvc_objs, yaml_creation_dir = helpers.create_bulk_pvcs(
@@ -101,10 +101,10 @@ class TestPVCCreationPerformance(E2ETest):
         total_time = (end_time - start_time).total_seconds()
         logging.info(f"{bulk_size} Bulk PVCs creation time is {total_time} seconds.")
 
-        if total_time > multi_creation_time_limit:
+        if total_time > bulk_creation_time_limit:
             raise ex.PerformanceException(
                 f"{bulk_size} Bulk PVCs creation time is {total_time} and "
-                f"greater than {multi_creation_time_limit} seconds"
+                f"greater than {bulk_creation_time_limit} seconds"
             )
 
         logging.info(f"Starting to delete bulk of {bulk_size} PVCs")

--- a/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_multiple_creation_deletion_performance.py
@@ -4,6 +4,7 @@ Test to verify PVC creation performance
 import logging
 import pytest
 import math
+import time
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
 from concurrent.futures import ThreadPoolExecutor
@@ -23,7 +24,114 @@ class TestPVCCreationPerformance(E2ETest):
     pvc_size = "1Gi"
 
     @pytest.fixture()
-    def base_setup(self, request, interface_iterate, storageclass_factory):
+    def base_setup(self, interface_type, storageclass_factory):
+        """
+        A setup phase for the test
+
+        Args:
+            interface_type: Interface type
+            storageclass_factory: A fixture to create everything needed for a
+                storageclass
+        """
+        self.interface = interface_type
+        self.sc_obj = storageclass_factory(self.interface)
+
+    @pytest.mark.parametrize(
+        argnames=["interface_type", "bulk_size"],
+        argvalues=[
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL, 60],
+                marks=[pytest.mark.performance],
+            ),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL, 720],
+                marks=[pytest.mark.performance],
+            ),
+            pytest.param(
+                *[constants.CEPHFILESYSTEM, 60],
+                marks=[pytest.mark.performance],
+            ),
+            pytest.param(
+                *[constants.CEPHFILESYSTEM, 720],
+                marks=[pytest.mark.performance],
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures(base_setup.__name__)
+    @polarion_id("OCS-1620")
+    def test_bulk_pvc_creation_deletion_measurement_performance(
+        self, teardown_factory, bulk_size
+    ):
+
+        """
+        Measuring PVC creation time of 120 PVCs in 180 seconds
+
+        Args:
+            teardown_factory: A fixture used when we want a new resource that was created during the tests
+                               to be removed in the teardown phase.
+            bulk_size: Size of the bulk to be tested
+        Returns:
+
+        """
+        multi_creation_time_limit = bulk_size / 2
+        log.info(f"Start creating new {bulk_size} PVCs")
+
+        pvc_objs, yaml_creation_dir = helpers.create_bulk_pvcs(
+            sc_name=self.sc_obj.name,
+            namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+            number_of_pvc=bulk_size,
+            size=self.pvc_size,
+        )
+        logging.info(f"PVC creation dir is {yaml_creation_dir}")
+
+        for pvc_obj in pvc_objs:
+            pvc_obj.reload()
+            teardown_factory(pvc_obj)
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            for pvc_obj in pvc_objs:
+                executor.submit(
+                    helpers.wait_for_resource_state, pvc_obj, constants.STATUS_BOUND
+                )
+
+                executor.submit(pvc_obj.reload)
+
+        start_time = helpers.get_provision_time(
+            self.interface, pvc_objs, status="start"
+        )
+        end_time = helpers.get_provision_time(self.interface, pvc_objs, status="end")
+        total_time = (end_time - start_time).total_seconds()
+        logging.info(f"{bulk_size} Bulk PVCs creation time is {total_time} seconds.")
+
+        if total_time > multi_creation_time_limit:
+            raise ex.PerformanceException(
+                f"{bulk_size} Bulk PVCs creation time is {total_time} and "
+                f"greater than {multi_creation_time_limit} seconds"
+            )
+
+        logging.info(f"Starting to delete bulk of {bulk_size} PVCs")
+        helpers.delete_bulk_pvcs(yaml_creation_dir)
+        logging.info(f"Deletion of bulk of {bulk_size} PVCs successfully completed")
+
+        pv_names_list = []
+        for pvc_obj in pvc_objs:
+            pv_names_list.append(pvc_obj.backed_pv)
+
+        start_deletion_time = helpers.get_pvc_bulk_deletion_time(
+            self.interface, pv_names_list, status="start"
+        )
+        end_deletion_time = helpers.get_pvc_bulk_deletion_time(
+            self.interface, pv_names_list, status="end"
+        )
+
+        total_deletion_time = (end_deletion_time - start_deletion_time).total_seconds()
+        logging.info(
+            f"{bulk_size} Bulk PVCs deletion time is {total_deletion_time} seconds."
+        )
+
+    @pytest.fixture()
+    def base_setup_creation_after_deletion(
+        self, interface_iterate, storageclass_factory
+    ):
         """
         A setup phase for the test
 
@@ -35,66 +143,7 @@ class TestPVCCreationPerformance(E2ETest):
         self.interface = interface_iterate
         self.sc_obj = storageclass_factory(self.interface)
 
-    # @pytest.mark.parametrize(
-    #     argnames=["pvc_size"],
-    #     argvalues=[
-    #         pytest.param(*["1Gi"], marks=pytest.mark.polarion_id("OCS-1225")),
-    #         pytest.param(*["10Gi"], marks=pytest.mark.polarion_id("OCS-2010")),
-    #         pytest.param(*["100Gi"], marks=pytest.mark.polarion_id("OCS-2011")),
-    #         pytest.param(*["1Ti"], marks=pytest.mark.polarion_id("OCS-2008")),
-    #         pytest.param(*["2Ti"], marks=pytest.mark.polarion_id("OCS-2009")),
-    #     ],
-    # )
-
-    @pytest.mark.usefixtures(base_setup.__name__)
-    @polarion_id("OCS-1620")
-    def test_multiple_pvc_creation_measurement_performance(self, teardown_factory):
-        """
-        Measuring PVC creation time of 120 PVCs in 180 seconds
-
-        Args:
-            teardown_factory: A fixture used when we want a new resource that was created during the tests
-                               to be removed in the teardown phase.
-        Returns:
-
-        """
-        number_of_pvcs = 120
-        multi_creation_time_limit = 60
-        log.info("Start creating new 120 PVCs")
-
-        pvc_objs = helpers.create_multiple_pvcs(
-            sc_name=self.sc_obj.name,
-            namespace=defaults.ROOK_CLUSTER_NAMESPACE,
-            number_of_pvc=number_of_pvcs,
-            size=self.pvc_size,
-            burst=True,
-        )
-        for pvc_obj in pvc_objs:
-            pvc_obj.reload()
-            teardown_factory(pvc_obj)
-        with ThreadPoolExecutor(max_workers=5) as executor:
-            for pvc_obj in pvc_objs:
-                executor.submit(
-                    helpers.wait_for_resource_state, pvc_obj, constants.STATUS_BOUND
-                )
-
-                executor.submit(pvc_obj.reload)
-        start_time = helpers.get_provision_time(
-            self.interface, pvc_objs, status="start"
-        )
-        end_time = helpers.get_provision_time(self.interface, pvc_objs, status="end")
-        total = end_time - start_time
-        total_time = total.total_seconds()
-        logging.info(f"{number_of_pvcs} PVCs creation time is {total_time} seconds.")
-
-        if total_time > 60:
-            raise ex.PerformanceException(
-                f"{number_of_pvcs} PVCs creation time is {total_time} and "
-                f"greater than {multi_creation_time_limit} seconds"
-            )
-        logging.info(f"{number_of_pvcs} PVCs creation time took {total_time} seconds")
-
-    @pytest.mark.usefixtures(base_setup.__name__)
+    @pytest.mark.usefixtures(base_setup_creation_after_deletion.__name__)
     @polarion_id("OCS-1270")
     @bugzilla("1741612")
     def test_multiple_pvc_creation_after_deletion_performance(self, teardown_factory):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -235,12 +235,12 @@ def create_pvcs(request):
 
     request.addfinalizer(finalizer)
 
-    class_instance.pvc_objs = helpers.create_multiple_pvcs(
+    class_instance.pvc_objs,_ = helpers.create_multiple_pvcs(
         sc_name=class_instance.sc_obj.name,
         number_of_pvc=class_instance.num_of_pvcs,
         size=class_instance.pvc_size,
         namespace=class_instance.namespace,
-    )[0]
+    )
     for pvc_obj in class_instance.pvc_objs:
         helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
         pvc_obj.reload()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -235,7 +235,7 @@ def create_pvcs(request):
 
     request.addfinalizer(finalizer)
 
-    class_instance.pvc_objs,_ = helpers.create_multiple_pvcs(
+    class_instance.pvc_objs, _ = helpers.create_multiple_pvcs(
         sc_name=class_instance.sc_obj.name,
         number_of_pvc=class_instance.num_of_pvcs,
         size=class_instance.pvc_size,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -240,7 +240,7 @@ def create_pvcs(request):
         number_of_pvc=class_instance.num_of_pvcs,
         size=class_instance.pvc_size,
         namespace=class_instance.namespace,
-    )
+    )[0]
     for pvc_obj in class_instance.pvc_objs:
         helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
         pvc_obj.reload()


### PR DESCRIPTION
Signed-off-by: Yulia Persky <ypersky@redhat.com>

The content of this PR: 

1) Adding Bulk Delete functionality 
2) Adding parametrization of bulk size 
Please note that It was decided to parametrize bulk size to 2 values: 120 and 720 . 
It is possible to add additional  bulk size test cases, but it will cause the test to run for additional hours. 
Since our goal is to have this test as rather short test ( in terms of run time) - it was chosen to have only 2 bulk sizes as a parameter. 
120 - for backward compatibility with Performance results in the previous versions ( for bulk creation) 
720 - since this is close to the maximal bulk size tested on 3 masters and 2 workers cluster and a multiplication of 120 ( 720 = 120*6). 
We would like to compare the 120 and 720 bulk size results and make sure that 720 bulk creation/time is not more than 6 time 
120 bulk creation /deletion time. 
