### PR TITLE
Skip test_osd_node_balacing due to bz

### DIFF
--- a/tests/e2e/scale/conftest.py
+++ b/tests/e2e/scale/conftest.py
@@ -17,6 +17,7 @@ def pytest_collection_modifyitems(items):
         "test_scale_osds_fill_75%_reboot_workers",
         "test_scale_pgsql",
         "test_scale_amq",
+        "test_osd_balance",
     ]
     if (
         config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM

--- a/tests/e2e/scale/test_osd_node_balancing.py
+++ b/tests/e2e/scale/test_osd_node_balancing.py
@@ -142,6 +142,9 @@ class ElasticData(PerfResult):
 @ipi_deployment_required
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2604")
+@pytest.mark.skip(
+    reason="Skipped due to bz https://bugzilla.redhat.com/show_bug.cgi?id=2004801"
+)
 class Test_Osd_Balance(PASTest):
     """
     There is no cleanup code in this test because the final


### PR DESCRIPTION
Skipped TC tests/e2e/scale/test_osd_node_balancing.py due to bugzilla bz

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>