### PR TITLE
Add failover and relocate tests for Regional DR

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -72,6 +72,7 @@ deployment = pytest.mark.deployment
 polarion_id = pytest.mark.polarion_id
 bugzilla = pytest.mark.bugzilla
 acm_import = pytest.mark.acm_import
+rdr_test = pytest.mark.rdr_test
 
 tier_marks = [
     tier1,

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,7 @@ markers =
     scale: scale related tests
     scale_long_run: scale tests which has execution time in days
     scale_changed_layout: scale capacity/node tests without teardown
+    rdr_test: Regional Disaster Recovery related tests
     deployment: deployment related tests
     ocs_upgrade: marker for OCS upgrade test
     ocp_upgrade: marker for OCP upgrade test

--- a/tests/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_failover.py
@@ -1,0 +1,91 @@
+import logging
+import pytest
+
+from time import sleep
+
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
+
+logger = logging.getLogger(__name__)
+
+
+@rdr_test
+class TestFailover:
+    """
+    Test Failover action
+
+    """
+
+    @pytest.mark.parametrize(
+        argnames=["primary_cluster_down"],
+        argvalues=[
+            pytest.param(
+                False, marks=pytest.mark.polarion_id("OCS-4429"), id="primary_up"
+            ),
+            pytest.param(
+                True, marks=pytest.mark.polarion_id("OCS-4426"), id="primary_down"
+            ),
+        ],
+    )
+    def test_failover(
+        self,
+        primary_cluster_down,
+        nodes_multicluster,
+        rdr_workload,
+        node_restart_teardown,
+    ):
+        """
+        Tests to verify application failover between managed clusters
+        There are two test cases:
+            1) Failover to secondary cluster when primary cluster is UP
+            2) Failover to secondary cluster when primary cluster is DOWN
+
+        """
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        primary_cluster_index = config.cur_index
+        node_objs = get_node_objs()
+
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload.workload_namespace
+        )
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Stop primary cluster nodes
+        if primary_cluster_down:
+            nodes_multicluster[primary_cluster_index].stop_nodes(node_objs)
+
+        # Failover action
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.failover(secondary_cluster_name, rdr_workload.workload_namespace)
+
+        # Verify resources creation on new primary cluster (failoverCluster)
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        dr_helpers.wait_for_all_resources_creation(
+            rdr_workload.workload_pvc_count,
+            rdr_workload.workload_pod_count,
+            rdr_workload.workload_namespace,
+        )
+
+        # Verify resources deletion from previous primary or current secondary cluster
+        dr_helpers.set_current_secondary_cluster_context(
+            rdr_workload.workload_namespace
+        )
+        # Start nodes if cluster is down
+        if primary_cluster_down:
+            logger.info(
+                f"Waiting for {wait_time} minutes before starting nodes of previous primary cluster"
+            )
+            sleep(wait_time * 60)
+            nodes_multicluster[primary_cluster_index].start_nodes(node_objs)
+            wait_for_nodes_status([node.name for node in node_objs])
+        dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
+
+        dr_helpers.wait_for_mirroring_status_ok()
+
+        # TODO: Add data integrity checks

