### PR TITLE
Changing test_create_pool_block_pool.py to 4.9 and check compression efficiency in UI

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1182,6 +1182,25 @@ def validate_compression(pool_name):
     raise PoolNotFound(f"Pool {pool_name} not found on cluster")
 
 
+def get_pool_id(pool_name):
+    """
+    Get pool ID from pool name
+
+    Args:
+        pool_name (str): name of the pool to get the id.
+
+    Returns:
+        pool id if found else None
+
+    """
+    ceph_df_detail_output = get_ceph_df_detail()
+    pool_list = ceph_df_detail_output.get("pools")
+    for pool in pool_list:
+        if pool.get("name") == pool_name:
+            return pool.get("id")
+    return None
+
+
 def validate_osd_utilization(osd_used=80):
     """
     Validates osd utilization matches osd_used value

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -340,6 +340,14 @@ class PoolNotReplicatedAsNeeded(Exception):
     pass
 
 
+class PoolIdNotFound(Exception):
+    pass
+
+
+class PoolUiEfficiencyParametersNotEqualToPrometheus(Exception):
+    pass
+
+
 class ImageIsNotDeletedOrNotFound(Exception):
     pass
 

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -365,7 +365,7 @@ class PageNavigator(BaseUI):
         logger.info("Navigate to ODF tab under Storage section")
         self.choose_expanded_mode(mode=True, locator=self.page_nav["Storage"])
         self.do_click(locator=self.page_nav["odf_tab"], timeout=90)
-        self.page_has_loaded(retries=15, sleep_time=5)
+        self.page_has_loaded(retries=15, sleep_time=1)
         logger.info("Successfully navigated to ODF tab under Storage section")
 
     def navigate_quickstarts_page(self):
@@ -435,7 +435,7 @@ class PageNavigator(BaseUI):
         self.do_click(
             self.page_nav["installed_operators_page"], enable_screenshot=False
         )
-        self.page_has_loaded(retries=15, sleep_time=5)
+        self.page_has_loaded(retries=15, sleep_time=1)
 
     def navigate_to_ocs_operator_page(self):
         """
@@ -586,8 +586,18 @@ class PageNavigator(BaseUI):
 
         """
         logger.info("Navigate to block pools page")
-        self.navigate_to_ocs_operator_page()
-        self.do_click(locator=self.page_nav["block_pool_link"])
+        ocp_version = get_ocp_version()
+        if Version.coerce(self.ocp_version) > Version.coerce("4.8"):
+            self.navigate_odf_overview_page()
+            self.do_click(locators[ocp_version]["validation"]["storage_systems"])
+            self.do_click(
+                locators[ocp_version]["validation"]["ocs-storagecluster-storagesystem"]
+            )
+            self.do_click(locators[ocp_version]["validation"]["blockpools"])
+        else:
+            self.navigate_to_ocs_operator_page()
+            self.do_click(locator=self.page_nav["block_pool_link"])
+        self.page_has_loaded(retries=15)
 
     def verify_current_page_resource_status(self, status_to_check, timeout=30):
         """

--- a/ocs_ci/ocs/ui/block_pool.py
+++ b/ocs_ci/ocs/ui/block_pool.py
@@ -6,8 +6,11 @@ from ocs_ci.ocs.ui.views import locators
 from ocs_ci.utility.utils import get_ocp_version
 from selenium.webdriver.common.by import By
 from ocs_ci.helpers.helpers import create_unique_resource_name
-from ocs_ci.ocs.exceptions import PoolStateIsUnknow
+from ocs_ci.ocs.exceptions import PoolStateIsUnknow, PoolIdNotFound
 import ocs_ci.ocs.resources.pod as pod
+from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.ocs.cluster import get_pool_id
+from ocs_ci.utility.utils import convert_bytes_into_right_measure
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +72,9 @@ class BlockPoolUI(PageNavigator):
             bool: True if pool is in the list of pools page, otherwise False
 
         """
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_block_pool_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         pool_existence = self.wait_until_expected_text_is_found(
             (f"a[data-test-operand-link={pool_name}]", By.CSS_SELECTOR), pool_name, 5
         )
@@ -90,9 +93,9 @@ class BlockPoolUI(PageNavigator):
 
         """
 
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_block_pool_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         self.do_click((f"{pool_name}", By.LINK_TEXT))
         self.do_click(self.bp_loc["actions_inside_pool"])
         self.do_click(self.bp_loc["delete_pool_inside_pool"])
