### PR TITLE
Update NTP server

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1360,7 +1360,7 @@ HAPROXY_SERVICE = "/etc/systemd/system/haproxy.service"
 CHRONY_CONF = "/etc/chrony.conf"
 
 # NTP server
-RH_NTP_CLOCK = "clock.redhat.com"
+RH_NTP_CLOCK = "clock1.rdu2.redhat.com"
 
 # Disruptions pod names
 OSD = "osd"


### PR DESCRIPTION
Since all are hosts in vSphere are using NTP server as clock1.rdu2.redhat.com,
changing in ocs-ci as well to maintain consistency

Signed-off-by: vavuthu <vavuthu@redhat.com>