### PR TITLE
Skip the testcase test_rbd_space_reclaim on External mode cluster

### DIFF
--- a/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     polarion_id,
     skipif_managed_service,
+    skipif_external_mode,
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -51,6 +52,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
     @polarion_id("OCS-2741")
     @tier1
+    @skipif_external_mode
     @skipif_managed_service
     def test_rbd_space_reclaim(self):
         """


### PR DESCRIPTION
The test case is skipped on External mode cluster because the test case creates new CephBlockPool.
Fixes: #5712 
Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>