### PR TITLE
Move platform check to setup function in test to avoid collection error

### DIFF
--- a/tests/manage/pv_services/test_del_mon_service_and_create_pvc.py
+++ b/tests/manage/pv_services/test_del_mon_service_and_create_pvc.py
@@ -42,9 +42,12 @@ class TestPvcCreationAfterDelMonService(E2ETest):
     """
 
     consumer_cluster_index = None
-    if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
-        # Get the index of consumer cluster
-        consumer_cluster_index = config.get_consumer_indexes_list()[0]
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
+            # Get the index of consumer cluster
+            self.consumer_cluster_index = config.get_consumer_indexes_list()[0]
 
     @bugzilla("1858195")
     @runs_on_provider


### PR DESCRIPTION
Move platform check to setup function in test to avoid collection error.
Updated tests/manage/pv_services/test_del_mon_service_and_create_pvc.py
 
Fixes #5888 
Signed-off-by: Jilju Joy <jijoy@redhat.com>