### PR TITLE
Skip storage system validation for upgrade cluster with OCP 4.10 + upgrade OCS version 4.10

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -605,6 +605,19 @@ def verify_storage_system():
             "Because of the BZ 2075422, we are skipping storage system validation!"
         )
         return
+    if config.UPGRADE.get("upgrade_ocs_version"):
+        upgrade_ocs_version = version.get_semantic_version(
+            config.UPGRADE.get("upgrade_ocs_version"), only_major_minor=True
+        )
+        if (
+            live_deployment
+            and ocp_version == version.VERSION_4_10
+            and upgrade_ocs_version == version.VERSION_4_10
+        ):
+            log.warning(
+                "Because of the BZ 2075422, we are skipping storage system validation after upgrade"
+            )
+            return
     if ocs_version >= version.VERSION_4_9 and not managed_service:
         log.info("Verifying storage system status")
         storage_system = OCP(


### PR DESCRIPTION
Skip storage system validation for upgrade cluster with OCP 4.10 + upgrade OCS version 4.10

Fixes: #6021 

W/A issue: #5995 

Signed-off-by: vavuthu <vavuthu@redhat.com>