### PR TITLE
Test case adjustment to run on MS

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -191,17 +191,12 @@ class Disruptions:
             node_name (str): Name of node in which the resource daemon is running
 
         """
-        kubeconfig_parameter = (
-            f"--kubeconfig {self.cluster_kubeconfig} "
-            if self.cluster_kubeconfig
-            else ""
-        )
         node_name = node_name or self.resource_obj[0].pod_data.get("spec").get(
             "nodeName"
         )
         awk_print = "'{print $1}'"
         pid_cmd = (
-            f"oc {kubeconfig_parameter}debug node/{node_name} -- chroot /host ps ax | grep"
+            f"oc {self.kubeconfig_parameter()}debug node/{node_name} -- chroot /host ps ax | grep"
             f" ' ceph-{self.resource} --' | grep -v grep | awk {awk_print}"
         )
         try:

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -10,7 +10,6 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
 log = logging.getLogger(__name__)
 
-POD = ocp.OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
 CEPH_PODS = ["mds", "mon", "mgr", "osd"]
 
 
@@ -25,6 +24,9 @@ class Disruptions:
     selector = None
     daemon_pid = None
     cluster_kubeconfig = ""
+    pod_ocp = ocp.OCP(
+        kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
+    )
 
     def kubeconfig_parameter(self):
         """
@@ -56,7 +58,7 @@ class Disruptions:
                 ),
             )
             self.cluster_kubeconfig = provider_kubeconfig
-            POD.cluster_kubeconfig = provider_kubeconfig
+            self.pod_ocp.cluster_kubeconfig = provider_kubeconfig
         resource_count = 0
         if self.resource == "mgr":
             self.resource_obj = pod.get_mgr_pods()
@@ -106,7 +108,7 @@ class Disruptions:
                 resource_id
             ].ocp.cluster_kubeconfig = self.cluster_kubeconfig
         self.resource_obj[resource_id].delete(force=True)
