### PR TITLE
[WIP] Modify the test test_nodes_restart to run on MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_vsphere_ipi,
     skipif_ibm_cloud,
     runs_on_provider,
+    skipif_managed_service,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs, get_nodes
@@ -151,6 +152,7 @@ class TestNodesRestart(ManageTest):
         ],
     )
     @skipif_ibm_cloud
+    @skipif_managed_service
     def test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node(
         self,
         nodes,
@@ -202,11 +204,6 @@ class TestNodesRestart(ManageTest):
         - Check cluster and Ceph health
 
         """
-        # Use consumer cluster context if the platform is Managed Services
-        if self.is_managed_services_platform:
-            config.switch_to_consumer()
-        self.node_ops_cluster_type = "consumer"
-
         if operation == "delete_resources":
             # Create resources that their deletion will be tested later
             self.sanity_helpers.create_resources(
@@ -301,6 +298,7 @@ class TestNodesRestart(ManageTest):
         ],
     )
     @skipif_ibm_cloud
+    @skipif_managed_service
     def test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node(
         self,
         nodes,
@@ -330,11 +328,6 @@ class TestNodesRestart(ManageTest):
         - Start the worker node
         - Check cluster and Ceph health
         """
-        # Use consumer cluster context if the platform is Managed Services
-        if self.is_managed_services_platform:
-            config.switch_to_consumer()
-        self.node_ops_cluster_type = "consumer"
-
         if operation == "delete_resources":
             # Create resources that their deletion will be tested later
             self.sanity_helpers.create_resources(


### PR DESCRIPTION
Modified the test cases given below to run on Managed services platform.

- tests/manage/z_cluster/nodes/test_nodes_restart.py::TestNodesRestart::test_rolling_nodes_restart
- tests/manage/z_cluster/nodes/test_nodes_restart.py::TestNodesRestart::test_nodes_restart[True]
tests/manage/z_cluster/nodes/test_nodes_restart.py::TestNodesRestart::test_nodes_restart[False]


Skip these tests on MS:
- tests/manage/z_cluster/nodes/test_nodes_restart.py::TestNodesRestart::test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node
tests/manage/z_cluster/nodes/test_nodes_restart.py::TestNodesRestart::test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node

Added the marker "runs_on_provider" in the test cases where the node operations should run on provider cluster. This is to switch the cluster context to provider before the start of the test case and switch back to the initial cluster context after completing the test case. Switching to consumer cluster context is done before creating PVC, pods etc.

The finalizer which is intended to recover the nodes should run on the cluster where the node operation is done. Used an additional variable to identify the cluster type.

Switching back to the initial cluster context is done in the finalizer.

Signed-off-by: Jilju Joy <jijoy@redhat.com>