### PR TITLE
Fix the ElasticSearch link

### DIFF
--- a/ocs_ci/ocs/perfresult.py
+++ b/ocs_ci/ocs/perfresult.py
@@ -157,7 +157,7 @@ class PerfResult:
         """
 
         res_link = f"http://{self.server}:{self.port}/{self.new_index}/"
-        res_link += f"_search?q=uuid:{self.uuid}"
+        res_link += f'_search?q=uuid:"{self.uuid}"'
         return res_link
 
 


### PR DESCRIPTION
In some cases (espachialy with FIO and SmallFiles), the link to the elasticsearch results pull more the the expected results.
quoting the UUID in the link is solving this issue.

Signed-off-by: Avi Layani <alayani@redhat.com>