### PR TITLE
Fix block pool testcase because some other PR erased return value

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4694,7 +4694,7 @@ def storageclass_factory_ui_fixture(request, cephblockpool_factory_ui, setup_ui)
                 )
 
     request.addfinalizer(finalizer)
-    return
+    return factory
 
 
 @pytest.fixture()


### PR DESCRIPTION
[commit](https://github.com/red-hat-storage/ocs-ci/pull/4893/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R4403-R4404)  from #4893 has erased the return value of the `def storageclass_factory_ui_fixture` factory by mistake. Added return factory
Fixes: #5885

Signed-off-by: Shay Rozen <shay.rozen@gmail.com>