### PR TITLE
cluster sanity checks for Longevity stages

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3865,7 +3865,7 @@ def get_noobaa_db_used_space():
         noobaa_label=constants.NOOBAA_DB_LABEL_47_AND_ABOVE
     )
     cmd_out = noobaa_db_pod_obj[0].exec_cmd_on_pod(
-        command=f"df -h /var/lib/pgsql/", out_yaml_format=False
+        command="df -h /var/lib/pgsql/", out_yaml_format=False
     )
     df_out = cmd_out.split()
     logger.info(

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -45,7 +45,6 @@ from ocs_ci.utility.utils import (
     update_container_with_mirrored_image,
 )
 from ocs_ci.utility.utils import convert_device_size
-from ocs_ci.ocs.resources.pod import get_mon_label
 
 
 logger = logging.getLogger(__name__)
@@ -3840,7 +3839,7 @@ def get_mon_db_size_in_kb(mon_pod_obj):
         convert_device_size (int): Converted Mon db size in KB
 
     """
-    mon_pod_label = get_mon_label(mon_pod_obj=mon_pod_obj)
+    mon_pod_label = pod.get_mon_label(mon_pod_obj=mon_pod_obj)
     logger.info(f"Getting the current mon db size for mon-{mon_pod_label}")
     size = mon_pod_obj.exec_cmd_on_pod(
         f"du -sh /var/lib/ceph/mon/ceph-{mon_pod_label}/store.db",

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -45,6 +45,7 @@ from ocs_ci.utility.utils import (
     update_container_with_mirrored_image,
 )
 from ocs_ci.utility.utils import convert_device_size
+from ocs_ci.ocs.resources.pod import get_mon_label
 
 
 logger = logging.getLogger(__name__)
@@ -3839,17 +3840,17 @@ def get_mon_db_size_in_kb(mon_pod_obj):
         convert_device_size (int): Converted Mon db size in KB
 
     """
-    mon_pod_name = mon_pod_obj.get().get("metadata").get("labels").get("mon")
-    logger.info(f"Getting the current mon db size for mon-{mon_pod_name}")
+    mon_pod_label = get_mon_label(mon_pod_obj=mon_pod_obj)
+    logger.info(f"Getting the current mon db size for mon-{mon_pod_label}")
     size = mon_pod_obj.exec_cmd_on_pod(
-        f"du -sh /var/lib/ceph/mon/ceph-{mon_pod_name}/store.db",
+        f"du -sh /var/lib/ceph/mon/ceph-{mon_pod_label}/store.db",
         out_yaml_format=False,
     )
     size = re.split("\t+", size)
-    assert len(size) > 0, f"Failed to get mon-{mon_pod_name} db size"
+    assert len(size) > 0, f"Failed to get mon-{mon_pod_label} db size"
     size = size[0]
     mon_db_size_kb = convert_device_size(size + "i", "KB")
-    logger.info(f"mon-{mon_pod_name} DB size: {mon_db_size_kb} KB")
+    logger.info(f"mon-{mon_pod_label} DB size: {mon_db_size_kb} KB")
     return mon_db_size_kb
 
 

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -44,6 +44,7 @@ from ocs_ci.utility.utils import (
     run_cmd,
     update_container_with_mirrored_image,
 )
+from ocs_ci.utility.utils import convert_device_size
 
 
 logger = logging.getLogger(__name__)
@@ -3820,3 +3821,54 @@ def create_sa_token_secret(sa_name, namespace=constants.OPENSHIFT_STORAGE_NAMESP
     create_resource(**token_secret)
     logger.info(f"Serviceaccount token secret {sa_name}-token created successfully")
     return token_secret["metadata"]["name"]
+
+
+def get_mon_db_size_in_kb(mon_pod_obj):
+    """
+    Get mon db size and returns the size in KB
+    The output of 'du -sh' command contains the size of the directory and its path as string
+    e.g. "67M\t/var/lib/ceph/mon/ceph-c/store.db"
+    The size is extracted by splitting the string with '\t'.
+    The size format for example: 1K, 234M, 2G
+    For uniformity, this test uses KB
+
+    Args:
+        mon_pod_obj (obj): Mon pod resource object
+
+    Returns:
+        convert_device_size (int): Converted Mon db size in KB
+
+    """
+    mon_pod_name = mon_pod_obj.get().get("metadata").get("labels").get("mon")
+    logger.info(f"Getting the current mon db size for mon-{mon_pod_name}")
+    size = mon_pod_obj.exec_cmd_on_pod(
+        f"du -sh /var/lib/ceph/mon/ceph-{mon_pod_name}/store.db",
+        out_yaml_format=False,
+    )
+    size = re.split("\t+", size)
+    assert len(size) > 0, f"Failed to get mon-{mon_pod_name} db size"
+    size = size[0]
+    mon_db_size_kb = convert_device_size(size + "i", "KB")
+    logger.info(f"mon-{mon_pod_name} DB size: {mon_db_size_kb} KB")
+    return mon_db_size_kb
+
+
+def get_noobaa_db_used_space():
+    """
+    Get noobaa db size
+
+    Returns:
+        df_out (str): noobaa_db used space
+
+    """
+    noobaa_db_pod_obj = pod.get_noobaa_pods(
+        noobaa_label=constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+    )
+    cmd_out = noobaa_db_pod_obj[0].exec_cmd_on_pod(
+        command=f"df -h /var/lib/pgsql/", out_yaml_format=False
+    )
+    df_out = cmd_out.split()
+    logger.info(
+        f"noobaa_db used space is {df_out[-4]} which is {df_out[-2]} of the total PVC size"
+    )
+    return df_out[-4]

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -538,3 +538,7 @@ class ROSAProdAdminLoginFailedException(Exception):
 
 class Md5CheckFailed(Exception):
     pass
+
+
+class ZombieProcessFoundException(Exception):
+    pass

--- a/ocs_ci/ocs/longevity.py
+++ b/ocs_ci/ocs/longevity.py
@@ -585,53 +585,49 @@ class Longevity(object):
             wait_for_pods_to_be_running(timeout=600)
 
         if db_usage:
-            cluster_sanity_list = []
+            mon_db_usage = []
             cluster_sanity_check_dict["db_usage"] = {}
             # Check mon db usage
             mon_pods = get_mon_pods()
             for mon_pod in mon_pods:
                 # Get mon db size
-                cluster_sanity_list.append(
-                    f" {mon_pod.name} DB usage: {get_mon_db_size_in_kb(mon_pod)} in KB"
+                mon_db_usage.append(
+                    f"{mon_pod.name} DB usage: {get_mon_db_size_in_kb(mon_pod)}KB"
                 )
-            cluster_sanity_check_dict["db_usage"]["mon_db_usage"] = cluster_sanity_list
-            cluster_sanity_list.clear()
+            cluster_sanity_check_dict["db_usage"]["mon_db_usage"] = mon_db_usage
             # Check Noobaa db usage
-            cluster_sanity_list.append(
-                f" Noobaa DB usage: {get_noobaa_db_used_space()}"
-            )
             cluster_sanity_check_dict["db_usage"][
                 "noobaa_db_usage"
-            ] = cluster_sanity_list
+            ] = get_noobaa_db_used_space()
 
         if resource_utilization:
-            cluster_sanity_list = []
+            res_util_list = []
             cluster_sanity_check_dict["resource_utilization"] = {}
             # Get the cpu and memory of each nodes from adm top
             master_top_dict_out = get_node_resource_utilization_from_adm_top(
                 node_type="master", print_table=True
             )
-            cluster_sanity_list.append(master_top_dict_out)
+            res_util_list.append(master_top_dict_out)
             worker_top_dict_out = get_node_resource_utilization_from_adm_top(
                 node_type="worker", print_table=True
             )
-            cluster_sanity_list.append(worker_top_dict_out)
+            res_util_list.append(worker_top_dict_out)
             cluster_sanity_check_dict["resource_utilization"][
                 "adm_top_nodes_res_util"
-            ] = cluster_sanity_list
+            ] = res_util_list
             # Get the cpu and memory from describe of nodes
             master_describe_dict_out = get_node_resource_utilization_from_oc_describe(
                 node_type="master", print_table=True
             )
-            cluster_sanity_list.clear()
-            cluster_sanity_list.append(master_describe_dict_out)
+            res_util_list.clear()
+            res_util_list.append(master_describe_dict_out)
             worker_describe_dict_out = get_node_resource_utilization_from_oc_describe(
                 node_type="worker", print_table=True
             )
-            cluster_sanity_list.append(worker_describe_dict_out)
+            res_util_list.append(worker_describe_dict_out)
             cluster_sanity_check_dict["resource_utilization"][
                 "oc_describe_nodes_res_util"
-            ] = cluster_sanity_list
+            ] = res_util_list
 
             # Get the resource utilization of the pods in openshift-storage namespace
             pod_raw_adm_out = pod_resource_utilization_raw_output_from_adm_top()
