### PR TITLE
Ypersky clone with multiple files

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -9,7 +9,7 @@ import urllib.request
 import os
 import statistics
 
-from ocs_ci.ocs import constants, node
+from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import performance
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.utility.utils import convert_device_size
@@ -386,7 +386,6 @@ class TestPVCClonePerformance(PASTest):
             os.makedirs(dir_path)
         urllib.request.urlretrieve(kernel_url, file_path)
 
-        time_measures, files_written_list, data_written_list = ([], [], [])
         # Create a PVC
         accessmode = constants.ACCESS_MODE_RWX
         if interface == constants.CEPHBLOCKPOOL:
@@ -447,17 +446,14 @@ class TestPVCClonePerformance(PASTest):
 
         logger.info("Getting the amount of data written to the PVC")
         rsh_cmd = f"exec {pod_name} -- df -h {pod_path}"
-        data_written_str = _ocp.exec_oc_cmd(rsh_cmd).split()[-4]
-        logger.info(f"The amount of written data is {data_written_str}")
-        data_written = float(data_written_str[:-1])
+        data_written = _ocp.exec_oc_cmd(rsh_cmd).split()[-4]
+        logger.info(f"The amount of written data is {data_written}")
 
         rsh_cmd = f"exec {pod_name} -- find {pod_path} -type f"
         files_written = len(_ocp.exec_oc_cmd(rsh_cmd).split())
         logger.info(
             f"For {interface} - The number of files written to the pod is {files_written}"
         )
-        files_written_list.append(files_written)
-        data_written_list.append(data_written)
 
         # delete the pod
         pod_obj.delete(wait=False)
@@ -468,9 +464,8 @@ class TestPVCClonePerformance(PASTest):
         )
         logger.info("The pod was deleted")
 
-
         num_of_clones = 11
-        #encreasing the timeout since clone creation time is longer than pod attach time
+        # increasing the timeout since clone creation time is longer than pod attach time
         timeout = 18000
 
         clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -5,10 +5,11 @@ Performance is measured by collecting clone creation/deletion speed.
 import datetime
 import logging
 import pytest
+import urllib.request
 import os
 import statistics
 
-from ocs_ci.ocs import constants
+from ocs_ci.ocs import constants, node
 from ocs_ci.framework.testlib import performance
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.utility.utils import convert_device_size
@@ -16,6 +17,8 @@ from ocs_ci.ocs.perfresult import ResultsAnalyse
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.resources import pvc
+from ocs_ci.ocs.exceptions import PVCNotCreated, PodNotCreated
+from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
@@ -307,20 +310,6 @@ class TestPVCClonePerformance(PASTest):
             # Create text file with results of all subtest (8 - according to the parameters)
             self.write_result_to_file(res_link)
 
