### PR TITLE
Enabling deployment on production environment

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -228,7 +228,7 @@ higher priority).
 * `http_proxy`, `https_proxy`, `no_proxy` - proxy configuration used for accessing external resources
 * `client_http_proxy` - proxy configuration used by client to access OCP cluster
 * `ibm_flash` - Set to `true` if you are running on the system with IBM Flash storageSystem.
-
+* `ms_env_type` - to choose managed service environment type staging or production, default set to staging
 #### UPGRADE
 
 Upgrade related configuration data.

--- a/conf/ocsci/ms_production_env.yaml
+++ b/conf/ocsci/ms_production_env.yaml
@@ -1,0 +1,5 @@
+ENV_DATA:
+  # Default type of managed service environment is stage
+  # to enable actions on  production environment use this
+  # as an additional config
+  ms_env_type : 'production'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -205,8 +205,10 @@ ENV_DATA:
   # ACM HUB deployment
   deploy_acm_hub_cluster: false
 
-  #Managed service - Managed StorageCluster size in TiB
+  # Managed service git stat  default configurations
+  # Managed StorageCluster size in TiB
   size: '20'
+  ms_env_type: 'staging'
 
 # This section is related to upgrade
 UPGRADE:

--- a/ocs_ci/utility/openshift_dedicated.py
+++ b/ocs_ci/utility/openshift_dedicated.py
@@ -22,7 +22,12 @@ def login():
     Login to OCM client
     """
     token = openshift_dedicated["token"]
-    cmd = f"ocm login --token={token} --url=staging"
+    ms_env = config.ENV_DATA.get("ms_env_type", "staging")
+    cmd = f"ocm login --token={token}"
+    if ms_env != "production":
+        # default MS environment consider is staging
+        cmd += " --url=staging"
+
     logger.info("Logging in to OCM cli")
     run_cmd(cmd, secrets=[token])
     logger.info("Successfully logged in to OCM")


### PR DESCRIPTION
By default deployment environment consider for managed service is
staging environment. As this is most used environment for deployment and testing
This PR enable deployment in production environment
Signed-off-by: suchita.gatfane <sgatfane@redhat.com>