### PR TITLE
Fix jenkins workload on OCP4.9

### DIFF
--- a/ocs_ci/ocs/jenkins.py
+++ b/ocs_ci/ocs/jenkins.py
@@ -330,7 +330,7 @@ class Jenkins(object):
                 "slaves.NodeProvisioner.MARGIN0=0.85",
             }
         )
-        if Version.coerce(self.ocp_version) >= Version.coerce("4.9"):
+        if Version.coerce(self.ocp_version) >= Version.coerce("4.8"):
             # Added "Pipeline Utility Steps" plugin via Jenkins Template
             # OCP team changed the default plugin list on OCP4.9
             tmp_dict["objects"][3]["spec"]["template"]["spec"]["containers"][0][

--- a/ocs_ci/ocs/jenkins.py
+++ b/ocs_ci/ocs/jenkins.py
@@ -331,6 +331,8 @@ class Jenkins(object):
             }
         )
         if Version.coerce(self.ocp_version) >= Version.coerce("4.9"):
+            # Added "Pipeline Utility Steps" plugin via Jenkins Template
+            # OCP team changed the default plugin list on OCP4.9
             tmp_dict["objects"][3]["spec"]["template"]["spec"]["containers"][0][
                 "env"
             ].append(

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -770,11 +770,7 @@ class OCP(object):
         # https://github.com/red-hat-storage/ocs-ci/issues/2312
         try:
             if self.data["items"][0]["kind"].lower() == "build" and (
-                self.data["items"][0]
-                .get("metadata")
-                .get("annotations")
-                .get("openshift.io/build-config.name")
-                == "jax-rs-build"
+                "jax-rs-build" in self.data["items"][0].get("metadata").get("name")
             ):
                 return resource_info[column_index - 1]
         except Exception:


### PR DESCRIPTION
Added "Pipeline Utility Steps" plugin via Jenkins Template
OCP team changed the default plugin list on OCP4.9
https://github.com/openshift/jenkins/commit/44deeafca418dc5a786b1dcd705b4aaef0d2fe3c#diff-2a93d798ca112ffa17e2d1d713ef42d02dab81e4704b8a783d9b03635b6470b3

Fixes: #4911 

Signed-off-by: Oded Viner <oviner@redhat.com>