### PR TITLE
Deploy KMS with CA Certificate[without Client Certificate and Client Private Key]

### DIFF
--- a/conf/ocsci/vault_external_standalone_ca_only_v1.yaml
+++ b/conf/ocsci/vault_external_standalone_ca_only_v1.yaml
@@ -8,8 +8,6 @@ ENV_DATA:
   KMS_PROVIDER: vault
   KMS_SERVICE_NAME: vault
   VAULT_CACERT: "ocs-kms-ca-secret"
-  VAULT_CLIENT_CERT: "ocs-kms-client-cert"
-  VAULT_CLIENT_KEY: "ocs-kms-client-key"
   VAULT_SKIP_VERIFY: false
   VAULT_CA_ONLY: true
   VAULT_BACKEND: "v1"

--- a/conf/ocsci/vault_external_standalone_ca_only_v1.yaml
+++ b/conf/ocsci/vault_external_standalone_ca_only_v1.yaml
@@ -1,0 +1,15 @@
+DEPLOYMENT:
+  kms_deployment: true
+
+ENV_DATA:
+  encryption_at_rest: true
+  vault_deploy_mode: external
+  use_vault_namespace: false
+  KMS_PROVIDER: vault
+  KMS_SERVICE_NAME: vault
+  VAULT_CACERT: "ocs-kms-ca-secret"
+  VAULT_CLIENT_CERT: "ocs-kms-client-cert"
+  VAULT_CLIENT_KEY: "ocs-kms-client-key"
+  VAULT_SKIP_VERIFY: false
+  VAULT_CA_ONLY: true
+  VAULT_BACKEND: "v1"

--- a/conf/ocsci/vault_external_standalone_ca_only_v2.yaml
+++ b/conf/ocsci/vault_external_standalone_ca_only_v2.yaml
@@ -1,0 +1,13 @@
+DEPLOYMENT:
+  kms_deployment: true
+
+ENV_DATA:
+  encryption_at_rest: true
+  vault_deploy_mode: external
+  use_vault_namespace: false
+  KMS_PROVIDER: vault
+  KMS_SERVICE_NAME: vault
+  VAULT_CACERT: "ocs-kms-ca-secret"
+  VAULT_SKIP_VERIFY: false
+  VAULT_CA_ONLY: true
+  VAULT_BACKEND: "v2"

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3585,3 +3585,21 @@ def check_number_of_mon_pods(expected_mon_num=3):
         return True
     logger.error(f"Number of Mons not equal to {expected_mon_num} {mon_pod_list}")
     return False
