### PR TITLE
extend timeout for rsync flexy work dir to cluster dir

### DIFF
--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -469,7 +469,7 @@ class FlexyBase(object):
         exec_cmd(chmod_cmd)
         # mirror flexy work dir to cluster path
         rsync_cmd = f"rsync -av {self.flexy_host_dir} {self.cluster_path}/"
-        exec_cmd(rsync_cmd, timeout=1200)
+        exec_cmd(rsync_cmd, timeout=3600)
 
         # mirror install-dir to cluster path (auth directory, metadata.json
         # file and other files)


### PR DESCRIPTION
- this should prevent failures, when NFS share or network is slower than
  usuall and the deployment fails only because the mirroring of flexy
  working directory to cluster dir on NFS share takes longer than usual

Signed-off-by: Daniel Horak <dahorak@redhat.com>