### PR TITLE
Use the correct port when adding nodes to the HAProxy config

### DIFF
--- a/ocs_ci/utility/load_balancer.py
+++ b/ocs_ci/utility/load_balancer.py
@@ -110,7 +110,7 @@ class LoadBalancer(object):
             for node in nodes:
                 cmd = (
                     f"sudo sed -i '0,/.*:{port} check$/s/.*:{port} check$/        server "
-                    f"{node} {node}:80 check\\n&/' {constants.HAPROXY_LOCATION}"
+                    f"{node} {node}:{port} check\\n&/' {constants.HAPROXY_LOCATION}"
                 )
                 self.lb.exec_cmd(cmd)
 


### PR DESCRIPTION
This should fix #4209 by adding the appropriate port for HTTPS endpoints.
However, I believe we should rewrite this part in a more Pythonic way, that replaces sed with more readable tools