### PR TITLE
Run the node managed service tests with cephfs workload

### DIFF
--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -25,6 +25,7 @@ class LogReaderWriterParallel(object):
     """
     This procedure in the test was originally created in the file
     'tests/e2e/workloads/test_data_consistency.py'. I just rearranged it in a class.
+
     Write and read logfile stored on cephfs volume, from all worker nodes of a
     cluster via k8s Deployment, while fetching content of the stored data via
     oc rsync to check the data locally.
@@ -75,6 +76,10 @@ class LogReaderWriterParallel(object):
         """
         Write and read logfile stored on cephfs volume, from all worker nodes of a
         cluster via k8s Deployment.
+
+        Raise:
+            NotFoundError: When given volume is not found in given spec
+            UnexpectedBehaviour: When an unexpected problem with starting the workload occurred
 
         """
 
@@ -140,6 +145,10 @@ class LogReaderWriterParallel(object):
         """
         while the workload is running, we will try to fetch and validate data
         from the cephfs volume of the workload.
+
+        Raise:
+            NotFoundError: When the given volume is not found in given spec
+            Exception: When the data verification job failed
 
         """
         # if no obvious problem was detected, run the logreader job to validate

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -77,7 +77,8 @@ class LogReaderWriterParallel(object):
         Raise:
             NotFoundError: When given volume is not found in given spec
             UnexpectedBehaviour: When an unexpected problem with starting the workload occurred, or when
-                an unexpected problem with linking the deployment with the PVC occurred.
+            an unexpected problem with linking the deployment with the PVC occurred.
+
         """
 
         # get deployment dict for the reproducer logwriter workload

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -1,0 +1,209 @@
+# -*- coding: utf8 -*-
+
+import logging
+import yaml
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs import exceptions
+from ocs_ci.ocs import ocp
+from ocs_ci.ocs.fio_artefacts import get_pvc_dict
+from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.ocs.resources import job
+from ocs_ci.ocs.resources import topology
+from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile, link_spec_volume
+from ocs_ci.utility.utils import update_container_with_mirrored_image
+from ocs_ci.helpers.helpers import storagecluster_independent_check
+
+
+logger = logging.getLogger(__name__)
+
+
+class LogReaderWriterParallel(object):
+
+    """
+    This procedure in the test was originally created in the file
+    'tests/e2e/workloads/test_data_consistency.py'. I just rearranged it in a class.
+    This is a temporary solution until the issue https://github.com/red-hat-storage/ocs-ci/issues/5724
+    will be completed.
+
+    Write and read logfile stored on cephfs volume, from all worker nodes of a
+    cluster via k8s Deployment, while fetching content of the stored data via
+    oc rsync to check the data locally.
+
+    """
+
+    def __init__(
+        self,
+        project,
+        tmp_path,
+        storage_size=2,
+    ):
+        """
+        Init of the LogReaderWriterParallel object
+
+        Args:
+            project (pytest fixture): The project fixture.
+            tmp_path (pytest fixture): The tmp_path fixture.
+            storage_size (str): The size of the storage in GB. The default value is 2 GB.
+
+        """
+        self.project = project
+        self.tmp_path = tmp_path
+
+        self.pvc_dict = get_pvc_dict()
+        # we need to mount the volume on every worker node, so RWX/cephfs
+        self.pvc_dict["metadata"]["name"] = "logwriter-cephfs-many"
+        self.pvc_dict["spec"]["accessModes"] = [constants.ACCESS_MODE_RWX]
+        if storagecluster_independent_check():
+            sc_name = constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_CEPHFS
+        else:
+            sc_name = constants.CEPHFILESYSTEM_SC
+        logger.info(f"Storage class name = {sc_name}")
+        self.pvc_dict["spec"]["storageClassName"] = sc_name
+        self.pvc_dict["spec"]["resources"]["requests"]["storage"] = f"{storage_size}Gi"
+
+        self.deploy_dict = {}
+        self.workload_file = None
+        self.ocp_pod = None
+
+        self.local_dir = self.tmp_path / "logwriter"
+        self.local_dir.mkdir()
+
+    def log_reader_writer_parallel(self):
+        """
+        Write and read logfile stored on cephfs volume, from all worker nodes of a
+        cluster via k8s Deployment.
+
+        """
+
+        # get deployment dict for the reproducer logwriter workload
+        with open(constants.LOGWRITER_CEPHFS_REPRODUCER, "r") as deployment_file:
+            self.deploy_dict = yaml.safe_load(deployment_file.read())
+        # if we are running in disconnected environment, we need to mirror the
+        # container image first, and then use the mirror instead of the original
+        if config.DEPLOYMENT.get("disconnected"):
+            update_container_with_mirrored_image(self.deploy_dict["spec"]["template"])
+        # we need to match deployment replicas with number of worker nodes
+        self.deploy_dict["spec"]["replicas"] = len(get_worker_nodes())
+        # drop topology spread constraints related to zones
+        topology.drop_topology_constraint(
+            self.deploy_dict["spec"]["template"]["spec"], topology.ZONE_LABEL
+        )
+        # and link the deployment with the pvc
+        try:
+            link_spec_volume(
+                self.deploy_dict["spec"]["template"]["spec"],
+                "logwriter-cephfs-volume",
+                self.pvc_dict["metadata"]["name"],
+            )
+        except Exception as ex:
+            error_msg = (
+                "LOGWRITER_CEPHFS_REPRODUCER no longer matches code of this test"
+            )
+            raise Exception(error_msg) from ex
+
+        # prepare k8s yaml file for deployment
+        self.workload_file = ObjectConfFile(
+            "log_reader_writer_parallel",
+            [self.pvc_dict, self.deploy_dict],
+            self.project,
+            self.tmp_path,
+        )
+        # deploy the workload, starting the log reader/writer pods
+        logger.info(
+            "starting log reader/writer workload via Deployment, one pod per worker"
+        )
+        self.workload_file.create()
+
+        logger.info("waiting for all pods of the workload Deployment to run")
+        self.ocp_pod = ocp.OCP(kind="Pod", namespace=self.project.namespace)
+        try:
+            self.ocp_pod.wait_for_resource(
+                resource_count=self.deploy_dict["spec"]["replicas"],
+                condition=constants.STATUS_RUNNING,
+                error_condition=constants.STATUS_ERROR,
+                timeout=300,
+                sleep=30,
+            )
+        except Exception as ex:
+            # this is not a problem with feature under test, but with infra,
+            # cluster configuration or unrelated bug which must have happened
+            # before this test case
+            error_msg = "unexpected problem with start of the workload, cluster is either misconfigured or broken"
+            logger.exception(error_msg)
+            logger.debug(self.workload_file.describe())
+            raise exceptions.UnexpectedBehaviour(error_msg) from ex
+
+    def fetch_and_validate_data(self):
+        """
+        while the workload is running, we will try to fetch and validate data
+        from the cephfs volume of the workload 'number_of_fetches' times.
+
+        """
+        # if no obvious problem was detected, run the logreader job to validate
+        # checksums in the log files (so that we are 100% sure that nothing went
+        # wrong with the IO or the data)
+        with open(constants.LOGWRITER_CEPHFS_READER, "r") as job_file:
+            job_dict = yaml.safe_load(job_file.read())
+        # if we are running in disconnected environment, we need to mirror the
+        # container image first, and then use the mirror instead of the original
+        if config.DEPLOYMENT.get("disconnected"):
+            update_container_with_mirrored_image(self.deploy_dict["spec"]["template"])
+        # drop topology spread constraints related to zones
+        topology.drop_topology_constraint(
+            job_dict["spec"]["template"]["spec"], topology.ZONE_LABEL
+        )
+        # we need to match number of jobs with the number used in the workload
+        job_dict["spec"]["completions"] = self.deploy_dict["spec"]["replicas"]
+        job_dict["spec"]["parallelism"] = self.deploy_dict["spec"]["replicas"]
+        # and reffer to the correct pvc name
+        try:
+            link_spec_volume(
+                job_dict["spec"]["template"]["spec"],
+                "logwriter-cephfs-volume",
+                self.pvc_dict["metadata"]["name"],
+            )
+        except Exception as ex:
+            error_msg = "LOGWRITER_CEPHFS_READER no longer matches code of this test"
+            raise Exception(error_msg) from ex
+        # prepare k8s yaml file for the job
+        job_file = ObjectConfFile("log_reader", [job_dict], self.project, self.tmp_path)
+        # deploy the job, starting the log reader pods
+        logger.info(
+            "starting log reader data validation job to fully check the log data",
+        )
+        job_file.create()
+        # wait for the logreader job to complete (this should be rather quick)
+        try:
+            job.wait_for_job_completion(
+                job_name=job_dict["metadata"]["name"],
+                namespace=self.project.namespace,
+                timeout=300,
+                sleep_time=30,
+            )
+        except exceptions.TimeoutExpiredError:
+            error_msg = (
+                "verification failed to complete in time: data loss or broken cluster?"
+            )
+            logger.exception(error_msg)
+        # and then check that the job completed with success
+        logger.info("checking the result of data validation job")
+        logger.debug(job_file.describe())
+        ocp_job = ocp.OCP(
+            kind="Job",
+            namespace=self.project.namespace,
+            resource_name=job_dict["metadata"]["name"],
+        )
+        job_status = ocp_job.get()["status"]
+        logger.info("last status of data verification job: %s", job_status)
+        if (
+            "failed" in job_status
+            or job_status["succeeded"] != self.deploy_dict["spec"]["replicas"]
+        ):
+            error_msg = "possible data corruption: data verification job failed!"
+            logger.error(error_msg)
+            job.log_output_of_job_pods(
+                job_name=job_dict["metadata"]["name"], namespace=self.project.namespace
+            )
+            raise Exception(error_msg)

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -14,6 +14,7 @@ from ocs_ci.ocs.resources import topology
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile, link_spec_volume
 from ocs_ci.utility.utils import update_container_with_mirrored_image
 from ocs_ci.helpers.helpers import storagecluster_independent_check
