### PR TITLE
Limit the MCG UI tests to run only on OCS 4.8

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -267,7 +267,7 @@ class PageNavigator(BaseUI):
         self.ocp_version = get_ocp_version()
         self.page_nav = locators[self.ocp_version]["page"]
         if Version.coerce(self.ocp_version) >= Version.coerce("4.8"):
-            self.generic_locators = locators[self.ocp_version]["generic"]
+            self.generic_locators = locators["4.8"]["generic"]
 
     def navigate_overview_page(self):
         """

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -267,7 +267,7 @@ class PageNavigator(BaseUI):
         self.ocp_version = get_ocp_version()
         self.page_nav = locators[self.ocp_version]["page"]
         if Version.coerce(self.ocp_version) >= Version.coerce("4.8"):
-            self.generic_locators = locators["4.8"]["generic"]
+            self.generic_locators = locators[self.ocp_version]["generic"]
 
     def navigate_overview_page(self):
         """

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -35,7 +35,7 @@ class TestStoreUserInterface(object):
                 ).delete(resource_name=store_name)
 
     @tier1
-    @skipif_ocs_version("<4.8")
+    @skipif_ocs_version("!=4.8")
     @skipif_disconnected_cluster
     @pytest.mark.parametrize(
         argnames=["kind"],
@@ -85,7 +85,7 @@ class TestStoreUserInterface(object):
 
 
 @tier1
-@skipif_ocs_version("<4.8")
+@skipif_ocs_version("!=4.8")
 @skipif_disconnected_cluster
 class TestBucketclassUserInterface(object):
     """
@@ -232,7 +232,7 @@ class TestObcUserInterface(object):
             )
 
     @tier1
-    @skipif_ocs_version("<4.8")
+    @skipif_ocs_version("!=4.8")
     @pytest.mark.parametrize(
         argnames=["storageclass", "bucketclass"],
         argvalues=[


### PR DESCRIPTION
Up until now, the tests were set to run on OCS 4.8 and above, regardless of OCP version.
However, due to extensive UI changes in 4.9, they can only run on OCS 4.8.
