### PR TITLE
Update Rosa CLI version to 1.2.5

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -214,7 +214,7 @@ ENV_DATA:
   # Managed StorageCluster size in TiB
   size: '20'
   ms_env_type: 'staging'
-  rosa_cli_version: '1.2.4'
+  rosa_cli_version: '1.2.5'
   appliance_mode: true
 
   # used in external mode deployment

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -214,7 +214,7 @@ ENV_DATA:
   # Managed StorageCluster size in TiB
   size: '20'
   ms_env_type: 'staging'
-  rosa_cli_version: '1.2.3'
+  rosa_cli_version: '1.2.4'
   appliance_mode: true
 
   # used in external mode deployment


### PR DESCRIPTION
New version of rosa CLI 1.2.5 is available now.
https://github.com/openshift/rosa/releases/tag/v1.2.5

Signed-off-by: suchita.gatfane <sgatfane@redhat.com>