### PR TITLE
Extend encrypted rbd pv/pvc test cases to include IBM HPCS as KMS option

### DIFF
--- a/conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml
+++ b/conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml
@@ -1,0 +1,40 @@
+
+# This is the basic config for IBM cloud usage with HPCS.
+DEPLOYMENT:
+  kms_deployment: true
+---
+ENV_DATA:
+  platform: 'ibm_cloud'
+  deployment_type: 'managed'
+  region: 'eu-de'
+  zone: 'eu-de-3'
+  provider: "vpc-gen2"
+  worker_instance_type: "mx2.16x128"
+  master_replicas: 0
+  worker_replicas: 3
+  rhel_workers: true
+  encryption_at_rest: true
+  hpcs_deploy_mode: external
+  KMS_PROVIDER: hpcs
+  KMS_SERVICE_NAME: hpcs
+  # Following values needs to be set in separate config and passed to ocs-ci in
+  # order to deploy OCP/OCS cluster on IBM Cloud
+  # vpc_id: VPC ID PLACEHOLDER
+  # subnet_id: SUBNET ID PLACEHOLDER
+  # cos_instance: COS INSTANCE PLACEHOLDER
+#AUTH:
+#  ibmcloud:
+#    api_key: IBM CLOUD API KEY PLACEHOLDER
+#    account_id: ACCOUNT ID PLACEHOLDER
+#    ibm_cos_access_key_id: KEY PLACEHOLDER
+#    ibm_cos_secret_access_key: SECRET PLACEHOLDER
+#DEPLOYMENT:
+#  ocs_secret_dockerconfigjson: BASE64 OF QUAY SECRET PLACEHOLDER
+REPORTING:
+  # We cannot use internal image for must gather cause of secret issue.
+  # To allow us testing NON GA version we have to use upstream image. For GAed
+  # version of OCS, we need to pass extra config file:
+  # conf/ocsci/live-must-gather.yaml
+  ocs_must_gather_image: "quay.io/ocs-dev/ocs-must-gather"
+  ocs_must_gather_latest_tag: 'latest'
+  overwrite_must_gather_image: false

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -24,6 +24,7 @@ from ocs_ci.ocs.constants import (
     ROSA_PLATFORM,
     OPENSHIFT_DEDICATED_PLATFORM,
     MANAGED_SERVICE_PLATFORMS,
+    HPCS_KMS_PROVIDER,
 )
 from ocs_ci.utility import version
 from ocs_ci.utility.aws import update_config_from_s3
