### PR TITLE
PVC Key for Locator in 4.9

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -580,6 +580,7 @@ locators = {
         "validation": {**validation, **validation_4_8, **validation_4_9},
         "acm_page": acm_page_nav,
         "add_capacity": add_capacity,
+        "pvc": {**pvc, **pvc_4_7, **pvc_4_8},
     },
     "4.8": {
         "login": login,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -322,6 +322,12 @@ pvc_4_8 = {
     "search_pvc": ("input[placeholder='Search by name...']", By.CSS_SELECTOR),
 }
 
+pvc_4_9 = {
+    "pvc_project_selector": (".pf-c-menu-toggle__text", By.CSS_SELECTOR),
+    "test-project-link": ("//span[contains(text(),'{}')]", By.XPATH),
+    "search-project": ("input[placeholder='Select project...']", By.CSS_SELECTOR),
+}
+
 page_nav = {
     "Home": ("//button[text()='Home']", By.XPATH),
     "overview_page": ("Overview", By.LINK_TEXT),
@@ -580,7 +586,7 @@ locators = {
         "validation": {**validation, **validation_4_8, **validation_4_9},
         "acm_page": acm_page_nav,
         "add_capacity": add_capacity,
-        "pvc": {**pvc, **pvc_4_7, **pvc_4_8},
+        "pvc": {**pvc, **pvc_4_7, **pvc_4_8, **pvc_4_9},
     },
     "4.8": {
         "login": login,


### PR DESCRIPTION
Added PVC key in the directory for 4.9 so that all the existing locators can be accessed by their respective tests and they do not skip or fail because of the missing key. Any locator changes can be added on per need basis if any failures are seen and analyzed with invalid locator error in the near future. 