### PR TITLE
Extend the MCG OBC health check timeout post upgrade

### DIFF
--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -104,7 +104,7 @@ def test_noobaa_postupgrade(
             awscli_pod=awscli_pod_session,
         ), "Checksum comparision between original and result object failed"
 
-    bucket.verify_health()
+    bucket.verify_health(timeout=100)
 
     # Clean up the temp dir
     awscli_pod_session.exec_cmd_on_pod(command=f'sh -c "rm -rf {LOCAL_TEMP_PATH}/*"')


### PR DESCRIPTION
Currently, the tests time out due to a race condition of a few seconds. The OBCs are bound by the time of the log collection, but not quickly enough to be caught by the default timeout period.
For an example, see the logs of run 1644190416.