### PR TITLE
Limit MCG UI tests based on OCP version

### DIFF
--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_disconnected_cluster,
     tier1,
+    skipif_ui_not_support,
 )
 from ocs_ci.ocs.ocp import OCP, get_all_resource_names_of_a_kind
 from ocs_ci.ocs.ui.mcg_ui import BucketClassUI, MCGStoreUI, ObcUI
@@ -16,6 +17,7 @@ from ocs_ci.ocs.ui.mcg_ui import BucketClassUI, MCGStoreUI, ObcUI
 logger = logging.getLogger(__name__)
 
 
+@skipif_ui_not_support("mcg_stores")
 class TestStoreUserInterface(object):
     """
     Test the MCG store UI
@@ -84,6 +86,7 @@ class TestStoreUserInterface(object):
         assert test_store.check_resource_existence(should_exist=False)
 
 
+@skipif_ui_not_support("bucketclass")
 @tier1
 @skipif_ocs_version("!=4.8")
 @skipif_disconnected_cluster
@@ -217,6 +220,7 @@ class TestBucketclassUserInterface(object):
         assert test_bc.check_resource_existence(should_exist=False)
 
 
+@skipif_ui_not_support("obc")
 class TestObcUserInterface(object):
     """
     Test the object bucket claim UI


### PR DESCRIPTION
Since the MCG UI is mostly dependent on the OCS version, I tried to support the tests to run based only on OCS version, and regardless of the OCP version. However, this has led to failures. This PR limits the tests to run only on OCP 4.8 (on top of the existing condition to only run on OCS 4.8)