### PR TITLE
Set lower memory for RHV prod configs

### DIFF
--- a/conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml
+++ b/conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml
@@ -12,7 +12,7 @@ ENV_DATA:
   master_num_cores: '2'
   master_num_sockets: '2'
   master_memory: '16384'
-  compute_memory: '65536'
+  compute_memory: '43008'
   # Following values needs to be set in separate config and passed to ocs-ci in
   # order to connect to RHVM and/or deploy OCP/OCS cluster on RHV
   # default_cluster_name: PLACEHOLDER

--- a/conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml
+++ b/conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml
@@ -13,7 +13,7 @@ ENV_DATA:
   master_num_cores: '2'
   master_num_sockets: '2'
   master_memory: '16384'
-  compute_memory: '65536'
+  compute_memory: '43008'
   local_storage_allow_rotational_disks: true
   # Following optional values can be passed to ocs-ci which will used when
   # attaching the disks to the VMs


### PR DESCRIPTION
In current RHV deployment we have we have maximum 191 GB of memory.
To accommodate it for all hosts we need to lower memory.
Based on documentation in total ODF requires 72 GB in total for all
nodes.

Signed-off-by: Petr Balogh <pbalogh@redhat.com>