### PR TITLE
SNO/LVMO deployment

### DIFF
--- a/conf/deployment/aws/ipi_1az_rhcos_lso_sno.yaml
+++ b/conf/deployment/aws/ipi_1az_rhcos_lso_sno.yaml
@@ -1,0 +1,20 @@
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+ENV_DATA:
+  platform: 'aws'
+  deployment_type: 'ipi'
+  region: 'us-east-2'
+  worker_availability_zones:
+    - 'us-east-2a'
+  master_availability_zones:
+    - 'us-east-2a'
+  worker_replicas: 0
+  master_replicas: 1
+  worker_instance_type: 'm5.4xlarge'
+  master_instance_type: 'm5.4xlarge'
+  device_size: 2328
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2196'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_1mw.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_1mw.yaml
@@ -1,0 +1,20 @@
+---
+# This config is suppose to work on most of DCs we have.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  lvmo_disks: 5
+  lvmo_disks_size: 150
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  sno: true
+  worker_replicas: 0
+  master_replicas: 1
+  worker_num_cpus: '16'
+  master_num_cpus: '16'
+  master_memory: '65536'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-3950'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,6 +154,9 @@ to the pytest.
     previous execution. If the file is provided, the execution will remove all the test cases
     which passed and will run only those test cases which were skipped / failed / or had error
     in the provided report.
+* `--install-lvmo` - Deploy LVMCluster, will skip ODF deployment.
+* `--lvmo-disks` - Number of disks to add to SNO deployment.
+* `--lvmo-disks-size` - Size of disks to add to SNO deployment.
 
 ## Examples
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -12,7 +12,6 @@ import tempfile
 import time
 from pathlib import Path
 import base64
-
 import yaml
 
 from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
@@ -241,6 +240,13 @@ class Deployment(object):
             deploy_dr = MultiClusterDROperatorsDeploy(dr_conf)
             deploy_dr.deploy()
 
+    def do_deploy_lvmo(self):
+        """
+        call lvm deploy
+
+        """
+        self.deploy_lvmo()
+
     def deploy_cluster(self, log_cli_level="DEBUG"):
         """
         We are handling both OCP and OCS deployment here based on flags
@@ -279,7 +285,7 @@ class Deployment(object):
             and ocp_version >= version.VERSION_4_9
         ):
             self.deploy_acm_hub()
-
+        self.do_deploy_lvmo()
         self.do_deploy_submariner()
         self.do_deploy_ocs()
         self.do_deploy_rdr()
@@ -1218,6 +1224,66 @@ class Deployment(object):
 
         # patch gp2/thin storage class as 'non-default'
         self.patch_default_sc_to_non_default()
+
+    def deploy_lvmo(self):
+        """
+        deploy lvmo for platform specific (for now only vsphere)
+        """
+        if not config.DEPLOYMENT["install_lvmo"]:
+            logger.warning("LVMO deployment will be skipped")
+            return
+
+        logger.info(f"Installing lvmo version {config.ENV_DATA['ocs_version']}")
+        lvmo_version = config.ENV_DATA["ocs_version"]
+        lvmo_version_without_period = lvmo_version.replace(".", "")
+        label_version = constants.LVMO_POD_LABEL
+        create_catalog_source()
+        cluster_config_file = os.path.join(
+            constants.TEMPLATE_DEPLOYMENT_DIR_LVMO,
+            f"lvm-cluster-{lvmo_version_without_period}.yaml",
+        )
+        bundle_config_file = os.path.join(
+            constants.TEMPLATE_DEPLOYMENT_DIR_LVMO, "lvm-bundle.yaml"
+        )
+        run_cmd(f"oc create -f {bundle_config_file} -n {self.namespace}")
+        pod = ocp.OCP(kind=constants.POD, namespace=self.namespace)
+        assert pod.wait_for_resource(
+            condition="Running",
+            selector=label_version[lvmo_version_without_period][
+                "controller_manager_label"
+            ],
+            resource_count=1,
+            timeout=300,
+        )
+        run_cmd(f"oc create -f {cluster_config_file} -n {self.namespace}")
+        assert pod.wait_for_resource(
+            condition="Running",
+            selector=label_version[lvmo_version_without_period][
+                "topolvm-controller_label"
+            ],
+            resource_count=1,
+            timeout=300,
+        )
+        assert pod.wait_for_resource(
+            condition="Running",
+            selector=label_version[lvmo_version_without_period]["topolvm-node_label"],
+            resource_count=1,
+            timeout=300,
+        )
+        assert pod.wait_for_resource(
+            condition="Running",
+            selector=label_version[lvmo_version_without_period]["vg-manager_label"],
+            resource_count=1,
+            timeout=300,
+        )
+        catalgesource = run_cmd(
+            "oc -n openshift-marketplace get  "
+            "catalogsources.operators.coreos.com redhat-operators -o json"
+        )
+        json_cts = json.loads(catalgesource)
+        logger.info(
+            f"LVMO installed successfully from image {json_cts['spec']['image']}"
+        )
 
     def destroy_cluster(self, log_level="DEBUG"):
         """

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -25,6 +25,7 @@ class OCPDeployment:
         self.pull_secret = {}
         self.metadata = {}
         self.deployment_platform = config.ENV_DATA["platform"].lower()
+        self.sno = config.ENV_DATA["sno"]
         self.deployment_type = config.ENV_DATA["deployment_type"].lower()
         if not hasattr(self, "flexy_deployment"):
             self.flexy_deployment = False

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -6,12 +6,16 @@ import glob
 import json
 import logging
 import os
-from shutil import rmtree
+from shutil import rmtree, copyfile
 import time
-
+import requests
+import base64
+from ping3 import ping
 import tempfile
 import hcl2
 import yaml
+import re
+import shutil
 
 from ocs_ci.deployment.helpers.vsphere_helpers import VSPHEREHELPERS
 from ocs_ci.deployment.helpers.prechecks import VSpherePreChecks
@@ -67,6 +71,9 @@ from ocs_ci.utility.vsphere import VSPHERE as VSPHEREUtil
 from semantic_version import Version
 from .deployment import Deployment
 from .flexy import FlexyVSPHEREUPI
