### PR TITLE
make the pas-test namespace uniq

### DIFF
--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -866,7 +866,7 @@ class PASTest(BaseTest):
         """
         Creating new project (namespace) for performance test
         """
-        self.namespace = "pas-test-namespace"
+        self.namespace = helpers.create_unique_resource_name("pas-test", "namespace")
         log.info(f"Creating new namespace ({self.namespace}) for the test")
         try:
             self.proj = helpers.create_project(project_name=self.namespace)


### PR DESCRIPTION
This PF fix issue which prevent from test to execute if previous test didn't complete successfully, and the test project didn't deleted.

with this fix failure of one test will not prevent running of next test.

Signed-off-by: Avi Layani <alayani@redhat.com>