### PR TITLE
Add marker in the test case test_rook_operator_restart_during_mon_failover to run on MS

### DIFF
--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
     ignore_leftovers,
+    runs_on_provider,
 )
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ log = logging.getLogger(__name__)
 @bugzilla("1959983")
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2572")
+@runs_on_provider
 class TestDrainNodeMon(ManageTest):
     """
     1.Get worker node name where monitoring pod run


### PR DESCRIPTION
Add marker 'runs_on_provider' in the test case 'test_rook_operator_restart_during_mon_failover' to run on Managed Services provider cluster. If the platform is MS in a multicluster run, the cluster context will be switched to provider cluster before the start of the test case. The cluster context will be changed back to the initial cluster context after the test case.

Signed-off-by: Jilju Joy <jijoy@redhat.com>