### PR TITLE
drop unnecessary log info call

### DIFF
--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -307,7 +307,6 @@ def validate_status(content):
     if status != "success":
         logger.error("content status is not success, but %s", status)
         raise ValueError("content status is not success")
-    logger.info("content status is success as expected")
 
 
 class PrometheusAPI(object):


### PR DESCRIPTION
Let's not pollute our logs when prometheus queries are run in bulk.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/6003