### PR TITLE
bulk_deletion_send_to_es

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -282,6 +282,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
             # Create text file with results of all subtest (4 - according to the parameters)
             self.write_result_to_file(res_link)
 
+    @pytest.mark.skip(SKIP_REASON)
     def test_pvc_creation_deletion_results(self):
         """
         This is not a test - it is only check that previous test ran and finish as expected
@@ -410,7 +411,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
         pvc_size = "1Gi"
         msg_prefix = f"Interface: {self.interface}, PVC size: {pvc_size}."
 
-        log.info(f"{msg_prefix} Start creating new 120 PVCs")
+        log.info(f"{msg_prefix} Start creating new {number_of_pvcs} PVCs")
 
         pvc_objs, _ = helpers.create_multiple_pvcs(
             sc_name=self.sc_obj.name,
@@ -491,13 +492,13 @@ class TestPVCCreationDeletionPerformance(PASTest):
             logging.info(f"{name} deletion time is: {a_time} seconds")
 
         if self.interface == constants.CEPHBLOCKPOOL:
-            sc = "RBD"
+            self.sc = "RBD"
         elif self.interface == constants.CEPHFILESYSTEM:
-            sc = "CephFS"
+            self.sc = "CephFS"
         elif self.interface == constants.CEPHBLOCKPOOL_THICK:
-            sc = "RBD-Thick"
+            self.sc = "RBD-Thick"
 
-        full_log_path = get_full_test_logs_path(cname=self) + f"-{sc}-{pvc_size}"
+        full_log_path = get_full_test_logs_path(cname=self) + f"-{self.sc}-{pvc_size}"
         self.results_path = get_full_test_logs_path(cname=self)
         log.info(f"Logs file path name is : {full_log_path}")
 
@@ -518,8 +519,8 @@ class TestPVCCreationDeletionPerformance(PASTest):
         full_results.add_key("pvc_size", pvc_size)
         full_results.all_results["bulk_deletion_time"] = pvc_deletion_time
 
-        if self.full_results.es_write():
-            res_link = self.full_results.results_link()
+        if full_results.es_write():
+            res_link = full_results.results_link()
             log.info(f"The Result can be found at : {res_link}")
 
             # Create text file with results of all subtest (3 - according to the parameters)
@@ -530,19 +531,13 @@ class TestPVCCreationDeletionPerformance(PASTest):
         This is not a test - it is only check that previous test ran and finish as expected
         and reporting the full results (links in the ES) of previous tests (3)
         """
-
+        self.number_of_tests = 3
         results_path = get_full_test_logs_path(
             cname=self, fname="test_multiple_pvc_deletion_measurement_performance"
         )
-        results_file = os.path.join(results_path, "all_results.txt")
-        log.info(f"Check results in {results_file}")
-        self.number_of_tests = 3
+        self.results_file = os.path.join(results_path, "all_results.txt")
+        log.info(f"Check results in {self.results_file}.")
         log.info("Check results for 'performance_extended' marker (3 tests)")
-        try:
-            self.check_tests_results()
-        except ex.BenchmarkTestFailed:
-            log.info("Look like performance_extended was not triggered")
-            log.info("Check results for 'performance' marker (9 tests)")
-            self.number_of_tests = 9
-            self.check_tests_results()
+        self.check_tests_results()
+
         self.push_to_dashboard(test_name="PVC Multiple-Delete")

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -489,3 +489,30 @@ class TestPVCCreationDeletionPerformance(PASTest):
         logging.info(f"{msg_prefix} {number_of_pvcs} PVCs deletion times are:")
         for name, a_time in pvc_deletion_time.items():
             logging.info(f"{name} deletion time is: {a_time} seconds")
+
+        full_log_path = get_full_test_logs_path(cname=self) + f"-{self.sc}-{pvc_size}"
+        log.info(f"Logs file path name is : {full_log_path}")
+
+        self.get_env_info()
+
+        # Initialize the results doc file.
+        full_results = self.init_full_results(
+            ResultsAnalyse(
+                self.uuid,
+                self.crd_data,
+                full_log_path,
+                "pvc_bulk_deletion_fullres",
+            )
+        )
+
+        full_results.add_key("interface", self.interface)
+        full_results.add_key("bulk_size", number_of_pvcs)
+        full_results.add_key("pvc_size", pvc_size)
+        full_results.all_results["bulk_deletion_time"] = pvc_deletion_time
+
+        if self.full_results.es_write():
+            res_link = self.full_results.results_link()
+            log.info(f"The Result can be found at : {res_link}")
+
+            # Create text file with results of all subtest (4 - according to the parameters)
+            self.write_result_to_file(res_link)

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -514,5 +514,5 @@ class TestPVCCreationDeletionPerformance(PASTest):
             res_link = self.full_results.results_link()
             log.info(f"The Result can be found at : {res_link}")
 
-            # Create text file with results of all subtest (4 - according to the parameters)
+            # Create text file with results of all subtest (3 - according to the parameters)
             self.write_result_to_file(res_link)

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -282,7 +282,6 @@ class TestPVCCreationDeletionPerformance(PASTest):
             # Create text file with results of all subtest (4 - according to the parameters)
             self.write_result_to_file(res_link)
 
-    @pytest.mark.skip(SKIP_REASON)
     def test_pvc_creation_deletion_results(self):
         """
         This is not a test - it is only check that previous test ran and finish as expected
@@ -537,7 +536,6 @@ class TestPVCCreationDeletionPerformance(PASTest):
         )
         self.results_file = os.path.join(results_path, "all_results.txt")
         log.info(f"Check results in {self.results_file}.")
-        log.info("Check results for 'performance_extended' marker (3 tests)")
         self.check_tests_results()
 
         self.push_to_dashboard(test_name="PVC Multiple-Delete")


### PR DESCRIPTION
This PR implements sending test_multiple_pvc_deletion_measurement_performance ( which measures bulk deletion time) results to the ES for later upload to the Performance Dashboard. 

Signed-off-by: Yulia Persky <ypersky@redhat.com>