### PR TITLE
Add skipif managed service marker and update it in OSD skip tests

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -229,6 +229,11 @@ skipif_bmpsi = pytest.mark.skipif(
     reason="Test will not run on Baremetal PSI",
 )
 
+skipif_managed_service = pytest.mark.skipif(
+    config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS,
+    reason="Test will not run on Managed service cluster",
+)
+
 skipif_openshift_dedicated = pytest.mark.skipif(
     config.ENV_DATA["platform"].lower() == OPENSHIFT_DEDICATED_PLATFORM,
     reason="Test will not run on Openshift dedicated cluster",

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
@@ -7,7 +7,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -35,7 +35,7 @@ MCG_NS_RESULT_DIR = "/result"
 MCG_NS_ORIGINAL_DIR = "/original"
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")
 class TestMcgNamespaceDisruptionsCrd(E2ETest):

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
@@ -8,7 +8,7 @@ import botocore.exceptions as boto3exception
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -41,7 +41,7 @@ MCG_NS_RESULT_DIR = "/result"
 MCG_NS_ORIGINAL_DIR = "/original"
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")
 class TestMcgNamespaceDisruptionsRpc(E2ETest):

--- a/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
     tier3,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     skipif_ocs_version,
     skipif_external_mode,
 )
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2605")
 @pytest.mark.bugzilla("1924047")
 @skipif_ocs_version("<4.6")
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_external_mode
 class TestNoobaaBackupAndRecovery(E2ETest):
     """

--- a/tests/e2e/kcs/test_noobaa_rebuild.py
+++ b/tests/e2e/kcs/test_noobaa_rebuild.py
@@ -6,7 +6,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
     tier3,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2653")
 @pytest.mark.bugzilla("1991361")
 @pytest.mark.bugzilla("2019577")
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_external_mode
 class TestNoobaaRebuild(E2ETest):
     """

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
@@ -8,7 +8,7 @@ import botocore.exceptions as boto3exception
 
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -63,7 +63,7 @@ def setup_base_objects(awscli_pod, amount=2):
         )
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")
 class TestMcgNamespaceLifecycleCrd(E2ETest):

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
@@ -7,7 +7,7 @@ import botocore.exceptions as boto3exception
 
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -55,7 +55,7 @@ def setup_base_objects(awscli_pod, amount=2):
         )
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")
 class TestMcgNamespaceLifecycleRpc(E2ETest):

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
@@ -7,7 +7,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -111,7 +111,7 @@ def multipart_setup(pod_obj):
 
 
 @pytest.mark.polarion_id("OCS-2296")
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")
 @tier2

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
@@ -7,7 +7,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs import bucket_utils
@@ -26,7 +26,7 @@ COPY_OBJ = "CopyKey-" + str(uuid.uuid4().hex)
 
 
 @pytest.mark.polarion_id("OCS-2296")
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")
 @tier2

--- a/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
@@ -16,7 +16,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3
 from ocs_ci.framework.testlib import E2ETest, workloads, tier1, ignore_leftovers
 from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ class Testopenshiftloggingonocs(E2ETest):
 
     @pytest.mark.polarion_id("OCS-657")
     @tier1
-    @skipif_openshift_dedicated
+    @skipif_managed_service
     def test_create_new_project_to_verify_logging(
         self, create_pvc_and_deploymentconfig_pod
     ):

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -14,12 +14,12 @@ from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.framework.testlib import MCGTest
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestBucketCreation(MCGTest):
     """
     Test creation of a bucket

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -10,7 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     acceptance,
     performance,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     bugzilla,
     skipif_ocs_version,
 )
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestBucketDeletion(MCGTest):
     """
     Test bucket Creation Deletion of buckets
@@ -322,7 +322,7 @@ class TestBucketDeletion(MCGTest):
         request.addfinalizer(finalizer)
 
     @tier3