@@ -111,9 +114,9 @@ class BlockPoolUI(PageNavigator):
             compression (bool): True if enable compression. False otherwise.
 
         """
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_block_pool_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         self.do_click([f"{pool_name}", By.LINK_TEXT])
         self.do_click(self.bp_loc["actions_inside_pool"])
         self.do_click(self.bp_loc["edit_pool_inside_pool"])
@@ -173,3 +176,130 @@ class BlockPoolUI(PageNavigator):
                     raise PoolStateIsUnknow(
                         f"pool {pool_name} is in unexpected state {pool_state}"
                     )
+
+    def check_ui_pool_efficiency_parameters_against_prometheus(
+        self, pool_name, expected_compression_saving
+    ):
+        """
+        Get pool compression efficiency from UI and compare them against prometheus metrics
+
+        Args:
+            pool_name (str): The pool name to be checked.
+            expected_compression_saving (str): The expected compression saving in string like "1.5 GiB"
+
+        Returns:
+            (bool): True if UI and prometheus parameters are equal to expected_compression_saving - else False.
+
+        """
+
+        # Navigate to pool page
+        self.navigate_installed_operators_page()
+        self.navigate_block_pool_page()
+        self.do_click([f"{pool_name}", By.LINK_TEXT])
+        self.page_has_loaded(retries=15)
+
+        # Get efficiency card values
+        eff_elements = self.driver.find_elements_by_class_name(
+            "ceph-storage-efficiency-card__item-text"
+        )
+        eff_value_array = []
+        for element in eff_elements:
+            eff_value_array.append(element.text)
+        compression_eligibility, compression_ratio, compression_saving = eff_value_array
+        compression_saving_value, compression_saving_unit = compression_saving.split(
+            " "
+        )
+        logger.info(
+            f"compression_saving_value {compression_saving_value} "
+            f"compression_saving_unit {compression_saving_unit}"
+        )
+        logger.info(
+            f"compression_eligibility {compression_eligibility} "
+            f"compression_ratio {compression_ratio} "
+            f" compression_saving {compression_saving}"
+        )
+
+        # Get pool id and query Prometheus
+        pool_id = get_pool_id(pool_name)
+        if pool_id is None:
+            raise PoolIdNotFound(f"Pool {pool_name} didn't return pool id")
+        new_prom = PrometheusAPI()
+        ceph_pool_compress_bytes_used_data = new_prom.query(
+            f'ceph_pool_compress_bytes_used{{pool_id="{pool_id}"}}'
+        )
+        ceph_pool_compress_under_bytes_data = new_prom.query(
+            f'ceph_pool_compress_under_bytes{{pool_id="{pool_id}"}}'
+        )
+
+        # Calculate compression savings
+        ceph_pool_compress_bytes_used_value = ceph_pool_compress_bytes_used_data[0].get(
+            "value"
+        )
+        ceph_pool_compress_under_bytes_value = ceph_pool_compress_under_bytes_data[
+            0
+        ].get("value")
+        final_saving = int(ceph_pool_compress_under_bytes_value[1]) - int(
+            ceph_pool_compress_bytes_used_value[1]
+        )
+        logger.info(f"final saving in bytes {final_saving}")
+
+        # Convert final saving to right measure
+        prometheus_final_saving_human = convert_bytes_into_right_measure(final_saving)
+        logger.info(f"Final saving in ui measure {prometheus_final_saving_human}")
+
+        # Calculate compression ratio
+        final_ratio = int(ceph_pool_compress_under_bytes_value[1]) / int(
+            ceph_pool_compress_bytes_used_value[1]
+        )
+        logger.info(f"final ratio {final_ratio}")
+
+        # Compare all parameters
+        (
+            expected_compression_value,
+            expected_compression_unit,
+        ) = expected_compression_saving.split(" ")
+
+        return_value_are_equal = True
+        prom_saving_value, prom_final_unit = prometheus_final_saving_human.split(" ")
+        if (
+            format(float(compression_saving_value), ".2f")
+            != format(float(expected_compression_value), ".2f")
+            or compression_saving_unit != expected_compression_unit
+        ):
+            return_value_are_equal = False
+            logger.info(
+                f"UI compression saving are not equal to expected saving: "
+                f"UI compression value is {compression_saving_value} "
+                f"and expected compression value is {expected_compression_value}. "
+                f"UI compression unit is {compression_saving_unit} "
+                f"and prometheus compression unit is {expected_compression_unit}"
+            )
+
+        if (
+            format(float(compression_saving_value), ".2f")
+            != format(float(prom_saving_value), ".2f")
+            or compression_saving_unit != prom_final_unit
+        ):
+            return_value_are_equal = False
+            logger.info(
+                f"UI compression saving are not equal to prometheus saving: "
+                f"UI compression value is {compression_saving_value} "
+                f"and prometheus compression value is {prom_saving_value}. "
+                f"UI compression unit is {compression_saving_unit} "
+                f"and prometheus compression unit is {prom_final_unit}"
+            )
+        if compression_eligibility != "100%":
+            return_value_are_equal = False
+            logger.info(
+                f"UI compression eligibility is {compression_eligibility} but should be 100%"
+            )
+
+        final_ratio = int(final_ratio)
+        first_ratio_value, second_ratio_value = compression_ratio.split(":")
+        final_ui_ratio = int(int(first_ratio_value) / int(second_ratio_value))
+        if final_ratio != final_ui_ratio:
+            return_value_are_equal = False
+            logger.info(
+                f"UI ratio is {final_ui_ratio} where prometheus ratio is {final_ratio}"
+            )
+        return return_value_are_equal

--- a/ocs_ci/ocs/ui/storageclass.py
+++ b/ocs_ci/ocs/ui/storageclass.py
@@ -32,9 +32,9 @@ class StorageClassUI(PageNavigator):
 
         """
 
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_storageclasses_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         sc_name = create_unique_resource_name("test", "storageclass")
         self.do_click(self.sc_loc["create_storageclass_button"])
         self.do_send_keys(self.sc_loc["input_storageclass_name"], sc_name)
