### PR TITLE
fix buildconfig file on jenkins workload

### DIFF
--- a/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
+++ b/ocs_ci/templates/workloads/jenkins/buildconfig.yaml
@@ -1,5 +1,5 @@
 kind: "BuildConfig"
-apiVersion: "v1"
+apiVersion: "build.openshift.io/v1"
 metadata:
   name: "jax-rs-build"
 spec:


### PR DESCRIPTION
```
$ oc -n myjenkins-1 create -f /tmp/BuildConfiglmw_dp44 -o yaml
W0516 17:38:29.390717   12720 shim_kubectl.go:58] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "build.openshift.io/v1" for your resource

```

Signed-off-by: Oded Viner <oviner@redhat.com>