### PR TITLE
Modify the cpu usage metric

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # cpu pod usage query inspired by Metrics Dashboard from OCP Console, see:
 # frontend/packages/dev-console/src/components/monitoring/queries.ts
 CPU_USAGE_POD = (
-    "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate"
+    "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"
 )
 
 


### PR DESCRIPTION
CPU usage metric has been modified due to change in the "rate" function to "irate"

References:
1. https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/619/commits/e996e00fa3a0c17a7a9f5d01f6c1a3544731bd33

2. https://monitoring.mixins.dev/kubernetes/

Signed-off-by: Sravika Balusu <sravika.balusu@ibm.com>