### PR TITLE
Skip tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py due to memory issue

### DIFF
--- a/tests/e2e/scale/conftest.py
+++ b/tests/e2e/scale/conftest.py
@@ -14,8 +14,6 @@ def pytest_collection_modifyitems(items):
 
     """
     skip_list = [
-        "test_scale_pvc_expand",
-        "test_ceph_pod_respin_in_scaled_cluster",
         "test_scale_osds_fill_75%_reboot_workers",
     ]
     if config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM:

--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 @scale
 @ignore_leftovers
 @skipif_external_mode
+@pytest.mark.skip(
+    reason="Skipped due to failure in 75% filling-up cluster "
+    "which created more PODs and failed for memory issue"
+)
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[


### PR DESCRIPTION
Skipped tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py TC due to hitting memory issue
Removed entries of 2 TC, which is enhanced to work on vmware

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>