### PR TITLE
Skip test cases on MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -31,6 +31,7 @@ from ocs_ci.framework.testlib import (
     ipi_deployment_required,
     skipif_bm,
     bugzilla,
+    skipif_managed_service,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
 from ocs_ci.ocs.resources import pod
@@ -110,6 +111,7 @@ class TestNodesMaintenance(ManageTest):
             pytest.skip(str(e))
 
     @tier1
+    @skipif_managed_service
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -2,7 +2,12 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    skipif_external_mode,
+    skipif_managed_service,
+)
 from ocs_ci.ocs.must_gather.must_gather import MustGather
 from ocs_ci.ocs.must_gather.const_must_gather import GATHER_COMMANDS_VERSION
 
@@ -35,7 +40,10 @@ class TestMustGather(ManageTest):
                 *["JSON"],
                 marks=[pytest.mark.polarion_id("OCS-1583"), skipif_external_mode]
             ),
-            pytest.param(*["OTHERS"], marks=pytest.mark.polarion_id("OCS-1583")),
+            pytest.param(
+                *["OTHERS"],
+                marks=[pytest.mark.polarion_id("OCS-1583"), skipif_managed_service]
+            ),
         ],
     )
     @pytest.mark.skipif(

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -2,12 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import (
-    ManageTest,
-    tier1,
-    skipif_external_mode,
-    skipif_managed_service,
-)
+from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
 from ocs_ci.ocs.must_gather.must_gather import MustGather
 from ocs_ci.ocs.must_gather.const_must_gather import GATHER_COMMANDS_VERSION
 
@@ -40,10 +35,7 @@ class TestMustGather(ManageTest):
                 *["JSON"],
                 marks=[pytest.mark.polarion_id("OCS-1583"), skipif_external_mode]
             ),
-            pytest.param(
-                *["OTHERS"],
-                marks=[pytest.mark.polarion_id("OCS-1583"), skipif_managed_service]
-            ),
+            pytest.param(*["OTHERS"], marks=pytest.mark.polarion_id("OCS-1583")),
         ],
     )
     @pytest.mark.skipif(


### PR DESCRIPTION
Skipping the test case given below in MS.

1. tests/manage/z_cluster/nodes/test_nodes_maintenance.py::TestNodesMaintenance::test_node_maintenance
Test case failed on MS due to the issue #5684. A new test case will be created specific for MS.


Signed-off-by: Jilju Joy <jijoy@redhat.com>