### PR TITLE
changing compressed FIO test timeout

### DIFF
--- a/ocs_ci/templates/workloads/fio/benchmark_fio_cmp.yaml
+++ b/ocs_ci/templates/workloads/fio/benchmark_fio_cmp.yaml
@@ -31,7 +31,7 @@ spec:
       storageclass: ocs-storagecluster-ceph-rbd-cmp
       storagesize: 12Gi
       cmp_ratio: 75
-      job_timeout: 18000
+      job_timeout: 36000
 #      rook_ceph_drop_caches: True
 #      rook_ceph_drop_cache_pod_ip:
 #######################################


### PR DESCRIPTION
currently all FIO test on compressed volume with 16 KiB block size are not completed on time.
This PR is increasing the time of the test, so it will finishe.

Signed-off-by: Avi Layani <alayani@redhat.com>