### PR TITLE
Do not fail when configuration file is emtpy

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -63,6 +63,8 @@ class Config:
         out non-overridden items
         """
         field_names = [f.name for f in fields(self)]
+        if user_dict is None:
+            return
         for k, v in user_dict.items():
             if k not in field_names:
                 raise ValueError(


### PR DESCRIPTION
If some of the configuration file passed `--ocsci-conf` parameter is empty, it fails the whole `run-ci` execution with following traceback:
```
$ run-ci --color=yes tests/ecosystem/ -m deployment  --collect-only --ocsci-conf /tmp/test.yaml 
Traceback (most recent call last):
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/bin/run-ci", line 33, in <module>
    sys.exit(load_entry_point('ocs-ci', 'console_scripts', 'run-ci')())
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/main.py", line 265, in main
    init_ocsci_conf(arguments)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/main.py", line 90, in init_ocsci_conf
    process_ocsci_conf(arguments)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/main.py", line 130, in process_ocsci_conf
    load_config(args.ocsci_conf)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/main.py", line 50, in load_config
    framework.config.update(custom_config_data)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/__init__.py", line 168, in update
    self.cluster_ctx.update(user_dict)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/__init__.py", line 66, in update
    for k, v in user_dict.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

With this change, it _ignores_ this file and properly continue.

Signed-off-by: Daniel Horak <dahorak@redhat.com>