+from ocs_ci.utility.vsphere import VSPHERE
+from ocs_ci.utility.connection import Connection
+from ocs_ci.ocs.exceptions import ConnectivityFail
 
 logger = logging.getLogger(__name__)
 
@@ -229,9 +236,12 @@ class VSPHEREBASE(Deployment):
 
     def delete_disks(self):
         """
-        Delete the extra disks from all the worker nodes
+        Delete the extra disks from all the worker nodes and is sno delete it from sno nodes which is compute also
         """
-        vms = self.get_compute_vms(self.datacenter, self.cluster)
+        if config.ENV_DATA["sno"]:
+            vms = self.get_vms_by_string(self.datacenter, self.cluster, "sno")
+        else:
+            vms = self.get_compute_vms(self.datacenter, self.cluster)
         if vms:
             for vm in vms:
                 self.vsphere.remove_disks(vm)
@@ -257,6 +267,27 @@ class VSPHEREBASE(Deployment):
                 config.ENV_DATA.get("cluster_name"), dc, cluster
             )
             return [vm for vm in vms if "compute" in vm.name or "rhel" in vm.name]
+
+    def get_vms_by_string(self, dc, cluster, vm_string_to_match):
+        """
+        Gets the sno VM's from resource pool
+
+        Args:
+            dc (str): Datacenter name
+            cluster (str): Cluster name
+            vm_string_to_match (str): string to match the VM's like "compute", "sno" etc
+
+        Returns:
+            list: VM instance
+
+        """
+        if self.vsphere.is_resource_pool_exist(
+            config.ENV_DATA["cluster_name"], self.datacenter, self.cluster
+        ):
+            vms = self.vsphere.get_all_vms_in_pool(
+                config.ENV_DATA.get("cluster_name"), dc, cluster
+            )
+            return [vm for vm in vms if vm_string_to_match in vm.name]
 
     def add_rdm_disks(self):
         """
@@ -434,10 +465,14 @@ class VSPHEREUPI(VSPHEREBASE):
             """
             super(VSPHEREUPI.OCPDeployment, self).deploy_prereq()
             # generate manifests
-            self.generate_manifests()
+            if not self.sno:
+                self.generate_manifests()
 
             # create chrony resource
-            if Version.coerce(get_ocp_version()) >= Version.coerce("4.5"):
+            if (
+                Version.coerce(get_ocp_version()) >= Version.coerce("4.5")
+                and not self.sno
+            ):
                 add_chrony_to_ocp_deployment()
 
             # create ignitions
@@ -473,16 +508,327 @@ class VSPHEREUPI(VSPHEREBASE):
             if config.ENV_DATA.get("sync_time_with_host"):
                 sync_time_with_host(vm_file, True)
 
