### PR TITLE
fix remove_rhcos_workers function

### DIFF
--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -648,7 +648,7 @@ class AWSUPI(AWSBase):
         for node in rhcos_workers:
             cordon = f"oc adm cordon {node}"
             run_cmd(cordon)
-            drain_nodes(node)
+            drain_nodes([node])
             delete = f"oc delete nodes {node}"
             run_cmd(delete)
         if len(self.get_rhcos_workers()):


### PR DESCRIPTION
Pass list of nodes to drain_nodes function.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/5760

Signed-off-by: Daniel Horak <dahorak@redhat.com>