### PR TITLE
Add marker for aws based platforms only test 

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -143,6 +143,13 @@ aws_platform_required = pytest.mark.skipif(
     reason="Test runs ONLY on AWS deployed cluster",
 )
 
+aws_based_platform_required = pytest.mark.skipif(
+    (
+        config.ENV_DATA["platform"].lower() != "aws"
+        and config.ENV_DATA["platform"].lower() != ROSA_PLATFORM
+    ),
+    reason="Test runs ONLY on AWS based deployed cluster",
+)
 azure_platform_required = pytest.mark.skipif(
     config.ENV_DATA["platform"].lower() != "azure",
     reason="Test runs ONLY on Azure deployed cluster",

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
     ManageTest,
-    aws_platform_required,
+    aws_based_platform_required,
     ipi_deployment_required,
     ignore_leftovers,
 )
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 @tier4
 @tier4b
 @ignore_leftovers
-@aws_platform_required
+@aws_based_platform_required
 @ipi_deployment_required
 class TestAutomatedRecoveryFromFailedNodes(ManageTest):
     """

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
     ManageTest,
-    aws_platform_required,
+    aws_based_platform_required,
     ipi_deployment_required,
     ignore_leftovers,
 )
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @tier4
 @tier4b
-@aws_platform_required
+@aws_based_platform_required
 @ipi_deployment_required
 class TestAutomatedRecoveryFromFailedNodes(ManageTest):
     """
@@ -189,7 +189,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @ignore_leftovers
 @tier4
 @tier4a
-@aws_platform_required
+@aws_based_platform_required
 @ipi_deployment_required
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 

--- a/tests/manage/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
     ManageTest,
-    aws_platform_required,
+    aws_based_platform_required,
     ipi_deployment_required,
     ignore_leftovers,
 )
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @tier4
 @tier4b
-@aws_platform_required
+@aws_based_platform_required
 @ipi_deployment_required
 class TestNodeReplacement(ManageTest):
     """

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -27,7 +27,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
     ManageTest,
-    aws_platform_required,
+    aws_based_platform_required,
     ignore_leftovers,
     ipi_deployment_required,
     skipif_bm,
@@ -313,7 +313,7 @@ class TestNodesMaintenance(ManageTest):
 
     @tier4
     @tier4b
-    @aws_platform_required
+    @aws_based_platform_required
     @ipi_deployment_required
     @pytest.mark.parametrize(
         argnames=["interface"],


### PR DESCRIPTION
ROSA is Redhat openshift service on AWS. Hence the test
applicable on aws should be consider for ROSA platform as well

Signed-off-by: Suchita Gatfane <sgatfane@redhat.com>