### PR TITLE
Fix failure in compression test

### DIFF
--- a/tests/manage/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
+++ b/tests/manage/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
@@ -75,7 +74,7 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
 
         log.info("Creating PVCs and PODs")
         for sc_obj in sc_obj_list:
-            pvc_obj = pvc_factory(interface=CEPHBLOCKPOOL, storageclass=sc_obj)
+            pvc_obj = pvc_factory(interface=CEPHBLOCKPOOL, storageclass=sc_obj, size=10)
             pod_obj_list.append(pod_factory(interface=CEPHBLOCKPOOL, pvc=pvc_obj))
 
         log.info("Running IO on pods")
@@ -84,16 +83,13 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
                 "fs",
                 size="1G",
                 rate="1500m",
-                runtime=0,
+                runtime=60,
                 buffer_compress_percentage=60,
                 buffer_pattern="0xdeadface",
                 bs="8K",
                 jobs=5,
                 readwrite="readwrite",
             )
-
-        for pod_obj in pod_obj_list:
-            get_fio_rw_iops(pod_obj)
 
         log.info(f"validating info on pool {pool_obj.name}")
         validate_rep_result = validate_replica_data(pool_obj.name, self.replica)

--- a/tests/manage/storageclass/test_create_2sc_at_once_with_io.py
+++ b/tests/manage/storageclass/test_create_2sc_at_once_with_io.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
@@ -69,25 +68,25 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
         pod_obj_list = []
         for sc_obj in sc_obj_list:
             for pod_num in range(1, 5):
-                pvc_obj = pvc_factory(interface=interface_type, storageclass=sc_obj)
+                pvc_obj = pvc_factory(
+                    interface=interface_type, storageclass=sc_obj, size=10
+                )
                 pod_obj_list.append(pod_factory(interface=interface_type, pvc=pvc_obj))
 
         log.info("Running io on pods")
+
         for pod_obj in pod_obj_list:
             pod_obj.run_io(
                 "fs",
-                size="1G",
+                size="2G",
                 rate="1500m",
-                runtime=0,
+                runtime=60,
                 buffer_compress_percentage=60,
                 buffer_pattern="0xdeadface",
                 bs="8K",
                 jobs=5,
                 readwrite="readwrite",
             )
-
-        for pod_obj in pod_obj_list:
-            get_fio_rw_iops(pod_obj)
 
         for sc_obj in sc_obj_list:
             cbp_name = sc_obj.get()["parameters"]["pool"]

--- a/tests/manage/storageclass/test_create_sc_reclaim_policy_rep2_comp.py
+++ b/tests/manage/storageclass/test_create_sc_reclaim_policy_rep2_comp.py
@@ -1,5 +1,4 @@
 import logging
-from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.framework.pytest_customization.marks import polarion_id
 from ocs_ci.framework.pytest_customization.marks import (
@@ -77,7 +76,7 @@ class TestScReclaimPolicyRetainRep2Comp(ManageTest):
         pool = sc_obj.get()["parameters"]["pool"]
 
         log.info("Creating PVCs and PODs")
-        pvc_obj = pvc_factory(interface=CEPHBLOCKPOOL, storageclass=sc_obj)
+        pvc_obj = pvc_factory(interface=CEPHBLOCKPOOL, storageclass=sc_obj, size=10)
         pod_obj = pod_factory(interface=CEPHBLOCKPOOL, pvc=pvc_obj)
 
         log.info("Running IO on pod")
@@ -85,14 +84,13 @@ class TestScReclaimPolicyRetainRep2Comp(ManageTest):
             "fs",
             size="1G",
             rate="1500m",
-            runtime=0,
+            runtime=60,
             buffer_compress_percentage=60,
             buffer_pattern="0xdeadface",
             bs="8K",
             jobs=5,
             readwrite="readwrite",
         )
-        get_fio_rw_iops(pod_obj)
 
         log.info(f"validating info on pool {pool}")
         validate_rep_result = validate_replica_data(pool, self.replica)

--- a/tests/manage/storageclass/test_multiple_sc_comp_rep_data_delete.py
+++ b/tests/manage/storageclass/test_multiple_sc_comp_rep_data_delete.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 from time import sleep
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
@@ -71,7 +70,9 @@ class TestMultipleScCompRepDataDelete(ManageTest):
 
         log.info("Creating PVCs and PODs")
         for sc_obj in sc_obj_list:
-            pvc_obj = pvc_factory(interface=interface_type, storageclass=sc_obj)
+            pvc_obj = pvc_factory(
+                interface=interface_type, storageclass=sc_obj, size=10
+            )
             pvc_obj_list.append(pvc_obj)
             pod_obj_list.append(pod_factory(interface=interface_type, pvc=pvc_obj))
 
@@ -81,16 +82,13 @@ class TestMultipleScCompRepDataDelete(ManageTest):
                 "fs",
                 size="1G",
                 rate="1500m",
-                runtime=0,
+                runtime=60,
                 buffer_compress_percentage=60,
                 buffer_pattern="0xdeadface",
                 bs="8K",
                 jobs=5,
                 readwrite="readwrite",
             )
-
-        for pod_obj in pod_obj_list:
-            get_fio_rw_iops(pod_obj)
 
         log.info("deleting PODs and PVCs")
         delete_pods(pod_obj_list, wait=True)

--- a/tests/manage/storageclass/test_new_sc_rbd_replica2_3.py
+++ b/tests/manage/storageclass/test_new_sc_rbd_replica2_3.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
@@ -54,7 +53,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
         )
 
         log.info(f"Creating a PVC using {sc_obj.name}")
-        pvc_obj = pvc_factory(interface=interface_type, storageclass=sc_obj)
+        pvc_obj = pvc_factory(interface=interface_type, storageclass=sc_obj, size=10)
         log.info(f"PVC: {pvc_obj.name} created successfully using " f"{sc_obj.name}")
 
         # Create app pod and mount each PVC
@@ -68,14 +67,13 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
             "fs",
             size="1G",
             rate="1500m",
-            runtime=0,
+            runtime=60,
             buffer_compress_percentage=60,
             buffer_pattern="0xdeadface",
             bs="8K",
             jobs=5,
             readwrite="readwrite",
         )
-        get_fio_rw_iops(pod_obj)
         cluster_used_space = get_percent_used_capacity()
         log.info(
             f"Cluster used space with replica size {replica}, "


### PR DESCRIPTION
tests/manage/storageclass/test_create_2sc_at_once_with_io.py::TestCreate2ScAtOnceWithIo::test_new_sc_rep2_rep3_at_once is failing in [run](https://ocs4-jenkins-csb-ocsqe.apps.ocp4.prod.psi.redhat.com/job/qe-deploy-ocs-cluster-prod/2228/)
There is some timeout issue and it not related to compression as checking it manually through the test I see compression is there. Added runtime to fio and removed getting results for the fio as they are not used and they are the one causing the timeout.