### PR TITLE
Add support to take consumer onboarding ticket from custom config

### DIFF
--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -250,7 +250,9 @@ def install_odf_addon(cluster):
         unit = config.ENV_DATA.get("unit", "Ti")
         storage_provider_endpoint = get_storage_provider_endpoint(provider_name)
         cmd += f' --unit "{unit}" --storage-provider-endpoint "{storage_provider_endpoint}"'
-        onboarding_ticket = generate_onboarding_token()
+        onboarding_ticket = config.DEPLOYMENT.get("onboarding_ticket", "")
+        if not onboarding_ticket:
+            onboarding_ticket = generate_onboarding_token()
         if onboarding_ticket:
             cmd += f' --onboarding-ticket "{onboarding_ticket}"'
         else:


### PR DESCRIPTION
This will fix issue #5802
The onboarding ticket input required for consumer addon install should be customizable.
Currently, it is autogenerated from the saved private key. However for covering a few cases such as
1. passing invalid onboarding key test case
2. To support consumer creation on the provider which is not created from Jenkins job
(Example Created a provider using an appliance model with different private and public keys)

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>