### PR TITLE
remove duplicate namespace from oc command

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -137,7 +137,7 @@ class OCP(object):
             if os.path.exists(cluster_dir_kubeconfig):
                 oc_cmd += f"--kubeconfig {cluster_dir_kubeconfig} "
 
-        if self.namespace:
+        if self.namespace and not command.find("-n "):
             oc_cmd += f"-n {self.namespace} "
 
         oc_cmd += command


### PR DESCRIPTION
Currently when we call to the exec_oc_cmd function and we have in the command the `-n {namespace}` string
and also the namespace argument is define, it duplicate the -n argument in the command that run.

This PR try to fix this so we will have the -n argument only once in the command.

Signed-off-by: Avi Layani <alayani@redhat.com>