### PR TITLE
Migrate S3 CLI relay pod to an STS to withstand node drains

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1055,18 +1055,16 @@ def write_random_objects_in_pod(io_pod, file_dir, amount, pattern="ObjKey-", bs=
     return obj_lst
 
 
-def setup_base_objects(awscli_pod, original_dir, result_dir, amount=2):
+def setup_base_objects(awscli_pod, original_dir, amount=2):
     """
     Prepares two directories and populate one of them with objects
 
      Args:
         awscli_pod (Pod): A pod running the AWS CLI tools
         original_dir (str): original directory name
-        result_dir (str): result directory name
         amount (Int): Number of test objects to create
 
     """
-    awscli_pod.exec_cmd_on_pod(command=f"mkdir {original_dir} {result_dir}")
     write_random_objects_in_pod(awscli_pod, original_dir, amount)
 
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -303,6 +303,7 @@ OCS_METRICS_EXPORTER = "app.kubernetes.io/name=ocs-metrics-exporter"
 MANAGED_PROMETHEUS_LABEL = "prometheus=managed-ocs-prometheus"
 MANAGED_ALERTMANAGER_LABEL = "alertmanager=managed-ocs-alertmanager"
 MANAGED_CONTROLLER_LABEL = "control-plane=controller-manager"
+S3CLI_LABEL = "app=s3cli"
 
 # Noobaa Deployments and Statefulsets
 NOOBAA_OPERATOR_DEPLOYMENT = "noobaa-operator"
@@ -484,6 +485,8 @@ AWSCLI_SERVICE_CA_YAML = os.path.join(
 AWSCLI_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "awscli.yaml")
 
 AWSCLI_MULTIARCH_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "awscli_multiarch.yaml")
+
+S3CLI_MULTIARCH_STS_YAML = os.path.join(TEMPLATE_MCG_DIR, "s3cli-sts.yaml")
 
 SERVICE_ACCOUNT_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "service_account.yaml")
 

