### PR TITLE
Add resource_name="cluster-monitoring-config" for remove_monitoring_stack_from_ocs

### DIFF
--- a/ocs_ci/ocs/uninstall.py
+++ b/ocs_ci/ocs/uninstall.py
@@ -22,6 +22,7 @@ def remove_monitoring_stack_from_ocs():
     monitoring_obj = ocp.OCP(
         namespace=constants.MONITORING_NAMESPACE,
         kind="ConfigMap",
+        resource_name="cluster-monitoring-config",
     )
     param_cmd = '[{"op": "replace", "path": "/data/config.yaml", "value": ""}]'
     monitoring_obj.patch(


### PR DESCRIPTION
Delete pvc in openshift-monitoring is always fail. The object which is patch is calling  all configmap in openshift-monitoring instead of the specific configmap cluster-monitoring-config.


Signed-off-by: Shay Rozen <shay.rozen@gmail.com>