### PR TITLE
Added ignore_leftovers decorator

### DIFF
--- a/tests/e2e/system/test_mcg_recovery.py
+++ b/tests/e2e/system/test_mcg_recovery.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
+    tier4,
     ignore_leftovers,
     polarion_id,
 )
@@ -17,8 +18,9 @@ class TestMCGRecovery(E2ETest):
 
     """
 
-    @ignore_leftovers
+    @tier4
     @tier4a
+    @ignore_leftovers
     @polarion_id("OCS-2716")
     @pytest.mark.parametrize(
         argnames=["bucket_amount", "object_amount"],

--- a/tests/e2e/system/test_mcg_recovery.py
+++ b/tests/e2e/system/test_mcg_recovery.py
@@ -2,12 +2,13 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier4
+from ocs_ci.framework.pytest_customization.marks import tier4a, ignore_leftovers
 from ocs_ci.framework.testlib import E2ETest
 
 log = logging.getLogger(__name__)
 
 
+@ignore_leftovers
 class TestMCGRecovery(E2ETest):
     """
     Test MCG system recovery
@@ -20,7 +21,7 @@ class TestMCGRecovery(E2ETest):
             pytest.param(
                 2,
                 15,
-                marks=[tier4, pytest.mark.polarion_id("OCS-2716")],
+                marks=[tier4a, pytest.mark.polarion_id("OCS-2716")],
             ),
         ],
     )

--- a/tests/e2e/system/test_mcg_recovery.py
+++ b/tests/e2e/system/test_mcg_recovery.py
@@ -1,29 +1,28 @@
 import logging
-
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier4a, ignore_leftovers
+from ocs_ci.framework.pytest_customization.marks import (
+    tier4a,
+    ignore_leftovers,
+    polarion_id,
+)
 from ocs_ci.framework.testlib import E2ETest
 
 log = logging.getLogger(__name__)
 
 
-@ignore_leftovers
 class TestMCGRecovery(E2ETest):
     """
     Test MCG system recovery
 
     """
 
+    @ignore_leftovers
+    @tier4a
+    @polarion_id("OCS-2716")
     @pytest.mark.parametrize(
         argnames=["bucket_amount", "object_amount"],
-        argvalues=[
-            pytest.param(
-                2,
-                15,
-                marks=[tier4a, pytest.mark.polarion_id("OCS-2716")],
-            ),
-        ],
+        argvalues=[pytest.param(2, 15)],
     )
     def test_mcg_db_backup_recovery(
         self,


### PR DESCRIPTION
On this test, we created PVC for noobaa and delete its old PVC. So we see leftovers saying Resources added & Resources removed.
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-trigger-test-pr/1976/testReport/tests.e2e.system.test_mcg_recovery/TestMCGRecovery/test_mcg_db_backup_recovery_2_15_/

Signed-off-by: Oded Viner <oviner@redhat.com>