### PR TITLE
Add possibility to skip index image prune and images mirroring on disconnected environment

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -121,7 +121,9 @@ anywhere else.
 * `cert_signing_service_url` - Automatic Certification Authority signing service URL.
 * `proxy_http_proxy`, `proxy_https_proxy` - proxy configuration used for installation of cluster behind proxy (vSphere deployment via Flexy)
 * `disconnected_http_proxy`, `disconnected_https_proxy`, `disconnected_no_proxy` - proxy configuration used for installation of disconnect cluster (vSphere deployment via Flexy)
+* `disconnected_env_skip_image_mirroring` - skip index image prune and mirroring on disconnected environment (this expects that all the required images will be mirrored outside of ocs-ci)
 * `customized_deployment_storage_class` - Customize the storage class type in the deployment.
+
 #### REPORTING
 
 Reporting related config. (Do not store secret data in the repository!).

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -914,7 +914,9 @@ class Deployment(object):
 
         # disconnected installation?
         load_cluster_info()
-        if config.DEPLOYMENT.get("disconnected"):
+        if config.DEPLOYMENT.get("disconnected") and not config.DEPLOYMENT.get(
+            "disconnected_env_skip_image_mirroring"
+        ):
             image = prepare_disconnected_ocs_deployment()
 
         if config.DEPLOYMENT["external_mode"]:

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -540,7 +540,9 @@ def run_ocs_upgrade(operation=None, *operation_args, **operation_kwargs):
     csv_name_pre_upgrade = upgrade_ocs.get_csv_name_pre_upgrade()
     pre_upgrade_images = upgrade_ocs.get_pre_upgrade_image(csv_name_pre_upgrade)
     upgrade_ocs.load_version_config_file(upgrade_version)
-    if config.DEPLOYMENT.get("disconnected"):
+    if config.DEPLOYMENT.get("disconnected") and not config.DEPLOYMENT.get(
+        "disconnected_env_skip_image_mirroring"
+    ):
         upgrade_ocs.ocs_registry_image = prepare_disconnected_ocs_deployment(
             upgrade=True
         )


### PR DESCRIPTION
- introduce new configuration parameter `DEPLOYMENT["disconnected_env_skip_image_mirroring"]` which allows skipping of preparation for disconnected deployment (index image pruning, mirroring images, catalog source creation,...)
- this will be useful, when the required images are mirrored and the environment is prepared outside of ocs-ci 

Signed-off-by: Daniel Horak <dahorak@redhat.com>