### PR TITLE
Add bugzilla marker in test test_connection_time_out

### DIFF
--- a/tests/managed-service/test_post_installation_state.py
+++ b/tests/managed-service/test_post_installation_state.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     runs_on_provider,
+    bugzilla,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 
@@ -40,6 +41,7 @@ class TestPostInstallationState(ManageTest):
         assert len(log_lines) > 100
 
     @tier1
+    @bugzilla("2073025")
     @runs_on_provider
     @pytest.mark.polarion_id("OCS-2695")
     @managed_service_required


### PR DESCRIPTION
Add bugzilla marker in the test case tests/managed-service/test_post_installation_state.py::TestPostInstallationState::test_connection_time_out

Signed-off-by: Jilju Joy <jijoy@redhat.com>