+        def create_sno_iso_and_upload(self):
+            """
+            Creating iso file with values for SNO deployment
+
+            """
+            # Getting ip from ipam
+            ipam = IPAM(
+                "address", config.ENV_DATA["ipam"], config.ENV_DATA["ipam_token"]
+            )
+            subnet = config.ENV_DATA["machine_cidr"].split("/")[0]
+            config.ENV_DATA["vm_ip_address"] = ipam.assign_ip(
+                f"{constants.SNO_NODE_NAME}.{config.ENV_DATA['cluster_name']}", subnet
+            )
+            logger.info(f"IP from ipam: {config.ENV_DATA['vm_ip_address']}")
+            self.change_ignition_ip_and_hostname(config.ENV_DATA["vm_ip_address"])
+            os.chdir(self.cluster_path)
+            iso_url_data = run_cmd(f"{self.installer} coreos print-stream-json")
+            resp = json.loads(iso_url_data)
+            iso_url = resp["architectures"]["x86_64"]["artifacts"]["metal"]["formats"][
+                "iso"
+            ]["disk"]["location"]
+            sno_image_name = f"{self.cluster_name}.iso"
+            logger.info(f"Downloading rh-cos is {iso_url}")
+            run_cmd(f"curl -L -o {sno_image_name} {iso_url}")
+
+            # Installing and compiling coreos-installer with prereq
+            run_cmd(f"curl -o {self.cluster_path}/rustup.sh {constants.RUST_URL} -sSf")
+            os.chmod(f"{self.cluster_path}/rustup.sh", 448)
+            run_cmd(f"{self.cluster_path}/rustup.sh -y")
+            os.environ["PATH"] += os.pathsep + f"{os.path.expanduser('~')}/.cargo/bin"
+            os.chdir(f"{constants.EXTERNAL_DIR}")
+            coreos_installer_repo_path = os.path.join(
+                constants.EXTERNAL_DIR,
+                "coreos-installer",
+            )
+            clone_repo(
+                constants.COREOS_INSTALLER_REPO, coreos_installer_repo_path, "main"
+            )
+            if os.path.isdir(f"{constants.EXTERNAL_DIR}/coreos-install"):
+                shutil.rmtree(f"{constants.EXTERNAL_DIR}/coreos-install")
+            os.mkdir(f"{constants.EXTERNAL_DIR}/coreos-install")
+            os.chdir(f"{constants.EXTERNAL_DIR}/coreos-installer/")
+            run_cmd("make")
+            run_cmd(f"make install DESTDIR={constants.EXTERNAL_DIR}/coreos-install/")
+            os.chdir(f"{self.cluster_path}")
+            coreos_installer_exec = (
+                f"{constants.EXTERNAL_DIR}/coreos-install/usr/bin/coreos-installer"
+            )
+            logger.info("coreos-installler installed successfully")
+            run_cmd(
+                f"{coreos_installer_exec} iso ignition embed -fi iso.ign {sno_image_name}"
+            )
+
+            # connecteing to vsanDataStore and uploading iso file
+            vsphere = VSPHERE(
+                config.ENV_DATA["vsphere_server"],
+                config.ENV_DATA["vsphere_user"],
+                config.ENV_DATA["vsphere_password"],
+            )
+
+            vsphere_content = vsphere.get_content
+            client_cookie = vsphere_content.propertyCollector._stub.soapStub.cookie
+            logger.info(f"this is the client cookie {client_cookie}")
+            remote_file = sno_image_name
+            resource = "/folder/ISO/" + remote_file
+            params = {
+                "dsName": config.ENV_DATA["vsphere_datastore"],
+                "dcPath": config.ENV_DATA["vsphere_datacenter"],
+            }
+            http_url = (
+                "https://" + config.ENV_DATA["vsphere_server"] + ":443" + resource
+            )
+            cookie_name = client_cookie.split("=", 1)[0]
+            cookie_value = client_cookie.split("=", 1)[1].split(";", 1)[0]
+            cookie_path = (
+                client_cookie.split("=", 1)[1]
+                .split(";", 1)[1]
+                .split(";", 1)[0]
+                .lstrip()
+            )
+            cookie_text = " " + cookie_value + "; $" + cookie_path
+            # # Make a cookie
+            cookie = dict()
+            cookie[cookie_name] = cookie_text
+            logger.info(cookie)
+            verify_cert = False
+            headers = {"Content-Type": "application/octet-stream"}
+            with open(f"{self.cluster_path}/{sno_image_name}", "rb") as file_data:
+                requests.put(
+                    http_url,
+                    params=params,
+                    data=file_data,
+                    headers=headers,
+                    cookies=cookie,
+                    verify=verify_cert,
+                )
+            logger.info(f"{sno_image_name} uploaded successfully to the VsanDataStore")
+            logger.info(f"Removing iso {sno_image_name} from {self.cluster_path}")
+            full_sno_image_path = os.path.join(self.cluster_path, sno_image_name)
+            os.remove(full_sno_image_path)
+
+        def change_ignition_ip_and_hostname(self, ip_address):
+            """
+            Embed into iso.ign ip address and hostname (sno-edge-0)
+            args:
+                ip_address (str): ip address we got from IPAM to embed inside iso"
+
+            """
+            logger.info(f"Changing {constants.SNO_BOOTSTRAP_IGN}")
+            with open(f"{self.cluster_path}/{constants.SNO_BOOTSTRAP_IGN}", "r") as fn:
+                ign_data = json.load(fn)
+            gw = config.ENV_DATA["gateway"]
+            dns = config.ENV_DATA["dns"]
+            logger.info(f"adding {ip_address} and hostname into bootkube.sh")
+            bootkube_source = []
+            new_files = []
+            for file in ign_data["storage"]["files"]:
+                if file["path"] == "/usr/local/bin/bootkube.sh":
+                    bootkube_source.append(
+                        f'nmcli connection modify "Wired connection 1" '
+                        f"ifname ens192 ipv4.method manual ipv4.addresses"
+                        f" {ip_address}/23 gw4 {gw} ipv4.dns {dns}"
+                        f' ipv4.dns-search "{self.cluster_name}.qe.rh-ocs.com"'
+                    )
+                    bootkube_source.append(
+                        'nmcli con up "Wired connection 1" ifname ens192'
+                    )
+                    bootkube_source.append(
+                        f"hostnamectl set-hostname {constants.SNO_NODE_NAME}"
+                    )
+                    pattern = re.compile(".*base64,(.*)")
+                    result = pattern.search(file["contents"]["source"])
+                    bootkube_base64_enc = result.group(1)
+                    bootkube_base64_enc_encode_ascii = bootkube_base64_enc.encode(
+                        "ascii"
+                    )
+                    bootkube_base64_decode = base64.b64decode(
+                        bootkube_base64_enc_encode_ascii
+                    )
+                    bootkube_base64_enc_encode_clean = bootkube_base64_decode.decode(
+                        "ascii"
+                    )
+                    bootkube_base64_script_array = (
+                        bootkube_base64_enc_encode_clean.split("\n")
+                    )
+                    final_script_array = []
+                    for script_line in bootkube_base64_script_array:
+                        if "#!/usr/bin/env bash" in script_line:
+                            final_script_array.append(script_line)
+                            for nmcli_line in bootkube_source:
+                                final_script_array.append(nmcli_line)
+                            continue
+                        final_script_array.append(script_line)
+                    final_script = "\n".join(final_script_array)
+                    final_script_ascii_enc = final_script.encode("ascii")
+                    final_script_base64_ascii_encode = base64.b64encode(
+                        final_script_ascii_enc
+                    )
+                    final_script_ready = final_script_base64_ascii_encode.decode(
+                        "ascii"
+                    )
+                    source_new_content = (
+                        f"data:text/plain;charset=utf-8;base64,{final_script_ready}"
+                    )
+                    file["contents"]["source"] = source_new_content
+                    new_files.append(file)
+                    continue
+                new_files.append(file)
+            ign_data["storage"]["files"] = new_files
+            logger.info(f"adding {ip_address} to system network-manager")
+            all_lines = []
+            ens_file = open(
+                f"{constants.TEMPLATE_DIR}/ocp-deployment/ens192.nmconnection", "r"
+            )
+            for line in ens_file:
+                line = line.strip()
+                line = line.replace("address=", f"address={ip_address}/23,{gw}")
+                line = line.replace("dns=", f"dns={dns}")
+                all_lines.append(line)
+            one_line_ens = "\n".join(all_lines)
+            one_line_ens_bytes = one_line_ens.encode("utf-8")
+            base64ens = base64.b64encode(one_line_ens_bytes).decode("utf-8")
+
+            ens_json_to_add = (
+                f'{{"overwrite": True, "path": "'
+                f'/etc/NetworkManager/system-connections/Wired connection 1.nmconnection"'
+                f', "user": {{"name": "root"}}, "contents": {{"source": "data:text/plain;'
+                f'charset=utf-8;base64,{base64ens}"}}, "mode": 420}}'
+            )
+            ens_dict = eval(ens_json_to_add)
+            ign_data["storage"]["files"].append(ens_dict)
+            hostname = constants.SNO_NODE_NAME
+            logger.info(f"Adding hostname {hostname} to /etc/hostname")
+            encode_hostname = hostname.encode("utf-8")
+            encode64_hostname = base64.b64encode(encode_hostname).decode("utf-8")
+            hostname_json_to_add = (
+                f'{{"overwrite": True, "path": "/etc/hostname",'
+                f' "user": {{"name": "root"}}, "contents": {{"source": "data'
+                f':text/plain;charset=utf-8;base64,{encode64_hostname}"}}, "mode": 420}}'
+            )
+            hostname_dict = eval(hostname_json_to_add)
+
+            ign_data["storage"]["files"].append(hostname_dict)
+
+            with open(f"{self.cluster_path}/iso.ign", "w") as ign_new_file:
+                json.dump(ign_data, ign_new_file)
+
+        def wait_for_sno_second_boot_change_ip_and_hostname(self, ip_address):
+            """
+            After second boot ocp is booting with the right ip address but after a while the ip is changed to dhcp.
+            We monitor the ip address and when it changed we ssh to the node and change back the ip address and hostname
+            args:
+                ip_address (str): The ip address given from the IPAM server
+            raises:
+                ConnectivityFail: Incase after the change we ping the ip_address. If it doesn't reply we raise.
+
+            """
+
+            # Connect to Vcenter
+            vsphere = VSPHERE(
+                config.ENV_DATA["vsphere_server"],
+                config.ENV_DATA["vsphere_user"],
+                config.ENV_DATA["vsphere_password"],
+            )
+            # Get the VM object
+            vm = vsphere.get_vm_in_pool_by_name(
+                name=constants.SNO_NODE_NAME,
+                dc=config.ENV_DATA["vsphere_datacenter"],
+                cluster=config.ENV_DATA["vsphere_cluster"],
+                pool=self.cluster_name,
+            )
+            gw = config.ENV_DATA["gateway"]
+            dns = config.ENV_DATA["dns"]
+            # Check the ip if it changes and when, there are few stages. first boot, None when server reboots,
+            # then second boot starts with defined ip but can be changed and we monitor that.
+            # If the ip is not changed after 20 retries we just change the hostname.
+            boot_got_ip_address = 0
+            got_none = 0
+            destination_boot_counter = 0
+            for i in range(0, 250):
+                ips = vsphere.get_vms_ips([vm])
+                ip = ips[0]
+                logger.info(f"try num {i} the ip is {ip}")
+                if ip == ip_address:
+                    boot_got_ip_address = 1
+
+                if ip is None and boot_got_ip_address == 1:
+                    got_none = 1
+                if got_none == 1 and ip == ip_address:
+                    destination_boot_counter += 1
+                if destination_boot_counter > 20:
+                    logger.info(
+                        f"{constants.SNO_NODE_NAME} stayed with same ip address {ip_address}- changing hostname"
+                    )
+                    node_ssh = Connection(
+                        host=ip,
+                        user="core",
+                        private_key=f"{os.path.expanduser('~')}/.ssh/openshift-dev.pem",
+                    )
+                    node_ssh.exec_cmd('echo "sleep 3" > changenet.sh')
+                    node_ssh.exec_cmd(
+                        f'echo "hostnamectl set-hostname {constants.SNO_NODE_NAME}" >> changenet.sh'
+                    )
+                    node_ssh.exec_cmd("chmod 700 changenet.sh")
+                    node_ssh.exec_cmd(
+                        "sudo nohup ./changenet.sh </dev/null &>/dev/null &"
+                    )
+                    break
+                if ip != ip_address and ip is not None and boot_got_ip_address == 1:
+                    node_ssh = Connection(
+                        host=ip,
+                        user="core",
+                        private_key=f"{os.path.expanduser('~')}/.ssh/openshift-dev.pem",
+                    )
+                    node_ssh.exec_cmd('echo "sleep 3" > changenet.sh')
+                    node_ssh.exec_cmd(
+                        f"echo \"nmcli connection modify 'Wired connection 1' "
+                        f"ifname ens192 ipv4.method manual ipv4.addresses"
+                        f" {ip_address}/23 gw4 {gw} ipv4.dns {dns}"
+                        f" ipv4.dns-search '{self.cluster_name}.qe.rh-ocs.com'\" >> changenet.sh"
+                    )
+                    node_ssh.exec_cmd(
+                        "echo \"nmcli con up 'Wired connection 1' ifname ens192\" >> changenet.sh"
+                    )
+
+                    node_ssh.exec_cmd(
+                        f'echo "hostnamectl set-hostname {constants.SNO_NODE_NAME}" >> changenet.sh'
+                    )
+                    node_ssh.exec_cmd("chmod 700 changenet.sh")
+                    node_ssh.exec_cmd(
+                        "sudo nohup ./changenet.sh </dev/null &>/dev/null &"
+                    )
+                    break
+                time.sleep(1)
+
+            for i in range(0, 20):
+                result = ping(ip_address)
+                if result is not None:
+                    logger.info(f"ip is changed to {ip_address}")
+                    break
+                time.sleep(1)
+                if i == 20:
+                    raise ConnectivityFail(f"ip {ip_address} is not reachable")
+
         def create_config(self):
             """
             Creates the OCP deploy config for the vSphere
             """
             # Generate install-config from template
             _templating = Templating()
