### PR TITLE
Fix storage_type parameter in the test test_ceph_daemon_kill_during_pod_pvc_deletion

### DIFF
--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -218,7 +218,12 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
         # Do setup for running IO on pods
         log.info("Setting up pods for running IO")
         for pod_obj in self.pod_objs:
-            pod_obj.workload_setup(storage_type="fs")
+            pvc_info = pod_obj.pvc.get()
+            if pvc_info["spec"]["volumeMode"] == "Block":
+                pod_obj.pvc.storage_type = "block"
+            else:
+                pod_obj.pvc.storage_type = "fs"
+            pod_obj.workload_setup(storage_type=pod_obj.pvc.storage_type)
         log.info("Setup for running IO is completed on pods")
 
         # Start IO on each pod. RWX PVC will be used on two pods. So split the
@@ -230,7 +235,10 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
             else:
                 io_size = self.pvc_size - 1
             pod_obj.run_io(
-                storage_type="fs", size=f"{io_size}G", fio_filename=f"{pod_obj.name}_io"
+                storage_type=pod_obj.pvc.storage_type,
+                size=f"{io_size}G",
+                fio_filename=f"{pod_obj.name}_io",
+                end_fsync=1,
             )
         log.info("IO started on all pods.")
 
@@ -300,7 +308,7 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
         # Verify PVs are deleted
         for pv_obj in pv_objs:
             assert pv_obj.ocp.wait_for_delete(
-                pv_obj.name, 120
+                pv_obj.name, 600
             ), f"PV {pv_obj.name} is not deleted"
         log.info("Verified: PVs are deleted.")
 

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -306,15 +306,9 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
         log.info("Verified: PVCs are deleted.")
 
         # Verify PVs are deleted
-        # WA for the issue 4905
-        pv_delete_timeout = (
-            600
-            if config.ENV_DATA["platform"].lower() == constants.ROSA_PLATFORM
-            else 200
-        )
         for pv_obj in pv_objs:
             assert pv_obj.ocp.wait_for_delete(
-                pv_obj.name, pv_delete_timeout
+                pv_obj.name, 120
             ), f"PV {pv_obj.name} is not deleted"
         log.info("Verified: PVs are deleted.")
 

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -306,9 +306,15 @@ class TestDaemonKillDuringPodPvcDeletion(ManageTest):
         log.info("Verified: PVCs are deleted.")
 
         # Verify PVs are deleted
+        # WA for the issue 4905
+        pv_delete_timeout = (
+            600
+            if config.ENV_DATA["platform"].lower() == constants.ROSA_PLATFORM
+            else 200
+        )
         for pv_obj in pv_objs:
             assert pv_obj.ocp.wait_for_delete(
-                pv_obj.name, 600
+                pv_obj.name, pv_delete_timeout
             ), f"PV {pv_obj.name} is not deleted"
         log.info("Verified: PVs are deleted.")
 


### PR DESCRIPTION
Fix storage_type parameter in the test test_ceph_daemon_kill_during_pod_pvc_deletion.
Fixes #4907
Signed-off-by: Jilju Joy <jijoy@redhat.com>