### PR TITLE
Enhance logger for multi cluster + adding cluster name in prefix

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -189,13 +189,14 @@ class MultiClusterConfig:
         ]
         self.to_dict = self.cluster_ctx.to_dict
         if self.RUN.get("kubeconfig"):
-            logger.debug("switching kubeconfig")
             os.environ["KUBECONFIG"] = self.RUN.get("kubeconfig")
 
     def switch_ctx(self, index=0):
         self.cluster_ctx = self.clusters[index]
         self.cur_index = index
         self._refresh_ctx()
+        # Log the switch after changing the current index
+        logger.info(f"Switched to cluster: {self.current_cluster_name()}")
 
     def switch_acm_ctx(self):
         self.switch_ctx(self.get_acm_index())
@@ -301,6 +302,16 @@ class MultiClusterConfig:
 
         """
         self.switch_ctx(self.get_cluster_index_by_name(cluster_name))
+
+    def current_cluster_name(self):
+        """
+        Get the Cluster name of the current context
+
+        Returns:
+            str: The cluster name which is stored as str in config (None if key not exist)
+
+        """
+        return self.ENV_DATA.get("cluster_name")
 
 
 config = MultiClusterConfig()

--- a/ocs_ci/framework/logger_factory.py
+++ b/ocs_ci/framework/logger_factory.py
@@ -12,7 +12,9 @@ def record_factory(*args, **kwargs):
     """
     record = current_factory(*args, **kwargs)
     # Customize the log format for cluster context:
-    record.clusterctx = f"- C[{config.cur_index}]" if config.nclusters > 1 else ""
+    record.clusterctx = (
+        f"- C[{config.current_cluster_name()}]" if config.nclusters > 1 else ""
+    )
 
     return record
 


### PR DESCRIPTION
It feels more comfortable looking in the logs by the cluster name rather than the index number, as the number of clusters grows in Managed Services + DR setups, it might be a better idea to simply print the cluster name itself.

Addressed the following in the PR:

 - Replaced a debug log in `_refresh_ctx()` with info log inside `switch_context` function. Prints out to what cluster name is changed
 - New method in the `MultiClusterConfig` class that retrieves the cluster name from `ENV_DATA` section
 - Replaced the call to `cur_index` attribute in the logger prefix, with the cluster name