### PR TITLE
Enhancement to "test_pv_scale_and_respin_ceph_pods" test with additional resource types

### DIFF
--- a/tests/e2e/performance/test_fio_benchmark.py
+++ b/tests/e2e/performance/test_fio_benchmark.py
@@ -494,6 +494,7 @@ class TestFIOBenchmark(PASTest):
             pytest.param(*["sequential", "16KiB", 60]),
         ],
     )
+    @pytest.mark.polarion_id("OCS-2617")
     def test_fio_compressed_workload(
         self, storageclass_factory, io_pattern, bs, cmp_ratio
     ):

--- a/tests/e2e/performance/test_pvc_bulk_clone_performance.py
+++ b/tests/e2e/performance/test_pvc_bulk_clone_performance.py
@@ -31,6 +31,7 @@ class TestBulkCloneCreation(E2ETest):
         self.interface = interface_iterate
 
     @pytest.mark.usefixtures(namespace.__name__)
+    @pytest.mark.polarion_id("OCS-2621")
     def test_bulk_clone_performance(self, namespace, tmp_path, pod_factory):
         """
         Creates number of PVCs in a bulk using kube job

--- a/tests/e2e/performance/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_creation_deletion_performance.py
@@ -389,6 +389,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
         ],
     )
     @pytest.mark.usefixtures(base_setup.__name__)
+    @pytest.mark.polarion_id("OCS-2618")
     def test_multiple_pvc_deletion_measurement_performance(self, teardown_factory):
         """
         Measuring PVC deletion time of 120 PVCs in 180 seconds

--- a/tests/e2e/performance/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/test_pvc_multi_clone_performance.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 
 import yaml
+import pytest
 
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,

--- a/tests/e2e/performance/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/test_pvc_multi_clone_performance.py
@@ -29,6 +29,7 @@ class TestPvcMultiClonePerformance(E2ETest):
     The test is supposed to create the maximum number of clones for one PVC
     """
 
+    @pytest.mark.polarion_id("OCS-2622")
     def test_pvc_multiple_clone_performance(
         self,
         interface_iterate,

--- a/tests/e2e/performance/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_multi_snapshot_performance.py
@@ -2,6 +2,8 @@ import os
 import logging
 import subprocess
 
+import pytest
+
 from ocs_ci.ocs import constants, exceptions
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.utility.utils import ocsci_log_path
@@ -24,6 +26,7 @@ class TestPvcMultiSnapshotPerformance(E2ETest):
     The test is trying to to take the maximum number of snapshot for one PVC
     """
 
+    @pytest.mark.polarion_id("OCS-2623")
     def test_pvc_multiple_snapshot_performance(
         self,
         interface_iterate,

--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -346,21 +346,27 @@ class TestPvcSnapshotPerformance(E2ETest):
         argvalues=[
             pytest.param(
                 *[32, 125000, 8, constants.CEPHBLOCKPOOL],
+                marks=[pytest.mark.polarion_id("OCS-2624")],
             ),
             pytest.param(
                 *[16, 250000, 8, constants.CEPHBLOCKPOOL],
+                marks=[pytest.mark.polarion_id("OCS-2624")],
             ),
             pytest.param(
                 *[8, 500000, 8, constants.CEPHBLOCKPOOL],
+                marks=[pytest.mark.polarion_id("OCS-2624")],
             ),
             pytest.param(
                 *[32, 125000, 8, constants.CEPHFILESYSTEM],
+                marks=[pytest.mark.polarion_id("OCS-2625")],
             ),
             pytest.param(
                 *[16, 250000, 8, constants.CEPHFILESYSTEM],
+                marks=[pytest.mark.polarion_id("OCS-2625")],
             ),
             pytest.param(
                 *[8, 500000, 8, constants.CEPHFILESYSTEM],
+                marks=[pytest.mark.polarion_id("OCS-2625")],
             ),
         ],
     )

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -104,7 +104,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
         delete_resource functions checks for the deleted pod back up and running
 
         Args:
-            resource_to_delete (str): Ceph resource type to be deleted, eg: mgr/mon/osd/mds
+            resource_to_delete (str): Ceph resource type to be deleted, eg: mgr/mon/osd/mds/rbdplugin_provisioner/cephfsplugin_provisioner/cephfsplugin/rbdplugin/operator
         """
         disruption = disruption_helpers.Disruptions()
         disruption.set_resource(resource=resource_to_delete)
@@ -132,6 +132,11 @@ class BasePvcCreateRespinCephPods(E2ETest):
         pytest.param(*["mon"], marks=[pytest.mark.polarion_id("OCS-764")]),
         pytest.param(*["osd"], marks=[pytest.mark.polarion_id("OCS-765")]),
         pytest.param(*["mds"], marks=[pytest.mark.polarion_id("OCS-613")]),
+        pytest.param(*["rbdplugin_provisioner"], marks=[pytest.mark.polarion_id("OCS-2639")]),
+        pytest.param(*["cephfsplugin_provisioner"], marks=[pytest.mark.polarion_id("OCS-2641")]),
+        pytest.param(*["cephfsplugin"], marks=[pytest.mark.polarion_id("OCS-2642")]),
+        pytest.param(*["rbdplugin"], marks=[pytest.mark.polarion_id("OCS-2643")]),
+        pytest.param(*["operator"], marks=[pytest.mark.polarion_id("OCS-2640")]),
     ],
 )
 class TestPVSTOcsCreatePVCsAndRespinCephPods(BasePvcCreateRespinCephPods):


### PR DESCRIPTION
Enhancement to "test_pv_scale_and_respin_ceph_pods". Apart from existing four resource type (mgr, mon, osd and mds) in ceph resource types, additional resource types are added (rbdplugin_provisioner, cephfsplugin_provisioner, cephfsplugin, rbdplugin and operator)