### PR TITLE
Extend the MCG DB deletion recovery timeout on external clusters

### DIFF
--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -75,7 +75,8 @@ class TestMCGResourcesDisruptions(MCGTest):
             condition=constants.STATUS_RUNNING,
             selector=self.labels_map[resource_to_delete],
             resource_count=1,
-            timeout=90,
+            timeout=800 if config.DEPLOYMENT.get("external_mode") else 90,
+            sleep=60,
         )
         self.cl_obj.wait_for_noobaa_health_ok()
 


### PR DESCRIPTION
We're currently seeing failures after waiting 90 seconds, but the pod seems to reach a Running state after 660~ seconds