-            ocp_install_template = (
-                f"install-config-{self.deployment_platform}-"
-                f"{self.deployment_type}.yaml.j2"
-            )
+
+            if self.sno:
+                ocp_install_template = (
+                    f"install-config-{self.deployment_platform}-"
+                    f"{self.deployment_type}-sno.yaml.j2"
+                )
+            else:
+                ocp_install_template = (
+                    f"install-config-{self.deployment_platform}-"
+                    f"{self.deployment_type}.yaml.j2"
+                )
             ocp_install_template_path = os.path.join(
                 "ocp-deployment", ocp_install_template
             )
@@ -492,7 +838,10 @@ class VSPHEREUPI(VSPHEREBASE):
 
             # Parse the rendered YAML so that we can manipulate the object directly
             install_config_obj = yaml.safe_load(install_config_str)
-            if version.get_semantic_ocp_version_from_config() >= version.VERSION_4_10:
+            if (
+                version.get_semantic_ocp_version_from_config() >= version.VERSION_4_10
+                and not self.sno
+            ):
                 install_config_obj["platform"]["vsphere"]["network"] = config.ENV_DATA[
                     "vm_network"
                 ]
@@ -535,10 +884,25 @@ class VSPHEREUPI(VSPHEREBASE):
             Creates the ignition files
             """
             logger.info("creating ignition files for the cluster")
-            run_cmd(
-                f"{self.installer} create ignition-configs "
-                f"--dir {self.cluster_path} "
-            )
+            if not self.sno:
+                run_cmd(
+                    f"{self.installer} create ignition-configs "
+                    f"--dir {self.cluster_path} "
+                )
+            else:
+                copyfile(
+                    f"{self.cluster_path}/install-config.yaml",
+                    f"{self.cluster_path}/install-config.yaml.bck",
+                )
+                run_cmd(
+                    f"{self.installer} create single-node-ignition-config "
+                    f"--dir {self.cluster_path} "
+                )
+                copyfile(
+                    f"{self.cluster_path}/install-config.yaml.bck",
+                    f"{self.cluster_path}/install-config.yaml",
+                )
+                self.create_sno_iso_and_upload()
 
         @retry(exceptions.CommandFailed, tries=10, delay=30, backoff=1)
         def configure_storage_for_image_registry(self, kubeconfig):
@@ -567,73 +931,105 @@ class VSPHEREUPI(VSPHEREBASE):
             os.chdir(self.terraform_data_dir)
             self.terraform.initialize()
             self.terraform.apply(self.terraform_var)
-            os.chdir(self.previous_dir)
-            logger.info("waiting for bootstrap to complete")
-            try:
+            if config.ENV_DATA["sno"]:
+                self.wait_for_sno_second_boot_change_ip_and_hostname(
+                    config.ENV_DATA["vm_ip_address"]
+                )
                 run_cmd(
-                    f"{self.installer} wait-for bootstrap-complete "
-                    f"--dir {self.cluster_path} "
+                    f"{self.installer} wait-for install-complete"
+                    f" --dir {self.cluster_path} "
                     f"--log-level {log_cli_level}",
                     timeout=3600,
                 )
-            except CommandFailed as e:
-                if constants.GATHER_BOOTSTRAP_PATTERN in str(e):
-                    try:
-                        gather_bootstrap()
-                    except Exception as ex:
-                        logger.error(ex)
-                raise e
+                vsphere = VSPHERE(
+                    config.ENV_DATA["vsphere_server"],
+                    config.ENV_DATA["vsphere_user"],
+                    config.ENV_DATA["vsphere_password"],
+                )
+                vm = vsphere.get_vm_in_pool_by_name(
+                    name=constants.SNO_NODE_NAME,
+                    dc=config.ENV_DATA["vsphere_datacenter"],
+                    cluster=config.ENV_DATA["vsphere_cluster"],
+                    pool=config.ENV_DATA["cluster_name"],
+                )
 
-            if self.folder_structure:
-                # comment bootstrap module
-                comment_bootstrap_in_lb_module()
+                vsphere.add_disks(
+                    config.DEPLOYMENT["lvmo_disks"],
+                    vm,
+                    config.DEPLOYMENT["lvmo_disks_size"],
+                )
 
-                # remove bootstrap IP in load balancer and
-                # restart haproxy
-                lb = LoadBalancer()
-                lb.rename_haproxy_conf_and_reload()
-                lb.remove_boostrap_in_proxy()
-                lb.restart_haproxy()
-
-            # remove bootstrap node
-            if not config.DEPLOYMENT["preserve_bootstrap_node"]:
-                logger.info("removing bootstrap node")
-                os.chdir(self.terraform_data_dir)
-                if self.folder_structure:
-                    self.terraform.destroy_module(
-                        self.terraform_var, constants.BOOTSTRAP_MODULE
+            os.chdir(self.previous_dir)
+            if not self.sno:
+                logger.info("waiting for bootstrap to complete")
+                try:
+                    run_cmd(
+                        f"{self.installer} wait-for bootstrap-complete "
+                        f"--dir {self.cluster_path} "
+                        f"--log-level {log_cli_level}",
+                        timeout=3600,
                     )
-                else:
-                    self.terraform.apply(self.terraform_var, bootstrap_complete=True)
-                os.chdir(self.previous_dir)
+                except CommandFailed as e:
+                    if constants.GATHER_BOOTSTRAP_PATTERN in str(e):
+                        try:
+                            gather_bootstrap()
+                        except Exception as ex:
+                            logger.error(ex)
+                    raise e
+
+                if self.folder_structure:
+                    # comment bootstrap module
+                    comment_bootstrap_in_lb_module()
+
+                    # remove bootstrap IP in load balancer and
+                    # restart haproxy
+                    lb = LoadBalancer()
+                    lb.rename_haproxy_conf_and_reload()
+                    lb.remove_boostrap_in_proxy()
+                    lb.restart_haproxy()
+
+                # remove bootstrap node
+                if not config.DEPLOYMENT["preserve_bootstrap_node"]:
+                    logger.info("removing bootstrap node")
+                    os.chdir(self.terraform_data_dir)
+                    if self.folder_structure:
+                        self.terraform.destroy_module(
+                            self.terraform_var, constants.BOOTSTRAP_MODULE
+                        )
+                    else:
+                        self.terraform.apply(
+                            self.terraform_var, bootstrap_complete=True
+                        )
+                    os.chdir(self.previous_dir)
 
             OCP.set_kubeconfig(self.kubeconfig)
+            if not config.ENV_DATA["sno"]:
+                timeout = 1800
+                # wait for all nodes to generate CSR
+                # From OCP version 4.4 and above, we have to approve CSR manually
+                # for all the nodes
+                ocp_version = get_ocp_version()
+                if Version.coerce(ocp_version) >= Version.coerce("4.4"):
+                    wait_for_all_nodes_csr_and_approve(timeout=1500, sleep=10)
 
-            # wait for all nodes to generate CSR
-            # From OCP version 4.4 and above, we have to approve CSR manually
-            # for all the nodes
-            ocp_version = get_ocp_version()
-            if Version.coerce(ocp_version) >= Version.coerce("4.4"):
-                wait_for_all_nodes_csr_and_approve(timeout=1500, sleep=10)
+                # wait for image registry to show-up
+                co = "image-registry"
+                wait_for_co(co)
 
-            # wait for image registry to show-up
-            co = "image-registry"
-            wait_for_co(co)
+                # patch image registry to null
+                self.configure_storage_for_image_registry(self.kubeconfig)
 
-            # patch image registry to null
-            self.configure_storage_for_image_registry(self.kubeconfig)
+                # wait for install to complete
+                logger.info("waiting for install to complete")
+                run_cmd(
+                    f"{self.installer} wait-for install-complete "
+                    f"--dir {self.cluster_path} "
+                    f"--log-level {log_cli_level}",
+                    timeout=timeout,
+                )
 
-            # wait for install to complete
-            logger.info("waiting for install to complete")
-            run_cmd(
-                f"{self.installer} wait-for install-complete "
-                f"--dir {self.cluster_path} "
-                f"--log-level {log_cli_level}",
-                timeout=1800,
-            )
-
-            # Approving CSRs here in-case if any exists
-            approve_pending_csr()
+                # Approving CSRs here in-case if any exists
+                approve_pending_csr()
 
             self.test_cluster()
 
@@ -758,6 +1154,8 @@ class VSPHEREUPI(VSPHEREBASE):
         )
 
         clone_openshift_installer()
+        if config.ENV_DATA["sno"]:
+            add_var_folder()
 
         # comment sensitive variable as current terraform version doesn't support
         if version.get_semantic_ocp_version_from_config() >= version.VERSION_4_11:
@@ -846,6 +1244,12 @@ class VSPHEREUPI(VSPHEREBASE):
             terraform.initialize(upgrade=True)
         terraform.destroy(tfvars, refresh=(not self.folder_structure))
         os.chdir(previous_dir)
+
+        # release IPAM ip from sno
+        if config.ENV_DATA["sno"]:
+            ipam = IPAM(appiapp="address")
+            hosts = [f"{constants.SNO_NODE_NAME}.{config.ENV_DATA['cluster_name']}"]
+            ipam.release_ips(hosts)
 
         # post destroy checks
         self.post_destroy_checks()
@@ -1120,9 +1524,22 @@ def clone_openshift_installer():
     ocp_version = get_ocp_version()
     # supporting folder structure from ocp4.5
     if Version.coerce(ocp_version) >= Version.coerce("4.5"):
-        clone_repo(
-            constants.VSPHERE_INSTALLER_REPO, upi_repo_path, f"release-{ocp_version}"
-        )
+        if config.ENV_DATA["sno"]:
+            constants.VSPHERE_INSTALLER_REPO = (
+                "https://github.com/shyRozen/installer.git"
+            )
+            clone_repo(
+                url=constants.VSPHERE_INSTALLER_REPO,
+                location=upi_repo_path,
+                branch="master",
+                clone_type="normal",
+            )
+        else:
+            clone_repo(
+                constants.VSPHERE_INSTALLER_REPO,
+                upi_repo_path,
+                f"release-{ocp_version}",
+            )
     elif Version.coerce(ocp_version) == Version.coerce("4.4"):
         clone_repo(
             constants.VSPHERE_INSTALLER_REPO,
@@ -1310,7 +1727,10 @@ def generate_terraform_vars_and_update_machine_conf():
         # update the machine configurations
         update_machine_conf(folder_structure)
 
-        if Version.coerce(ocp_version) >= Version.coerce("4.5"):
+        if (
+            Version.coerce(ocp_version) >= Version.coerce("4.5")
+            and not config.ENV_DATA["sno"]
+        ):
             modify_haproxyservice()
     else:
         # generate terraform variable file
@@ -1332,21 +1752,22 @@ def generate_terraform_vars_with_folder():
     )
     config.ENV_DATA["cluster_domain"] = cluster_domain
 
-    # Form the ignition paths
-    bootstrap_ignition_path = os.path.join(
-        config.ENV_DATA["cluster_path"], constants.BOOTSTRAP_IGN
-    )
-    control_plane_ignition_path = os.path.join(
-        config.ENV_DATA["cluster_path"], constants.MASTER_IGN
-    )
-    compute_ignition_path = os.path.join(
-        config.ENV_DATA["cluster_path"], constants.WORKER_IGN
-    )
+    if not config.ENV_DATA["sno"]:
+        # Form the ignition paths
+        bootstrap_ignition_path = os.path.join(
+            config.ENV_DATA["cluster_path"], constants.BOOTSTRAP_IGN
+        )
+        control_plane_ignition_path = os.path.join(
+            config.ENV_DATA["cluster_path"], constants.MASTER_IGN
+        )
+        compute_ignition_path = os.path.join(
+            config.ENV_DATA["cluster_path"], constants.WORKER_IGN
+        )
 
-    # Update ignition paths to ENV_DATA
-    config.ENV_DATA["bootstrap_ignition_path"] = bootstrap_ignition_path
-    config.ENV_DATA["control_plane_ignition_path"] = control_plane_ignition_path
-    config.ENV_DATA["compute_ignition_path"] = compute_ignition_path
+        # Update ignition paths to ENV_DATA
+        config.ENV_DATA["bootstrap_ignition_path"] = bootstrap_ignition_path
+        config.ENV_DATA["control_plane_ignition_path"] = control_plane_ignition_path
+        config.ENV_DATA["compute_ignition_path"] = compute_ignition_path
 
     # Copy DNS address to vm_dns_addresses
     config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA["dns"]
@@ -1364,8 +1785,13 @@ def generate_terraform_vars_with_folder():
     # This use-case is mainly used for early RHCOS testing
     if config.ENV_DATA.get("vm_template_overwrite"):
         config.ENV_DATA["vm_template"] = config.ENV_DATA["vm_template_overwrite"]
+    if config.ENV_DATA["sno"]:
+        config.ENV_DATA["iso_file"] = f"ISO/{config.ENV_DATA['cluster_name']}.iso"
+        config.ENV_DATA["vm_template"] = "sno_template1"
 
-    create_terraform_var_file("terraform_4_5.tfvars.j2")
+        create_terraform_var_file("terraform_4_5_sno.tfvars.j2")
+    else:
+        create_terraform_var_file("terraform_4_5.tfvars.j2")
 
 
 def create_terraform_var_file(terraform_var_template):

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -100,6 +100,7 @@ DEPLOYMENT:
   ingress_ssl_cert: "data/ingress-cert.crt"
   ingress_ssl_key: "data/ingress-cert.key"
   ingress_ssl_ca_cert: "data/ca.crt"
+  install_lvmo: False
 
 
 # Section for reporting configuration
@@ -125,6 +126,7 @@ ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
   storage_cluster_name: 'ocs-storagecluster'
   storage_device_sets_name: "storageDeviceSets"
+  sno: false
   cluster_namespace: 'openshift-storage'
   local_storage_namespace: 'openshift-local-storage'
   monitoring_enabled: true

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -122,6 +122,18 @@ def _pytest_addoption_cluster_specific(parser):
             type=int,
             help="OSD size in GB - for 2TB pass 2048, for 0.5TB pass 512 and so on.",
         )
+        parser.addoption(
+            f"--lvmo-disks{suffix}",
+            dest=f"lvmo_disks{suffix}",
+            type=int,
+            help="Number of disks to add to node for LVMO",
+        )
+        parser.addoption(
+            f"--lvmo-disks-size{suffix}",
+            dest=f"lvmo_disks_size{suffix}",
+            type=int,
+            help="Size of the disks to add to lvmo in GB",
+        )
 
 
 def pytest_addoption(parser):
@@ -301,6 +313,15 @@ def pytest_addoption(parser):
         Sets the default index of the cluster whose context needs to be
         loaded when run-ci starts
         """,
