### PR TITLE
fix typo of acm namespace

### DIFF
--- a/ocs_ci/ocs/acm/acm_constants.py
+++ b/ocs_ci/ocs/acm/acm_constants.py
@@ -1,5 +1,5 @@
 # Namespaces
-ACM_NAMESPACE = "import_clusters_with_acm"
+ACM_NAMESPACE = "open-cluster-management"
 
 # Resources
 ACM_MANAGED_CLUSTERS = "managedclusters"


### PR DESCRIPTION
Fixing type in acm namespace constant

Signed-off-by: aviadp <apolak@redhat.com>