### PR TITLE
Fix test failures in test_worker_nodes_network_failures.py 

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2073,7 +2073,7 @@ def validate_scc_policy(sa_name, namespace, scc_name=constants.PRIVILEGED):
 
 def add_scc_policy(sa_name, namespace):
     """
-    Adding ServiceAccount to scc privileged
+    Adding ServiceAccount to scc anyuid and privileged
 
     Args:
         sa_name (str): ServiceAccount name
@@ -2081,17 +2081,18 @@ def add_scc_policy(sa_name, namespace):
 
     """
     ocp = OCP()
-    out = ocp.exec_oc_cmd(
-        command=f"adm policy add-scc-to-user privileged system:serviceaccount:{namespace}:{sa_name}",
-        out_yaml_format=False,
-    )
-
-    logger.info(out)
+    scc_list = [constants.ANYUID, constants.PRIVILEGED]
+    for scc in scc_list:
+        out = ocp.exec_oc_cmd(
+            command=f"adm policy add-scc-to-user {scc} system:serviceaccount:{namespace}:{sa_name}",
+            out_yaml_format=False,
+        )
+        logger.info(out)
 
 
 def remove_scc_policy(sa_name, namespace):
     """
-    Removing ServiceAccount from scc privileged
+    Removing ServiceAccount from scc anyuid and privileged
 
     Args:
         sa_name (str): ServiceAccount name
@@ -2099,12 +2100,13 @@ def remove_scc_policy(sa_name, namespace):
 
     """
     ocp = OCP()
-    out = ocp.exec_oc_cmd(
-        command=f"adm policy remove-scc-from-user privileged system:serviceaccount:{namespace}:{sa_name}",
-        out_yaml_format=False,
-    )
-
-    logger.info(out)
+    scc_list = [constants.ANYUID, constants.PRIVILEGED]
+    for scc in scc_list:
+        out = ocp.exec_oc_cmd(
+            command=f"adm policy remove-scc-from-user {scc} system:serviceaccount:{namespace}:{sa_name}",
+            out_yaml_format=False,
+        )
+        logger.info(out)
 
 
 def craft_s3_command(cmd, mcg_obj=None, api=False):

--- a/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -3,18 +3,16 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_i3,
     skipif_vsphere_ipi,
     skipif_ibm_power,
 )
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier4, tier4c
-from ocs_ci.ocs import constants, machine, node
+from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.helpers import helpers
 
 logger = logging.getLogger(__name__)
 
@@ -34,116 +32,49 @@ class TestWorkerNodesFailure(ManageTest):
     short_nw_fail_time = 300  # Duration in seconds for short network failure
 
     @pytest.fixture()
-    def setup(
-        self,
-        request,
-        scenario,
-        nodes,
-        multi_pvc_factory,
-        service_account_factory,
-        dc_pod_factory,
-    ):
+    def setup(self, request, interface, multi_pvc_factory, dc_pod_factory):
         """
-        Identify the nodes and start multiple dc pods for the test
+        Create PVCs and DeploymentConfig based app pods for the test
 
         Args:
-            scenario (str): Scenario of app pods running on OCS or dedicated nodes
-                (eg., 'colocated', 'dedicated')
-            nodes: A fixture to get instance of the relevant platform nodes class
+            interface(str): The type of the interface
+                (e.g. CephBlockPool, CephFileSystem)
             multi_pvc_factory: A fixture create a set of new PVCs
-            service_account_factory: A fixture to create a service account
             dc_pod_factory: A fixture to create dc pod
 
         Returns:
             list: dc pod objs
 
         """
-        worker_nodes = node.get_worker_nodes()
-        ocs_nodes = machine.get_labeled_nodes(constants.OPERATOR_NODE_LABEL)
-        non_ocs_nodes = list(set(worker_nodes) - set(ocs_nodes))
 
         def finalizer():
