### PR TITLE
Handle webhook errors during store deletion

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -140,6 +140,7 @@ VOLUMESNAPSHOTCONTENT = "VolumeSnapshotContent"
 POD_DISRUPTION_BUDGET = "PodDisruptionBudget"
 STATEFULSET = "StatefulSet"
 BACKINGSTORE = "Backingstore"
+NAMESPACESTORE = "Namespacestore"
 BUCKETCLASS = "Bucketclass"
 
 # Provisioners

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -84,12 +84,13 @@ class BackingStore:
         def _oc_deletion_flow():
             try:
                 OCP(
-                    kind="backingstore", namespace=config.ENV_DATA["cluster_namespace"]
+                    kind=constants.BACKINGSTORE,
+                    namespace=config.ENV_DATA["cluster_namespace"],
                 ).delete(resource_name=self.name)
                 return True
             except CommandFailed as e:
                 if "not found" in e.args[0].lower():
-                    log.warning(f"Namespacestore {self.name} was already deleted.")
+                    log.warning(f"Backingstore {self.name} was already deleted.")
                     return True
                 elif all(
                     err in e.args[0]

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -103,7 +103,7 @@ class NamespaceStore:
         if self.method == "oc":
             try:
                 OCP(
-                    kind="namespacestore",
+                    kind=constants.NAMESPACESTORE,
                     namespace=config.ENV_DATA["cluster_namespace"],
                     resource_name=self.name,
                 ).get()
@@ -186,7 +186,7 @@ class NamespaceStore:
 
 def namespace_store_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
     """
-    Create a Backing Store factory.
+    Create a NamespaceStore factory.
     Calling this fixture lets the user create namespace stores.
 
     Args:
@@ -220,7 +220,7 @@ def namespace_store_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
         Tracks creation and cleanup of all the namespace stores that were created in the current scope
 
         Args:
-            method (str): String for selecting method of backing store creation (CLI/OC)
+            method (str): String for selecting method of namespace store creation (CLI/OC)
             nss_dict (dict): Dictionary containing storage provider as key and a list of tuples
             as value.
             Namespace store dictionary examples - 'CloudName': [(amount, region), (amount, region)]


### PR DESCRIPTION
Since admission control webhooks were added, the deletion of stores is sometimes blocked to the time it takes for buckets above them to fully delete.
This code handles the webhook error and continues to try.