+
+
+def get_secret_names(namespace=defaults.ROOK_CLUSTER_NAMESPACE, resource_name=""):
+    """
+    Get secrets names
+
+    Args:
+         namespace (str): The name of the project
+         resource_name (str): The resource name to fetch
+
+    Returns:
+        dict: secret names
+
+    """
+    logger.info(f"Get secret names on project {namespace}")
+    secret_obj = ocp.OCP(kind=constants.SECRET, namespace=namespace)
+    secrets_objs = secret_obj.get(resource_name=resource_name)
+    return [secret_obj["metadata"]["name"] for secret_obj in secrets_objs["items"]]

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3592,8 +3592,8 @@ def get_secret_names(namespace=defaults.ROOK_CLUSTER_NAMESPACE, resource_name=""
     Get secrets names
 
     Args:
-         namespace (str): The name of the project
-         resource_name (str): The resource name to fetch
+         namespace (str): The name of the project.
+         resource_name (str): The resource name to fetch.
 
     Returns:
         dict: secret names

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -533,9 +533,9 @@ def verify_kms_ca_only():
     logging.info("Verify KMS deployment with only CA Certificate")
     secret_names = get_secret_names()
     if (
-        "ocs-kms-client-cert" not in secret_names
-        and "ocs-kms-client-key" not in secret_names
-        and "ocs-kms-ca-secret" in secret_names
+        "ocs-kms-client-cert" in secret_names
+        or "ocs-kms-client-key" in secret_names
+        or "ocs-kms-ca-secret" not in secret_names
     ):
         raise ValueError(
             f"ocs-kms-client-cert and/or ocs-kms-client-key exist on ca_only mode {secret_names}"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -532,7 +532,11 @@ def verify_kms_ca_only():
     """
     logging.info("Verify KMS deployment with only CA Certificate")
     secret_names = get_secret_names()
-    if "ocs-kms-client-cert" in secret_names or "ocs-kms-client-key" in secret_names:
+    if (
+        "ocs-kms-client-cert" not in secret_names
+        and "ocs-kms-client-key" not in secret_names
+        and "ocs-kms-ca-secret" in secret_names
+    ):
         raise ValueError(
             f"ocs-kms-client-cert and/or ocs-kms-client-key exist on ca_only mode {secret_names}"
         )

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -30,6 +30,7 @@ from ocs_ci.ocs.resources.pod import (
 from ocs_ci.ocs.resources.pv import check_pvs_present_for_ocs_expansion
 from ocs_ci.ocs.resources.pvc import get_deviceset_pvcs
 from ocs_ci.ocs.node import get_osds_per_node, add_new_disk_for_vsphere
+from ocs_ci.helpers.helpers import get_secret_names
 from ocs_ci.utility import (
     localstorage,
     utils,
@@ -463,6 +464,8 @@ def ocs_install_verification(
         if config.DEPLOYMENT.get("kms_deployment"):
             kms = KMS.get_kms_deployment()
             kms.post_deploy_verification()
+            if config.ENV_DATA.get("VAULT_CA_ONLY", None):
+                verify_kms_ca_only()
 
     storage_cluster_obj = get_storage_cluster()
     is_flexible_scaling = (
@@ -519,6 +522,20 @@ def osd_encryption_verification():
                 f"The output of lsblk command on node {worker_node} is not as expected:\n{lsblk_output}"
             )
             raise ValueError("OSD is not encrypted")
+
+
+def verify_kms_ca_only():
+    """
+    Verify KMS deployment with only CA Certificate
+    without Client Certificate and without Client Private Key
+
+    """
+    logging.info("Verify KMS deployment with only CA Certificate")
+    secret_names = get_secret_names()
+    if "ocs-kms-client-cert" in secret_names or "ocs-kms-client-key" in secret_names:
+        raise ValueError(
+            f"ocs-kms-client-cert and/or ocs-kms-client-key exist on ca_only mode {secret_names}"
+        )
 
 
 def add_capacity(osd_size_capacity_requested, add_extra_disk_to_existing_worker=True):

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -271,23 +271,26 @@ class Vault(KMS):
         ca_data["data"]["cert"] = self.ca_cert_base64
         self.create_resource(ca_data, prefix="ca")
 
-        # create client cert secret
-        client_cert_data = templating.load_yaml(constants.EXTERNAL_VAULT_CLIENT_CERT)
-        self.client_cert_name = get_default_if_keyval_empty(
-            config.ENV_DATA, "VAULT_CLIENT_CERT", defaults.VAULT_DEFAULT_CLIENT_CERT
-        )
-        client_cert_data["metadata"]["name"] = self.client_cert_name
-        client_cert_data["data"]["cert"] = self.client_cert_base64
-        self.create_resource(client_cert_data, prefix="clientcert")
+        if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
+            # create client cert secret
+            client_cert_data = templating.load_yaml(
+                constants.EXTERNAL_VAULT_CLIENT_CERT
+            )
+            self.client_cert_name = get_default_if_keyval_empty(
+                config.ENV_DATA, "VAULT_CLIENT_CERT", defaults.VAULT_DEFAULT_CLIENT_CERT
+            )
+            client_cert_data["metadata"]["name"] = self.client_cert_name
+            client_cert_data["data"]["cert"] = self.client_cert_base64
+            self.create_resource(client_cert_data, prefix="clientcert")
 
-        # create client key secert
-        client_key_data = templating.load_yaml(constants.EXTERNAL_VAULT_CLIENT_KEY)
-        self.client_key_name = get_default_if_keyval_empty(
-            config.ENV_DATA, "VAULT_CLIENT_KEY", defaults.VAULT_DEFAULT_CLIENT_KEY
-        )
-        client_key_data["metadata"]["name"] = self.client_key_name
-        client_key_data["data"]["key"] = self.client_key_base64
-        self.create_resource(client_key_data, prefix="clientkey")
+            # create client key secert
+            client_key_data = templating.load_yaml(constants.EXTERNAL_VAULT_CLIENT_KEY)
+            self.client_key_name = get_default_if_keyval_empty(
+                config.ENV_DATA, "VAULT_CLIENT_KEY", defaults.VAULT_DEFAULT_CLIENT_KEY
+            )
+            client_key_data["metadata"]["name"] = self.client_key_name
+            client_key_data["data"]["key"] = self.client_key_base64
+            self.create_resource(client_key_data, prefix="clientkey")
 
     def create_ocs_vault_resources(self):
         """
@@ -316,8 +319,9 @@ class Vault(KMS):
         connection_data["data"]["VAULT_ADDR"] = os.environ["VAULT_ADDR"]
         connection_data["data"]["VAULT_BACKEND_PATH"] = self.vault_backend_path
         connection_data["data"]["VAULT_CACERT"] = self.ca_cert_name
-        connection_data["data"]["VAULT_CLIENT_CERT"] = self.client_cert_name
-        connection_data["data"]["VAULT_CLIENT_KEY"] = self.client_key_name
+        if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
+            connection_data["data"]["VAULT_CLIENT_CERT"] = self.client_cert_name
+            connection_data["data"]["VAULT_CLIENT_KEY"] = self.client_key_name
         connection_data["data"]["VAULT_NAMESPACE"] = self.vault_namespace
         connection_data["data"]["VAULT_TLS_SERVER_NAME"] = self.vault_tls_server
         connection_data["data"]["VAULT_BACKEND"] = self.vault_backend_version

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -240,10 +240,10 @@ class Vault(KMS):
         if (
             not config.ENV_DATA.get("VAULT_SKIP_VERIFY")
             and config.ENV_DATA.get("vault_deploy_mode") == "external"
+            and not config.ENV_DATA.get("VAULT_CA_ONLY", None)
         ):
-            if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
-                self.setup_vault_client_cert()
-                os.environ["VAULT_CACERT"] = constants.VAULT_CLIENT_CERT_PATH
+            self.setup_vault_client_cert()
+            os.environ["VAULT_CACERT"] = constants.VAULT_CLIENT_CERT_PATH
 
     def setup_vault_client_cert(self):
         """

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -241,8 +241,9 @@ class Vault(KMS):
             not config.ENV_DATA.get("VAULT_SKIP_VERIFY")
             and config.ENV_DATA.get("vault_deploy_mode") == "external"
         ):
-            self.setup_vault_client_cert()
-            os.environ["VAULT_CACERT"] = constants.VAULT_CLIENT_CERT_PATH
+            if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
+                self.setup_vault_client_cert()
+                os.environ["VAULT_CACERT"] = constants.VAULT_CLIENT_CERT_PATH
 
     def setup_vault_client_cert(self):
         """
@@ -323,6 +324,9 @@ class Vault(KMS):
         if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
             connection_data["data"]["VAULT_CLIENT_CERT"] = self.client_cert_name
             connection_data["data"]["VAULT_CLIENT_KEY"] = self.client_key_name
+        else:
+            connection_data["data"].pop("VAULT_CLIENT_CERT")
+            connection_data["data"].pop("VAULT_CLIENT_KEY")
         connection_data["data"]["VAULT_NAMESPACE"] = self.vault_namespace
         connection_data["data"]["VAULT_TLS_SERVER_NAME"] = self.vault_tls_server
         connection_data["data"]["VAULT_BACKEND"] = self.vault_backend_version

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -131,8 +131,9 @@ class Vault(KMS):
         self.port = self.vault_conf["PORT"]
         if not config.ENV_DATA.get("VAULT_SKIP_VERIFY"):
             self.ca_cert_base64 = self.vault_conf["VAULT_CACERT_BASE64"]
-            self.client_cert_base64 = self.vault_conf["VAULT_CLIENT_CERT_BASE64"]
-            self.client_key_base64 = self.vault_conf["VAULT_CLIENT_KEY_BASE64"]
+            if not config.ENV_DATA.get("VAULT_CA_ONLY", None):
+                self.client_cert_base64 = self.vault_conf["VAULT_CLIENT_CERT_BASE64"]
+                self.client_key_base64 = self.vault_conf["VAULT_CLIENT_KEY_BASE64"]
             self.vault_tls_server = self.vault_conf["VAULT_TLS_SERVER_NAME"]
         self.vault_root_token = self.vault_conf["VAULT_ROOT_TOKEN"]
 


### PR DESCRIPTION
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1970641, we need to import only the CA Certificate file and not use Client Certificate and Client Private Key.[for deployment cluster with KMS] 

Signed-off-by: Oded Viner <oviner@redhat.com>