### PR TITLE
Skip the test 'test_rwo_pvc_fencing_unfencing' when using ms

### DIFF
--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.testlib import (
     skipif_vsphere_ipi,
     skipif_tainted_nodes,
     tier4b,
+    skipif_managed_service,
 )
 from ocs_ci.ocs import constants, machine, node, ocp
 from ocs_ci.ocs.cluster import CephCluster, CephClusterExternal
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @tier4b
 @ignore_leftovers
 @skipif_vsphere_ipi
+@skipif_managed_service
 class TestRwoPVCFencingUnfencing(ManageTest):
     """
     KNIP-677 OCS support for Automated fencing/unfencing RWO PV


### PR DESCRIPTION
The test 'test_rwo_pvc_fencing_unfencing' when using ms is not applicable for now; already been tested on the product; network failure on AWS is not a priority for testing. 