### PR TITLE
fix purple squad assignment

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1332,7 +1332,7 @@ SQUADS = {
     "Green": ["/pv_services/", "/storageclass/"],
     "Blue": ["/monitoring/"],
     "Red": ["/mcg/", "/rgw/"],
-    "Purple": ["/test_must_gather", "/upgrade/"],
+    "Purple": ["/test_must_gather", "/ecosystem/"],
     "Magenta": ["/workloads/", "/flowtest/", "/lifecycle/", "/kcs/"],
     "Grey": ["/performance/"],
     "Orange": ["/scale/"],


### PR DESCRIPTION
change assignment pattern for purple squad from `/upgrade/` to `/ecosystem/`

Signed-off-by: Daniel Horak <dahorak@redhat.com>