### PR TITLE
add support for VM query on  VSPHERE IPI

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -177,6 +177,8 @@ BOOTSTRAP_MACHINE = "bootstrap"
 INFRA_MACHINE = "infra"
 MOUNT_POINT = "/var/lib/www/html"
 TOLERATION_KEY = "node.ocs.openshift.io/storage"
+DEPLOYMENT_TYPE_UPI = "upi"
+DEPLOYMENT_TYPE_IPI = "ipi"
 
 OCP_QE_MISC_REPO = "https://gitlab.cee.redhat.com/aosqe/flexy-templates.git"
 CRITICAL_ERRORS = ["core dumped", "oom_reaper"]

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -217,14 +217,25 @@ class VMWareNodes(NodesBase):
             list: vSphere vm objects list
 
         """
-        vms_in_pool = self.vsphere.get_all_vms_in_pool(
-            self.cluster_name, self.datacenter, self.cluster
-        )
-        node_names = [node.get().get("metadata").get("name") for node in nodes]
+        vms_all = []
         vms = []
+        logger.info(f"deployment type: {self.deployment_type}")
+        if self.deployment_type == "upi":
+            vms_all = self.vsphere.get_all_vms_in_pool(
+                self.cluster_name, self.datacenter, self.cluster
+            )
+        elif self.deployment_type == "ipi":
+            vms_all = self.vsphere.get_all_vms_in_dc(self.datacenter)
+
+        else:
+            logger.error("Deployment type not detected")
+
+        node_names = [node.get().get("metadata").get("name") for node in nodes]
+
         for node in node_names:
-            node_vms = [vm for vm in vms_in_pool if vm.name in node]
+            node_vms = [vm for vm in vms_all if vm.name in node]
             vms.extend(node_vms)
+
         return vms
 
     def get_data_volumes(self, pvs=None):

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -220,15 +220,16 @@ class VMWareNodes(NodesBase):
         vms_all = []
         vms = []
         logger.info(f"deployment type: {self.deployment_type}")
-        if self.deployment_type == "upi":
+        if self.deployment_type == constants.DEPLOYMENT_TYPE_UPI:
             vms_all = self.vsphere.get_all_vms_in_pool(
                 self.cluster_name, self.datacenter, self.cluster
             )
-        elif self.deployment_type == "ipi":
+        elif self.deployment_type == constants.DEPLOYMENT_TYPE_IPI:
             vms_all = self.vsphere.get_all_vms_in_dc(self.datacenter)
 
         else:
             logger.error("Deployment type not detected")
+            return None
 
         node_names = [node.get().get("metadata").get("name") for node in nodes]
 


### PR DESCRIPTION
Signed-off-by: Anna Sandler <asandler@redhat.com>
until today, VM query was using resource pools. In IPI deployments there are no pools
this PR checks for deployment type:
UPI - was not changed. using pools.
IPI - added query using DC 