### PR TITLE
Extend ceph object

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -825,7 +825,7 @@ class CephCluster(object):
         """
         # Make sure the the default filesystem is not deleted.
         if fs_name == "ocs-storagecluster-cephfilesystem":
-            pass
+            return
 
         # Delete the filesystem
         self.CEPHFS.delete(resource_name=fs_name)
@@ -876,7 +876,7 @@ class CephCluster(object):
         """
         # Make sure the the default RBD pool is not deleted.
         if pool_name == "ocs-storagecluster-cephblockpool":
-            pass
+            return
 
         # Delete the RBD pool
         self.RBD.delete(resource_name=pool_name)

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -791,6 +791,21 @@ class CephCluster(object):
             logger.error(err_msg)
             raise exceptions.CephHealthException(err_msg)
 
+    def delete_filesystem(self, fs_name):
+        """
+        Delete a ceph filesystem - not the default one - from the cluster
+
+        Args:
+            fs_name (str): the name of the filesystem to delete
+        """
+        # Make sure the the default filesystem is not deleted.
+        if fs_name == "ocs-storagecluster-cephfilesystem":
+            pass
+
+        # Delete the filesystem
+        self.CEPHFS.delete(resource_name=fs_name)
+        self.CEPHFS.wait_for_delete(resource_name=fs_name)
+
 
 class CephHealthMonitor(threading.Thread):
     """

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -730,6 +730,41 @@ class CephCluster(object):
         time_taken = time.time() - start_time
         return time_taken / 60
 
+    def set_pgs(self, poolname, pgs):
+        """
+        Setting up the PG / PGP / PG_MIN number of a pool
+        if the pg_num_min is not setting to the pg_num number, the autoscale will
+        set automaticlly the pg_num to 32 (incase you try to set pg_num > 32)
+
+        Args:
+            poolname (str): the pool name that need to be modify
+            pgs (int): new number of PG's
+
+        """
+        for key in ["pg_num", "pgp_num", "pg_num_min"]:
+            cmd = f"ceph osd pool set {poolname} {key} {pgs}"
+            try:
+                logger.debug(f"Try to set {key} to {pgs}")
+                _ = self.toolbox.exec_ceph_cmd(ceph_cmd=cmd, format=None)
+            except Exception as ex:
+                logger.error(f"Failed to setup {key} : {ex}")
+
+    def set_target_ratio(self, poolname, ratio):
+        """
+        Setting the target_size_ratio of a ceph pool
+
+        Args:
+            poolname (str): the pool name
+            ratio (float): the new ratio to set
+
+        """
+        cmd = f"ceph osd pool set {poolname} target_size_ratio {ratio}"
+        try:
+            logger.debug(f"Try to set target_size_ratio on {poolname} to : {ratio}")
+            _ = self.toolbox.exec_ceph_cmd(ceph_cmd=cmd, format=None)
+        except Exception as ex:
+            logger.error(f"Failed to change the ratio : {ex}")
+
 
 class CephHealthMonitor(threading.Thread):
     """


### PR DESCRIPTION
This PR Add to the ceph object the functionality of : 

- Creating new pools (RBD / CephFS)
- Deleting pools (RBD / CephFS), while insuring that the defaults polls will not be deleted (accidently)
- Changing the PG number of a pool
- Changing the target_size_ratio of a pool

All of that is for using in heavy loaded test (filling up the cluster), new pools that can be deleted in the end, 
so the actual cleanup will be very fast.
