### PR TITLE
Total creation time fix and csi time added

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2297,13 +2297,13 @@ def memory_leak_analysis(median_dict):
         logger.info(f"End value {end_value}")
         # Convert the values to kb for calculations
         if start_value.__contains__("g"):
-            start_value = float(1024 ** 2 * float(start_value[:-1]))
+            start_value = float(1024**2 * float(start_value[:-1]))
         elif start_value.__contains__("m"):
             start_value = float(1024 * float(start_value[:-1]))
         else:
             start_value = float(start_value)
         if end_value.__contains__("g"):
-            end_value = float(1024 ** 2 * float(end_value[:-1]))
+            end_value = float(1024**2 * float(end_value[:-1]))
         elif end_value.__contains__("m"):
             end_value = float(1024 * float(end_value[:-1]))
         else:

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -13,6 +13,7 @@ from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
 DATE_TIME_FORMAT = "%Y I%m%d %H:%M:%S.%f"
+
 interface_data = {
     constants.CEPHBLOCKPOOL: {
         "prov": "csi-rbdplugin-provisioner",
@@ -400,6 +401,166 @@ def extruct_timestamp_from_log(line):
     results = f"{this_year} {mon_day}"
     logger.debug(f"The Results timestamp is : {results}")
     return results
+
+
+def measure_total_snapshot_creation_time(snap_name, start_time):
+    """
+    Measure Snapshot creation time based on logs
+
+    Args:
+        snap_name (str): Name of the snapshot for creation time measurement
+        start_time (str): start time, starting from which the logs are searched
+
+    Returns:
+        float: Creation time for the snapshot
+
+    """
+    start = get_snapshot_time(snap_name, "start", start_time)
+    end = get_snapshot_time(snap_name, "end", start_time)
+
+    if start and end:
+        total = end - start
+        return total.total_seconds()
+
+    if start is None:
+        err_msg = f"Can not find start creation time of snapshot {snap_name}"
+        logger.error(err_msg)
+        raise Exception(err_msg)
+    if end is None:
+        err_msg = f"Can not find end creation time of snapshot {snap_name}"
+        logger.error(err_msg)
+        raise Exception(err_msg)
+
+
+def get_snapshot_time(snap_name, status, start_time):
+    """
+    Get the starting/ending creation time of a snapshot based on logs
+
+    The time and date extraction code below has been modified to read
+    the month and day data in the logs.  This fixes an error where negative
+    time values are calculated when test runs cross midnight.  Also, previous
+    calculations would not set the year, and so the calculations were done
+    as if the year were 1900.  This is not a problem except that 1900 was
+    not a leap year and so the next February 29th would throw ValueErrors
+    for the whole day.  To avoid this problem, changes were made to also
+    include the current year.
+
+    Incorrect times will still be given for tests that cross over from
+    December 31 to January 1.
+
+    Args:
+        pvc_name (str / list): Name of the PVC(s) for creation time
+                               the list will be list of pvc objects
+        status (str): the status that we want to get - Start / End
+        start_time (str): start time, starting from which the logs are searched
+
+    Returns:
+        datetime object: Time of searched snapshot operation
+
+    """
+
+    def get_pattern_time(log, snapname, pattern):
+        """
+        Get the time of pattern in the log
+
+        Args:
+            log (list): list of all lines in the log file
+            snapname (str): the name of the snapshot
+            pattern (str): the pattern that need to be found in the log (start / bound)
+
+        Returns:
+            str: string of the pattern timestamp in the log, if not found None
+
+        """
+        this_year = str(datetime.now().year)
+        for line in log:
+            if re.search(snapname, line) and re.search(pattern, line):
+                mon_day = " ".join(line.split(" ")[0:2])
+                return f"{this_year} {mon_day}"
+        return None
+
+    pods = run_oc_command(cmd="get pod", namespace="openshift-cluster-storage-operator")
+
+    if "Error in command" in pods:
+        raise Exception("Can not get csi controller pod")
+
+    log_names = []
+    for line in pods:
+        if (
+            "csi-snapshot-controller" in line
+            and not "csi-snapshot-controller-operator" in line
+        ):
+            log_names.append(line.split()[0])
+
+    log_lines = []
+    for log in log_names:
+        sublog_lines = run_oc_command(
+            f"logs {log} --since-time={start_time}",
+            "openshift-cluster-storage-operator",
+        )
+        for l in sublog_lines:
+            log_lines.extend(l.split("\n"))
+
+    if status.lower() == "start":
+        pattern = "Creating content for snapshot"
+    elif status.lower() == "end":
+        pattern = "ready to use"
+    else:
+        logger.error(f"the status {status} is invalid.")
+        return None
+
+    time = get_pattern_time(log_lines, snap_name, pattern)
+    if time:
+        return datetime.strptime(time, DATE_TIME_FORMAT)
+    else:
+        return None
+
+
+def measure_csi_snapshot_creation_time(interface, snapshot_id, start_time):
+    """
+
+    Measure PVC creation time, provided pvc name and time after which the PVC was created
+
+    Args:
+        interface (str) : an interface (RBD or CephFS) to run on
+        snapshot_id (str) : Id of the snapshot which creation time is measured
+        start_time (str): Formatted time from which and on to search the relevant logs
+
+    Returns:
+        (float) snapshot creation time in seconds
+
+    """
+    log_names = get_logfile_names(interface)
+    logs = read_csi_logs(log_names, interface_data[interface]["csi_cnt"], start_time)
+
+    st = None
+    et = None
+    time_format = "%H:%M:%S.%f"
+    for sublog in logs:
+        for line in sublog:
+            if (
+                "GRPC call: /csi.v1.Controller/CreateSnapshot" in line
+                and snapshot_id in line
+            ):
+                st = line.split(" ")[1]
+                st = datetime.strptime(st, time_format)
+            elif "GRPC response" in line and snapshot_id in line:
+                et = line.split(" ")[1]
+                et = datetime.strptime(et, time_format)
+    if st is None:
+        logger.error(f"Can not find start time of snapshot {snapshot_id}")
+        raise Exception(f"Can not find start time of snapshot {snapshot_id}")
+
+    if et is None:
+        logger.error(f"Can not find end time of snapshot {snapshot_id}")
+        raise Exception(f"Can not find end time of snapshot {snapshot_id}")
+
+    total_time = (et - st).total_seconds()
+    if total_time < 0:
+        # for start-time > end-time (before / after midnigth) adding 24H to the time.
+        total_time += 24 * 60 * 60
+
+    return total_time
 
 
 def calculate_operation_time(name, times):

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -488,7 +488,7 @@ def get_snapshot_time(snap_name, status, start_time):
     for line in pods:
         if (
             "csi-snapshot-controller" in line
-            and not "csi-snapshot-controller-operator" in line
+            and "csi-snapshot-controller-operator" not in line
         ):
             log_names.append(line.split()[0])
 

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -1,6 +1,7 @@
 # Builtin modules
 import logging
 import time
+import datetime
 import os
 from uuid import uuid4
 
@@ -22,7 +23,7 @@ from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.resources import pod, pvc
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.helpers import helpers
+from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs.perfresult import ResultsAnalyse
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.framework.testlib import (
@@ -127,7 +128,9 @@ class TestPvcSnapshotPerformance(PASTest):
         full_results.add_key("index", full_results.new_index)
         return full_results
 
-    def measure_create_snapshot_time(self, pvc_name, snap_name, namespace, interface):
+    def measure_create_snapshot_time(
+        self, pvc_name, snap_name, namespace, interface, start_time=None
+    ):
         """
         Creation volume snapshot, and measure the creation time
 
@@ -171,9 +174,10 @@ class TestPvcSnapshotPerformance(PASTest):
         log.info(f"The snapshot UID is :{self.snap_uid}")
 
         # Measure the snapshot creation time
-        c_time = helpers.measure_snapshot_creation_time(
-            interface, snap_name, self.snap_content.name, self.snap_uid
+        c_time = performance_lib.measure_total_snapshot_creation_time(
+            snap_name, start_time
         )
+
         return c_time
 
     @pytest.mark.parametrize(
@@ -183,16 +187,18 @@ class TestPvcSnapshotPerformance(PASTest):
     @pytest.mark.usefixtures(base_setup.__name__)
     def test_pvc_snapshot_performance(self, pvc_size):
         """
-        1. Run I/O on a pod file.
-        2. Calculate md5sum of the file.
-        3. Take a snapshot of the PVC and measure the time of creation.
+        1. Run I/O on a pod file
+        2. Calculate md5sum of the file
+        3. Take a snapshot of the PVC
+        4. Measure the total snapshot creation time and the CSI snapshot creation time
         4. Restore From the snapshot and measure the time
-        5. Attach a new pod to it.
-        6. Verify that the file is present on the new pod also.
+        5. Attach a new pod to it
+        6. Verify that the file is present on the new pod also
         7. Verify that the md5sum of the file on the new pod matches
-           with the md5sum of the file on the original pod.
+           with the md5sum of the file on the original pod
 
-        This scenario run 3 times and report all results
+        This scenario run 3 times and report all the average results of the 3 runs
+        and will send them to the ES
         Args:
             pvc_size: the size of the PVC to be tested - parametrize
 
@@ -238,6 +244,7 @@ class TestPvcSnapshotPerformance(PASTest):
         self.full_results.add_key("pvc_size", pvc_size + " GiB")
         self.full_results.add_key("interface", self.sc)
         self.full_results.all_results["creation_time"] = []
+        self.full_results.all_results["csi_creation_time"] = []
         self.full_results.all_results["creation_speed"] = []
         self.full_results.all_results["restore_time"] = []
         self.full_results.all_results["restore_speed"] = []
@@ -245,7 +252,7 @@ class TestPvcSnapshotPerformance(PASTest):
             test_results = {
                 "test_num": test_num + 1,
                 "dataset": (test_num + 1) * filesize * 1024,  # size in MiB
-                "create": {"time": None, "speed": None},
+                "create": {"time": None, "csi_time": None, "speed": None},
                 "restore": {"time": None, "speed": None},
             }
             log.info(f"Starting test phase number {test_num}")
@@ -280,18 +287,33 @@ class TestPvcSnapshotPerformance(PASTest):
             )
             log.info(f"Taking snapshot of the PVC {snap_name}")
 
+            start_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
             test_results["create"]["time"] = self.measure_create_snapshot_time(
                 pvc_name=self.pvc_obj.name,
                 snap_name=snap_name,
                 namespace=self.pod_object.namespace,
                 interface=self.interface,
+                start_time=start_time,
             )
+
+            test_results["create"][
+                "csi_time"
+            ] = performance_lib.measure_csi_snapshot_creation_time(
+                interface=self.interface,
+                snapshot_id=self.snap_uid,
+                start_time=start_time,
+            )
+
             test_results["create"]["speed"] = int(
                 test_results["dataset"] / test_results["create"]["time"]
             )
             log.info(f' Test {test_num} dataset is {test_results["dataset"]} MiB')
             log.info(
-                f'Snapshot creation time is : {test_results["create"]["time"]} sec.'
+                f'Snapshot name {snap_name} and id {self.snap_uid} creation time is : {test_results["create"]["time"]} sec.'
+            )
+            log.info(
+                f'Snapshot name {snap_name} and id {self.snap_uid} csi creation time is : {test_results["create"]["csi_time"]} sec.'
             )
             log.info(f'Snapshot speed is : {test_results["create"]["speed"]} MB/sec')
 
@@ -381,15 +403,19 @@ class TestPvcSnapshotPerformance(PASTest):
             all_results.append(test_results)
 
         # logging the test summary, all info in one place for easy log reading
-        c_speed, c_runtime, r_speed, r_runtime = (0 for i in range(4))
+        c_speed, c_runtime, c_csi_runtime, r_speed, r_runtime = (0 for i in range(5))
 
         log.info("Test summary :")
         for tst in all_results:
             c_speed += tst["create"]["speed"]
             c_runtime += tst["create"]["time"]
+            c_csi_runtime += tst["create"]["csi_time"]
             r_speed += tst["restore"]["speed"]
             r_runtime += tst["restore"]["time"]
             self.full_results.all_results["creation_time"].append(tst["create"]["time"])
+            self.full_results.all_results["csi_creation_time"].append(
+                tst["create"]["csi_time"]
+            )
             self.full_results.all_results["creation_speed"].append(
                 tst["create"]["speed"]
             )
@@ -407,15 +433,20 @@ class TestPvcSnapshotPerformance(PASTest):
             )
 
         avg_snap_c_time = c_runtime / self.tests_numbers
+        avg_snap_csi_c_time = c_csi_runtime / self.tests_numbers
         avg_snap_c_speed = c_speed / self.tests_numbers
         avg_snap_r_time = r_runtime / self.tests_numbers
         avg_snap_r_speed = r_speed / self.tests_numbers
         log.info(f" Average snapshot creation time is {avg_snap_c_time} sec.")
+        log.info(f" Average csi snapshot creation time is {avg_snap_csi_c_time} sec.")
         log.info(f" Average snapshot creation speed is {avg_snap_c_speed} MiB/sec")
         log.info(f" Average snapshot restore time is {avg_snap_r_time} sec.")
         log.info(f" Average snapshot restore speed is {avg_snap_r_speed} MiB/sec")
 
         self.full_results.add_key("avg_snap_creation_time_insecs", avg_snap_c_time)
+        self.full_results.add_key(
+            "avg_snap_csi_creation_time_insecs", avg_snap_csi_c_time
+        )
         self.full_results.add_key("avg_snap_creation_speed", avg_snap_c_speed)
         self.full_results.add_key("avg_snap_restore_time_insecs", avg_snap_r_time)
         self.full_results.add_key("avg_snap_restore_speed", avg_snap_r_speed)
@@ -546,6 +577,8 @@ class TestPvcSnapshotPerformance(PASTest):
         self.full_results.add_key("interface", interface)
         for test_num in range(self.tests_numbers):
 
+            test_results = {"creation_time": None, "csi_creation_time": None}
+
             # deploy the smallfile workload
             log.info("Running SmallFile bench")
             sf_obj = OCS(**sf_data)
@@ -599,14 +632,29 @@ class TestPvcSnapshotPerformance(PASTest):
             snap_name = pvc_name.replace("claim", "snapshot-")
             log.info(f"Taking snapshot of the PVC {pvc_name}")
             log.info(f"Snapshot name : {snap_name}")
-            creation_time = self.measure_create_snapshot_time(
+
+            start_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            test_results["creation_time"] = self.measure_create_snapshot_time(
                 pvc_name=pvc_name,
                 snap_name=snap_name,
                 namespace=BMO_NAME,
                 interface=interface,
             )
-            log.info(f"Snapshot creation time is {creation_time} seconds")
-            all_results.append(creation_time)
+            log.info(
+                f'Snapshot with name {snap_name} and id {self.snap_uid} creation time is {test_results["creation_time"]} seconds'
+            )
+
+            test_results[
+                "csi_creation_time"
+            ] = performance_lib.measure_csi_snapshot_creation_time(
+                interface=interface, snapshot_id=self.snap_uid, start_time=start_time
+            )
+            log.info(
+                f'Snapshot with name {snap_name} and id {self.snap_uid} csi creation time is {test_results["csi_creation_time"]} seconds'
+            )
+
+            all_results.append(test_results)
 
             # Delete the smallfile workload - which will delete also the PVC
             log.info("Deleting the smallfile workload")
@@ -627,14 +675,25 @@ class TestPvcSnapshotPerformance(PASTest):
         log.info("Deleting the elastic-search instance")
         self.es.cleanup()
 
-        avg_c_time = statistics.mean(all_results)
+        creation_times = [t["creation_time"] for t in all_results]
+        avg_c_time = statistics.mean(creation_times)
+        csi_creation_times = [t["csi_creation_time"] for t in all_results]
+        avg_csi_c_time = statistics.mean(csi_creation_times)
+
         t_dateset = int(data_set / 3)
 
         log.info(f"Full test report for {interface}:")
         log.info(
-            f"Test ran {self.tests_numbers} times, " f"All results are {all_results}"
+            f"Test ran {self.tests_numbers} times, "
+            f"All snapshot creation results are {creation_times}"
         )
-        log.info(f"The average creation time is : {avg_c_time}")
+        log.info(f"The average snapshot creation time is : {avg_c_time}")
+        log.info(
+            f"Test ran {self.tests_numbers} times, "
+            f"All snapshot csi creation results are {csi_creation_times}"
+        )
+        log.info(f"The average csi snapshot creation time is : {avg_csi_c_time}")
+
         log.info(
             f"Number of Files on the volume : {total_files:,}, "
             f"Total dataset : {t_dateset} GiB"
@@ -643,7 +702,8 @@ class TestPvcSnapshotPerformance(PASTest):
         self.full_results.add_key("avg_snapshot_creation_time_insecs", avg_c_time)
         self.full_results.all_results["total_files"] = total_files
         self.full_results.all_results["total_dataset"] = t_dateset
-        self.full_results.all_results["creation_time"] = all_results
+        self.full_results.all_results["creation_time"] = creation_times
+        self.full_results.all_results["csi_creation_time"] = csi_creation_times
 
         # Write the test results into the ES server
         log.info("writing results to elastic search server")

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -310,10 +310,12 @@ class TestPvcSnapshotPerformance(PASTest):
             )
             log.info(f' Test {test_num} dataset is {test_results["dataset"]} MiB')
             log.info(
-                f'Snapshot name {snap_name} and id {self.snap_uid} creation time is : {test_results["create"]["time"]} sec.'
+                f"Snapshot name {snap_name} and id {self.snap_uid} creation time is"
+                f' : {test_results["create"]["time"]} sec.'
             )
             log.info(
-                f'Snapshot name {snap_name} and id {self.snap_uid} csi creation time is : {test_results["create"]["csi_time"]} sec.'
+                f"Snapshot name {snap_name} and id {self.snap_uid} csi creation time is"
+                f' : {test_results["create"]["csi_time"]} sec.'
             )
             log.info(f'Snapshot speed is : {test_results["create"]["speed"]} MB/sec')
 
@@ -642,7 +644,8 @@ class TestPvcSnapshotPerformance(PASTest):
                 interface=interface,
             )
             log.info(
-                f'Snapshot with name {snap_name} and id {self.snap_uid} creation time is {test_results["creation_time"]} seconds'
+                f"Snapshot with name {snap_name} and id {self.snap_uid} creation time is"
+                f' {test_results["creation_time"]} seconds'
             )
 
             test_results[
@@ -651,7 +654,8 @@ class TestPvcSnapshotPerformance(PASTest):
                 interface=interface, snapshot_id=self.snap_uid, start_time=start_time
             )
             log.info(
-                f'Snapshot with name {snap_name} and id {self.snap_uid} csi creation time is {test_results["csi_creation_time"]} seconds'
+                f"Snapshot with name {snap_name} and id {self.snap_uid} csi creation time is"
+                f' {test_results["csi_creation_time"]} seconds'
             )
 
             all_results.append(test_results)

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -642,7 +642,7 @@ class TestPvcSnapshotPerformance(PASTest):
                 snap_name=snap_name,
                 namespace=BMO_NAME,
                 interface=interface,
-                start_time = start_time
+                start_time=start_time,
             )
             log.info(
                 f"Snapshot with name {snap_name} and id {self.snap_uid} creation time is"

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -642,6 +642,7 @@ class TestPvcSnapshotPerformance(PASTest):
                 snap_name=snap_name,
                 namespace=BMO_NAME,
                 interface=interface,
+                start_time = start_time
             )
             log.info(
                 f"Snapshot with name {snap_name} and id {self.snap_uid} creation time is"


### PR DESCRIPTION
The current PR handles the following: 

1) fixes calculation of the total creation time ( different logs are parsed and the calculation is done differently) 
The existing def get_snapshot_time(interface, snap_name, status): was deleted, since the implementation was wrong, and it measuring wrong Total snapshot creation time. 
2) CSI snapshot creation times was added

Signed-off-by: Yulia Persky <ypersky@redhat.com>