-    def test_pvc_clone_results(self):
-        """
-        This is not a test - it is only check that previous test ran and finish as expected
-        and reporting the full results (links in the ES) of previous tests (8)
-        """
-        self.number_of_tests = 8
-        self.results_path = get_full_test_logs_path(
-            cname=self, fname="test_clone_create_delete_performance"
-        )
-        self.results_file = os.path.join(self.results_path, "all_results.txt")
-        logger.info(f"Check results in {self.results_file}.")
-        self.check_tests_results()
-        self.push_to_dashboard(test_name="PVC Clone Performance")
-
     def init_full_results(self, full_results):
         """
         Initialize the full results object which will send to the ES server
@@ -336,3 +325,297 @@ class TestPVCClonePerformance(PASTest):
             full_results.add_key(key, self.environment[key])
         full_results.add_key("index", full_results.new_index)
         return full_results
+
+    @pytest.fixture()
+    def base_multiple_setup(self, interface):
+        """
+        A setup phase for the test
+        Args:
+            interface: Interface parameter
+
+        """
+
+        self.interface = interface
+
+        if self.interface == constants.CEPHFILESYSTEM:
+            self.sc = "CephFS"
+        if self.interface == constants.CEPHBLOCKPOOL:
+            self.sc = "RBD"
+
+        self.full_log_path = get_full_test_logs_path(cname=self)
+        self.full_log_path += f"-{self.sc}"
+
+    @pytest.mark.parametrize(
+        argnames=["interface", "copies", "timeout"],
+        argvalues=[
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL, 2, 600],
+                marks=pytest.mark.polarion_id("OCS-2673"),
+            ),
+            pytest.param(
+                *[constants.CEPHFILESYSTEM, 2, 600],
+                marks=pytest.mark.polarion_id("OCS-2674"),
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures(base_multiple_setup.__name__)
+    def test_pvc_clone_performance_multiple_files(
+        self,
+        pvc_factory,
+        teardown_factory,
+        interface,
+        copies,
+        timeout,
+    ):
+        """
+        Test assign nodeName to a pod using RWX pvc
+        Each kernel (unzipped) is 892M and 61694 files
+        The test creates samples_num pvcs and pods, writes kernel files multiplied by number of copies
+        and calculates average reattach time and standard deviation
+        """
+        kernel_url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.5.tar.gz"
+        download_path = "tmp"
+
+        test_start_time = PASTest.get_time()
+        helpers.pull_images(constants.PERF_IMAGE)
+        # Download a linux Kernel
+
+        dir_path = os.path.join(os.getcwd(), download_path)
+        file_path = os.path.join(dir_path, "file.gz")
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+        urllib.request.urlretrieve(kernel_url, file_path)
+
+        time_measures, files_written_list, data_written_list = ([], [], [])
+        # Create a PVC
+        accessmode = constants.ACCESS_MODE_RWX
+        if interface == constants.CEPHBLOCKPOOL:
+            accessmode = constants.ACCESS_MODE_RWO
+
+        pvc_size = "100"
+        try:
+            pvc_obj = pvc_factory(
+                interface=interface,
+                access_mode=accessmode,
+                status=constants.STATUS_BOUND,
+                size=pvc_size,
+            )
+        except Exception as e:
+            logger.error(f"The PVC sample was not created, exception {str(e)}")
+            raise PVCNotCreated("PVC did not reach BOUND state.")
+
+        # Create a pod on one node
+        logger.info(f"Creating Pod with pvc {pvc_obj.name}")
+
+        try:
+            pod_obj = helpers.create_pod(
+                interface_type=interface,
+                pvc_name=pvc_obj.name,
+                namespace=pvc_obj.namespace,
+                pod_dict_path=constants.PERF_POD_YAML,
+            )
+        except Exception as e:
+            logger.error(
+                f"Pod on PVC {pvc_obj.name} was not created, exception {str(e)}"
+            )
+            raise PodNotCreated("Pod on PVC was not created.")
+
+        # Confirm that pod is running on the selected_nodes
+        logger.info("Checking whether pods are running on the selected nodes")
+        helpers.wait_for_resource_state(
+            resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
+        )
+
+        pod_name = pod_obj.name
+        pod_path = "/mnt"
+
+        _ocp = OCP(namespace=pvc_obj.namespace)
+
+        rsh_cmd = f"rsync {dir_path} {pod_name}:{pod_path}"
+        _ocp.exec_oc_cmd(rsh_cmd)
+
+        rsh_cmd = f"exec {pod_name} -- tar xvf {pod_path}/tmp/file.gz -C {pod_path}/tmp"
+        _ocp.exec_oc_cmd(rsh_cmd)
+
+        for x in range(copies):
+            rsh_cmd = f"exec {pod_name} -- mkdir -p {pod_path}/folder{x}"
+            _ocp.exec_oc_cmd(rsh_cmd)
+            rsh_cmd = f"exec {pod_name} -- cp -r {pod_path}/tmp {pod_path}/folder{x}"
+            _ocp.exec_oc_cmd(rsh_cmd)
+            rsh_cmd = f"exec {pod_name} -- sync"
+            _ocp.exec_oc_cmd(rsh_cmd)
+
+        logger.info("Getting the amount of data written to the PVC")
+        rsh_cmd = f"exec {pod_name} -- df -h {pod_path}"
+        data_written_str = _ocp.exec_oc_cmd(rsh_cmd).split()[-4]
+        logger.info(f"The amount of written data is {data_written_str}")
+        data_written = float(data_written_str[:-1])
+
+        rsh_cmd = f"exec {pod_name} -- find {pod_path} -type f"
+        files_written = len(_ocp.exec_oc_cmd(rsh_cmd).split())
+        logger.info(
+            f"For {interface} - The number of files written to the pod is {files_written}"
+        )
+        files_written_list.append(files_written)
+        data_written_list.append(data_written)
+
+        num_of_clones = 2
+        timeout = 18000
+
+        clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
+        if interface == constants.CEPHFILESYSTEM:
+            clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
+
+        clone_creation_measures = []
+        csi_clone_creation_measures = []
+        clone_deletion_measures = []
+        csi_clone_deletion_measures = []
+
+        # taking the time, so parsing the provision log will be faster.
+        start_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        for i in range(num_of_clones):
+            logger.info(f"Start creation of clone number {i + 1}.")
+            cloned_pvc_obj = pvc.create_pvc_clone(
+                pvc_obj.backed_sc,
+                pvc_obj.name,
+                clone_yaml,
+                pvc_obj.namespace,
+                storage_size=pvc_size + "Gi",
+            )
+            teardown_factory(cloned_pvc_obj)
+            helpers.wait_for_resource_state(
+                cloned_pvc_obj, constants.STATUS_BOUND, timeout
+            )
+
+            cloned_pvc_obj.reload()
+            logger.info(
+                f"Clone with name {cloned_pvc_obj.name} for {pvc_size} pvc {pvc_obj.name} was created."
+            )
+            create_time = helpers.measure_pvc_creation_time(
+                interface, cloned_pvc_obj.name
+            )
+            logger.info(
+                f"Clone number {i+1} creation time is {create_time} secs for {pvc_size} GB pvc."
+            )
+            clone_creation_measures.append(create_time)
+            csi_clone_creation_measures.append(
+                performance_lib.csi_pvc_time_measure(
+                    interface, cloned_pvc_obj, "create", start_time
+                )
+            )
+
+            pvc_reclaim_policy = cloned_pvc_obj.reclaim_policy
+            cloned_pvc_obj.delete()
+            logger.info(
+                f"Deletion of clone number {i + 1} , the clone name is {cloned_pvc_obj.name}."
+            )
+            cloned_pvc_obj.ocp.wait_for_delete(cloned_pvc_obj.name, timeout)
+            if pvc_reclaim_policy == constants.RECLAIM_POLICY_DELETE:
+                helpers.validate_pv_delete(cloned_pvc_obj.backed_pv)
+            delete_time = helpers.measure_pvc_deletion_time(
+                interface, cloned_pvc_obj.backed_pv
+            )
+            logger.info(
+                f"Clone number {i + 1} deletion time is {delete_time} secs for {pvc_size} GB pvc."
+            )
+
+            clone_deletion_measures.append(delete_time)
+            csi_clone_deletion_measures.append(
+                performance_lib.csi_pvc_time_measure(
+                    interface, cloned_pvc_obj, "delete", start_time
+                )
+            )
+
+        os.remove(file_path)
+        os.rmdir(dir_path)
+        teardown_factory(pvc_obj)
+
+        average_creation_time = statistics.mean(clone_creation_measures)
+        logger.info(f"Average creation time is  {average_creation_time} secs.")
+        average_csi_creation_time = statistics.mean(csi_clone_creation_measures)
+        logger.info(f"Average csi creation time is  {average_csi_creation_time} secs.")
+
+        average_deletion_time = statistics.mean(clone_deletion_measures)
+        logger.info(f"Average deletion time is  {average_deletion_time} secs.")
+        average_csi_deletion_time = statistics.mean(csi_clone_deletion_measures)
+        logger.info(f"Average csi deletion time is  {average_csi_deletion_time} secs.")
+
+        # Produce ES report
+
+        # Collecting environment information
+        self.get_env_info()
+        self.results_path = get_full_test_logs_path(cname=self)
+        # Initialize the results doc file.
+        full_results = self.init_full_results(
+            ResultsAnalyse(
+                self.uuid,
+                self.crd_data,
+                self.full_log_path,
+                "test_pvc_clone_performance_multiple_files_fullres",
+            )
+        )
+
+        full_results.add_key("files_number", files_written)
+
+        test_end_time = PASTest.get_time()
+
+        full_results.add_key(
+            "test_time", {"start": test_start_time, "end": test_end_time}
+        )
+
+        full_results.add_key("interface", interface)
+        full_results.add_key("clones_number", num_of_clones)
+        full_results.add_key("pvc_size", pvc_size)
+        full_results.add_key("average_clone_creation_time", average_creation_time)
+        full_results.add_key(
+            "average_csi_clone_creation_time", average_csi_creation_time
+        )
+        full_results.add_key("average_clone_deletion_time", average_deletion_time)
+        full_results.add_key(
+            "average_csi_clone_deletion_time", average_csi_deletion_time
+        )
+
+        full_results.all_results = {
+            "clone_creation_time": clone_creation_measures,
+            "csi_clone_creation_time": csi_clone_creation_measures,
+            "clone_deletion_time": clone_deletion_measures,
+            "csi_clone_deletion_time": csi_clone_deletion_measures,
+        }
+
+        # Write the test results into the ES server
+        if full_results.es_write():
+            res_link = full_results.results_link()
+            logger.info(f"The Result can be found at : {res_link}")
+
+            # Create text file with results of all subtest (4 - according to the parameters)
+            self.results_path = get_full_test_logs_path(
+                cname=self, fname="test_pvc_clone_performance_multiple_files"
+            )
+            self.write_result_to_file(res_link)
+
+    def test_pvc_clone_performance_results(self):
+        """
+        This is not a test - it is only check that previous tests ran and finished as expected
+        and reporting the full results (links in the ES) of previous tests (6 + 2)
+        """
+
+        workloads = [
+            {
+                "name": "test_clone_create_delete_performance",
+                "tests": 8,
+                "test_name": "PVC Clone Performance",
+            },
+            {
+                "name": "test_pvc_clone_performance_multiple_files",
+                "tests": 2,
+                "test_name": "PVC Clone Multiple Files Performance",
+            },
+        ]
+        for wl in workloads:
+            self.number_of_tests = wl["tests"]
+            self.results_path = get_full_test_logs_path(cname=self, fname=wl["name"])
+            self.results_file = os.path.join(self.results_path, "all_results.txt")
+            logger.info(f"Check results for [{wl['name']}] in : {self.results_file}")
+            self.check_tests_results()
+            self.push_to_dashboard(test_name=wl["test_name"])

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -376,7 +376,7 @@ class TestPVCClonePerformance(PASTest):
         kernel_url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.5.tar.gz"
         download_path = "tmp"
 
-        test_start_time = PASTest.get_time()
+        test_start_time = self.get_time()
         helpers.pull_images(constants.PERF_IMAGE)
         # Download a linux Kernel
 
@@ -563,7 +563,7 @@ class TestPVCClonePerformance(PASTest):
 
         full_results.add_key("files_number", files_written)
 
-        test_end_time = PASTest.get_time()
+        test_end_time = self.get_time()
 
         full_results.add_key(
             "test_time", {"start": test_start_time, "end": test_end_time}


### PR DESCRIPTION
The current PR adds a test : creation of number of samples of Clones for a PVC with multiple files ( ~1 million files). 
The test creates clones for such PVC, calculates creation and deletion times of the samples , also CSI creation and deletion times, and creation /deletion/csi creation/csi deletion averages.
The test sends the results to the ES server and uploads those results to the Performance Dashboard. 