--- a/ocs_ci/templates/mcg/s3cli-sts.yaml
+++ b/ocs_ci/templates/mcg/s3cli-sts.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: openshift-storage
+  name: s3cli
+spec:
+  selector:
+    matchLabels:
+      app: s3cli
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: OrderedReady
+  volumeClaimTemplates: []
+  template:
+    metadata:
+      labels:
+        app: s3cli
+    spec:
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: service-ca
+          configMap:
+            name: awscli-service-ca
+      containers:
+        - name: s3cli
+          image: quay.io/ocsci/s3-cli-with-test-objects-multiarch:1.0
+          command: ['/bin/sh']
+          stdin: true
+          tty: true
+          volumeMounts:
+            - name: service-ca
+              mountPath: /cert/service-ca.crt
+              subPath: service-ca.crt

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
@@ -86,7 +86,7 @@ def get_list_and_verify(
         assert listed_versions.sort() == keys.sort(), "List mismatch"
 
 
-def multipart_setup(pod_obj):
+def multipart_setup(pod_obj, origin_dir, result_dir):
     """
     Creates directories and files needed for multipart upload
 
@@ -98,16 +98,9 @@ def multipart_setup(pod_obj):
 
     """
     mpu_key = "MpuKey-" + str(uuid.uuid4().hex)
-    origin_dir = "/aws/objectdir"
-    res_dir = "/aws/partsdir"
     # Creates a 500MB file and splits it into multiple parts
-    pod_obj.exec_cmd_on_pod(
-        f'sh -c "mkdir {origin_dir}; mkdir {res_dir}; '
-        f"dd if=/dev/urandom of={origin_dir}/{mpu_key} bs=1MB count=500; "
-        f'split -a 1 -b 41m {origin_dir}/{mpu_key} {res_dir}/part"'
-    )
-    parts = pod_obj.exec_cmd_on_pod(f'sh -c "ls -1 {res_dir}"').split()
-    return mpu_key, origin_dir, res_dir, parts
+    parts = pod_obj.exec_cmd_on_pod(f'sh -c "ls -1 {result_dir}"').split()
+    return mpu_key, origin_dir, result_dir, parts
 
 
 @pytest.mark.polarion_id("OCS-2296")
@@ -120,9 +113,6 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
     Test various supported S3 operations on namespace buckets
 
     """
-
-    MCG_NS_RESULT_DIR = "/result"
-    MCG_NS_ORIGINAL_DIR = "/original"
 
     @pytest.mark.parametrize(
         argnames=["bucketclass_dict"],
@@ -590,7 +580,12 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         ids=["AWS-OC-Single", "Azure-OC-Single", "RGW-OC-Single", "AWS-OC-Cache"],
     )
     def test_mcg_namespace_mpu_crd(
-        self, mcg_obj, awscli_pod, bucket_factory, bucketclass_dict
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        bucketclass_dict,
+        test_directory_setup,
     ):
         """
         Test multipart upload S3 operations on namespace buckets(created by CRDs)
@@ -610,7 +605,9 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         logger.info(
             f"Setting up test files for mpu and aborting any mpu on bucket: {ns_bucket}"
         )
-        mpu_key, origin_dir, res_dir, parts = multipart_setup(awscli_pod)
+        mpu_key, origin_dir, res_dir, parts = multipart_setup(
+            awscli_pod, test_directory_setup.origin_dir, test_directory_setup.result_dir
+        )
         bucket_utils.abort_all_multipart_upload(mcg_obj, ns_bucket, COPY_OBJ)
 
         # Initiate mpu, Upload part copy, List and Abort operations

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
@@ -429,7 +429,13 @@ class TestMcgNamespaceS3OperationsRpc(E2ETest):
         ],
     )
     def test_mcg_namespace_mpu_rpc(
-        self, mcg_obj, awscli_pod, ns_resource_factory, bucket_factory, platform
+        self,
+        mcg_obj,
+        awscli_pod,
+        ns_resource_factory,
+        bucket_factory,
+        test_directory_setup,
+        platform,
     ):
         """
         Test multipart upload S3 operations on namespace buckets(RPC)
@@ -449,7 +455,9 @@ class TestMcgNamespaceS3OperationsRpc(E2ETest):
         logger.info(
             f"Setting up test files for mpu and aborting any mpu on bucket: {ns_bucket}"
         )
-        mpu_key, origin_dir, res_dir, parts = multipart_setup(awscli_pod)
+        mpu_key, origin_dir, res_dir, parts = multipart_setup(
+            awscli_pod, test_directory_setup.origin_dir, test_directory_setup.result_dir
+        )
         bucket_utils.abort_all_multipart_upload(mcg_obj, ns_bucket, COPY_OBJ)
 
         # Initiate mpu, Upload part copy, List and Abort operations

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -3,14 +3,12 @@ import logging
 import pytest
 from flaky import flaky
 
-from ocs_ci.framework.testlib import MCGTest, tier1, tier2, tier3
+from ocs_ci.framework.testlib import MCGTest, tier1, tier2
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     retrieve_test_objects_to_pod,
     sync_object_directory,
-    craft_s3_command,
     verify_s3_object_integrity,
-    retrieve_anon_s3_resource,
 )
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
@@ -93,15 +91,19 @@ class TestObjectIntegrity(MCGTest):
         ],
     )
     def test_check_object_integrity(
-        self, mcg_obj, awscli_pod, bucket_factory, bucketclass_dict
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        bucketclass_dict,
+        test_directory_setup,
     ):
         """
         Test object integrity using md5sum
         """
         bucketname = bucket_factory(1, bucketclass=bucketclass_dict)[0].name
-        original_dir = "/original"
-        result_dir = "/result"
-        awscli_pod.exec_cmd_on_pod(command=f"mkdir {result_dir}")
+        original_dir = test_directory_setup.origin_dir
+        result_dir = test_directory_setup.result_dir
         # Retrieve a list of all objects on the test-objects bucket and
         # downloads them to the pod
         full_object_path = f"s3://{bucketname}"
@@ -120,99 +122,20 @@ class TestObjectIntegrity(MCGTest):
                 awscli_pod=awscli_pod,
             ), "Checksum comparison between original and result object failed"
 
-    @pytest.mark.parametrize(
-        argnames="amount,file_type",
-        argvalues=[
-            pytest.param(
-                *[1, "large"],
-                marks=[pytest.mark.polarion_id("OCS-1944"), tier2, FILESIZE_SKIP],
-            ),
-            pytest.param(
-                *[100, "large"],
-                marks=[pytest.mark.polarion_id("OCS-1946"), tier3, FILESIZE_SKIP],
-            ),
-            pytest.param(
-                *[1, "small"], marks=[pytest.mark.polarion_id("OCS-1950"), tier2]
-            ),
-            pytest.param(
-                *[1000, "small"],
-                marks=[pytest.mark.polarion_id("OCS-1951"), tier3, RUNTIME_SKIP],
-            ),
-            pytest.param(
-                *[100, "large_small"],
-                marks=[pytest.mark.polarion_id("OCS-1952"), tier3, FILESIZE_SKIP],
-            ),
-        ],
-    )
-    def test_check_multi_object_integrity(
-        self, mcg_obj, awscli_pod, bucket_factory, amount, file_type
-    ):
-        """
-        Test write multiple files to bucket and check integrity
-        """
-        original_dir = "/original"
-        result_dir = "/result"
-        if file_type == "large":
-            public_bucket = PUBLIC_BUCKET
-            obj_key = LARGE_FILE_KEY
-        elif file_type == "small":
-            public_bucket = constants.TEST_FILES_BUCKET
-            obj_key = "random1.txt"
-        elif file_type == "large_small":
-            public_bucket = PUBLIC_BUCKET
-            obj_key = LARGE_FILE_KEY.rsplit("/", 1)[0]
-
-        # Download the file to pod
-        awscli_pod.exec_cmd_on_pod(command=f"mkdir {original_dir} {result_dir}")
-        public_s3_client = retrieve_anon_s3_resource().meta.client
-        download_files = []
-        # Use obj_key as prefix to download multiple files for large_small
-        # case, it also works with single file
-        for obj in public_s3_client.list_objects(
-            Bucket=public_bucket, Prefix=obj_key
-        ).get("Contents"):
-            # Skip the extra file in large file type
-            if file_type == "large" and obj["Key"] != obj_key:
-                continue
-            logger.info(f'Downloading {obj["Key"]} from AWS bucket {public_bucket}')
-            download_obj_cmd = f'cp s3://{public_bucket}/{obj["Key"]} {original_dir}'
-            awscli_pod.exec_cmd_on_pod(
-                command=craft_s3_command(download_obj_cmd), out_yaml_format=False
-            )
-            download_files.append(obj["Key"].split("/")[-1])
-
-        # Write downloaded objects to the new bucket and check integrity
-        bucketname = bucket_factory(1)[0].name
-        base_path = f"s3://{bucketname}"
-        for i in range(amount):
-            full_object_path = base_path + f"/{i}/"
-            sync_object_directory(awscli_pod, original_dir, full_object_path, mcg_obj)
-
-            # Retrieve all objects from MCG bucket to result dir in Pod
-            logger.info("Downloading objects from MCG bucket to awscli pod")
-            sync_object_directory(awscli_pod, full_object_path, result_dir, mcg_obj)
-
-            # Checksum is compared between original and result object
-            for obj in download_files:
-                assert verify_s3_object_integrity(
-                    original_object_path=f"{original_dir}/{obj}",
-                    result_object_path=f"{result_dir}/{obj}",
-                    awscli_pod=awscli_pod,
-                ), "Checksum comparison between original and result object failed"
-
     @pytest.mark.polarion_id("OCS-1945")
     @tier2
-    def test_empty_file_integrity(self, mcg_obj, awscli_pod, bucket_factory):
+    def test_empty_file_integrity(
+        self, mcg_obj, awscli_pod, bucket_factory, test_directory_setup
+    ):
         """
         Test write empty files to bucket and check integrity
         """
-        original_dir = "/data"
-        result_dir = "/result"
+        original_dir = test_directory_setup.origin_dir
+        result_dir = test_directory_setup.result_dir
         bucketname = bucket_factory(1)[0].name
         full_object_path = f"s3://{bucketname}"
 
-        # Touch create 1000 empty files in pod
-        awscli_pod.exec_cmd_on_pod(command=f"mkdir {original_dir} {result_dir}")
+        # Touch create 100 empty files in pod
         command = "for i in $(seq 1 100); do touch /data/test$i; done"
         awscli_pod.exec_sh_cmd_on_pod(command=command, sh="sh")
         # Write all empty objects to the new bucket


### PR DESCRIPTION
At the moment, certain node drain tests have lead to the AWSCLI session pod being removed.
Now, with the S3 CLI pod being replaced with an STS, it's going to respin automatically regardless of drains.

As part of this change, *all* MCG tests were refactored to use the session-scope S3 CLI pod, in order to both improve performance, and avoid STS naming conflicts.

Also removed several outdated tests that were already skipped for a while.