### PR TITLE
test_pvc_bulk_creation_deletion_performance.py - change of E2Etest to PASTest

### DIFF
--- a/tests/e2e/performance/test_pvc_bulk_creation_deletion_performance.py
+++ b/tests/e2e/performance/test_pvc_bulk_creation_deletion_performance.py
@@ -8,15 +8,16 @@ import datetime
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework.testlib import performance, E2ETest, polarion_id, bugzilla
+from ocs_ci.framework.testlib import performance, polarion_id, bugzilla
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import defaults, constants
+from ocs_ci.ocs.perftests import PASTest
 
 log = logging.getLogger(__name__)
 
 
 @performance
-class TestPVCCreationPerformance(E2ETest):
+class TestPVCCreationPerformance(PASTest):
     """
     Test to verify PVC creation and deletion performance
     """


### PR DESCRIPTION
This PR contains one small but important change that by mistake was not included in the previous big PR that implemented bulk deletion. This is changing E2ETest to PASTest. 

Signed-off-by: Yulia Persky <ypersky@redhat.com>