### PR TITLE
WA for lvmo snapshot and clone  for 2 feature_blocker and label change

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2176,7 +2176,8 @@ class LVM(object):
         lvmc_ocs = lvmc_cop.data
         return lvmc_ocs
 
-    def get_lvm_version(self):
+    @staticmethod
+    def get_lvm_version():
         """
         Get redhat-operators version (4.10, 4.11)
         returns:
@@ -2262,3 +2263,22 @@ def check_clusters():
             config.RUN["cephcluster"] = False
         else:
             config.RUN["cephcluster"] = True
+
+
+def get_lvm_full_version():
+    """
+    Get redhat-operators version (4.11-xxx)
+    returns:
+        (str) lvmo full version
+    """
+    redhat_operators_catalogesource_ocp = OCP(
+        namespace=constants.MARKETPLACE_NAMESPACE,
+        kind="catalogsource",
+        resource_name="redhat-operators",
+    )
+    redhat_operators_catalogesource_ocs = OCS(
+        **redhat_operators_catalogesource_ocp.data
+    )
+    image = getattr(redhat_operators_catalogesource_ocs, "data")["spec"]["image"]
+    full_version = image.split(":")[1]
+    return full_version

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1804,5 +1804,11 @@ LVMO_POD_LABEL = {
         "topolvm-node_label": "app.kubernetes.io/name=topolvm-node",
         "vg-manager_label": "app.kubernetes.io/name=vg-manager",
     },
+    "411-old": {
+        "controller_manager_label": "app.kubernetes.io/name=lvm-operator",
+        "topolvm-controller_label": "app.lvm.openshift.io=topolvm-controller",
+        "topolvm-node_label": "app.lvm.openshift.io=topolvm-node",
+        "vg-manager_label": "app.lvm.openshift.io=vg-manager",
+    },
 }
 LVM_PROVISIONER = "topolvm.cybozu.com"


### PR DESCRIPTION
TL;DR

- from 4.11.0-99 lvmo pod in crashloopback. There is an automation workaround and it is applied from 99-110 where it is solved.
- from 4.11.0-105 labels where change.
- from 4.11.0.105 restores of snapshot and clone are empty till a build with the fix will be available
Need to continue deployment for latest versions for other features than snap/clone and for automation effort of snap/clone need to be able to deploy older versions than 4.11.0-105
Till latest will be stable this is the only solution to keep on working. Even PR validations will not work without this fix. not so tldr :)

In 4.11-105 lvmo pods labels were changed and [#6079 ](https://github.com/red-hat-storage/ocs-ci/pull/6079) was merged. Now that we have a blocker [BZ-2103818](https://bugzilla.redhat.com/show_bug.cgi?id=2103818) that is applicable from 4.11-105 and above we and also have  [BZ-2101139](https://bugzilla.redhat.com/show_bug.cgi?id=2101139) which need WA from version 4.11-99-110 also we are stuck with PR validation and tests. This PR is intended to allow install all versions to allow other features to work on latest and snapshot and clone for earlier builds. Also PR validation not work without this fix.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>