### PR TITLE
Adjust the test case test_node_maintenance for MS

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2023,7 +2023,8 @@ class CephClusterExternal(CephCluster):
         # https://github.com/red-hat-storage/ocs-ci/issues/5186
         logger.info("Sleep for 60 seconds before verifying MCG")
         time.sleep(60)
-        self.wait_for_nooba_cr()
+        if config.ENV_DATA["platform"] not in constants.MANAGED_SERVICE_PLATFORMS:
+            self.wait_for_nooba_cr()
 
     @property
     def cluster_name(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3441,6 +3441,8 @@ def namespace_store_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
             a namespacestore
 
     """
+    if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
+        return
     return namespacestore_factory_implementation(
         request, cld_mgr, mcg_obj, cloud_uls_factory
     )

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -41,6 +41,7 @@ from ocs_ci.helpers.helpers import (
     verify_pdb_mon,
 )
 from ocs_ci.helpers import helpers
+from ocs_ci.framework import config
 
 
 log = logging.getLogger(__name__)
@@ -146,9 +147,15 @@ class TestNodesMaintenance(ManageTest):
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
         # run IO and delete the resources
-        self.sanity_helpers.create_resources(
-            pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
-        )
+        if config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS:
+            self.sanity_helpers.create_resources(
+                pvc_factory, pod_factory, bucket_factory=None, rgw_bucket_factory=None
+            )
+        else:
+            self.sanity_helpers.create_resources(
+                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+            )
+
         self.sanity_helpers.delete_resources()
 
         # Mark the node back to schedulable

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -147,14 +147,9 @@ class TestNodesMaintenance(ManageTest):
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
         # run IO and delete the resources
-        if config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS:
-            self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory=None, rgw_bucket_factory=None
-            )
-        else:
-            self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
-            )
+        self.sanity_helpers.create_resources(
+            pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+        )
 
         self.sanity_helpers.delete_resources()
 

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -149,7 +149,6 @@ class TestNodesMaintenance(ManageTest):
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
         )
-
         self.sanity_helpers.delete_resources()
 
         # Mark the node back to schedulable

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -41,7 +41,6 @@ from ocs_ci.helpers.helpers import (
     verify_pdb_mon,
 )
 from ocs_ci.helpers import helpers
-from ocs_ci.framework import config
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The test case give below is failing on MS platform. tests/manage/z_cluster/nodes/test_nodes_maintenance.py::TestNodesMaintenance::test_node_maintenance

The test case is failing when trying to obtain noobaa operator pod which is not present in MS.

Modified the test case to fix the issue. Added the necessary adjustments to run the test case on MS.

Fixes #5684
Signed-off-by: Jilju Joy <jijoy@redhat.com>