### PR TITLE
changing the reporting of OCS version in performance tests

### DIFF
--- a/ocs_ci/ocs/version.py
+++ b/ocs_ci/ocs/version.py
@@ -28,7 +28,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node, ocp
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.utility import utils, version
+from ocs_ci.utility import utils
 
 
 logger = logging.getLogger(__name__)
@@ -76,9 +76,7 @@ def get_environment_info():
     results["ceph_version"] = utils.get_ceph_version()
     results["rook_version"] = utils.get_rook_version()
 
-    results[
-        "ocs_build"
-    ] = f"{version.get_ocs_version_from_csv(ignore_pre_release=True)}"
+    results["ocs_build"] = utils.get_ocs_build_number()
 
     # Getting the instance type for cloud or Arch type for None cloud
     worker_lbl = node.get_nodes(num_of_nodes=1)[0].data["metadata"]["labels"]


### PR DESCRIPTION
In this PR i changed the OCS version reporting in the Performance test to include build number, as implemented on other tests, to be align with the 4.9 reporting. 

Signed-off-by: Avi Layani <alayani@redhat.com>