@@ -224,20 +225,18 @@ ms_consumer_required = pytest.mark.skipif(
 )
 
 kms_config_required = pytest.mark.skipif(
-    # (
-    #    config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER
-    #    and load_auth_config().get("vault", {}).get("VAULT_ADDR") is None
-    # )
-    # or
-    # (
-    #    not
-    #    (
-    #        config.ENV_DATA["KMS_PROVIDER"].lower() == HPCS_KMS_PROVIDER
-    #        and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_10
-    #        and load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is not None,
-    #    )
-    # ),
-    load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is None,
+    (
+        config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER
+        and load_auth_config().get("vault", {}).get("VAULT_ADDR") is None
+    )
+    or (
+        not (
+            config.ENV_DATA["KMS_PROVIDER"].lower() == HPCS_KMS_PROVIDER
+            and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_10
+            and load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID")
+            is not None,
+        )
+    ),
     reason="KMS config not found in auth.yaml",
 )
 

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -224,8 +224,16 @@ ms_consumer_required = pytest.mark.skipif(
 )
 
 kms_config_required = pytest.mark.skipif(
-    load_auth_config().get("vault", {}).get("VAULT_ADDR") is None,
-    reason="Vault config not found in auth.yaml",
+    # (
+    # config.ENV_DATA["platform"].lower() != IBMCLOUD_PLATFORM
+    # and load_auth_config().get("vault", {}).get("VAULT_ADDR") is None
+    # )
+    # or
+    # (
+    # config.ENV_DATA["platform"].lower() ==
+    load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is None,
+    # ),
+    reason="KMS config not found in auth.yaml",
 )
 
 skipif_aws_i3 = pytest.mark.skipif(

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -225,14 +225,19 @@ ms_consumer_required = pytest.mark.skipif(
 
 kms_config_required = pytest.mark.skipif(
     # (
-    # config.ENV_DATA["platform"].lower() != IBMCLOUD_PLATFORM
-    # and load_auth_config().get("vault", {}).get("VAULT_ADDR") is None
+    #    config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER
+    #    and load_auth_config().get("vault", {}).get("VAULT_ADDR") is None
     # )
     # or
     # (
-    # config.ENV_DATA["platform"].lower() ==
-    load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is None,
+    #    not
+    #    (
+    #        config.ENV_DATA["KMS_PROVIDER"].lower() == HPCS_KMS_PROVIDER
+    #        and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_10
+    #        and load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is not None,
+    #    )
     # ),
+    load_auth_config().get("hpcs", {}).get("IBM_KP_SERVICE_INSTANCE_ID") is None,
     reason="KMS config not found in auth.yaml",
 )
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -613,6 +613,17 @@ RBD_CSI_VAULT_TENANT_CONFIGMAP = os.path.join(
 CEPH_CONFIG_DEBUG_LOG_LEVEL_CONFIGMAP = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "ceph-debug-log-level-configmap.yaml"
 )
+# External hpcs kms yamls
+EXTERNAL_HPCS_TEMPLATES = os.path.join(TEMPLATE_OPENSHIFT_INFRA_DIR, "hpcs")
+EXTERNAL_HPCS_KMS_CONNECTION_DETAILS = os.path.join(
+    EXTERNAL_HPCS_TEMPLATES, "ocs-kms-connection-details.yaml"
+)
+EXTERNAL_HPCS_CSI_KMS_CONNECTION_DETAILS = os.path.join(
+    TEMPLATE_CSI_RBD_DIR, "csi-kms-connection-details-hpcs.yaml"
+)
+EXTERNAL_IBM_KP_KMS_SECRET = os.path.join(
+    EXTERNAL_HPCS_TEMPLATES, "ibm-kp-kms-secret.yaml"
+)
 # Multicluster related yamls
 ODF_MULTICLUSTER_ORCHESTRATOR = os.path.join(
     TEMPLATE_MULTICLUSTER_DIR, "odf_multicluster_orchestrator.yaml"
@@ -1458,9 +1469,11 @@ VAULT_DEFAULT_POLICY_PREFIX = "rook"
 VAULT_DEFAULT_NAMESPACE_PREFIX = "ocs-namespace"
 VAULT_DEFAULT_TLS_SERVER = ""
 VAULT_KMS_CONNECTION_DETAILS_RESOURCE = "ocs-kms-connection-details"
+HPCS_KMS_CONNECTION_DETAILS_RESOURCE = "ocs-kms-connection-details"
 VAULT_KMS_TOKEN_RESOURCE = "ocs-kms-token"
 VAULT_CLIENT_CERT_PATH = os.path.join(DATA_DIR, "vault-client.crt")
 VAULT_KMS_PROVIDER = "vault"
+HPCS_KMS_PROVIDER = "hpcs"
 VAULT_NOOBAA_ROOT_SECRET_PATH = "NOOBAA_ROOT_SECRET_PATH"
 VAULT_KMS_CSI_CONNECTION_DETAILS = "csi-kms-connection-details"
 VAULT_KMS_CSI_TOKEN = "ceph-csi-kms-token"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1469,7 +1469,6 @@ VAULT_DEFAULT_POLICY_PREFIX = "rook"
 VAULT_DEFAULT_NAMESPACE_PREFIX = "ocs-namespace"
 VAULT_DEFAULT_TLS_SERVER = ""
 VAULT_KMS_CONNECTION_DETAILS_RESOURCE = "ocs-kms-connection-details"
-HPCS_KMS_CONNECTION_DETAILS_RESOURCE = "ocs-kms-connection-details"
 VAULT_KMS_TOKEN_RESOURCE = "ocs-kms-token"
 VAULT_CLIENT_CERT_PATH = os.path.join(DATA_DIR, "vault-client.crt")
 VAULT_KMS_PROVIDER = "vault"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -110,3 +110,17 @@ VAULT_TENANT_SA_CONNECTION_CONF = {
 # External cluster username
 EXTERNAL_CLUSTER_USER = "client.healthchecker"
 EXTERNAL_CLUSTER_OBJECT_STORE_USER = "rgw-admin-ops-user"
+# Hpcs related defaults
+#
+# To be used for adding additional hpcs connections
+# to csi-kms-connection-details resource
+HPCS_CSI_CONNECTION_CONF = {
+    "1-hpcs": {
+        "KMS_PROVIDER": "ibmkeyprotect",
+        "KMS_SERVICE_NAME": "1-hpcs",
+        "IBM_KP_SERVICE_INSTANCE_ID": "",
+        "IBM_KP_SECRET_NAME": "ibm-kp-kms-test-secret",
+        "IBM_KP_BASE_URL": "",
+        "IBM_KP_TOKEN_URL": "https://iam.cloud.ibm.com/oidc/token",
+    }
+}

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -364,6 +364,10 @@ class VaultOperationError(Exception):
     pass
 
 
+class HpcsDeploymentError(Exception):
+    pass
+
+
 class KMSNotSupported(Exception):
     pass
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -364,7 +364,7 @@ class VaultOperationError(Exception):
     pass
 
 
-class HpcsDeploymentError(Exception):
+class HPCSDeploymentError(Exception):
     pass
 
 

--- a/ocs_ci/templates/CSI/rbd/csi-kms-connection-details-hpcs.yaml
+++ b/ocs_ci/templates/CSI/rbd/csi-kms-connection-details-hpcs.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  1-hpcs: '{"KMS_PROVIDER":"ibmkeyprotect","KMS_SERVICE_NAME":"1-hpcs","IBM_KP_SERVICE_INSTANCE_ID":"<ibm_kp_service_instance_id>","IBM_KP_SECRET_NAME":"ibm-kp-kms-test-secret","IBM_KP_BASE_URL":"<ibm_kp_base_url>","IBM_KP_TOKEN_URL":"https://iam.cloud.ibm.com/oidc/token"}'
+kind: ConfigMap
+metadata:
+  name: csi-kms-connection-details
+  namespace: openshift-storage

--- a/ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml
+++ b/ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ibm-kp-kms-test-secret
+  namespace: openshift-storage
+data:
+  IBM_KP_CUSTOMER_ROOT_KEY: <ibm_kp_customer_root_key>
+  IBM_KP_SERVICE_API_KEY: <ibm_kp_service_api_key>
+type: Opaque

--- a/ocs_ci/templates/openshift-infra/hpcs/ocs-kms-connection-details.yaml
+++ b/ocs_ci/templates/openshift-infra/hpcs/ocs-kms-connection-details.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  IBM_KP_BASE_URL: ""
+  IBM_KP_SECRET_NAME: ""
+  IBM_KP_SERVICE_INSTANCE_ID: ""
+  IBM_KP_TOKEN_URL: ""
+  KMS_PROVIDER: ibmkeyprotect
+  KMS_SERVICE_NAME: 1-hpcs
+kind: ConfigMap
+metadata:
+  name: ocs-kms-connection-details
+  namespace: openshift-storage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4151,10 +4151,10 @@ def pv_encryption_kms_setup_factory(request):
     """
 
     # set the KMS provider based on KMS_PROVIDER env value.
-    # if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-    return pv_encryption_hpcs_setup_factory(request)
-    # else:
-    #   return pv_encryption_vault_setup_factory(request)
+    if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+        return pv_encryption_hpcs_setup_factory(request)
+    else:
+        return pv_encryption_vault_setup_factory(request)
 
 
 def pv_encryption_vault_setup_factory(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4242,15 +4242,16 @@ def pv_encryption_hpcs_setup_factory(request):
     Create hpcs resources and setup csi-kms-connection-details configMap
 
     """
-    hpcs = KMS.Hpcs()
+    hpcs = KMS.HPCS()
 
     def factory(kv_version):
         """
         Args:
             kv_version(str): KV version to be used
         Returns:
-            object: Hpcs(KMS) object
-
+            object: HPCS(KMS) object
+        Raises:
+            CommandFailed: if fails to get csi-kms-connection-details configmap
         """
         hpcs.gather_init_hpcs_conf()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4149,6 +4149,19 @@ def pv_encryption_kms_setup_factory(request):
     """
     Create vault resources and setup csi-kms-connection-details configMap
     """
+
+    # set the KMS provider based on platform
+    # if config.ENV_DATA["platform"].lower() == constants.IBM_PLATFORM:
+    return pv_encryption_hpcs_setup_factory()
+    # else:
+    # return pv_encryption_vault_setup_factory()
+
+
+def pv_encryption_vault_setup_factory(request):
+    """
+    Create vault resources and setup csi-kms-connection-details configMap
+
+    """
     vault = KMS.Vault()
 
     def factory(kv_version):
@@ -4219,6 +4232,78 @@ def pv_encryption_kms_setup_factory(request):
         vault.remove_vault_backend_path()
         vault.remove_vault_policy()
         vault.remove_vault_namespace()
+
+    request.addfinalizer(finalizer)
+    return factory
+
+
+def pv_encryption_hpcs_setup_factory(request):
+    """
+    Create hpcs resources and setup csi-kms-connection-details configMap
+
+    """
+    hpcs = KMS.Hpcs()
+
+    def factory():
+        """
+        Args:
+            kv_version(str): KV version to be used, either v1 or v2
+
+        Returns:
+            object: Hpcs(KMS) object
+
+        """
+        hpcs.gather_init_hpcs_conf()
+
+        # Check if hpcs kms secret already exist, if not create hpcs secret
+        ocp_obj = OCP(kind="secret", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        try:
+            ocp_obj.get_resource(resource_name=hpcs.ibm_kp_secret_name, column="NAME")
+        except CommandFailed as cfe:
+            if "not found" not in str(cfe):
+                raise
+            else:
+                hpcs.ibm_kp_secret_name = hpcs.create_ibm_kp_kms_secret()
+
+        # Create or update hpcs related confimap.
+        hpcs_resource_name = create_unique_resource_name("test", "hpcs")
+        ocp_obj = OCP(kind="configmap", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        # If csi-kms-connection-details exists, edit the configmap to add new hpcs config
+        try:
+            ocp_obj.get_resource(
+                resource_name="csi-kms-connection-details", column="NAME"
+            )
+            new_kmsid = hpcs_resource_name
+            hdict = defaults.HPCS_CSI_CONNECTION_CONF
+            for key in hdict.keys():
+                old_key = key
+            hdict[new_kmsid] = hdict.pop(old_key)
+            hdict[new_kmsid][
+                "IBM_KP_SERVICE_INSTANCE_ID"
+            ] = hpcs.ibm_kp_service_instance_id
+            hdict[new_kmsid]["IBM_KP_SECRET_NAME"] = hpcs.ibm_kp_secret_name
+            hdict[new_kmsid]["IBM_KP_BASE_URL"] = hpcs.ibm_kp_base_url
+            hdict[new_kmsid]["IBM_KP_TOKEN_URL"] = hpcs.ibm_kp_token_url
+            hdict[new_kmsid]["KMS_SERVICE_NAME"] = new_kmsid
+            hpcs.kmsid = hpcs_resource_name
+            KMS.update_csi_kms_vault_connection_details(hdict)
+
+        except CommandFailed as cfe:
+            if "not found" not in str(cfe):
+                raise
+            else:
+                hpcs.kmsid = "1-hpcs"
+                hpcs.create_hpcs_csi_kms_connection_details()
+
+        return hpcs
+
+    def finalizer():
+        """
+        Remove the hpcs config from csi-kms-connection-details configMap
+
+        """
+        if len(KMS.get_encryption_kmsid()) > 1:
+            KMS.remove_kmsid(hpcs.kmsid)
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4244,9 +4244,10 @@ def pv_encryption_hpcs_setup_factory(request):
     """
     hpcs = KMS.Hpcs()
 
-    def factory():
+    def factory(kv_version):
         """
-
+        Args:
+            kv_version(str): KV version to be used
         Returns:
             object: Hpcs(KMS) object
 

--- a/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     kms_config_required,
     skipif_managed_service,
+    config,
 )
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs.resources import pod
@@ -22,17 +23,17 @@ from ocs_ci.utility import kms
 log = logging.getLogger(__name__)
 
 # Set the arg values based on KMS provider.
-# if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-kmsprovider = constants.HPCS_KMS_PROVIDER
-argvalues = [
-    pytest.param("v1", kmsprovider),
-]
-# else:
-#   kmsprovider = constants.VAULT_KMS_PROVIDER
-#  argvalues=[
-#     pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2650")),
-#    pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2651")),
-# ]
+if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+    kmsprovider = constants.HPCS_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider),
+    ]
+else:
+    kmsprovider = constants.VAULT_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2650")),
+        pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2651")),
+    ]
 
 
 @tier1
@@ -49,12 +50,6 @@ class TestEncryptedRbdClone(ManageTest):
     Tests to verify PVC to PVC clone feature for encrypted RBD Block VolumeMode PVCs
 
     """
-
-    # set the KMS provider based on KMS_PROVIDER env value.
-    # if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-    #   kmsprovider = constants.HPCS_KMS_PROVIDER
-    # else:
-    #   kmsprovider = constants.VAULT_KMS_PROVIDER
 
     @pytest.fixture(autouse=True)
     def setup(

--- a/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
@@ -54,6 +54,7 @@ class TestEncryptedRbdClone(ManageTest):
     @pytest.fixture(autouse=True)
     def setup(
         self,
+        kv_version,
         kms_provider,
         pv_encryption_kms_setup_factory,
         project_factory,
@@ -67,7 +68,7 @@ class TestEncryptedRbdClone(ManageTest):
         """
 
         log.info("Setting up csi-kms-connection-details configmap")
-        self.kms = pv_encryption_kms_setup_factory()
+        self.kms = pv_encryption_kms_setup_factory(kv_version)
         log.info("csi-kms-connection-details setup successful")
 
         # Create a project

--- a/tests/manage/pv_services/pvc_snapshot/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_encrypted_rbd_pvc_snapshot.py
@@ -26,17 +26,17 @@ from ocs_ci.utility import kms
 log = logging.getLogger(__name__)
 
 # Set the arg values based on KMS provider.
-# if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-kmsprovider = constants.HPCS_KMS_PROVIDER
-argvalues = [
-    pytest.param("v1", kmsprovider),
-]
-# else:
-#   kmsprovider = constants.VAULT_KMS_PROVIDER
-#  argvalues=[
-#    pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2612")),
-#    pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2613")),
-# ]
+if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+    kmsprovider = constants.HPCS_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider),
+    ]
+else:
+    kmsprovider = constants.VAULT_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2612")),
+        pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2613")),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/manage/pv_services/pvc_snapshot/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_encrypted_rbd_pvc_snapshot.py
@@ -71,7 +71,7 @@ class TestEncryptedRbdBlockPvcSnapshot(ManageTest):
         """
 
         log.info("Setting up csi-kms-connection-details configmap")
-        self.kms = pv_encryption_kms_setup_factory()
+        self.kms = pv_encryption_kms_setup_factory(kv_version)
         log.info("csi-kms-connection-details setup successful")
 
         # Create a project

--- a/tests/manage/pv_services/test_rbd_pv_encryption.py
+++ b/tests/manage/pv_services/test_rbd_pv_encryption.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
+    config,
 )
 from ocs_ci.helpers.helpers import (
     create_pods,
@@ -21,17 +22,17 @@ from ocs_ci.utility import kms
 log = logging.getLogger(__name__)
 
 # Set the arg values based on KMS provider.
-# if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-kmsprovider = constants.HPCS_KMS_PROVIDER
-argvalues = [
-    pytest.param("v1", kmsprovider),
-]
-# else:
-#   kmsprovider = constants.VAULT_KMS_PROVIDER
-#  argvalues=[
-#     pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2585")),
-#    pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2592")),
-# ]
+if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+    kmsprovider = constants.HPCS_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider),
+    ]
+else:
+    kmsprovider = constants.VAULT_KMS_PROVIDER
+    argvalues = [
+        pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2585")),
+        pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2592")),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -46,12 +47,6 @@ class TestRbdPvEncryption(ManageTest):
     Test to verify RBD PV encryption
 
     """
