### PR TITLE
Adding csi bulk pod attach measurements

### DIFF
--- a/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
@@ -129,6 +129,7 @@ class TestBulkPodAttachPerformance(PASTest):
 
         # Getting the test start time
         test_start_time = self.get_time()
+        csi_start_time = self.get_time("csi")
 
         log.info(f"Start creating bulk of new {bulk_size} PVCs")
         self.pvc_objs, _ = helpers.create_multiple_pvcs(
@@ -143,7 +144,7 @@ class TestBulkPodAttachPerformance(PASTest):
         performance_lib.wait_for_resource_bulk_status(
             "pvc", bulk_size, self.namespace, constants.STATUS_BOUND, timeout, 10
         )
-        # incase of creation faliure, the wait_for_resource_bulk_status function
+        # in case of creation faliure, the wait_for_resource_bulk_status function
         # will raise an exception. so in this point the creation succeed
         log.info("All PVCs was created and in Bound state.")
 
@@ -182,6 +183,10 @@ class TestBulkPodAttachPerformance(PASTest):
         bulk_total_time = bulk_end_time - bulk_start_time
         log.info(f"Bulk attach time of {bulk_size} pods is {bulk_total_time} seconds")
 
+        csi_bulk_total_time = performance_lib.pod_bulk_attach_csi_time(
+            self.interface, self.pvc_objs, csi_start_time, self.namespace
+        )
+
         # Collecting environment information
         self.get_env_info()
 
@@ -194,6 +199,7 @@ class TestBulkPodAttachPerformance(PASTest):
 
         full_results.add_key("storageclass", Interfaces_info[self.interface]["name"])
         full_results.add_key("pod_bulk_attach_time", bulk_total_time)
+        full_results.add_key("pod_csi_bulk_attach_time", csi_bulk_total_time)
         full_results.add_key("pvc_size", self.pvc_size)
         full_results.add_key("bulk_size", bulk_size)
 
@@ -212,7 +218,7 @@ class TestBulkPodAttachPerformance(PASTest):
             # write the ES link to the test results in the test log.
             log.info(f"The result can be found at : {res_link}")
 
-            # Create text file with results of all subtest (4 - according to the parameters)
+            # Create text file with results of all subtests (4 - according to the parameters)
             self.write_result_to_file(res_link)
 
     def test_bulk_pod_attach_results(self):

--- a/tests/e2e/performance/csi_tests/test_pod_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_attachtime.py
@@ -133,7 +133,7 @@ class TestPodStartTime(PASTest):
             self.csi_time_dict_list.append(
                 performance_lib.pod_attach_csi_time(
                     self.interface, pvc_obj.backed_pv, csi_start_time, self.namespace
-                )
+                )[0]
             )
 
     def init_full_results(self, full_results):

--- a/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
@@ -255,7 +255,7 @@ class TestPodReattachTimePerformance(PASTest):
 
             csi_time = performance_lib.pod_attach_csi_time(
                 self.interface, pvc_obj.backed_pv, csi_start_time, pvc_obj.namespace
-            )
+            )[0]
             csi_time_measures.append(csi_time)
             logger.info(
                 f"PVC #{pvc_obj.name} pod {pod_name} creation time took {total_time} seconds, "


### PR DESCRIPTION
This PR handles the following: 

- pod_bulk_attach_csi_time function was added to performance lib to calculate csi time of bulk pod attach operation 
- pod_attach_csi_time was enhanced to return values used later for pod_bulk_attach_csi_time calculation
- as a result test_pod_attachtime and test_pod reattachtime were slightly modified to suit the modified pod_attach_csi_time
- test_bulk_pod_attachtime_performance test was enhanced with the measurement of csi bulk pod attach time

Signed-off-by: Yulia Persky <ypersky@redhat.com>