### PR TITLE
Add wait time after cluster load is paused for a test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1662,6 +1662,12 @@ def reduce_cluster_load_implementation(request, pause, resume=True):
         try:
             for load_status in TimeoutSampler(300, 3, config.RUN.get, "load_status"):
                 if load_status in ["paused", "reduced"]:
+                    # Wait for 45 seconds for cluster load to pause/reduce effectively
+                    wait_time = 45
+                    log.info(
+                        f"Waiting for {wait_time} seconds for cluster load to pause/reduce..."
+                    )
+                    time.sleep(wait_time)
                     break
         except TimeoutExpiredError:
             log.error(

--- a/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import time
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
@@ -62,11 +61,6 @@ class TestRbdSpaceReclaim(ManageTest):
         7. Verify the decreased used size of the RBD pool
         8. Verify the presence of other files in the folder
         """
-
-        # Wait for 45 seconds for cluster load to pause effectively
-        wait_time = 45
-        log.info(f"Waiting for {wait_time} seconds...")
-        time.sleep(wait_time)
 
         pvc_obj = self.pvc[0]
         pod_obj = self.pod[0]

--- a/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -48,7 +48,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
     @polarion_id("OCS-2759")
     @tier1
-    def test_rbd_space_reclaim_cronjob(self):
+    def test_rbd_space_reclaim_cronjob(self, pause_and_resume_cluster_load):
         """
         Test to verify RBD space reclamation
         Steps:

--- a/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import (
@@ -61,6 +62,12 @@ class TestRbdSpaceReclaim(ManageTest):
         7. Verify the decreased used size of the RBD pool
         8. Verify the presence of other files in the folder
         """
+
+        # Wait for 45 seconds for cluster load to pause effectively
+        wait_time = 45
+        log.info(f"Waiting for {wait_time} seconds...")
+        time.sleep(wait_time)
+
         pvc_obj = self.pvc[0]
         pod_obj = self.pod[0]
 

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -3,9 +3,7 @@ A test case to verify after deleting pvc whether
 size is returned to backend pool
 """
 import logging
-
 import pytest
-import time
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -65,10 +63,6 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         Test case to verify after delete pvc size returned to backend pools
         """
 
-        # Wait for 45 seconds for cluster load to pause effectively
-        wait_time = 45
-        logger.info(f"Waiting for {wait_time} seconds...")
-        time.sleep(wait_time)
         cbp_name = helpers.default_ceph_block_pool()
 
         # TODO: Get exact value of replica size

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -5,6 +5,7 @@ size is returned to backend pool
 import logging
 
 import pytest
+import time
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -63,6 +64,11 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         """
         Test case to verify after delete pvc size returned to backend pools
         """
+
+        # Wait for 45 seconds for cluster load to pause effectively
+        wait_time = 45
+        logger.info(f"Waiting for {wait_time} seconds...")
+        time.sleep(wait_time)
         cbp_name = helpers.default_ceph_block_pool()
 
         # TODO: Get exact value of replica size


### PR DESCRIPTION
Fixes: #6125 
          #5310 

Wait time was added after the cluster load is paused before the test execution, to allow the proper used size to be collected.

Signed-off-by: rachael-george <rgeorge@redhat.com>