### PR TITLE
Patch the consumer ceph-too-pod when checking the ceph health

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2050,6 +2050,20 @@ def is_managed_service_cluster():
     return config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
 
 
+def is_ms_consumer_cluster():
+    """
+    Check if the cluster is a managed service consumer cluster
+
+    Returns:
+        bool: True, if the cluster is a managed service consumer cluster. False, otherwise
+
+    """
+    return (
+        config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
+        and config.ENV_DATA["cluster_type"].lower() == "consumer"
+    )
+
+
 class CephClusterExternal(CephCluster):
     """
     Handle all external ceph cluster related functionalities


### PR DESCRIPTION
After a destructive test on the consumer, the rook ceph tool pod may delete, and we will get the error: 

> [errno 1] RADOS permission error (error connecting to the cluster)
 command terminated with exit code 1

In such a case, we want to patch the consumer rook ceph tool deployment with the ceph-admin key.