### PR TITLE
Updateing test parameters for Smallfiles performance test

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3100,7 +3100,7 @@ def fetch_used_size(cbp_name, exp_val=None):
     return used_in_gb
 
 
-def get_full_test_logs_path(cname):
+def get_full_test_logs_path(cname, fname=None):
     """
     Getting the full path of the logs file for particular test
 
@@ -3111,6 +3111,7 @@ def get_full_test_logs_path(cname):
 
     Args:
         cname (obj): the Class object which was run and called this function
+        fname (str): the function name for different tests log path
 
     Return:
         str : full path of the test logs relative to the ocs-ci base logs path
@@ -3123,10 +3124,11 @@ def get_full_test_logs_path(cname):
     # The name of the class
     mname = type(cname).__name__
 
+    if fname is None:
+        fname = inspect.stack()[1][3]
+
     # the full log path (relative to ocs-ci base path)
-    full_log_path = (
-        f"{ocsci_log_path()}/{log_file_name}/{mname}/{inspect.stack()[1][3]}"
-    )
+    full_log_path = f"{ocsci_log_path()}/{log_file_name}/{mname}/{fname}"
 
     return full_log_path
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -430,3 +430,7 @@ class ElasticSearchNotDeployed(Exception):
 
 class ConfigurationError(Exception):
     pass
+
+
+class BenchmarkTestFailed(Exception):
+    pass

--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -1,9 +1,13 @@
 # import pytest
 import time
 import logging
+import os
 import re
 
-from elasticsearch import Elasticsearch
+import requests
+import json
+
+from elasticsearch import Elasticsearch, exceptions as esexp
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import BaseTest
@@ -43,6 +47,10 @@ class PASTest(BaseTest):
         self.client_pod = None  # Place holder for the client pod object
         self.dev_mode = config.RUN["cli_params"].get("dev_mode")
         self.pod_obj = OCP(kind="pod", namespace=benchmark_operator.BMO_NAME)
+
+        # Place holders for test results file (all sub-tests together)
+        self.results_path = ""
+        self.results_file = ""
 
         # Collecting all Environment configuration Software & Hardware
         # for the performance report.
@@ -232,7 +240,7 @@ class PASTest(BaseTest):
         self.benchmark_obj.create()
 
         # This time is only for reporting - when the benchmark started.
-        self.start_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
+        self.start_time = self.get_time()
 
         # Wait for benchmark client pod to be created
         log.info(f"Waiting for {self.client_pod_name} to Start")
@@ -310,7 +318,7 @@ class PASTest(BaseTest):
 
             if status == "Succeeded":
                 # Getting the end time of the benchmark - for reporting.
-                self.end_time = time.strftime("%Y-%m-%dT%H:%M:%SGMT", time.gmtime())
+                self.end_time = self.get_time()
                 self.test_logs = self.pod_obj.exec_oc_cmd(
                     f"logs {self.client_pod}", out_yaml_format=False
                 )
@@ -441,6 +449,62 @@ class PASTest(BaseTest):
             OK = False
 
         return OK
+
+    def get_kibana_indexid(self, server, name):
+        """
+        Get the kibana Index ID by its name.
+
+        Args:
+            server (str): the IP (or name) of the Kibana server
+            name (str): the name of the index
+
+        Returns:
+            str : the index ID of the given name
+                  return None if the index does not exist.
+
+        """
+
+        port = 5601
+        http_link = f"http://{server}:{port}/api/saved_objects"
+        search_string = f"_find?type=index-pattern&search_fields=title&search='{name}'"
+        log.info(f"Connecting to Kibana {server} on port {port}")
+        try:
+            res = requests.get(f"{http_link}/{search_string}")
+            res = json.loads(res.content.decode())
+            for ind in res.get("saved_objects"):
+                if ind.get("attributes").get("title") in [name, f"{name}*"]:
+                    log.info(f"The Kibana indexID for {name} is {ind.get('id')}")
+                    return ind.get("id")
+        except esexp.ConnectionError:
+            log.warning("Cannot connect to Kibana server {}:{}".format(server, port))
+        log.warning(f"Can not find the Kibana index : {name}")
+        return None
+
+    def write_result_to_file(self, res_link):
+        """
+        Write the results link into file, to combine all sub-tests results
+        together in one file, so it can be easily pushed into the performance dashboard
+
+        Args:
+            res_link (str): http link to the test results in the ES server
+
+        """
+        if not os.path.exists(self.results_path):
+            os.makedirs(self.results_path)
+        self.results_file = os.path.join(self.results_path, "all_results.txt")
+
+        log.info(f"Try to push results into : {self.results_file}")
+        try:
+            with open(self.results_file, "a+") as f:
+                f.write(f"{res_link}\n")
+            f.close()
+        except FileNotFoundError:
+            log.info("The file does not exist, so create new one.")
+            with open(self.results_file, "w+") as f:
+                f.write(f"{res_link}\n")
+            f.close()
+        except OSError as err:
+            log.error(f"OS error: {err}")
 
     @staticmethod
     def get_time():

--- a/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
+++ b/ocs_ci/templates/workloads/smallfile/SmallFile.yaml
@@ -31,5 +31,7 @@ spec:
       storageclass: ocs-storageclass-ceph-rbd
       storagesize: 100Gi
       job_timeout: 18000
-      # un comment the next line when the  drop-cache-kernel will support multi-arch
-      drop_cache_kernel: true
+      response-times: true
+      # Un comments the next line when the drop-cache-kernel will support multi-arch
+      #drop_cache_kernel: true
+      #drop_cache_rook_ceph: true

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -469,7 +469,7 @@ class TestSmallFileWorkload(PASTest):
         stime = self.start_time.replace("GMT", ".000Z")
         etime = self.end_time.replace("GMT", ".000Z")
         kibana_id = self.get_kibana_indexid(
-            self.crd_data["spec"]["elasticsearch"]["server"],
+            self.crd_data["spec"]["elasticsearch"]["host"],
             index,
         )
         result = (

--- a/tests/e2e/performance/test_small_file_workload.py
+++ b/tests/e2e/performance/test_small_file_workload.py
@@ -473,7 +473,7 @@ class TestSmallFileWorkload(PASTest):
             index,
         )
         result = (
-            f"http://{self.crd_data['spec']['elasticsearch']['server']}:5601/app/discover#/"
+            f"http://{self.crd_data['spec']['elasticsearch']['host']}:5601/app/discover#/"
             f"?_a=(columns:!({columns}),filters:!(),index:'{kibana_id}',interval:auto,"
             f"query:(language:kuery,query:'uuid:{self.uuid}'),sort:!())"
             f"&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'{stime}',to:'{etime}'))"


### PR DESCRIPTION
change the number of threads / clients (pods) /files per thread and increase the number of samples from 3 to 5
improve the read from elasticsearch function, to read more then 10000 records
Update the CRD file with response-times and disable cache dropping

Signed-off-by: Avi Layani <alayani@redhat.com>