### PR TITLE
Increase wait time of fetch_used_size to workaround 5310 and 5707

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2877,7 +2877,7 @@ def wait_for_pv_delete(pv_objs):
         pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
 
-@retry(UnexpectedBehaviour, tries=20, delay=10, backoff=1)
+@retry(UnexpectedBehaviour, tries=40, delay=10, backoff=1)
 def fetch_used_size(cbp_name, exp_val=None):
     """
     Fetch used size in the pool


### PR DESCRIPTION
The issues #5310 and #5707 are observed in production runs only. The cause of both the issues looks the same. The used size of the pool is not getting updated within the given timeout. Many attempts was done to reproduce these issues locally and using jenkins by running these tests along with some other tests. The issue was not observed in these runs. As a workaround for the issue, the wait time to reflect the correct size of the pool is increased in this PR. This can be considered as a fix if the issue is not reproducible with this code change. 


Signed-off-by: Jilju Joy <jijoy@redhat.com>