### PR TITLE
test_mcg_hpa uses both 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ from ocs_ci.ocs.resources.pod import (
     Pod,
 )
 from ocs_ci.ocs.resources.pvc import PVC, create_restore_pvc
-from ocs_ci.ocs.version import get_ocs_version, report_ocs_version
+from ocs_ci.ocs.version import get_ocs_version, get_ocp_version_dict, report_ocs_version
 from ocs_ci.ocs.cluster_load import ClusterLoad, wrap_msg
 from ocs_ci.utility import (
     aws,
@@ -364,7 +364,8 @@ def log_ocs_version(cluster):
     elif skip_ocs_deployment:
         log.info("Skipping version reporting since OCS deployment is skipped.")
         return
-    cluster_version, image_dict = get_ocs_version()
+    cluster_version = get_ocp_version_dict()
+    image_dict = get_ocs_version()
     file_name = os.path.join(
         config.ENV_DATA["cluster_path"], "ocs_version." + datetime.now().isoformat()
     )

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -1,10 +1,12 @@
 import logging
 
 from ocs_ci.framework.pytest_customization import marks
+from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants, defaults, ocp
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.ocs.version import get_ocp_version
+from ocs_ci.utility.version import get_semantic_version, VERSION_4_10
 
 logger = logging.getLogger(__name__)
 
@@ -20,22 +22,32 @@ def test_hpa_noobaa_endpoint_metric():
     Test to verify HPA noobaa-endpoint cpu metrics is available.
     Since 4.10, it uses horizontal-pod-autoscaler-v2 API.
     """
+    ocp_version = get_semantic_version(get_ocp_version(), only_major_minor=True)
     ocp_obj = ocp.OCP(
         kind=constants.HPA,
         resource_name="noobaa-endpoint",
         namespace=defaults.ROOK_CLUSTER_NAMESPACE,
     )
-
     status = ocp_obj.get()["status"]
-    assert "currentMetrics" in status, "Failed: metrics not provided in noobaa-endpoint"
-
+    logger.info("Looking for cpu utilization value for hpa/noobaa-endpoint")
     cpu_utilization = None
-    for metric in status["currentMetrics"]:
-        if metric["type"] != "Resource":
-            continue
-        if metric["resource"]["name"] != "cpu":
-            continue
-        cpu_utilization = metric["resource"]["current"]["averageUtilization"]
+    if ocp_version < VERSION_4_10:
+        logger.info("using horizontal-pod-autoscaler-v1 API")
+        assert (
+            "currentCPUUtilizationPercentage" in status
+        ), "Failed: noobaa-endpoint cpu metrics is unavailable"
+        cpu_utilization = status["currentCPUUtilizationPercentage"]
+    else:
+        logger.info("using horizontal-pod-autoscaler-v2 API")
+        assert (
+            "currentMetrics" in status
+        ), "Failed: metrics not provided in noobaa-endpoint"
+        for metric in status["currentMetrics"]:
+            if metric["type"] != "Resource":
+                continue
+            if metric["resource"]["name"] != "cpu":
+                continue
+            cpu_utilization = metric["resource"]["current"]["averageUtilization"]
     assert (
         cpu_utilization is not None
     ), "Failed: noobaa-endpoint cpu metrics not available"


### PR DESCRIPTION
Update  `test_mcg_hpa` to use either horizontal-pod-autoscaler-v1 API (when OCP version < 4.10) or  horizontal-pod-autoscaler-v2 API otherwise.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/5361 again (it turned out we still don't use the stable version branches in production CI jobs).