### PR TITLE
[WIP] Add brew.registry.redhat.io support to ocs-ci

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1285,6 +1285,15 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         )
         run_cmd(f"oc apply -f {constants.STAGE_IMAGE_CONTENT_SOURCE_POLICY_YAML}")
         wait_for_machineconfigpool_status("all", timeout=1800)
+    if ( 'brew' in image or 'registry-proxy' in image ):
+        run_cmd(
+            "oc patch image.config.openshift.io/cluster --type merge -p '"
+            '{"spec": {"registrySources": {"insecureRegistries": '
+            '["brew.registry.redhat.io"]'
+            "}}}'"
+        )
+        run_cmd(f"oc apply -f {constants.BREW_IMAGE_CONTENT_SOURCE_POLICY_YAML}")
+        wait_for_machineconfigpool_status("all", timeout=1800)
     if not ignore_upgrade:
         upgrade = config.UPGRADE.get("upgrade", False)
     else:

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -509,6 +509,10 @@ STAGE_IMAGE_CONTENT_SOURCE_POLICY_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "stageImageContentSourcePolicy.yaml"
 )
 
+BREW_IMAGE_CONTENT_SOURCE_POLICY_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "brewImageContentSourcePolicy.yaml"
+)
+
 SUBSCRIPTION_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "subscription.yaml")
 
 SUBSCRIPTION_ODF_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "subscription_odf.yaml")

--- a/ocs_ci/templates/ocs-deployment/brewImageContentSourcePolicy.yaml
+++ b/ocs_ci/templates/ocs-deployment/brewImageContentSourcePolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.stage.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry-proxy.engineering.redhat.com


### PR DESCRIPTION
Instead of relying on builds being mirrored to quay, let's add the option to deploy OCS/ODF with builds from the brew registry proxy.