@@ -682,7 +678,7 @@ class Longevity(object):
         for key1 in cluster_sanity_out_dict:
             with open(f"{destination_dir}/{key1}", "w") as f:
                 for key2, value in cluster_sanity_out_dict[key1].items():
-                    f.write(f"{key2} : {value}\n")
+                    f.write(f"{key2} : {value}\n\n")
 
     def stage_0(
         self, num_of_pvc, num_of_obc, namespace, pvc_size, ignore_teardown=True

--- a/ocs_ci/ocs/longevity.py
+++ b/ocs_ci/ocs/longevity.py
@@ -525,10 +525,10 @@ class Longevity(object):
             fetched from the kube job obc yaml dict
 
         Returns:
-        obc_bound_list (list): List of all OBCs which is in Bound state.
+            obc_bound_list (list): List of all OBCs which is in Bound state.
 
         Raises:
-        AssertionError: If not all OBC reached to Bound state
+            AssertionError: If not all OBC reached to Bound state
 
         """
         log.info("validate that all the OBCs in the kube job list reached BOUND state")
@@ -566,6 +566,9 @@ class Longevity(object):
             db_usage (bool): Get the mon and noobaa db usage if set to True
             resource_utilization (bool): Get the Memory, CPU utilization of nodes and pods if set to True
             disk_utilization (bool): Get the osd and total cluster disk utilization if set to True
+
+        Returns:
+            cluster_sanity_check_dict (dict): Returns cluster sanity checks outputs in a nested dictionary
 
         """
         log.info("Starting Cluster Sanity checks....")

--- a/ocs_ci/ocs/longevity.py
+++ b/ocs_ci/ocs/longevity.py
@@ -686,7 +686,7 @@ class Longevity(object):
         for key1 in cluster_sanity_out_dict:
             fopen = open(f"{destination_dir}/{key1}", "w")
             for key2, value in cluster_sanity_out_dict[key1].items():
-                fopen.write("%s:%s\n" % (key2, value))
+                fopen.write(f"{key2} : {value}\n")
             fopen.close()
 
     def stage_0(

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2400,3 +2400,26 @@ def wait_for_node_count_to_reach_status(
                 f"The nodes {node_names_in_expected_status} reached the expected status {expected_status}, "
                 f"but we were waiting for {node_count} of them to reach status {expected_status}"
             )
+
+
+def check_for_zombie_process_on_node(node_name=None):
+    """
+    Check if there are any zombie process on the nodes
+
+    Args:
+        node_name (list): Node names list to check for zombie process
+
+    Raise:
+        ZombieProcessFoundException: In case zombie process are found on the node
+
+    """
+    node_obj_list = get_node_objs(node_name) if node_name else get_node_objs()
+    for node_obj in node_obj_list:
+        debug_cmd = f'debug nodes/{node_obj.name} -- chroot /host /bin/bash -c "top -b1 -n1 | grep Z"'
+        out = node_obj.ocp.exec_oc_cmd(command=debug_cmd, out_yaml_format=False)
+        log.info(f"Zombie process check command output: {out}")
+        if not out:
+            log.info(f"No Zombie process found on the node: {node_obj.name}")
+        else:
+            log.error(f"Zombie process found on node: {node_obj.name}")
+            raise exceptions.ZombieProcessFoundException

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2415,11 +2415,11 @@ def check_for_zombie_process_on_node(node_name=None):
     """
     node_obj_list = get_node_objs(node_name) if node_name else get_node_objs()
     for node_obj in node_obj_list:
-        debug_cmd = f'debug nodes/{node_obj.name} -- chroot /host /bin/bash -c "top -b1 -n1 | grep Z"'
+        debug_cmd = f'debug nodes/{node_obj.name} -- chroot /host /bin/bash -c "ps -A -ostat,pid,ppid | grep -e "[zZ]""'
         out = node_obj.ocp.exec_oc_cmd(command=debug_cmd, out_yaml_format=False)
-        log.info(f"Zombie process check command output: {out}")
         if not out:
             log.info(f"No Zombie process found on the node: {node_obj.name}")
         else:
             log.error(f"Zombie process found on node: {node_obj.name}")
+            log.error(f"pid and ppid details: {out}")
             raise exceptions.ZombieProcessFoundException

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2649,3 +2649,17 @@ def pod_resource_utilization_raw_output_from_adm_top(
     logger.info("Command RAW output of adm top pods")
     logger.info(f"{resource_utilization_all_pods}")
     return resource_utilization_all_pods
+
+
+def get_mon_label(mon_pod_obj):
+    """
+    Gets the mon pod label
+
+    Args:
+        mon_pod_obj (Pod): The pod object
+
+    Returns:
+        str: The mon pod label (eg: a)
+
+    """
+    return mon_pod_obj.get().get("metadata").get("labels").get("mon")

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2633,3 +2633,18 @@ def wait_for_osd_pods_having_ids(osd_ids, timeout=180, sleep=10):
         if len(osd_pods) == len(osd_ids):
             logger.info(f"Found all the osd pods with the ids: {osd_ids}")
             return osd_pods
+
+
+def pod_resource_utilization_raw_output_from_adm_top(
+    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+):
+    """
+    Gets the pod's memory utilization using adm top command.
+
+    """
+    obj = ocp.OCP()
+    resource_utilization_all_pods = obj.exec_oc_cmd(
+        command=f"adm top pods -n {namespace}", out_yaml_format=False
+    )
+    logging.info("Command RAW output of adm top pods")
+    logging.info(f"{resource_utilization_all_pods}")

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2648,3 +2648,4 @@ def pod_resource_utilization_raw_output_from_adm_top(
     )
     logger.info("Command RAW output of adm top pods")
     logger.info(f"{resource_utilization_all_pods}")
+    return resource_utilization_all_pods

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2641,6 +2641,12 @@ def pod_resource_utilization_raw_output_from_adm_top(
     """
     Gets the pod's memory utilization using adm top command.
 
+    Args:
+        namespace (str) : The pod's namespace where the adm top command has to be run
+
+    Returns:
+        str : Raw output of adm top pods command
+
     """
     obj = ocp.OCP()
     resource_utilization_all_pods = obj.exec_oc_cmd(

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2646,5 +2646,5 @@ def pod_resource_utilization_raw_output_from_adm_top(
     resource_utilization_all_pods = obj.exec_oc_cmd(
         command=f"adm top pods -n {namespace}", out_yaml_format=False
     )
-    logging.info("Command RAW output of adm top pods")
-    logging.info(f"{resource_utilization_all_pods}")
+    logger.info("Command RAW output of adm top pods")
+    logger.info(f"{resource_utilization_all_pods}")

--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -103,7 +103,7 @@ class TestMonLogTrimming(E2ETest):
         Check mon db size while fio runs in the background
         """
         while not self.stop_checking_mon_db:
-            temp_mon_db_size = self.get_mon_db_size_in_kb()
+            temp_mon_db_size = get_mon_db_size_in_kb()
             assert temp_mon_db_size is not None, "Failed to get mon db size"
             log.info(
                 f"Monitoring mon-{self.selected_mon_pod} db size: {temp_mon_db_size}K"

--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -98,12 +98,12 @@ class TestMonLogTrimming(E2ETest):
 
         request.addfinalizer(finalizer)
 
-    def check_mon_db_trim(self):
+    def check_mon_db_trim(self, mon_pod_obj):
         """
         Check mon db size while fio runs in the background
         """
         while not self.stop_checking_mon_db:
-            temp_mon_db_size = get_mon_db_size_in_kb()
+            temp_mon_db_size = get_mon_db_size_in_kb(mon_pod_obj)
             assert temp_mon_db_size is not None, "Failed to get mon db size"
             log.info(
                 f"Monitoring mon-{self.selected_mon_pod} db size: {temp_mon_db_size}K"
@@ -146,7 +146,9 @@ class TestMonLogTrimming(E2ETest):
             size="100M",
             runtime=480,
         )
-        thread1 = threading.Thread(target=self.check_mon_db_trim)
+        thread1 = threading.Thread(
+            target=self.check_mon_db_trim(self.selected_mon_pod_obj)
+        )
         thread1.start()
 
         thread2 = threading.Thread(target=self.restart_osd_pod)

--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -147,7 +147,7 @@ class TestMonLogTrimming(E2ETest):
             runtime=480,
         )
         thread1 = threading.Thread(
-            target=self.check_mon_db_trim(self.selected_mon_pod_obj)
+            target=self.check_mon_db_trim, args=(self.selected_mon_pod_obj,)
         )
         thread1.start()
 

--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -1,14 +1,13 @@
 import logging
 import random
 import threading
-import re
 import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import E2ETest, bugzilla, tier2
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_mon_pods
-from ocs_ci.utility.utils import convert_device_size
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.helpers.helpers import get_mon_db_size_in_kb
 
 log = logging.getLogger(__name__)
 
@@ -135,30 +134,12 @@ class TestMonLogTrimming(E2ETest):
             num_of_deletions = num_of_deletions + 1
         log.info(f"Number of osd deletions: {num_of_deletions}")
 
-    def get_mon_db_size_in_kb(self):
-        """
-        Get mon db size and returns the size in KB
-        The output of 'du -sh' command contains the size of the directory and its path as string
-        e.g. "67M\t/var/lib/ceph/mon/ceph-c/store.db"
-        The size is extracted by splitting the string with '\t'.
-        The size format for example: 1K, 234M, 2G
-        For uniformity, this test uses KB
-        """
-        size = self.selected_mon_pod_obj.exec_cmd_on_pod(
-            f"du -sh /var/lib/ceph/mon/ceph-{self.selected_mon_pod}/store.db",
-            out_yaml_format=False,
-        )
-        size = re.split("\t+", size)
-        assert len(size) > 0, f"Failed to get mon-{self.selected_mon_pod} db size"
-        size = size[0]
-        return convert_device_size(size + "i", "KB")
-
     def test_mon_log_trimming(self):
         """
         Check that mon db actually get trimmed while running fio and OSD Pod restart
 
         """
-        self.initial_db_size = self.get_mon_db_size_in_kb()
+        self.initial_db_size = get_mon_db_size_in_kb(self.selected_mon_pod_obj)
         log.info(f"Initial db size: {self.initial_db_size}K")
         self.fio_pod_obj.run_io(
             storage_type="fs",
@@ -180,7 +161,7 @@ class TestMonLogTrimming(E2ETest):
         thread1.join()
         thread2.join()
 
-        final_db_size = self.get_mon_db_size_in_kb()
+        final_db_size = get_mon_db_size_in_kb(self.selected_mon_pod_obj)
         log.info(f"Final db size: {final_db_size}K")
 
         assert self.mon_db_trim_count > 0, (


### PR DESCRIPTION
This PR covers,
*. Cluster sanity checks for Longevity stages
*.  Collect cluster sanity checks outputs and store the outputs in ocs-ci log directory
*. OCP watchlist BZ#2049102 automation as part of closed loop

Signed-off-by: Prasad Desala <tdesala@redhat.com>