### PR TITLE
Label change in LVMO pods in image quay.io/rhceph-dev/ocs-registry:4.11.0-105

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1775,8 +1775,8 @@ LVMO_POD_LABEL = {
     },
     "411": {
         "controller_manager_label": "app.kubernetes.io/name=lvm-operator",
-        "topolvm-controller_label": "app.lvm.openshift.io=topolvm-controller",
-        "topolvm-node_label": "app.lvm.openshift.io=topolvm-node",
-        "vg-manager_label": "app.lvm.openshift.io=vg-manager",
+        "topolvm-controller_label": "app.kubernetes.io/name=topolvm-controller",
+        "topolvm-node_label": "app.kubernetes.io/name=topolvm-node",
+        "vg-manager_label": "app.kubernetes.io/name=vg-manager",
     },
 }


### PR DESCRIPTION
As we opened a [BZ2100352](https://bugzilla.redhat.com/show_bug.cgi?id=2100352) to make some order in lvm pods labels the change is in image quay.io/rhceph-dev/ocs-registry:4.11.0-105.
Adjusting the labels to new change.


Signed-off-by: Shay Rozen <shay.rozen@gmail.com>