### PR TITLE
add compare_versions(expression) function

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -442,3 +442,7 @@ class ConfigurationError(Exception):
 
 class BenchmarkTestFailed(Exception):
     pass
+
+
+class WrongVersionExpression(ValueError):
+    pass

--- a/ocs_ci/utility/tests/test_version.py
+++ b/ocs_ci/utility/tests/test_version.py
@@ -147,7 +147,7 @@ def test_compare_versions(expression, expected):
 def test_compare_versions_wrong_expression(expression):
     """
     This test is suppose to test if the compare_versions raises
-    expected exception for wron expression.
+    expected exception for wrong expression.
     """
 
     with pytest.raises(WrongVersionExpression):

--- a/ocs_ci/utility/tests/test_version.py
+++ b/ocs_ci/utility/tests/test_version.py
@@ -2,6 +2,7 @@ from semantic_version import Version
 
 import pytest
 
+from ocs_ci.ocs.exceptions import WrongVersionExpression
 from ocs_ci.utility import version
 
 
@@ -63,3 +64,91 @@ def test_compare_from_get_semantic_version():
     """
     tested_version = version.get_semantic_version("4.5.11", only_major_minor=True)
     assert tested_version < Version.coerce("4.11")
+
+
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        ("4.1<4.1", False),
+        ("4.1>4.1", False),
+        ("4.1<=4.1", True),
+        ("4.1>=4.1", True),
+        ("4.1==4.1", True),
+        ("4.1!=4.1", False),
+        ("4.1<4.2", True),
+        ("4.1>4.2", False),
+        ("4.1<=4.2", True),
+        ("4.1>=4.2", False),
+        ("4.1==4.2", False),
+        ("4.1!=4.2", True),
+        ("4.2<4.1", False),
+        ("4.2>4.1", True),
+        ("4.2<=4.1", False),
+        ("4.2>=4.1", True),
+        ("4.2==4.1", False),
+        ("4.2!=4.1", True),
+        ("4.10<4.1", False),
+        ("4.10>4.1", True),
+        ("4.10<=4.1", False),
+        ("4.10>=4.1", True),
+        ("4.10==4.1", False),
+        ("4.10!=4.1", True),
+        ("4.1<4.10", True),
+        ("4.1>4.10", False),
+        ("4.1<=4.10", True),
+        ("4.1>=4.10", False),
+        ("4.1==4.10", False),
+        ("4.1!=4.10", True),
+        ("4.10<4.5", False),
+        ("4.10>4.5", True),
+        ("4.10<=4.5", False),
+        ("4.10>=4.5", True),
+        ("4.10==4.5", False),
+        ("4.10!=4.5", True),
+        ("4.5<4.10", True),
+        ("4.5>4.10", False),
+        ("4.5<=4.10", True),
+        ("4.5>=4.10", False),
+        ("4.5==4.10", False),
+        ("4.5!=4.10", True),
+        ("4.11<4.5", False),
+        ("4.11>4.5", True),
+        ("4.11<=4.5", False),
+        ("4.11>=4.5", True),
+        ("4.11==4.5", False),
+        ("4.11!=4.5", True),
+        ("4.5<4.11", True),
+        ("4.5>4.11", False),
+        ("4.5<=4.11", True),
+        ("4.5>=4.11", False),
+        ("4.5==4.11", False),
+        ("4.5!=4.11", True),
+    ],
+)
+def test_compare_versions(expression, expected):
+    """
+    This test is suppose to test if the compare_versions returns
+    expected values for different expressions.
+    """
+
+    assert version.compare_versions(expression) == expected
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "4.1??4.1",
+        "4.1 ===4.1",
+        "Foo version",
+        "<4.1",
+        "==4.1",
+    ],
+)
+def test_compare_versions_wrong_expression(expression):
+    """
+    This test is suppose to test if the compare_versions raises
+    expected exception for wron expression.
+    """
+
+    with pytest.raises(WrongVersionExpression):
+        version.compare_versions(expression)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2478,7 +2478,9 @@ def skipif_ocp_version(expressions):
     """
     ocp_version = get_running_ocp_version()
     expr_list = [expressions] if isinstance(expressions, str) else expressions
-    return any(ocp_version + expr for expr in expr_list)
+    return any(
+        version_module.compare_versions(ocp_version + expr) for expr in expr_list
+    )
 
 
 def skipif_ocs_version(expressions):
@@ -2495,7 +2497,10 @@ def skipif_ocs_version(expressions):
         'True' if test needs to be skipped else 'False'
     """
     expr_list = [expressions] if isinstance(expressions, str) else expressions
-    return any(config.ENV_DATA["ocs_version"] + expr for expr in expr_list)
+    return any(
+        version_module.compare_versions(config.ENV_DATA["ocs_version"] + expr)
+        for expr in expr_list
+    )
 
 
 def skipif_ui_not_support(ui_test):

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2476,14 +2476,9 @@ def skipif_ocp_version(expressions):
         'True' if test needs to be skipped else 'False'
 
     """
-    skip_this = True
     ocp_version = get_running_ocp_version()
     expr_list = [expressions] if isinstance(expressions, str) else expressions
-    for expr in expr_list:
-        comparision_str = ocp_version + expr
-        skip_this = skip_this and eval(comparision_str)
-    # skip_this will be either True or False after eval
-    return skip_this
+    return any(ocp_version + expr for expr in expr_list)
 
 
 def skipif_ocs_version(expressions):
@@ -2500,7 +2495,7 @@ def skipif_ocs_version(expressions):
         'True' if test needs to be skipped else 'False'
     """
     expr_list = [expressions] if isinstance(expressions, str) else expressions
-    return any(eval(config.ENV_DATA["ocs_version"] + expr) for expr in expr_list)
+    return any(config.ENV_DATA["ocs_version"] + expr for expr in expr_list)
 
 
 def skipif_ui_not_support(ui_test):


### PR DESCRIPTION
- fix skipif_ocp_version and skipif_ocs_version functions
- add unittest for the compare_versions function

NOTE: it changes the behavior of `skipif_ocp_version` for multiple expressions passed, but since we use everywhere only one expression, it should be safe and it also unify it with `skipif_ocs_version`.


Fixes: https://github.com/red-hat-storage/ocs-ci/issues/5260

Signed-off-by: Daniel Horak <dahorak@redhat.com>