### PR TITLE
Adding pytest skip markers to tests that are being modified to address tear down issues

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -20,7 +20,7 @@ from ocs_ci.helpers import performance_lib
 
 log = logging.getLogger(__name__)
 
-SKIP_REASON = "Skipping multiple clone test until github issue 5198 is addressed"
+SKIP_REASON = "Skipping multiple clone tests until github issue 5198 is addressed"
 
 
 @performance

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -20,6 +20,8 @@ from ocs_ci.helpers import performance_lib
 
 log = logging.getLogger(__name__)
 
+SKIP_REASON = "Test is re-written to fix teardown issues, Hence skipping this test"
+
 
 @performance
 @skipif_ocp_version("<4.6")
@@ -31,6 +33,7 @@ class TestPvcMultiClonePerformance(E2ETest):
     """
 
     @pytest.mark.polarion_id("OCS-2622")
+    @pytest.mark.skip(SKIP_REASON)
     def test_pvc_multiple_clone_performance(
         self,
         interface_iterate,

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -20,7 +20,7 @@ from ocs_ci.helpers import performance_lib
 
 log = logging.getLogger(__name__)
 
-SKIP_REASON = "Test is re-written to fix teardown issues, Hence skipping this test"
+SKIP_REASON = "Skipping multiple clone test until github issue 5198 is addressed"
 
 
 @performance

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -16,7 +16,7 @@ from ocs_ci.framework.testlib import (
 
 log = logging.getLogger(__name__)
 
-SKIP_REASON = "Skipping multiple snapshot test until github issue 5197 is addressed"
+SKIP_REASON = "Skipping multiple snapshot tests until github issue 5197 is addressed"
 
 
 @performance

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -16,7 +16,7 @@ from ocs_ci.framework.testlib import (
 
 log = logging.getLogger(__name__)
 
-SKIP_REASON = "Test is re-written to fix teardown issues, Hence skipping this test"
+SKIP_REASON = "Skipping multiple snapshot test until github issue 5197 is addressed"
 
 
 @performance

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -16,6 +16,8 @@ from ocs_ci.framework.testlib import (
 
 log = logging.getLogger(__name__)
 
+SKIP_REASON = "Test is re-written to fix teardown issues, Hence skipping this test"
+
 
 @performance
 @skipif_ocp_version("<4.6")
@@ -26,6 +28,7 @@ class TestPvcMultiSnapshotPerformance(E2ETest):
     The test is trying to to take the maximum number of snapshot for one PVC
     """
 
+    @pytest.mark.skip(SKIP_REASON)
     @pytest.mark.polarion_id("OCS-2623")
     def test_pvc_multiple_snapshot_performance(
         self,

--- a/tests/e2e/performance/io_workload/test_fio_benchmark.py
+++ b/tests/e2e/performance/io_workload/test_fio_benchmark.py
@@ -22,6 +22,8 @@ from ocs_ci.ocs import benchmark_operator
 
 log = logging.getLogger(__name__)
 
+SKIP_REASON = "Skipping FIO compressed test until github issue 5099 is addressed"
+
 
 class FIOResultsAnalyse(PerfResult):
     """
@@ -483,6 +485,7 @@ class TestFIOBenchmark(PASTest):
             log.info(f"The Result can be found at : {full_results.results_link()}")
 
     @skipif_ocs_version("<4.6")
+    @pytest.mark.skip(SKIP_REASON)
     @pytest.mark.parametrize(
         argnames=["io_pattern", "bs", "cmp_ratio"],
         argvalues=[


### PR DESCRIPTION
At present "test_pvc_multi_clone_performance.py" and "test_pvc_multi_snapshot_performance.py" are being modified to address tear down issues. These tests would be run manually on need basis. Also due to https://github.com/red-hat-storage/ocs-ci/issues/5099 compressed scenarios are failing in "test_fio_benchmark.py", hence adding pytest skip marker to all these tests