### PR TITLE
Teardown fixes in "test_pvc_bulk_creation_deletion_performance" test case

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -735,14 +735,14 @@ def create_multiple_pvcs(
     return ocs_objs, tmpdir
 
 
-def delete_bulk_pvcs(pvc_yaml_dir, pv_names_list):
+def delete_bulk_pvcs(pvc_yaml_dir, pv_names_list, namespace):
     """
     Deletes all the pvcs created from yaml file in a provided dir
     Args:
         pvc_yaml_dir (str): Directory in which yaml file resides
         pv_names_list (str): List of pv objects to be deleted
     """
-    oc = OCP(kind="pod", namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    oc = OCP(kind="pod", namespace=namespace)
     cmd = f"delete -f {pvc_yaml_dir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
 

--- a/tests/e2e/performance/csi_tests/test_pvc_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_attachtime.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class ResultsAnalyse(PerfResult):
     """
     This class generates results for all tests as one unit
-    and saves them to an elastic search server on the cluster
+    and saves them to an elastic search server on the cluster 
 
     """
 

--- a/tests/e2e/performance/csi_tests/test_pvc_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_attachtime.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class ResultsAnalyse(PerfResult):
     """
     This class generates results for all tests as one unit
-    and saves them to an elastic search server on the cluster 
+    and saves them to an elastic search server on the cluster
 
     """
 


### PR DESCRIPTION
This PR runs the "test_pvc_bulk_creation_deletion_performance" test in new namespace instead of existing namespace and deletes the namespace at the end of the test.

Also deleting pvc objects solves tear down issues in "tests.e2e.performance.test_pvc_bulk_creation_deletion_performance.TestPVCCreationPerformance.test_bulk_pvc_creation_after_deletion_performance[CephFS]"