### PR TITLE
Increasing timeout to avoid test case failures and subsequent skips

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -916,13 +916,13 @@ def add_node(machine_set, count):
     return True
 
 
-def wait_for_new_node_to_be_ready(machine_set, timeout=600):
+def wait_for_new_node_to_be_ready(machine_set, timeout=900):
     """
     Wait for the new node to reach ready state
 
     Args:
         machine_set (str): Name of the machine set
-        timeout (int): Timeout in secs, default 10mins
+        timeout (int): Timeout in secs, default 15mins
 
     Raises:
         ResourceWrongStatusException: In case the new spun machine fails
@@ -939,7 +939,7 @@ def wait_for_new_node_to_be_ready(machine_set, timeout=600):
                 break
     except TimeoutExpiredError:
         log.error(
-            "New spun node failed to reach ready state OR "
+            "New spun node failed to reach ready state even with increased timeout from 600 to 900 seconds OR "
             "Replica count didn't match ready replica count"
         )
         raise ResourceWrongStatusException(

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2089,7 +2089,7 @@ def verify_osd_removal_job_completed_successfully(osd_id):
         osd_removal_pod_name, namespace=defaults.ROOK_CLUSTER_NAMESPACE
     )
 
-    timeout = 300
+    timeout = 600
     try:
         is_completed = osd_removal_pod_obj.ocp.wait_for_resource(
             condition=constants.STATUS_COMPLETED,
@@ -2099,6 +2099,9 @@ def verify_osd_removal_job_completed_successfully(osd_id):
         )
     # Don't failed the test yet if the ocs-osd-removal pod job is not completed
     except TimeoutExpiredError:
+        logger.info(
+            f"Increased timeout from 300 to 600 seconds for ocs-osd-removal pod {osd_removal_pod_name} to get completed"
+        )
         is_completed = False
 
     ocp_pod_obj = OCP(kind=constants.POD, namespace=defaults.ROOK_CLUSTER_NAMESPACE)


### PR DESCRIPTION
Signed-off-by: am-agrawa <amagrawa@redhat.com>

`ocs-ci results for OCS4-10-Downstream-OCP4-10-ocs-ci-results-for-ODF4-10-Downstream-OCP4-10-BROWN-SQUAD-TIER4a-on-VSphere-IPI (BUILD ID: 4.10.5-3 RUN ID: 1656514797)`

Fixes-
1. tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py::TestAutomatedRecoveryFromStoppedNodes::test_automated_recovery_from_stopped_node_and_start[True]

2. tests/manage/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_recovery_from_volume_deletion