### PR TITLE
use client http proxy if configured

### DIFF
--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -90,6 +90,14 @@ def init_ocsci_conf(arguments=None):
         process_ocsci_conf(arguments)
         check_config_requirements()
 
+    if (
+        framework.config.DEPLOYMENT.get("proxy")
+        or framework.config.DEPLOYMENT.get("disconnected")
+        or framework.config.ENV_DATA.get("private_link")
+    ) and framework.config.ENV_DATA.get("client_http_proxy"):
+        os.environ["http_proxy"] = framework.config.ENV_DATA["client_http_proxy"]
+        os.environ["https_proxy"] = framework.config.ENV_DATA["client_http_proxy"]
+
 
 def process_ocsci_conf(arguments):
     parser = argparse.ArgumentParser(add_help=False)

--- a/ocs_ci/utility/proxy.py
+++ b/ocs_ci/utility/proxy.py
@@ -17,7 +17,9 @@ def update_kubeconfig_with_proxy_url_for_client(kubeconfig):
 
     """
     if (
-        config.DEPLOYMENT.get("proxy") or config.DEPLOYMENT.get("disconnected")
+        config.DEPLOYMENT.get("proxy")
+        or config.DEPLOYMENT.get("disconnected")
+        or config.ENV_DATA.get("private_link")
     ) and config.ENV_DATA.get("client_http_proxy"):
         logger.info(
             f"Updating kubeconfig '{kubeconfig}' with 'proxy-url: "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4186,6 +4186,22 @@ def setup_acm_ui_fixture(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def use_client_proxy(request):
+    """
+    This fixture configure required env variables for using client http proxy
+    if configured.
+    """
+    if (
+        config.DEPLOYMENT.get("proxy")
+        or config.DEPLOYMENT.get("disconnected")
+        or config.ENV_DATA.get("private_link")
+    ) and config.ENV_DATA.get("client_http_proxy"):
+        log.info(f"Configuring client proxy: {config.ENV_DATA['client_http_proxy']}")
+        os.environ["http_proxy"] = config.ENV_DATA["client_http_proxy"]
+        os.environ["https_proxy"] = config.ENV_DATA["client_http_proxy"]
+
+
+@pytest.fixture(scope="session", autouse=True)
 def load_cluster_info_file(request):
     """
     This fixture tries to load cluster_info.json file if exists (on cluster


### PR DESCRIPTION
set `http_proxy` and `https_proxy` env variables, if client http proxy is required and configured

Signed-off-by: Daniel Horak <dahorak@redhat.com>