### PR TITLE
Enhancement to "test_pv_scale_and_respin_ceph_pods" test with additional resource types

### DIFF
--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -105,7 +105,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
 
         Args:
             resource_to_delete (str): Ceph resource type to be deleted.
-            eg: mgr/mon/osd/mds/cephfsplugin/rbdplugin/cephfsplugin_provisioner/rbdplugin_provisioner/operator
+            eg: mgr/mon/osd/mds/cephfsplugin/rbdplugin/cephfsplugin_provisioner/rbdplugin_provisioner
         """
         disruption = disruption_helpers.Disruptions()
         disruption.set_resource(resource=resource_to_delete)
@@ -140,7 +140,6 @@ class BasePvcCreateRespinCephPods(E2ETest):
             *["rbdplugin_provisioner"], marks=[pytest.mark.polarion_id("OCS-2639")]
         ),
         pytest.param(*["rbdplugin"], marks=[pytest.mark.polarion_id("OCS-2643")]),
-        pytest.param(*["operator"], marks=[pytest.mark.polarion_id("OCS-2640")]),
         pytest.param(*["cephfsplugin"], marks=[pytest.mark.polarion_id("OCS-2642")]),
     ],
 )

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -104,7 +104,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
         delete_resource functions checks for the deleted pod back up and running
 
         Args:
-            resource_to_delete (str): Ceph resource type to be deleted, eg: mgr/mon/osd/mds
+            resource_to_delete (str): Ceph resource type to be deleted, eg: mgr/mon/osd/mds/cephfsplugin/cephfsplugin_provisioner/rbdplugin_provisioner/rbdplugin_provisioner/rbdplugin
         """
         disruption = disruption_helpers.Disruptions()
         disruption.set_resource(resource=resource_to_delete)
@@ -132,6 +132,15 @@ class BasePvcCreateRespinCephPods(E2ETest):
         pytest.param(*["mon"], marks=[pytest.mark.polarion_id("OCS-764")]),
         pytest.param(*["osd"], marks=[pytest.mark.polarion_id("OCS-765")]),
         pytest.param(*["mds"], marks=[pytest.mark.polarion_id("OCS-613")]),
+        pytest.param(
+            *["cephfsplugin_provisioner"], marks=[pytest.mark.polarion_id("OCS-2641")]
+        ),
+        pytest.param(
+            *["rbdplugin_provisioner"], marks=[pytest.mark.polarion_id("OCS-2639")]
+        ),
+        pytest.param(*["rbdplugin"], marks=[pytest.mark.polarion_id("OCS-2643")]),
+        pytest.param(*["operator"], marks=[pytest.mark.polarion_id("OCS-2640")]),
+        pytest.param(*["cephfsplugin"], marks=[pytest.mark.polarion_id("OCS-2642")]),
     ],
 )
 class TestPVSTOcsCreatePVCsAndRespinCephPods(BasePvcCreateRespinCephPods):
@@ -210,5 +219,7 @@ class TestPVSTOcsCreatePVCsAndRespinCephPods(BasePvcCreateRespinCephPods):
 
         # Added sleep for test case run time and for capturing memory leak after scale
         time.sleep(test_run_time)
-        utils.ceph_health_check()
+        assert utils.ceph_health_check(
+            delay=180
+        ), "Ceph health in bad state after pod respins"
         helpers.memory_leak_analysis(median_dict)

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -104,7 +104,8 @@ class BasePvcCreateRespinCephPods(E2ETest):
         delete_resource functions checks for the deleted pod back up and running
 
         Args:
-            resource_to_delete (str): Ceph resource type to be deleted, eg: mgr/mon/osd/mds/cephfsplugin/cephfsplugin_provisioner/rbdplugin_provisioner/rbdplugin_provisioner/rbdplugin
+            resource_to_delete (str): Ceph resource type to be deleted.
+            eg: mgr/mon/osd/mds/cephfsplugin/rbdplugin/cephfsplugin_provisioner/rbdplugin_provisioner/operator
         """
         disruption = disruption_helpers.Disruptions()
         disruption.set_resource(resource=resource_to_delete)


### PR DESCRIPTION
Enhancement to "test_pv_scale_and_respin_ceph_pods". Apart from existing four resource type (mgr, mon, osd and mds) in ceph resource types, additional resource types are added (rbdplugin_provisioner, cephfsplugin_provisioner, cephfsplugin, rbdplugin and operator)

Enhancements are part of "Automate scale tests with CSI pod re-spin" test