### PR TITLE
Remove legacy reportportal

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -136,7 +136,6 @@ Reporting related config. (Do not store secret data in the repository!).
 * `gather_on_deploy_failure` - Run must-gather on deployment failure or not (Default: true)
 * `collect_logs_on_success_run` - Run must-gather on successful run or not (Default: false)
 * `must_gather_timeout` - Time (in seconds) to wait before timing out during must-gather
-* `rp_client_log_level` - Log level for the reportportal_client logger (Default: ERROR)
 
 #### ENV_DATA
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -2,73 +2,27 @@
 
 ## Report Portal
 
-Sending test results to report portal is supported via the [pytest agent](https://github.com/reportportal/agent-python-pytest).
+Sending test results to report portal is now done via
+[rp_preproc](https://gitlab.cee.redhat.com/ccit/reportportal/rp_preproc/-/blob/rpv5/docs/Users.md).
+We have automated a lot of the process around rp_preproc such that you should only need
+to provide a JUnit XML report and the corresponding ocs-ci logs directory. For more
+information on that process works check out the
+[README](https://gitlab.cee.redhat.com/ocs/ocs4-jenkins/-/blob/master/scripts/python/report_portal/README.md).
 
-#### Configuration
+### Launch Attributes
 
-We have a configuration file template that you can fill out with our team's report portal
-instance and user information in order to enable posting results.
+Launches are tagged with various attributes, so we can create filters in report portal.
+Launch attributes are either single string values or key:value pairs delimited by a
+colon (:). More information on how these are defined and consumed
+[here](https://gitlab.cee.redhat.com/ocs/ocs4-jenkins/-/blob/master/scripts/python/report_portal/README.md).
 
-1. Copy the config template located at `templates/reporting/report_portal.cfg` to another location
-2. Edit the placeholder values here with the report portal instance/user details.
+#### Examples
+Some attributes will be single strings like `upstream`, `stage`, or `fips`. This will
+generally be the case with "boolean" type attributes.
 
-You will now be able to post your test results to report portal by providing the appropriate CLI options.
+Other attributes will be represented by key:value pairs like `platform:aws`,
+`ocp_version:4.8`, or `worker_instance_type:m4.xlarge`. For these attributes there are
+several values that could be paired with the key, so we choose this format.
 
-Ex.
-```bash
-run-ci tests/test_pytest.py --reportportal --rp-launch CfgTest --rp-launch-desc "An example launch description" -c /home/$USER/report_portal.cfg
-```
-
-
-#### Tags
-
-Launches are tagged with various information so we can create filters
-in report portal.
-
-##### Basic Tags
-Several tags have different values based on the type of deployment or
+Several attributes have different values based on the type of deployment or
 cluster environment.
-
-platform
-```
-aws / vsphere / baremetal
-```
-deployment_type
-```
-ipi / upi
-```
-us_ds
-```
-upstream / downstream
-```
-
-##### Key/Value Tags
-Some tags are key:value pairs. These are usually used for versions.
-
-```
-worker_instance_type:m4.xlarge
-```
-```
-ocs_version:4.5
-```
-```
-ocp_version:4.5
-```
-```
-ocs_registry_image:quay.io/rhceph-dev/ocs-olm-operator:latest-4.5
-```
-```
-ocs_registry_tag:latest-4.5
-```
-
-##### Boolean Tags
-Several tags will not exist if the tag does not apply to the deployment
-or the cluster environment.
-
-```
-ui_deployment
-live_deployment
-stage_deployment
-production
-fips
-```

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -32,7 +32,6 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.ocs.resources.ocs import get_ocs_csv, get_version_info
 from ocs_ci.ocs.utils import collect_ocs_logs, collect_prometheus_metrics
-from ocs_ci.utility import reporting
 from ocs_ci.utility.utils import (
     dump_config_to_file,
     get_ceph_version,
@@ -298,7 +297,6 @@ def pytest_configure(config):
 
     """
     set_log_level(config)
-    set_rp_client_log_level()
     # Somewhat hacky but this lets us differentiate between run-ci executions
     # and plain pytest unit test executions
     ocscilib_module = "ocs_ci.framework.pytest_customization.ocscilib"
@@ -321,9 +319,6 @@ def pytest_configure(config):
                 f"Dump of the consolidated config file is located here: "
                 f"{config_file}"
             )
-            if config.getoption("--reportportal"):
-                set_rp_client_log_level()
-                set_report_portal_config(config)
 
             # Add OCS related versions to the html report and remove
             # extraneous metadata
@@ -656,28 +651,6 @@ def pytest_runtest_makereport(item, call):
             log.exception("Failed to collect performance stats")
 
 
-def set_report_portal_config(config):
-    """
-    Add settings for report portal like description and tags for the launch.
-
-    Args:
-        config (pytest.config): Pytest config object
-
-    """
-    rp_attrs = reporting.get_rp_launch_attributes()
-    for key, value in rp_attrs.items():
-        if value is True:
-            config.addinivalue_line("rp_launch_tags", key.lower())
-        elif value is False:
-            pass
-        else:
-            config.addinivalue_line("rp_launch_tags", f"{key.lower()}:{value.lower()}")
-
-    description = reporting.get_rp_launch_description()
-    if description:
-        config.option.rp_launch_description = description
-
-
 def set_log_level(config):
     """
     Set the log level of this module based on the pytest.ini log_cli_level
@@ -688,13 +661,3 @@ def set_log_level(config):
     """
     level = config.getini("log_cli_level") or "INFO"
     log.setLevel(logging.getLevelName(level))
-
-
-def set_rp_client_log_level():
-    """
-    Change log level of the reportportal_client logger. Default value is ERROR to limit
-    the amount of noise in our log files from this logger.
-    """
-    rp_logger = logging.getLogger("reportportal_client")
-    level = ocsci_config.REPORTING.get("rp_client_log_level")
-    rp_logger.setLevel(logging.getLevelName(level))

--- a/ocs_ci/templates/reporting/report_portal.cfg
+++ b/ocs_ci/templates/reporting/report_portal.cfg
@@ -1,6 +1,0 @@
-[tool:pytest]
-rp_uuid = <USER UUID HERE>
-rp_endpoint = <WEB ADDRESS HERE>
-rp_project = <USER NAME HERE>
-rp_ignore_errors = True
-rp_verify_ssl = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -61,13 +61,3 @@ addopts = --ignore=ocs_ci --no-print-logs
 testpaths = tests
 # Pin junit_family to xunit 1.0
 junit_family = xunit1
-
-rp_endpoint = http://cistatus.ceph.redhat.com
-rp_uuid = 3480128b-943d-4cc7-9414-6306e498a7f7
-rp_verify_ssl = False
-rp_launch = "Tier test"
-rp_project = ocs
-
-rp_log_batch_size = 50
-rp_ignore_errors = True
-# rp_hierarchy_dirs = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
--e git+https://github.com/vasukulkarni/agent-python-pytest@v1.10.2#egg=pytest-reportportal
 -e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.1.0#egg=ocp-network-split
 -e .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3753,22 +3753,6 @@ def pvc_clone_factory(request):
 def reportportal_customization(request):
     if config.REPORTING.get("rp_launch_url"):
         request.config._metadata["RP Launch URL:"] = config.REPORTING["rp_launch_url"]
-    elif hasattr(request.node.config, "py_test_service"):
-        rp_service = request.node.config.py_test_service
-        if not hasattr(rp_service.RP, "rp_client"):
-            request.config._metadata[
-                "RP Launch URL:"
-            ] = "Problem with RP, launch URL is not available!"
-            return
-        launch_id = rp_service.RP.rp_client.launch_id
-        project = rp_service.RP.rp_client.project
-        endpoint = rp_service.RP.rp_client.endpoint
-        launch_url = f"{endpoint}/ui/#{project}/launches/all/{launch_id}/{launch_id}"
-        config.REPORTING["rp_launch_url"] = launch_url
-        config.REPORTING["rp_launch_id"] = launch_id
-        config.REPORTING["rp_endpoint"] = endpoint
-        config.REPORTING["rp_project"] = project
-        request.config._metadata["RP Launch URL:"] = launch_url
 
 
 @pytest.fixture()


### PR DESCRIPTION
Remove pytest-reportportal integration code now that we have moved to utilizing rp_preproc.