### PR TITLE
Update PV encryption test cases

### DIFF
--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -85,7 +85,7 @@ VAULT_CSI_CONNECTION_CONF = {
         "VAULT_CACERT": "ocs-kms-ca-secret",
         "VAULT_TLS_SERVER_NAME": "",
         "VAULT_NAMESPACE": "",
-        "VAULT_TOKEN_NAME": "ocs-kms-token",
+        "VAULT_TOKEN_NAME": "ceph-csi-kms-token",
         "VAULT_CACERT_FILE": "fullchain.pem",
         "VAULT_CLIENT_CERT_FILE": "cert.pem",
         "VAULT_CLIENT_KEY_FILE": "privkey.pem",

--- a/ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml
+++ b/ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  1-vault: '{"KMS_PROVIDER":"vaulttokens","KMS_SERVICE_NAME":"vault","VAULT_ADDR":"https://vault.qe.rh-ocs.com:8200","VAULT_BACKEND_PATH":"kv-v2","VAULT_CACERT":"ocs-kms-ca-secret","VAULT_TLS_SERVER_NAME":"","VAULT_NAMESPACE":"","VAULT_TOKEN_NAME":"ocs-kms-token","VAULT_CACERT_FILE":"fullchain.pem","VAULT_CLIENT_CERT_FILE":"cert.pem","VAULT_CLIENT_KEY_FILE":"privkey.pem","VAULT_BACKEND": "kv"}'
+  1-vault: '{"KMS_PROVIDER":"vaulttokens","KMS_SERVICE_NAME":"vault","VAULT_ADDR":"https://vault.qe.rh-ocs.com:8200","VAULT_BACKEND_PATH":"kv-v2","VAULT_CACERT":"ocs-kms-ca-secret","VAULT_TLS_SERVER_NAME":"","VAULT_NAMESPACE":"","VAULT_TOKEN_NAME":"ceph-csi-kms-token","VAULT_CACERT_FILE":"fullchain.pem","VAULT_CLIENT_CERT_FILE":"cert.pem","VAULT_CLIENT_KEY_FILE":"privkey.pem","VAULT_BACKEND": "kv"}'
   vault-tenant-sa: '{"encryptionKMSType": "vaulttenantsa", "vaultAddress": "https://vault.qe.rh-ocs.com:8200","vaultAuthPath": "","vaultAuthNamespace": "","vaultNamespace": "","vaultBackendPath": "kv-v2","vaultCAFromSecret": "ocs-kms-ca-secret","vaultClientCertFromSecret": "ocs-kms-client-cert","vaultClientCertKeyFromSecret": "ocs-kms-client-key"}'
 
 kind: ConfigMap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4167,10 +4167,11 @@ def pv_encryption_vault_setup_factory(request):
     """
     vault = KMS.Vault()
 
-    def factory(kv_version):
+    def factory(kv_version, use_vault_namespace=False):
         """
         Args:
             kv_version(str): KV version to be used, either v1 or v2
+            use_vault_namespace (bool): True, to use vault namespace
         Returns:
             object: Vault(KMS) object
         """
@@ -4189,7 +4190,8 @@ def pv_encryption_vault_setup_factory(request):
 
         # Create vault namespace, backend path and policy in vault
         vault_resource_name = create_unique_resource_name("test", "vault")
-        vault.vault_create_namespace(namespace=vault_resource_name)
+        if use_vault_namespace:
+            vault.vault_create_namespace(namespace=vault_resource_name)
         vault.vault_create_backend_path(
             backend_path=vault_resource_name, kv_version=kv_version
         )
@@ -4208,7 +4210,8 @@ def pv_encryption_vault_setup_factory(request):
                 old_key = key
             vdict[new_kmsid] = vdict.pop(old_key)
             vdict[new_kmsid]["VAULT_BACKEND_PATH"] = vault_resource_name
-            vdict[new_kmsid]["VAULT_NAMESPACE"] = vault_resource_name
+            if use_vault_namespace:
+                vdict[new_kmsid]["VAULT_NAMESPACE"] = vault_resource_name
             vault.kmsid = vault_resource_name
             if kv_version == "v1":
                 vdict[new_kmsid]["VAULT_BACKEND"] = "kv"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4237,7 +4237,8 @@ def pv_encryption_vault_setup_factory(request):
             KMS.remove_kmsid(vault.kmsid)
         vault.remove_vault_backend_path()
         vault.remove_vault_policy()
-        vault.remove_vault_namespace()
+        if vault.vault_namespace:
+            vault.remove_vault_namespace()
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -14,25 +14,34 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers import helpers
+
 from ocs_ci.ocs.exceptions import (
     KMSResourceCleaneupError,
     ResourceNotFoundError,
 )
 from ocs_ci.utility import kms
+from semantic_version import Version
+
 
 log = logging.getLogger(__name__)
 
 # Set the arg values based on KMS provider.
 if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
     kmsprovider = constants.HPCS_KMS_PROVIDER
+    argnames = ["kv_version", "kms_provider"]
     argvalues = [
         pytest.param("v1", kmsprovider),
     ]
 else:
     kmsprovider = constants.VAULT_KMS_PROVIDER
+    argnames = ["kv_version", "kms_provider", "use_vault_namespace"]
     argvalues = [
-        pytest.param("v1", kmsprovider, marks=pytest.mark.polarion_id("OCS-2650")),
-        pytest.param("v2", kmsprovider, marks=pytest.mark.polarion_id("OCS-2651")),
+        pytest.param(
+            "v1", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2650")
+        ),
+        pytest.param(
+            "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2651")
+        ),
     ]
 
 
@@ -42,10 +51,9 @@ else:
 @kms_config_required
 @skipif_managed_service
 @pytest.mark.parametrize(
-    argnames=["kv_version", "kms_provider"],
+    argnames=argnames,
     argvalues=argvalues,
 )
-
 class TestEncryptedRbdClone(ManageTest):
     """
     Tests to verify PVC to PVC clone feature for encrypted RBD Block VolumeMode PVCs
@@ -57,6 +65,7 @@ class TestEncryptedRbdClone(ManageTest):
         self,
         kv_version,
         kms_provider,
+        use_vault_namespace,
         pv_encryption_kms_setup_factory,
         project_factory,
         multi_pvc_factory,
@@ -69,7 +78,7 @@ class TestEncryptedRbdClone(ManageTest):
         """
 
         log.info("Setting up csi-kms-connection-details configmap")
-        self.kms = pv_encryption_kms_setup_factory(kv_version)
+        self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
         log.info("csi-kms-connection-details setup successful")
 
         # Create a project
@@ -262,7 +271,9 @@ class TestEncryptedRbdClone(ManageTest):
 
         if kms_provider == constants.VAULT_KMS_PROVIDER:
             # Verify if the keys for parent and cloned PVCs are deleted from Vault
-            if kv_version == "v1":
+            if kv_version == "v1" or Version.coerce(
+                config.ENV_DATA["ocs_version"]
+            ) >= Version.coerce("4.9"):
                 log.info(
                     "Verify whether the keys for cloned PVCs are deleted from vault"
                 )

--- a/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_encrypted_rbd_pvc_clone.py
@@ -45,6 +45,7 @@ else:
     argnames=["kv_version", "kms_provider"],
     argvalues=argvalues,
 )
+
 class TestEncryptedRbdClone(ManageTest):
     """
     Tests to verify PVC to PVC clone feature for encrypted RBD Block VolumeMode PVCs


### PR DESCRIPTION
This PR contains fixes for the following:

- fixes #5607 
- Move PV encryption tests to anew folder for better management
- Add Key deletion check for kv-v2 