### PR TITLE
Add WebDriver Data type hint in UI Base Class

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -11,6 +11,7 @@ from selenium.common.exceptions import (
     WebDriverException,
     NoSuchElementException,
 )
+from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -51,7 +52,7 @@ class BaseUI:
 
     """
 
-    def __init__(self, driver):
+    def __init__(self, driver: WebDriver):
         self.driver = driver
         self.screenshots_folder = os.path.join(
             os.path.expanduser(ocsci_config.RUN["log_dir"]),


### PR DESCRIPTION
Signed-off-by: Cem Erginbas <cerginba@cerginba.tlv.csb>

Motivation:
For future upcoming UI tests, it is beneficial to have auto completions on your IDEs. The child classes are not aware that `self.driver` is actually a WebDriver object.
By using this type-hint, we will see all the available methods no matter which classes you work on that inherits `BaseUI`

Please see the difference in those examples:

Example without the `WebDriver` type hint:
![bad](https://user-images.githubusercontent.com/49904449/152986167-2c192508-4c5c-4ff1-8b96-2d8f43c2bf4c.PNG)


Example with the `WebDriver` type hint:
![good](https://user-images.githubusercontent.com/49904449/152986211-0970b2c3-434b-47ba-8587-e36a7a11ca65.png)

