### PR TITLE
refactoring pvc_clones test

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -68,7 +68,6 @@ class TestPVCClonePerformance(PASTest):
         """
         self.interface = interface_type
         self.pvc_size = pvc_size
-        self.sc_obj = storageclass_factory(interface_type)
 
         self.pvc_obj = pvc_factory(
             interface=interface_type, size=pvc_size, status=constants.STATUS_BOUND

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -196,8 +196,12 @@ class TestPVCClonePerformance(PASTest):
 
         # Delete the test project (namespace)
         self.delete_test_project()
+        logger.info(f"Try to delete the Storage pool {self.pool_name}")
         try:
             self.delete_ceph_pool(self.pool_name)
+        except Exception:
+            pass
+        finally:
             # Verify deletion by checking the backend CEPH pools using the toolbox
             results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
             logger.debug(f"Existing pools are : {results}")
@@ -211,8 +215,6 @@ class TestPVCClonePerformance(PASTest):
                 )
             else:
                 logger.info(f"The pool {self.pool_name} was deleted successfully")
-        except Exception:
-            pass
 
         super(TestPVCClonePerformance, self).teardown()
 

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -196,25 +196,26 @@ class TestPVCClonePerformance(PASTest):
 
         # Delete the test project (namespace)
         self.delete_test_project()
-        logger.info(f"Try to delete the Storage pool {self.pool_name}")
-        try:
-            self.delete_ceph_pool(self.pool_name)
-        except Exception:
-            pass
-        finally:
-            # Verify deletion by checking the backend CEPH pools using the toolbox
-            results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
-            logger.debug(f"Existing pools are : {results}")
-            if self.pool_name in results.split():
-                logger.warning(
-                    "The pool did not deleted by CSI, forcing delete it manually"
-                )
-                self.ceph_cluster.toolbox.exec_cmd_on_pod(
-                    f"ceph osd pool delete {self.pool_name} {self.pool_name} "
-                    "--yes-i-really-really-mean-it"
-                )
-            else:
-                logger.info(f"The pool {self.pool_name} was deleted successfully")
+        if self.interface == constants.CEPHBLOCKPOOL:
+            logger.info(f"Try to delete the Storage pool {self.pool_name}")
+            try:
+                self.delete_ceph_pool(self.pool_name)
+            except Exception:
+                pass
+            finally:
+                # Verify deletion by checking the backend CEPH pools using the toolbox
+                results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
+                logger.debug(f"Existing pools are : {results}")
+                if self.pool_name in results.split():
+                    logger.warning(
+                        "The pool did not deleted by CSI, forcing delete it manually"
+                    )
+                    self.ceph_cluster.toolbox.exec_cmd_on_pod(
+                        f"ceph osd pool delete {self.pool_name} {self.pool_name} "
+                        "--yes-i-really-really-mean-it"
+                    )
+                else:
+                    logger.info(f"The pool {self.pool_name} was deleted successfully")
 
         super(TestPVCClonePerformance, self).teardown()
 

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -39,6 +39,19 @@ class TestPVCClonePerformance(PASTest):
         super(TestPVCClonePerformance, self).setup()
         self.benchmark_name = "pvc_clone_permorance"
 
+        self.create_test_project()
+
+    def teardown(self):
+        """
+        Cleanup the test environment
+        """
+        logger.info("Starting the test environment celanup")
+
+        # Delete the test project (namespace)
+        self.delete_test_project()
+
+        super(TestPVCClonePerformance, self).teardown()
+
     @pytest.fixture()
     def base_setup(
         self, interface_type, pvc_size, pvc_factory, pod_factory, storageclass_factory

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -251,8 +251,9 @@ class TestPVCClonePerformance(PASTest):
     def create_pod_and_wait_for_compleat(self, **kwargs):
         # Creating pod yaml file to run as a Job, the command to run on the pod and
         # arguments to it will replace in the create_pod function
-        self.create_fio_pod_yaml(pvc_size=int(self.pvc_size), filesize="1M")
-
+        self.create_fio_pod_yaml(
+            pvc_size=int(self.pvc_size), filesize=kwargs.pop("filesize", "1M")
+        )
         # Create a pod
         logger.info(f"Creating Pod with pvc {self.pvc_obj.name}")
 
@@ -397,8 +398,7 @@ class TestPVCClonePerformance(PASTest):
         # Create a PVC
         self.create_pvc_and_wait_for_bound()
         # Create a POD
-        self.create_pod_and_wait_for_compleat()
-
+        self.create_pod_and_wait_for_compleat(filesize=f"{file_size_mb}M")
         # taking the time, so parsing the provision log will be faster.
         start_time = self.get_time("csi")
         self.clones_list = self.create_and_delete_clones()

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -2,11 +2,8 @@
 Test to verify clone creation and deletion performance for PVC with data written to it.
 Performance is measured by collecting clone creation/deletion speed.
 """
-import datetime
 import logging
 import pytest
-import urllib.request
-import os
 import statistics
 
 from ocs_ci.ocs import constants
@@ -18,14 +15,110 @@ from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs.exceptions import PVCNotCreated, PodNotCreated
-from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
 Interfaces_info = {
-    constants.CEPHBLOCKPOOL: {"name": "RBD", "sc": constants.CEPHBLOCKPOOL_SC},
-    constants.CEPHFILESYSTEM: {"name": "CephFS", "sc": constants.CEPHFILESYSTEM_SC},
+    constants.CEPHBLOCKPOOL: {
+        "name": "RBD",
+        "sc": constants.CEPHBLOCKPOOL_SC,
+        "clone_yaml": constants.CSI_RBD_PVC_CLONE_YAML,
+        "accessmode": constants.ACCESS_MODE_RWO,
+    },
+    constants.CEPHFILESYSTEM: {
+        "name": "CephFS",
+        "sc": constants.CEPHFILESYSTEM_SC,
+        "clone_yaml": constants.CSI_CEPHFS_PVC_CLONE_YAML,
+        "accessmode": constants.ACCESS_MODE_RWX,
+    },
 }
