### PR TITLE
Fix to 'list index out of range error in 'helpers.py::get_provision_time' and added 'namespace' argument in 'test_pvc_snapshot_performance_multiple_files' test

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1363,8 +1363,8 @@ def get_provision_time(interface, pvc_name, status="start"):
     # Extract the time for the list of PVCs provisioning
     if isinstance(pvc_name, list):
         all_stats = []
-        for pv_name in pvc_name:
-            name = pv_name.name
+        for i in range(0, len(pvc_name)):
+            name = pvc_name[i].name
             stat = [i for i in logs if re.search(f"provision.*{name}.*{operation}", i)]
             mon_day = " ".join(stat[0].split(" ")[0:2])
             stat = f"{this_year} {mon_day}"

--- a/tests/e2e/performance/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/test_pvc_snapshot_performance.py
@@ -482,7 +482,10 @@ class TestPvcSnapshotPerformance(PASTest):
             log.info(f"Taking snapshot of the PVC {pvc_name}")
             log.info(f"Snapshot name : {snap_name}")
             creation_time = self.measure_create_snapshot_time(
-                pvc_name=pvc_name, snap_name=snap_name, interface=interface
+                pvc_name=pvc_name,
+                snap_name=snap_name,
+                namespace=BMO_NAME,
+                interface=interface,
             )
             log.info(f"Snapshot creation time is {creation_time} seconds")
             all_results.append(creation_time)


### PR DESCRIPTION
The content of this PR:

1. for loop syntax was updated in 'helpers.py::get_provision_time' to avoid list index going out of range error.
2. namespace argument was added in 'tests/e2e/performance/test_pvc_snapshot_performance.py::measure_create_snapshot_time', since 'pvc.create_pvc_snapshot' function expects namespace argument.

This PR is in continuation to PR#4861

