### PR TITLE
Skip reclaim policy "Retain" tests on managed services platforms

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     skipif_ocp_version,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -16,6 +17,7 @@ log = logging.getLogger(__name__)
 
 
 @tier1
+@skipif_managed_service
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @pytest.mark.polarion_id("OCS-2424")

--- a/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, skipif_managed_service
 from ocs_ci.ocs.constants import RECLAIM_POLICY_DELETE, RECLAIM_POLICY_RETAIN
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.helpers import (
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_RETAIN],
-            marks=pytest.mark.polarion_id("OCS-962"),
+            marks=[pytest.mark.polarion_id("OCS-962"), skipif_managed_service],
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_DELETE],
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_RETAIN],
-            marks=pytest.mark.polarion_id("OCS-964"),
+            marks=[pytest.mark.polarion_id("OCS-964"), skipif_managed_service],
         ),
     ],
 )

--- a/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -1,7 +1,13 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import ManageTest, tier1, acceptance
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    acceptance,
+    skipif_managed_service,
+)
+from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources import pod
@@ -42,9 +48,13 @@ class TestDynamicPvc(ManageTest):
             tuple: containing the storage class instance and list of worker nodes
 
         """
-        # Create storage class
-        sc_obj = storageclass_factory(
-            interface=interface_type, reclaim_policy=reclaim_policy
+        # Create storage class if reclaim policy is not "Delete"
+        sc_obj = (
+            default_storage_class(interface_type)
+            if reclaim_policy == constants.RECLAIM_POLICY_DELETE
+            else storageclass_factory(
+                interface=interface_type, reclaim_policy=reclaim_policy
+            )
         )
         worker_nodes_list = node.get_worker_nodes()
 
@@ -77,6 +87,7 @@ class TestDynamicPvc(ManageTest):
                 marks=[
                     pytest.mark.polarion_id("OCS-530"),
                     pytest.mark.bugzilla("1772990"),
+                    skipif_managed_service,
                 ],
             ),
             pytest.param(
@@ -94,6 +105,7 @@ class TestDynamicPvc(ManageTest):
                     pytest.mark.bugzilla("1751866"),
                     pytest.mark.bugzilla("1750916"),
                     pytest.mark.bugzilla("1772990"),
+                    skipif_managed_service,
                 ],
             ),
             pytest.param(
@@ -210,7 +222,7 @@ class TestDynamicPvc(ManageTest):
         argvalues=[
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_RETAIN],
-                marks=pytest.mark.polarion_id("OCS-542"),
+                marks=[pytest.mark.polarion_id("OCS-542"), skipif_managed_service],
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_DELETE],

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -3,8 +3,14 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 import pytest
 
+from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
-from ocs_ci.framework.testlib import tier1, ManageTest, acceptance
+from ocs_ci.framework.testlib import (
+    tier1,
+    ManageTest,
+    acceptance,
+    skipif_managed_service,
+)
 from ocs_ci.ocs import constants, node
 from ocs_ci.helpers import helpers
 from ocs_ci.framework import config
@@ -22,7 +28,8 @@ log = logging.getLogger(__name__)
             constants.RECLAIM_POLICY_DELETE, marks=pytest.mark.polarion_id("OCS-751")
         ),
         pytest.param(
-            constants.RECLAIM_POLICY_RETAIN, marks=pytest.mark.polarion_id("OCS-750")
+            constants.RECLAIM_POLICY_RETAIN,
+            marks=[pytest.mark.polarion_id("OCS-750"), skipif_managed_service],
         ),
     ],
 )
@@ -43,11 +50,15 @@ class TestRawBlockPV(ManageTest):
     @pytest.fixture()
     def storageclass(self, storageclass_factory, reclaim_policy):
         """
-        Create storage class with reclaim policy
+        Create storage class if reclaim policy is not "Delete"
         """
         self.reclaim_policy = reclaim_policy
-        self.sc_obj = storageclass_factory(
-            interface=constants.CEPHBLOCKPOOL, reclaim_policy=self.reclaim_policy
+        self.sc_obj = (
+            default_storage_class(constants.CEPHBLOCKPOOL)
+            if reclaim_policy == constants.RECLAIM_POLICY_DELETE
+            else storageclass_factory(
+                interface=constants.CEPHBLOCKPOOL, reclaim_policy=self.reclaim_policy
+            )
         )
 
     @property


### PR DESCRIPTION
The test cases which require a storage class with reclaim policy "Retain" should be skipped on managed services platform.
Test cases modified to create new storage only if the reclaim policy is not "Delete".

Signed-off-by: Jilju Joy <jijoy@redhat.com>