+from ocs_ci.ocs.cluster import is_managed_service_cluster
 
 
 logger = logging.getLogger(__name__)
@@ -24,12 +25,12 @@ class LogReaderWriterParallel(object):
     """
     This procedure in the test was originally created in the file
     'tests/e2e/workloads/test_data_consistency.py'. I just rearranged it in a class.
-    This is a temporary solution until the issue https://github.com/red-hat-storage/ocs-ci/issues/5724
-    will be completed.
-
     Write and read logfile stored on cephfs volume, from all worker nodes of a
     cluster via k8s Deployment, while fetching content of the stored data via
     oc rsync to check the data locally.
+
+    TO DO: Update the test after the issue https://github.com/red-hat-storage/ocs-ci/issues/5724
+    will be completed.
 
     """
 
@@ -55,7 +56,7 @@ class LogReaderWriterParallel(object):
         # we need to mount the volume on every worker node, so RWX/cephfs
         self.pvc_dict["metadata"]["name"] = "logwriter-cephfs-many"
         self.pvc_dict["spec"]["accessModes"] = [constants.ACCESS_MODE_RWX]
-        if storagecluster_independent_check():
+        if storagecluster_independent_check() and not is_managed_service_cluster():
             sc_name = constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_CEPHFS
         else:
             sc_name = constants.CEPHFILESYSTEM_SC
