### PR TITLE
Patch rook-ceph-tools deployment on consumer

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -16,7 +16,7 @@ from ocs_ci.utility.aws import AWS as AWSUtil
 from ocs_ci.utility.utils import ceph_health_check, get_ocp_version
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.ocs.managedservice import update_pull_secret
+from ocs_ci.ocs.managedservice import update_pull_secret, patch_consumer_toolbox
 from ocs_ci.ocs.resources import pvc
 
 logger = logging.getLogger(name=__file__)
@@ -165,6 +165,8 @@ class ROSA(CloudDeploymentBase):
         )
         if config.DEPLOYMENT.get("pullsecret_workaround"):
             update_pull_secret()
+        if config.ENV_DATA.get("cluster_type") == "consumer":
+            patch_consumer_toolbox()
 
         # Verify health of ceph cluster
         ceph_health_check(namespace=self.namespace, tries=60, delay=10)

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -147,22 +147,25 @@ class ROSA(CloudDeploymentBase):
             logger.info("Running OCS basic installation")
         rosa.install_odf_addon(self.cluster_name)
         pod = ocp.OCP(kind=constants.POD, namespace=self.namespace)
-        # Check for Ceph pods
-        assert pod.wait_for_resource(
-            condition="Running",
-            selector="app=rook-ceph-mon",
-            resource_count=3,
-            timeout=600,
-        )
-        assert pod.wait_for_resource(
-            condition="Running", selector="app=rook-ceph-mgr", timeout=600
-        )
-        assert pod.wait_for_resource(
-            condition="Running",
-            selector="app=rook-ceph-osd",
-            resource_count=3,
-            timeout=600,
-        )
+
+        if config.ENV_DATA.get("cluster_type") != "consumer":
+            # Check for Ceph pods
+            assert pod.wait_for_resource(
+                condition="Running",
+                selector="app=rook-ceph-mon",
+                resource_count=3,
+                timeout=600,
+            )
+            assert pod.wait_for_resource(
+                condition="Running", selector="app=rook-ceph-mgr", timeout=600
+            )
+            assert pod.wait_for_resource(
+                condition="Running",
+                selector="app=rook-ceph-osd",
+                resource_count=3,
+                timeout=600,
+            )
+
         if config.DEPLOYMENT.get("pullsecret_workaround"):
             update_pull_secret()
         if config.ENV_DATA.get("cluster_type") == "consumer":

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -152,16 +152,16 @@ class ROSA(CloudDeploymentBase):
             # Check for Ceph pods
             assert pod.wait_for_resource(
                 condition="Running",
-                selector="app=rook-ceph-mon",
+                selector=constants.MON_APP_LABEL,
                 resource_count=3,
                 timeout=600,
             )
             assert pod.wait_for_resource(
-                condition="Running", selector="app=rook-ceph-mgr", timeout=600
+                condition="Running", selector=constants.MGR_APP_LABEL, timeout=600
             )
             assert pod.wait_for_resource(
                 condition="Running",
-                selector="app=rook-ceph-osd",
+                selector=constants.OSD_APP_LABEL,
                 resource_count=3,
                 timeout=600,
             )

--- a/ocs_ci/ocs/managedservice.py
+++ b/ocs_ci/ocs/managedservice.py
@@ -151,7 +151,7 @@ def patch_consumer_toolbox(ceph_admin_key=None):
     except Exception as exe:
         logger.warning(
             "Failed to patch rook-ceph-tools deployment in consumer cluster. "
-            f"The can be done manually after deployment. Error {str(exe)}"
+            f"The patch can be applied manually after deployment. Error {str(exe)}"
         )
         return
 

--- a/ocs_ci/ocs/managedservice.py
+++ b/ocs_ci/ocs/managedservice.py
@@ -1,10 +1,13 @@
 import base64
 import json
 import logging
+import os
 import tempfile
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults, ocp
+from ocs_ci.helpers import helpers
+from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_pods_having_label, Pod
 from ocs_ci.utility.utils import exec_cmd
 
 
@@ -93,3 +96,72 @@ def get_consumer_names():
     )
     consumer_yamls = consumer.get().get("items")
     return [consumer["metadata"]["name"] for consumer in consumer_yamls]
+
+
+def patch_consumer_toolbox(ceph_admin_key=None):
+    """
+    Patch the rook-ceph-tools deployment with ceph.admin key. Applicable for MS platform only to enable rook-ceph-tools
+    to run ceph commands.
+
+    Args:
+        ceph_admin_key (str): The ceph admin key which should be used to patch rook-ceph-tools deployment on consumer
+
+    """
+
+    # Get the admin key if available
+    ceph_admin_key = (
+        ceph_admin_key
+        or os.environ.get("CEPHADMINKEY")
+        or config.AUTH.get("external", {}).get("ceph_admin_key")
+    )
+
+    if not ceph_admin_key:
+        # TODO: Get the key from provider rook-ceph-tools pod after implementing multicluster deployment
+        logger.warning(
+            "Ceph admin key not found to patch rook-ceph-tools deployment on consumer with ceph.admin key. "
+            "Skipping the step."
+        )
+        return
+
+    consumer_tools_pod = get_ceph_tools_pod()
+
+    # Check whether ceph command is working on tools pod. Patch is needed only if the error is "RADOS permission error"
+    try:
+        consumer_tools_pod.exec_ceph_cmd("ceph health")
+    except Exception as exc:
+        if "RADOS permission error" not in str(exc):
+            logger.warning(
+                f"Ceph command on rook-ceph-tools deployment is failing with error {str(exc)}. "
+                "This error cannot be fixed by patching the rook-ceph-tools deployment with ceph admin key."
+            )
+            return
+
+    consumer_tools_deployment = ocp.OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+        resource_name="rook-ceph-tools",
+    )
+    patch_value = (
+        f'[{{"op": "replace", "path": "/spec/template/spec/containers/0/env", '
+        f'"value":[{{"name": "ROOK_CEPH_USERNAME", "value": "client.admin"}}, '
+        f'{{"name": "ROOK_CEPH_SECRET", "value": "{ceph_admin_key}"}}]}}]'
+    )
+    try:
+        consumer_tools_deployment.patch(params=patch_value, format_type="json")
+    except Exception as exe:
+        logger.warning(
+            "Failed to patch rook-ceph-tools deployment in consumer cluster. "
+            f"The can be done manually after deployment. Error {str(exe)}"
+        )
+        return
+
+    # Wait for the existing tools pod to delete
+    consumer_tools_pod.ocp.wait_for_delete(resource_name=consumer_tools_pod.name)
+
+    # Wait for the new tools pod to reach Running state
+    new_tools_pod_info = get_pods_having_label(
+        label=constants.TOOL_APP_LABEL,
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+    )[0]
+    new_tools_pod = Pod(**new_tools_pod_info)
+    helpers.wait_for_resource_state(new_tools_pod, constants.STATUS_RUNNING)

--- a/ocs_ci/ocs/managedservice.py
+++ b/ocs_ci/ocs/managedservice.py
@@ -128,6 +128,7 @@ def patch_consumer_toolbox(ceph_admin_key=None):
     # Check whether ceph command is working on tools pod. Patch is needed only if the error is "RADOS permission error"
     try:
         consumer_tools_pod.exec_ceph_cmd("ceph health")
+        return
     except Exception as exc:
         if "RADOS permission error" not in str(exc):
             logger.warning(


### PR DESCRIPTION
Patch rook-ceph-tools deployment on consumer to run ceph commands. The patch is done after deployment.
Signed-off-by: Jilju Joy <jijoy@redhat.com>