### PR TITLE
Fix `test_delete_cached_object`

### DIFF
--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -829,7 +829,7 @@ class TestNamespace(MCGTest):
             awscli_pod_session,
             bucket_to_write=bucket_obj.name,
             original_dir=original_folder,
-            amount=3,
+            amount=1,
         )
         wait_for_cache(mcg_obj, bucket_obj.name, writen_objs_names)
 


### PR DESCRIPTION
The written object amount was changed from 1 to 3 in #3754. This has led the test to fail, because only one object is deleted in the test, which then expects no object to remain. However, two remain due to the amount change.