### PR TITLE
switch to default cluster ctx after config inititalization

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -373,8 +373,8 @@ def pytest_configure(config):
 
             config._metadata["Test Run Name"] = get_testrun_name()
             gather_version_info_for_report(config)
-    # switch the configuration context back to the first cluster
-    ocsci_config.switch_ctx(0)
+    # switch the configuration context back to the default cluster
+    ocsci_config.switch_default_cluster_ctx()
 
 
 def gather_version_info_for_report(config):


### PR DESCRIPTION
switch to proper default cluster context after config initialization

Signed-off-by: Daniel Horak <dahorak@redhat.com>