### PR TITLE
rephrase pullsecret_workaround parameter

### DIFF
--- a/conf/deployment/rosa/managed_1az_consumer_qe_3m_3w_m52x.yaml
+++ b/conf/deployment/rosa/managed_1az_consumer_qe_3m_3w_m52x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_1az_consumer_qe_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_1az_consumer_qe_3m_3w_m54x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_1az_consumer_stage_3m_3w_m52x.yaml
+++ b/conf/deployment/rosa/managed_1az_consumer_stage_3m_3w_m52x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_1az_consumer_stage_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_1az_consumer_stage_3m_3w_m54x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_1az_provider_qe_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_1az_provider_qe_3m_3w_m54x.yaml
@@ -18,7 +18,6 @@ DEPLOYMENT:
   force_download_installer: True
   force_download_client: True
   host_network: true
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_1az_provider_stage_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_1az_provider_stage_3m_3w_m54x.yaml
@@ -18,7 +18,6 @@ DEPLOYMENT:
   force_download_installer: True
   force_download_client: True
   host_network: true
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_consumer_qe_3m_3w_m52x.yaml
+++ b/conf/deployment/rosa/managed_3az_consumer_qe_3m_3w_m52x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_consumer_qe_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_3az_consumer_qe_3m_3w_m54x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_consumer_stage_3m_3w_m52x.yaml
+++ b/conf/deployment/rosa/managed_3az_consumer_stage_3m_3w_m52x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_consumer_stage_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_3az_consumer_stage_3m_3w_m54x.yaml
@@ -21,7 +21,6 @@ DEPLOYMENT:
   rosa_cli_version: '1.1.12'
   force_download_installer: True
   force_download_client: True
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_provider_qe_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_3az_provider_qe_3m_3w_m54x.yaml
@@ -18,7 +18,6 @@ DEPLOYMENT:
   force_download_installer: True
   force_download_client: True
   host_network: true
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/managed_3az_provider_stage_3m_3w_m54x.yaml
+++ b/conf/deployment/rosa/managed_3az_provider_stage_3m_3w_m54x.yaml
@@ -18,7 +18,6 @@ DEPLOYMENT:
   force_download_installer: True
   force_download_client: True
   host_network: true
-  pullsecret_workaround: True
 REPORTING:
   # This is useful as a W/A for Openshift Dedicated, as there is an issue
   # to use internal image for must gather

--- a/conf/deployment/rosa/pullsecret_for_non_ga.yaml
+++ b/conf/deployment/rosa/pullsecret_for_non_ga.yaml
@@ -1,0 +1,4 @@
+DEPLOYMENT:
+  # In managed service platform this workaround should be
+  # enable for execution on non-GAed version
+  pullsecret_workaround: True


### PR DESCRIPTION
The pullsecrete_workaround only if execution is
on non-gaed version so instead of modifying
configs after and before release.Hence seperating
this configuration from other generic configs

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>