### PR TITLE
Run tier4c pagerduty tests on provider

### DIFF
--- a/tests/manage/monitoring/pagerduty/test_deployment_status.py
+++ b/tests/manage/monitoring/pagerduty/test_deployment_status.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
     tier4c,
+    runs_on_provider,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.utility import pagerduty
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
 @tier4c
 @managed_service_required
 @skipif_ms_consumer
+@runs_on_provider
 @bugzilla("1998056")
 @pytest.mark.polarion_id("OCS-2766")
 def test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
@@ -49,6 +51,7 @@ def test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
 @tier4c
 @managed_service_required
 @skipif_ms_consumer
+@runs_on_provider
 @pytest.mark.polarion_id("OCS-2769")
 def test_ceph_osd_stopped_pd(measure_stop_ceph_osd):
     """
@@ -112,6 +115,7 @@ def test_stop_worker_nodes_pd(measure_stop_worker_nodes):
 @tier4c
 @managed_service_required
 @skipif_ms_consumer
+@runs_on_provider
 @pytest.mark.polarion_id("OCS-3716")
 def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
     """
@@ -144,6 +148,7 @@ def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
 @tier4c
 @managed_service_required
 @skipif_ms_consumer
+@runs_on_provider
 @pytest.mark.polarion_id("OCS-3717")
 @pytest.mark.parametrize("create_mon_quorum_loss", [True])
 def test_ceph_mons_quorum_lost_pd(measure_stop_ceph_mon):

--- a/tests/manage/monitoring/pagerduty/test_deployment_status.py
+++ b/tests/manage/monitoring/pagerduty/test_deployment_status.py
@@ -50,7 +50,6 @@ def test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
 @tier4
 @tier4c
 @managed_service_required
-@skipif_ms_consumer
 @runs_on_provider
 @pytest.mark.polarion_id("OCS-2769")
 def test_ceph_osd_stopped_pd(measure_stop_ceph_osd):
@@ -114,7 +113,6 @@ def test_stop_worker_nodes_pd(measure_stop_worker_nodes):
 @tier4
 @tier4c
 @managed_service_required
-@skipif_ms_consumer
 @runs_on_provider
 @pytest.mark.polarion_id("OCS-3716")
 def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
@@ -147,7 +145,6 @@ def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
 @tier4
 @tier4c
 @managed_service_required
-@skipif_ms_consumer
 @runs_on_provider
 @pytest.mark.polarion_id("OCS-3717")
 @pytest.mark.parametrize("create_mon_quorum_loss", [True])

--- a/tests/manage/monitoring/pagerduty/test_deployment_status.py
+++ b/tests/manage/monitoring/pagerduty/test_deployment_status.py
@@ -20,7 +20,6 @@ log = logging.getLogger(__name__)
 @tier4
 @tier4c
 @managed_service_required
-@skipif_ms_consumer
 @runs_on_provider
 @bugzilla("1998056")
 @pytest.mark.polarion_id("OCS-2766")


### PR DESCRIPTION
The test cases given below will require provider cluster to run. Adding the marker runs_on_provider to switch the context to provider cluster if the provider cluster is available in a multicluster run.

tests/manage/monitoring/pagerduty/test_deployment_status.py::test_ceph_osd_stopped_pd
tests/manage/monitoring/pagerduty/test_deployment_status.py::test_ceph_monitor_stopped_pd
tests/manage/monitoring/pagerduty/test_deployment_status.py::test_ceph_mons_quorum_lost_pd[True]
tests/manage/monitoring/pagerduty/test_deployment_status.py::test_ceph_manager_stopped_pd

Signed-off-by: Jilju Joy <jijoy@redhat.com>