### PR TITLE
Wait for storage class to be present

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -489,6 +489,11 @@ def default_storage_class(
         else:
             resource_name = constants.DEFAULT_STORAGECLASS_CEPHFS
         base_sc = OCP(kind="storageclass", resource_name=resource_name)
+    base_sc.wait_for_resource(
+        condition=resource_name,
+        column="NAME",
+        timeout=240,
+    )
     sc = OCS(**base_sc.data)
     return sc
 


### PR DESCRIPTION
Fixes: #4868

As we saw already few times that SC was created just after we called the
function to get data for SC I am adding here logic to wait_for_resource
which should make sure SC exist before getting data from it.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>