### PR TITLE
Add test case for Clusterwide encryption with auth path

### DIFF
--- a/conf/ocsci/vault_external_standalone_kube_auth_path_v1.yaml
+++ b/conf/ocsci/vault_external_standalone_kube_auth_path_v1.yaml
@@ -5,7 +5,7 @@ ENV_DATA:
   encryption_at_rest: true
   vault_deploy_mode: external
   use_vault_namespace: false
-  use_auth_path: false
+  use_auth_path: true
   KMS_PROVIDER: vault
   KMS_SERVICE_NAME: vault
   VAULT_CACERT: "ocs-kms-ca-secret"

--- a/conf/ocsci/vault_external_standalone_kube_auth_path_v2.yaml
+++ b/conf/ocsci/vault_external_standalone_kube_auth_path_v2.yaml
@@ -5,7 +5,7 @@ ENV_DATA:
   encryption_at_rest: true
   vault_deploy_mode: external
   use_vault_namespace: false
-  use_auth_path: false
+  use_auth_path: true
   KMS_PROVIDER: vault
   KMS_SERVICE_NAME: vault
   VAULT_CACERT: "ocs-kms-ca-secret"
@@ -13,4 +13,4 @@ ENV_DATA:
   VAULT_CLIENT_KEY: "ocs-kms-client-key"
   VAULT_SKIP_VERIFY: false
   VAULT_AUTH_METHOD: kubernetes
-  VAULT_BACKEND: v1
+  VAULT_BACKEND: v2

--- a/conf/ocsci/vault_external_standalone_kube_auth_v2.yaml
+++ b/conf/ocsci/vault_external_standalone_kube_auth_v2.yaml
@@ -5,6 +5,7 @@ ENV_DATA:
   encryption_at_rest: true
   vault_deploy_mode: external
   use_vault_namespace: false
+  use auth_path: false
   KMS_PROVIDER: vault
   KMS_SERVICE_NAME: vault
   VAULT_CACERT: "ocs-kms-ca-secret"

--- a/ocs_ci/templates/openshift-infra/vault/ocs-kms-connection-details.yaml
+++ b/ocs_ci/templates/openshift-infra/vault/ocs-kms-connection-details.yaml
@@ -5,6 +5,7 @@ data:
   VAULT_ADDR: PLACEHOLDER
   VAULT_AUTH_METHOD: token
   VAULT_AUTH_KUBERNETES_ROLE: odf-rook-ceph-op
+  VAULT_AUTH_MOUNT_PATH: ""
   VAULT_BACKEND_PATH: ""
   VAULT_CACERT: ocs-kms-ca-secret
   VAULT_CLIENT_CERT: ocs-kms-client-cert

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -37,6 +37,7 @@ from ocs_ci.utility.utils import (
     get_running_cluster_id,
     get_default_if_keyval_empty,
     get_cluster_name,
+    encode,
 )
 
 
@@ -140,6 +141,12 @@ class Vault(KMS):
         self.vault_unseal()
         if config.ENV_DATA.get("use_vault_namespace"):
             self.vault_create_namespace()
+        if config.ENV_DATA.get("use_auth_path"):
+            self.cluster_id = get_running_cluster_id()
+            self.vault_kube_auth_path = (
+                f"{constants.VAULT_DEFAULT_PATH_PREFIX}-{self.cluster_id}-"
+                f"{get_cluster_name(config.ENV_DATA['cluster_path'])}"
+            )
         self.vault_create_backend_path()
         self.create_ocs_vault_resources()
 
@@ -357,7 +364,10 @@ class Vault(KMS):
         if config.ENV_DATA.get("VAULT_AUTH_METHOD") == constants.VAULT_KUBERNETES_AUTH:
             self.vault_auth_method = constants.VAULT_KUBERNETES_AUTH
             self.create_ocs_kube_auth_resources()
-            self.vault_kube_auth_setup(token_reviewer_name=self.vault_cwd_kms_sa_name)
+            self.vault_kube_auth_setup(
+                auth_path=self.vault_kube_auth_path,
+                token_reviewer_name=self.vault_cwd_kms_sa_name,
+            )
             self.create_vault_kube_auth_role(
                 namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
                 role_name=self.vault_kube_auth_role,
@@ -372,10 +382,7 @@ class Vault(KMS):
             # create oc resource secret for token
             token_data = templating.load_yaml(constants.EXTERNAL_VAULT_KMS_TOKEN)
             # token has to base64 encoded (with padding)
-            token_data["data"]["token"] = base64.b64encode(
-                # encode() because b64encode expects a byte type
-                self.vault_path_token.encode()
-            ).decode()  # decode() because b64encode returns a byte type
+            token_data["data"]["token"] = encode(self.vault_path_token)
             self.create_resource(token_data, prefix="token")
 
         # create ocs-kms-connection-details
@@ -399,8 +406,13 @@ class Vault(KMS):
             connection_data["data"][
                 "VAULT_AUTH_KUBERNETES_ROLE"
             ] = constants.VAULT_KUBERNETES_AUTH_ROLE
+
         else:
             connection_data["data"].pop("VAULT_AUTH_KUBERNETES_ROLE")
+        if config.ENV_DATA.get("use_auth_path"):
+            connection_data["data"]["VAULT_AUTH_MOUNT_PATH"] = self.vault_kube_auth_path
+        else:
+            connection_data["data"].pop("VAULT_AUTH_MOUNT_PATH")
         self.create_resource(connection_data, prefix="kmsconnection")
 
     def vault_unseal(self):
@@ -1038,12 +1050,10 @@ class Vault(KMS):
 
         # enable kubernetes auth method
         if auth_path and auth_namespace:
-            self.vault_kube_auth_path = auth_path
             self.vault_kube_auth_namespace = auth_namespace
             cmd = f"vault auth enable -namespace={auth_namespace} -path={auth_path} kubernetes"
 
         elif auth_path:
-            self.vault_kube_auth_path = auth_path
             cmd = f"vault auth enable -path={auth_path} kubernetes"
 
         elif auth_namespace:


### PR DESCRIPTION
This PR will enable deployment of clusterwide encryption enabled clusters with kubernetes authentication method which uses custom authentication path in Vault
Signed-off-by: rachael-george <rgeorge@redhat.com>