### PR TITLE
Skip RBD thick SC verification in 4.9

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -247,7 +247,7 @@ def ocs_install_verification(
         f"{storage_cluster_name}-cephfs",
         f"{storage_cluster_name}-ceph-rbd",
     }
-    if Version.coerce(ocs_version) >= Version.coerce("4.9"):
+    if Version.coerce(ocs_version) >= Version.coerce("4.10"):
         # TODO: Add rbd-thick storage class verification in external mode cluster upgraded
         # to OCS 4.8 when the bug 1978542 is fixed
         # Skip rbd-thick storage class verification in external mode upgraded cluster. This is blocked by bug 1978542


### PR DESCRIPTION
Skip RBD thick storage class verification due to the bug https://bugzilla.redhat.com/show_bug.cgi?id=2000865
Signed-off-by: Jilju Joy <jijoy@redhat.com>