### PR TITLE
use string instead text in soup object

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1492,7 +1492,7 @@ def move_summary_to_top(soup):
 
     """
     summary = []
-    summary.append(soup.find("h2", text="Summary"))
+    summary.append(soup.find("h2", string="Summary"))
     for tag in summary[0].next_siblings:
         if tag.name == "h2":
             break


### PR DESCRIPTION
Fixes the DeprecationWarning: The 'text' argument to find()-type methods
is deprecated. Use 'string' instead.

Fixes: #5871 
Signed-off-by: vavuthu <vavuthu@redhat.com>