### PR TITLE
doc update: use bugzilla_api_key for bugzilla authentication

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,8 +134,7 @@ to the pytest.
   ```bash
   [DEFAULT]
   bugzilla_url = https://bugzilla.redhat.com/xmlrpc.cgi
-  bugzilla_username = kerberos@redhat.com
-  bugzilla_password = yourPassword
+  bugzilla_api_key = <API_KEY>
   ```
 * `--collect-logs` - to collect OCS logs for failed test cases.
 * `--collect-logs-on-success-run` - Collect must gather logs at the end of the


### PR DESCRIPTION
There are issue like 2 factor authentication and too many current logins if we
use username and password for authentication. To avoid such problems, we
need API key for bugzilla authentication.

Signed-off-by: vavuthu <vavuthu@redhat.com>