### PR TITLE
Update fixture patch_consumer_toolbox_with_secret

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4680,6 +4680,17 @@ def patch_consumer_toolbox_with_secret():
     for cluster in config.clusters:
         if cluster.ENV_DATA.get("cluster_type") == "consumer":
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            consumer_tools_pod = get_ceph_tools_pod()
+
+            # Check whether ceph command is working on tools pod.
+            # Patch is needed only if the error is "RADOS permission error"
+            try:
+                consumer_tools_pod.exec_ceph_cmd("ceph health")
+                continue
+            except Exception as exc:
+                if "RADOS permission error" not in str(exc):
+                    raise
+
             consumer_tools_deployment = OCP(
                 kind=constants.DEPLOYMENT,
                 namespace=defaults.ROOK_CLUSTER_NAMESPACE,
@@ -4693,6 +4704,18 @@ def patch_consumer_toolbox_with_secret():
             assert consumer_tools_deployment.patch(
                 params=patch_value, format_type="json"
             ), "Failed to patch rook-ceph-tools deployment in consumer cluster"
+
+            # Wait for the existing tools pod to delete
+            consumer_tools_pod.ocp.wait_for_delete(
+                resource_name=consumer_tools_pod.name
+            )
+
+            # Wait for the new tools pod to reach Running state
+            new_tools_pod = get_pods_having_label(
+                label=constants.TOOL_APP_LABEL,
+                namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+            )[0]
+            helpers.wait_for_resource_state(new_tools_pod, constants.STATUS_RUNNING)
 
     log.info("Switching back to the initial cluster context")
     config.switch_ctx(restore_ctx_index)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4711,10 +4711,11 @@ def patch_consumer_toolbox_with_secret():
             )
 
             # Wait for the new tools pod to reach Running state
-            new_tools_pod = get_pods_having_label(
+            new_tools_pod_info = get_pods_having_label(
                 label=constants.TOOL_APP_LABEL,
                 namespace=defaults.ROOK_CLUSTER_NAMESPACE,
             )[0]
+            new_tools_pod = Pod(**new_tools_pod_info)
             helpers.wait_for_resource_state(new_tools_pod, constants.STATUS_RUNNING)
 
     log.info("Switching back to the initial cluster context")


### PR DESCRIPTION
The fixture patch_consumer_toolbox_with_secret is updated to:
*  patch the rook-ceph-tools deployment only if the ceph command is failing due to an expected error.
*  wait for the existing  rook-ceph-tools pod to delete.
*  wait for the new rook-ceph-tools pod to reach the state 'Running'

Signed-off-by: Jilju Joy <jijoy@redhat.com>