### PR TITLE
Fix UI deployment on OCS4.8 [404 Page Not found]

### DIFF
--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -138,6 +138,9 @@ class DeploymentUI(PageNavigator):
             self.do_click(
                 locator=self.dep_loc["storage_cluster_tab"], enable_screenshot=True
             )
+            if self.check_element_text("404"):
+                logger.info("Refresh storage cluster page")
+                self.refresh_page()
         self.do_click(
             locator=self.dep_loc["create_storage_cluster"], enable_screenshot=True
         )


### PR DESCRIPTION
#5546 

404 Page Not found on storage cluster page
![image](https://user-images.githubusercontent.com/61982127/156944237-959d6c3a-f5c8-4483-8bcb-cad483ce0842.png)

Signed-off-by: Oded Viner <oviner@redhat.com>