-
-    # set the KMS provider based on KMS_PROVIDER env value.
-    # if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-    #   kmsprovider = constants.HPCS_KMS_PROVIDER
-    # else:
-    #   kmsprovider = constants.VAULT_KMS_PROVIDER
 
     @pytest.fixture(autouse=True)
     def setup(

--- a/tests/manage/pv_services/test_rbd_pv_encryption.py
+++ b/tests/manage/pv_services/test_rbd_pv_encryption.py
@@ -9,27 +9,34 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
 )
 from ocs_ci.helpers.helpers import (
-    create_unique_resource_name,
     create_pods,
 )
-from ocs_ci.ocs import constants, defaults
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import (
-    CommandFailed,
     KMSResourceCleaneupError,
     ResourceNotFoundError,
 )
 from ocs_ci.utility import kms
-from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
+# Set the arg values based on KMS provider.
+# if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+kmsprovider = constants.HPCS_KMS_PROVIDER
+argvalues = [
+    pytest.param("v1", kmsprovider),
+]
+# else:
+#   kmsprovider = constants.VAULT_KMS_PROVIDER
+#  argvalues=[
+#     pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2585")),
+#    pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2592")),
+# ]
+
 
 @pytest.mark.parametrize(
-    argnames=["kv_version"],
-    argvalues=[
-        pytest.param("v1", marks=pytest.mark.polarion_id("OCS-2585")),
-        pytest.param("v2", marks=pytest.mark.polarion_id("OCS-2592")),
-    ],
+    argnames=["kv_version", "kms_provider"],
+    argvalues=argvalues,
 )
 @skipif_ocs_version("<4.7")
 @kms_config_required