+    )
+    parser.addoption(
+        "--install-lvmo",
+        dest="install_lvmo",
+        action="store_true",
+        default=False,
+        help="""
+            set for installing lvmo operator and lvmo cluster
+            """,
     )
 
 
@@ -509,6 +530,19 @@ def process_cluster_cli_params(config):
     ocs_registry_image = get_cli_param(config, f"ocs_registry_image{suffix}")
     if ocs_registry_image:
         ocsci_config.DEPLOYMENT["ocs_registry_image"] = ocs_registry_image
+    install_lvmo = get_cli_param(config, "install_lvmo")
+    if install_lvmo:
+        ocsci_config.DEPLOYMENT["install_lvmo"] = True
+        number_of_disks = get_cli_param(config, "lvmo_disks")
+        if number_of_disks is None:
+            ocsci_config.DEPLOYMENT["lvmo_disks"] = 3
+        else:
+            ocsci_config.DEPLOYMENT["lvmo_disks"] = number_of_disks
+        disk_size = get_cli_param(config, "lvmo_disks_size")
+        if disk_size is None:
+            ocsci_config.DEPLOYMENT["lvmo_disks_size"] = 200
+        else:
+            ocsci_config.DEPLOYMENT["lvmo_disks_size"] = disk_size
     upgrade_ocs_registry_image = get_cli_param(config, "upgrade_ocs_registry_image")
     if upgrade_ocs_registry_image:
         ocsci_config.UPGRADE["upgrade_ocs_registry_image"] = upgrade_ocs_registry_image

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -26,6 +26,7 @@ TEMPLATE_CLEANUP_DIR = os.path.join(TEMPLATE_DIR, "cleanup")
 REPO_DIR = os.path.join(TOP_DIR, "ocs_ci", "repos")
 EXTERNAL_DIR = os.path.join(TOP_DIR, "external")
 TEMPLATE_DEPLOYMENT_DIR = os.path.join(TEMPLATE_DIR, "ocs-deployment")
