### PR TITLE
Fix tests selection based on squad marks

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -23,8 +23,6 @@ from ocs_ci.ocs.constants import (
     CLUSTER_NAME_MIN_CHARACTERS,
     LOG_FORMAT,
     OCP_VERSION_CONF_DIR,
-    SQUADS,
-    TOP_DIR,
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -573,16 +571,6 @@ def pytest_collection_modifyitems(session, config, items):
                 f"{item.name} in {item.fspath}",
                 exc_info=True,
             )
-
-        # Add squad markers to each test item based on filepath
-        for squad, paths in SQUADS.items():
-            for _path in paths:
-                # Limit the test_path to the tests directory
-                test_path = item.fspath.strpath.lstrip(TOP_DIR)
-                if _path in test_path:
-                    item.add_marker(f"{squad.lower()}_squad")
-                    item.user_properties.append(("squad", squad))
-                    break
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def pytest_collection_modifyitems(session, items):
         for squad, paths in constants.SQUADS.items():
             for _path in paths:
                 # Limit the test_path to the tests directory
-                test_path = item.fspath.strpath.lstrip(constants.TOP_DIR)
+                test_path = os.path.relpath(item.fspath.strpath, constants.TOP_DIR)
                 if _path in test_path:
                     item.add_marker(f"{squad.lower()}_squad")
                     item.user_properties.append(("squad", squad))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,17 @@ def pytest_collection_modifyitems(session, items):
     deploy = config.RUN["cli_params"].get("deploy")
     skip_ocs_deployment = config.ENV_DATA["skip_ocs_deployment"]
 
+    # Add squad markers to each test item based on filepath
+    for item in items:
+        for squad, paths in constants.SQUADS.items():
+            for _path in paths:
+                # Limit the test_path to the tests directory
+                test_path = item.fspath.strpath.lstrip(constants.TOP_DIR)
+                if _path in test_path:
+                    item.add_marker(f"{squad.lower()}_squad")
+                    item.user_properties.append(("squad", squad))
+                    break
+
     if not (teardown or deploy or skip_ocs_deployment):
         for item in items[:]:
             skipif_ocp_version_marker = item.get_closest_marker("skipif_ocp_version")


### PR DESCRIPTION
With this fix, it should be possible to use squad marks for test execution like
`-m brown_squad`.

For example:
```
$ run-ci --collect-only -m purple_squad
    ...
collected 865 items / 769 deselected / 96 selected                             
<Module tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py>
  <Function test_scale_pvcs_pods_pre_upgrade>
<Module tests/ecosystem/upgrade/test_configuration.py>
  <Function test_load_crush_map>
<Module tests/ecosystem/upgrade/test_noobaa.py>
  <Function test_fill_bucket>
  <Function test_buckets_before_upgrade>
  <Function test_start_upgrade_mcg_io>
<Module tests/ecosystem/upgrade/test_resources.py>
  <Function test_start_pre_upgrade_pod_io>
<Module tests/ecosystem/upgrade/test_monitoring_after_ocp_upgrade.py>
  <Function test_monitoring_before_ocp_upgrade>
<Module tests/ecosystem/upgrade/test_upgrade_ocp.py>
  <Class TestUpgradeOCP>
      <Function test_upgrade_ocp>
<Module tests/ecosystem/upgrade/test_logging_upgrade.py>
  <Class TestUpgradeLogging>
      <Function test_upgrade_logging>
<Module tests/ecosystem/upgrade/test_monitoring_after_ocp_upgrade.py>
  <Function test_monitoring_after_ocp_upgrade>
<Module tests/ecosystem/upgrade/test_upgrade.py>
  <Function test_upgrade>
<Package /home/dahorak/RedHat/OCS/ocs-ci/tests/manage/z_cluster/upgrade>
  <Module test_check_pdb_post_upgrade.py>
    <Class TestToCheckPDBPostUpgrade>
        <Function test_check_mon_pdb_post_upgrade>
        <Function test_check_osd_pdb_post_upgrade>
<Module tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py>
  <Function test_scale_pvcs_pods_post_upgrade>
<Module tests/ecosystem/upgrade/test_configuration.py>
  <Function test_crush_map_unchanged>
<Module tests/ecosystem/upgrade/test_noobaa.py>
  <Function test_noobaa_postupgrade>
  <Function test_buckets_after_upgrade>
  <Function test_upgrade_mcg_io>
<Module tests/ecosystem/upgrade/test_resources.py>
  <Function test_storage_pods_running>
  <Function test_pod_io>
  <Function test_pod_log_after_upgrade>
  <Function test_noobaa_service_mon_after_ocs_upgrade>
<Module tests/ecosystem/upgrade/test_upgrade.py>
  <Function test_worker_node_abrupt_shutdown>
  <Function test_worker_node_permanent_shutdown>
  <Function test_osd_reboot>
<Package /home/dahorak/RedHat/OCS/ocs-ci/tests/manage/z_cluster>
  <Module test_must_gather.py>
    <Class TestMustGather>
        <Function test_must_gather[CEPH]>
        <Function test_must_gather[JSON]>
        <Function test_must_gather[OTHERS]>

====================== 769 deselected in 78.10s (0:01:18) ======================
```

Signed-off-by: Daniel Horak <dahorak@redhat.com>
