### PR TITLE
deployment: remove checks for rbd-thick sc

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -257,12 +257,6 @@ def ocs_install_verification(
         f"{storage_cluster_name}-cephfs",
         f"{storage_cluster_name}-ceph-rbd",
     }
-    if ocs_version >= version.VERSION_4_10:
-        # TODO: Add rbd-thick storage class verification in external mode cluster upgraded
-        # to OCS 4.8 when the bug 1978542 is fixed
-        # Skip rbd-thick storage class verification in external mode upgraded cluster. This is blocked by bug 1978542
-        if not (config.DEPLOYMENT["external_mode"] and post_upgrade_verification):
-            required_storage_classes.update({f"{storage_cluster_name}-ceph-rbd-thick"})
     skip_storage_classes = set()
     if disable_cephfs:
         skip_storage_classes.update(

--- a/tests/ui/test_pvc_ui.py
+++ b/tests/ui/test_pvc_ui.py
@@ -5,7 +5,6 @@ from ocs_ci.framework.testlib import tier1, skipif_ui_not_support
 from ocs_ci.ocs.ui.pvc_ui import PvcUI
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
-    skipif_ocp_version,
 )
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
 from ocs_ci.ocs import constants
@@ -43,13 +42,6 @@ class TestPvcUserInterface(object):
                 "Block",
             ),
             pytest.param(
-                "ocs-storagecluster-ceph-rbd-thick",
-                "ReadWriteMany",
-                "4",
-                "Block",
-                marks=[skipif_ocp_version("<4.9")],
-            ),
-            pytest.param(
                 "ocs-storagecluster-cephfs",
                 "ReadWriteOnce",
                 "10",
@@ -62,24 +54,10 @@ class TestPvcUserInterface(object):
                 "Block",
             ),
             pytest.param(
-                "ocs-storagecluster-ceph-rbd-thick",
-                "ReadWriteOnce",
-                "12",
-                "Block",
-                marks=[skipif_ocp_version("<4.9")],
-            ),
-            pytest.param(
                 "ocs-storagecluster-ceph-rbd",
                 "ReadWriteOnce",
                 "13",
                 "Filesystem",
-            ),
-            pytest.param(
-                "ocs-storagecluster-ceph-rbd-thick",
-                "ReadWriteOnce",
-                "4",
-                "Filesystem",
-                marks=[skipif_ocp_version("<4.9")],
             ),
         ],
     )
@@ -147,7 +125,6 @@ class TestPvcUserInterface(object):
         # Creating Pod via CLI
         logger.info("Creating Pod")
         if sc_name in (
-            constants.DEFAULT_STORAGECLASS_RBD_THICK,
             constants.DEFAULT_STORAGECLASS_RBD,
         ):
             interface_type = constants.CEPHBLOCKPOOL

--- a/tests/ui/test_pvc_ui.py
+++ b/tests/ui/test_pvc_ui.py
@@ -3,9 +3,7 @@ import pytest
 
 from ocs_ci.framework.testlib import tier1, skipif_ui_not_support
 from ocs_ci.ocs.ui.pvc_ui import PvcUI
-from ocs_ci.framework.testlib import (
-    skipif_ocs_version,
-)
+from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
 from ocs_ci.ocs import constants
 from ocs_ci.helpers import helpers
@@ -124,9 +122,7 @@ class TestPvcUserInterface(object):
 
         # Creating Pod via CLI
         logger.info("Creating Pod")
-        if sc_name in (
-            constants.DEFAULT_STORAGECLASS_RBD,
-        ):
+        if sc_name in (constants.DEFAULT_STORAGECLASS_RBD,):
             interface_type = constants.CEPHBLOCKPOOL
         else:
             interface_type = constants.CEPHFILESYSTEM


### PR DESCRIPTION
Thick provisioning is being deprecated, removing the storage class
check and tests. Complete code cleanup is still pending.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>