### PR TITLE
[WIP] Managed Services - I/O consumer to provider

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -481,7 +481,7 @@ def default_storage_class(
         config.DEPLOYMENT["external_mode"]
         or (
             config.multicluster
-            and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer"
+            and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
         )
         or config.ENV_DATA.get("cluster_type") == "consumer"
     )
@@ -3023,7 +3023,7 @@ def default_volumesnapshotclass(interface_type):
         config.DEPLOYMENT["external_mode"]
         or (
             config.multicluster
-            and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer"
+            and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
         )
         or config.ENV_DATA.get("cluster_type") == "consumer"
     )

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -26,7 +26,7 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
-from ocs_ci.ocs.utils import mirror_image
+from ocs_ci.ocs.utils import mirror_image, get_primary_cluster_config
 from ocs_ci.ocs import constants, defaults, node, ocp
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -477,7 +477,14 @@ def default_storage_class(
     Returns:
         OCS: Existing StorageClass Instance
     """
-    external = config.DEPLOYMENT["external_mode"]
+    external = (
+        config.DEPLOYMENT["external_mode"]
+        or (
+            config.multicluster
+            and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer"
+        )
+        or config.ENV_DATA.get("cluster_type") == "consumer"
+    )
     if interface_type == constants.CEPHBLOCKPOOL:
         if external:
             resource_name = constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD
@@ -3012,7 +3019,14 @@ def default_volumesnapshotclass(interface_type):
     Returns:
         OCS: VolumeSnapshotClass Instance
     """
-    external = config.DEPLOYMENT["external_mode"]
+    external = (
+        config.DEPLOYMENT["external_mode"]
+        or (
+            config.multicluster
+            and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer"
+        )
+        or config.ENV_DATA.get("cluster_type") == "consumer"
+    )
     if interface_type == constants.CEPHBLOCKPOOL:
         resource_name = (
             constants.DEFAULT_EXTERNAL_MODE_VOLUMESNAPSHOTCLASS_RBD

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -132,10 +132,18 @@ class OCP(object):
         oc_cmd = "oc "
         # Managed services multicluster run - Use provider cluster in certain cases
         # TODO: Create a better solution to switch context when needed
-        if config.multicluster and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer" and any(res_type in command.lower() for res_type in ["cephfilesystem", "cephblockpool"]):
+        if (
+            config.multicluster
+            and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
+            and any(
+                res_type in command.lower()
+                for res_type in ["cephfilesystem", "cephblockpool"]
+            )
+        ):
             provider_cluster_config = get_provider_cluster_config()
             cluster_dir_kubeconfig = os.path.join(
-                provider_cluster_config.ENV_DATA["cluster_path"], provider_cluster_config.RUN.get("kubeconfig_location")
+                provider_cluster_config.ENV_DATA["cluster_path"],
+                provider_cluster_config.RUN.get("kubeconfig_location"),
             )
             if os.path.exists(cluster_dir_kubeconfig):
                 oc_cmd += f"--kubeconfig {cluster_dir_kubeconfig} "
@@ -143,7 +151,8 @@ class OCP(object):
             env_kubeconfig = os.getenv("KUBECONFIG")
             if not env_kubeconfig or not os.path.exists(env_kubeconfig):
                 cluster_dir_kubeconfig = os.path.join(
-                    config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
+                    config.ENV_DATA["cluster_path"],
+                    config.RUN.get("kubeconfig_location"),
                 )
                 if os.path.exists(cluster_dir_kubeconfig):
                     oc_cmd += f"--kubeconfig {cluster_dir_kubeconfig} "

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -128,15 +128,16 @@ class OCP(object):
             str: If out_yaml_format is False.
 
         """
-        oc_cmd = "oc "
-        # Managed services multicluster run - Use provider cluster in certain cases
-        # TODO: Create a better solution to switch context when needed
         # Importing here to avoid circular import
         from ocs_ci.ocs.utils import (
             get_primary_cluster_config,
             get_provider_cluster_config,
         )
 
+        oc_cmd = "oc "
+
+        # Managed services multicluster run - Use provider cluster in certain cases
+        # TODO: Create a better solution to switch context when needed
         if (
             config.multicluster
             and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -143,7 +143,7 @@ class OCP(object):
             and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
             and any(
                 res_type in command.lower()
-                for res_type in ["cephfilesystem", "cephblockpool"]
+                for res_type in [" cephfilesystem ", " cephblockpool "]
             )
         ):
             provider_cluster_config = get_provider_cluster_config()

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -19,7 +19,6 @@ from ocs_ci.ocs.exceptions import (
     ResourceNameNotSpecifiedException,
     TimeoutExpiredError,
 )
-from ocs_ci.ocs.utils import get_primary_cluster_config, get_provider_cluster_config
 from ocs_ci.utility.proxy import update_kubeconfig_with_proxy_url_for_client
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
@@ -132,6 +131,12 @@ class OCP(object):
         oc_cmd = "oc "
         # Managed services multicluster run - Use provider cluster in certain cases
         # TODO: Create a better solution to switch context when needed
+        # Importing here to avoid circular import
+        from ocs_ci.ocs.utils import (
+            get_primary_cluster_config,
+            get_provider_cluster_config,
+        )
+
         if (
             config.multicluster
             and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1258,3 +1258,16 @@ def get_primary_cluster_config():
     for cluster in ocsci_config.clusters:
         if cluster.MULTICLUSTER["primary_cluster"]:
             return cluster
+
+
+def get_provider_cluster_config():
+    """
+    Get the provider cluster config object in a MS scenario
+
+    Return:
+        framework.config: provider cluster config object from config.clusters
+
+    """
+    for cluster in ocsci_config.clusters:
+        if cluster.ENV_DATA.get('cluster_type') == "provider":
+            return cluster

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1269,5 +1269,5 @@ def get_provider_cluster_config():
 
     """
     for cluster in ocsci_config.clusters:
-        if cluster.ENV_DATA.get('cluster_type') == "provider":
+        if cluster.ENV_DATA.get("cluster_type") == "provider":
             return cluster

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -571,9 +571,19 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     original_cmd = cmd
     # Managed services multicluster run - Use provider cluster in certain cases
     # TODO: Create a better solution to switch context when needed
-    if "--kubeconfig " not in original_cmd and config.multicluster and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer" and any(res_type in original_cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]):
+    if (
+        "--kubeconfig " not in original_cmd
+        and config.multicluster
+        and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
+        and any(
+            res_type in original_cmd.lower()
+            for res_type in ["cephfilesystem", "cephblockpool"]
+        )
+    ):
         log.debug("Switching to provider")
-        config.switch_ctx(get_provider_cluster_config().MULTICLUSTER["multicluster_index"])
+        config.switch_ctx(
+            get_provider_cluster_config().MULTICLUSTER["multicluster_index"]
+        )
     masked_cmd = mask_secrets(cmd, secrets)
     log.info(f"Executing command: {masked_cmd}")
     if isinstance(cmd, str):
@@ -604,7 +614,15 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
             f"\nError is {masked_stderr}"
         )
     # TODO: Create a better solution to switch context when needed
-    if "--kubeconfig " not in original_cmd and config.multicluster and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer" and any(res_type in original_cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]):
+    if (
+        "--kubeconfig " not in original_cmd
+        and config.multicluster
+        and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
+        and any(
+            res_type in original_cmd.lower()
+            for res_type in ["cephfilesystem", "cephblockpool"]
+        )
+    ):
         log.debug("Switching to default context")
         config.reset_ctx()
     return completed_process

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -578,7 +578,8 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         and config.multicluster
         and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
         and any(
-            res_type in cmd.lower() for res_type in [" cephfilesystem ", " cephblockpool "]
+            res_type in cmd.lower()
+            for res_type in [" cephfilesystem ", " cephblockpool "]
         )
     ):
         log.debug("Switching to provider")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -44,6 +44,7 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedOSType,
     InteractivePromptException,
 )
