### PR TITLE
Use timeoutsampler for getting reboot events for node

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -506,3 +506,7 @@ class CephToolBoxNotFoundException(Exception):
 
 class UnsupportedWorkloadError(Exception):
     pass
+
+
+class RebootEventNotFoundException(Exception):
+    pass


### PR DESCRIPTION
In some cases where node takes more time ( > 30 sec ) to come online after reboot, events are
not captured within 30 sec

Fixes: #5882 
Signed-off-by: vavuthu <vavuthu@redhat.com>