@@ -138,7 +139,7 @@ class LogReaderWriterParallel(object):
     def fetch_and_validate_data(self):
         """
         while the workload is running, we will try to fetch and validate data
-        from the cephfs volume of the workload 'number_of_fetches' times.
+        from the cephfs volume of the workload.
 
         """
         # if no obvious problem was detected, run the logreader job to validate

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -23,9 +23,6 @@ logger = logging.getLogger(__name__)
 class LogReaderWriterParallel(object):
 
     """
-    This procedure in the test was originally created in the file
-    'tests/e2e/workloads/test_data_consistency.py'. I just rearranged it in a class.
-
     Write and read logfile stored on cephfs volume, from all worker nodes of a
     cluster via k8s Deployment, while fetching content of the stored data via
     oc rsync to check the data locally.
@@ -143,7 +140,7 @@ class LogReaderWriterParallel(object):
 
     def fetch_and_validate_data(self):
         """
-        while the workload is running, we will try to fetch and validate data
+        While the workload is running, try to validate the data
         from the cephfs volume of the workload.
 
         Raise:

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -76,8 +76,7 @@ class LogReaderWriterParallel(object):
 
         Raise:
             NotFoundError: When given volume is not found in given spec
-            UnexpectedBehaviour: When an unexpected problem with starting the workload occurred, or when
-            an unexpected problem with linking the deployment with the PVC occurred.
+            UnexpectedBehaviour: When an unexpected problem with starting the workload occurred
 
         """
 
@@ -101,15 +100,12 @@ class LogReaderWriterParallel(object):
                 "logwriter-cephfs-volume",
                 self.pvc_dict["metadata"]["name"],
             )
-        except exceptions.NotFoundError as ex:
-            raise ex
-        except Exception as ex:
-            error_msg = (
+        except (exceptions.NotFoundError, KeyError) as ex:
+            logger.warning(
                 "Failed to link the deployment with the pvc. We may need to check if the "
                 "LOGWRITER_CEPHFS_REPRODUCER still matches the code of this test"
             )
-            logger.exception(error_msg)
-            raise exceptions.UnexpectedBehaviour(error_msg) from ex
+            raise ex
 
         # prepare k8s yaml file for deployment
         self.workload_file = ObjectConfFile(
@@ -150,7 +146,6 @@ class LogReaderWriterParallel(object):
 
         Raise:
             NotFoundError: When the given volume is not found in given spec
-            UnexpectedBehaviour: When an unexpected problem with linking the deployment with the PVC occurred
             Exception: When the data verification job failed
 
         """
