### PR TITLE
Performance Dashboard - remove the check if cluster is compressed

### DIFF
--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -761,15 +761,6 @@ class PASTest(BaseTest):
             if odf_back_storage != "gp2":
                 platform = f"{platform}-{odf_back_storage}"
 
-        # Check if compression is enabled
-        my_obj = OCP(
-            kind="cephblockpool", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
-        )
-        for pool in my_obj.data.get("items"):
-            if pool.get("spec").get("compressionMode", None) is not None:
-                platform = f"{platform}-CMP"
-                break
-
         if self.dev_mode:
             port = "8181"
         else:


### PR DESCRIPTION
when pushing data to the dashboard the test if the test ran on compressed volume is irrelevant, since this test is running after actual tests was ran and the volumes (compressed) was deleted already.

Signed-off-by: Avi Layani <alayani@redhat.com>