+
+
+class ClonesResultsAnalyse(ResultsAnalyse):
+    """
+    This class is reading all test results from elasticsearch server (which the
+    benchmark-operator running of the benchmark is generate), aggregate them by :
+        test operation (e.g. create / delete etc.)
+        sample (for test to be valid it need to run with more the one sample)
+        host (test can be run on more then one pod {called host})
+
+    it generates results for all tests as one unit which will be valid only
+    if the deviation between samples is less the 5%
+
+    """
+
+    def analyse_results(self, test_times, speed=False, total_data=0):
+
+        creation_time_list = []
+        csi_creation_time_list = []
+
+        deletion_time_list = []
+        csi_deletion_time_list = []
+
+        if speed:
+            creation_speed_list = []
+            deletion_speed_list = []
+
+        # Print the results into the log.
+        for clone in test_times:
+
+            creation_time_list.append(test_times[clone]["create"]["time"])
+            csi_creation_time_list.append(test_times[clone]["csi_create"]["time"])
+            deletion_time_list.append(test_times[clone]["delete"]["time"])
+            csi_deletion_time_list.append(test_times[clone]["csi_delete"]["time"])
+
+            logger.info(f"Test report for clone {clone} :")
+            logger.info(
+                f"Creation time is     : {test_times[clone]['create']['time']} Secounds"
+            )
+            logger.info(
+                f"CSI-Creation time is : {test_times[clone]['csi_create']['time']} Secounds"
+            )
+            logger.info(
+                f"Deletion time is     : {test_times[clone]['delete']['time']} Secounds"
+            )
+            logger.info(
+                f"CSI-Deletion time is : {test_times[clone]['csi_delete']['time']} Secounds"
+            )
+
+            if speed:
+                creation_speed = total_data / test_times[clone]["create"]["time"]
+                deleteion_speed = total_data / test_times[clone]["delete"]["time"]
+                logger.info(f"Creation speed is    : {creation_speed:,.3f} MB/Sec.")
+                logger.info(f"Deletion speed is    : {deleteion_speed:,.3f} MB/Sec.")
+                creation_speed_list.append(float(creation_speed))
+                deletion_speed_list.append(float(deleteion_speed))
+
+        average_creation_time = f"{statistics.mean(creation_time_list):.3f}"
+        average_csi_creation_time = f"{statistics.mean(csi_creation_time_list):.3f}"
+        average_deletion_time = f"{statistics.mean(deletion_time_list):.3f}"
+        average_csi_deletion_time = f"{statistics.mean(csi_deletion_time_list):.3f}"
+
+        logger.info("========== Average results ==========")
+        logger.info(f"Average creation time is     : {average_creation_time} secs.")
+        logger.info(f"Average csi-creation time is : {average_csi_creation_time} secs.")
+        logger.info(f"Average deletion time is     : {average_deletion_time} secs.")
+        logger.info(f"Average csi-deletion time is : {average_csi_deletion_time} secs.")
+
+        self.add_key("average_clone_creation_time", average_creation_time)
+        self.add_key("average_csi_clone_creation_time", average_csi_creation_time)
+        self.add_key("average_clone_deletion_time", average_deletion_time)
+        self.add_key("average_csi_clone_deletion_time", average_csi_deletion_time)
+
+        if speed:
+            average_creation_speed = f"{statistics.mean(creation_speed_list):.3f}"
+            average_deletion_speed = f"{statistics.mean(deletion_speed_list):.3f}"
+            logger.info(
+                f"Average creation speed is    : {average_creation_speed} MB/Sec."
+            )
+            logger.info(
+                f"Average deletion speed is    : {average_deletion_speed} MB/Sec."
+            )
+            self.add_key("average_clone_creation_speed", average_creation_speed)
+            self.add_key("average_clone_deletion_speed", average_deletion_speed)
+
+        self.all_results = test_times
+        logger.info("test_clones_creation_performance finished successfully.")
 
 
 @performance
@@ -43,8 +136,18 @@ class TestPVCClonePerformance(PASTest):
         logger.info("Starting the test setup")
         super(TestPVCClonePerformance, self).setup()
         self.benchmark_name = "pvc_clone_permorance"
+        helpers.pull_images(constants.PERF_IMAGE)
 
         self.create_test_project()
