### PR TITLE
Always log stdout from aws upi scrip even in case of failure

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -358,6 +358,7 @@ class AWSUPI(AWSBase):
             # Change dir back to ocs-ci dir
             os.chdir(cidir)
 
+            logger.info(stdout)
             if proc.returncode:
                 logger.error(stderr)
                 if constants.GATHER_BOOTSTRAP_PATTERN in stderr:
@@ -366,7 +367,6 @@ class AWSUPI(AWSBase):
                     except Exception as ex:
                         logger.error(ex)
                 raise exceptions.CommandFailed("upi install script failed")
-            logger.info(stdout)
 
             self.test_cluster()
 


### PR DESCRIPTION
Without this change, the stdout output from AWS UPI script is not printed to log if there is some failure and it makes the debugging impossible.

For example in [this job](https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/8507/console) the log looks like this:
```
2021-12-16 15:04:25  14:04:24 - MainThread - ocs_ci.deployment.aws - INFO - Executing UPI install script
2021-12-16 15:04:25  14:04:24 - MainThread - ocs_ci.deployment.aws - ERROR - 
2021-12-16 15:04:25  14:04:24 - MainThread - ocs_ci.deployment.deployment - ERROR - upi install script failed
2021-12-16 15:04:25  14:04:24 - MainThread - ocs_ci.ocs.utils - INFO - Must gather image: quay.io/openshift/origin-must-gather will be used.
```

Signed-off-by: Daniel Horak <dahorak@redhat.com>