### PR TITLE
skip mcg-operator check for ODF 4.9 with live deployment 

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -659,6 +659,9 @@ class Deployment(object):
                 ocs_operator_names.append(defaults.MCG_OPERATOR)
             else:
                 ocs_operator_names.append(defaults.NOOBAA_OPERATOR)
+            # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2075422
+            if live_deployment and ocs_version == version.VERSION_4_9:
+                ocs_operator_names.remove(defaults.MCG_OPERATOR)
         else:
             ocs_operator_names = [defaults.OCS_OPERATOR_NAME]
 


### PR DESCRIPTION
skip mcg-operator check for ODF 4.9 with live deployment 
due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2075422

Signed-off-by: vavuthu <vavuthu@redhat.com>