### PR TITLE
Use Basic auth for accessing OCP repos

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -533,12 +533,12 @@ class AWSUPI(AWSBase):
         repo_file = os.path.basename(repo)
         pod.upload(rhel_pod_obj.name, repo, repo_dst_path)
         # prepare credential files for mirror.openshift.com
-        (
+        with prepare_mirror_openshift_credential_files() as (
             mirror_user_file,
             mirror_password_file,
-        ) = prepare_mirror_openshift_credential_files()
-        pod.upload(rhel_pod_obj.name, mirror_user_file, constants.YUM_VARS_PATH)
-        pod.upload(rhel_pod_obj.name, mirror_password_file, constants.YUM_VARS_PATH)
+        ):
+            pod.upload(rhel_pod_obj.name, mirror_user_file, constants.YUM_VARS_PATH)
+            pod.upload(rhel_pod_obj.name, mirror_password_file, constants.YUM_VARS_PATH)
 
         # Install scp on pod
         rhel_pod_obj.install_packages("openssh-clients")

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -532,14 +532,6 @@ class AWSUPI(AWSBase):
         assert os.path.exists(repo), f"Required repo file {repo} doesn't exist!"
         repo_file = os.path.basename(repo)
         pod.upload(rhel_pod_obj.name, repo, repo_dst_path)