--- a/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -1,0 +1,118 @@
+import logging
+import pytest
+
+from time import sleep
+
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
+
+logger = logging.getLogger(__name__)
+
+
+@rdr_test
+class TestFailoverAndRelocate:
+    """
+    Test Failover and Relocate actions
+
+    """
+
+    @pytest.mark.parametrize(
+        argnames=["primary_cluster_down"],
+        argvalues=[
+            pytest.param(
+                False, marks=pytest.mark.polarion_id("OCS-4430"), id="primary_up"
+            ),
+            pytest.param(
+                True, marks=pytest.mark.polarion_id("OCS-4427"), id="primary_down"
+            ),
+        ],
+    )
+    def test_failover_and_relocate(
+        self,
+        primary_cluster_down,
+        nodes_multicluster,
+        rdr_workload,
+        node_restart_teardown,
+    ):
+        """
+        Tests to verify application failover and relocate between managed clusters
+        There are two test cases:
+            1) Failover to secondary cluster when primary cluster is UP and Relocate
+                back to primary cluster
+            2) Failover to secondary cluster when primary cluster is DOWN and Relocate
+                back to primary cluster once it recovers
+
+        """
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        primary_cluster_index = config.cur_index
+        node_objs = get_node_objs()
+
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload.workload_namespace
+        )
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Stop primary cluster nodes
+        if primary_cluster_down:
+            nodes_multicluster[primary_cluster_index].stop_nodes(node_objs)
+
+        # Failover action
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.failover(secondary_cluster_name, rdr_workload.workload_namespace)
+
+        # Verify resources creation on new primary cluster (failoverCluster)
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        dr_helpers.wait_for_all_resources_creation(
+            rdr_workload.workload_pvc_count,
+            rdr_workload.workload_pod_count,
+            rdr_workload.workload_namespace,
+        )
+
+        # Verify resources deletion from previous primary or current secondary cluster
+        dr_helpers.set_current_secondary_cluster_context(
+            rdr_workload.workload_namespace
+        )
+        # Start nodes if cluster is down
+        if primary_cluster_down:
+            logger.info(
+                f"Waiting for {wait_time} minutes before starting nodes of previous primary cluster"
+            )
+            sleep(wait_time * 60)
+            nodes_multicluster[primary_cluster_index].start_nodes(node_objs)
+            wait_for_nodes_status([node.name for node in node_objs])
+        dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
+
+        dr_helpers.wait_for_mirroring_status_ok()
+
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Relocate action
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.relocate(secondary_cluster_name, rdr_workload.workload_namespace)
+
+        # Verify resources deletion from previous primary or current secondary cluster
+        dr_helpers.set_current_secondary_cluster_context(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
+
+        # Verify resources creation on new primary cluster (preferredCluster)
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        dr_helpers.wait_for_all_resources_creation(
+            rdr_workload.workload_pvc_count,
+            rdr_workload.workload_pod_count,
+            rdr_workload.workload_namespace,
+        )
+
+        dr_helpers.wait_for_mirroring_status_ok()
+
+        # TODO: Add data integrity checks

--- a/tests/disaster-recovery/regional-dr/test_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_relocate.py
@@ -1,0 +1,54 @@
+import logging
+import pytest
+
+from time import sleep
+
+from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.helpers import dr_helpers
+
+logger = logging.getLogger(__name__)
+
+
+@rdr_test
+@pytest.mark.polarion_id("OCS-4425")
+class TestRelocate:
+    """
+    Test Relocate action
+
+    """
+
+    def test_relocate(self, rdr_workload):
+        """
+        Test to verify relocation of application between managed clusters
+
+        """
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload.workload_namespace
+        )
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Relocate action
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.relocate(secondary_cluster_name, rdr_workload.workload_namespace)
+
+        # Verify resources deletion from previous primary or current secondary cluster
+        dr_helpers.set_current_secondary_cluster_context(
+            rdr_workload.workload_namespace
+        )
+        dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
+
+        # Verify resources creation on new primary cluster (preferredCluster)
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
+        dr_helpers.wait_for_all_resources_creation(
+            rdr_workload.workload_pvc_count,
+            rdr_workload.workload_pod_count,
+            rdr_workload.workload_namespace,
+        )
+
+        dr_helpers.wait_for_mirroring_status_ok()
+
+        # TODO: Add data integrity checks


### PR DESCRIPTION
Add basic failover and relocate tests for Regional DR
Test cases added:
1) tests/disaster-recovery/regional-dr/test_failover.py
    This covers two cases:
    -   Failover to secondary cluster when primary cluster is UP
    -   Failover to secondary cluster when primary cluster is DOWN
2) tests/disaster-recovery/regional-dr/test_relocate.py
3) tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
    This covers two cases:
    -   Failover to secondary cluster when primary cluster is UP and Relocate back to primary cluster
    -   Failover to secondary cluster when primary cluster is DOWN and Relocate back to primary cluster once it recovers

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>