@@ -40,156 +47,29 @@ class TestRbdPvEncryption(ManageTest):
 
     """
 
+    # set the KMS provider based on KMS_PROVIDER env value.
+    # if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
+    #   kmsprovider = constants.HPCS_KMS_PROVIDER
+    # else:
+    #   kmsprovider = constants.VAULT_KMS_PROVIDER
+
     @pytest.fixture(autouse=True)
-    def setup(self, kv_version, request):
+    def setup(
+        self,
+        pv_encryption_kms_setup_factory,
+    ):
         """
         Setup csi-kms-connection-details configmap
 
         """
-
-        # set the KMS provider based on platform
-        # if config.ENV_DATA["platform"].lower() == constants.IBM_PLATFORM:
-        self.kmsprovider = constants.HPCS_KMS_PROVIDER
-        # else:
-        #   self.kmsprovider = constants.VAULT_KMS_PROVIDER
-        if self.kmsprovider == constants.VAULT_KMS_PROVIDER:
-            self.setupvault(request, kv_version)
-        else:
-            self.setuphpcs(request)
-
-    # setup vault related resources.
-    def setupvault(self, request, kv_version):
-        """
-        Setup csi-kms-connection-details configmap as per vault configuration
-
-        """
-        # Initialize Vault
-        self.vault = kms.Vault()
-        self.vault.gather_init_vault_conf()
-        self.vault.update_vault_env_vars()
-
-        # Check if cert secrets already exist, if not create cert resources
-        ocp_obj = OCP(kind="secret", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
-        try:
-            ocp_obj.get_resource(resource_name="ocs-kms-ca-secret", column="NAME")
-        except CommandFailed as cfe:
-            if "not found" not in str(cfe):
-                raise
-            else:
-                self.vault.create_ocs_vault_cert_resources()
-
-        # Create vault namespace, backend path and policy in vault
-        self.vault_resource_name = create_unique_resource_name("test", "vault")
-        self.vault.vault_create_namespace(namespace=self.vault_resource_name)
-        self.vault.vault_create_backend_path(
-            backend_path=self.vault_resource_name, kv_version=kv_version
-        )
-        self.vault.vault_create_policy(policy_name=self.vault_resource_name)
-
-        ocp_obj = OCP(kind="configmap", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
-
-        # If csi-kms-connection-details exists, edit the configmap to add new vault config
-        try:
-            ocp_obj.get_resource(
-                resource_name="csi-kms-connection-details", column="NAME"
-            )
-            self.new_kmsid = self.vault_resource_name
-            vdict = defaults.VAULT_CSI_CONNECTION_CONF
-            for key in vdict.keys():
-                old_key = key
-            vdict[self.new_kmsid] = vdict.pop(old_key)
-            vdict[self.new_kmsid]["VAULT_BACKEND_PATH"] = self.vault_resource_name
-            vdict[self.new_kmsid]["VAULT_NAMESPACE"] = self.vault_resource_name
-
-            # Workaround for BZ-1997624
-            if kv_version == "v1":
-                vdict[self.new_kmsid]["VAULT_BACKEND"] = "kv"
-            else:
-                vdict[self.new_kmsid]["VAULT_BACKEND"] = "kv-v2"
-
-            kms.update_csi_kms_vault_connection_details(vdict)
-
-        except CommandFailed as cfe:
-            if "not found" not in str(cfe):
-                raise
-            else:
-                self.new_kmsid = "1-vault"
-                self.vault.create_vault_csi_kms_connection_details(
-                    kv_version=kv_version
-                )
-
-        def finalizer():
-            # Remove the vault config from csi-kms-connection-details configMap
-            if len(kms.get_encryption_kmsid()) > 1:
-                kms.remove_kmsid(self.new_kmsid)
-
-            # Delete the resources in vault
-            self.vault.remove_vault_backend_path()
-            self.vault.remove_vault_policy()
-            self.vault.remove_vault_namespace()
-
-        request.addfinalizer(finalizer)
-
-    # setup hpcs related resources.
-    def setuphpcs(self, request):
-        """
-        Setup csi-kms-connection-details configmap as per HPCS configuration.
-
-        """
-        # Initialize HPCS
-        self.hpcs = kms.Hpcs()
-        self.hpcs.gather_init_hpcs_conf()
-
-        # Create ibm_kp_kms_secret with a unique name, raise an error if a secret
-        # with same name exists.
-        self.hpcs.ibm_kp_secret_name = self.hpcs.create_ibm_kp_kms_secret()
-
-        # Create or update hpcs related confimap.
-        self.hpcs_resource_name = create_unique_resource_name("test", "hpcs")
-        ocp_obj = OCP(kind="configmap", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
-        # If csi-kms-connection-details exists, edit the configmap to add new hpcs config
-        try:
-            ocp_obj.get_resource(
-                resource_name="csi-kms-connection-details", column="NAME"
-            )
-            self.new_kmsid = self.hpcs_resource_name
-            hdict = defaults.HPCS_CSI_CONNECTION_CONF
-            for key in hdict.keys():
-                old_key = key
-            hdict[self.new_kmsid] = hdict.pop(old_key)
-            hdict[self.new_kmsid][
-                "IBM_KP_SERVICE_INSTANCE_ID"
-            ] = self.hpcs.ibm_kp_service_instance_id
-            hdict[self.new_kmsid]["IBM_KP_SECRET_NAME"] = self.hpcs.ibm_kp_secret_name
-            hdict[self.new_kmsid]["IBM_KP_BASE_URL"] = self.hpcs.ibm_kp_base_url
-            hdict[self.new_kmsid]["IBM_KP_TOKEN_URL"] = self.hpcs.ibm_kp_token_url
-            hdict[self.new_kmsid]["KMS_SERVICE_NAME"] = self.new_kmsid
-
-            kms.update_csi_kms_vault_connection_details(hdict)
-
-        except CommandFailed as cfe:
-            if "not found" not in str(cfe):
-                raise
-            else:
-                self.new_kmsid = "1-hpcs"
-                self.hpcs.create_hpcs_csi_kms_connection_details()
-
-        def finalizer():
-            # Remove the hpcs config from csi-kms-connection-details configMap
-            if len(kms.get_encryption_kmsid()) > 1:
-                kms.remove_kmsid(self.new_kmsid)
-            # remove the kms secret created to store hpcs creds
-            self.hpcs.delete_resource(
-                self.hpcs.ibm_kp_secret_name,
-                "secret",
-                constants.OPENSHIFT_STORAGE_NAMESPACE,
-            )
-
-        request.addfinalizer(finalizer)
+        log.info("Setting up csi-kms-connection-details configmap")
+        self.kms = pv_encryption_kms_setup_factory()
+        log.info("csi-kms-connection-details setup successful")
 
     @tier1
     def test_rbd_pv_encryption(
         self,
+        kms_provider,
         project_factory,
         storageclass_factory,
         multi_pvc_factory,
@@ -200,11 +80,6 @@ class TestRbdPvEncryption(ManageTest):
         Test to verify creation and deletion of encrypted RBD PVC
 
         """
