### PR TITLE
check luks header info for encrypted devices

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -628,7 +628,8 @@ def osd_encryption_verification():
             )
             raise ValueError("OSD is not encrypted")
 
-    if ocs_version > version.VERSION_4_6:
+    # skip OCS 4.8 as the fix for luks header info is still not available on it
+    if ocs_version > version.VERSION_4_6 and ocs_version != version.VERSION_4_8:
         log.info("Verify luks header label for encrypted devices")
         worker_nodes = get_osd_running_nodes()
         failures = 0


### PR DESCRIPTION
made changes to skip ocs 4.8 as https://bugzilla.redhat.com/show_bug.cgi?id=2069722 