### PR TITLE
fix disconnected odf > 4.9.0-231 deployment

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1154,6 +1154,7 @@ DISCON_CL_REQUIRED_PACKAGES = [
     "cluster-logging",
     "elasticsearch-operator",
     "local-storage-operator",
+    "mcg-operator",
     "noobaa-operator",
     "ocs-operator",
     "odf-multicluster-orchestrator",


### PR DESCRIPTION
`noobaa-operator` package was renamed to `mcg-operator` (we can keep there both names, as it skips those which are not available)

Related to https://github.com/red-hat-storage/ocs-ci/issues/5080.
Signed-off-by: Daniel Horak <dahorak@redhat.com>