### PR TITLE
Added skip test marker in "test_nodes_maintenance.py" and "test_disk_failures.py" for external mode clusters

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -187,3 +187,4 @@ class SanityExternalCluster(Sanity):
         self.pod_objs = list()
         self.obc_objs = list()
         self.ceph_cluster = CephClusterExternal()
+        self.ceph_cluster_external = CephClusterExternal()

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -7,6 +7,7 @@ from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs.resources.pvc import delete_pvcs
 from ocs_ci.helpers import helpers
+from ocs_ci.helpers.helpers import storagecluster_independent_check
 from ocs_ci.ocs.bucket_utils import s3_delete_object, s3_get_object, s3_put_object
 from ocs_ci.helpers.pvc_ops import create_pvcs
 from ocs_ci.utility.utils import ceph_health_check
@@ -31,6 +32,7 @@ class Sanity:
         self.obc_objs = list()
         self.obj_data = ""
         self.ceph_cluster = CephCluster()
+        self.ceph_cluster_external = CephClusterExternal()
 
     def health_check(self, cluster_check=True, tries=20):
         """
@@ -44,7 +46,9 @@ class Sanity:
             ceph_health_check(
                 namespace=config.ENV_DATA["cluster_namespace"], tries=tries
             )
-            if cluster_check:
+            if cluster_check and storagecluster_independent_check:
+                self.ceph_cluster_external.cluster_health_check(timeout=60)
+            elif cluster_check:
                 self.ceph_cluster.cluster_health_check(timeout=60)
 
     def create_resources(

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -187,4 +187,3 @@ class SanityExternalCluster(Sanity):
         self.pod_objs = list()
         self.obc_objs = list()
         self.ceph_cluster = CephClusterExternal()
-        self.ceph_cluster_external = CephClusterExternal()

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -135,6 +135,8 @@ class Pod(OCS):
         Raises:
             Exception: In case of exception from FIO
         """
+        if helpers.storagecluster_independent_check:
+            timeout = 1800
         logger.info(f"Waiting for FIO results from pod {self.name}")
         try:
             result = self.fio_thread.result(timeout)

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -204,9 +204,9 @@ class TestDiskFailures(ManageTest):
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
         )
 
+    @skipif_external_mode
     @bugzilla("1830702")
     @vsphere_platform_required
-    @skipif_external_mode
     @pytest.mark.polarion_id("OCS-2172")
     def test_recovery_from_volume_deletion(
         self, nodes, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -10,8 +10,8 @@ from ocs_ci.framework.testlib import (
     cloud_platform_required,
     vsphere_platform_required,
     bugzilla,
-    skipif_ibm_cloud,
     skipif_external_mode,
+    skipif_ibm_cloud,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import (

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     vsphere_platform_required,
     bugzilla,
     skipif_ibm_cloud,
+    skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import (
@@ -205,6 +206,7 @@ class TestDiskFailures(ManageTest):
 
     @bugzilla("1830702")
     @vsphere_platform_required
+    @skipif_external_mode
     @pytest.mark.polarion_id("OCS-2172")
     def test_recovery_from_volume_deletion(
         self, nodes, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -438,10 +438,10 @@ class TestNodesMaintenance(ManageTest):
         # Perform cluster and Ceph health checks
         self.sanity_helpers.health_check()
 
+    @skipif_external_mode
     @bugzilla("1861104")
     @bugzilla("1946573")
     @pytest.mark.polarion_id("OCS-2524")
-    @skipif_external_mode
     @tier4a
     def test_pdb_check_simultaneous_node_drains(
         self,

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -17,8 +17,8 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
-    add_new_node_and_label_it,
     skipif_external_mode,
+    add_new_node_and_label_it,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework.testlib import (

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs.node import (
     get_osd_running_nodes,
     get_node_objs,
     add_new_node_and_label_it,
+    skipif_external_mode,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework.testlib import (
@@ -440,6 +441,7 @@ class TestNodesMaintenance(ManageTest):
     @bugzilla("1861104")
     @bugzilla("1946573")
     @pytest.mark.polarion_id("OCS-2524")
+    @skipif_external_mode
     @tier4a
     def test_pdb_check_simultaneous_node_drains(
         self,

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -17,7 +17,6 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
-    skipif_external_mode,
     add_new_node_and_label_it,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
@@ -32,6 +31,7 @@ from ocs_ci.framework.testlib import (
     ipi_deployment_required,
     skipif_bm,
     bugzilla,
+    skipif_external_mode,
     skipif_managed_service,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -64,7 +64,14 @@ class TestNodesRestart(ManageTest):
         ],
     )
     def test_nodes_restart(
-        self, nodes, pvc_factory, pod_factory, force, bucket_factory, rgw_bucket_factory, timeout =300
+        self,
+        nodes,
+        pvc_factory,
+        pod_factory,
+        force,
+        bucket_factory,
+        rgw_bucket_factory,
+        timeout=300,
     ):
         """
         Test nodes restart (from the platform layer, i.e, EC2 instances, VMWare VMs)
@@ -75,9 +82,7 @@ class TestNodesRestart(ManageTest):
         while True:
             nodes.restart_nodes_by_stop_and_start(nodes=ocp_nodes, force=force)
             if timeout < (time.time() - start_time):
-                msg = (
-                    f"Timeout when waiting for nodes to restart "
-                )
+                msg = "Timeout when waiting for nodes to restart"
                 raise TimeoutError(msg)
         self.sanity_helpers.health_check()
         self.sanity_helpers.create_resources(

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 
 from ocs_ci.framework.testlib import (
@@ -71,6 +72,7 @@ class TestNodesRestart(ManageTest):
         """
         ocp_nodes = get_node_objs()
         nodes.restart_nodes_by_stop_and_start(nodes=ocp_nodes, force=force)
+        time.sleep(300)
         self.sanity_helpers.health_check()
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory


### PR DESCRIPTION

These tests need to be skipped for external mode cluster as per https://github.com/red-hat-storage/ocs-ci/issues/5720