### PR TITLE
Import Clusters to ACM Hub including a separated test mark

### DIFF
--- a/conf/ocsci/import_clusters_to_acm.yaml
+++ b/conf/ocsci/import_clusters_to_acm.yaml
@@ -1,0 +1,4 @@
+---
+ENV_DATA:
+  skip_ocs_deployment: true
+  import_clusters_to_acm: true

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -70,6 +70,7 @@ scale_changed_layout = pytest.mark.scale_changed_layout
 deployment = pytest.mark.deployment
 polarion_id = pytest.mark.polarion_id
 bugzilla = pytest.mark.bugzilla
+acm_import = pytest.mark.acm_import
 
 tier_marks = [
     tier1,

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -342,7 +342,6 @@ def pytest_configure(config):
             # Add OCS related versions to the html report and remove
             # extraneous metadata
             markers_arg = config.getoption("-m")
-
             # add logs url
             logs_url = ocsci_config.RUN.get("logs_url")
             if logs_url:
@@ -355,6 +354,12 @@ def pytest_configure(config):
                 log.info(
                     "Skipping versions collecting because: Deploy or destroy of "
                     "cluster is performed."
+                )
+                continue
+            elif markers_arg == "acm_import":
+                log.info(
+                    "Skipping auto pytest executions and version collecting because "
+                    "Import Clusters to ACM is performed."
                 )
                 continue
             elif ocsci_config.ENV_DATA["skip_ocs_deployment"]:

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -706,6 +706,9 @@ def login_ui(console_url=None):
             chrome_options.add_argument("--ignore-ssl-errors=yes")
             chrome_options.add_argument("--ignore-certificate-errors")
             chrome_options.add_argument("--allow-insecure-localhost")
+            if config.ENV_DATA.get("import_clusters_to_acm"):
+                # Dev shm should be disabled when sending big amonut characters, like the cert sections of a kubeconfig
+                chrome_options.add_argument("--disable-dev-shm-usage")
             capabilities = chrome_options.to_capabilities()
             capabilities["acceptInsecureCerts"] = True
 
@@ -772,11 +775,14 @@ def login_ui(console_url=None):
     wait = WebDriverWait(driver, 60)
     driver.maximize_window()
     driver.get(console_url)
-    if config.ENV_DATA["flexy_deployment"]:
+    if config.ENV_DATA["flexy_deployment"] or config.ENV_DATA["import_clusters_to_acm"]:
         try:
             element = wait.until(
                 ec.element_to_be_clickable(
-                    (login_loc["flexy_kubeadmin"][1], login_loc["flexy_kubeadmin"][0])
+                    (
+                        login_loc["kubeadmin_login_approval"][1],
+                        login_loc["kubeadmin_login_approval"][0],
+                    )
                 )
             )
             element.click()

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -10,7 +10,7 @@ login = {
     "username": ("inputUsername", By.ID),
     "password": ("inputPassword", By.ID),
     "click_login": ("//button[text()='Log in']", By.XPATH),
-    "flexy_kubeadmin": ('a[title="Log in with kube:admin"]', By.CSS_SELECTOR),
+    "kubeadmin_login_approval": ('a[title="Log in with kube:admin"]', By.CSS_SELECTOR),
 }
 
 deployment = {
@@ -392,7 +392,7 @@ acm_page_nav = {
     "Import_cluster_enter_name": ("clusterName", By.ID),
     "Import_mode": ('button[class="pf-c-select__toggle"]', By.CSS_SELECTOR),
     "choose_kubeconfig": ("//button[text()='Kubeconfig']", By.XPATH),
-    "Kubeconfig_text": ('textarea[label="Kubeconfig"]', By.CSS_SELECTOR),
+    "Kubeconfig_text": ("kubeConfigEntry", By.ID),
     "Submit_import": ("//button[text()='Import']", By.XPATH),
 }
 

--- a/tests/ecosystem/deployment/test_acm.py
+++ b/tests/ecosystem/deployment/test_acm.py
@@ -1,14 +1,13 @@
 from ocs_ci.ocs.acm.acm import import_clusters_with_acm
-from ocs_ci.ocs.acm.acm import AcmAddClusters
-
+from ocs_ci.framework.testlib import acm_import
 
 ####################################################################################################
 # This file is placeholder for calling import ACM as test, until full solution will be implimented #
 ####################################################################################################
 
 
-def test_import_acm(setup_acm_ui):
-    acm_obj = AcmAddClusters(setup_acm_ui)
+@acm_import
+def test_acm_import(setup_acm_ui):
     import_clusters_with_acm()
-    acm_obj.install_submariner_ui()
-    acm_obj.submariner_validation_ui()
+    # TODO: Install the submariner and run validation by calling the methods:
+    # install_submariner_ui() and submarines_validation_ui() from AcmAddClusters Class


### PR DESCRIPTION
Signed-off-by: Cem Erginbas <cerginba@cerginba.tlv.csb>
Changes that are required for the importing scenario.
Some of the changes:
 - Added a new mark of `acm_import` as it will be a good solution for skipping pytest auto-use calls when entering run-ci
 - Added a new config file `conf/ocsci/import_clusters_to_acm.yaml` that skips ocs deployment and configures import_clusters_to_acm=True
 - Bug fixes in `ocsci/ocs/acm/acm.py` file that were required for the execution of the UI automation successfully to import the clusters
 - in `ocs_ci/ocs/ui/base_ui.py`  added chrome option of: `--disable-dev-shm-usage` when we pass the import_clusters_to_acm configuration. In such a scenario, the kubeconfig needs to be copied and sent as a text via UI automation. Since kubeconfig is a large file, Selenium crashes while trying to send those keys.
 - In `test_acm.py` file - the calls for submariner installation are deleted. We only want to handle import clusters for now.