### PR TITLE
Fix `test_host_node_failure` to wait longer for OBC to bind after node restart

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -200,7 +200,7 @@ class ObjectBucket(ABC):
             logger.error(f"{self.name} was not deleted within {timeout} seconds.")
             assert False, f"{self.name} was not deleted within {timeout} seconds."
 
-    def verify_health(self, timeout=60, interval=5):
+    def verify_health(self, timeout=60, interval=5, **kwargs):
         """
         Health verification function that tries to verify
         the a bucket's health by using its appropriate internal_verify_health

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2250,7 +2250,7 @@ def bucket_factory_fixture(
             current_call_created_buckets.append(created_bucket)
             created_buckets.append(created_bucket)
             if verify_health:
-                created_bucket.verify_health()
+                created_bucket.verify_health(**kwargs)
 
         return current_call_created_buckets
 

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -56,7 +56,7 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
     def create_obc_creation(self, bucket_factory, mcg_obj, key):
 
         # Create a bucket then read & write
-        bucket_name = bucket_factory(amount=1, interface="OC")[0].name
+        bucket_name = bucket_factory(amount=1, interface="OC", timeout=120)[0].name
         obj_data = "A random string data"
         assert s3_put_object(
             mcg_obj, bucket_name, key, obj_data


### PR DESCRIPTION
Also added general support for passing `timeout` and `interval` functions to the bucket factory.