### PR TITLE
fix config initialization for multicluster

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -362,10 +362,10 @@ def pytest_configure(config):
                     "Skipping version collection because we skipped "
                     "the OCS deployment"
                 )
-                return
+                continue
             elif ocsci_config.RUN["cli_params"].get("dev_mode"):
                 log.info("Running in development mode")
-                return
+                continue
             # remove extraneous metadata
             for extra_meta in ["Python", "Packages", "Plugins", "Platform"]:
                 if config._metadata.get(extra_meta):
@@ -373,6 +373,8 @@ def pytest_configure(config):
 
             config._metadata["Test Run Name"] = get_testrun_name()
             gather_version_info_for_report(config)
+    # switch the configuration context back to the first cluster
+    ocsci_config.switch_ctx(0)
 
 
 def gather_version_info_for_report(config):


### PR DESCRIPTION
The `return` statement was replaced by `continue` otherwise the configuration for second and following clusters was skipped.
Also switch back to the configuration context of the first cluster at the end of `pytest_configure()` function.

Signed-off-by: Daniel Horak <dahorak@redhat.com>