### PR TITLE
ODF 4.9 Dashboard UI

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -30,7 +30,6 @@ from ocs_ci.ocs.exceptions import (
     PageNotLoaded,
 )
 from ocs_ci.ocs.ui.views import locators
-from ocs_ci.utility import version
 from ocs_ci.utility.templating import Templating
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
@@ -286,7 +285,7 @@ class BaseUI:
             expected_text (str): Text which needs to be searched on UI
             timeout (int): Looks for a web element repeatedly until timeout (sec) occurs
 
-        return:
+        Returns:
             bool: Returns True if the expected element text is found, False otherwise
 
         """
@@ -313,14 +312,14 @@ class BaseUI:
         """
         Check if an web element is present on the web console or not.
 
+
         Args:
              locator (tuple): (GUI element needs to operate on (str), type (By))
              timeout (int): Looks for a web element repeatedly until timeout (sec) occurs
-        return:
-            bool: True if the element is found, raises NoSuchElementException and returns False otherwise
+        Returns:
+            bool: True if the element is found, returns False otherwise and raises NoSuchElementException
 
         """
-
         try:
             wait = WebDriverWait(self.driver, timeout=timeout, poll_frequency=1)
             wait.until(ec.presence_of_element_located(locator))
@@ -362,15 +361,11 @@ class PageNavigator(BaseUI):
         Navigate to OpenShift Data Foundation Overview Page
 
         """
