### PR TITLE
pvc_create_delete refactoring

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -688,7 +688,7 @@ def create_multiple_pvcs(
                 volume_mode=volume_mode,
             )
             for _ in range(number_of_pvc)
-        ]
+        ], None
 
     pvc_data = templating.load_yaml(constants.CSI_PVC_YAML)
     pvc_data["metadata"]["namespace"] = namespace

--- a/ocs_ci/ocs/perfresult.py
+++ b/ocs_ci/ocs/perfresult.py
@@ -123,7 +123,7 @@ class PerfResult:
                 )
                 return True
             except Exception as e:
-                if retry > 0:
+                if retry > 1:
                     log.warning("Failed to write data to ES, retrying in 3 sec...")
                     retry -= 1
                     time.sleep(3)

--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -879,3 +879,14 @@ class PASTest(BaseTest):
         except CommandFailed:
             log.error(f"Cannot delete project {self.namespace}")
             raise CommandFailed(f"{self.namespace} was not created")
+
+    def set_results_path_and_file(self, func_name):
+        """
+        Setting the results_path and results_file parameter for a specific test
+
+        Args:
+            func_name (str): the name of the function which use for the test
+        """
+
+        self.results_path = os.path.join("/", *self.results_path, func_name)
+        self.results_file = os.path.join(self.results_path, "all_results.txt")

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -305,7 +305,7 @@ class TestPVCCreationDeletionPerformance(PASTest):
 
         mesure_data = "create"
         rec_policy = performance_lib.run_oc_command(
-            f'oc get sc {Interface_Info[self.interface]["sc"]} -o jsonpath="'
+            f'get sc {Interface_Info[self.interface]["sc"]} -o jsonpath="'
             + '{.reclaimPolicy}"'
         )
         if rec_policy == constants.RECLAIM_POLICY_DELETE:


### PR DESCRIPTION
This PR improve the TC runtime and the memory consumption during the test.
The Original TC ran for 5 Hours and 45 Min with memory consumption of up to 2.2 GiB of memory, while after this PR
the TC will run for only 1 Hour and 15 Min, with memory consumption of up to 380 MiB only.

as can be seen in this graph: <img width="1061" alt="Screen Shot 2022-03-27 at 11 35 22" src="https://user-images.githubusercontent.com/54134264/160273649-b7fbfcf8-9eff-4792-8ade-ce274571f720.png">

This PR also:
* reduce duplicated code
* improvement of the ES report
* fix issue with the ES report, said it written even if not

Signed-off-by: Avi Layani <alayani@redhat.com>