### PR TITLE
Increasing timeouts to avoid couchbase failures

### DIFF
--- a/ocs_ci/ocs/pillowfight.py
+++ b/ocs_ci/ocs/pillowfight.py
@@ -1,7 +1,6 @@
 """
 Pillowfight Class to run various workloads and scale tests
 """
-import time
 import logging
 import tempfile
 import re
@@ -93,7 +92,6 @@ class PillowFight(object):
             )
             lpillowfight = OCS(**pfight)
             lpillowfight.create()
-            time.sleep(15)
         self.pods_info = {}
 
         for pillowfight_pods in TimeoutSampler(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2961,12 +2961,15 @@ def couchbase_factory_fixture(request):
         # Create couchbase workers
         couchbase.create_cb_cluster(replicas=3, sc_name=sc_name)
         couchbase.create_data_buckets()
+        # adding wait for the buckets created to be reconciled with the couchbase cluster
+        time.sleep(10)
         # Run couchbase workload
         couchbase.run_workload(
             replicas=replicas,
             run_in_bg=run_in_bg,
             num_items=num_items,
             num_threads=num_threads,
+            timeout=2100,
         )
         # Run sanity check on data logs
         couchbase.analyze_run(skip_analyze=skip_analyze)

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
@@ -88,7 +88,6 @@ class TestCouchBaseNodeReboot(E2ETest):
         )(wait_for_nodes_status(timeout=1800))
         bg_handler = flowtest.BackgroundOps()
         bg_ops = [self.cb.result]
-
         retry((CommandFailed), tries=60, delay=15)(
             bg_handler.wait_for_bg_operations(bg_ops, timeout=3600)
         )

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
@@ -88,6 +88,7 @@ class TestCouchBaseNodeReboot(E2ETest):
         )(wait_for_nodes_status(timeout=1800))
         bg_handler = flowtest.BackgroundOps()
         bg_ops = [self.cb.result]
+
         retry((CommandFailed), tries=60, delay=15)(
             bg_handler.wait_for_bg_operations(bg_ops, timeout=3600)
         )


### PR DESCRIPTION
1. Added 10 second wait after the couch base bucket creation, so that newly created bucket will reconcile with the existing couch base cluster
2. Increased timeout used for pillowfight benchmarking. This is used to wait until all three Job completes benchmarking.  
Signed-off-by: mashetty <mashetty@redhat.com>