@@ -177,15 +172,13 @@ class LogReaderWriterParallel(object):
                 "logwriter-cephfs-volume",
                 self.pvc_dict["metadata"]["name"],
             )
-        except exceptions.NotFoundError as ex:
-            raise ex
-        except Exception as ex:
-            error_msg = (
+        except (exceptions.NotFoundError, KeyError) as ex:
+            logger.warning(
                 "Failed to link the deployment with the pvc. We may need to check if the "
                 "LOGWRITER_CEPHFS_REPRODUCER still matches the code of this test"
             )
-            logger.exception(error_msg)
-            raise exceptions.UnexpectedBehaviour(error_msg) from ex
+            raise ex
+
         # prepare k8s yaml file for the job
         job_file = ObjectConfFile("log_reader", [job_dict], self.project, self.tmp_path)
         # deploy the job, starting the log reader pods

--- a/ocs_ci/ocs/cephfs_workload.py
+++ b/ocs_ci/ocs/cephfs_workload.py
@@ -190,10 +190,8 @@ class LogReaderWriterParallel(object):
                 sleep_time=30,
             )
         except exceptions.TimeoutExpiredError:
-            error_msg = (
-                "verification failed to complete in time: data loss or broken cluster?"
-            )
-            logger.exception(error_msg)
+            error_msg = "verification failed to complete in time: probably data loss or broken cluster"
+            raise Exception(error_msg)
         # and then check that the job completed with success
         logger.info("checking the result of data validation job")
         logger.debug(job_file.describe())

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2319,3 +2319,31 @@ def wait_for_nodes_racks_or_zones(failure_domain, node_names, timeout=120):
         if all(nodes_racks_or_zones):
             log.info("All the nodes racks or zones exist!")
             break
+
+
+def wait_for_new_worker_node_ipi(machineset, old_wnodes, timeout=900):
+    """
+    Wait for the new worker node to be ready
+
+    Args:
+        machineset (str): The machineset name
+        old_wnodes (list): The old worker nodes
+        timeout (int): Time to wait for the new worker node to be ready.
+
+    Returns:
+        ocs_ci.ocs.resources.ocs.OCS: The new worker node object
+
+    Raise:
+        ResourceWrongStatusException: In case the new spun machine fails to reach Ready state
+            or replica count didn't match. Or in case one or more nodes haven't reached
+            the desired state.
+
+    """
+    machine.wait_for_new_node_to_be_ready(machineset, timeout=timeout)
+    new_wnode_names = list(set(get_worker_nodes()) - set(old_wnodes))
+    new_wnode = get_node_objs(new_wnode_names)[0]
+    log.info(f"Successfully created a new node {new_wnode.name}")
+
+    wait_for_nodes_status([new_wnode.name])
+    log.info(f"The new worker node {new_wnode.name} is in a Ready state!")
+    return new_wnode

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2388,6 +2388,21 @@ def get_pod_ip(pod_obj):
 
 
 def wait_for_osd_pods_having_ids(osd_ids, timeout=180, sleep=10):
