### PR TITLE
test_s3_benchmark_object_bucket: Increase timeout for bucket health check.

### DIFF
--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -207,5 +207,4 @@ class HsBench(object):
         """
         log.info("Deleting pods and deployment config")
         run_cmd(f"oc delete deploymentconfig/{self.pod_name} -n {self.namespace}")
-        self.pod_obj.delete()
         self.pvc_obj.delete()

--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -67,7 +67,7 @@ class HsBench(object):
             deploy_pod_status=constants.STATUS_COMPLETED,
         )
 
-    def install_hsbench(self, timeout=2400):
+    def install_hsbench(self, timeout=4200):
         """
         Install HotSauce S3 benchmark:
         https://github.com/markhpc/hsbench

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 from ocs_ci.ocs import hsbench
 from ocs_ci.utility import utils
-from ocs_ci.framework.testlib import E2ETest, scale, ignore_leftovers
+from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     bugzilla,
@@ -43,7 +43,6 @@ def s3bench(request):
 
 
 @scale
-@ignore_leftovers
 class TestHsBench(E2ETest):
     """
     Test writing one million S3 objects to a single bucket

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 from ocs_ci.ocs import hsbench
 from ocs_ci.utility import utils
-from ocs_ci.framework.testlib import E2ETest, scale
+from ocs_ci.framework.testlib import E2ETest, scale, ignore_leftovers
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     bugzilla,
@@ -12,10 +12,13 @@ from ocs_ci.framework.pytest_customization.marks import (
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function")
 def hsbenchs3(request):
 
     hsbenchs3 = hsbench.HsBench()
+    hsbenchs3.create_test_user()
+    hsbenchs3.create_resource_hsbench()
+    hsbenchs3.install_hsbench()
 
     def teardown():
         hsbenchs3.delete_test_user()
@@ -25,7 +28,7 @@ def hsbenchs3(request):
     return hsbenchs3
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function")
 def s3bench(request):
 
     s3bench = hsbench.HsBench()
@@ -40,6 +43,7 @@ def s3bench(request):
 
 
 @scale
+@ignore_leftovers
 class TestHsBench(E2ETest):
     """
     Test writing one million S3 objects to a single bucket
@@ -55,14 +59,6 @@ class TestHsBench(E2ETest):
         * Install hs S3 benchmark
         * Run hs S3 benchmark to create 1M objects
         """
-        # Create RGW user
-        hsbenchs3.create_test_user()
-
-        # Create resource for hsbench
-        hsbenchs3.create_resource_hsbench()
-
-        # Install hsbench
-        hsbenchs3.install_hsbench()
 
         # Running hsbench
         hsbenchs3.run_benchmark(num_obj=1000000, timeout=7200)

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -12,7 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(autouse=True)
 def hsbenchs3(request):
 
     hsbenchs3 = hsbench.HsBench()
@@ -25,7 +25,7 @@ def hsbenchs3(request):
     return hsbenchs3
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(autouse=True)
 def s3bench(request):
 
     s3bench = hsbench.HsBench()
@@ -87,7 +87,8 @@ class TestHsBench(E2ETest):
         * Post writing objects verify OBC creation
         """
         # Create an Object bucket
-        object_bucket = bucket_factory(amount=1, interface="OC")[0]
+        object_bucket = bucket_factory(amount=1, interface="OC", verify_health=False)[0]
+        object_bucket.verify_health(timeout=180)
 
         # Write 700k objects to the object bucket
         s3bench.run_benchmark(
@@ -99,4 +100,5 @@ class TestHsBench(E2ETest):
         )
 
         # Create new OBC and verify it is bound
-        bucket_factory(interface="OC")
+        bucket = bucket_factory(interface="OC", verify_health=False)[0]
+        bucket.verify_health(timeout=180)


### PR DESCRIPTION
Increase timeout for bucket health check.
Fixed ResourceLeftoversException issue: [PR#5604](https://github.com/red-hat-storage/ocs-ci/issues/5604)