### PR TITLE
Fix marker in test_resource_deletion_during_pvc_pod_creation_and_io

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4c,
     ignore_leftover_label,
-    skipif_ms_consumer,
+    skipif_ms_provider,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 @tier4
 @tier4c
-@skipif_ms_consumer
+@skipif_ms_provider
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],


### PR DESCRIPTION
The marker 'skipif_ms_consumer' is not appropriate for the test test_resource_deletion_during_pvc_pod_creation_and_io. Changing it to 'skipif_ms_provider'.
Signed-off-by: Jilju Joy <jijoy@redhat.com>