+TEMPLATE_DEPLOYMENT_DIR_LVMO = os.path.join(TEMPLATE_DIR, "lvmo-deployment")
 TEMPLATE_MULTICLUSTER_DIR = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "multicluster")
 TEMPLATE_CEPH_DIR = os.path.join(TEMPLATE_DIR, "ceph")
 TEMPLATE_CSI_DIR = os.path.join(TEMPLATE_DIR, "CSI")
@@ -820,11 +821,12 @@ AWS_LSO_WORKER_INSTANCE = "i3en.2xlarge"
 BOOTSTRAP_IGN = "bootstrap.ign"
 MASTER_IGN = "master.ign"
 WORKER_IGN = "worker.ign"
+SNO_BOOTSTRAP_IGN = "bootstrap-in-place-for-live-iso.ign"
 
 # terraform provider constants
 TERRAFORM_IGNITION_PROVIDER_VERSION = "v2.1.0"
 
-# Minimum storage needed for vSphere Datastore in bytes
+# Minimum storage needed for vSphere Datastore in bytes.
 MIN_STORAGE_FOR_DATASTORE = 1.1 * 1024**4
 
 # vSphere related constants
@@ -860,6 +862,8 @@ SCALEUP_VSPHERE_ROUTE53_VARIABLES = os.path.join(
 SCALEUP_VSPHERE_MACHINE_CONF = os.path.join(
     SCALEUP_VSPHERE_DIR, "machines/vsphere-rhel-machine.tf"
 )
+RUST_URL = "https://sh.rustup.rs"
+COREOS_INSTALLER_REPO = "https://github.com/coreos/coreos-installer.git"
 
 # v4-scaleup
 CLUSTER_LAUNCHER_VSPHERE_DIR = os.path.join(
@@ -1754,3 +1758,19 @@ SPACE = " "
 
 # Longevity constants
 STAGE_0_NAMESPACE = "ever-running-project"
+# Sno and lvmo constants
+SNO_NODE_NAME = "sno-edge-0"
+LVMO_POD_LABEL = {
+    "410": {
+        "controller_manager_label": "control-plane=controller-manager",
+        "topolvm-controller_label": "app.kubernetes.io/name=topolvm-controller",
+        "topolvm-node_label": "app=topolvm-node",
+        "vg-manager_label": "app=vg-manager",
+    },
+    "411": {
+        "controller_manager_label": "app.kubernetes.io/name=lvm-operator",
+        "topolvm-controller_label": "app.lvm.openshift.io=topolvm-controller",
+        "topolvm-node_label": "app.lvm.openshift.io=topolvm-node",
+        "vg-manager_label": "app.lvm.openshift.io=vg-manager",
+    },
+}

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -522,3 +522,7 @@ class UnsupportedWorkloadError(Exception):
 
 class RebootEventNotFoundException(Exception):
     pass
+
+
+class ConnectivityFail(Exception):
+    pass

--- a/ocs_ci/templates/lvmo-deployment/lvm-bundle.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvm-bundle.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-lvm-operator
+  namespace: openshift-storage
+spec:
+  installPlanApproval: Automatic
+  name: odf-lvm-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ocs_ci/templates/lvmo-deployment/lvm-cluster-410.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvm-cluster-410.yaml
@@ -1,0 +1,9 @@
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1

--- a/ocs_ci/templates/lvmo-deployment/lvm-cluster-411.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvm-cluster-411.yaml
@@ -1,0 +1,12 @@
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      thinPoolConfig:
+        name: thin-pool-1
+        overprovisionRatio: 50

--- a/ocs_ci/templates/lvmo-deployment/lvmo_deployment_10_disk_X_200GB.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvmo_deployment_10_disk_X_200GB.yaml
@@ -1,0 +1,6 @@
+DEPLOYMENT:
+  install_lvmo: True
+  lvmo_disks: 10
+  lvmo_disks_size: 200
+ENV_DATA:
+  skip_ocs_deployment: True

--- a/ocs_ci/templates/lvmo-deployment/lvmo_deployment_3_disk_X_500GB.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvmo_deployment_3_disk_X_500GB.yaml
@@ -1,0 +1,6 @@
+DEPLOYMENT:
+  install_lvmo: True
+  lvmo_disks: 3
+  lvmo_disks_size: 500
+ENV_DATA:
+  skip_ocs_deployment: True

--- a/ocs_ci/templates/lvmo-deployment/lvmo_deployment_5_disk_X_150GB.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvmo_deployment_5_disk_X_150GB.yaml
@@ -1,0 +1,6 @@
+DEPLOYMENT:
+  install_lvmo: True
+  lvmo_disks: 5
+  lvmo_disks_size: 150
+ENV_DATA:
+  skip_ocs_deployment: True

--- a/ocs_ci/templates/ocp-deployment/ens192.nmconnection
+++ b/ocs_ci/templates/ocp-deployment/ens192.nmconnection
@@ -1,0 +1,23 @@
+[connection]
+id="Wired connection 1"
+uuid=d7a375d7-1d57-4d79-9cf6-c66999243a3e
+type=ethernet
+autoconnect-retries=1
+interface-name=ens192
+#multi-connect=1
+permissions=
+
+[ethernet]
+mac-address-blacklist=
+
+[ipv4]
+address=
+dns=
+dns-search=
+method=manual
+
+[ipv6]
+addr-gen-mode=eui64
+dhcp-timeout=90
+dns-search=
+method=auto

--- a/ocs_ci/templates/ocp-deployment/install-config-vsphere-upi-sno.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-vsphere-upi-sno.yaml.j2
@@ -1,0 +1,27 @@
+apiVersion: {{ api_version | default('v1') }}
+baseDomain: {{ base_domain | default('qe.rh-ocs.com') }}
+metadata:
+  name: '{{ cluster_name }}'
+compute:
+- name: worker
+  replicas: 0 
+controlPlane:
+  name: master
+  replicas: 1 
+networking:
+  clusterNetwork:
+    - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
+      hostPrefix: {{ cluster_host_prefix | default(23) }}
+  machineCIDR: '{{ machine_cidr }}'
+  serviceNetwork:
+    - {{ service_network_cidr | default('172.30.0.0/16') }}
+bootstrapInPlace:
+  installationDisk: /dev/sda
+{% if fips %}
+fips: {{ fips }}
+{% endif %}
+platform:
+   none: {}
+pullSecret: ''
+sshKey: |
+  ''

--- a/ocs_ci/templates/ocp-deployment/terraform_4_5_sno.tfvars.j2
+++ b/ocs_ci/templates/ocp-deployment/terraform_4_5_sno.tfvars.j2
@@ -1,0 +1,25 @@
+cluster_id: {{ cluster_name }}
+cluster_domain: {{ cluster_domain }}
+base_domain: {{ base_domain | default('qe.rh-ocs.com') }}
+vsphere_server: {{ vsphere_server }}
+vsphere_user: {{ vsphere_user | default('Administrator@vsphere.local') }}
+vsphere_password: {{ vsphere_password }}
+vsphere_cluster: {{ vsphere_cluster }}
+vsphere_datacenter: {{ vsphere_datacenter }}
+vsphere_datastore: {{ vsphere_datastore }}
+vm_template: {{ vm_template }}
+machine_cidr: {{ machine_cidr }}
+control_plane_count: {{ master_replicas | default(3) }}
+compute_count: {{ worker_replicas | default(3) }}
+ipam: {{ ipam | default('139.178.89.254') }}
+ipam_token: {{ ipam_token }}
+vm_network: {{ vm_network | default('VLAN_172') }}
+control_plane_memory: {{ master_memory | default('16384') }}
+compute_memory: {{ compute_memory | default('16384') }}
+control_plane_num_cpus: {{ master_num_cpus | default('4') }}
+compute_num_cpus: {{ worker_num_cpus | default('12') }}
+vm_dns_addresses: {{ vm_dns_addresses }}
+iso_file: {{ iso_file }}
+ssh_public_key_path: {{ ssh_public_key_path | default('~/.ssh/openshift-dev.pub')}}
+folder: {{ folder }}
+vm_ip_address: {{vm_ip_address}}

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "gevent==20.9.0",
         "reportportal-client==3.2.3",
         "requests==2.23.0",
-        "paramiko==2.10.1",
+        "paramiko==2.11.0",
         "pyyaml>=4.2b1",
         "jinja2==3.0.3",
         "openshift==0.11.2",
@@ -80,6 +80,7 @@ setup(
         "pexpect>=4.8.0",
         # googleapis-common-protos 1.56.2 needs to have protobuf<4.0.0>=3.15.0
         "protobuf==3.20.1",
+        "ping3>=4.0.3",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
SNO and LVMO deployment support both lvmo and ocp/sno 4.10 and 4.11. Use --lvmo-install for lvmo deployment.
--lvmo-disks for number of disk to add for lvmo (default=3) and --lvmo-disks-size for disk size in GB.
For lvmo version use --ocs-version as they are using the same catalogsource.
Please review also SNO terraform file at [https://github.com/shyRozen/installer](https://github.com/shyRozen/installer) . in process to have them merged into openshift/installer github as SNO deployment