### PR TITLE
Replace coreos-installer git with tag v0.14.0

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -550,6 +550,7 @@ class VSPHEREUPI(VSPHEREBASE):
                 shutil.rmtree(f"{constants.EXTERNAL_DIR}/coreos-install")
             os.mkdir(f"{constants.EXTERNAL_DIR}/coreos-install")
             os.chdir(f"{constants.EXTERNAL_DIR}/coreos-installer/")
+            run_cmd("git checkout tags/v0.14.0")
             run_cmd("make")
             run_cmd(f"make install DESTDIR={constants.EXTERNAL_DIR}/coreos-install/")
             os.chdir(f"{self.cluster_path}")


### PR DESCRIPTION
Coreos-installer v0.15.0 require some lib that have dependencies and SNO deployment is failing. Going back to v0.14.0.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>