### PR TITLE
Skip Running status check of 'Completed' pods when checking for all pods in the namespace openshift-storage

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1768,6 +1768,10 @@ def check_pods_in_running_state(
             ("rook-ceph-osd-prepare" not in p.name)
             and ("rook-ceph-drain-canary" not in p.name)
             and ("debug" not in p.name)
+            and not (
+                config.ENV_DATA["platform"] in constants.MANAGED_SERVICE_PLATFORMS
+                and p.name[:-5] in p.labels.get("job-name", "")
+            )
         ):
             status = ocp_pod_obj.get_resource(p.name, "STATUS")
             if status not in "Running":

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1733,9 +1733,12 @@ def check_pods_in_running_state(
     namespace=defaults.ROOK_CLUSTER_NAMESPACE,
     pod_names=None,
     raise_pod_not_found_error=False,
+    skip_for_status=None,
 ):
     """
-    checks whether all the pods in a given namespace are in Running state or not
+    Checks whether the pods in a given namespace are in Running state or not.
+    The pods which are in 'Completed' state will be skipped when checking for all pods in the
+    namespace openshift-storage. 'Completed' will be the expected state of such pods.
 
     Args:
         namespace (str): Name of cluster namespace(default: defaults.ROOK_CLUSTER_NAMESPACE)
@@ -1744,7 +1747,9 @@ def check_pods_in_running_state(
         raise_pod_not_found_error (bool): If True, it raises an exception, if one of the pods
             in the pod names are not found. If False, it ignores the case of pod not found and
             returns the pod objects of the rest of the pod names. The default value is False
-
+        skip_for_status(list): List of pod status that should be skipped. If the status of a pod is in the given list,
+            the check for 'Running' status of that particular pod will be skipped.
+            eg: ["Pending", "Completed"]
     Returns:
         Boolean: True, if all pods in Running state. False, otherwise
 
@@ -1770,6 +1775,9 @@ def check_pods_in_running_state(
             and ("debug" not in p.name)
         ):
             status = ocp_pod_obj.get_resource(p.name, "STATUS")
+            if skip_for_status:
+                if status in skip_for_status:
+                    continue
             # Skip the pods which are in 'Completed' state when checking for all pods in the
             # namespace openshift-storage. 'Completed' will be the expected state of such pods.
             if (


### PR DESCRIPTION
Fixing the test case tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py::TestDrainNodeMon::test_rook_operator_restart_during_mon_failover on Managed Services platform.

This test case is running on provider and these pods will be in Completed state.
```
$ oc get pods | grep -v -
NAME                                                              READY   STATUS      RESTARTS       AGE
83c3be2b7fc4205dc1cefb3affc660a2c60990fefc639824a531791870j8xlm   0/1     Completed   0              3h44m
8f0dad2ef3cd12d5193c166e42e56f8ccae06c14bd61e23751e126d13czd4jh   0/1     Completed   0              3h44m
```
Running status check for these pods should be skipped.

Skip the pods which are in 'Completed' state when checking for all pods in the namespace openshift-storage. 'Completed' will be the expected state of such pods. This is actually applicable for all platforms.

Fixes #6062

Signed-off-by: Jilju Joy <jijoy@redhat.com>