### PR TITLE
Return to const usage for noobaa scc test

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -14,7 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.utility import templating, version
+from ocs_ci.utility import templating
 from ocs_ci.utility.ssl_certs import get_root_ca_cert
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
 from ocs_ci.helpers.helpers import create_resource

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -201,23 +201,6 @@ def rm_object_recursive(podobj, target, mcg_obj, option=""):
     )
 
 
-def get_db_scc_and_sa():
-    """
-    Gets Noobaa DB's SCC and SA according to the cluster's version
-
-    Returns:
-        list: the SCC name and full SA path
-
-    """
-    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_9:
-        return constants.NOOBAA_SERVICE_ACCOUNT_NAME, constants.NOOBAA_SERVICE_ACCOUNT
-    else:
-        return (
-            constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME,
-            constants.NOOBAA_DB_SERVICE_ACCOUNT,
-        )
-
-
 def get_rgw_restart_counts():
     """
     Gets the restart count of the RGW pods

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -17,7 +17,6 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
 from ocs_ci.ocs import cluster, constants, defaults, ocp
-from ocs_ci.ocs.bucket_utils import get_db_scc_and_sa
 from ocs_ci.ocs.node import drain_nodes, wait_for_nodes_status
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
@@ -170,9 +169,11 @@ class TestMCGResourcesDisruptions(MCGTest):
         Make sure noobaa db pod is running and scc is reverted back to noobaa.
 
         """
+
         # Teardown function to revert back the scc changes made
         def finalizer():
-            scc_name, service_account = get_db_scc_and_sa()
+            scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
+            service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
             pod_obj = pod.Pod(
                 **pod.get_pods_having_label(
                     label=self.labels_map["noobaa_db"],
@@ -236,7 +237,8 @@ class TestMCGResourcesDisruptions(MCGTest):
         Test noobaa db is assigned with scc(anyuid) after changing the default noobaa SCC
 
         """
-        scc_name, service_account = get_db_scc_and_sa()
+        scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
+        service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
         pod_obj = pod.Pod(
             **pod.get_pods_having_label(
                 label=self.labels_map["noobaa_db"],


### PR DESCRIPTION
after a discussion with dev team we understood that the user used by the db is now the same across previous versions (backported) so the check for version is no longer needed 

Signed-off-by: Amit Berner <aberner@redhat.com>