### PR TITLE
Skip couchbase workload tests

### DIFF
--- a/tests/e2e/workloads/couchbase/test_couchbase.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase.py
@@ -20,9 +20,7 @@ def couchbase(request):
 
 
 @workloads
-@pytest.mark.skip(
-    reason="Skip the test until cb-example pod Readiness probe fail resolved"
-)
+@pytest.mark.skip(reason="ocs-ci issue: 4488, cb-example pod readiness probe fail")
 @pytest.mark.polarion_id("OCS-785")
 class TestCouchBaseWorkload(E2ETest):
     """

--- a/tests/e2e/workloads/couchbase/test_couchbase.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase.py
@@ -20,6 +20,9 @@ def couchbase(request):
 
 
 @workloads
+@pytest.mark.skip(
+    reason="Skip the test until cb-example pod Readiness probe fail resolved"
+)
 @pytest.mark.polarion_id("OCS-785")
 class TestCouchBaseWorkload(E2ETest):
     """

--- a/tests/e2e/workloads/couchbase/test_couchbase_node_drain.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_node_drain.py
@@ -13,6 +13,9 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
+@pytest.mark.skip(
+    reason="Skip the test until cb-example pod Readiness probe fail resolved"
+)
 class TestCouchBaseNodeDrain(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/couchbase/test_couchbase_node_drain.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_node_drain.py
@@ -13,9 +13,7 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
-@pytest.mark.skip(
-    reason="Skip the test until cb-example pod Readiness probe fail resolved"
-)
+@pytest.mark.skip(reason="ocs-ci issue: 4488, cb-example pod readiness probe fail")
 class TestCouchBaseNodeDrain(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/couchbase/test_couchbase_node_reboot.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_node_reboot.py
@@ -22,6 +22,9 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
+@pytest.mark.skip(
+    reason="Skip the test until cb-example pod Readiness probe fail resolved"
+)
 class TestCouchBaseNodeReboot(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/couchbase/test_couchbase_node_reboot.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_node_reboot.py
@@ -22,9 +22,7 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
-@pytest.mark.skip(
-    reason="Skip the test until cb-example pod Readiness probe fail resolved"
-)
+@pytest.mark.skip(reason="ocs-ci issue: 4488, cb-example pod readiness probe fail")
 class TestCouchBaseNodeReboot(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/couchbase/test_couchbase_pod_respin.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_pod_respin.py
@@ -11,9 +11,7 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
-@pytest.mark.skip(
-    reason="Skip the test until cb-example pod Readiness probe fail resolved"
-)
+@pytest.mark.skip(reason="ocs-ci issue: 4488, cb-example pod readiness probe fail")
 class TestCouchBasePodRespin(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/couchbase/test_couchbase_pod_respin.py
+++ b/tests/e2e/workloads/couchbase/test_couchbase_pod_respin.py
@@ -11,6 +11,9 @@ log = logging.getLogger(__name__)
 
 @workloads
 @ignore_leftovers
+@pytest.mark.skip(
+    reason="Skip the test until cb-example pod Readiness probe fail resolved"
+)
 class TestCouchBasePodRespin(E2ETest):
     """
     Deploy an CouchBase workload using operator

--- a/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -29,7 +29,6 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
         self,
         storageclass_factory,
         amq_factory_fixture,
-        couchbase_factory_fixture,
         pgsql_factory_fixture,
         replica,
         compression,
@@ -48,18 +47,6 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
         executor_run_bg_ios_ops = ThreadPoolExecutor(max_workers=5)
         self.amq, self.threads = amq_factory_fixture(sc_name=sc_obj.name)
 
-        cb_workload = executor_run_bg_ios_ops.submit(
-            bg_handler.handler,
-            couchbase_factory_fixture,
-            sc_name=sc_obj.name,
-            replicas=3,
-            skip_analyze=True,
-            run_in_bg=False,
-            num_items="1000",
-            num_threads="1",
-            iterations=1,
-        )
-
         pgsql_workload = executor_run_bg_ios_ops.submit(
             bg_handler.handler,
             pgsql_factory_fixture,
@@ -71,7 +58,7 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
             iterations=1,
         )
         bg_handler = flowtest.BackgroundOps()
-        bg_ops = [pgsql_workload, cb_workload]
+        bg_ops = [pgsql_workload]
         bg_handler.wait_for_bg_operations(bg_ops, timeout=3600)
         # AMQ Validate the results
         log.info("Validate message run completely")


### PR DESCRIPTION
We are seeing couchbase workload failing to run from OCP 4.8 onward, i.e cb-example pod fails to come with Readiness probe failure, skipping those tests until we find the root cause and resolve it.

Signed-off-by: Akarsha-rai <akrai@redhat.com>