-        assert POD.wait_for_resource(
+        assert self.pod_ocp.wait_for_resource(
             condition="Running",
             selector=self.selector,
             resource_count=self.resource_count,

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -35,7 +35,9 @@ class Disruptions:
                 Empty string if the the attribute 'cluster_kubeconfig' is empty.
         """
         kubeconfig_parameter = (
-            f"--kubeconfig {self.cluster_kubeconfig} " if self.cluster_kubeconfig else ""
+            f"--kubeconfig {self.cluster_kubeconfig} "
+            if self.cluster_kubeconfig
+            else ""
         )
         return kubeconfig_parameter
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -48,6 +48,7 @@ class OCP(object):
         resource_name="",
         selector=None,
         field_selector=None,
+        cluster_kubeconfig_dir="",
     ):
         """
         Initializer function
@@ -61,6 +62,7 @@ class OCP(object):
                 priority than resource_name and is used instead of the name.
             field_selector (str): Selector (field query) to filter on, supports
                 '=', '==', and '!='. (e.g. status.phase=Running)
+            cluster_kubeconfig_dir (str): Path to the cluster kubeconfig file. Useful in a multicluster run
         """
         self._api_version = api_version
         self._kind = kind
@@ -69,6 +71,7 @@ class OCP(object):
         self._data = {}
         self.selector = selector
         self.field_selector = field_selector
+        self.cluster_kubeconfig = cluster_kubeconfig_dir
 
     @property
     def api_version(self):
@@ -130,8 +133,12 @@ class OCP(object):
         """
         oc_cmd = "oc "
         env_kubeconfig = os.getenv("KUBECONFIG")
-        if not env_kubeconfig or not os.path.exists(env_kubeconfig):
-            cluster_dir_kubeconfig = os.path.join(
+        kubeconfig_path = (
+            self.cluster_kubeconfig if os.path.exists(self.cluster_kubeconfig) else None
+        )
+
+        if kubeconfig_path or not env_kubeconfig or not os.path.exists(env_kubeconfig):
+            cluster_dir_kubeconfig = kubeconfig_path or os.path.join(
                 config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
             )
             if os.path.exists(cluster_dir_kubeconfig):

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -48,7 +48,7 @@ class OCP(object):
         resource_name="",
         selector=None,
         field_selector=None,
-        cluster_kubeconfig_dir="",
+        cluster_kubeconfig="",
     ):
         """
         Initializer function
@@ -62,7 +62,7 @@ class OCP(object):
                 priority than resource_name and is used instead of the name.
             field_selector (str): Selector (field query) to filter on, supports
                 '=', '==', and '!='. (e.g. status.phase=Running)
-            cluster_kubeconfig_dir (str): Path to the cluster kubeconfig file. Useful in a multicluster run
+            cluster_kubeconfig (str): Path to the cluster kubeconfig file. Useful in a multicluster configuration
         """
         self._api_version = api_version
         self._kind = kind
@@ -71,7 +71,7 @@ class OCP(object):
         self._data = {}
         self.selector = selector
         self.field_selector = field_selector
-        self.cluster_kubeconfig = cluster_kubeconfig_dir
+        self.cluster_kubeconfig = cluster_kubeconfig
 
     @property
     def api_version(self):

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4c,
     ignore_leftover_label,
+    skipif_ms_consumer,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
@@ -29,6 +30,7 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4c
+@skipif_ms_consumer
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -195,7 +195,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         """
         # If the platform is Managed Services, then the ceph pods will be present in the provider cluster.
         # Consumer cluster will be the primary cluster. Switching to provider cluster is required to get ceph pods
-        switch_to_provier_needed = (
+        switch_to_provider_needed = (
             True
             if (
                 config.ENV_DATA["platform"].lower()
@@ -210,7 +210,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         proj_obj = pvc_objs[0].project
         storageclass = pvc_objs[0].storageclass
 
-        if switch_to_provier_needed:
+        if switch_to_provider_needed:
             # Switch to provider cluster context to get ceph pods
             config.switch_to_provider()
 
@@ -234,7 +234,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Get number of pods of type 'resource_to_delete'
         initial_pods_num = len(pod_functions[resource_to_delete]())
 
-        if switch_to_provier_needed:
+        if switch_to_provider_needed:
             # Switch back to consumer cluster context to access PVCs and pods
             config.switch_to_consumer(self.consumer_cluster_index)
 
@@ -358,7 +358,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         for pod_obj in all_pod_objs:
             pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
 
-        if switch_to_provier_needed:
+        if switch_to_provider_needed:
             # Switch to provider cluster context to get ceph pods
             config.switch_to_provider()
 
@@ -371,7 +371,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
             f"{final_pods_num}"
         )
 
-        if switch_to_provier_needed:
+        if switch_to_provider_needed:
             # Switch back to consumer cluster context
             config.switch_to_consumer(self.consumer_cluster_index)
 

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -8,7 +8,6 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4c,
     ignore_leftover_label,
-    skipif_managed_service,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
@@ -23,13 +22,13 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers import helpers, disruption_helpers
+from ocs_ci.framework import config
 
 log = logging.getLogger(__name__)
 
 
 @tier4
 @tier4c
-@skipif_managed_service
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],
@@ -94,10 +93,21 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
     pvc_size = 5
 
     @pytest.fixture()
-    def setup(self, interface, multi_pvc_factory, pod_factory):
+    def setup(self, request, interface, multi_pvc_factory, pod_factory):
         """
         Create PVCs and pods
         """
+        if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
+            # Get the index of current consumer cluster
+            self.consumer_cluster_index = config.cur_index
+
+            def teardown():
+                # Switching to provider cluster context will be done during the test case.
+                # Switch back to consumer cluster context after the test case.
+                config.switch_to_consumer(self.consumer_cluster_index)
+
+            request.addfinalizer(teardown)
+
         access_modes = [constants.ACCESS_MODE_RWO]
         if interface == constants.CEPHFILESYSTEM:
             access_modes.append(constants.ACCESS_MODE_RWX)
@@ -183,10 +193,26 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         Delete resource 'resource_to_delete' while PVCs creation, Pods
         creation and IO operation are progressing.
         """
+        # If the platform is Managed Services, then the ceph pods will be present in the provider cluster.
+        # Consumer cluster will be the primary cluster. Switching to provider cluster is required to get ceph pods
+        switch_to_provier_needed = (
+            True
+            if (
+                config.ENV_DATA["platform"].lower()
+                in constants.MANAGED_SERVICE_PLATFORMS
+            )
+            and (resource_to_delete in ["mds", "mon", "mgr", "osd"])
+            else False
+        )
+
         num_of_new_pvcs = 5
         pvc_objs, io_pods, pvc_objs_new_pods, access_modes = setup
         proj_obj = pvc_objs[0].project
         storageclass = pvc_objs[0].storageclass
+
+        if switch_to_provier_needed:
+            # Switch to provider cluster context to get ceph pods
+            config.switch_to_provider()
 
         pod_functions = {
             "mds": partial(get_mds_pods),
@@ -207,6 +233,10 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         # Get number of pods of type 'resource_to_delete'
         initial_pods_num = len(pod_functions[resource_to_delete]())
+
+        if switch_to_provier_needed:
+            # Switch back to consumer cluster context to access PVCs and pods
+            config.switch_to_consumer(self.consumer_cluster_index)
 
         # Do setup for running IO on pods
         log.info("Setting up pods for running IO")
@@ -328,6 +358,10 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         for pod_obj in all_pod_objs:
             pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
 
+        if switch_to_provier_needed:
+            # Switch to provider cluster context to get ceph pods
+            config.switch_to_provider()
+
         # Verify number of 'resource_to_delete' type pods
         final_pods_num = len(pod_functions[resource_to_delete]())
         assert final_pods_num == initial_pods_num, (
@@ -336,6 +370,10 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
             f"{initial_pods_num}. Total number of pods present now: "
             f"{final_pods_num}"
         )
+
+        if switch_to_provier_needed:
+            # Switch back to consumer cluster context
+            config.switch_to_consumer(self.consumer_cluster_index)
 
         # Verify volumes are unmapped from nodes after deleting the pods
         node_pv_mounted = helpers.verify_pv_mounted_on_node(node_pv_dict)


### PR DESCRIPTION
Update the test case given below to run on Managed Services platform. Switching between provider and consumer cluster is added because ceph pods will be present in the provider cluster only.
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py::TestResourceDeletionDuringCreationOperations::test_resource_deletion_during_pvc_pod_creation_and_io

Signed-off-by: Jilju Joy <jijoy@redhat.com>