### PR TITLE
Increased vmware IPI deployment timeout to 1.30hrs

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -872,7 +872,7 @@ class VSPHEREIPI(VSPHEREBASE):
                     f"{self.installer} create cluster "
                     f"--dir {self.cluster_path} "
                     f"--log-level {log_cli_level}",
-                    timeout=3600,
+                    timeout=5400,
                 )
             except CommandFailed as e:
                 if constants.GATHER_BOOTSTRAP_PATTERN in str(e):


### PR DESCRIPTION
Increase vmware IPI deployment timeout to 1.30hrs for testing issues in DC_13 & DC_15

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>