### PR TITLE
Increase node_up validation timeout for scale vmware tests

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -922,6 +922,7 @@ def wait_for_new_node_to_be_ready(machine_set, timeout=600):
 
     Args:
         machine_set (str): Name of the machine set
+        timeout (int): Timeout in secs, default 10mins
 
     Raises:
         ResourceWrongStatusException: In case the new spun machine fails

--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -979,7 +979,7 @@ def check_and_add_enough_worker(worker_count):
             for name in ms_name:
                 machine.add_node(machine_set=name, count=exp_count)
             for ms in ms_name:
-                machine.wait_for_new_node_to_be_ready(ms)
+                machine.wait_for_new_node_to_be_ready(ms, 900)
             worker_list = node.get_worker_nodes()
             ocs_worker_list = machine.get_labeled_nodes(constants.OPERATOR_NODE_LABEL)
             scale_label_worker = machine.get_labeled_nodes(constants.SCALE_LABEL)
@@ -1539,7 +1539,7 @@ def scale_ocs_node(node_count=3):
         for ms in ms_name:
             process = threading.Thread(
                 target=machine_utils.wait_for_new_node_to_be_ready,
-                kwargs={"machine_set": ms.name},
+                kwargs={"machine_set": ms.name, "timeout": 900},
             )
             process.start()
             threads.append(process)


### PR DESCRIPTION
Increased node to be up validation timeout for scale tests
Observed Issues in vmware IPI tests for new spun node due to timeout, due to this increased the timeout.

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>