### PR TITLE
Update OCP deployment templates to be able to use different pod network

### DIFF
--- a/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-aws-ipi.yaml.j2
@@ -29,12 +29,12 @@ metadata:
   name: '{{ cluster_name }}'
 networking:
   clusterNetwork:
-    - cidr: 10.128.0.0/14
+    - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
       hostPrefix: {{ cluster_host_prefix | default(23) }}
   machineCIDR: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}

--- a/ocs_ci/templates/ocp-deployment/install-config-aws-upi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-aws-upi.yaml.j2
@@ -29,12 +29,12 @@ metadata:
   name: '{{ cluster_name }}'
 networking:
   clusterNetwork:
-    - cidr: 10.128.0.0/14
+    - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
       hostPrefix: {{ cluster_host_prefix | default(23) }}
   machineCIDR: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}

--- a/ocs_ci/templates/ocp-deployment/install-config-azure-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-azure-ipi.yaml.j2
@@ -29,12 +29,12 @@ metadata:
   name: '{{ cluster_name }}'
 networking:
   clusterNetwork:
-    - cidr: 10.128.0.0/14
+    - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
       hostPrefix: 23
   machineCIDR: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}

--- a/ocs_ci/templates/ocp-deployment/install-config-gcp-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-gcp-ipi.yaml.j2
@@ -29,12 +29,12 @@ metadata:
   name: '{{ cluster_name }}'
 networking:
   clusterNetwork:
-    - cidr: 10.128.0.0/14
+    - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
       hostPrefix: 23
   machineCIDR: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}

--- a/ocs_ci/templates/ocp-deployment/install-config-vsphere-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-vsphere-ipi.yaml.j2
@@ -30,7 +30,7 @@ networking:
       hostPrefix: {{ cluster_host_prefix | default(23) }}
   machineCIDR: '{{ machine_cidr }}'
   serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}


### PR DESCRIPTION
Update OCP deployment templates to be able to use different pod network when `conf/ocsci/enable_diff_pod_nw.yaml` conf file is specified.
Few templates already have the required format, this PR is for updating the remaining templates.
 
Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>