### PR TITLE
log error for a failed assert via assert hook

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,15 @@ class OCSLogFormatter(logging.Formatter):
         super(OCSLogFormatter, self).__init__(fmt)
 
 
+def pytest_assertrepr_compare(config, op, left, right):
+    """
+    Log error message for a failed assert, so that it's possible to locate a
+    moment of the failure in test logs. Returns None so that it won't actually
+    change assert explanation.
+    """
+    log.error("'assert %s %s %s' failed", left, op, right)
+
+
 def pytest_logger_config(logger_config):
     logger_config.add_loggers([""], stdout_level="info")
     logger_config.set_log_option_default("")


### PR DESCRIPTION
Use `pytest_assertrepr_compare` hook to log error for a failed assert.

This is useful when a test case fails on assert, but there are no other errors reported in the log. With this hook, it's possible to find a moment of the failure in the logs fast without additional effort: just look for an ERROR log message.

Limitation: it won't catch the most simple assert statements like `assert False` or `assert True`, because these are translated into `AssertionError` exception without invoking the repr hook, but I still find it useful.