### PR TITLE
Fix: Added retry for sync_object_directory() in test_multiregion_mirror

### DIFF
--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -16,7 +16,7 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
 )
 from ocs_ci.ocs.constants import BS_AUTH_FAILED, BS_OPTIMAL, AWSCLI_TEST_OBJ_DIR
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility.retry import retry
 

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.ocs.constants import BS_AUTH_FAILED, BS_OPTIMAL, AWSCLI_TEST_OBJ_DIR
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class TestMultiRegion(MCGTest):
         mcg_bucket_path = f"s3://{bucket_name}"
 
         # Upload test objects to the NooBucket
-        sync_object_directory(
+        retry(CommandFailed, tries=3, delay=10)(sync_object_directory)(
             awscli_pod_session, local_testobjs_dir_path, mcg_bucket_path, mcg_obj
         )
 
@@ -120,7 +121,7 @@ class TestMultiRegion(MCGTest):
 
         # Verify integrity of B
         # Retrieve all objects from MCG bucket to result dir in Pod
-        sync_object_directory(
+        retry(CommandFailed, tries=3, delay=10)(sync_object_directory)(
             awscli_pod_session, mcg_bucket_path, local_temp_path, mcg_obj
         )
 
@@ -151,7 +152,7 @@ class TestMultiRegion(MCGTest):
 
         # Verify integrity of A
         # Retrieve all objects from MCG bucket to result dir in Pod
-        sync_object_directory(
+        retry(CommandFailed, tries=3, delay=10)(sync_object_directory)(
             awscli_pod_session, mcg_bucket_path, local_temp_path, mcg_obj
         )
 


### PR DESCRIPTION
**Fix:**
Added retry() to the sync_object_directory() in the
test_multiregion_mirror, as the tests might fail mnay times due to some
race condtions. This will help avoid that issue.

Fixes: #5969

Signed-off-by: nik-redhat <nladha@redhat.com>