### PR TITLE
Use default storage class in test test_change_reclaim_policy_of_pv if the reclaim policy is Delete

### DIFF
--- a/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
@@ -4,11 +4,13 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.ocs.constants import RECLAIM_POLICY_DELETE, RECLAIM_POLICY_RETAIN
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.helpers import (
     wait_for_resource_state,
     verify_volume_deleted_in_backend,
     default_ceph_block_pool,
+    default_storage_class,
 )
 
 log = logging.getLogger(__name__)
@@ -19,19 +21,19 @@ log = logging.getLogger(__name__)
     argnames=["interface", "reclaim_policy"],
     argvalues=[
         pytest.param(
-            *[constants.CEPHBLOCKPOOL, "Delete"],
+            *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_DELETE],
             marks=pytest.mark.polarion_id("OCS-939"),
         ),
         pytest.param(
-            *[constants.CEPHBLOCKPOOL, "Retain"],
+            *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_RETAIN],
             marks=pytest.mark.polarion_id("OCS-962"),
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "Delete"],
+            *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_DELETE],
             marks=pytest.mark.polarion_id("OCS-963"),
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "Retain"],
+            *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_RETAIN],
             marks=pytest.mark.polarion_id("OCS-964"),
         ),
     ],
@@ -59,9 +61,13 @@ class TestChangeReclaimPolicyOfPv(ManageTest):
         """
         Create pvc and pod
         """
-        # Create storage class
-        self.sc_obj = storageclass_factory(
-            interface=interface, reclaim_policy=reclaim_policy
+        # Create storage class if reclaim policy is not "Delete"
+        self.sc_obj = (
+            default_storage_class(interface)
+            if reclaim_policy == RECLAIM_POLICY_DELETE
+            else storageclass_factory(
+                interface=interface, reclaim_policy=reclaim_policy
+            )
         )
 
         # Create PVCs


### PR DESCRIPTION
Use the default storage class in the test test_change_reclaim_policy_of_pv if the reclaim policy is "Delete". New storage class should be created only if the reclaim policy is "Retain". This will help running the tests which require the reclaim policy "Delete" on the platforms where the creation of new storage class is not supported/recommended. 

Signed-off-by: Jilju Joy <jijoy@redhat.com>