### PR TITLE
Skip test cases on MS

### DIFF
--- a/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -5,7 +5,12 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
-from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    skipif_external_mode,
+    skipif_managed_service,
+)
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret,
@@ -18,6 +23,7 @@ SC_OBJ = None
 
 
 @skipif_external_mode
+@skipif_managed_service
 @tier1
 @pytest.mark.usefixtures(
     create_rbd_secret.__name__,

--- a/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -5,12 +5,7 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
-from ocs_ci.framework.testlib import (
-    ManageTest,
-    tier1,
-    skipif_external_mode,
-    skipif_managed_service,
-)
+from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret,
@@ -23,7 +18,6 @@ SC_OBJ = None
 
 
 @skipif_external_mode
-@skipif_managed_service
 @tier1
 @pytest.mark.usefixtures(
     create_rbd_secret.__name__,

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -10,7 +10,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_bmpsi,
     skipif_ibm_power,
-    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_bmpsi,
     skipif_ibm_power,
+    skipif_managed_service,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -102,6 +103,7 @@ def add_capacity_test():
 @skipif_bmpsi
 @skipif_external_mode
 @skipif_ibm_power
+@skipif_managed_service
 class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
@@ -122,6 +124,7 @@ class TestAddCapacity(ManageTest):
 @skipif_bm
 @skipif_external_mode
 @cloud_platform_required
+@skipif_managed_service
 class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -5,14 +5,14 @@ from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_flexy_deployment,
     skipif_ibm_flash,
-    skipif_ms_consumer,
+    skipif_managed_service,
 )
 
 logger = logging.getLogger(__name__)
 
 
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
-@skipif_ms_consumer
+@skipif_managed_service
 @skipif_flexy_deployment
 @skipif_ibm_flash
 @ignore_leftovers

--- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -2,7 +2,10 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import skipif_flexy_deployment
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_flexy_deployment,
+    skipif_managed_service,
+)
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
 from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
@@ -12,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_flexy_deployment
+@skipif_managed_service
 @tier1
 @pytest.mark.polarion_id("OCS-2490")
 @pytest.mark.bugzilla("1794389")

--- a/tests/manage/z_cluster/test_ceph_default_values_check.py
+++ b/tests/manage/z_cluster/test_ceph_default_values_check.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     skipif_external_mode,
     post_ocs_upgrade,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.cluster import get_pg_balancer_status, get_mon_config_value
@@ -149,6 +150,7 @@ class TestCephDefaultValuesCheck(ManageTest):
     @bugzilla("2012930")
     @post_ocs_upgrade
     @pytest.mark.polarion_id("OCS-2739")
+    @skipif_managed_service
     def test_noobaa_postgres_cm_post_ocs_upgrade(self):
         """
         Validate noobaa postgres configmap post OCS upgrade


### PR DESCRIPTION
Skip the test cases on Managed Services platform.
1. tests.manage.z_cluster.test_ceph_default_values_check.TestCephDefaultValuesCheck.test_noobaa_postgres_cm_post_ocs_upgrade
2. tests.manage.z_cluster.cluster_expansion.test_verify_ceph_csidriver_runs_on_non_ocs_nodes.TestCheckTolerationForCephCsiDriverDs.test_ceph_csidriver_runs_on_non_ocs_nodes
3. tests.manage.z_cluster.cluster_expansion.test_node_expansion.TestAddNode.test_add_ocs_node


Signed-off-by: Jilju Joy <jijoy@redhat.com>