### PR TITLE
Managed Service pod disruption test

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -125,6 +125,9 @@ class Disruptions:
         if self.resource == "prometheus_operator":
             self.resource_obj = [pod.get_prometheus_operator_pod()]
             self.selector = constants.PROMETHEUS_OPERATOR_LABEL
+        if self.resource == "ocs_provider_server":
+            self.resource_obj = [pod.get_ocs_provider_server_pod()]
+            self.selector = constants.PROVIDER_SERVER_LABEL
 
         self.resource_count = resource_count or len(self.resource_obj)
 

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -103,6 +103,28 @@ class Disruptions:
         if self.resource == "operator":
             self.resource_obj = pod.get_operator_pods()
             self.selector = constants.OPERATOR_LABEL
+        if self.resource == "ocs_operator":
+            self.resource_obj = [pod.get_ocs_operator_pod()]
+            self.selector = constants.OCS_OPERATOR_LABEL
+        if self.resource == "alertmanager_managed_ocs_alertmanager":
+            self.resource_obj = pod.get_alertmanager_managed_ocs_alertmanager_pods()
+            self.selector = constants.MANAGED_ALERTMANAGER_LABEL
+        if self.resource == "ocs_osd_controller_manager":
+            self.resource_obj = [pod.get_ocs_osd_controller_manager_pod()]
+            self.selector = constants.MANAGED_CONTROLLER_LABEL
+            # Setting resource_count because odf-operator-controller-manager pod also have the same label.
+            resource_count = len(
+                pod.get_pods_having_label(
+                    constants.MANAGED_CONTROLLER_LABEL,
+                    config.ENV_DATA["cluster_namespace"],
+                )
+            )
+        if self.resource == "prometheus_managed_ocs_prometheus":
+            self.resource_obj = [pod.get_prometheus_managed_ocs_prometheus_pod()]
+            self.selector = constants.MANAGED_PROMETHEUS_LABEL
+        if self.resource == "prometheus_operator":
+            self.resource_obj = [pod.get_prometheus_operator_pod()]
+            self.selector = constants.PROMETHEUS_OPERATOR_LABEL
 
         self.resource_count = resource_count or len(self.resource_obj)
 

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -231,6 +231,7 @@ def create_pod(
         elif (
             pod_dict_path == constants.NGINX_POD_YAML
             or pod_dict == constants.CSI_RBD_POD_YAML
+            or pod_dict == constants.PERF_POD_YAML
         ):
             temp_dict = [
                 {

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -309,6 +309,7 @@ MANAGED_PROMETHEUS_LABEL = "prometheus=managed-ocs-prometheus"
 MANAGED_ALERTMANAGER_LABEL = "alertmanager=managed-ocs-alertmanager"
 MANAGED_CONTROLLER_LABEL = "control-plane=controller-manager"
 PROVIDER_SERVER_LABEL = "app=ocsProviderApiServer"
+PROMETHEUS_OPERATOR_LABEL = "app.kubernetes.io/name=prometheus-operator"
 
 # Noobaa Deployments and Statefulsets
 NOOBAA_OPERATOR_DEPLOYMENT = "noobaa-operator"

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -71,11 +71,7 @@ class OCP(object):
         self._data = {}
         self.selector = selector
         self.field_selector = field_selector
-        # Setting cluster_kubeconfig to current cluster if not specified
-        self.cluster_kubeconfig = cluster_kubeconfig or os.path.join(
-            config.clusters[config.cur_index].ENV_DATA["cluster_path"],
-            config.clusters[config.cur_index].RUN.get("kubeconfig_location"),
-        )
+        self.cluster_kubeconfig = cluster_kubeconfig
 
     @property
     def api_version(self):

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -71,7 +71,11 @@ class OCP(object):
         self._data = {}
         self.selector = selector
         self.field_selector = field_selector
-        self.cluster_kubeconfig = cluster_kubeconfig
+        # Setting cluster_kubeconfig to current cluster if not specified
+        self.cluster_kubeconfig = cluster_kubeconfig or os.path.join(
+            config.clusters[config.cur_index].ENV_DATA["cluster_path"],
+            config.clusters[config.cur_index].RUN.get("kubeconfig_location"),
+        )
 
     @property
     def api_version(self):

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -86,8 +86,10 @@ class OCS(object):
         After creating a resource from a yaml file, the actual yaml file is
         being changed and more information about the resource is added.
         """
+        cluster_kubeconfig = self.ocp.cluster_kubeconfig
         self.data = self.get()
         self.__init__(**self.data)
+        self.ocp.cluster_kubeconfig = cluster_kubeconfig
 
     def get(self, out_yaml_format=True):
         return self.ocp.get(resource_name=self.name, out_yaml_format=out_yaml_format)

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -271,13 +271,14 @@ class Pod(OCS):
             .get("mountPath")
         )
 
-    def workload_setup(self, storage_type, jobs=1):
+    def workload_setup(self, storage_type, jobs=1, fio_installed=False):
         """
         Do setup on pod for running FIO
 
         Args:
             storage_type (str): 'fs' or 'block'
             jobs (int): Number of jobs to execute FIO
+            fio_installed (bool): True if fio is already installed on the pod
         """
         work_load = "fio"
         name = f"test_workload_{work_load}"
@@ -285,7 +286,8 @@ class Pod(OCS):
         # few io parameters for Fio
 
         self.wl_obj = workload.WorkLoad(name, path, work_load, storage_type, self, jobs)
-        assert self.wl_obj.setup(), f"Setup for FIO failed on pod {self.name}"
+        if not (fio_installed and work_load == "fio"):
+            assert self.wl_obj.setup(), f"Setup for FIO failed on pod {self.name}"
         self.wl_setup_done = True
 
     def run_io(
@@ -308,6 +310,7 @@ class Pod(OCS):
         readwrite=None,
         direct=0,
         verify=False,
+        fio_installed=False,
     ):
         """
         Execute FIO on a pod
@@ -343,10 +346,13 @@ class Pod(OCS):
             readwrite (str): Type of I/O pattern default is randrw from yaml
             direct(int): If value is 1, use non-buffered I/O. This is usually O_DIRECT. Fio default is 0.
             verify (bool): This method verifies file contents after each iteration of the job. e.g. crc32c, md5
+            fio_installed (bool): True if fio is already installed on the pod
 
         """
         if not self.wl_setup_done:
-            self.workload_setup(storage_type=storage_type, jobs=jobs)
+            self.workload_setup(
+                storage_type=storage_type, jobs=jobs, fio_installed=fio_installed
+            )
 
         if io_direction == "rw":
             self.io_params = templating.load_yaml(constants.FIO_IO_RW_PARAMS_YAML)
@@ -697,6 +703,90 @@ def get_ocs_operator_pod(ocs_label=constants.OCS_OPERATOR_LABEL, namespace=None)
     ocs_operator = get_pods_having_label(ocs_label, namespace)
     ocs_operator_pod = Pod(**ocs_operator[0])
     return ocs_operator_pod
+
+
+def get_alertmanager_managed_ocs_alertmanager_pods(
+    label=constants.MANAGED_ALERTMANAGER_LABEL, namespace=None
+):
+    """
+    Get alertmanager-managed-ocs-alertmanager pods in the cluster
+
+    Args:
+        label (str): Label associated with alertmanager-managed-ocs-alertmanager pods
+        namespace (str): Namespace in which alertmanager-managed-ocs-alertmanager pods are residing
+
+    Returns:
+        list: Pod objects of alertmanager-managed-ocs-alertmanager pods
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    alertmanager_managed_pods = get_pods_having_label(label, namespace)
+    return [
+        Pod(**alertmanager_managed)
+        for alertmanager_managed in alertmanager_managed_pods
+    ]
+
+
+def get_ocs_osd_controller_manager_pod(
+    label=constants.MANAGED_CONTROLLER_LABEL, namespace=None
+):
+    """
+    Get ocs-osd-controller-manager pod in the cluster
+
+    Args:
+        label (str): Label associated with ocs-osd-controller-manager pod
+        namespace (str): Namespace in which ocs-osd-controller-manager pod is residing
+
+    Returns:
+        Pod: Pod objects of ocs-osd-controller-manager pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    # odf-operator-controller-manager pod also have the same label. Select ocs-osd-controller-manager pod only.
+    controller_manager_pods = [
+        controller_manager
+        for controller_manager in get_pods_having_label(label, namespace)
+        if "ocs-osd-controller-manager" in controller_manager["metadata"]["name"]
+    ]
+    return Pod(**controller_manager_pods[0])
+
+
+def get_prometheus_managed_ocs_prometheus_pod(
+    label=constants.MANAGED_PROMETHEUS_LABEL, namespace=None
+):
+    """
+    Get prometheus-managed-ocs-prometheus pod in the cluster
+
+    Args:
+        label (str): Label associated with prometheus-managed-ocs-prometheus pod
+        namespace (str): Namespace in which prometheus-managed-ocs-prometheus pod is residing
+
+    Returns:
+        Pod: Pod objects of prometheus-managed-ocs-prometheus pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    prometheus_managed_ocs_prometheus = get_pods_having_label(label, namespace)
+    return Pod(**prometheus_managed_ocs_prometheus[0])
+
+
+def get_prometheus_operator_pod(
+    label=constants.PROMETHEUS_OPERATOR_LABEL, namespace=None
+):
+    """
+    Get prometheus-operator pod in the cluster
+
+    Args:
+        label (str): Label associated with prometheus-operator pod
+        namespace (str): Namespace in which prometheus-operator pod is residing
+
+    Returns:
+        Pod: Pod objects of prometheus-operator pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    prometheus_operator = get_pods_having_label(label, namespace)
+    return Pod(**prometheus_operator[0])
 
 
 def list_ceph_images(pool_name="rbd"):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -738,7 +738,7 @@ def get_ocs_osd_controller_manager_pod(
         namespace (str): Namespace in which ocs-osd-controller-manager pod is residing
 
     Returns:
-        Pod: Pod objects of ocs-osd-controller-manager pod
+        Pod: Pod object of ocs-osd-controller-manager pod
 
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
@@ -762,7 +762,7 @@ def get_prometheus_managed_ocs_prometheus_pod(
         namespace (str): Namespace in which prometheus-managed-ocs-prometheus pod is residing
 
     Returns:
-        Pod: Pod objects of prometheus-managed-ocs-prometheus pod
+        Pod: Pod object of prometheus-managed-ocs-prometheus pod
 
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
@@ -781,12 +781,29 @@ def get_prometheus_operator_pod(
         namespace (str): Namespace in which prometheus-operator pod is residing
 
     Returns:
-        Pod: Pod objects of prometheus-operator pod
+        Pod: Pod object of prometheus-operator pod
 
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     prometheus_operator = get_pods_having_label(label, namespace)
     return Pod(**prometheus_operator[0])
+
+
+def get_ocs_provider_server_pod(label=constants.PROVIDER_SERVER_LABEL, namespace=None):
+    """
+    Get ocs-provider-server pod in the cluster
+
+    Args:
+        label (str): Label associated with ocs-provider-server pod
+        namespace (str): Namespace in which ocs-provider-server pod is residing
+
+    Returns:
+        Pod: Pod object of ocs-provider-server pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    ocs_provider_server = get_pods_having_label(label, namespace)
+    return Pod(**ocs_provider_server[0])
 
 
 def list_ceph_images(pool_name="rbd"):

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -78,6 +78,7 @@ class PVC(OCS):
         data["kind"] = "PersistentVolume"
         data["metadata"] = {"name": self.backed_pv, "namespace": self.namespace}
         pv_obj = OCS(**data)
+        pv_obj.ocp.cluster_kubeconfig = self.ocp.cluster_kubeconfig
         pv_obj.reload()
         return pv_obj
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5145,6 +5145,7 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
         deployment_config=False,
         sc_rbd=None,
         sc_cephfs=None,
+        pod_dict_path=None,
     ):
         """
         Args:
@@ -5173,6 +5174,8 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
                 of 'StorageClass' kind
             sc_cephfs (OCS): Cephfs storage class. ocs_ci.ocs.resources.ocs.OCS instance
                 of 'StorageClass' kind
+            pod_dict_path (str): YAML path for the pod.
+
         Returns:
             tuple: List of pvcs and pods
         """
@@ -5243,13 +5246,12 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
             else:
                 interface = constants.CEPHBLOCKPOOL
 
-            # TODO: Remove pod_dict_path variable if issue 2524 is fixed
             if deployment_config:
-                pod_dict_path = constants.FEDORA_DC_YAML
+                pod_dict_path = pod_dict_path or constants.FEDORA_DC_YAML
             elif pvc_obj.volume_mode == "Block":
-                pod_dict_path = constants.CSI_RBD_RAW_BLOCK_POD_YAML
+                pod_dict_path = pod_dict_path or constants.CSI_RBD_RAW_BLOCK_POD_YAML
             else:
-                pod_dict_path = ""
+                pod_dict_path = pod_dict_path if pod_dict_path else ""
 
             num_pods = (
                 pods_for_rwx if pvc_obj.access_mode == constants.ACCESS_MODE_RWX else 1

--- a/tests/managed-service/test_pod_disruptions.py
+++ b/tests/managed-service/test_pod_disruptions.py
@@ -1,0 +1,223 @@
+import logging
+import os
+from itertools import cycle
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier4c,
+    ignore_leftover_label,
+    managed_service_required,
+)
+from ocs_ci.ocs.managedservice import patch_consumer_toolbox
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources import csv
+from ocs_ci.helpers import disruption_helpers
+from ocs_ci.framework import config
+from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster
+
+log = logging.getLogger(__name__)
+
+
+@tier4c
+@managed_service_required
+@ignore_leftover_label("rook-ceph-tools")
+@pytest.mark.polarion_id("")
+class TestPodDisruptions(ManageTest):
+    """
+    Tests to verify pod disruption
+
+    """
+
+    provider_cluster_index = config.get_provider_index()
+    consumer_indexes = config.get_consumer_indexes_list()
+
+    @pytest.fixture(autouse=True)
+    def setup(self, request, create_pvcs_and_pods):
+        """
+        Prepare pods for the test and add finalizer.
+
+        """
+        if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
+            # Get the index of current cluster
+            initial_cluster_index = config.cur_index
+
+            def teardown():
+                # ocs-operator pod deletion on consumer cluster will trigger rook-ceph-tools pod respin. Patching of
+                # rook-ceph-tools pod is done in the test case after ocs-operator pod respin. But if the automatic
+                # respin of rook-ceph-tools pod is delayed by few seconds, the patching step in the test case will not
+                # run. So doing patch at the end of the test to ensure that the rook-ceph-tools pod on consumers
+                # can run ceph command.
+                for consumer_index in self.consumer_indexes:
+                    config.switch_ctx(consumer_index)
+                    patch_consumer_toolbox()
+                # Switching cluster context will be done during the test case.
+                # Switch back to current cluster context after the test case.
+                config.switch_ctx(initial_cluster_index)
+
+            request.addfinalizer(teardown)
+
+        self.io_pods = list()
+        for cluster_index in self.consumer_indexes:
+            config.switch_ctx(cluster_index)
+            consumer_cluster_kubeconfig = os.path.join(
+                config.clusters[cluster_index].ENV_DATA["cluster_path"],
+                config.clusters[cluster_index].RUN.get("kubeconfig_location"),
+            )
+            _, io_pods = create_pvcs_and_pods(
+                pvc_size=25,
+                pods_for_rwx=1,
+                access_modes_rbd=None,
+                access_modes_cephfs=None,
+                num_of_rbd_pvc=None,
+                num_of_cephfs_pvc=None,
+                replica_count=1,
+                deployment_config=False,
+                sc_rbd=None,
+                sc_cephfs=None,
+                pod_dict_path=constants.PERF_POD_YAML,
+            )
+            for io_pod in io_pods:
+                io_pod.ocp.cluster_kubeconfig = consumer_cluster_kubeconfig
+            self.io_pods.extend(io_pods)
+
+    def test_pod_disruptions(self):
+        """
+        Test to perform pod disruption in consumer and provider cluster
+
+        """
+        # List of pods to be disrupted. Using different list for consumer and provider for the easy implementation
+        pods_on_consumer = [
+            "alertmanager_managed_ocs_alertmanager",
+            "ocs_osd_controller_manager",
+            "prometheus_managed_ocs_prometheus",
+            "prometheus_operator",
+            "ocs_operator",
+        ]
+        pods_on_provider = [
+            "alertmanager_managed_ocs_alertmanager",
+            "ocs_osd_controller_manager",
+            "prometheus_managed_ocs_prometheus",
+            "prometheus_operator",
+            "ocs_provider_server",
+            "ocs_operator",
+        ]
+        disruption_on_consumer = []
+        disruption_on_provider = []
+
+        # Start I/O
+        log.info("Starting fio on all pods")
+        for pod_obj in self.io_pods:
+            if pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK:
+                storage_type = "block"
+                direct = 1
+            else:
+                storage_type = "fs"
+                direct = 0
+            pod_obj.run_io(
+                storage_type=storage_type,
+                size="10G",
+                fio_filename=f"{pod_obj.name}",
+                runtime=320,
+                end_fsync=1,
+                direct=direct,
+                invalidate=0,
+                fio_installed=True,
+            )
+
+        consumer_index_iter = cycle(self.consumer_indexes)
+
+        # Create Disruptions instance for each pod to be disrupted on consumer
+        for pod_type in pods_on_consumer:
+            consumer_index = next(consumer_index_iter)
+            config.switch_ctx(consumer_index)
+            disruption_obj = disruption_helpers.Disruptions()
+            # Select each pod to be disrupted from different consumers
+            disruption_obj.set_resource(resource=pod_type, cluster_index=consumer_index)
+            disruption_obj.index_of_consumer = consumer_index
+            disruption_on_consumer.append(disruption_obj)
+
+        # Create Disruptions instance for each pod to be disrupted on provider
+        config.switch_to_provider()
+        for pod_type in pods_on_provider:
+            disruption_obj = disruption_helpers.Disruptions()
+            disruption_obj.set_resource(
+                resource=pod_type, cluster_index=self.provider_cluster_index
+            )
+            disruption_on_provider.append(disruption_obj)
+
+        # Delete pods on consumer one at a time
+        log.info("Starting pod disruptions on consumer clusters")
+        for disruptions_obj in disruption_on_consumer:
+            disruptions_obj.delete_resource()
+            # ocs-operator respin will trigger rook-ceph-tools pod respin.
+            # Patch rook-ceph-tools pod to run ceph commands.
+            if disruptions_obj.resource == "ocs_operator":
+                config.switch_ctx(disruptions_obj.index_of_consumer)
+                patch_consumer_toolbox()
+
+        # Delete pods on provider one at a time
+        log.info("Starting pod disruptions on provider cluster")
+        for disruptions_obj in disruption_on_provider:
+            disruptions_obj.delete_resource()
+
+        log.info("Wait for IO to complete on pods")
+        for pod_obj in self.io_pods:
+            pod_obj.get_fio_results()
+            log.info(f"Verified IO on pod {pod_obj.name}")
+        log.info("IO is successful on all pods")
+
+        # Performs different checks in the clusters
+        for cluster_index in [self.provider_cluster_index] + self.consumer_indexes:
+            config.switch_ctx(cluster_index)
+
+            # Verify managedocs components are Ready
+            log.info("Verifying managedocs components state")
+            managedocs_obj = OCP(
+                kind="managedocs",
+                resource_name="managedocs",
+                namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            )
+            for component in {"alertmanager", "prometheus", "storageCluster"}:
+                assert (
+                    managedocs_obj.get()["status"]["components"][component]["state"]
+                    == "Ready"
+                ), f"{component} status is {managedocs_obj.get()['status']['components'][component]['state']}"
+
+            # Verify storagecluster status
+            log.info("Verifying storagecluster status")
+            verify_storage_cluster()
+
+            # Verify CSV status
+            for managed_csv in {
+                constants.OCS_CSV_PREFIX,
+                constants.OSD_DEPLOYER,
+                constants.OSE_PROMETHEUS_OPERATOR,
+            }:
+                csvs = csv.get_csvs_start_with_prefix(
+                    managed_csv, constants.OPENSHIFT_STORAGE_NAMESPACE
+                )
+                assert (
+                    len(csvs) == 1
+                ), f"Unexpected number of CSVs with {managed_csv} prefix: {len(csvs)}"
+                csv_name = csvs[0]["metadata"]["name"]
+                csv_obj = csv.CSV(
+                    resource_name=csv_name,
+                    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                )
+                log.info(f"Check if {csv_name} is in Succeeded phase.")
+                csv_obj.wait_for_phase(phase="Succeeded", timeout=600)
+
+            # Verify the phase of ceph cluster
+            log.info("Verify the phase of ceph cluster")
+            cephcluster = OCP(
+                kind="CephCluster", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            )
+            cephcluster_yaml = cephcluster.get().get("items")[0]
+            expected_phase = "Connected"
+            if cluster_index == self.provider_cluster_index:
+                expected_phase = "Ready"
+            assert (
+                cephcluster_yaml["status"]["phase"] == expected_phase
+            ), f"Status of cephcluster {cephcluster_yaml['metadata']['name']} is {cephcluster_yaml['status']['phase']}"

--- a/tests/managed-service/test_pod_disruptions.py
+++ b/tests/managed-service/test_pod_disruptions.py
@@ -65,7 +65,7 @@ class TestPodDisruptions(ManageTest):
                 config.clusters[cluster_index].ENV_DATA["cluster_path"],
                 config.clusters[cluster_index].RUN.get("kubeconfig_location"),
             )
-            _, io_pods = create_pvcs_and_pods(
+            pvcs, io_pods = create_pvcs_and_pods(
                 pvc_size=25,
                 pods_for_rwx=1,
                 access_modes_rbd=None,
@@ -78,6 +78,8 @@ class TestPodDisruptions(ManageTest):
                 sc_cephfs=None,
                 pod_dict_path=constants.PERF_POD_YAML,
             )
+            for pvc_obj in pvcs:
+                pvc_obj.ocp.cluster_kubeconfig = consumer_cluster_kubeconfig
             for io_pod in io_pods:
                 io_pod.ocp.cluster_kubeconfig = consumer_cluster_kubeconfig
             self.io_pods.extend(io_pods)

--- a/tests/managed-service/test_pod_disruptions.py
+++ b/tests/managed-service/test_pod_disruptions.py
@@ -82,6 +82,7 @@ class TestPodDisruptions(ManageTest):
                 pvc_obj.ocp.cluster_kubeconfig = consumer_cluster_kubeconfig
             for io_pod in io_pods:
                 io_pod.ocp.cluster_kubeconfig = consumer_cluster_kubeconfig
+            pvcs[0].project.cluster_kubeconfig = consumer_cluster_kubeconfig
             self.io_pods.extend(io_pods)
 
     def test_pod_disruptions(self):

--- a/tests/managed-service/test_pod_disruptions.py
+++ b/tests/managed-service/test_pod_disruptions.py
@@ -29,6 +29,7 @@ class TestPodDisruptions(ManageTest):
     Tests to verify pod disruption
 
     """
+
     pvc_size = 25
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
RHSTOR-3176 - Managed Service specific pod disruption test

I/O will be running on all consumers when performing pod deletion.

Provider pods to delete:
ocs-osd-controller-manager
alertmanager-managed-ocs-alertmanager
ocs-provider-server
prometheus-operator
prometheus-managed-ocs-prometheus
ocs-operator

Consumer pods to delete:
alertmanager-managed-ocs-alertmanager
ocs-osd-controller-manager
prometheus-managed-ocs-prometheus
prometheus-operator
ocs-operator

Signed-off-by: Jilju Joy <jijoy@redhat.com>