### PR TITLE
fix dployment of OCP 4.11 via Flexy on vsphere (Disconnected and Proxy environment)

### DIFF
--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -33,6 +33,7 @@ from ocs_ci.utility.flexy import (
     configure_allowed_domains_in_proxy,
     load_cluster_info,
 )
+from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
@@ -488,9 +489,8 @@ class FlexyBase(object):
             terraform_data_dir = os.path.join(
                 self.cluster_path, constants.TERRAFORM_DATA_DIR
             )
-            ocp_version = get_ocp_version()
             # related to flexy-templates changes 4a4099541
-            if Version.coerce(ocp_version) >= Version.coerce("4.11"):
+            if version.get_semantic_ocp_running_version() >= version.VERSION_4_11:
                 files_to_copy = (
                     "upi_on_vsphere-terraform-scripts/terraform.tfstate",
                     "terraform.tfvars",

--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -488,7 +488,16 @@ class FlexyBase(object):
             terraform_data_dir = os.path.join(
                 self.cluster_path, constants.TERRAFORM_DATA_DIR
             )
-            for _file in ("terraform.tfstate", "terraform.tfvars"):
+            ocp_version = get_ocp_version()
+            # related to flexy-templates changes 4a4099541
+            if Version.coerce(ocp_version) >= Version.coerce("4.11"):
+                files_to_copy = (
+                    "upi_on_vsphere-terraform-scripts/terraform.tfstate",
+                    "terraform.tfvars",
+                )
+            else:
+                files_to_copy = ("terraform.tfstate", "terraform.tfvars")
+            for _file in files_to_copy:
                 shutil.copy2(
                     os.path.join(flexy_terraform_dir, _file), terraform_data_dir
                 )


### PR DESCRIPTION
- recent changes in flexy-templates (commit 4a4099541) changed location
  of terraform.tfstate file for the vSphere deployment of OCP 4.11

Signed-off-by: Daniel Horak <dahorak@redhat.com>