### PR TITLE
Allow passing `timeout` to the bucket creation's `verify_health` method

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2463,7 +2463,10 @@ def bucket_factory_fixture(
             current_call_created_buckets.append(created_bucket)
             created_buckets.append(created_bucket)
             if verify_health:
-                created_bucket.verify_health(timeout=180, **kwargs)
+                created_bucket.verify_health(
+                    timeout=kwargs.pop("timeout") if "timeout" in kwargs else 180,
+                    **kwargs,
+                )
 
         return current_call_created_buckets
 


### PR DESCRIPTION
Currently, the method fails due to the following error -
>               created_bucket.verify_health(timeout=180, **kwargs)
E               TypeError: verify_health() got multiple values for keyword argument 'timeout'