-            helpers.remove_label_from_worker_node(
-                node_list=worker_nodes, label_key="nodetype"
-            )
-
             # Check ceph health
             ceph_health_check(tries=80)
 
         request.addfinalizer(finalizer)
 
-        if (scenario == "dedicated") and len(non_ocs_nodes) == 0:
-            if config.ENV_DATA.get("deployment_type").lower() == "ipi":
-                machines = machine.get_machinesets()
-                node.add_new_node_and_label_it(
-                    machines[0], num_nodes=1, mark_for_ocs_label=False
-                )
-            else:
-                if (
-                    config.ENV_DATA.get("platform").lower()
-                    == constants.VSPHERE_PLATFORM
-                ):
-                    pytest.skip(
-                        "Skipping add node in VSPHERE due to https://bugzilla.redhat.com/show_bug.cgi?id=1844521"
-                    )
-                is_rhel = config.ENV_DATA.get("rhel_workers") or config.ENV_DATA.get(
-                    "rhel_user"
-                )
-                node_type = constants.RHEL_OS if is_rhel else constants.RHCOS
-                node.add_new_node_and_label_upi(
-                    node_type=node_type, num_nodes=1, mark_for_ocs_label=False
-                )
-            non_ocs_nodes = list(set(node.get_worker_nodes()) - set(ocs_nodes))
+        access_modes = [constants.ACCESS_MODE_RWO]
+        if interface == constants.CEPHBLOCKPOOL:
+            access_modes.extend(
+                [
+                    f"{constants.ACCESS_MODE_RWO}-Block",
+                    f"{constants.ACCESS_MODE_RWX}-Block",
+                ]
+            )
+        else:
+            access_modes.append(constants.ACCESS_MODE_RWX)
 
-        app_pod_nodes = ocs_nodes if (scenario == "colocated") else non_ocs_nodes
-
-        # Label nodes to be able to run app pods
-        helpers.label_worker_node(
-            node_list=app_pod_nodes, label_key="nodetype", label_value="app-pod"
-        )
-
-        access_modes_rbd = [
-            constants.ACCESS_MODE_RWO,
-            f"{constants.ACCESS_MODE_RWX}-Block",
-        ]
-
-        access_modes_cephfs = [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]
-
-        pvcs_rbd = multi_pvc_factory(
-            interface=constants.CEPHBLOCKPOOL,
+        pvcs = multi_pvc_factory(
+            interface=interface,
             size=self.pvc_size,
-            access_modes=access_modes_rbd,
+            access_modes=access_modes,
             status=constants.STATUS_BOUND,
-            num_of_pvc=len(access_modes_rbd),
+            num_of_pvc=len(access_modes),
         )
-
-        project = pvcs_rbd[0].project
-
-        pvcs_cephfs = multi_pvc_factory(
-            interface=constants.CEPHFILESYSTEM,
-            project=project,
-            size=self.pvc_size,
-            access_modes=access_modes_cephfs,
-            status=constants.STATUS_BOUND,
-            num_of_pvc=len(access_modes_cephfs),
-        )
-
-        pvcs = pvcs_cephfs + pvcs_rbd
-        # Set volume mode on PVC objects
-        for pvc_obj in pvcs:
-            pvc_info = pvc_obj.get()
-            setattr(pvc_obj, "volume_mode", pvc_info["spec"]["volumeMode"])
-
-        sa_obj = service_account_factory(project=project)
-        pods = []
 
         # Create pods
+        pods = []
         for pvc_obj in pvcs:
-            if constants.CEPHFS_INTERFACE in pvc_obj.storageclass.name:
-                interface = constants.CEPHFILESYSTEM
-            else:
-                interface = constants.CEPHBLOCKPOOL
-
             num_pods = 2 if pvc_obj.access_mode == constants.ACCESS_MODE_RWX else 1
             logger.info("Creating app pods")
             for _ in range(num_pods):
@@ -151,23 +82,22 @@ class TestWorkerNodesFailure(ManageTest):
                     dc_pod_factory(
                         interface=interface,
                         pvc=pvc_obj,
-                        node_selector={"nodetype": "app-pod"},
-                        raw_block_pv=pvc_obj.volume_mode == "Block",
-                        sa_obj=sa_obj,
+                        raw_block_pv=pvc_obj.get_pvc_vol_mode == "Block",
                     )
                 )
 
