### PR TITLE
Update test_must_gather to run on MS

### DIFF
--- a/ocs_ci/ocs/must_gather/const_must_gather.py
+++ b/ocs_ci/ocs/must_gather/const_must_gather.py
@@ -758,6 +758,29 @@ GATHER_COMMANDS_OTHERS_EXTERNAL_EXCLUDE = [
     "ocs-storagecluster-rbdplugin-snapclass.yaml",
 ]
 
+GATHER_COMMANDS_OTHERS_MANAGED_SERVICES_EXCLUDE = [
+    "noobaa-db-pg-0-db.log",
+    "NooBaaList_crs.yaml",
+    "noobaa-core-0-core.log",
+    "NamespaceStoreList_crs.yaml",
+    "noobaa-db-pg-0-initialize-database.log",
+    "BackingStoreList_crs.yaml",
+    "ocs-storagecluster-cephfilesystem.yaml",
+    "ocs-storagecluster-cephblockpool.yaml",
+    "noobaa-db-pg-0-init.log",
+    "noobaa-endpoint-scc-describe.txt",
+    "noobaa-core-0-pod-describe.txt",
+    "noobaa-db-pg-0.log",
+    "obc_list",
+    "BucketClassList_crs.yaml",
+    "noobaa-db-pg-0-pod-describe.txt",
+    "odf-operator.yaml",
+    "noobaa-db-pg-0.yaml",
+    "db-noobaa-db-pg-0.yaml",
+    "noobaa-scc-describe.txt",
+    "db-noobaa-db-pg-0-pvc-describe.txt",
+]
+
 if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
     GATHER_COMMANDS_OTHERS = list(
         set(GATHER_COMMANDS_OTHERS) - set(GATHER_COMMANDS_OPENSHIFT_DEDICATED_EXCLUDE)
@@ -819,6 +842,14 @@ GATHER_COMMANDS_VERSION = {
         "OTHERS": GATHER_COMMANDS_OTHERS
         + GATHER_COMMANDS_OTHERS_4_7
         + GATHER_COMMANDS_OTHERS_4_10,
+        "OTHERS_MANAGED_SERVICES": list(
+            set(
+                GATHER_COMMANDS_OTHERS
+                + GATHER_COMMANDS_OTHERS_4_7
+                + GATHER_COMMANDS_OTHERS_4_10
+            )
+            - set(GATHER_COMMANDS_OTHERS_MANAGED_SERVICES_EXCLUDE)
+        ),
         "OTHERS_EXTERNAL": list(
             set(GATHER_COMMANDS_OTHERS_EXTERNAL + GATHER_COMMANDS_OTHERS_EXTERNAL_4_8)
             - set(GATHER_COMMANDS_OTHERS_EXTERNAL_EXCLUDE)

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -63,7 +63,12 @@ class MustGather(object):
         ocs_version = float(
             f"{version.get_ocs_version_from_csv(only_major_minor=True)}"
         )
-        if self.type_log == "OTHERS" and storagecluster_independent_check():
+        if (
+            self.type_log == "OTHERS"
+            and config.ENV_DATA["platform"] in MANAGED_SERVICE_PLATFORMS
+        ):
+            files = GATHER_COMMANDS_VERSION[ocs_version]["OTHERS_MANAGED_SERVICES"]
+        elif self.type_log == "OTHERS" and storagecluster_independent_check():
             files = GATHER_COMMANDS_VERSION[ocs_version]["OTHERS_EXTERNAL"]
         else:
             files = GATHER_COMMANDS_VERSION[ocs_version][self.type_log]


### PR DESCRIPTION
Excluded the files which are not relevant for managed services from the list of files to verify in must-gather.
With this change, the test case given below will be able to run on MS platform.
_tests/manage/z_cluster/test_must_gather.py::TestMustGather::test_must_gather[OTHERS]_

Signed-off-by: Jilju Joy <jijoy@redhat.com>