### PR TITLE
vSphere IPI/UPI specs conf: Reduce master and increase worker memory

### DIFF
--- a/conf/ocsci/vsphere_ipi.yaml
+++ b/conf/ocsci/vsphere_ipi.yaml
@@ -10,6 +10,6 @@ ENV_DATA:
   worker_replicas: 3
   master_replicas: 3
   fio_storageutilization_min_mbps: 10.0
-  master_memory: '16384'
-  compute_memory: '32768'
+  master_memory: '12288'
+  compute_memory: '36864'
   worker_num_cpus: '12'

--- a/conf/ocsci/vsphere_upi.yaml
+++ b/conf/ocsci/vsphere_upi.yaml
@@ -10,6 +10,6 @@ ENV_DATA:
   worker_replicas: 3
   master_replicas: 3
   fio_storageutilization_min_mbps: 10.0
-  master_memory: '16384'
-  compute_memory: '32768'
+  master_memory: '12288'
+  compute_memory: '36864'
   worker_num_cpus: '12'


### PR DESCRIPTION
In order to utilize vsphere_upi.yaml and vsphere_ipi.yaml more in day to day testing, I am proposing to increase the worker nodes mem from 32 to 36 GB and reduce the master nodes mem from 16 to 12 GB

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>