+from ocs_ci.ocs.utils import get_primary_cluster_config, get_provider_cluster_config
 from ocs_ci.utility import version as version_module
 from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility.retry import retry
@@ -567,6 +568,12 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         stderr     (str): The standard error (None if not captured).
 
     """
+    original_cmd = cmd
+    # Managed services multicluster run - Use provider cluster in certain cases
+    # TODO: Create a better solution to switch context when needed
+    if "--kubeconfig " not in original_cmd and config.multicluster and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer" and any(res_type in original_cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]):
+        log.debug("Switching to provider")
+        config.switch_ctx(get_provider_cluster_config().MULTICLUSTER["multicluster_index"])
     masked_cmd = mask_secrets(cmd, secrets)
     log.info(f"Executing command: {masked_cmd}")
     if isinstance(cmd, str):
@@ -596,6 +603,10 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
             f"Error during execution of command: {masked_cmd}."
             f"\nError is {masked_stderr}"
         )
+    # TODO: Create a better solution to switch context when needed
+    if "--kubeconfig " not in original_cmd and config.multicluster and get_primary_cluster_config().ENV_DATA.get('cluster_type') == "consumer" and any(res_type in original_cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]):
+        log.debug("Switching to default context")
+        config.reset_ctx()
     return completed_process
 
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -578,8 +578,7 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         and config.multicluster
         and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
         and any(
-            res_type in cmd.lower()
-            for res_type in ["cephfilesystem", "cephblockpool"]
+            res_type in cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]
         )
     ):
         log.debug("Switching to provider")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -578,7 +578,7 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
         and config.multicluster
         and get_primary_cluster_config().ENV_DATA.get("cluster_type") == "consumer"
         and any(
-            res_type in cmd.lower() for res_type in ["cephfilesystem", "cephblockpool"]
+            res_type in cmd.lower() for res_type in [" cephfilesystem ", " cephblockpool "]
         )
     ):
         log.debug("Switching to provider")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -44,7 +44,6 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedOSType,
     InteractivePromptException,
 )
-from ocs_ci.ocs.utils import get_primary_cluster_config, get_provider_cluster_config
 from ocs_ci.utility import version as version_module
 from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility.retry import retry
@@ -571,6 +570,9 @@ def exec_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     original_cmd = cmd
     # Managed services multicluster run - Use provider cluster in certain cases
     # TODO: Create a better solution to switch context when needed
+    # Importing here to avoid circular import
+    from ocs_ci.ocs.utils import get_primary_cluster_config, get_provider_cluster_config
+
     if (
         "--kubeconfig " not in original_cmd
         and config.multicluster


### PR DESCRIPTION
Code change for managed services to run I/O from consumer to provider.

```
run-ci multicluster 2 tests/ --cluster1 --cluster-name consumer-cluster-name --cluster-path /home/user/ms-consumer-cluster-path/ --ocsci-conf conf/deployment/rosa/managed_1az_consumer_qe_3m_3w_m54x.yaml --ocsci-conf conf/ocsci/multicluster_primary_cluster.yaml --cluster2 --cluster-name provider-cluster-name --cluster-path /home/user/ms-provider-cluster-path/ --ocsci-conf conf/deployment/rosa/managed_3az_provider_qe_3m_3w_m54x.yaml
```
Signed-off-by: Jilju Joy <jijoy@redhat.com>