### PR TITLE
Revert "Reducing limits for nooba-endpoints"

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -898,8 +898,8 @@ class Deployment(object):
             }
             if ocs_version >= version.VERSION_4_5:
                 cluster_data["spec"]["resources"]["noobaa-endpoint"] = {
-                    "limits": {"cpu": "100m", "memory": "100Mi"},
-                    "requests": {"cpu": "100m", "memory": "100Mi"},
+                    "limits": {"cpu": 1, "memory": "500Mi"},
+                    "requests": {"cpu": 1, "memory": "500Mi"},
                 }
         else:
             local_storage = config.DEPLOYMENT.get("local_storage")


### PR DESCRIPTION
Reverts red-hat-storage/ocs-ci#4884. #4884 seems to have not been tested with any IO tests, and leads to product crashes the moment I/O begins to flow in or out, with endpoint pods entering a CrashLoopBackOff.