### PR TITLE
Fix for get_ceph_default_replica returning None value.

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -527,8 +527,8 @@ class CephCluster(object):
              int : the default replica count - 0 if not found.
         """
         ceph_pod = pod.get_ceph_tools_pod()
-        ceph_status = ceph_pod.exec_ceph_cmd(ceph_cmd="ceph status")
-        av_mod = ceph_status.get("mgrmap").get("available_modules")
+        ceph_status = ceph_pod.exec_ceph_cmd(ceph_cmd="ceph mgr dump")
+        av_mod = ceph_status.get("available_modules")
         for mod in av_mod:
             if mod["name"] == "localpool":
                 return mod.get("module_options").get("num_rep").get("default_value")

--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -204,7 +204,7 @@ class TestPvcSnapshotPerformance(PASTest):
                 "pvc-test", f"snapshot-test{test_num}"
             )
             log.info(f"Taking snapshot of the PVC {snap_name}")
-            
+
             test_results["create"]["time"] = self.measure_create_snapshot_time(
                 pvc_name=self.pvc_obj.name,
                 snap_name=snap_name,

--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -68,12 +68,11 @@ class TestPvcSnapshotPerformance(PASTest):
         self.pvc_obj = pvc_factory(
             interface=self.interface, size=pvc_size, status=constants.STATUS_BOUND
         )
-
         self.pod_object = pod_factory(
             interface=self.interface, pvc=self.pvc_obj, status=constants.STATUS_RUNNING
         )
 
-    def measure_create_snapshot_time(self, pvc_name, snap_name, interface):
+    def measure_create_snapshot_time(self, pvc_name, snap_name, namespace, interface):
         """
         Creation volume snapshot, and measure the creation time
 
@@ -97,6 +96,7 @@ class TestPvcSnapshotPerformance(PASTest):
             pvc_name=pvc_name,
             snap_yaml=snap_yaml,
             snap_name=snap_name,
+            namespace=namespace,
             sc_name=helpers.default_volumesnapshotclass(interface).name,
         )
 
@@ -178,7 +178,6 @@ class TestPvcSnapshotPerformance(PASTest):
             log.info(f"Starting IO on the POD {self.pod_object.name}")
             # Going to run only write IO to fill the PVC for the snapshot
             self.pod_object.fillup_fs(size=file_size, fio_filename=file_name)
-
             # Wait for fio to finish
             fio_result = self.pod_object.get_fio_results()
             err_count = fio_result.get("jobs")[0].get("error")
@@ -203,10 +202,10 @@ class TestPvcSnapshotPerformance(PASTest):
                 "pvc-test", f"snapshot-test{test_num}"
             )
             log.info(f"Taking snapshot of the PVC {snap_name}")
-
             test_results["create"]["time"] = self.measure_create_snapshot_time(
                 pvc_name=self.pvc_obj.name,
                 snap_name=snap_name,
+                namespace=self.pod_object.namespace,
                 interface=self.interface,
             )
             test_results["create"]["speed"] = int(

--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -68,6 +68,7 @@ class TestPvcSnapshotPerformance(PASTest):
         self.pvc_obj = pvc_factory(
             interface=self.interface, size=pvc_size, status=constants.STATUS_BOUND
         )
+
         self.pod_object = pod_factory(
             interface=self.interface, pvc=self.pvc_obj, status=constants.STATUS_RUNNING
         )
@@ -178,6 +179,7 @@ class TestPvcSnapshotPerformance(PASTest):
             log.info(f"Starting IO on the POD {self.pod_object.name}")
             # Going to run only write IO to fill the PVC for the snapshot
             self.pod_object.fillup_fs(size=file_size, fio_filename=file_name)
+
             # Wait for fio to finish
             fio_result = self.pod_object.get_fio_results()
             err_count = fio_result.get("jobs")[0].get("error")
@@ -202,6 +204,7 @@ class TestPvcSnapshotPerformance(PASTest):
                 "pvc-test", f"snapshot-test{test_num}"
             )
             log.info(f"Taking snapshot of the PVC {snap_name}")
+            
             test_results["create"]["time"] = self.measure_create_snapshot_time(
                 pvc_name=self.pvc_obj.name,
                 snap_name=snap_name,


### PR DESCRIPTION
In OCS4.9, 'ceph status' doesnot give replica count value. Hence 'ceph mgr dump' command is used.
