### PR TITLE
Solve 7 hour of marks collection between deploy and teardown when odf-operator not installed

### DIFF
--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -14,8 +14,9 @@ from ocs_ci.ocs.resources.packagemanifest import (
     get_selector_for_ocs_operator,
     PackageManifest,
 )
-from ocs_ci.ocs.exceptions import CSVNotFound
+from ocs_ci.ocs.exceptions import CSVNotFound, CommandFailed
 from ocs_ci.utility import templating, utils
+from ocs_ci.ocs.cluster import CephCluster
 
 log = logging.getLogger(__name__)
 
@@ -212,6 +213,12 @@ def get_ocs_csv():
         CSVNotFound: In case no CSV found.
 
     """
+    try:
+        CephCluster()
+    except CommandFailed:
+        raise CSVNotFound
+    except FileNotFoundError:
+        raise CSVNotFound
     namespace = config.ENV_DATA["cluster_namespace"]
     operator_selector = get_selector_for_ocs_operator()
     subscription_plan_approval = config.DEPLOYMENT.get("subscription_plan_approval")


### PR DESCRIPTION
This issue [get_ocs_csv loops for 7 hours waiting for nonexistent OCS version](https://github.com/red-hat-storage/ocs-ci/issues/5789) is causing 7H delay in PR validation when odf-operator is not istalled. I cases like ACM, SNO, OCP (skip_ocs_deployment) between the run-ci which deploy and the run-ci which do teardown there is this:
`run-ci --color=yes tests/ -m deployment -k '' --ocs-version 4.11 --ocp-version 4.11 --ocsci-conf=/tmp/DCRKJQVFDIYB '--ocsci-conf=~/current-cluster-dir/ocsci_conf.yaml' --ocsci-conf=conf/ocsci/production-aws-ipi.yaml --ocsci-conf=conf/deployment/vsphere/upi_1az_rhcos_vsan_1mw.yaml --ocsci-conf=ocs_ci/templates/lvmo-deployment/lvmo_deployment_5_disk_X_150GB.yaml --cluster-name jnk-pr5715-b2963 --cluster-path /home/jenkins/current-cluster-dir/openshift-cluster-dir --junit-xml /home/jenkins/current-cluster-dir/logs/test_results_1655682703.xml -o junit_suite_name=testsuite '--html=~/current-cluster-dir/logs/test_report_1655682703.html' --self-contained-html --bugzilla --email=srozen@redhat.com --squad-analysis`
Is is iterating over testcases to check marks and they are some marks that call csv.
The problem is here:
`ocs_csv.wait_for_phase(phase="Succeeded", timeout=600)`

The function has also retry:
`    @retry(ResourceWrongStatusException, tries=4, delay=5, backoff=1)
    def wait_for_phase(self, phase, timeout=300, sleep=5):
`
So multiple the testcases*timeout*retry you'll get 7H
The solution is that everytime `def get_ocs_csv():` is called there is a check if cephcluster object can be initiated and if not it returns CSVNotFound which `def get_ocs_csv():` is declaring to raise.
It takes 2 minutes instead of 7H. There are some errors but maybe they are related to my local run-ci which tries to imitate what is going in the run-ci in jenkins run.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>