### PR TITLE
pin cryptography to 36.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     license="MIT",
     install_requires=[
         "apache-libcloud==3.1.0",
+        "cryptography==36.0.2",
         "docopt==0.6.2",
         "gevent==20.9.0",
         "reportportal-client==3.2.3",


### PR DESCRIPTION
Blowfish is deprecated in cryptography 37.0.0 which was used by paramiko

Fixes: #5902 

Signed-off-by: vavuthu <vavuthu@redhat.com>