### PR TITLE
fix image mirroring for upgrade on OCP 4.11

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -270,7 +270,8 @@ def mirror_index_image_via_oc_mirror(index_image, packages, icsp=None):
     )
     cmd = (
         f"oc mirror --config {imageset_config_file} "
-        f"docker://{config.DEPLOYMENT['mirror_registry']} --dest-skip-tls"
+        f"docker://{config.DEPLOYMENT['mirror_registry']} "
+        "--dest-skip-tls --ignore-history"
     )
     exec_cmd(cmd, timeout=7200)
 


### PR DESCRIPTION
The mirror registry used for disconnected deployment doesn't support
some operations required by oc-mirror command. When ignoring the images
mirrored during deployment, the additional features are not required.

fixes: https://github.com/red-hat-storage/ocs-ci/issues/6028

Signed-off-by: Daniel Horak <dahorak@redhat.com>