### PR TITLE
Fixed timeout and cosmetic changes for scale tests

### DIFF
--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -334,12 +334,13 @@ class FioPodScale(object):
 
         return self.kube_job_pod_list, self.kube_job_pvc_list
 
-    def pvc_expansion(self, pvc_new_size):
+    def pvc_expansion(self, pvc_new_size, wait_time=30):
         """
         Function to expand PVC size and verify the new size is reflected.
 
         Args:
             pvc_new_size (int): Updated/extended PVC size
+            wait_time: timeout for all the pvc in kube job to get extended size
 
         """
 
@@ -369,6 +370,7 @@ class FioPodScale(object):
                 namespace=self.namespace,
                 no_of_pvc=len(yaml_data),
                 resize_value=pvc_new_size,
+                timeout=wait_time,
             )
 
     def cleanup(self):
@@ -1754,10 +1756,10 @@ def validate_all_expanded_pvc_size_in_kube_job(
             time.sleep(timeout)
             while_iteration_count += 1
             # Breaking while loop after 10 Iteration i.e. after timeout*10 secs of wait_time
-            # And if PVCs still not in bound state then there will be assert.
+            # And if PVCs size still not extended then there will be assert.
             if while_iteration_count >= 10:
                 assert logging.error(
-                    f" Listed PVCs took more than {timeout*10} secs to bound {pvc_not_extended_list}"
+                    f" Listed PVC size not expanded in {timeout*10} secs, PVCs {pvc_not_extended_list}"
                 )
                 break
             pvc_not_extended_list.clear()

--- a/tests/e2e/scale/conftest.py
+++ b/tests/e2e/scale/conftest.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 def pytest_collection_modifyitems(items):
     """
-    A pytest hook to skip certain tests when running on vSphere.
+    A pytest hook to skip tests from summary report
 
     Args:
         items: list of collected tests
@@ -15,8 +15,13 @@ def pytest_collection_modifyitems(items):
     """
     skip_list = [
         "test_scale_osds_fill_75%_reboot_workers",
+        "test_scale_pgsql",
+        "test_scale_amq",
     ]
-    if config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM:
+    if (
+        config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM
+        or config.ENV_DATA["platform"].lower() == constants.CLOUD_PLATFORMS
+    ):
         for item in items.copy():
             for testname in skip_list:
                 if testname in str(item.fspath):

--- a/tests/e2e/scale/test_scale_pvc_expand.py
+++ b/tests/e2e/scale/test_scale_pvc_expand.py
@@ -69,7 +69,10 @@ class TestPVCExpand(E2ETest):
 
         # Expand PVC to new size
         logging.info(f"Starting expanding PVC size to {pvc_new_size}Gi")
-        resize_pvc.pvc_expansion(pvc_new_size=pvc_new_size)
+        resize_pvc.pvc_expansion(
+            pvc_new_size=pvc_new_size,
+            wait_time=45,
+        )
 
         # Check ceph health status
         utils.ceph_health_check()


### PR DESCRIPTION
Increased timeout for tests/e2e/scale/test_scale_pvc_expand.py TC, since it failed for 1 PVC not expand on the given time.
Made some cosmetic changes to log message and comments in function validate_all_expanded_pvc_size_in_kube_job().
Updated conftest to skip 3 testcases from report summary

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>