### PR TITLE
adding csi times and renaming the test

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -758,7 +758,9 @@ def wait_for_resource_bulk_status(
     raise Exception(err_msg)
 
 
-def pod_csi_time(interface, pv_name, start_time, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE):
+def pod_csi_time(
+    interface, pv_name, start_time, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+):
     """
     Get the starting/ending creation time of a PVC based on provisioner logs
 
@@ -776,7 +778,7 @@ def pod_csi_time(interface, pv_name, start_time, namespace=constants.OPENSHIFT_S
 
     """
     volume_handle = None
-    for line in run_oc_command(f'describe pv {pv_name}', namespace=namespace):
+    for line in run_oc_command(f"describe pv {pv_name}", namespace=namespace):
         if "VolumeHandle:" in line:
             volume_handle = line.split()[1]
             break

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -811,12 +811,10 @@ def pod_csi_time(interface, pv_name, start_time, namespace=constants.OPENSHIFT_S
     node_publish_et = None
     for sublog in logs:
         for line in sublog:
-            if ("GRPC response:" in line
-                and f"ID: {node_stage_id}" in line):
-                    node_stage_et = string_to_time(line.split(" ")[1])
-            if ("GRPC response:" in line
-                and f"ID: {node_publish_id}" in line):
-                    node_publish_et = string_to_time(line.split(" ")[1])
+            if "GRPC response:" in line and f"ID: {node_stage_id}" in line:
+                node_stage_et = string_to_time(line.split(" ")[1])
+            if "GRPC response:" in line and f"ID: {node_publish_id}" in line:
+                node_publish_et = string_to_time(line.split(" ")[1])
 
     if node_stage_et is None:
         raise Exception("Cannot find node stage GRPC response")
@@ -845,4 +843,3 @@ def pod_csi_time(interface, pv_name, start_time, namespace=constants.OPENSHIFT_S
     logger.info(f"Total csi pod attach time is {total_time} seconds")
 
     return total_time
-

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -157,7 +157,7 @@ def get_logfile_names(interface, provisioning=True):
     Args:
         interface (str) : an interface (RBD or CephFS) to run on
         provisioning (bool): if True, look for the provisioner log pods
-        
+
     Returns:
         log names (list) : names of the log files relevant for searching in
 

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -153,16 +153,11 @@ def string_to_time(time_string):
 def get_logfile_names(interface, provisioning=True):
     """
     Finds names for log files pods in which logs for pvc creation are located
-    If provisioning is True, this will be
-        For CephFS: 2 pods that start with "csi-cephfsplugin-provisioner" prefix
-        For RBD: 2 pods that start with "csi-rbdplugin-provisioner" prefix
-    If provisioning is False, this will be
-        For CephFS: pods that have csi-cephfsplugin but not with "csi-cephfsplugin-provisioner" prefix
-        For RBD: pods that have "csi-rbdplugin" but not "csi-rbdplugin-provisioner" prefix
 
     Args:
         interface (str) : an interface (RBD or CephFS) to run on
-
+        provisioning (bool): if True, look for the provisioner log pods
+        
     Returns:
         log names (list) : names of the log files relevant for searching in
 

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -156,9 +156,10 @@ def get_logfile_names(interface, provisioning=True):
     If provisioning is True, this will be
         For CephFS: 2 pods that start with "csi-cephfsplugin-provisioner" prefix
         For RBD: 2 pods that start with "csi-rbdplugin-provisioner" prefix
-     If provisioning is False, this will be
+    If provisioning is False, this will be
         For CephFS: pods that have csi-cephfsplugin but not with "csi-cephfsplugin-provisioner" prefix
         For RBD: pods that have "csi-rbdplugin" but not "csi-rbdplugin-provisioner" prefix
+
     Args:
         interface (str) : an interface (RBD or CephFS) to run on
 

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -754,16 +754,16 @@ def wait_for_resource_bulk_status(
     raise Exception(err_msg)
 
 
-def pod_csi_time(
+def pod_attach_csi_time(
     interface, pv_name, start_time, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
 ):
     """
-    Get the starting/ending creation time of a PVC based on provisioner logs
+    Get the pod start/attach csi time of a pod based on csi-rbdplugin container in csi-rbdplugin pods
 
     Args:
         interface (str): The interface backed the PVC
         pv_name (str): Name of the PV
-        start_time (time): the starttime of the test to reduce log size reading
+        start_time (time): the start time of the test to reduce log size reading
         namespace (str): the tests namespace
 
     Return:

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -167,7 +167,7 @@ def get_logfile_names(interface, provisioning=True):
     pods = run_oc_command(cmd="get pod", namespace="openshift-storage")
 
     if "Error in command" in pods:
-        raise Exception("Can not get csi controller pod")
+        raise Exception("Cannot get csi controller pod")
 
     provisioning_name = interface_data[interface]["prov"]
     csi_name = interface_data[interface]["csi_cnt"]
@@ -243,12 +243,12 @@ def measure_pvc_creation_time(interface, pvc_name, start_time):
                 et = string_to_time(line.split(" ")[1])
 
     if st is None:
-        logger.error(f"Can not find start time of {pvc_name}")
-        raise Exception(f"Can not find start time of {pvc_name}")
+        logger.error(f"Cannot find start time of {pvc_name}")
+        raise Exception(f"Cannot find start time of {pvc_name}")
 
     if et is None:
-        logger.error(f"Can not find end time of {pvc_name}")
-        raise Exception(f"Can not find end time of {pvc_name}")
+        logger.error(f"Cannot find end time of {pvc_name}")
+        raise Exception(f"Cannot find end time of {pvc_name}")
 
     total_time = (et - st).total_seconds()
     if total_time < 0:
@@ -297,12 +297,12 @@ def csi_pvc_time_measure(interface, pvc_obj, operation, start_time):
                 et = string_to_time(line.split(" ")[1])
 
     if st is None:
-        err_msg = f"Can not find CSI start time of {pvc_obj.name}"
+        err_msg = f"Cannot find CSI start time of {pvc_obj.name}"
         logger.error(err_msg)
         raise Exception(err_msg)
 
     if et is None:
-        err_msg = f"Can not find CSI end time of {pvc_obj.name}"
+        err_msg = f"Cannot find CSI end time of {pvc_obj.name}"
         logger.error(err_msg)
         raise Exception(err_msg)
 
@@ -362,12 +362,12 @@ def csi_bulk_pvc_time_measure(interface, pvc_objs, operation, start_time):
                     single_et = string_to_time(line.split(" ")[1])
 
         if single_st is None:
-            err_msg = f"Can not find CSI start time of {pvc.name}"
+            err_msg = f"Cannot find CSI start time of {pvc.name}"
             logger.error(err_msg)
             raise Exception(err_msg)
 
         if single_et is None:
-            err_msg = f"Can not find CSI end time of {pvc.name}"
+            err_msg = f"Cannot find CSI end time of {pvc.name}"
             logger.error(err_msg)
             raise Exception(err_msg)
 
@@ -427,11 +427,11 @@ def measure_total_snapshot_creation_time(snap_name, start_time):
         return total.total_seconds()
 
     if start is None:
-        err_msg = f"Can not find start creation time of snapshot {snap_name}"
+        err_msg = f"Cannot find start creation time of snapshot {snap_name}"
         logger.error(err_msg)
         raise Exception(err_msg)
     if end is None:
-        err_msg = f"Can not find end creation time of snapshot {snap_name}"
+        err_msg = f"Cannot find end creation time of snapshot {snap_name}"
         logger.error(err_msg)
         raise Exception(err_msg)
 
@@ -486,7 +486,7 @@ def get_snapshot_time(snap_name, status, start_time):
     pods = run_oc_command(cmd="get pod", namespace="openshift-cluster-storage-operator")
 
     if "Error in command" in pods:
-        raise Exception("Can not get csi controller pod")
+        raise Exception("Cannot get csi controller pod")
 
     log_names = []
     for line in pods:
@@ -552,12 +552,12 @@ def measure_csi_snapshot_creation_time(interface, snapshot_id, start_time):
                 et = line.split(" ")[1]
                 et = datetime.strptime(et, time_format)
     if st is None:
-        logger.error(f"Can not find start time of snapshot {snapshot_id}")
-        raise Exception(f"Can not find start time of snapshot {snapshot_id}")
+        logger.error(f"Cannot find start time of snapshot {snapshot_id}")
+        raise Exception(f"Cannot find start time of snapshot {snapshot_id}")
 
     if et is None:
-        logger.error(f"Can not find end time of snapshot {snapshot_id}")
-        raise Exception(f"Can not find end time of snapshot {snapshot_id}")
+        logger.error(f"Cannot find end time of snapshot {snapshot_id}")
+        raise Exception(f"Cannot find end time of snapshot {snapshot_id}")
 
     total_time = (et - st).total_seconds()
     if total_time < 0:
@@ -779,7 +779,8 @@ def pod_csi_time(
             volume_handle = line.split()[1]
             break
     if volume_handle is None:
-        raise Exception("Can not get volume handle")
+        logger.error("Cannot get volume handle")
+        raise Exception("Cannot get volume handle")
 
     log_names = get_logfile_names(interface, provisioning=False)
     logs = read_csi_logs(log_names, interface_data[interface]["csi_cnt"], start_time)
@@ -797,9 +798,11 @@ def pod_csi_time(
                 node_publish_id = line.split()[5]
 
     if node_stage_st is None:
+        logger.error("Cannot find node stage GRPC call")
         raise Exception("Cannot find node stage GRPC call")
 
     if node_publish_st is None:
+        logger.error("Cannot find node publish GRPC call")
         raise Exception("Cannot find node publish GRPC call")
 
     logger.info(f"Node stage GRPC call start time is: {node_stage_st}")
@@ -815,9 +818,11 @@ def pod_csi_time(
                 node_publish_et = string_to_time(line.split(" ")[1])
 
     if node_stage_et is None:
+        logger.error("Cannot find node stage GRPC response")
         raise Exception("Cannot find node stage GRPC response")
 
     if node_publish_et is None:
+        logger.error("Cannot find node publish GRPC response")
         raise Exception("Cannot find node publish GRPC response")
 
     logger.info(f"Node stage GRPC response time is: {node_stage_et}")

--- a/tests/e2e/performance/csi_tests/test_pod_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_attachtime.py
@@ -131,7 +131,7 @@ class TestPodStartTime(PASTest):
             # Get the POD start time including the attache time
             self.start_time_dict_list.append(helpers.pod_start_time(pod_obj))
             self.csi_time_dict_list.append(
-                performance_lib.pod_csi_time(
+                performance_lib.pod_attach_csi_time(
                     self.interface, pvc_obj.backed_pv, csi_start_time, self.namespace
                 )
             )


### PR DESCRIPTION
This PR contains the following enhancements: 

1) Renaming the test so that similarly to bulk pod attach and pod reattach test this test will be called "pod attach" and not "pvc attach" test

2) Adding CSI measurements for pod attach action and reporting those measurements to the ES. 

Signed-off-by: Yulia Persky <ypersky@redhat.com>