### PR TITLE
allow override automatically added squad marks

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -312,3 +312,15 @@ skipif_ibm_flash = pytest.mark.skipif(
     config.ENV_DATA.get("ibm_flash"),
     reason="This test doesn't work correctly on IBM Flash system",
 )
+
+# Squad marks
+red_squad = pytest.mark.red_squad
+brown_squad = pytest.mark.brown_squad
+green_squad = pytest.mark.green_squad
+blue_squad = pytest.mark.blue_squad
+red_squad = pytest.mark.red_squad
+purple_squad = pytest.mark.purple_squad
+magenta_squad = pytest.mark.magenta_squad
+grey_squad = pytest.mark.grey_squad
+orange_squad = pytest.mark.orange_squad
+black_squad = pytest.mark.black_squad

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -314,13 +314,12 @@ skipif_ibm_flash = pytest.mark.skipif(
 )
 
 # Squad marks
-red_squad = pytest.mark.red_squad
+black_squad = pytest.mark.black_squad
+blue_squad = pytest.mark.blue_squad
 brown_squad = pytest.mark.brown_squad
 green_squad = pytest.mark.green_squad
-blue_squad = pytest.mark.blue_squad
-red_squad = pytest.mark.red_squad
-purple_squad = pytest.mark.purple_squad
-magenta_squad = pytest.mark.magenta_squad
 grey_squad = pytest.mark.grey_squad
+magenta_squad = pytest.mark.magenta_squad
 orange_squad = pytest.mark.orange_squad
-black_squad = pytest.mark.black_squad
+purple_squad = pytest.mark.purple_squad
+red_squad = pytest.mark.red_squad

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,9 @@ def pytest_collection_modifyitems(session, items):
 
     # Add squad markers to each test item based on filepath
     for item in items:
+        # check, if test already have squad marker manually assigned
+        if any(map(lambda x: "_squad" in x.name, item.iter_markers())):
+            continue
         for squad, paths in constants.SQUADS.items():
             for _path in paths:
                 # Limit the test_path to the tests directory


### PR DESCRIPTION
Do not automatically add squad mark to tests, which already have squad mark manually assigned.

Signed-off-by: Daniel Horak <dahorak@redhat.com>