### PR TITLE
Possibility to add param --binary-image to opm index prune command

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -91,6 +91,8 @@ anywhere else.
 * `mirror_registry` - Hostname of the mirror registry
 * `mirror_registry_user` - Username for disconnected cluster mirror registry
 * `mirror_registry_password` - Password for disconnected cluster mirror registry
+* `opm_index_prune_binary_image` - Required only for IBM Power Systems and IBM Z images: Operator Registry base image with the tag that matches the target OpenShift Container Platform cluster major and minor version.
+  [doc](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/administrator-tasks#olm-pruning-index-image_olm-managing-custom-catalogs)
 * `min_noobaa_endpoints` - Sets minimum noobaa endpoints (Workaround for https://github.com/red-hat-storage/ocs-ci/issues/2861)
 * `host_network` - Enable host network in the storage cluster CR and prepare rules needed in AWS for host network during OCP deployment
 * `subscription_plan_approval` - 'Manual' or 'Automatic' subscription approval for OCS upgrade

--- a/conf/README.md
+++ b/conf/README.md
@@ -92,6 +92,7 @@ anywhere else.
 * `mirror_registry_user` - Username for disconnected cluster mirror registry
 * `mirror_registry_password` - Password for disconnected cluster mirror registry
 * `opm_index_prune_binary_image` - Required only for IBM Power Systems and IBM Z images: Operator Registry base image with the tag that matches the target OpenShift Container Platform cluster major and minor version.
+  (for example: `registry.redhat.io/openshift4/ose-operator-registry:v4.9`)
   [doc](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/operators/administrator-tasks#olm-pruning-index-image_olm-managing-custom-catalogs)
 * `min_noobaa_endpoints` - Sets minimum noobaa endpoints (Workaround for https://github.com/red-hat-storage/ocs-ci/issues/2861)
 * `host_network` - Enable host network in the storage cluster CR and prepare rules needed in AWS for host network during OCP deployment

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -93,6 +93,10 @@ def prune_and_mirror_index_image(
         f"-p {','.join(packages)} "
         f"-t {mirrored_index_image}"
     )
+    if config.DEPLOYMENT.get("opm_index_prune_binary_image"):
+        cmd += (
+            f" --binary-image {config.DEPLOYMENT.get('opm_index_prune_binary_image')}"
+        )
     # opm tool doesn't have --authfile parameter, we have to supply auth
     # file through env variable
     os.environ["REGISTRY_AUTH_FILE"] = pull_secret_path


### PR DESCRIPTION
This parameter is required for non x86_64 architectures.

Signed-off-by: Daniel Horak <dahorak@redhat.com>