### PR TITLE
Modify test test_resource_deletion_during_pvc_clone for MS

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -40,7 +40,7 @@ class Disruptions:
         )
         return kubeconfig_parameter
 
-    def set_resource(self, resource, leader_type="provisioner"):
+    def set_resource(self, resource, leader_type="provisioner", cluster_index=None):
         self.resource = resource
         if (config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS) and (
             resource in CEPH_PODS
@@ -55,6 +55,16 @@ class Disruptions:
                 ),
             )
             self.cluster_kubeconfig = provider_kubeconfig
+        elif config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS:
+            # cluster_index is used to identify the the cluster in which the pod is residing. If cluster_index is not
+            # passed, assume that the context is already changed to the cluster where the pod is residing.
+            cluster_index = (
+                cluster_index if cluster_index is not None else config.cur_index
+            )
+            self.cluster_kubeconfig = os.path.join(
+                config.clusters[cluster_index].ENV_DATA["cluster_path"],
+                config.clusters[cluster_index].RUN.get("kubeconfig_location"),
+            )
         resource_count = 0
         if self.resource == "mgr":
             self.resource_obj = pod.get_mgr_pods()

--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -46,7 +46,7 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
             # provider cluster index is required
             self.provider_index = config.get_provider_index()
             # Get the index of a consumer cluster
-            self.consumer_index = config.get_consumer_indexes_list()
+            self.consumer_index = config.get_consumer_indexes_list()[0]
 
             def finalizer():
                 # Switching to provider cluster context will be done during the test case.
@@ -116,12 +116,13 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
         for disruption, pod_type in zip(disruption_ops, pods_to_delete):
             cluster_index = None
             # 'provider_index' will not be None if the platform is Managed Services
-            if self.provider_index is not None and pod_type in ["osd", "mgr"]:
-                cluster_index = self.provider_index
-                config.switch_to_provider()
-            elif self.provider_index:
-                cluster_index = self.consumer_index
-                config.switch_ctx(cluster_index)
+            if self.provider_index is not None:
+                if pod_type in ["osd", "mgr"]:
+                    cluster_index = self.provider_index
+                    config.switch_to_provider()
+                else:
+                    cluster_index = self.consumer_index
+                    config.switch_ctx(cluster_index)
 
             disruption.set_resource(resource=pod_type, cluster_index=cluster_index)
 

--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -126,6 +126,10 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
 
             disruption.set_resource(resource=pod_type, cluster_index=cluster_index)
 
+        # Switch cluster context if the platform is MS. 'provider_index' will not be None if platform is MS.
+        if self.provider_index is not None:
+            config.switch_ctx(self.consumer_index)
+
         # Clone PVCs
         log.info("Start creating clone of PVCs")
         for pvc_obj in self.pvcs:


### PR DESCRIPTION
Modify the test case given below to run on Managed Services platform.
tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py::TestResourceDeletionDuringPvcClone::test_resource_deletion_during_pvc_clone

Signed-off-by: Jilju Joy <jijoy@redhat.com>