### PR TITLE
adding additional keys to the ES reports

### DIFF
--- a/tests/e2e/performance/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/test_bulk_pod_attachtime_performance.py
@@ -133,6 +133,9 @@ class TestBulkPodAttachPerformance(PASTest):
         Returns:
 
         """
+        # Getting the test start time
+        test_start_time = PASTest.get_time()
+
         log.info(f"Start creating bulk of new {bulk_size} PVCs")
 
         pvc_objs, _ = helpers.create_multiple_pvcs(
@@ -220,6 +223,17 @@ class TestBulkPodAttachPerformance(PASTest):
 
         full_results.add_key("storageclass", self.sc)
         full_results.add_key("pod_bulk_attach_time", bulk_total_time)
+        full_results.add_key("pvc_size", self.pvc_size)
+        full_results.add_key("interface", self.interface)
+        full_results.add_key("bulk_size", bulk_size)
+
+        # Getting the test end time
+        test_end_time = PASTest.get_time()
+
+        # Add the test time to the ES report
+        full_results.add_key(
+            "test_time", {"start": test_start_time, "end": test_end_time}
+        )
 
         # Write the test results into the ES server
         full_results.es_write()

--- a/tests/e2e/performance/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/test_bulk_pod_attachtime_performance.py
@@ -224,7 +224,6 @@ class TestBulkPodAttachPerformance(PASTest):
         full_results.add_key("storageclass", self.sc)
         full_results.add_key("pod_bulk_attach_time", bulk_total_time)
         full_results.add_key("pvc_size", self.pvc_size)
-        full_results.add_key("interface", self.interface)
         full_results.add_key("bulk_size", bulk_size)
 
         # Getting the test end time

--- a/tests/e2e/performance/test_pvc_attachtime.py
+++ b/tests/e2e/performance/test_pvc_attachtime.py
@@ -226,7 +226,6 @@ class TestPodStartTime(PASTest):
             "test_time", {"start": self.test_start_time, "end": self.test_end_time}
         )
 
-        self.full_results.add_key("interface", self.interface)
         self.full_results.add_key("samples_number", self.samples_num)
         self.full_results.add_key("pvc_size", self.pvc_size)
 

--- a/tests/e2e/performance/test_pvc_attachtime.py
+++ b/tests/e2e/performance/test_pvc_attachtime.py
@@ -127,6 +127,8 @@ class TestPodStartTime(PASTest):
         pod_result_list = []
 
         self.msg_prefix = f"Interface: {self.interface}, PVC size: {pvc_size}."
+        self.samples_num = samples_num
+        self.pvc_size = pvc_size
 
         if self.interface == constants.CEPHBLOCKPOOL_THICK:
             self.sc_obj = storageclass_factory(
@@ -223,6 +225,10 @@ class TestPodStartTime(PASTest):
         self.full_results.add_key(
             "test_time", {"start": self.test_start_time, "end": self.test_end_time}
         )
+
+        self.full_results.add_key("interface", self.interface)
+        self.full_results.add_key("samples_number", self.samples_num)
+        self.full_results.add_key("pvc_size", self.pvc_size)
 
         # Write the test results into the ES server
         self.full_results.es_write()


### PR DESCRIPTION
The current PR contains improvements to the following tests: 

1) test_pvc_attachtime.py
2) test_bulk_pod_attachtime_performance.py 

The improbvements are : adding additional keys and values to the data sent to the ES server, for further production of a comprehensive performance report. 

Signed-off-by: Yulia Persky <ypersky@redhat.com>