### PR TITLE
Skip the deletion flow for ULSs that were not created

### DIFF
--- a/ocs_ci/ocs/resources/cloud_uls.py
+++ b/ocs_ci/ocs/resources/cloud_uls.py
@@ -105,16 +105,16 @@ def cloud_uls_factory(request, cld_mgr):
 
     def uls_cleanup():
         for cloud, uls_set in all_created_uls.items():
-            if len(uls_set) > 0:
-                client = ulsMap.get(cloud)
-                if client is not None:
-                    all_existing_uls = client.get_all_uls_names()
-                    for uls in uls_set:
-                        if uls in all_existing_uls:
-                            log.info(f"Cleaning up uls {uls}")
-                            client.delete_uls(uls)
-                        else:
-                            log.warning(f"Underlying Storage {uls} not found.")
+            client = ulsMap.get(cloud)
+            if len(uls_set) == 0 or client is None:
+                continue
+            all_existing_uls = client.get_all_uls_names()
+            for uls in uls_set:
+                if uls in all_existing_uls:
+                    log.info(f"Cleaning up uls {uls}")
+                    client.delete_uls(uls)
+                else:
+                    log.warning(f"Underlying Storage {uls} not found.")
 
     request.addfinalizer(uls_cleanup)
 

--- a/ocs_ci/ocs/resources/cloud_uls.py
+++ b/ocs_ci/ocs/resources/cloud_uls.py
@@ -105,15 +105,16 @@ def cloud_uls_factory(request, cld_mgr):
 
     def uls_cleanup():
         for cloud, uls_set in all_created_uls.items():
-            client = ulsMap.get(cloud)
-            if client is not None:
-                all_existing_uls = client.get_all_uls_names()
-                for uls in uls_set:
-                    if uls in all_existing_uls:
-                        log.info(f"Cleaning up uls {uls}")
-                        client.delete_uls(uls)
-                    else:
-                        log.warning(f"Underlying Storage {uls} not found.")
+            if len(uls_set) > 0:
+                client = ulsMap.get(cloud)
+                if client is not None:
+                    all_existing_uls = client.get_all_uls_names()
+                    for uls in uls_set:
+                        if uls in all_existing_uls:
+                            log.info(f"Cleaning up uls {uls}")
+                            client.delete_uls(uls)
+                        else:
+                            log.warning(f"Underlying Storage {uls} not found.")
 
     request.addfinalizer(uls_cleanup)
 


### PR DESCRIPTION
Currently, CloudManager lists all the buckets in all of the storage providers for which credentials are supplied.
This takes a lot of time, and is not needed when no underlying storage was created in particular storage providers.