+
+        # Collecting environment information
+        self.get_env_info()
+
+        self.number_of_clones = 11
+        if self.dev_mode:
+            self.number_of_clones = 3
+
+        self.clones_list = []
 
     def teardown(self):
         """
@@ -53,25 +156,174 @@ class TestPVCClonePerformance(PASTest):
         logger.info("Starting the test environment celanup")
 
         # Delete The test POD
-        self.pod_object.delete()
-        # Wait for the POD to be deleted
-        performance_lib.wait_for_resource_bulk_status(
-            "pod", 0, self.namespace, constants.STATUS_RUNNING, 60, 5
-        )
-        logger.info("The POD was deleted successfully")
+        try:
+            self.pod_object.delete()
+            # Wait for the POD to be deleted
+            performance_lib.wait_for_resource_bulk_status(
+                "pod", 0, self.namespace, constants.STATUS_RUNNING, 60, 5
+            )
+            logger.info("The POD was deleted successfully")
+        except Exception:
+            pass
 
         # Delete the test PVC
-        self.pvc_obj.delete()
-        # Wait for the PVC to be deleted
-        performance_lib.wait_for_resource_bulk_status(
-            "pvc", 0, self.namespace, constants.STATUS_BOUND, 60, 5
-        )
-        logger.info("The PVC was deleted successfully")
+        try:
+            pv = self.pvc_obj.get("spec")["spec"]["volumeName"]
+            self.pvc_obj.delete()
+            # Wait for the PVC to be deleted
+            performance_lib.wait_for_resource_bulk_status(
+                "pvc", 0, self.namespace, constants.STATUS_BOUND, 60, 5
+            )
+            logger.info("The PVC was deleted successfully")
+        except Exception:
+            pass
+
+        # Delete the backend PV of the PVC
+        logger.info(f"Try to delete the backend PV : {pv}")
+        try:
+            performance_lib.run_oc_command(f"delete pv {pv}")
+        except Exception as ex:
+            err_msg = f"cannot delete PV {pv} - [{ex}]"
+            logger.error(err_msg)
+
+        logger.info(f"Deleting the test StorageClass : {self.sc_obj.name}")
+        try:
+            self.sc_obj.delete()
+            logger.info("Wait until the SC is deleted.")
+            self.sc_obj.ocp.wait_for_delete(resource_name=self.sc_obj.name)
+        except Exception as ex:
+            logger.error(f"Can not delete the test sc : {ex}")
 
         # Delete the test project (namespace)
         self.delete_test_project()
+        self.delete_ceph_pool(self.pool_name)
+        # Verify deletion by checking the backend CEPH pools using the toolbox
+        results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
+        logger.debug(f"Existing pools are : {results}")
+        if self.pool_name in results.split():
+            logger.warning(
+                "The pool did not deleted by CSI, forcing delete it manually"
+            )
+            self.ceph_cluster.toolbox.exec_cmd_on_pod(
+                f"ceph osd pool delete {self.pool_name} {self.pool_name} "
+                "--yes-i-really-really-mean-it"
+            )
+        else:
+            logger.info(f"The pool {self.pool_name} was deleted successfully")
 
         super(TestPVCClonePerformance, self).teardown()
+
+    def create_new_pool_and_sc(self, secret_factory):
+        self.pool_name = (
+            f"pas-test-pool-{Interfaces_info[self.interface]['name'].lower()}"
+        )
+        self.create_new_pool(self.pool_name)
+        # Creating new StorageClass (pool) for the test.
+        secret = secret_factory(interface=self.interface)
+        self.sc_obj = helpers.create_storage_class(
+            interface_type=self.interface,
+            interface_name=self.pool_name,
+            secret_name=secret.name,
+            sc_name=self.pool_name,
+            fs_name=self.pool_name,
+        )
+        logger.info(f"The new SC is : {self.sc_obj.name}")
+
+    def create_pvc_and_wait_for_bound(self):
+        logger.info("Creating PVC to be cloned")
+        try:
+            self.pvc_obj = helpers.create_pvc(
+                sc_name=self.sc_obj.name,
+                pvc_name="pvc-pas-test",
+                size=f"{self.pvc_size}Gi",
+                namespace=self.namespace,
+                access_mode=Interfaces_info[self.interface]["accessmode"],
+            )
+        except Exception as e:
+            logger.exception(f"The PVC was not created, exception [{str(e)}]")
+            raise PVCNotCreated("PVC did not reach BOUND state.")
+        # Wait for the PVC to be Bound
+        performance_lib.wait_for_resource_bulk_status(
+            "pvc", 1, self.namespace, constants.STATUS_BOUND, self.timeout, 5
+        )
+        logger.info(f"The PVC {self.pvc_obj.name} was created and in Bound state.")
+
+    def create_pod_and_wait_for_compleat(self, **kwargs):
+        # Creating pod yaml file to run as a Job, the command to run on the pod and
+        # arguments to it will replace in the create_pod function
+        self.create_fio_pod_yaml(pvc_size=int(self.pvc_size), filesize="1M")
+
+        # Create a pod
+        logger.info(f"Creating Pod with pvc {self.pvc_obj.name}")
+
+        try:
+            self.pod_object = helpers.create_pod(
+                pvc_name=self.pvc_obj.name,
+                namespace=self.namespace,
+                interface_type=self.interface,
+                pod_name="pod-pas-test",
+                pod_dict_path=self.pod_yaml_file.name,
+                **kwargs,
+                # pod_dict_path=constants.PERF_POD_YAML,
+            )
+        except Exception as e:
+            logger.exception(
+                f"Pod attached to PVC {self.pod_object.name} was not created, exception [{str(e)}]"
+            )
+            raise PodNotCreated("Pod attached to PVC was not created.")
+
+        # Confirm that pod is running on the selected_nodes
+        logger.info("Checking whether the pod is running")
+        helpers.wait_for_resource_state(
+            resource=self.pod_object,
+            state=constants.STATUS_COMPLETED,
+            timeout=self.timeout,
+        )
+
+    def create_and_delete_clones(self):
+        # Creating the clones one by one and wait until they bound
+        logger.info(
+            f"Start creating {self.number_of_clones} clones on {self.interface} PVC of size {self.pvc_size} GB."
+        )
+        clones_list = []
+        for i in range(self.number_of_clones):
+            index = i + 1
+            logger.info(f"Start creation of clone number {index}.")
+            cloned_pvc_obj = pvc.create_pvc_clone(
+                sc_name=self.pvc_obj.backed_sc,
+                parent_pvc=self.pvc_obj.name,
+                pvc_name=f"clone-pas-test-{index}",
+                clone_yaml=Interfaces_info[self.interface]["clone_yaml"],
+                namespace=self.namespace,
+                storage_size=self.pvc_size + "Gi",
+            )
+            helpers.wait_for_resource_state(
+                cloned_pvc_obj, constants.STATUS_BOUND, self.timeout
+            )
+            # TODO: adding flattern for RBD devices
+            cloned_pvc_obj.reload()
+            clones_list.append(cloned_pvc_obj)
+            logger.info(
+                f"Clone with name {cloned_pvc_obj.name} for {self.pvc_size} pvc {self.pvc_obj.name} was created."
+            )
+
+        # Delete the clones one by one and wait for deletion
+        logger.info(
+            f"Start deleteing {self.number_of_clones} clones on {self.interface} PVC of size {self.pvc_size} GB."
+        )
+        index = 0
+        for clone in clones_list:
+            index += 1
+            pvc_reclaim_policy = clone.reclaim_policy
+            clone.delete()
+            logger.info(
+                f"Deletion of clone number {index} , the clone name is {clone.name}."
+            )
+            clone.ocp.wait_for_delete(clone.name, self.timeout)
+            if pvc_reclaim_policy == constants.RECLAIM_POLICY_DELETE:
+                helpers.validate_pv_delete(clone.backed_pv)
+
+        return clones_list
 
     @pytest.mark.parametrize(
         argnames=["interface_type", "pvc_size", "file_size"],
@@ -111,7 +363,7 @@ class TestPVCClonePerformance(PASTest):
         ],
     )
     def test_clone_create_delete_performance(
-        self, interface_type, pvc_size, file_size, teardown_factory
+        self, secret_factory, interface_type, pvc_size, file_size
     ):
         """
         Write data (60% of PVC capacity) to the PVC created in setup