-        if Version.coerce(self.ocp_version) >= Version.coerce("4.9"):
-            ocs_version = version.get_semantic_ocs_version_from_config()
-            if ocs_version >= version.VERSION_4_9:
-                logger.info("Navigate to ODF tab under Storage section")
-                self.choose_expanded_mode(mode=True, locator=self.page_nav["Storage"])
-                self.do_click(locator=self.page_nav["odf_tab"], timeout=90)
-                self.page_has_loaded(retries=15, sleep_time=5)
-                time.sleep(1)
-                logger.info("Successfully navigated to ODF tab under Storage section")
+        logger.info("Navigate to ODF tab under Storage section")
+        self.choose_expanded_mode(mode=True, locator=self.page_nav["Storage"])
+        self.do_click(locator=self.page_nav["odf_tab"], timeout=90)
+        self.page_has_loaded(retries=15, sleep_time=5)
+        logger.info("Successfully navigated to ODF tab under Storage section")
 
     def navigate_quickstarts_page(self):
         """
@@ -439,11 +434,7 @@ class PageNavigator(BaseUI):
         self.do_click(
             self.page_nav["installed_operators_page"], enable_screenshot=False
         )
-        if Version.coerce(self.ocp_version) >= Version.coerce("4.9"):
-            ocs_version = version.get_semantic_ocs_version_from_config()
-            if ocs_version >= version.VERSION_4_9:
-                self.page_has_loaded(retries=10, sleep_time=5)
-                time.sleep(1)
+        self.page_has_loaded(retries=15, sleep_time=5)
 
     def navigate_to_ocs_operator_page(self):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -134,20 +134,6 @@ deployment_4_9 = {
     ),
     "internal_mode_odf": ('input[id="bs-existing"]', By.CSS_SELECTOR),
     "create_storage_system": ("//button[text()='Create StorageSystem']", By.XPATH),
-    "console_plugin_option": (
-        ".pf-c-button.pf-m-link.pf-m-inline[data-test='edit-console-plugin']",
-        By.CSS_SELECTOR,
-    ),
-    "save_console_plugin_settings": ("#confirm-action", By.CSS_SELECTOR),
-    "warning-alert": ("div[aria-label='Warning Alert']", By.CSS_SELECTOR),
-    "refresh-web-console": (
-        "//button[normalize-space()='Refresh web console']",
-        By.XPATH,
-    ),
-    "odf-operator": ("//h1[normalize-space()='OpenShift Data Foundation']", By.XPATH),
-    "project-dropdown": (".pf-c-menu-toggle__text", By.CSS_SELECTOR),
-    "project-search-bar": ("input[placeholder='Select project...']", By.CSS_SELECTOR),
-    "plugin-available": (".pf-c-button.pf-m-link.pf-m-inline", By.CSS_SELECTOR),
 }
 
 generic_locators = {
@@ -498,7 +484,7 @@ validation_4_8 = {
     ),
 }
 
-dashboard_4_9 = {
+validation_4_9 = {
     "storage_systems": (
         "a[data-test-id='horizontal-link-Storage Systems']",
         By.CSS_SELECTOR,
@@ -539,6 +525,21 @@ dashboard_4_9 = {
         By.CSS_SELECTOR,
     ),
     "storagesystems": (".pf-c-breadcrumb__link", By.CSS_SELECTOR),
+    "console_plugin_option": (
+        ".pf-c-button.pf-m-link.pf-m-inline[data-test='edit-console-plugin']",
+        By.CSS_SELECTOR,
+    ),
+    "save_console_plugin_settings": ("#confirm-action", By.CSS_SELECTOR),
+    "warning-alert": ("div[aria-label='Warning Alert']", By.CSS_SELECTOR),
+    "refresh-web-console": (
+        "//button[normalize-space()='Refresh web console']",
+        By.XPATH,
+    ),
+    "odf-operator": ("//h1[normalize-space()='OpenShift Data Foundation']", By.XPATH),
+    "project-dropdown": (".pf-c-menu-toggle__text", By.CSS_SELECTOR),
+    "project-search-bar": ("input[placeholder='Select project...']", By.CSS_SELECTOR),
+    "plugin-available": (".pf-c-button.pf-m-link.pf-m-inline", By.CSS_SELECTOR),
+    "show-default-projects": ("label[for='no-label-switch-on']", By.CSS_SELECTOR),
 }
 
 locators = {
@@ -547,8 +548,7 @@ locators = {
         "page": page_nav,
         "deployment": {**deployment, **deployment_4_7, **deployment_4_9},
         "generic": generic_locators,
-        "dashboard": dashboard_4_9,
-        "validation": {**validation, **validation_4_8},
+        "validation": {**validation, **validation_4_8, **validation_4_9},
     },
     "4.8": {
         "login": login,

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -2,6 +2,7 @@ import logging
 
 from ocs_ci.framework.testlib import tier1, skipif_ui_not_support
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
+from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ class TestUserInterfaceValidation(object):
 
     @tier1
     @skipif_ui_not_support("validation")
-    def test_validation_ui(self, setup_ui):
+    def test_dashboard_validation_ui(self, setup_ui):
         """
         Validate User Interface
 
@@ -23,21 +24,14 @@ class TestUserInterfaceValidation(object):
 
         """
         validation_ui_obj = ValidationUI(setup_ui)
-        validation_ui_obj.verification_ui()
+        ocs_version = version.get_semantic_ocs_version_from_config()
+        if ocs_version >= version.VERSION_4_9:
+            validation_ui_obj.odf_overview_ui()
+        else:
+            validation_ui_obj.verification_ui()
 
     @tier1
-    def test_odf_overview_ui(self, setup_ui):
-        """
-        Validate User Interface for ODF Overview Tab for ODF 4.9
-
-        Args:
-            setup_ui: login function on conftest file
-
-        """
-        validation_ui_obj = ValidationUI(setup_ui)
-        validation_ui_obj.odf_overview_ui()
-
-    @tier1
+    @skipif_ui_not_support("validation")
     def test_odf_storagesystems_ui(self, setup_ui):
         """
         Validate User Interface for ODF Storage Systems Tab for ODF 4.9


### PR DESCRIPTION
This PR mainly contains 2 functions to verify changes/ validate elements on ODF Overview and ODF StorageSystems page.
This will be further improvised by adding more validations when all the dashboard bugs are resolved.

Here the intention is to check if the console plugin is enabled or not, if not, enable it so as to see ODF tab under Storage section which is a bigger change as part of re-branding of OCS to ODF and then doing further validation.