### PR TITLE
benchmark-operator workaround

### DIFF
--- a/ocs_ci/ocs/benchmark_operator.py
+++ b/ocs_ci/ocs/benchmark_operator.py
@@ -149,7 +149,12 @@ class BenchmarkOperator(object):
         """
         log.info("Deploy the benchmark-operator project")
         try:
-            run("make deploy", shell=True, check=True, cwd=self.dir)
+            run(
+                "make deploy IMG=quay.io/ocsci/benchmark-operator:testing",
+                shell=True,
+                check=True,
+                cwd=self.dir,
+            )
         except Exception as ex:
             log.error(f"Failed to deploy benchmark operator : {ex}")
 


### PR DESCRIPTION
This workaround fix issue with benchmark-operator which prevent from creating the fio-client-pod

I created Image from latest working commit, upload it to quay.io/ocsci and use this image in the test.
once the issue will be fix in the original repo (may take some time) this PR can be revert.

Signed-off-by: Avi Layani <alayani@redhat.com>