### PR TITLE
Replace naïve version comparisons with semantic ones in MCG tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,7 @@ from ocs_ci.utility import (
     reporting,
     templating,
     users,
+    version,
 )
 from ocs_ci.utility.environment_check import (
     get_status_before_execution,
@@ -3729,7 +3730,7 @@ def nb_ensure_endpoint_count(request):
     should_wait = False
 
     # prior to 4.6 we configured the ep count directly on the noobaa cr.
-    if float(config.ENV_DATA["ocs_version"]) < 4.6:
+    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_6:
         noobaa = OCP(kind="noobaa", namespace=namespace)
         resource = noobaa.get()["items"][0]
         endpoints = resource.get("spec", {}).get("endpoints", {})

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -40,6 +40,7 @@ from ocs_ci.ocs.constants import (
 )
 from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,7 @@ class TestS3BucketPolicy(MCGTest):
         else:
             assert False, "Get object succeeded when it should have failed"
 
-        if float(config.ENV_DATA["ocs_version"]) == 4.6:
+        if version.get_semantic_ocs_version_from_config() == version.VERSION_4_6:
             logger.info(
                 f"Verifying whether the user: "
                 f"{obc_obj.obc_account} is able to access Get action"
@@ -636,21 +637,21 @@ class TestS3BucketPolicy(MCGTest):
             )
             object_versions.append(obj["VersionId"])
 
-        for version in object_versions:
-            logger.info(f"Reading version: {version} of {object_key}")
+        for obj_ver in object_versions:
+            logger.info(f"Reading version: {obj_ver} of {object_key}")
             assert s3_get_object(
                 s3_obj=obc_obj,
                 bucketname=obc_obj.bucket_name,
                 object_key=object_key,
-                versionid=version,
-            ), f"Failed: To Read object {version}"
-            logger.info(f"Deleting version: {version} of {object_key}")
+                versionid=obj_ver,
+            ), f"Failed: To Read object {obj_ver}"
+            logger.info(f"Deleting version: {obj_ver} of {object_key}")
             assert s3_delete_object(
                 s3_obj=obc_obj,
                 bucketname=obc_obj.bucket_name,
                 object_key=object_key,
-                versionid=version,
-            ), f"Failed: To Delete object with {version}"
+                versionid=obj_ver,
+            ), f"Failed: To Delete object with {obj_ver}"
 
         bucket_policy_generated = gen_bucket_policy(
             user_list=obc_obj.obc_account,

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -243,9 +243,11 @@ class TestS3BucketPolicy(MCGTest):
         bucket_policy_generated = gen_bucket_policy(
             user_list=[obc_obj.obc_account, user.email_id],
             actions_list=["PutObject"]
-            if float(config.ENV_DATA["ocs_version"]) <= 4.6
+            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
             else ["GetObject", "DeleteObject"],
-            effect="Allow" if float(config.ENV_DATA["ocs_version"]) <= 4.6 else "Deny",
+            effect="Allow"
+            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
+            else "Deny",
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
         )
         bucket_policy = json.dumps(bucket_policy_generated)
@@ -283,7 +285,7 @@ class TestS3BucketPolicy(MCGTest):
             f" is denied to Get object"
         )
         try:
-            if float(config.ENV_DATA["ocs_version"]) >= 4.6:
+            if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_6:
                 s3_get_object(user, obc_obj.bucket_name, object_key)
             else:
                 s3_get_object(obc_obj, obc_obj.bucket_name, object_key)
@@ -330,7 +332,7 @@ class TestS3BucketPolicy(MCGTest):
             f"is denied to Delete object"
         )
         try:
-            if float(config.ENV_DATA["ocs_version"]) >= 4.6:
+            if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_6:
                 s3_delete_object(user, obc_obj.bucket_name, object_key)
             else:
                 s3_delete_object(obc_obj, obc_obj.bucket_name, object_key)
@@ -352,7 +354,9 @@ class TestS3BucketPolicy(MCGTest):
             actions_list=["GetObject", "DeleteObject"]
             if float(config.ENV_DATA["ocs_version"]) <= 4.6
             else ["PutObject"],
-            effect="Allow" if float(config.ENV_DATA["ocs_version"]) <= 4.6 else "Deny",
+            effect="Allow"
+            if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_6
+            else "Deny",
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
         )
         new_policy = json.dumps(new_policy_generated)

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -20,6 +20,7 @@ from ocs_ci.ocs import cluster, constants, defaults, ocp
 from ocs_ci.ocs.node import drain_nodes, wait_for_nodes_status
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.utility import version
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ class TestMCGResourcesDisruptions(MCGTest):
 
     nb_db_label = (
         constants.NOOBAA_DB_LABEL_46_AND_UNDER
-        if float(config.ENV_DATA["ocs_version"]) < 4.7
+        if version.get_semantic_ocs_version_from_config() < version.VERSION_4_7
         else constants.NOOBAA_DB_LABEL_47_AND_ABOVE
     )
     labels_map = {

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -1,6 +1,5 @@
 import logging
 
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     polarion_id,
     bugzilla,
@@ -9,7 +8,7 @@ from ocs_ci.framework.testlib import (
     tier4a,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.utility import prometheus
+from ocs_ci.utility import prometheus, version
 from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
@@ -29,7 +28,7 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
     alerts = measure_noobaa_exceed_bucket_quota.get("prometheus_alerts")
 
     # since version 4.5 all NooBaa alerts have defined Pending state
-    if float(config.ENV_DATA["ocs_version"]) < 4.5:
+    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_5:
         expected_alerts = [
             (
                 constants.ALERT_BUCKETREACHINGQUOTASTATE,


### PR DESCRIPTION
With 4.10 on the horizon, we've already begun to see failures. This will prevent them from recurring.