-    @skipif_openshift_dedicated
+    @skipif_managed_service
     @bugzilla("1980299")
     @pytest.mark.polarion_id("OCS-2704")
     @skipif_ocs_version("<4.9")

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -38,14 +38,14 @@ from ocs_ci.ocs.constants import (
     bucket_version_action_list,
     object_version_action_list,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_ocs_version("<4.3")
 class TestS3BucketPolicy(MCGTest):
     """

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -1,12 +1,12 @@
 from ocs_ci.framework.testlib import MCGTest, tier1, skipif_ocs_version
 from ocs_ci.ocs import constants, defaults, ocp
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 
 # @pytest.mark.polarion_id("OCS-XXXX")
 # Skipped above 4.6 because of https://github.com/red-hat-storage/ocs-ci/issues/4129
 @skipif_ocs_version(["<4.5", ">4.6"])
-@skipif_openshift_dedicated
+@skipif_managed_service
 @tier1
 class TestEndpointAutoScale(MCGTest):
     """

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -12,7 +12,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4a,
     tier3,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -230,7 +230,7 @@ class TestMCGResourcesDisruptions(MCGTest):
     @tier3
     @pytest.mark.polarion_id("OCS-2513")
     @marks.bugzilla("1903573")
-    @skipif_openshift_dedicated
+    @skipif_managed_service
     @skipif_ocs_version("<4.7")
     def test_db_scc(self, teardown):
         """

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_aws_creds_are_missing,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.bucket_utils import (
@@ -23,7 +23,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 class TestMultiRegion(MCGTest):
     """

--- a/tests/manage/mcg/test_multicloud.py
+++ b/tests/manage/mcg/test_multicloud.py
@@ -4,12 +4,12 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import MCGTest
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestMultiCloud(MCGTest):
     """
     Test the multi cloud functionality

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -14,7 +14,7 @@ from ocs_ci.ocs.bucket_utils import (
     complete_multipart_upload,
     sync_object_directory,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def setup(pod_obj, bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestS3MultipartUpload(MCGTest):
     """
     Test Multipart upload on Noobaa buckets

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -36,13 +36,13 @@ from ocs_ci.ocs import constants, bucket_utils
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.ocs.resources.bucket_policy import HttpResponseParser
 
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")
 class TestNamespace(MCGTest):

--- a/tests/manage/mcg/test_namespace_rpc.py
+++ b/tests/manage/mcg/test_namespace_rpc.py
@@ -10,7 +10,7 @@ import pytest
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     tier1,
     tier2,
     tier3,
@@ -27,7 +27,7 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")
 class TestNamespace(MCGTest):

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -13,7 +13,7 @@ from ocs_ci.ocs.bucket_utils import (
     retrieve_anon_s3_resource,
 )
 from ocs_ci.framework.pytest_customization.marks import (
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     skipif_ocs_version,
 )
 
@@ -26,7 +26,7 @@ RUNTIME_SKIP = pytest.mark.skip("Runtime is too long; Code needs to be paralleli
 
 
 @flaky
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestObjectIntegrity(MCGTest):
     """
     Test data integrity of various objects

--- a/tests/manage/mcg/test_verify_noobaa_status.py
+++ b/tests/manage/mcg/test_verify_noobaa_status.py
@@ -2,7 +2,7 @@ import logging
 
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import polarion_id, bugzilla
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 log = logging.getLogger(__name__)
 
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @tier1
 @polarion_id("OCS-2084")
 @bugzilla("1799077")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_verify_noobaa_status_cli(mcg_obj_session):
     """
     Verify noobaa status output is clean without any errors using the noobaa cli

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs.bucket_utils import (
     retrieve_test_objects_to_pod,
     craft_s3_command,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def pod_io(pods):
             p.submit(pod.run_io, "fs", "1G")
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 class TestBucketIO(MCGTest):
     """
     Test IO of a bucket

--- a/tests/manage/monitoring/prometheus/test_hpa.py
+++ b/tests/manage/monitoring/prometheus/test_hpa.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 @skipif_ocp_version("<4.6")
 @marks.polarion_id("OCS-2375")
 @marks.bugzilla("1836299")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_hpa_maxreplica_alert():
     """
     Test to verify that no HPA max replica alert is triggered

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -3,7 +3,7 @@ import logging
 from ocs_ci.framework.testlib import (
     polarion_id,
     bugzilla,
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     tier4,
     tier4a,
 )
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 @tier4a
 @polarion_id("OCS-1254")
 @bugzilla("1835290")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
     """
     Test that there are appropriate alerts when NooBaa Bucket Quota is reached.
@@ -92,7 +92,7 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
 @tier4
 @tier4a
 @polarion_id("OCS-2498")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted):
     """
     Test that there are appropriate alerts when target bucket used of

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -4,7 +4,7 @@ from ocs_ci.framework.pytest_customization import marks
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants, defaults, ocp
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @skipif_ocp_version("<4.6")
 @marks.polarion_id("OCS-2376")
 @marks.bugzilla("1873162")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_hpa_noobaa_endpoint_metric():
     """
     Test to verify HPA noobaa-endpoint cpu metrics is available.

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs import metrics
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.prometheus import PrometheusAPI, check_query_range_result_enum
 from ocs_ci.helpers.helpers import storagecluster_independent_check
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.post_ocp_upgrade
 @pytest.mark.first
 @pytest.mark.polarion_id("OCS-1261")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_monitoring_enabled():
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
@@ -76,7 +76,7 @@ def test_monitoring_enabled():
 
 @tier1
 @pytest.mark.polarion_id("OCS-1265")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_ceph_mgr_dashboard_not_deployed():
     """
     Check that `ceph mgr dashboard`_ is not deployed after installation of OCS
@@ -112,7 +112,7 @@ def test_ceph_mgr_dashboard_not_deployed():
 @tier1
 @pytest.mark.bugzilla("1779336")
 @pytest.mark.polarion_id("OCS-1267")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_ceph_rbd_metrics_available():
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
@@ -132,7 +132,7 @@ def test_ceph_rbd_metrics_available():
 @tier1
 @metrics_for_external_mode_required
 @pytest.mark.polarion_id("OCS-1268")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_ceph_metrics_available():
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
@@ -162,7 +162,7 @@ def test_ceph_metrics_available():
 @metrics_for_external_mode_required
 @pytest.mark.post_ocp_upgrade
 @pytest.mark.polarion_id("OCS-1302")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_monitoring_reporting_ok_when_idle(workload_idle):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -11,7 +11,7 @@ from ocs_ci.framework.pytest_customization import marks
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.prometheus import check_query_range_result_limits
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ CPU_USAGE_POD = (
 @tier1
 @marks.polarion_id("OCS-2364")
 @marks.bugzilla("1849309")
-@skipif_openshift_dedicated
+@skipif_managed_service
 def test_mcg_cpu_usage(workload_idle):
     """
     Without any IO  workload, cpu utilization of MCG pods should be minimal.

--- a/tests/manage/rgw/test_object_bucket_size.py
+++ b/tests/manage/rgw/test_object_bucket_size.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants, ocp, defaults
 from ocs_ci.framework.pytest_customization.marks import (
-    skipif_openshift_dedicated,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.bucket_utils import get_bucket_available_size
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour, NoobaaConditionException
@@ -56,7 +56,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
         )
 
 
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_ocs_version("<4.7")
 @pytest.mark.polarion_id("OCS-2476")
 @bugzilla("1880747")

--- a/tests/manage/storageclass/conftest.py
+++ b/tests/manage/storageclass/conftest.py
@@ -1,0 +1,25 @@
+import logging
+from ocs_ci.framework import config
+from ocs_ci.ocs.constants import MANAGED_SERVICE_PLATFORMS
+
+log = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(items):
+    """
+    A pytest hook to filter out storageclass tests
+    when running on managed service platforms
+
+    Args:
+        items: list of collected tests
+
+    """
+    if config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS:
+        for item in items.copy():
+            if "manage/storageclass" in str(item.fspath):
+                log.info(
+                    f"Test {item} is removed from the collected items"
+                    f" New storage-class creation is not supported on"
+                    f" {config.ENV_DATA['platform'].lower()}"
+                )
+                items.remove(item)

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -28,7 +28,7 @@ from ocs_ci.ocs.cluster import (
     is_flexible_scaling_enabled,
 )
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.ocs.ui.helpers_ui import ui_add_capacity_conditions, ui_add_capacity
 
 
@@ -96,7 +96,7 @@ def add_capacity_test():
 @acceptance
 @polarion_id("OCS-1191")
 @pytest.mark.second_to_last
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_aws_i3
 @skipif_bm
 @skipif_bmpsi

--- a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes
 from ocs_ci.helpers.helpers import get_failure_domin
 from ocs_ci.framework import config
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @bugzilla("1898808")
 @skipif_external_mode
-@skipif_openshift_dedicated
+@skipif_managed_service
 @pytest.mark.polarion_id("OCS-2594")
 class TestAddNodeCrashCollector(ManageTest):
     """

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -3,7 +3,7 @@ import logging
 from ocs_ci.framework.testlib import tier1, ignore_leftovers, ManageTest
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.framework.pytest_customization.marks import (
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     skipif_flexy_deployment,
     skipif_ibm_flash,
 )
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_flexy_deployment
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_ibm_flash
 @ignore_leftovers
 @tier1

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -17,7 +17,7 @@ from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.cluster import CephCluster, is_lso_cluster
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.framework.pytest_customization.marks import (
-    skipif_openshift_dedicated,
+    skipif_managed_service,
     skipif_bmpsi,
     bugzilla,
     skipif_external_mode,
@@ -156,7 +156,7 @@ def delete_and_create_osd_node(osd_node_name):
 @tier4a
 @ignore_leftovers
 @ipi_deployment_required
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_bmpsi
 @skipif_external_mode
 class TestNodeReplacementWithIO(ManageTest):
@@ -230,7 +230,7 @@ class TestNodeReplacementWithIO(ManageTest):
 @tier4
 @tier4a
 @ignore_leftovers
-@skipif_openshift_dedicated
+@skipif_managed_service
 @skipif_bmpsi
 @skipif_external_mode
 class TestNodeReplacement(ManageTest):


### PR DESCRIPTION
Created a common skipif marker for rosa and OSD
The test skip applicable for OSD platform is also
applicable for rosa platform. hence replacing
skipif_openshiftdedicated marker with skipif_managed_service
Signed-off-by: suchita.gatfane <sgatfane@redhat.com>