### PR TITLE
Repair db_scc test to support 4.7.z service account

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -14,7 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.utility import templating
+from ocs_ci.utility import templating, version
 from ocs_ci.utility.ssl_certs import get_root_ca_cert
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
 from ocs_ci.helpers.helpers import create_resource
@@ -199,6 +199,21 @@ def rm_object_recursive(podobj, target, mcg_obj, option=""):
             mcg_obj.s3_internal_endpoint,
         ],
     )
+
+
+def get_db_scc_and_sa():
+    """
+    Gets Noobaa DB's SCC and SA according to the cluster's version
+    Returns:
+        list: the SCC name and full SA path
+    """
+    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_8:
+        return constants.NOOBAA_SERVICE_ACCOUNT_NAME, constants.NOOBAA_SERVICE_ACCOUNT
+    else:
+        return (
+            constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME,
+            constants.NOOBAA_DB_SERVICE_ACCOUNT,
+        )
 
 
 def get_rgw_restart_counts():

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
 from ocs_ci.ocs import cluster, constants, defaults, ocp
+from ocs_ci.ocs.bucket_utils import get_db_scc_and_sa
 from ocs_ci.ocs.node import drain_nodes, wait_for_nodes_status
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
@@ -172,8 +173,7 @@ class TestMCGResourcesDisruptions(MCGTest):
 
         # Teardown function to revert back the scc changes made
         def finalizer():
-            scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
-            service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
+            scc_name, service_account = get_db_scc_and_sa()
             pod_obj = pod.Pod(
                 **pod.get_pods_having_label(
                     label=self.labels_map["noobaa_db"],
@@ -237,8 +237,7 @@ class TestMCGResourcesDisruptions(MCGTest):
         Test noobaa db is assigned with scc(anyuid) after changing the default noobaa SCC
 
         """
-        scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
-        service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
+        scc_name, service_account = get_db_scc_and_sa()
         pod_obj = pod.Pod(
             **pod.get_pods_having_label(
                 label=self.labels_map["noobaa_db"],


### PR DESCRIPTION
version 4.7.z still uses "noobaa" SA instead of the new "noobaa-endpoint" account which causes the test to fail, this pr verifies the cluster's version and send it back to the test. this pr is to revert the deletion of this check function since 4.7.z has not received the backport with the SA name change
Signed-off-by: Amit Berner <aberner@redhat.com>