### PR TITLE
Retry mcg status check

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -1015,7 +1015,7 @@ class MCG:
                 )
 
     @property
-    @retry(exception_to_check=CommandFailed, tries=20, delay=20, backoff=1)
+    @retry(exception_to_check=CommandFailed, tries=10, delay=6, backoff=1)
     def status(self):
         """
         Verify the status of NooBaa, and its default backing store and bucket class

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -1015,6 +1015,7 @@ class MCG:
                 )
 
     @property
+    @retry(exception_to_check=CommandFailed, tries=20, delay=20, backoff=1)
     def status(self):
         """
         Verify the status of NooBaa, and its default backing store and bucket class


### PR DESCRIPTION
External mode deployment failed with the error :
```
E           ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc -n openshift-storage get backingstore noobaa-default-backing-store -n openshift-storage -o yaml.
E           Error is Error from server (NotFound): backingstores.noobaa.io "noobaa-default-backing-store" not found

ocs_ci/utility/utils.py:511: CommandFailed
```
Add a retry to check the status of mcg. 
Signed-off-by: Jilju Joy <jijoy@redhat.com>