### PR TITLE
Add pytest-repeat module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "pyopenssl",
         "pyparsing ==2.4.7",
         "mysql-connector-python==8.0.27",
+        "pytest-repeat",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
There is a requirement to be able to run the same test or set of tests multiple times (see issue https://github.com/red-hat-storage/ocs-ci/issues/5009). It seems, that [`pytest-repeat`](https://pypi.org/project/pytest-repeat/) module allows exactly that - via new argument `--count`.

Signed-off-by: Daniel Horak <dahorak@redhat.com>