@@ -60,9 +60,9 @@ class StorageClassUI(PageNavigator):
 
         """
 
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_storageclasses_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         sc_existence = self.wait_until_expected_text_is_found(
             (f"a[data-test-id={sc_name}]", By.CSS_SELECTOR), sc_name, 5
         )
@@ -80,9 +80,9 @@ class StorageClassUI(PageNavigator):
 
         """
 
-        self.navigate_overview_page()
+        self.navigate_installed_operators_page()
         self.navigate_storageclasses_page()
-        self.page_has_loaded()
+        self.page_has_loaded(retries=15)
         logger.info(f"sc_name is {sc_name}")
         self.do_click((f"{sc_name}", By.LINK_TEXT))
         self.do_click(self.sc_loc["action_inside_storageclass"])

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -422,6 +422,13 @@ block_pool = {
     "pool_state_inside_pool": ('span[data-test="status-text"]', By.CSS_SELECTOR),
 }
 
+block_pool_4_9 = {
+    "storage_efficiency_text_aray": (
+        'span[class="ceph-storage-efficiency-card__item-text"',
+        By.CSS_SELECTOR,
+    )
+}
+
 storageclass = {
     "create_storageclass_button": ("Create StorageClass", By.LINK_TEXT),
     "input_storageclass_name": ('input[id="storage-class-name"]', By.CSS_SELECTOR),
@@ -567,6 +574,8 @@ locators = {
         "generic": generic_locators,
         "validation": {**validation, **validation_4_8, **validation_4_9},
         "acm_page": acm_page_nav,
+        "block_pool": {**block_pool, **block_pool_4_9},
+        "storageclass": storageclass,
     },
     "4.8": {
         "login": login,

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 import traceback
 import stat
+import math
 from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -2651,6 +2652,26 @@ def convert_device_size(unformatted_size, units_to_covert_to):
         "B": {"Ti": abso * 1e12, "Gi": abso * 1e9, "Mi": abso * 1e6, "Ki": abso * 1000},
     }
     return conversion[units_to_covert_to][units]
+
+
+def convert_bytes_into_right_measure(size_bytes):
+    """
+    Convert bytes in the appropriate measure unit
+
+    Args:
+        size_bytes (int): The size in bytes.
+
+    Returns:
+        (str): The converted size as string like "15 GiB"
+
+    """
+    if size_bytes == 0:
+        return "0B"
+    size_name = ("B", "KB", "MB", "GiB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(math.floor(math.log(size_bytes, 1024)))
+    p = math.pow(1024, i)
+    s = round(size_bytes / p, 2)
+    return "%s %s" % (s, size_name[i])
 
 
 def prepare_customized_pull_secret(images=None):


### PR DESCRIPTION
Update the testcase for 4.9 with different location for block_pool page, handling default binding mode for storageclass and checking compression efficiency from UI with prometheus values.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>