@@ -122,196 +374,15 @@ class TestPVCClonePerformance(PASTest):
         Note: by increasing max_num_of_clones value you increase number of the clones to be created/deleted
         """
 
+        # Initialize some variabels
         self.interface = interface_type
+        self.timeout = 18000
         self.pvc_size = pvc_size
-
-        # Creating the basic PVC to be cloned
-        logger.info("Creating PVC to be cloned")
-        self.pvc_obj = helpers.create_pvc(
-            sc_name=Interfaces_info[self.interface]["sc"],
-            pvc_name="pvc-pas-test",
-            size=f"{pvc_size}Gi",
-            namespace=self.namespace,
-        )
-        # Wait for the PVC to be Bound
-        performance_lib.wait_for_resource_bulk_status(
-            "pvc", 1, self.namespace, constants.STATUS_BOUND, 60, 5
-        )
-        logger.info(f"The PVC {self.pvc_obj.name} was created and in Bound state.")
-
-        # Creating pod which fill the PVC with data
-        self.create_fio_pod_yaml(pvc_size=int(self.pvc_size), filesize=file_size)
-
-        logger.info("Creating Pod and Starting IO on it")
-        self.pod_object = helpers.create_pod(
-            pvc_name=self.pvc_obj.name,
-            namespace=self.namespace,
-            interface_type=self.interface,
-            pod_name="pod-pas-test",
-            pod_dict_path=self.pod_yaml_file.name,
-        )
-        assert self.pod_object, "Failed to create pod"
-
-        logger.info("Wait for the POD to be created, and compleat running I/O")
-        performance_lib.wait_for_resource_bulk_status(
-            "pod", 1, self.namespace, constants.STATUS_COMPLETED, 600, 5
-        )
-        logger.info("I/O Completed on all POD(s)")
-
-        max_num_of_clones = 10
-        if self.dev_mode:
-            max_num_of_clones = 3
-
-        clone_creation_measures = []
-        csi_clone_creation_measures = []
-        clones_list = []
-        timeout = 18000
-        sc_name = self.pvc_obj.backed_sc
-        parent_pvc = self.pvc_obj.name
-        clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
-        namespace = self.pvc_obj.namespace
-        if interface_type == constants.CEPHFILESYSTEM:
-            clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
+        self.results_path = get_full_test_logs_path(cname=self)
         file_size_mb = convert_device_size(file_size, "MB")
-
-        logger.info(
-            f"Start creating {max_num_of_clones} clones on {interface_type} PVC of size {pvc_size} GB."
-        )
-
-        # taking the time, so parsing the provision log will be faster.
-        start_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-
-        for i in range(max_num_of_clones):
-            logger.info(f"Start creation of clone number {i + 1}.")
-            cloned_pvc_obj = pvc.create_pvc_clone(
-                sc_name, parent_pvc, clone_yaml, namespace, storage_size=pvc_size + "Gi"
-            )
-            teardown_factory(cloned_pvc_obj)
-            helpers.wait_for_resource_state(
-                cloned_pvc_obj, constants.STATUS_BOUND, timeout
-            )
-
-            cloned_pvc_obj.reload()
-            logger.info(
-                f"Clone with name {cloned_pvc_obj.name} for {pvc_size} pvc {parent_pvc} was created."
-            )
-            clones_list.append(cloned_pvc_obj)
-            create_time = helpers.measure_pvc_creation_time(
-                interface_type, cloned_pvc_obj.name
-            )
-            creation_speed = int(file_size_mb / create_time)
-            logger.info(
-                f"Clone number {i+1} creation time is {create_time} secs for {pvc_size} GB pvc."
-            )
-            logger.info(
-                f"Clone number {i+1} creation speed is {creation_speed} MB/sec for {pvc_size} GB pvc."
-            )
-            creation_measures = {
-                "clone_num": i + 1,
-                "time": create_time,
-                "speed": creation_speed,
-            }
-            clone_creation_measures.append(creation_measures)
-            csi_clone_creation_measures.append(
-                performance_lib.csi_pvc_time_measure(
-                    self.interface, cloned_pvc_obj, "create", start_time
-                )
-            )
-
-        # deleting one by one and measuring deletion times and speed for each one of the clones create above
-        # in case of single clone will run one time
-        clone_deletion_measures = []
-        csi_clone_deletion_measures = []
-
-        logger.info(
-            f"Start deleting {max_num_of_clones} clones on {interface_type} PVC of size {pvc_size} GB."
-        )
-
-        for i in range(max_num_of_clones):
-            cloned_pvc_obj = clones_list[i]
-            pvc_reclaim_policy = cloned_pvc_obj.reclaim_policy
-            cloned_pvc_obj.delete()
-            logger.info(
-                f"Deletion of clone number {i + 1} , the clone name is {cloned_pvc_obj.name}."
-            )
-            cloned_pvc_obj.ocp.wait_for_delete(cloned_pvc_obj.name, timeout)
-            if pvc_reclaim_policy == constants.RECLAIM_POLICY_DELETE:
-                helpers.validate_pv_delete(cloned_pvc_obj.backed_pv)
-            delete_time = helpers.measure_pvc_deletion_time(
-                interface_type, cloned_pvc_obj.backed_pv
-            )
-            logger.info(
-                f"Clone number {i + 1} deletion time is {delete_time} secs for {pvc_size} GB pvc."
-            )
-
-            deletion_speed = int(file_size_mb / delete_time)
-            logger.info(
-                f"Clone number {i+1} deletion speed is {deletion_speed} MB/sec for {pvc_size} GB pvc."
-            )
-            deletion_measures = {
-                "clone_num": i + 1,
-                "time": delete_time,
-                "speed": deletion_speed,
-            }
-            clone_deletion_measures.append(deletion_measures)
-            csi_clone_deletion_measures.append(
-                performance_lib.csi_pvc_time_measure(
-                    self.interface, cloned_pvc_obj, "delete", start_time
-                )
-            )
-
-        logger.info(
-            f"Printing clone creation time and speed for {max_num_of_clones} clones "
-            f"on {interface_type} PVC of size {pvc_size} GB:"
-        )
-        for c in clone_creation_measures:
-            logger.info(
-                f"Clone number {c['clone_num']} creation time is {c['time']} secs for {pvc_size} GB pvc ."
-            )
-            logger.info(
-                f"Clone number {c['clone_num']} creation speed is {c['speed']} MB/sec for {pvc_size} GB pvc."
-            )
-        logger.info(
-            f"Clone deletion time and speed for {interface_type} PVC of size {pvc_size} GB are:"
-        )
-        creation_time_list = [r["time"] for r in clone_creation_measures]
-        creation_speed_list = [r["speed"] for r in clone_creation_measures]
-        average_creation_time = statistics.mean(creation_time_list)
-        average_csi_creation_time = statistics.mean(csi_clone_creation_measures)
-        average_creation_speed = statistics.mean(creation_speed_list)
-        logger.info(f"Average creation time is  {average_creation_time} secs.")
-        logger.info(f"Average creation speed is  {average_creation_speed} Mb/sec.")
-
-        for d in clone_deletion_measures:
-            logger.info(
-                f"Clone number {d['clone_num']} deletion time is {d['time']} secs for {pvc_size} GB pvc."
-            )
-            logger.info(
-                f"Clone number {d['clone_num']} deletion speed is {d['speed']} MB/sec for {pvc_size} GB pvc."
-            )
-
-        deletion_time_list = [r["time"] for r in clone_deletion_measures]
-        deletion_speed_list = [r["speed"] for r in clone_deletion_measures]
-        average_deletion_time = statistics.mean(deletion_time_list)
-        average_csi_deletion_time = statistics.mean(csi_clone_deletion_measures)
-        average_deletion_speed = statistics.mean(deletion_speed_list)
-        logger.info(f"Average deletion time is  {average_deletion_time} secs.")
-        logger.info(f"Average deletion speed is  {average_deletion_speed} Mb/sec.")
-        logger.info("test_clones_creation_performance finished successfully.")
-
-        self.results_path = get_full_test_logs_path(cname=self)
-        # Produce ES report
-        # Collecting environment information
-        self.get_env_info()
-
-        self.full_log_path = get_full_test_logs_path(cname=self)
-        self.results_path = get_full_test_logs_path(cname=self)
-        self.full_log_path += f"-{self.interface}-{pvc_size}-{file_size}"
-        logger.info(f"Logs file path name is : {self.full_log_path}")
-
         # Initialize the results doc file.
         full_results = self.init_full_results(
-            ResultsAnalyse(
+            ClonesResultsAnalyse(
                 self.uuid,
                 self.crd_data,
                 self.full_log_path,
@@ -319,29 +390,39 @@ class TestPVCClonePerformance(PASTest):
             )
         )
 
-        full_results.add_key("interface", self.interface)
-        full_results.add_key("total_clone_number", max_num_of_clones)
-        full_results.add_key("pvc_size", self.pvc_size)
-        full_results.add_key("average_clone_creation_time", average_creation_time)
-        full_results.add_key(
-            "average_csi_clone_creation_time", average_csi_creation_time
-        )
-        full_results.add_key("average_clone_deletion_time", average_deletion_time)
-        full_results.add_key(
-            "average_csi_clone_deletion_time", average_csi_deletion_time
-        )
-        full_results.add_key("average_clone_creation_speed", average_creation_speed)
-        full_results.add_key("average_clone_deletion_speed", average_deletion_speed)
+        test_start_time = self.get_time()
 
-        full_results.all_results = {
-            "clone_creation_time": creation_time_list,
-            "csi_clone_creation_time": csi_clone_creation_measures,
-            "clone_deletion_time": deletion_time_list,
-            "csi_clone_deletion_time": csi_clone_deletion_measures,
-            "clone_creation_speed": creation_speed_list,
-            "clone_deletion_speed": deletion_speed_list,
-        }
+        # Creating new pool to run the test on it
+        self.create_new_pool_and_sc(secret_factory)
+        # Create a PVC
+        self.create_pvc_and_wait_for_bound()
+        # Create a POD
+        self.create_pod_and_wait_for_compleat()
 
+        # taking the time, so parsing the provision log will be faster.
+        start_time = self.get_time("csi")
+        self.clones_list = self.create_and_delete_clones()
+
+        # Mesure Creation / Deletion time of all clones
+        results_times = performance_lib.get_pvc_provision_times(
+            interface=self.interface,
+            pvc_name=self.clones_list,
+            start_time=start_time,
+        )
+
+        test_end_time = self.get_time()
+
+        logger.info(
+            f"Printing clone creation time and speed for {self.number_of_clones} clones "
+            f"on {self.interface} PVC of size {self.pvc_size} GB:"
+        )
+        # Produce ES report
+        full_results.analyse_results(results_times, total_data=file_size_mb)
+        # Add the test time to the ES report
+        full_results.add_key(
+            "test_time", {"start": test_start_time, "end": test_end_time}
+        )
+        full_results.add_key("total_clone_number", self.number_of_clones)
         # Write the test results into the ES server
         if full_results.es_write():
             res_link = full_results.results_link()
@@ -363,27 +444,9 @@ class TestPVCClonePerformance(PASTest):
         """
         for key in self.environment:
             full_results.add_key(key, self.environment[key])
