### PR TITLE
add rbd_mirror_die_after_seconds to rook ceph configmap

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1642,6 +1642,20 @@ mon_data_avail_warn = 15
 osd_memory_target_cgroup_limit_ratio = 0.8
 """
 
+ROOK_CEPH_CONFIG_VALUES_411 = """
+[global]
+bdev_flock_retry = 20
+mon_osd_full_ratio = .85
+mon_osd_backfillfull_ratio = .8
+mon_osd_nearfull_ratio = .75
+mon_max_pg_per_osd = 600
+mon_pg_warn_max_object_skew = 0
+mon_data_avail_warn = 15
+rbd_mirror_die_after_seconds = 3600
+[osd]
+osd_memory_target_cgroup_limit_ratio = 0.8
+"""
+
 CEPH_DEBUG_CONFIG_VALUES = """
 [mon]
 debug_mon = 20


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/6200

Signed-off-by: Elad Ben Aharon <ebenahar@redhat.com>