### PR TITLE
Remove duplicated constants

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -12,7 +12,7 @@ and with consideration of the entire project.
 import os
 
 # Logging
-LOG_FORMAT = f"%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s - [{}]"
+LOG_FORMAT = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"
 
 # Directories
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -12,7 +12,7 @@ and with consideration of the entire project.
 import os
 
 # Logging
-LOG_FORMAT = "%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s"
+LOG_FORMAT = f"%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s - [{}]"
 
 # Directories
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -90,7 +90,6 @@ STATUS_BOUND = "Bound"
 STATUS_RELEASED = "Released"
 STATUS_COMPLETED = "Completed"
 STATUS_ERROR = "Error"
-STATUS_CLBO = "CrashLoopBackOff"
 STATUS_READYTOUSE = "READYTOUSE"
 STATUS_FAILED = "Failed"
 STATUS_FAILEDOVER = "FailedOver"
@@ -114,7 +113,6 @@ CEPHFILESYSTEM_SC = "ocs-storagecluster-cephfs"
 NOOBAA_SC = "openshift-storage.noobaa.io"
 LOCALSTORAGE_SC = "localblock"
 DEPLOYMENT = "Deployment"
-JOB = "Job"
 STORAGECLASS = "StorageClass"
 STORAGESYSTEM = "StorageSystem"
 PV = "PersistentVolume"
@@ -158,7 +156,6 @@ SERVICE_ACCOUNT = "Serviceaccount"
 SCC = "SecurityContextConstraints"
 PRIVILEGED = "privileged"
 ANYUID = "anyuid"
-CLUSTER_SERVICE_VERSION = "csv"
 
 # Other
 SECRET = "Secret"


### PR DESCRIPTION
This just had to be addressed some time as a fix from adding multiple variables with the same value for no reason.

Addressed the following:
 - Line 161 was emoved, since 133 has the value of CLUSTER_SERVICE_VERSION = "csv"

 - Line 117 was removed since 134 has the value of 
JOB = "Job" (Line 134 overrides "job", so left the one with the lowercase)

 - Line 93 was removed since 88 has the value of STATUS_CLBO = "CrashLoopBackOff"


@clacroix12 @petr-balogh This might be too much to handle in our tox.ini, but I believe there must be a way to provide a pre-commit hook that might take a look into values that are used on the fly, while they exist in our `ocs_ci/ocs/constants.py` file.