-        full_results.add_key("index", full_results.new_index)
+        full_results.add_key("interface", Interfaces_info[self.interface]["name"])
+        full_results.add_key("pvc_size", self.pvc_size)
         return full_results
-
-    @pytest.fixture()
-    def base_multiple_setup(self, interface):
-        """
-        A setup phase for the test
-        Args:
-            interface: Interface parameter
-
-        """
-
-        self.interface = interface
-
-        if self.interface == constants.CEPHFILESYSTEM:
-            self.sc = "CephFS"
-        if self.interface == constants.CEPHBLOCKPOOL:
-            self.sc = "RBD"
-
-        self.full_log_path = get_full_test_logs_path(cname=self)
-        self.full_log_path += f"-{self.sc}"
 
     @pytest.mark.parametrize(
         argnames=["interface", "copies", "timeout"],
@@ -398,10 +461,9 @@ class TestPVCClonePerformance(PASTest):
             ),
         ],
     )
-    @pytest.mark.usefixtures(base_multiple_setup.__name__)
     def test_pvc_clone_performance_multiple_files(
         self,
-        pvc_factory,
+        secret_factory,
         interface,
         copies,
         timeout,
@@ -413,227 +475,86 @@ class TestPVCClonePerformance(PASTest):
         The test creates number of clones samples, calculates creation and deletion times for each one the clones
         and calculates the average creation and average deletion times
         """
-        kernel_url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.5.tar.gz"
-        download_path = "tmp"
 
-        test_start_time = self.get_time()
-        helpers.pull_images(constants.PERF_IMAGE)
-        # Download a linux Kernel
-
-        dir_path = os.path.join(os.getcwd(), download_path)
-        file_path = os.path.join(dir_path, "file.gz")
-        if not os.path.exists(dir_path):
-            os.makedirs(dir_path)
-        urllib.request.urlretrieve(kernel_url, file_path)
-
-        # Create a PVC
-        accessmode = constants.ACCESS_MODE_RWX
-        if interface == constants.CEPHBLOCKPOOL:
-            accessmode = constants.ACCESS_MODE_RWO
-
-        pvc_size = "100"
-        try:
-            pvc_obj = pvc_factory(
-                interface=interface,
-                access_mode=accessmode,
-                status=constants.STATUS_BOUND,
-                size=pvc_size,
-            )
-        except Exception as e:
-            logger.error(f"The PVC sample was not created, exception {str(e)}")
-            raise PVCNotCreated("PVC did not reach BOUND state.")
-
-        # Create a pod on one node
-        logger.info(f"Creating Pod with pvc {pvc_obj.name}")
-
-        try:
-            pod_obj = helpers.create_pod(
-                interface_type=interface,
-                pvc_name=pvc_obj.name,
-                namespace=pvc_obj.namespace,
-                pod_dict_path=constants.PERF_POD_YAML,
-            )
-        except Exception as e:
-            logger.error(
-                f"Pod on PVC {pvc_obj.name} was not created, exception {str(e)}"
-            )
-            raise PodNotCreated("Pod on PVC was not created.")
-
-        # Confirm that pod is running on the selected_nodes
-        logger.info("Checking whether pods are running on the selected nodes")
-        helpers.wait_for_resource_state(
-            resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
-        )
-
-        pod_name = pod_obj.name
-        pod_path = "/mnt"
-
-        _ocp = OCP(namespace=pvc_obj.namespace)
-
-        rsh_cmd = f"rsync {dir_path} {pod_name}:{pod_path}"
-        _ocp.exec_oc_cmd(rsh_cmd)
-
-        rsh_cmd = f"exec {pod_name} -- tar xvf {pod_path}/tmp/file.gz -C {pod_path}/tmp"
-        _ocp.exec_oc_cmd(rsh_cmd)
-
-        for x in range(copies):
-            rsh_cmd = f"exec {pod_name} -- mkdir -p {pod_path}/folder{x}"
-            _ocp.exec_oc_cmd(rsh_cmd)
-            rsh_cmd = f"exec {pod_name} -- cp -r {pod_path}/tmp {pod_path}/folder{x}"
-            _ocp.exec_oc_cmd(rsh_cmd)
-            rsh_cmd = f"exec {pod_name} -- sync"
-            _ocp.exec_oc_cmd(rsh_cmd)
-
-        logger.info("Getting the amount of data written to the PVC")
-        rsh_cmd = f"exec {pod_name} -- df -h {pod_path}"
-        data_written = _ocp.exec_oc_cmd(rsh_cmd).split()[-4]
-        logger.info(f"The amount of written data is {data_written}")
-
-        rsh_cmd = f"exec {pod_name} -- find {pod_path} -type f"
-        files_written = len(_ocp.exec_oc_cmd(rsh_cmd).split())
-        logger.info(
-            f"For {interface} - The number of files written to the pod is {files_written}"
-        )
-
-        # delete the pod
-        pod_obj.delete(wait=False)
-
-        logger.info("Wait for the pod to be deleted")
-        performance_lib.wait_for_resource_bulk_status(
-            "pod", 0, pvc_obj.namespace, constants.STATUS_COMPLETED, timeout, 5
-        )
-        logger.info("The pod was deleted")
-
-        num_of_clones = 11
-        # increasing the timeout since clone creation time is longer than pod attach time
-        timeout = 18000
-
-        clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
-        if interface == constants.CEPHFILESYSTEM:
-            clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
-
-        clone_creation_measures = []
-        csi_clone_creation_measures = []
-        clone_deletion_measures = []
-        csi_clone_deletion_measures = []
-
-        # taking the time, so parsing the provision log will be faster.
-        start_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-
-        for i in range(num_of_clones):
-            logger.info(f"Start creation of clone number {i + 1}.")
-            cloned_pvc_obj = pvc.create_pvc_clone(
-                pvc_obj.backed_sc,
-                pvc_obj.name,
-                clone_yaml,
-                pvc_obj.namespace,
-                storage_size=pvc_size + "Gi",
-            )
-            helpers.wait_for_resource_state(
-                cloned_pvc_obj, constants.STATUS_BOUND, timeout
-            )
-
-            cloned_pvc_obj.reload()
-            logger.info(
-                f"Clone with name {cloned_pvc_obj.name} for {pvc_size} pvc {pvc_obj.name} was created."
-            )
-            create_time = helpers.measure_pvc_creation_time(
-                interface, cloned_pvc_obj.name
-            )
-            logger.info(
-                f"Clone number {i+1} creation time is {create_time} secs for {pvc_size} GB pvc."
-            )
-            clone_creation_measures.append(create_time)
-            csi_clone_creation_measures.append(
-                performance_lib.csi_pvc_time_measure(
-                    interface, cloned_pvc_obj, "create", start_time
-                )
-            )
-
-            pvc_reclaim_policy = cloned_pvc_obj.reclaim_policy
-            cloned_pvc_obj.delete()
-            logger.info(
-                f"Deletion of clone number {i + 1} , the clone name is {cloned_pvc_obj.name}."
-            )
-            cloned_pvc_obj.ocp.wait_for_delete(cloned_pvc_obj.name, timeout)
-            if pvc_reclaim_policy == constants.RECLAIM_POLICY_DELETE:
-                helpers.validate_pv_delete(cloned_pvc_obj.backed_pv)
-            delete_time = helpers.measure_pvc_deletion_time(
-                interface, cloned_pvc_obj.backed_pv
-            )
-            logger.info(
-                f"Clone number {i + 1} deletion time is {delete_time} secs for {pvc_size} GB pvc."
-            )
-
-            clone_deletion_measures.append(delete_time)
-            csi_clone_deletion_measures.append(
-                performance_lib.csi_pvc_time_measure(
-                    interface, cloned_pvc_obj, "delete", start_time
-                )
-            )
-
-        os.remove(file_path)
-        os.rmdir(dir_path)
-        pvc_obj.delete()
-
-        average_creation_time = statistics.mean(clone_creation_measures)
-        logger.info(f"Average creation time is  {average_creation_time} secs.")
-        average_csi_creation_time = statistics.mean(csi_clone_creation_measures)
-        logger.info(f"Average csi creation time is  {average_csi_creation_time} secs.")
-
-        average_deletion_time = statistics.mean(clone_deletion_measures)
-        logger.info(f"Average deletion time is  {average_deletion_time} secs.")
-        average_csi_deletion_time = statistics.mean(csi_clone_deletion_measures)
-        logger.info(f"Average csi deletion time is  {average_csi_deletion_time} secs.")
-
-        # Produce ES report
-
-        # Collecting environment information
-        self.get_env_info()
+        # Initialize some variabels
+        self.interface = interface
+        self.timeout = timeout
+        self.pvc_size = "100"
+        if self.dev_mode:
+            self.pvc_size = "10"
+            copies = 1
         self.results_path = get_full_test_logs_path(cname=self)
         # Initialize the results doc file.
         full_results = self.init_full_results(
-            ResultsAnalyse(
+            ClonesResultsAnalyse(
                 self.uuid,
                 self.crd_data,
                 self.full_log_path,
-                "test_pvc_clone_performance_multiple_files_fullres",
+                "test_pvc_clone_performance_multiple_files",
             )
         )
+        files_written = ""
+        data_written = ""
 
-        full_results.add_key("files_number", files_written)
+        test_start_time = self.get_time()
+
+        # Creating new pool to run the test on it
+        self.create_new_pool_and_sc(secret_factory)
+        # Create a PVC
+        self.create_pvc_and_wait_for_bound()
+        # Create a POD
+        self.create_pod_and_wait_for_compleat(
+            command=["/opt/multiple_files.sh"],
+            command_args=[f"{copies}", "/mnt"],
+        )
+
+        # Get the number of files and total written data from the pod
+        for line in self.pod_object.ocp.get_logs(name=self.pod_object.name).split("\n"):
+            if "Number Of Files" in line:
+                files_written = line.split(" ")[-1]
+            if "Total Data" in line:
+                data_written = line.split(" ")[-1]
+        logger.info("Getting the amount of data written to the PVC")
+        logger.info(f"The amount of written data is {data_written}")
+        logger.info(
+            f"For {self.interface} - The number of files written to the pod is {int(files_written):,}"
+        )
+
+        # increasing the timeout since clone creation time is longer than pod attach time
+        self.timeout = 18000
+
+        # taking the time, so parsing the provision log will be faster.
+        start_time = self.get_time("csi")
+        clones_list = self.create_and_delete_clones()
+
+        # Mesure Creation / Deletion time of all clones
+        results_times = performance_lib.get_pvc_provision_times(
+            interface=self.interface,
+            pvc_name=clones_list,
+            start_time=start_time,
+        )
 
         test_end_time = self.get_time()
 
+        logger.info(
+            f"Printing clone creation and deletion times for {self.number_of_clones} clones "
+            f"on {self.interface} PVC of size {self.pvc_size} GB:"
+        )
+        # Produce ES report
+        full_results.analyse_results(results_times, speed=False)
+        # Add the test time to the ES report
         full_results.add_key(
             "test_time", {"start": test_start_time, "end": test_end_time}
         )
-
-        full_results.add_key("interface", interface)
-        full_results.add_key("clones_number", num_of_clones)
-        full_results.add_key("pvc_size", pvc_size)
-        full_results.add_key("average_clone_creation_time", average_creation_time)
-        full_results.add_key(
-            "average_csi_clone_creation_time", average_csi_creation_time
-        )
-        full_results.add_key("average_clone_deletion_time", average_deletion_time)
-        full_results.add_key(
-            "average_csi_clone_deletion_time", average_csi_deletion_time
-        )
-
-        full_results.all_results = {
-            "clone_creation_time": clone_creation_measures,
-            "csi_clone_creation_time": csi_clone_creation_measures,
-            "clone_deletion_time": clone_deletion_measures,
-            "csi_clone_deletion_time": csi_clone_deletion_measures,
-        }
-
+        full_results.add_key("clones_number", self.number_of_clones)
+        full_results.add_key("files_number", files_written)
+        full_results.all_results = results_times
         # Write the test results into the ES server
         if full_results.es_write():
             res_link = full_results.results_link()
             logger.info(f"The Result can be found at : {res_link}")
 
-            # Create text file with results of all subtest (4 - according to the parameters)
+            # Create text file with results of all subtest (2 - according to the parameters)
             self.results_path = get_full_test_logs_path(
                 cname=self, fname="test_pvc_clone_performance_multiple_files"
             )
@@ -645,22 +566,14 @@ class TestPVCClonePerformance(PASTest):
         and reporting the full results (links in the ES) of previous tests (8 + 2)
         """
 
-        workloads = [
-            {
-                "name": "test_clone_create_delete_performance",
-                "tests": 8,
-                "test_name": "PVC Clone Performance",
-            },
-            {
-                "name": "test_pvc_clone_performance_multiple_files",
-                "tests": 2,
-                "test_name": "PVC Clone Multiple Files Performance",
-            },
-        ]
-        for wl in workloads:
-            self.number_of_tests = wl["tests"]
-            self.results_path = get_full_test_logs_path(cname=self, fname=wl["name"])
-            self.results_file = os.path.join(self.results_path, "all_results.txt")
-            logger.info(f"Check results for [{wl['name']}] in : {self.results_file}")
-            self.check_tests_results()
-            self.push_to_dashboard(test_name=wl["test_name"])
+        self.add_test_to_results_check(
+            test="test_clone_create_delete_performance",
+            test_count=8,
+            test_name="PVC Clone",
+        )
+        self.add_test_to_results_check(
+            test="test_pvc_clone_performance_multiple_files",
+            test_count=2,
+            test_name="PVC Clone Multiple Filese",
+        )
+        self.check_results_and_push_to_dashboard()

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -515,8 +515,18 @@ class TestPVCClonePerformance(PASTest):
 
         test_start_time = self.get_time()
 
-        # Creating new pool to run the test on it
-        self.create_new_pool_and_sc(secret_factory)
+        # Create new pool and sc only for RBD, for CepgFS use thr default
+        if self.interface == constants.CEPHBLOCKPOOL:
+            # Creating new pool to run the test on it
+            self.create_new_pool_and_sc(secret_factory)
+        else:
+            self.sc_obj = ocs.OCS(
+                kind="StorageCluster",
+                metadata={
+                    "namespace": self.namespace,
+                    "name": Interfaces_info[self.interface]["sc"],
+                },
+            )
         # Create a PVC
         self.create_pvc_and_wait_for_bound()
         # Create a POD

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -122,6 +122,9 @@ class TestPVCClonePerformance(PASTest):
         performance_lib.write_fio_on_pod(self.pod_object, file_size_for_io)
 
         max_num_of_clones = 10
+        if self.dev_mode:
+            max_num_of_clones = 3
+
         clone_creation_measures = []
         csi_clone_creation_measures = []
         clones_list = []

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -62,10 +62,14 @@ class ClonesResultsAnalyse(ResultsAnalyse):
         # Print the results into the log.
         for clone in test_times:
 
-            creation_time_list.append(test_times[clone]["create"]["time"])
-            csi_creation_time_list.append(test_times[clone]["csi_create"]["time"])
-            deletion_time_list.append(test_times[clone]["delete"]["time"])
-            csi_deletion_time_list.append(test_times[clone]["csi_delete"]["time"])
+            creation_time_list.append(test_times[clone]["create"].get("time", 0))
+            csi_creation_time_list.append(
+                test_times[clone]["csi_create"].get("time", 0)
+            )
+            deletion_time_list.append(test_times[clone]["delete"].get("time", 0))
+            csi_deletion_time_list.append(
+                test_times[clone]["csi_delete"].get("time", 0)
+            )
 
             logger.info(f"Test report for clone {clone} :")
             logger.info(

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -57,8 +57,7 @@ class ClonesResultsAnalyse(ResultsAnalyse):
             avg_data[op] = []
 
         if speed:
-            creation_speed_list = []
-            deletion_speed_list = []
+            speeds = {"create": [], "delete": []}
 
         # Print the results into the log.
         for clone in test_times:
@@ -69,39 +68,27 @@ class ClonesResultsAnalyse(ResultsAnalyse):
                 title = f"{op.capitalize()}ion time is"
                 logger.info(f"{title:29} : {data} Secounds")
                 if data is None:
-                    data = 0
-                all_data[op].append(data)
-
-            if speed:
-                creation_speed = total_data / test_times[clone]["create"]["time"]
-                deleteion_speed = total_data / test_times[clone]["delete"]["time"]
-                logger.info(
-                    f"Creation speed is             : {creation_speed:,.3f} MB/Sec."
-                )
-                logger.info(
-                    f"Deletion speed is             : {deleteion_speed:,.3f} MB/Sec."
-                )
-                creation_speed_list.append(float(creation_speed))
-                deletion_speed_list.append(float(deleteion_speed))
+                    logger.warning(f"   There is no {op.capitalize()}ion time !")
+                else:
+                    all_data[op].append(data)
+                if speed and "csi" not in op:
+                    speeds[op].append(float(total_data / test_times[clone][op]["time"]))
+                    logger.info(
+                        f"{op.capitalize()}ion speed is            : {speeds[op][-1]:,.2f} MB/Sec."
+                    )
 
         logger.info("=============== Average results ================")
         for op in op_types:
-            avg_data[op] = f"{statistics.mean(all_data[op]):.3f}"
+            avg_data[op] = statistics.mean(all_data[op])
             title = f"Average {op.capitalize()}ion time is"
-            logger.info(f"{title:29} : {avg_data[op]} Secounds")
+            logger.info(f"{title:29} : {avg_data[op]:.3f} Secounds")
             self.add_key(f"average_clone_{op}ion_time", avg_data[op])
-
-        if speed:
-            average_creation_speed = f"{statistics.mean(creation_speed_list):.3f}"
-            average_deletion_speed = f"{statistics.mean(deletion_speed_list):.3f}"
-            logger.info(
-                f"Average creation speed is     : {average_creation_speed} MB/Sec."
-            )
-            logger.info(
-                f"Average deletion speed is     : {average_deletion_speed} MB/Sec."
-            )
-            self.add_key("average_clone_creation_speed", average_creation_speed)
-            self.add_key("average_clone_deletion_speed", average_deletion_speed)
+            if speed and "csi" not in op:
+                average_speed = statistics.mean(speeds[op])
+                logger.info(
+                    f"Average {op}ion speed is    : {average_speed:,.2f} MB/Sec."
+                )
+                self.add_key(f"average_clone_{op}ion_speed", average_speed)
 
         self.all_results = test_times
         logger.info("test_clones_creation_performance finished successfully.")


### PR DESCRIPTION
This PR refractor the test for pvc_clones to reduce the memory consumption.

The original test consume more then 2GiB of memory, which cause the test to failed  , and now the test consume **only** ~400MiB 