### PR TITLE
Disable the redundant tier4 pv_services tests

### DIFF
--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4b
+from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
@@ -14,8 +14,10 @@ from ocs_ci.helpers import helpers, disruption_helpers
 log = logging.getLogger(__name__)
 
 
-@tier4
-@tier4b
+@pytest.mark.skip(
+    reason="This test is disabled because this scenario is covered in the "
+    "test test_daemon_kill_during_pvc_pod_creation_and_io.py"
+)
 @pytest.mark.parametrize(
     argnames=["interface", "operation_to_disrupt", "resource_to_delete"],
     argvalues=[

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4b
+from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -30,8 +30,10 @@ from ocs_ci.helpers import disruption_helpers
 log = logging.getLogger(__name__)
 
 
-@tier4
-@tier4b
+@pytest.mark.skip(
+    reason="This test is disabled because this scenario is covered in the "
+    "test test_daemon_kill_during_pvc_pod_deletion_and_io.py"
+)
 @pytest.mark.parametrize(
     argnames=["interface", "operation_to_disrupt", "resource_name"],
     argvalues=[

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4a, ignore_leftover_label
+from ocs_ci.framework.testlib import ManageTest, ignore_leftover_label
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pvc import get_all_pvcs
@@ -17,8 +17,10 @@ logger = logging.getLogger(__name__)
 DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 
-@tier4
-@tier4a
+@pytest.mark.skip(
+    reason="This test is disabled because this scenario is covered in the test "
+    "test_resource_deletion_during_pvc_pod_creation_and_io.py"
+)
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "operation_to_disrupt", "resource_to_delete"],

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4c, ignore_leftover_label
+from ocs_ci.framework.testlib import ManageTest, ignore_leftover_label
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
@@ -214,8 +214,10 @@ class DisruptionBase(ManageTest):
         log.info("Ceph cluster health is OK")
 
 
-@tier4
-@tier4c
+@pytest.mark.skip(
+    reason="This test is disabled because this scenario is covered in the "
+    "test test_resource_deletion_during_pvc_pod_deletion_and_io.py"
+)
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "operation_to_disrupt", "resource_to_delete"],


### PR DESCRIPTION
There are some tier4 tests  in /manage/pv_services which are redundant since the test scenarios are covered in other tests.
These redundant tests are disabled in this PR.

1. tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py  covered in the test  tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
2. tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py covered in the test  tests/manage/pv_services/test_daemon_kill_during_pvc_pod_deletion_and_io.py
3. tests/manage/pv_services/test_pvc_disruptive.py covered in the test  tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
4.  tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py covered in the test  tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py

Signed-off-by: Jilju Joy <jijoy@redhat.com>