### PR TITLE
Updated the osd prepare pod name

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1432,7 +1432,7 @@ def wait_for_storage_pods(timeout=200):
 
     for pod_obj in all_pod_obj:
         state = constants.STATUS_RUNNING
-        if any(i in pod_obj.name for i in ["-1-deploy", "ocs-deviceset"]):
+        if any(i in pod_obj.name for i in ["-1-deploy", "osd-prepare"]):
             state = constants.STATUS_COMPLETED
         helpers.wait_for_resource_state(resource=pod_obj, state=state, timeout=timeout)
 


### PR DESCRIPTION
ODF pods in COMPLETED state are not recognized due to old name of "osd-prepare" pods in ocs-ci code

Signed-off-by: Sravika Balusu <sravika.balusu@ibm.com>