### PR TITLE
Skip the test case test_rbd_space_reclaim in MS

### DIFF
--- a/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     polarion_id,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -50,6 +51,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
     @polarion_id("OCS-2741")
     @tier1
+    @skipif_managed_service
     def test_rbd_space_reclaim(self):
         """
         Test to verify RBD space reclamation


### PR DESCRIPTION
The test case is skipped in Managed services platform because the test case creates new CephBlockPool. 
Signed-off-by: Jilju Joy <jijoy@redhat.com>