### PR TITLE
Including version 4.8 after fix for luks header info issue in 4.8.11

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -705,7 +705,7 @@ def osd_encryption_verification():
             raise ValueError("OSD is not encrypted")
 
     # skip OCS 4.8 as the fix for luks header info is still not available on it
-    if ocs_version > version.VERSION_4_6 and ocs_version != version.VERSION_4_8:
+    if ocs_version > version.VERSION_4_6:
         log.info("Verify luks header label for encrypted devices")
         worker_nodes = get_osd_running_nodes()
         failures = 0


### PR DESCRIPTION
Signed-off-by: mashetty <mashetty@redhat.com>

[BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2069722) was raised for the luks header info issue with OCS 4.8. Now its fixed and verified in 4.8.11. Hence removing the condition to skip 4.8 version under osd encryption verification module.
