### PR TITLE
Upgrade external cluster

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -122,11 +122,12 @@ class ExternalCluster(object):
         logger.debug(f"RHEL version on external RHCS cluster is {out}")
         return pattern.search(out).groups()[0]
 
-    def update_permission_caps(self):
+    def update_permission_caps(self, user=None):
         """
         Update permission caps on the external RHCS cluster
         """
-        params = "--upgrade"
+        user = user if user else defaults.EXTERNAL_CLUSTER_USER
+        params = f"--upgrade --run-as-user={user}"
         out = self.run_exporter_script(params=params)
         logger.info(f"updated permissions for the user are set as {out}")
 

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -109,3 +109,4 @@ VAULT_TENANT_SA_CONNECTION_CONF = {
 
 # External cluster username
 EXTERNAL_CLUSTER_USER = "client.healthchecker"
+EXTERNAL_CLUSTER_OBJECT_STORE_USER = "rgw-admin-ops-user"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -106,3 +106,6 @@ VAULT_TENANT_SA_CONNECTION_CONF = {
         "vaultBackend": "kv-v2",
     }
 }
+
+# External cluster username
+EXTERNAL_CLUSTER_USER = "client.healthchecker"

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -252,6 +252,10 @@ class ExternalClusterExporterRunFailed(Exception):
     pass
 
 
+class ExternalClusterObjectStoreUserCreationFailed(Exception):
+    pass
+
+
 class ExternalClusterRGWEndPointMissing(Exception):
     pass
 

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -642,31 +642,6 @@ def run_ocs_upgrade(operation=None, *operation_args, **operation_kwargs):
             time.sleep(30)
             # End of workaround
 
-        # update external secrets
-        if config.DEPLOYMENT["external_mode"] and not (
-            original_ocs_version == "4.7" and upgrade_version == "4.8"
-        ):
-            external_cluster.update_permission_caps()
-            external_cluster.get_external_cluster_details()
-
-            # update the external cluster details in secrets
-            log.info("updating external cluster secret")
-            external_cluster_details = NamedTemporaryFile(
-                mode="w+",
-                prefix="external-cluster-details-",
-                delete=False,
-            )
-            with open(external_cluster_details.name, "w") as fd:
-                decoded_external_cluster_details = decode(
-                    config.EXTERNAL_MODE["external_cluster_details"]
-                )
-                fd.write(decoded_external_cluster_details)
-            cmd = (
-                f"oc set data secret/rook-ceph-external-cluster-details -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
-                f"--from-file=external_cluster_details={external_cluster_details.name}"
-            )
-            exec_cmd(cmd)
-
         for sample in TimeoutSampler(
             timeout=725,
             sleep=5,
@@ -688,6 +663,30 @@ def run_ocs_upgrade(operation=None, *operation_args, **operation_kwargs):
         upgrade_ocs.get_parsed_versions()[1],
         upgrade_ocs.version_before_upgrade,
     )
+
+    # update external secrets
+    if config.DEPLOYMENT["external_mode"]:
+        external_cluster.update_permission_caps()
+        external_cluster.get_external_cluster_details()
+
+        # update the external cluster details in secrets
+        log.info("updating external cluster secret")
+        external_cluster_details = NamedTemporaryFile(
+            mode="w+",
+            prefix="external-cluster-details-",
+            delete=False,
+        )
+        with open(external_cluster_details.name, "w") as fd:
+            decoded_external_cluster_details = decode(
+                config.EXTERNAL_MODE["external_cluster_details"]
+            )
+            fd.write(decoded_external_cluster_details)
+        cmd = (
+            f"oc set data secret/rook-ceph-external-cluster-details -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+            f"--from-file=external_cluster_details={external_cluster_details.name}"
+        )
+        exec_cmd(cmd)
+
     ocs_install_verification(
         timeout=600,
         skip_osd_distribution_check=True,


### PR DESCRIPTION
supports ODF upgrade external cluster dynamically

This PR supports below upgrade scenarios which was missed few steps in previous releases.
Apart from that, In this PR we are creating object store user dynamically if it doesn't exists.

1. upgrade from 4.8 to 4.9
2. upgrade from 4.7 to 4.8
3. upgrade from 4.6 to 4.7
4. upgrade from 4.5 to 4.6

Signed-off-by: vavuthu <vavuthu@redhat.com>