### PR TITLE
Increase time in test_rgw_unavailable to wait for clearing alert

### DIFF
--- a/tests/manage/monitoring/prometheus/test_rgw.py
+++ b/tests/manage/monitoring/prometheus/test_rgw.py
@@ -47,7 +47,7 @@ def test_rgw_unavailable(measure_stop_rgw):
         severity="error",
     )
     api.check_alert_cleared(
-        label=target_label, measure_end_time=measure_stop_rgw.get("stop")
+        label=target_label, measure_end_time=measure_stop_rgw.get("stop"), time_min=300
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/5398

Signed-off-by: Filip Balak <fbalak@redhat.com>