### PR TITLE
Change the default imagepullpolicy for performance test

### DIFF
--- a/ocs_ci/templates/app-pods/performance.yaml
+++ b/ocs_ci/templates/app-pods/performance.yaml
@@ -8,6 +8,7 @@ spec:
   containers:
    - name: performance
      image: quay.io/ocsci/perf:latest
+     imagePullPolicy: IfNotPresent
      command: ['/bin/sh']
      stdin: true
      tty: true

--- a/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
@@ -7,13 +7,11 @@ import os
 import pytest
 import pathlib
 import time
-from uuid import uuid4
 
 from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.testlib import performance, polarion_id
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import get_full_test_logs_path
-from ocs_ci.framework import config
 from ocs_ci.ocs import defaults, constants, scale_lib
 from ocs_ci.ocs.resources.pod import get_pod_obj
 from ocs_ci.ocs.perftests import PASTest
@@ -40,18 +38,9 @@ class TestBulkPodAttachPerformance(PASTest):
         super(TestBulkPodAttachPerformance, self).setup()
         self.benchmark_name = "bulk_pod_attach_time"
 
-        self.uuid = uuid4().hex
-        self.crd_data = {
-            "spec": {
-                "test_user": "Homer simpson",
-                "clustername": "test_cluster",
-                "elasticsearch": {
-                    "server": config.PERF.get("production_es_server"),
-                    "port": config.PERF.get("production_es_port"),
-                    "url": f"http://{config.PERF.get('production_es_server')}:{config.PERF.get('production_es_port')}",
-                },
-            }
-        }
+        # Pulling the pod image to the worker node, so pull image will not calculate
+        # in the total attach time
+        helpers.pull_images(constants.PERF_IMAGE)
 
     @pytest.fixture()
     def base_setup(self, project_factory, interface_type, storageclass_factory):
@@ -78,19 +67,15 @@ class TestBulkPodAttachPerformance(PASTest):
         argvalues=[
             pytest.param(
                 *[constants.CEPHBLOCKPOOL, 120],
-                marks=[pytest.mark.performance],
             ),
             pytest.param(
                 *[constants.CEPHBLOCKPOOL, 240],
-                marks=[pytest.mark.performance],
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, 120],
-                marks=[pytest.mark.performance],
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, 240],
-                marks=[pytest.mark.performance],
             ),
         ],
     )

--- a/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
@@ -5,10 +5,8 @@ import urllib.request
 import time
 import statistics
 import os
-from uuid import uuid4
 
 from ocs_ci.framework.testlib import performance
-from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import constants, node
@@ -32,25 +30,6 @@ class TestPodReattachTimePerformance(PASTest):
         logging.info("Starting the test setup")
         super(TestPodReattachTimePerformance, self).setup()
         self.benchmark_name = "pod_reattach_time"
-        self.uuid = uuid4().hex
-        self.crd_data = {
-            "spec": {
-                "test_user": "Homer simpson",
-                "clustername": "test_cluster",
-                "elasticsearch": {
-                    "server": config.PERF.get("production_es_server"),
-                    "port": config.PERF.get("production_es_port"),
-                    "url": f"http://{config.PERF.get('production_es_server')}:{config.PERF.get('production_es_port')}",
-                },
-            }
-        }
-        # during development use the dev ES so the data in the Production ES will be clean.
-        if self.dev_mode:
-            self.crd_data["spec"]["elasticsearch"] = {
-                "server": config.PERF.get("dev_es_server"),
-                "port": config.PERF.get("dev_es_port"),
-                "url": f"http://{config.PERF.get('dev_es_server')}:{config.PERF.get('dev_es_port')}",
-            }
 
     def init_full_results(self, full_results):
         """


### PR DESCRIPTION
The default image pull policy is : Always
Which mean that in the pod attach / reattach we are measuring the pull image time in the total attach time.

This PR change the default image pull policy to : IfNotPresent
So, the image pull time will no calculate in the attach time, since we are pulling it separately in the beginning of the test and not as part as the pod creation process.

This PR also remove some code duplication from the pod_reattach test.

the Pulling image is also implements in the bulk_pod_attach test
some duplicated code remove from the bulk_pod_attach test.