### PR TITLE
simple OCP deployment for external mode

### DIFF
--- a/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_3w_external.yaml
+++ b/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_3w_external.yaml
@@ -1,0 +1,14 @@
+---
+# This config is suppose to work on DC-CP, DC-ECO, DC-PS
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'ipi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '4'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '16384'
+  fio_storageutilization_min_mbps: 10.0


### PR DESCRIPTION
Proposed deployment configurations for external mode and Metro DR use cases:

- ~deployment of OCP for standalone RHACM Hub~ (proposed config with 0 worker nodes is not a valid configuration from openshift's perspective, so we are dropping this)
- [X] deployment of OCP for external ODF cluster