### PR TITLE
Fix test_snapshot_restore_using_different_sc for external mode cluster

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -10,7 +10,10 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
-from ocs_ci.helpers.helpers import wait_for_resource_state
+from ocs_ci.helpers.helpers import (
+    storagecluster_independent_check,
+    wait_for_resource_state,
+)
 from ocs_ci.utility import version
 
 log = logging.getLogger(__name__)
@@ -112,7 +115,10 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
 
         # If ODF >=4.9 create one more storage class that will use new pool
         # to verify the bug 1901954
-        if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_9:
+        if (
+            not storagecluster_independent_check()
+            and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_9
+        ):
             sc_objs[constants.CEPHBLOCKPOOL].append(
                 storageclass_factory(
                     interface=constants.CEPHBLOCKPOOL, new_rbd_pool=True


### PR DESCRIPTION
Test `test_snapshot_restore_using_different_sc` will now skip the creation of storage class which requires creation of new pool in case of external mode cluster
Fixes: #5479 
Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>