### PR TITLE
Pushing PVC create and delete results into performance dashboard

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -302,7 +302,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
             log.info("Check results for 'performance' marker (9 tests)")
             self.number_of_tests = 9
             self.check_tests_results()
-        self.push_to_dashboard(test_name=self.benchmark_name)
+        self.push_to_dashboard(test_name="PVC Create-Delete")
 
     def process_time_measurements(
         self, action_name, time_measures, accepted_deviation_percent, msg_prefix

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -18,37 +18,11 @@ from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import get_full_test_logs_path
-from ocs_ci.ocs.perfresult import PerfResult
+from ocs_ci.ocs.perfresult import ResultsAnalyse
 from ocs_ci.framework import config
 
 
 log = logging.getLogger(__name__)
-
-
-class ResultsAnalyse(PerfResult):
-    """
-    This class generates results for all tests as one unit
-    and saves them to an elastic search server on the cluster
-
-    """
-
-    def __init__(self, uuid, crd, full_log_path):
-        """
-        Initialize the object by reading some of the data from the CRD file and
-        by connecting to the ES server and read all results from it.
-
-        Args:
-            uuid (str): the unique uid of the test
-            crd (dict): dictionary with test parameters - the test yaml file
-                        that modify it in the test itself.
-            full_log_path (str): the path of the results files to be found
-
-        """
-        super(ResultsAnalyse, self).__init__(uuid, crd)
-        self.new_index = "pvc_create_delete_fullres"
-        self.full_log_path = full_log_path
-        # make sure we have connection to the elastic search server
-        self.es_connect()
 
 
 @performance
@@ -118,10 +92,10 @@ class TestPVCCreationDeletionPerformance(PASTest):
         Initialize the full results object which will send to the ES server
 
         Args:
-            full_results (obj): an empty FIOResultsAnalyse object
+            full_results (obj): an empty ResultsAnalyse object
 
         Returns:
-            FIOResultsAnalyse (obj): the input object fill with data
+            ResultsAnalyse (obj): the input object fill with data
 
         """
         for key in self.environment:
@@ -198,7 +172,12 @@ class TestPVCCreationDeletionPerformance(PASTest):
 
         # Initialize the results doc file.
         self.full_results = self.init_full_results(
-            ResultsAnalyse(self.uuid, self.crd_data, self.full_log_path)
+            ResultsAnalyse(
+                self.uuid,
+                self.crd_data,
+                self.full_log_path,
+                "pvc_create_delete_fullres",
+            )
         )
         self.full_results.add_key("pvc_size", pvc_size)
         num_of_samples = 5

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -294,7 +294,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
         self.results_file = os.path.join(self.results_path, "all_results.txt")
         log.info(f"Check results in {self.results_file}")
         self.number_of_tests = 3
-        log.into("Check results for 'performance_extended' marker (3 tests)")
+        log.info("Check results for 'performance_extended' marker (3 tests)")
         try:
             self.check_tests_results()
         except ex.BenchmarkTestFailed:


### PR DESCRIPTION
This PR is writing all he elasticsearch links (for each individual test from parametrize) to the results into single file, and then push them into the performance dashboard (only if all tests finished OK)

Signed-off-by: Avi Layani <alayani@redhat.com>