### PR TITLE
ceph health check at the end of deploymnet TC

### DIFF
--- a/tests/ecosystem/deployment/test_deployment.py
+++ b/tests/ecosystem/deployment/test_deployment.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
 )
 from ocs_ci.ocs.utils import get_non_acm_cluster_config
 from ocs_ci.utility.reporting import get_polarion_id
-from ocs_ci.utility.utils import is_cluster_running
+from ocs_ci.utility.utils import is_cluster_running, ceph_health_check
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
 
 log = logging.getLogger(__name__)
@@ -51,6 +51,9 @@ def test_deployment(pvc_factory, pod_factory):
                     sanity_helpers = Sanity()
                 sanity_helpers.health_check()
                 sanity_helpers.delete_resources()
+                # Verify ceph health
+                log.info("Verifying ceph health after deployment")
+                assert ceph_health_check(tries=10, delay=30)
 
     if teardown:
         log.info("Cluster will be destroyed during teardown part of this test.")


### PR DESCRIPTION
There are case where ceph health check failed during teardown but its recovered after some
retries. To avoid deployment failures, we need to have health check at the end of
deployment test case

Fixes: #5921 

Signed-off-by: vavuthu <vavuthu@redhat.com>