### PR TITLE
update time out of add-on install check

### DIFF
--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -247,7 +247,7 @@ def install_odf_addon(cluster):
 
     utils.run_cmd(cmd, timeout=1200)
     for addon_info in utils.TimeoutSampler(
-        4000, 30, get_addon_info, cluster, addon_name
+        7200, 30, get_addon_info, cluster, addon_name
     ):
         logger.info(f"Current addon installation info: " f"{addon_info}")
         if "ready" in addon_info:


### PR DESCRIPTION
Usually after 2hours add-on moved to failed status
Also sometime 1 hour is not sufficient for add-on install
hence incresing the add-on install timout to 2 hours

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>