### PR TITLE
tox: avoid install or sdist setup for logging env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,9 @@ skipsdist = true
 commands = black . --check
 
 [testenv:logging]
+deps =
+skip_install = true
+skipsdist = true
 whitelist_externals =
     git
     bash


### PR DESCRIPTION
This will prevent tox to install ocs-ci (including dependencies) or
create sdist tarball for testenv:logging, which just performs a source
code check, which doesn't require any of this. This should save us some
small but noticeable time required to run unit tests.