### PR TITLE
ignoring node count missmatch error in deployment test for MS

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1612,9 +1612,16 @@ def verify_all_nodes_created():
 
     existing_num_nodes = len(get_all_nodes())
     if expected_num_nodes != existing_num_nodes:
-        raise NotAllNodesCreated(
-            f"Expected number of nodes is {expected_num_nodes} but created during deployment is {existing_num_nodes}"
-        )
+        if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
+            log.warning(
+                f"Expected number of nodes is {expected_num_nodes} but "
+                f"created during deployment is {existing_num_nodes}"
+            )
+        else:
+            raise NotAllNodesCreated(
+                f"Expected number of nodes is {expected_num_nodes} but "
+                f"created during deployment is {existing_num_nodes}"
+            )
 
 
 def add_node_to_lvd_and_lvs(node_name):


### PR DESCRIPTION
This PR is to ignore known is\sue and
reduce the fleakyness in the deployment pipeline
https://github.com/red-hat-storage/ocs-ci/issues/6066

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>