+    """
+    Wait for the osd pods having specific ids
+
+    Args:
+        osd_ids (list): The list of the osd ids
+        timeout (int): Time to wait for the osd pods having the specified ids
+        sleep (int): Time in seconds to sleep between attempts
+
+    Returns:
+        list: The osd pods having the specified ids
+
+    Raise:
+        TimeoutExpiredError: In case it didn't find all the osd pods with the specified ids
+
+    """
     for osd_pods in TimeoutSampler(
         timeout=timeout,
         sleep=sleep,

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2385,3 +2385,15 @@ def get_pod_ip(pod_obj):
 
     """
     return pod_obj.get().get("status").get("podIP")
+
+
+def wait_for_osd_pods_having_ids(osd_ids, timeout=180, sleep=10):
+    for osd_pods in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_osd_pods_having_ids,
+        osd_ids=osd_ids,
+    ):
+        if len(osd_pods) == len(osd_ids):
+            logger.info(f"Found all the osd pods with the ids: {osd_ids}")
+            return osd_pods

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -6,7 +6,6 @@ from ocs_ci.framework.testlib import (
     tier4b,
     ManageTest,
     managed_service_required,
-    skipif_ms_consumer,
     ignore_leftovers,
 )
 
@@ -29,14 +28,15 @@ from ocs_ci.ocs.node import (
     get_node_osd_ids,
     wait_for_nodes_status,
     recover_node_to_ready_state,
-    get_ocs_nodes,
     get_node_rook_ceph_pod_names,
     verify_worker_nodes_security_groups,
     wait_for_osd_ids_come_up_on_node,
     unschedule_nodes,
     schedule_nodes,
+    wait_for_new_worker_node_ipi,
 )
 from ocs_ci.ocs.cephfs_workload import LogReaderWriterParallel
+from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 
 log = logging.getLogger(__name__)
 
@@ -60,25 +60,6 @@ def get_node_pod_names_expected_to_terminate(node_name):
     ]
 
 
-def get_all_pod_names_expected_to_terminate():
-    """
-    Get the pod names of all the ocs nodes, that expected to be in a Terminating state
-
-    Returns:
-         list: list of the pod names of all the ocs nodes, that expected to be in a Terminating state
-
-    """
-    ocs_nodes = get_ocs_nodes()
-    ocs_node_names = [n.name for n in ocs_nodes]
-    pod_names_expected_to_terminate = []
-    for node_name in ocs_node_names:
-        pod_names_expected_to_terminate.extend(
-            get_node_pod_names_expected_to_terminate(node_name)
-        )
-
-    return pod_names_expected_to_terminate
-
-
 def check_automated_recovery_from_stopped_node(nodes):
     """
     1) Stop node.
