### PR TITLE
allow usage of client proxy on private link cluster

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -461,7 +461,9 @@ class OCP(object):
         # defined, update kubeconfig file with proxy-url parameter to redirect
         # client access through proxy server
         if (
-            config.DEPLOYMENT.get("proxy") or config.DEPLOYMENT.get("disconnected")
+            config.DEPLOYMENT.get("proxy")
+            or config.DEPLOYMENT.get("disconnected")
+            or config.ENV_DATA.get("private_link")
         ) and config.ENV_DATA.get("client_http_proxy"):
             kubeconfig = os.getenv("KUBECONFIG")
             if not kubeconfig or not os.path.exists(kubeconfig):

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -773,7 +773,9 @@ def login_ui(console_url=None):
 
         # use proxy server, if required
         if (
-            config.DEPLOYMENT.get("proxy") or config.DEPLOYMENT.get("disconnected")
+            config.DEPLOYMENT.get("proxy")
+            or config.DEPLOYMENT.get("disconnected")
+            or config.ENV_DATA.get("private_link")
         ) and config.ENV_DATA.get("client_http_proxy"):
             client_proxy = urlparse(config.ENV_DATA.get("client_http_proxy"))
             # there is a big difference between configuring not authenticated


### PR DESCRIPTION
allow configuration of ENV_DATA["client_http_proxy"] for pirvate link cluster

Signed-off-by: Daniel Horak <dahorak@redhat.com>