### PR TITLE
Replace current working private installer git for SNO

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1531,7 +1531,7 @@ def clone_openshift_installer():
     if Version.coerce(ocp_version) >= Version.coerce("4.5"):
         if config.ENV_DATA["sno"]:
             constants.VSPHERE_INSTALLER_REPO = (
-                "https://github.com/shyRozen/installer.git"
+                "https://gitlab.cee.redhat.com/srozen/installer.git"
             )
             clone_repo(
                 url=constants.VSPHERE_INSTALLER_REPO,

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2127,8 +2127,8 @@ def clone_repo(url, location, branch="master", to_checkout=None, clone_type="sha
         if "coreos" not in location:
             installer_dir = os.path.join(constants.EXTERNAL_DIR, "installer")
             remote_output = run_cmd(f"git -C {installer_dir} remote -v")
-            if (("shyRozen" in remote_output) and ("openshift" in url)) or (
-                ("openshift" in remote_output) and ("shyRozen" in url)
+            if (("srozen" in remote_output) and ("openshift" in url)) or (
+                ("openshift" in remote_output) and ("srozen" in url)
             ):
                 shutil.rmtree(installer_dir)
                 log.info(


### PR DESCRIPTION
Till now terraform for sno was using [https://github.com/shyRozen/installer.git](https://github.com/shyRozen/installer.git) as there is no openshift/installer terraform for SNO.
As I want to do changes and try to commit it to openshift/installer I'm moving the private fork to [https://gitlab.cee.redhat.com/srozen/installer](https://gitlab.cee.redhat.com/srozen/installer) till PR and merge will happen to upstream.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>