@@ -87,8 +68,15 @@ def check_automated_recovery_from_stopped_node(nodes):
     4) The new osd pods with the same ids should start on the stopped node after it powered on.
 
     """
+    old_wnodes = get_worker_nodes()
+    log.info(f"start worker nodes: {old_wnodes}")
+
     osd_node_name = random.choice(get_osd_running_nodes())
     osd_node = get_node_objs([osd_node_name])[0]
+
+    machine_name = machine.get_machine_from_node_name(osd_node_name)
+    machineset = machine.get_machineset_from_machine_name(machine_name)
+    log.info(f"machineset name: {machineset}")
 
     old_osd_pod_ids = get_node_osd_ids(osd_node_name)
     log.info(f"osd pod ids: {old_osd_pod_ids}")
@@ -106,15 +94,19 @@ def check_automated_recovery_from_stopped_node(nodes):
     )
     assert res, "Not all the node rook ceph pods are in a Terminating state"
 
-    # This is a workaround until we find what should be the behavior
-    # when shutting down a worker node
-    nodes.start_nodes(nodes=[osd_node])
+    try:
+        log.info(f"Wait for the node: {osd_node_name} to power on")
+        wait_for_nodes_status([osd_node_name])
+        log.info(f"Successfully powered on node {osd_node_name}")
+    except ResourceWrongStatusException as e:
+        log.info(
+            f"The worker node {osd_node_name} didn't start due to the exception {str(e)} "
+            f"Probably it has been removed from the cluster. Waiting for a new node to come up..."
+        )
+        new_wnode = wait_for_new_worker_node_ipi(machineset, old_wnodes)
+        osd_node_name = new_wnode.name
 
-    log.info(f"Wait for the node: {osd_node_name} to power on")
-    wait_for_nodes_status([osd_node_name])
-    log.info(f"Successfully powered on node {osd_node_name}")
-
-    assert wait_for_osd_ids_come_up_on_node(osd_node_name, old_osd_pod_ids)
+    assert wait_for_osd_ids_come_up_on_node(osd_node_name, old_osd_pod_ids, timeout=300)
     log.info(
         f"the osd ids {old_osd_pod_ids} Successfully come up on the node {osd_node_name}"
     )
@@ -131,16 +123,14 @@ def check_automated_recovery_from_terminated_node(nodes):
     old_wnodes = get_worker_nodes()
     log.info(f"start worker nodes: {old_wnodes}")
 
-    old_osd_node_names = get_osd_running_nodes()
-    old_osd_nodes = get_node_objs(old_osd_node_names)
-    osd_node = random.choice(old_osd_nodes)
-    log.info(f"osd node name: {osd_node.name}")
+    osd_node_name = random.choice(get_osd_running_nodes())
+    osd_node = get_node_objs([osd_node_name])[0]
 
-    machine_name = machine.get_machine_from_node_name(osd_node.name)
+    machine_name = machine.get_machine_from_node_name(osd_node_name)
     machineset = machine.get_machineset_from_machine_name(machine_name)
     log.info(f"machineset name: {machineset}")
 
-    old_osd_pod_ids = get_node_osd_ids(osd_node.name)
+    old_osd_pod_ids = get_node_osd_ids(osd_node_name)
     log.info(f"osd pod ids: {old_osd_pod_ids}")
 
     pod_names_expected_to_terminate = get_node_pod_names_expected_to_terminate(
@@ -148,7 +138,7 @@ def check_automated_recovery_from_terminated_node(nodes):
     )
 
     nodes.terminate_nodes([osd_node], wait=True)
-    log.info(f"Successfully terminated the node: {osd_node.name}")
+    log.info(f"Successfully terminated the node: {osd_node_name}")
 
     log.info("Verify the node rook ceph pods go into a Terminating state")
     res = wait_for_pods_to_be_in_statuses(
@@ -156,17 +146,11 @@ def check_automated_recovery_from_terminated_node(nodes):
     )
     assert res, "Not all the node rook ceph pods are in a Terminating state"
 
-    machine.wait_for_new_node_to_be_ready(machineset, timeout=900)
-    new_wnode_names = list(set(get_worker_nodes()) - set(old_wnodes))
-    new_wnode = get_node_objs(new_wnode_names)[0]
-    log.info(f"Successfully created a new node {new_wnode.name}")
-
-    wait_for_nodes_status([new_wnode.name])
-    log.info(f"The new worker node {new_wnode.name} is in a Ready state!")
+    new_wnode = wait_for_new_worker_node_ipi(machineset, old_wnodes)
 
     wait_for_osd_ids_come_up_on_node(new_wnode.name, old_osd_pod_ids, timeout=300)
     log.info(
-        f"the osd ids {old_osd_pod_ids} Successfully come up on the node {osd_node.name}"
+        f"the osd ids {old_osd_pod_ids} Successfully come up on the node {new_wnode.name}"
     )
 
 
@@ -221,59 +205,7 @@ FAILURE_TYPE_FUNC_CALL_DICT = {
 @ignore_leftovers
 @tier4b
 @managed_service_required
-@skipif_ms_consumer
 class TestAutomatedRecoveryFromFailedNodeReactiveMS(ManageTest):
-    @pytest.fixture(autouse=True)
-    def teardown(self, request, nodes):
-        def finalizer():
-            log.info("Verify that all the worker nodes are in a Ready state")
-            wnodes = get_nodes(node_type=constants.WORKER_MACHINE)
-            for wnode in wnodes:
-                is_recovered = recover_node_to_ready_state(wnode)
-                if not is_recovered:
-                    log.warning(f"The node {wnode.name} has failed to recover")
-
-            log.info("Verify again that the ceph health is OK")
-            ceph_health_check()
-
-        request.addfinalizer(finalizer)
-
-    @pytest.mark.parametrize(
-        argnames=["failure"],
-        argvalues=[
-            pytest.param("stopped_node"),
-            pytest.param("terminate_node"),
-            pytest.param("drain_node"),
-        ],
-    )
-    def test_automated_recovery_from_failed_nodes_reactive_ms(
-        self,
-        nodes,
-        failure,
-    ):
-        """
-        We have 3 test cases to check:
-            A) Automated recovery from stopped worker node
-            B) Automated recovery from termination of a worker node
-            C) Automated recovery from unschedule and reschedule a worker node.
-        """
-        log.info("Start executing the node test function on the provider...")
-        FAILURE_TYPE_FUNC_CALL_DICT[failure](nodes)
-
-        # Verification steps after the automated recovery.
-        assert check_pods_after_node_replacement(), "Not all the pods are running"
-        assert (
-            verify_worker_nodes_security_groups()
-        ), "Not all the worker nodes security groups set correctly"
-
-        log.info("Checking that the ceph health is ok")
-        ceph_health_check()
-
-
-@ignore_leftovers
-@tier4b
-@managed_service_required
-class TestAutomatedRecoveryFromFailedNodeReactiveMSWithIO(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request, nodes):
         def finalizer():
@@ -304,7 +236,7 @@ class TestAutomatedRecoveryFromFailedNodeReactiveMSWithIO(ManageTest):
             pytest.param("drain_node"),
         ],
     )
-    def test_automated_recovery_from_failed_nodes_reactive_ms_with_io(
+    def test_automated_recovery_from_failed_nodes_reactive_ms(
         self,
         nodes,
         failure,

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -64,12 +64,14 @@ def check_automated_recovery_from_stopped_node(nodes):
     """
     1) Stop node.
     2) The rook ceph pods associated with the node should change to a Terminating state.
