### PR TITLE
define yellow_squad marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -50,6 +50,7 @@ markers =
     grey_squad: marker for grey squad
     orange_squad: marker for orange squad
     black_squad: marker for black squad
+    yellow_squad: marker for yellow squad
 
 
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
Fixing the following warning:
```
venv/lib64/python3.9/site-packages/_pytest/mark/structures.py:323
  /home/ocsqe/projects/ocs-ci-deploy/venv/lib64/python3.9/site-packages/_pytest/mark/structures.py:323: PytestUnknownMarkWarning: Unknown pytest.mark.yellow_squad - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```