### PR TITLE
Change test_snapshot_at_different_usage_level to tier2

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -8,7 +8,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
-    tier1,
+    tier2,
     skipif_ocp_version,
 )
 from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
@@ -17,7 +17,7 @@ from ocs_ci.helpers.helpers import wait_for_resource_state, get_snapshot_content
 log = logging.getLogger(__name__)
 
 
-@tier1
+@tier2
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @pytest.mark.polarion_id("OCS-2318")


### PR DESCRIPTION
Moving the test case ```TestSnapshotAtDifferentPvcUsageLevel.test_snapshot_at_different_usage_level```  from tier1 to tier2 as it's not about basic product functionality.
Partial fix for #5283
Signed-off-by: Jilju Joy <jijoy@redhat.com>