-    3) The node should power on automatically.
-    4) The new osd pods with the same ids should start on the stopped node after it powered on.
+    3) The node should power on automatically, or if removed from the cluster,
+       a new node should create automatically.
+    4) The new osd pods with the same ids should start on the stopped node after it powered on,
+       or to start on the new osd node.
 
     """
     old_wnodes = get_worker_nodes()
-    log.info(f"start worker nodes: {old_wnodes}")
+    log.info(f"Current worker nodes: {old_wnodes}")
 
     osd_node_name = random.choice(get_osd_running_nodes())
     osd_node = get_node_objs([osd_node_name])[0]
@@ -121,7 +123,7 @@ def check_automated_recovery_from_terminated_node(nodes):
 
     """
     old_wnodes = get_worker_nodes()
-    log.info(f"start worker nodes: {old_wnodes}")
+    log.info(f"Current worker nodes: {old_wnodes}")
 
     osd_node_name = random.choice(get_osd_running_nodes())
     osd_node = get_node_objs([osd_node_name])[0]

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -14,6 +14,9 @@ from ocs_ci.ocs import machine, constants
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_in_statuses,
     check_pods_after_node_replacement,
+    get_osd_pods_having_ids,
+    delete_pods,
+    wait_for_osd_pods_having_ids,
 )
 from ocs_ci.utility.utils import ceph_health_check
 
@@ -26,11 +29,11 @@ from ocs_ci.ocs.node import (
     wait_for_nodes_status,
     recover_node_to_ready_state,
     get_ocs_nodes,
-    get_osd_ids_per_node,
     get_node_rook_ceph_pod_names,
     verify_worker_nodes_security_groups,
     wait_for_osd_ids_come_up_on_node,
-    wait_for_all_osd_ids_come_up_on_nodes,
+    unschedule_nodes,
+    schedule_nodes,
 )
 
 log = logging.getLogger(__name__)
@@ -165,45 +168,51 @@ def check_automated_recovery_from_terminated_node(nodes):
     )
 
 
-def check_automated_recovery_from_full_cluster_shutdown(nodes):
+def check_automated_recovery_from_drain_node(nodes):
     """
-    1) Stop all the worker nodes.
-    2) The rook ceph pods associated with the osd nodes should change to a Terminating state.
-    3) The worker nodes should be powered on automatically.
-    4) The new osd pods with the same ids should start on the same worker nodes.
+    1) Drain one worker node.
+    2) Delete the OSD pods associated with the node.
+    3) The new OSD pods with the same ids that come up, should be in a Pending state.
+    4) Schedule the worker node.
+    5) The OSD pods associated with the node, should back into a Running state, and come up
+        on the same node.
 
     """
-    old_osd_ids_per_node = get_osd_ids_per_node()
-    log.info(f"old osd ids per node: {old_osd_ids_per_node}")
+    osd_node_name = random.choice(get_osd_running_nodes())
+    old_osd_pod_ids = get_node_osd_ids(osd_node_name)
+    log.info(f"osd pod ids: {old_osd_pod_ids}")
+    node_osd_pods = get_osd_pods_having_ids(old_osd_pod_ids)
 
