### PR TITLE
fix cluster health check for MS Consumer cluster

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -248,6 +248,15 @@ class CephCluster(object):
 
         if not sample.wait_for_func_status(result=True):
             raise exceptions.CephHealthException("Cluster health is NOT OK")
+        # This way of checking health of different cluster entities and
+        # raising only CephHealthException is not elegant.
+        # TODO: add an attribute in CephHealthException, called "reason"
+        # which should tell because of which exact cluster entity health
+        # is not ok ?
+        expected_mon_count = self.mon_count
+        expected_mds_count = self.mds_count
+
+        self.scan_cluster()
 
         if (
             config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS
@@ -267,15 +276,6 @@ class CephCluster(object):
                 )
             return True
 
-        # This way of checking health of different cluster entities and
-        # raising only CephHealthException is not elegant.
-        # TODO: add an attribute in CephHealthException, called "reason"
-        # which should tell because of which exact cluster entity health
-        # is not ok ?
-        expected_mon_count = self.mon_count
-        expected_mds_count = self.mds_count
-
-        self.scan_cluster()
         try:
             self.mon_health_check(expected_mon_count)
         except exceptions.MonCountException as e:

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -248,6 +248,25 @@ class CephCluster(object):
 
         if not sample.wait_for_func_status(result=True):
             raise exceptions.CephHealthException("Cluster health is NOT OK")
+
+        if (
+            config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS
+            and config.ENV_DATA["cluster_type"] == "consumer"
+        ):
+            # on Managed Service Consumer cluster, check that there are no
+            # extra Ceph pods
+            mon_pods = pod.get_mon_pods()
+            if mon_pods:
+                raise exceptions.CephHealthException(
+                    "Managed Service Consumer cluster shouldn't have any mon pods!"
+                )
+            mds_pods = pod.get_mds_pods()
+            if mds_pods:
+                raise exceptions.CephHealthException(
+                    "Managed Service Consumer cluster shouldn't have any mds pods!"
+                )
+            return True
+
         # This way of checking health of different cluster entities and
         # raising only CephHealthException is not elegant.
         # TODO: add an attribute in CephHealthException, called "reason"

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -269,6 +269,11 @@ class CephCluster(object):
                 raise exceptions.CephHealthException(
                     "Managed Service Consumer cluster shouldn't have any mon pods!"
                 )
+            osd_pods = pod.get_osd_pods()
+            if osd_pods:
+                raise exceptions.CephHealthException(
+                    "Managed Service Consumer cluster shouldn't have any osd pods!"
+                )
             mds_pods = pod.get_mds_pods()
             if mds_pods:
                 raise exceptions.CephHealthException(


### PR DESCRIPTION
There shouldn't be no extra ceph pods on Managed Service Consumer cluster.

Without this change, the Consumer cluster deployment is failing during post deployment checks on this issue https://github.com/red-hat-storage/ocs-ci/issues/5827.

Signed-off-by: Daniel Horak <dahorak@redhat.com>