### PR TITLE
Pass build name when creating images

### DIFF
--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -373,7 +373,7 @@ def image_pull_and_push(project_name, template, image="", pattern="", wait=True)
     if config.DEPLOYMENT.get("disconnected"):
         mirror_image(image=image)
     else:
-        cmd = f"new-app --template={template} -n {project_name}"
+        cmd = f"new-app --template={template} -n {project_name} --name=build1"
         ocp_obj = ocp.OCP()
         ocp_obj.exec_oc_cmd(command=cmd, out_yaml_format=False)
 

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -382,7 +382,8 @@ def image_pull_and_push(project_name, template, image="", pattern="", wait=True)
         if wait:
             if template == "redis-ephemeral":
                 wait_time = 180
-                logger.info(f"Wait for {wait_time} seconds for deplpyment to come up")
+                logger.info(f"Wait for {wait_time} seconds for deployment to come up")
+                time.sleep(180)
                 ocp_obj = ocp.OCP(kind=constants.POD, namespace=project_name)
                 deploy_pod_name = get_pod_name_by_pattern(
                     pattern="deploy", namespace=project_name

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -350,7 +350,13 @@ def check_image_exists_in_registry(image_url):
     return return_value
 
 
-def image_pull_and_push(project_name, template, image="", pattern="", wait=True):
+def image_pull_and_push(
+    project_name,
+    template="redis-ephemeral",
+    image="registry.redhat.io/rhel8/redis",
+    pattern="",
+    wait=True,
+):
     """
     Pull and push images running oc new-app command
     Args:
@@ -434,11 +440,11 @@ def get_build_name_by_pattern(pattern="", namespace=None):
     return build_list
 
 
-def validate_image_exists(namespace=None):
+def validate_image_exists(app="redis"):
     """
     Validate image exists on registries path
     Args:
-        namespace (str): Namespace where the images/builds are created
+        app (str): Label or application name
 
     Returns:
         image_list (str): Dir/Files/Images are listed in string format
@@ -459,7 +465,7 @@ def validate_image_exists(namespace=None):
                 )
 
                 return pod_obj.exec_cmd_on_pod(
-                    command=f"find /registry/docker/registry/v2/repositories/{namespace}"
+                    command=f"find /registry/docker/registry/v2/repositories/openshift/{app}"
                 )
 
 

--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -367,6 +367,7 @@ def image_pull_and_push(project_name, template, image="", pattern="", wait=True)
         if f'"{template}" not found' in str(cfe):
             logger.warn(f"Template {template} not found")
             template = "redis-ephemeral"
+            image = "registry.redhat.io/rhel8/redis"
         else:
             raise
 
@@ -380,6 +381,8 @@ def image_pull_and_push(project_name, template, image="", pattern="", wait=True)
         # Validate it completed
         if wait:
             if template == "redis-ephemeral":
+                wait_time = 180
+                logger.info(f"Wait for {wait_time} seconds for deplpyment to come up")
                 ocp_obj = ocp.OCP(kind=constants.POD, namespace=project_name)
                 deploy_pod_name = get_pod_name_by_pattern(
                     pattern="deploy", namespace=project_name
@@ -453,6 +456,7 @@ def validate_image_exists(namespace=None):
                     name=pod_name,
                     namespace=constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE,
                 )
+
                 return pod_obj.exec_cmd_on_pod(
                     command=f"find /registry/docker/registry/v2/repositories/{namespace}"
                 )

--- a/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
@@ -74,15 +74,10 @@ class TestRegistryByIncreasingNumPods(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
         # Reduce number to 2
         assert modify_registry_pod_count(count=2)

--- a/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
@@ -72,15 +72,10 @@ class TestRegistryPodRespin(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
         # Validate image registry pods
         validate_registry_pod_status()

--- a/tests/e2e/workloads/ocp/registry/test_registry_pull_and_push_images_to_registry.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_pull_and_push_images_to_registry.py
@@ -49,15 +49,10 @@ class TestRegistryPullAndPushImagestoRegistry(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
         # Validate image registry pods
         validate_registry_pod_status()

--- a/tests/e2e/workloads/ocp/registry/test_registry_reboot_node.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_reboot_node.py
@@ -64,15 +64,10 @@ class TestRegistryRebootNode(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
         # Reboot one node
         nodes.restart_nodes(node, wait=False)
@@ -99,7 +94,7 @@ class TestRegistryRebootNode(E2ETest):
         validate_registry_pod_status()
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
     @pytest.mark.parametrize(
         argnames=["node_type"],
@@ -118,15 +113,10 @@ class TestRegistryRebootNode(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()
 
         for node in node_list:
 
@@ -171,4 +161,4 @@ class TestRegistryRebootNode(E2ETest):
         validate_registry_pod_status()
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()

--- a/tests/e2e/workloads/ocp/registry/test_registry_shutdown_and_recovery_node.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_shutdown_and_recovery_node.py
@@ -58,12 +58,7 @@ class TestRegistryShutdownAndRecoveryNode(E2ETest):
 
         # Pull and push images to registries
         log.info("Pull and push images to registries")
-        image_pull_and_push(
-            project_name=self.project_name,
-            template="eap-cd-basic-s2i",
-            image="registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8:latest",
-            pattern="eap-app",
-        )
+        image_pull_and_push(project_name=self.project_name)
 
         # Get the node list
         node_list = get_nodes(node_type="worker")
@@ -103,4 +98,4 @@ class TestRegistryShutdownAndRecoveryNode(E2ETest):
         validate_registry_pod_status()
 
         # Validate image exists in registries path
-        validate_image_exists(namespace=self.project_name)
+        validate_image_exists()


### PR DESCRIPTION
Fixes: #5405

Template `eap-cd-basic-s2i` is been removed from openshift samples as a quick fix passing build name when creating images so that template `redis-ephemeral` will be used default and will create a build

Signed-off-by: Akarsha-rai <akrai@redhat.com>