### PR TITLE
Increasing timeout for the test case and collecting ocp must-gather in case of failure for debugging purpose

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -659,7 +659,14 @@ def pytest_runtest_makereport(item, call):
         test_case_name = item.name
         ocp_logs_collection = (
             True
-            if any(x in item.location[0] for x in ["ecosystem", "e2e/performance"])
+            if any(
+                x in item.location[0]
+                for x in [
+                    "ecosystem",
+                    "e2e/performance",
+                    "test_ceph_csidriver_runs_on_non_ocs_nodes",
+                ]
+            )
             else False
         )
         ocs_logs_collection = (

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -354,7 +354,7 @@ def add_new_node_and_label_it(machineset_name, num_nodes=1, mark_for_ocs_label=T
 
     # wait for the new node to come to ready state
     log.info("Waiting for the new node to be in ready state")
-    machine.wait_for_new_node_to_be_ready(machineset_name)
+    machine.wait_for_new_node_to_be_ready(machineset_name, timeout=900)
 
     # Get the node name of new spun node
     nodes_after_new_spun_node = get_worker_nodes()


### PR DESCRIPTION
Signed-off-by: am-agrawa <amagrawa@redhat.com>

For run id 1656660125
test-
tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py::TestCheckTolerationForCephCsiDriverDs::test_ceph_csidriver_runs_on_non_ocs_nodes

Also fixes #5863 