### PR TITLE
PR to add more logging and validation in test scale_pvc_create_delete

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1546,6 +1546,12 @@ def measure_pvc_creation_time_bulk(interface, pvc_name_list, wait_time=60):
             start = [i for i in logs if re.search(f"provision.*{name}.*started", i)]
             end = [i for i in logs if re.search(f"provision.*{name}.*succeeded", i)]
             if not start or not end:
+                logging.info(f"PVC {name} missing start or end time")
+                try:
+                    logging.info(f"PVC {name} creation start {start}")
+                    logging.info(f"PVC {name} creation complete {end}")
+                except UnexpectedBehaviour:
+                    logging.warning(f"PVC {name} creation data missing")
                 no_data_list.append(name)
 
         if no_data_list:
@@ -1622,6 +1628,12 @@ def measure_pv_deletion_time_bulk(
             start = [i for i in logs if re.search(f'delete "{pv}": started', i)]
             end = [i for i in logs if re.search(f'delete "{pv}": succeeded', i)]
             if not start or not end:
+                logging.info(f"PVC {pv} missing start or end time")
+                try:
+                    logging.info(f"PVC {pv} deletion start {start}")
+                    logging.info(f"PVC {pv} deletion complete {end}")
+                except UnexpectedBehaviour:
+                    logging.warning(f"PVC {pv} deletion data missing")
                 no_data_list.append(pv)
 
         if no_data_list:

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -136,7 +136,13 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # Delete kube_job
         job_file1.delete(namespace=self.namespace)
+        job_file1.wait_for_delete(
+            resource_name=job_file1.name, namespace=self.namespace
+        )
         job_file2.delete(namespace=self.namespace)
+        job_file2.wait_for_delete(
+            resource_name=job_file2.name, namespace=self.namespace
+        )
 
         # Adding 1min wait time for PVC deletion logs to be updated
         # Observed failure when we immediately check the logs for pvc delete time
@@ -260,7 +266,13 @@ class TestPVCCreationDeletionScale(E2ETest):
 
         # Delete kube_job
         job_file_rbd.delete(namespace=self.namespace)
+        job_file_rbd.wait_for_delete(
+            resource_name=job_file_rbd.name, namespace=self.namespace
+        )
         job_file_cephfs.delete(namespace=self.namespace)
+        job_file_cephfs.wait_for_delete(
+            resource_name=job_file_cephfs.name, namespace=self.namespace
+        )
 
         # Adding 1min wait time for PVC deletion logs to be updated
         # Observed failure when we immediately check the logs for pvc delete time


### PR DESCRIPTION
Added more logging to PVC create/delete function to identify the failure more speifically
Added more validation for kube_obj deletion is successful

Signed-off-by: Ramakrishnan <rperiyas@redhat.com>