### PR TITLE
Skip RBD thick test cases

### DIFF
--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -27,7 +27,7 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 @tier4
 @tier4a
-@pytest.mark.skip(reason="Depricated")
+@pytest.mark.skip(reason="Deprecated")
 class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
     Test to delete rbd provisioner leader pod while thick provisioning is progressing

--- a/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
+++ b/tests/manage/pv_services/test_delete_provisioner_pod_while_thick_provisioning.py
@@ -8,7 +8,6 @@ from ocs_ci.framework.testlib import (
     tier4a,
     polarion_id,
     bugzilla,
-    skipif_ocs_version,
 )
 from ocs_ci.helpers.helpers import (
     verify_volume_deleted_in_backend,
@@ -28,7 +27,7 @@ DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 @tier4
 @tier4a
-@skipif_ocs_version("<=4.9")
+@pytest.mark.skip(reason="Depricated")
 class TestDeleteProvisionerPodWhileThickProvisioning(ManageTest):
     """
     Test to delete rbd provisioner leader pod while thick provisioning is progressing

--- a/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
+++ b/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
@@ -7,7 +7,6 @@ from ocs_ci.framework.testlib import (
     tier2,
     tier4,
     polarion_id,
-    skipif_ocs_version,
     bugzilla,
 )
 from ocs_ci.helpers.helpers import (
@@ -60,7 +59,7 @@ class TestDeletePvcWhileProvisioning(ManageTest):
         """
         self.proj_obj = project_factory()
 
-    @skipif_ocs_version("<=4.9")
+    @pytest.mark.skip(reason="Depricated")
     def test_delete_rbd_pvc_while_thick_provisioning(
         self,
         resource_to_delete,

--- a/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
+++ b/tests/manage/pv_services/test_delete_pvc_while_provisioning.py
@@ -59,7 +59,7 @@ class TestDeletePvcWhileProvisioning(ManageTest):
         """
         self.proj_obj = project_factory()
 
-    @pytest.mark.skip(reason="Depricated")
+    @pytest.mark.skip(reason="Deprecated")
     def test_delete_rbd_pvc_while_thick_provisioning(
         self,
         resource_to_delete,

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
             *["thick", "thick"],
             marks=[
                 polarion_id("OCS-2502"),
-                pytest.mark.skip(reason="Depricated"),
+                pytest.mark.skip(reason="Deprecated"),
                 bugzilla("1959793"),
             ],
         ),
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
             *["thin", "thick"],
             marks=[
                 polarion_id("OCS-2507"),
-                pytest.mark.skip(reason="Depricated"),
+                pytest.mark.skip(reason="Deprecated"),
                 bugzilla("1959793"),
             ],
         ),
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
             *["thick", "thin"],
             marks=[
                 polarion_id("OCS-2508"),
-                pytest.mark.skip(reason="Depricated"),
+                pytest.mark.skip(reason="Deprecated"),
                 bugzilla("1959793"),
             ],
         ),

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
             *["thick", "thick"],
             marks=[
                 polarion_id("OCS-2502"),
-                skipif_ocs_version("<=4.9"),
+                pytest.mark.skip(reason="Depricated"),
                 bugzilla("1959793"),
             ],
         ),
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
             *["thin", "thick"],
             marks=[
                 polarion_id("OCS-2507"),
-                skipif_ocs_version("<=4.9"),
+                pytest.mark.skip(reason="Depricated"),
                 bugzilla("1959793"),
             ],
         ),
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
             *["thick", "thin"],
             marks=[
                 polarion_id("OCS-2508"),
-                skipif_ocs_version("<=4.9"),
+                pytest.mark.skip(reason="Depricated"),
                 bugzilla("1959793"),
             ],
         ),

--- a/tests/manage/pv_services/test_rbd_thick_provisioning.py
+++ b/tests/manage/pv_services/test_rbd_thick_provisioning.py
@@ -15,7 +15,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(reason="Depricated")
+@pytest.mark.skip(reason="Deprecated")
 class TestRbdThickProvisioning(ManageTest):
     """
     Tests to verify PVC creation and consumption using RBD thick provisioning enabled storage class

--- a/tests/manage/pv_services/test_rbd_thick_provisioning.py
+++ b/tests/manage/pv_services/test_rbd_thick_provisioning.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
-    skipif_ocs_version,
     polarion_id,
     ManageTest,
     tier1,
@@ -16,7 +15,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
-@skipif_ocs_version("<=4.9")
+@pytest.mark.skip(reason="Depricated")
 class TestRbdThickProvisioning(ManageTest):
     """
     Tests to verify PVC creation and consumption using RBD thick provisioning enabled storage class

--- a/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
+++ b/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
@@ -6,7 +6,6 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
     polarion_id,
-    skipif_ocs_version,
 )
 from ocs_ci.helpers.helpers import (
     default_thick_storage_class,
@@ -19,7 +18,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
-@skipif_ocs_version("<=4.9")
+@pytest.mark.skip(reason="Depricated")
 class TestVerifyRbdThickPvcUtilization(ManageTest):
     """
     Tests to verify storage utilization of RBD thick provisioned PVC

--- a/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
+++ b/tests/manage/pv_services/test_verify_thick_pvc_utilization.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(reason="Depricated")
+@pytest.mark.skip(reason="Deprecated")
 class TestVerifyRbdThickPvcUtilization(ManageTest):
     """
     Tests to verify storage utilization of RBD thick provisioned PVC


### PR DESCRIPTION
Skipping RBD thick tests because the feature will be deprecated.
Fixes #5059 
Signed-off-by: Jilju Joy <jijoy@redhat.com>