-        # copy the .pem file for our internal repo on all nodes
-        # including ansible pod
-        # get it from URL
-        mirror_pem_file_path = os.path.join(
-            constants.DATA_DIR, constants.INTERNAL_MIRROR_PEM_FILE
-        )
-        dst = "/etc/pki/ca-trust/source/anchors/"
-        pod.upload(rhel_pod_obj.name, mirror_pem_file_path, dst)
         # prepare credential files for mirror.openshift.com
         (
             mirror_user_file,
@@ -572,21 +564,6 @@ class AWSUPI(AWSBase):
                 host,
                 pem_dst_path,
                 f'sudo mv {os.path.join("/tmp", repo_file)} {repo_dst_path}',
-                user=self.rhel_worker_user,
-            )
-            rhel_pod_obj.copy_to_server(
-                host,
-                pem_dst_path,
-                os.path.join(dst, constants.INTERNAL_MIRROR_PEM_FILE),
-                os.path.join("/tmp", constants.INTERNAL_MIRROR_PEM_FILE),
-                user=self.rhel_worker_user,
-            )
-            rhel_pod_obj.exec_cmd_on_node(
-                host,
-                pem_dst_path,
-                f"sudo mv "
-                f'{os.path.join("/tmp", constants.INTERNAL_MIRROR_PEM_FILE)} '
-                f"{dst}",
                 user=self.rhel_worker_user,
             )
             for file_name in (

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -52,7 +52,6 @@ class OCPINSTALLRHEL(object):
         self.pod_ssh_key_pem = os.path.join(
             constants.POD_UPLOADPATH, self.ssh_key_pem.split("/")[-1]
         )
-        self.ops_mirror_pem = os.path.join(f"{constants.DATA_DIR}", constants.OCP_PEM)
         self.cluster_path = config.ENV_DATA["cluster_path"]
         self.kubeconfig = os.path.join(
             config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
@@ -94,7 +93,6 @@ class OCPINSTALLRHEL(object):
         """
         upload(self.pod_name, self.ssh_key_pem, constants.POD_UPLOADPATH)
         upload(self.pod_name, ocp_repo, constants.YUM_REPOS_PATH)
-        upload(self.pod_name, self.ops_mirror_pem, constants.PEM_PATH)
         # prepare and copy credential files for mirror.openshift.com
         (
             mirror_user_file,
@@ -222,19 +220,6 @@ class OCPINSTALLRHEL(object):
                 node, self.pod_ssh_key_pem, cmd, user=constants.VM_RHEL_USER
             )
 
-            # copy ops-mirror.pem
-            self.rhelpod.copy_to_server(
-                node,
-                self.pod_ssh_key_pem,
-                os.path.join(constants.PEM_PATH, constants.OCP_PEM),
-                constants.RHEL_TMP_PATH,
-                user=constants.VM_RHEL_USER,
-            )
-            pem_path_in_rhel = os.path.join(constants.RHEL_TMP_PATH, constants.OCP_PEM)
-            cmd = f"sudo cp {pem_path_in_rhel} {constants.PEM_PATH}"
-            self.rhelpod.exec_cmd_on_node(
-                node, self.pod_ssh_key_pem, cmd, user=constants.VM_RHEL_USER
-            )
             # prepare and copy credential files for mirror.openshift.com
             (
                 mirror_user_file,

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -229,7 +229,7 @@ class OCPINSTALLRHEL(object):
                     self.pod_ssh_key_pem,
                     os.path.join(constants.YUM_VARS_PATH, file_name),
                     os.path.join(constants.RHEL_TMP_PATH, file_name),
-                    user=self.rhel_worker_user,
+                    user=constants.VM_RHEL_USER,
                 )
                 self.rhelpod.exec_cmd_on_node(
                     node,
@@ -237,7 +237,7 @@ class OCPINSTALLRHEL(object):
                     f"sudo mv "
                     f"{os.path.join(constants.RHEL_TMP_PATH, file_name)} "
                     f"{constants.YUM_VARS_PATH}",
-                    user=self.rhel_worker_user,
+                    user=constants.VM_RHEL_USER,
                 )
 
     def execute_ansible_playbook(self):

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -94,12 +94,12 @@ class OCPINSTALLRHEL(object):
         upload(self.pod_name, self.ssh_key_pem, constants.POD_UPLOADPATH)
         upload(self.pod_name, ocp_repo, constants.YUM_REPOS_PATH)
         # prepare and copy credential files for mirror.openshift.com
-        (
+        with prepare_mirror_openshift_credential_files() as (
             mirror_user_file,
             mirror_password_file,
-        ) = prepare_mirror_openshift_credential_files()
-        upload(self.pod_name, mirror_user_file, constants.YUM_VARS_PATH)
-        upload(self.pod_name, mirror_password_file, constants.YUM_VARS_PATH)
+        ):
+            upload(self.pod_name, mirror_user_file, constants.YUM_VARS_PATH)
+            upload(self.pod_name, mirror_password_file, constants.YUM_VARS_PATH)
         upload(self.pod_name, self.kubeconfig, constants.POD_UPLOADPATH)
         upload(self.pod_name, self.pull_secret_path, constants.POD_UPLOADPATH)
         if config.ENV_DATA["folder_structure"]:
@@ -220,11 +220,6 @@ class OCPINSTALLRHEL(object):
                 node, self.pod_ssh_key_pem, cmd, user=constants.VM_RHEL_USER
             )
 
-            # prepare and copy credential files for mirror.openshift.com
-            (
-                mirror_user_file,
-                mirror_password_file,
-            ) = prepare_mirror_openshift_credential_files()
             for file_name in (
                 constants.MIRROR_OPENSHIFT_USER_FILE,
                 constants.MIRROR_OPENSHIFT_PASSWORD_FILE,

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -823,7 +823,6 @@ LATEST_TAGS = (
     "latest-stable",
     "-rc",
 )
-INTERNAL_MIRROR_PEM_FILE = "ops-mirror.pem"
 EC2_USER = "ec2-user"
 OCS_SUBSCRIPTION = "ocs-operator"
 ODF_SUBSCRIPTION = "odf-operator"
@@ -853,9 +852,6 @@ INVENTORY_FILE_HAPROXY = "inventory_haproxy.yaml"
 
 # users
 VM_RHEL_USER = "test"
-
-# PEM
-OCP_PEM = "ops-mirror.pem"
 
 # playbooks
 SCALEUP_ANSIBLE_PLAYBOOK = "/usr/share/ansible/openshift-ansible/playbooks/scaleup.yml"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -799,6 +799,7 @@ RHEL_POD_PACKAGES = [
 # common locations
 POD_UPLOADPATH = RHEL_TMP_PATH = "/tmp/"
 YUM_REPOS_PATH = "/etc/yum.repos.d/"
+YUM_VARS_PATH = "/etc/yum/vars/"
 PEM_PATH = "/etc/pki/ca-trust/source/anchors/"
 FIPS_LOCATION = "/proc/sys/crypto/fips_enabled"
 
@@ -829,6 +830,8 @@ ODF_SUBSCRIPTION = "odf-operator"
 ROOK_OPERATOR_CONFIGMAP = "rook-ceph-operator-config"
 ROOK_CONFIG_OVERRIDE_CONFIGMAP = "rook-config-override"
 ROOK_CEPH_MON_ENDPOINTS = "rook-ceph-mon-endpoints"
+MIRROR_OPENSHIFT_USER_FILE = "mirror_openshift_user"
+MIRROR_OPENSHIFT_PASSWORD_FILE = "mirror_openshift_password"
 
 # UI Deployment constants
 HTPASSWD_SECRET_NAME = "htpass-secret"

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -893,12 +893,12 @@ class AWSNodes(NodesBase):
         repo_file = os.path.basename(repo)
         pod.upload(rhel_pod_obj.name, repo, repo_dst_path)
         # prepare credential files for mirror.openshift.com
-        (
+        with prepare_mirror_openshift_credential_files() as (
             mirror_user_file,
             mirror_password_file,
-        ) = prepare_mirror_openshift_credential_files()
-        pod.upload(rhel_pod_obj.name, mirror_user_file, constants.YUM_VARS_PATH)
-        pod.upload(rhel_pod_obj.name, mirror_password_file, constants.YUM_VARS_PATH)
+        ):
+            pod.upload(rhel_pod_obj.name, mirror_user_file, constants.YUM_VARS_PATH)
+            pod.upload(rhel_pod_obj.name, mirror_password_file, constants.YUM_VARS_PATH)
         # Install scp on pod
         rhel_pod_obj.install_packages("openssh-clients")
         # distribute repo file to all RHEL workers

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -892,14 +892,6 @@ class AWSNodes(NodesBase):
         assert os.path.exists(repo), f"Required repo file {repo} doesn't exist!"
         repo_file = os.path.basename(repo)
         pod.upload(rhel_pod_obj.name, repo, repo_dst_path)
-        # copy the .pem file for our internal repo on all nodes
-        # including ansible pod
-        # get it from URL
-        mirror_pem_file_path = os.path.join(
-            constants.DATA_DIR, constants.INTERNAL_MIRROR_PEM_FILE
-        )
-        dst = constants.PEM_PATH
-        pod.upload(rhel_pod_obj.name, mirror_pem_file_path, dst)
         # prepare credential files for mirror.openshift.com
         (
             mirror_user_file,
@@ -932,21 +924,6 @@ class AWSNodes(NodesBase):
                 pem_dst_path,
                 f'sudo mv {os.path.join("/tmp", repo_file)} {repo_dst_path}',
                 user=constants.EC2_USER,
-            )
-            rhel_pod_obj.copy_to_server(
-                host,
-                pem_dst_path,
-                os.path.join(dst, constants.INTERNAL_MIRROR_PEM_FILE),
-                os.path.join("/tmp", constants.INTERNAL_MIRROR_PEM_FILE),
-                user=constants.EC2_USER,
-            )
-            cmd = (
-                f"sudo mv "
-                f'{os.path.join("/tmp/", constants.INTERNAL_MIRROR_PEM_FILE)} '
-                f"{dst}"
-            )
-            rhel_pod_obj.exec_cmd_on_node(
-                host, pem_dst_path, cmd, user=constants.EC2_USER
             )
             for file_name in (
                 constants.MIRROR_OPENSHIFT_USER_FILE,

--- a/ocs_ci/repos/ocp_4_10.repo
+++ b/ocs_ci/repos/ocp_4_10.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.10/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-optional]
@@ -30,8 +30,8 @@ name=RHoptional
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-optional-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-fast]
@@ -39,8 +39,8 @@ name=RHfast
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-fast-datapath-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -48,5 +48,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_2.repo
+++ b/ocs_ci/repos/ocp_4_2.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.2/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -30,5 +30,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_3.repo
+++ b/ocs_ci/repos/ocp_4_3.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.3/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -30,5 +30,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_4.repo
+++ b/ocs_ci/repos/ocp_4_4.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.4/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -30,5 +30,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_5.repo
+++ b/ocs_ci/repos/ocp_4_5.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.5/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -30,5 +30,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_6.repo
+++ b/ocs_ci/repos/ocp_4_6.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.6/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-optional]
@@ -30,8 +30,8 @@ name=RHoptional
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-optional-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-fast]
@@ -39,8 +39,8 @@ name=RHfast
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-fast-datapath-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -48,5 +48,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_7.repo
+++ b/ocs_ci/repos/ocp_4_7.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.7/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-optional]
@@ -30,8 +30,8 @@ name=RHoptional
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-optional-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-fast]
@@ -39,8 +39,8 @@ name=RHfast
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-fast-datapath-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -48,5 +48,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_8.repo
+++ b/ocs_ci/repos/ocp_4_8.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.8/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-optional]
@@ -30,8 +30,8 @@ name=RHoptional
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-optional-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-fast]
@@ -39,8 +39,8 @@ name=RHfast
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-fast-datapath-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -48,5 +48,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/repos/ocp_4_9.repo
+++ b/ocs_ci/repos/ocp_4_9.repo
@@ -3,8 +3,8 @@ name=RHopenshift
 baseurl=https://mirror.openshift.com/enterprise/all/4.9/latest/x86_64/os/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-server]
@@ -12,8 +12,8 @@ name=RHserver
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-extras]
@@ -21,8 +21,8 @@ name=RHextra
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-extras-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-optional]
@@ -30,8 +30,8 @@ name=RHoptional
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-server-optional-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [rhel-fast]
@@ -39,8 +39,8 @@ name=RHfast
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-fast-datapath-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password
 
 
 [ansible]
@@ -48,5 +48,5 @@ name=RHansible
 baseurl=https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-7-server-ansible-2.9-rpms/
 enabled=1
 gpgcheck=0
-sslverify=0
-sslclientcert=/etc/pki/ca-trust/source/anchors/ops-mirror.pem
+username=$mirror_openshift_user
+password=$mirror_openshift_password

--- a/ocs_ci/utility/mirror_openshift.py
+++ b/ocs_ci/utility/mirror_openshift.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import logging
 import os
 
@@ -8,11 +9,15 @@ from ocs_ci.ocs import constants, exceptions
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
 def prepare_mirror_openshift_credential_files():
     """
+    This function is a context manager.
+
     Prepare local files containing username and password for mirror.openshift.com:
         data/mirror_openshift_user,
         data/mirror_openshift_password.
+
     Those files are used as variable files for repo files (stored in /etc/yum/vars/
     on the target RHEL nodes or pods).
 
@@ -43,7 +48,11 @@ def prepare_mirror_openshift_credential_files():
         logger.debug(
             f"Credentials for mirror.openshift.com saved to files '{user_file}' and '{password_file}'"
         )
-        return user_file, password_file
+        try:
+            yield user_file, password_file
+        finally:
+            os.remove(user_file)
+            os.remove(password_file)
     else:
         raise exceptions.ConfigurationError(
             "Credentials for mirror.openshift.com are not provided in data/auth.yaml file."

--- a/ocs_ci/utility/mirror_openshift.py
+++ b/ocs_ci/utility/mirror_openshift.py
@@ -1,0 +1,50 @@
+import logging
+import os
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, exceptions
+
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_mirror_openshift_credential_files():
+    """
+    Prepare local files containing username and password for mirror.openshift.com:
+        data/mirror_openshift_user,
+        data/mirror_openshift_password.
+    Those files are used as variable files for repo files (stored in /etc/yum/vars/
+    on the target RHEL nodes or pods).
+
+    Returns:
+        (tuple): tuple containing two strings - file names for username file and password file
+
+    Raises
+        ConfigurationError: if mirror_openshift credentials are not provided in auth.yaml file
+
+    """
+    if (
+        config.AUTH.get("mirror_openshift")
+        and config.AUTH["mirror_openshift"].get("user")
+        and config.AUTH["mirror_openshift"].get("password")
+    ):
+        user_file = os.path.join(
+            constants.DATA_DIR, constants.MIRROR_OPENSHIFT_USER_FILE
+        )
+        with open(user_file, "w") as u_file:
+            u_file.writelines(config.AUTH["mirror_openshift"]["user"])
+
+        password_file = os.path.join(
+            constants.DATA_DIR, constants.MIRROR_OPENSHIFT_PASSWORD_FILE
+        )
+        with open(password_file, "w") as p_file:
+            p_file.writelines(config.AUTH["mirror_openshift"]["password"])
+
+        logger.debug(
+            f"Credentials for mirror.openshift.com saved to files '{user_file}' and '{password_file}'"
+        )
+        return user_file, password_file
+    else:
+        raise exceptions.ConfigurationError(
+            "Credentials for mirror.openshift.com are not provided in data/auth.yaml file."
+        )

--- a/ocs_ci/utility/mirror_openshift.py
+++ b/ocs_ci/utility/mirror_openshift.py
@@ -24,7 +24,7 @@ def prepare_mirror_openshift_credential_files():
     Returns:
         (tuple): tuple containing two strings - file names for username file and password file
 
-    Raises
+    Raises:
         ConfigurationError: if mirror_openshift credentials are not provided in auth.yaml file
 
     """


### PR DESCRIPTION
Since the recent changes in authentication method for `mirror.openshift.com/enterprise`, we have to replace the original authentication via certificate by newly used basic auth.

Signed-off-by: Daniel Horak <dahorak@redhat.com>