### PR TITLE
Skip tests on MS platform

### DIFF
--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     ignore_leftover_label,
     skipif_ocp_version,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers import disruption_helpers
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 @tier4c
+@skipif_managed_service
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @ignore_leftover_label(constants.drain_canary_pod_label)

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     ignore_leftover_label,
     skipif_upgraded_from,
+    skipif_managed_service,
 )
 from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 from ocs_ci.helpers import disruption_helpers
@@ -17,6 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @tier4c
+@skipif_managed_service
 @skipif_ocs_version("<4.5")
 @skipif_upgraded_from(["4.4"])
 @ignore_leftover_label(constants.drain_canary_pod_label)

--- a/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     ignore_leftover_label,
     skipif_ocp_version,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers import disruption_helpers
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
 @tier4c
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
+@skipif_managed_service
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.polarion_id("OCS-2369")
 class TestResourceDeletionDuringSnapshotRestore(ManageTest):

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -6,7 +6,13 @@ from time import sleep
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4c, polarion_id
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier4,
+    tier4c,
+    polarion_id,
+    skipif_managed_service,
+)
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pvc import delete_pvcs
@@ -32,6 +38,7 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4c
+@skipif_managed_service
 class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
     """
     Kill ceph daemon while creation/deletion of PVCs, and pods are progressing

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -3,7 +3,13 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4c, ignore_leftover_label
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier4,
+    tier4c,
+    ignore_leftover_label,
+    skipif_managed_service,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods,
@@ -23,6 +29,7 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4c
+@skipif_managed_service
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -5,7 +5,13 @@ from itertools import cycle
 import pytest
 from functools import partial
 
-from ocs_ci.framework.testlib import ManageTest, tier4, tier4c, ignore_leftover_label
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier4,
+    tier4c,
+    ignore_leftover_label,
+    skipif_managed_service,
+)
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
@@ -38,6 +44,7 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4c
+@skipif_managed_service
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],


### PR DESCRIPTION
Skip the tests in tests/pv_services which need to access provider and consumer at the same time.
New MS specific test cases will be created for the relevant scenarios skipped in these tests.
Signed-off-by: Jilju Joy <jijoy@redhat.com>