-        # set the KMS provider based on platform
-        # if config.ENV_DATA["platform"].lower() == constants.IBM_PLATFORM:
-        self.kmsprovider = constants.HPCS_KMS_PROVIDER
-        # else:
-        #   self.kmsprovider = constants.VAULT_KMS_PROVIDER
         # Create a project
         proj_obj = project_factory()
 
@@ -212,10 +87,10 @@ class TestRbdPvEncryption(ManageTest):
         sc_obj = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL,
             encrypted=True,
-            encryption_kms_id=self.new_kmsid,
+            encryption_kms_id=self.kms.kmsid,
         )
 
-        if self.kmsprovider == constants.VAULT_KMS_PROVIDER:
+        if kms_provider == constants.VAULT_KMS_PROVIDER:
             # Create ceph-csi-kms-token in the tenant namespace
             self.vault.vault_path_token = self.vault.generate_vault_token()
             self.vault.create_vault_csi_kms_token(namespace=proj_obj.namespace)
@@ -252,7 +127,7 @@ class TestRbdPvEncryption(ManageTest):
             vol_handle = pv_obj.get().get("spec").get("csi").get("volumeHandle")
             vol_handles.append(vol_handle)
 
-            if self.kmsprovider == constants.VAULT_KMS_PROVIDER:
+            if kms_provider == constants.VAULT_KMS_PROVIDER:
                 # Check if encryption key is created in Vault
                 if kms.is_key_present_in_path(
                     key=vol_handle, path=self.vault.vault_backend_path
@@ -296,7 +171,7 @@ class TestRbdPvEncryption(ManageTest):
             pvc_obj.delete()
             pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name)
 
-        if self.kmsprovider == constants.VAULT_KMS_PROVIDER:
+        if kms_provider == constants.VAULT_KMS_PROVIDER:
             # Verify whether the key is deleted in Vault. Skip check for kv-v2 due to BZ#1979244
             if kv_version == "v1":
                 for vol_handle in vol_handles:


### PR DESCRIPTION
This PR includes the below changes:

- Extend `encrypted RBD PV creation and deletion` test case to include IBM's HPCS as KMS option.
**Jenkins Job link** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10655/
**Jenkins Job link for Vault** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10841/

- Extend `encrypted RBD PVC to PVC clone` test case to include IBM's HPCS as KMS option.
**Jenkins Job link** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10638/
**Jenkins Job link for Vault** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10859/

- Extend `encrypted RBD PVC snapshot` test case to include IBM's HPCS as KMS option.
**Jenkins Job link** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10669/
**Jenkins Job link for Vault** - https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/10864/


NOTE: Above test cases has been verified on AWS IPI platform as more details are in above Jenkins jobs.

Signed-off-by: “Sagar-Kumar3” <Sagar.Kumar3@ibm.com>