-    wnode_names = get_worker_nodes()
-    wnodes = get_node_objs(wnode_names)
+    unschedule_nodes([osd_node_name])
+    log.info(f"Successfully unschedule the node: {osd_node_name}")
 
-    pod_names_expected_to_terminate = get_all_pod_names_expected_to_terminate()
+    log.info("Delete the node osd pods")
+    delete_pods(node_osd_pods)
 
-    nodes.stop_nodes(wnodes)
-    log.info(f"Successfully stopped the worker nodes: {wnode_names}")
-
+    new_osd_pods = wait_for_osd_pods_having_ids(osd_ids=old_osd_pod_ids)
+    new_osd_pod_names = [p.name for p in new_osd_pods]
+    log.info(f"Verify the new osd pods {new_osd_pod_names} go into a Pending state")
     res = wait_for_pods_to_be_in_statuses(
-        [constants.STATUS_TERMINATING], pod_names_expected_to_terminate
+        [constants.STATUS_PENDING],
+        new_osd_pod_names,
+        raise_pod_not_found_error=True,
     )
-    assert res, "Not all the rook ceph pods are in a Terminating state"
+    assert res, "Not all the node osd pods are in a Pending state"
 
-    # This is a workaround until we find what should be the behavior
-    # when shutting down a worker node
-    nodes.start_nodes(nodes=wnodes)
+    log.info(f"Wait for the node: {osd_node_name} to be scheduled")
+    schedule_nodes([osd_node_name])
+    log.info(f"Successfully scheduled the node {osd_node_name}")
 
-    wait_for_nodes_status(wnode_names, timeout=360)
-    log.info("All the worker nodes are in a Ready state!")
-
-    assert wait_for_all_osd_ids_come_up_on_nodes(old_osd_ids_per_node)
-    log.info("The osd ids successfully come up on the osd nodes")
+    assert wait_for_osd_ids_come_up_on_node(osd_node_name, old_osd_pod_ids)
+    log.info(
+        f"the osd ids {old_osd_pod_ids} Successfully come up on the node {osd_node_name}"
+    )
 
 
 FAILURE_TYPE_FUNC_CALL_DICT = {
     "stopped_node": check_automated_recovery_from_stopped_node,
     "terminate_node": check_automated_recovery_from_terminated_node,
-    "full_cluster_shutdown": check_automated_recovery_from_full_cluster_shutdown,
+    "drain_node": check_automated_recovery_from_drain_node,
 }
 
 
@@ -232,7 +241,7 @@ class TestAutomatedRecoveryFromFailedNodeReactiveMS(ManageTest):
         argvalues=[
             pytest.param("stopped_node"),
             pytest.param("terminate_node"),
-            pytest.param("full_cluster_shutdown"),
+            pytest.param("drain_node"),
         ],
     )
     def test_automated_recovery_from_failed_nodes_reactive_ms(
@@ -244,7 +253,7 @@ class TestAutomatedRecoveryFromFailedNodeReactiveMS(ManageTest):
         We have 3 test cases to check:
             A) Automated recovery from stopped worker node
             B) Automated recovery from termination of a worker node
-            C) Automated recovery from full cluster shutdown
+            C) Automated recovery from unschedule and reschedule a worker node.
         """
         log.info("Start executing the node test function on the provider...")
         FAILURE_TYPE_FUNC_CALL_DICT[failure](nodes)


### PR DESCRIPTION
The tests are only for the managed service platform when using provider and consumer.

We test 3 node scenarios on the provider cluster while on the consumer cluster - writing and reading logfile stored on cephfs volume, from all worker nodes of a cluster via k8s Deployment.
The 3 node scenarios are:

- Automated recovery from stopped worker node
- Automated recovery from termination of a worker node
- Automated recovery from unscheduled and rescheduled a worker node.

If we dive into more details, the flow is:

1. writing and reading logfile stored on cephfs volume, from all worker nodes of a cluster via k8s Deployment on the consumer cluster.
2. Start one of the node scenario tests described above on the provider.
3. Check that the OCS pods are running and the worker node's security groups are set correctly on the provider cluster.
4. fetch and validate data from the cephfs volume of the workload on the consumer cluster.
