### PR TITLE
Disable default sources when upgrading

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -13,7 +13,7 @@ from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
 from ocs_ci.ocs.defaults import OCS_OPERATOR_NAME
 from ocs_ci.ocs.ocp import get_images, OCP
 from ocs_ci.ocs.node import get_nodes
-from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.ocs.resources.catalog_source import CatalogSource, disable_default_sources
 from ocs_ci.ocs.resources.csv import CSV
 from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
 from ocs_ci.ocs.resources.pod import verify_pods_upgraded
@@ -438,6 +438,7 @@ class OCSUpgrade(object):
         )
 
         if not self.upgrade_in_current_source:
+            disable_default_sources()
             if not ocs_catalog.is_exist():
                 log.info("OCS catalog source doesn't exist. Creating new one.")
                 create_catalog_source(self.ocs_registry_image, ignore_upgrade=True)

--- a/ocs_ci/ocs/resources/catalog_source.py
+++ b/ocs_ci/ocs/resources/catalog_source.py
@@ -2,6 +2,7 @@
 CatalogSource related functionalities
 """
 import logging
+from time import sleep
 
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
@@ -131,6 +132,8 @@ def disable_default_sources():
     """
     logger.info("Disabling default sources")
     run_cmd(constants.PATCH_DEFAULT_SOURCES_CMD.format(disable="true"))
+    logger.info("Waiting 5 seconds after disabling default sources")
+    sleep(5)
 
 
 def enable_default_sources():
@@ -139,3 +142,5 @@ def enable_default_sources():
     """
     logger.info("Enabling default sources")
     run_cmd(constants.PATCH_DEFAULT_SOURCES_CMD.format(disable="false"))
+    logger.info("Waiting 20 seconds after enabling default sources")
+    sleep(20)


### PR DESCRIPTION
Fixes: #4929

In the case of live deployment and then upgrade to internal build,
we have to disable default sources as we cannot change the image in
the default redhat-operators.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>