-        logger.info(
-            f"Created {len(pods)} pods using {len(pvcs_cephfs)} cephfs, {len(pvcs_rbd)} rbd PVCs."
-        )
-
+        logger.info(f"Created {len(pods)} pods using {len(pvcs)} PVCs.")
         return pods
 
     @pytest.mark.parametrize(
-        argnames=["scenario"],
+        argnames=["interface"],
         argvalues=[
-            pytest.param(*["colocated"], marks=pytest.mark.polarion_id("OCS-1432")),
-            pytest.param(*["dedicated"], marks=pytest.mark.polarion_id("OCS-1433")),
+            pytest.param(
+                constants.CEPHBLOCKPOOL, marks=pytest.mark.polarion_id("OCS-1432")
+            ),
+            pytest.param(
+                constants.CEPHFILESYSTEM, marks=pytest.mark.polarion_id("OCS-1433")
+            ),
         ],
     )
     def test_all_worker_nodes_short_network_failure(
@@ -189,7 +119,9 @@ class TestWorkerNodesFailure(ManageTest):
         with ThreadPoolExecutor() as executor:
             for pod_obj in pod_objs:
                 logger.info(f"Starting IO on pod {pod_obj.name}")
-                storage_type = "block" if pod_obj.pvc.volume_mode == "Block" else "fs"
+                storage_type = (
+                    "block" if pod_obj.pvc.get_pvc_vol_mode == "Block" else "fs"
+                )
                 executor.submit(
                     pod_obj.run_io,
                     storage_type=storage_type,
@@ -224,14 +156,14 @@ class TestWorkerNodesFailure(ManageTest):
             node.wait_for_nodes_status(
                 node_names=worker_nodes, status=constants.NODE_READY
             )
-            logger.info("Verifying StorageCluster pods are in running/completed state")
-            pod.wait_for_storage_pods(timeout=720)
+            logger.info("Wait for OCS pods to be in running state")
+            if not pod.wait_for_pods_to_be_running(timeout=720):
+                raise ResourceWrongStatusException("Pods are not in running state")
         except ResourceWrongStatusException:
             # Restart nodes
             nodes.restart_nodes(node.get_node_objs(worker_nodes))
 
-        assert ceph_health_check(tries=80), "Ceph cluster health is not OK"
-        logger.info("Ceph cluster health is OK")
+        ceph_health_check(tries=80)
 
         # Get current info of app pods
         new_pod_objs = list()
@@ -270,7 +202,9 @@ class TestWorkerNodesFailure(ManageTest):
             for pod_obj in new_pod_objs:
                 logger.info(f"Starting IO on pod {pod_obj.name}")
                 pod_obj.wl_setup_done = False
-                storage_type = "block" if pod_obj.pvc.volume_mode == "Block" else "fs"
+                storage_type = (
+                    "block" if pod_obj.pvc.get_pvc_vol_mode == "Block" else "fs"
+                )
                 executor.submit(
                     pod_obj.run_io,
                     storage_type=storage_type,


### PR DESCRIPTION
This PR contains following changes:
In test_worker_nodes_network_failures.py:
 - Use interface value instead of scenario for parametrization
 - Minor enhancements and removal of code which is not required

`scenario` parametrization is not required since now we have separate runs with tainted nodes
The test will now use interface value instead of scenario for parametrization.
Fixes: #4895 

In helpers.py:
 - Add SA to an additional `anyuid` SCC to allow it's usage during pod creation when `privileged` SCC not needed. 
Fixes: #4896 

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>