### PR TITLE
Skip monitoring prometheus tests when using MS

### DIFF
--- a/tests/manage/monitoring/prometheus/test_ceph.py
+++ b/tests/manage/monitoring/prometheus/test_ceph.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import tier4, tier4a
+from ocs_ci.framework.testlib import tier4, tier4a, skipif_managed_service
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 @tier4a
 @pytest.mark.polarion_id("OCS-903")
 @pytest.mark.skip(reason="measure_corrupt_pg fixture makes current test runs unstable")
+@skipif_managed_service
 def test_corrupt_pg_alerts(measure_corrupt_pg):
     """
     Test that there are appropriate alerts when Placement group
@@ -58,6 +59,7 @@ def test_corrupt_pg_alerts(measure_corrupt_pg):
 @tier4a
 @pytest.mark.polarion_id("OCS-898")
 @pytest.mark.skip(reason="measure_corrupt_pg fixture makes current test runs unstable")
+@skipif_managed_service
 def test_ceph_health(measure_stop_ceph_mon, measure_corrupt_pg):
     """
     Test that there are appropriate alerts for Ceph health triggered.


### PR DESCRIPTION
The tests modified in the PR are not relevant to MS. Prometheus provided by standard offering is not being tested in MS testing. Instead, we are testing alerts in PagerDuty, SendGrid, and DeadManSnitch.