### PR TITLE
Update default size to 20 Tib

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -206,7 +206,7 @@ ENV_DATA:
   deploy_acm_hub_cluster: false
 
   #Managed service - Managed StorageCluster size in TiB
-  size: '4'
+  size: '20'
 
 # This section is related to upgrade
 UPGRADE:


### PR DESCRIPTION
Now in managed service provider add-on of stagging and production
the only available storage cluster size is 20 TiB .

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>