### PR TITLE
Fix cephcluster/lvmcluster sampling and silent the error from the cluster that is not found.

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -399,7 +399,7 @@ def pytest_configure(config):
 
             config._metadata["Test Run Name"] = get_testrun_name()
             check_clusters()
-            if ocsci_config.RUN["cephcluster"]:
+            if ocsci_config.RUN.get("cephcluster"):
                 gather_version_info_for_report(config)
     # switch the configuration context back to the default cluster
     ocsci_config.switch_default_cluster_ctx()

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -440,7 +440,13 @@ def mask_secrets(plaintext, secrets):
 
 
 def run_cmd(
-    cmd, secrets=None, timeout=600, ignore_error=False, threading_lock=None, **kwargs
+    cmd,
+    secrets=None,
+    timeout=600,
+    ignore_error=False,
+    threading_lock=None,
+    silent=False,
+    **kwargs,
 ):
     """
     *The deprecated form of exec_cmd.*
@@ -456,6 +462,7 @@ def run_cmd(
             raise the exception.
         threading_lock (threading.Lock): threading.Lock object that is used
             for handling concurrent oc commands
+        silent (bool): If True will silent errors from the server, default false
 
     Raises:
         CommandFailed: In case the command execution fails
@@ -464,7 +471,7 @@ def run_cmd(
         (str) Decoded stdout of command
     """
     completed_process = exec_cmd(
-        cmd, secrets, timeout, ignore_error, threading_lock, **kwargs
+        cmd, secrets, timeout, ignore_error, threading_lock, silent=silent, **kwargs
     )
     return mask_secrets(completed_process.stdout.decode(), secrets)
 
@@ -552,7 +559,13 @@ def run_cmd_multicluster(
 
 
 def exec_cmd(
-    cmd, secrets=None, timeout=600, ignore_error=False, threading_lock=None, **kwargs
+    cmd,
+    secrets=None,
+    timeout=600,
+    ignore_error=False,
+    threading_lock=None,
+    silent=False,
+    **kwargs,
 ):
     """
     Run an arbitrary command locally
@@ -570,6 +583,7 @@ def exec_cmd(
             raise the exception.
         threading_lock (threading.Lock): threading.Lock object that is used
             for handling concurrent oc commands
+        silent (bool): If True will silent errors from the server, default false
 
     Raises:
         CommandFailed: In case the command execution fails
@@ -607,7 +621,8 @@ def exec_cmd(
 
     masked_stderr = mask_secrets(completed_process.stderr.decode(), secrets)
     if len(completed_process.stderr) > 0:
-        log.warning(f"Command stderr: {masked_stderr}")
+        if not silent:
+            log.warning(f"Command stderr: {masked_stderr}")
     else:
         log.debug("Command stderr is empty")
     log.debug(f"Command return code: {completed_process.returncode}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1422,7 +1422,7 @@ def health_checker(request, tier_marks_name):
     node = request.node
     request.addfinalizer(finalizer)
     for mark in node.iter_markers():
-        if mark.name in tier_marks_name and config.RUN["cephcluster"]:
+        if mark.name in tier_marks_name and config.RUN.get("cephcluster"):
             log.info("Checking for Ceph Health OK ")
             try:
                 status = ceph_health_check_base()
@@ -1489,7 +1489,9 @@ def cluster(
     else:
         if config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM:
             ibmcloud.login()
-    if not config.ENV_DATA["skip_ocs_deployment"] and config.RUN["cephcluster"]:
+    if "cephcluster" not in config.RUN.keys():
+        check_clusters()
+    if not config.ENV_DATA["skip_ocs_deployment"] and config.RUN.get("cephcluster"):
         record_testsuite_property("rp_ocs_build", get_ocs_build_number())
 
 
@@ -3365,7 +3367,7 @@ def ceph_toolbox(request):
     and if it does not already exist.
     """
     teardown = config.RUN["cli_params"].get("teardown")
-    if "cephcluster" not in config.RUN and not teardown:
+    if "cephcluster" not in config.RUN.keys() and not teardown:
         check_clusters()
     deploy = config.RUN["cli_params"]["deploy"]
     skip_ocs = config.ENV_DATA["skip_ocs_deployment"]

--- a/tests/lvmo/test_lvm_clone_base.py
+++ b/tests/lvmo/test_lvm_clone_base.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import get_ocp_version
 from ocs_ci.ocs.cluster import LVM
@@ -46,81 +46,18 @@ class TestLvmSnapshot(ManageTest):
     pvc_size = 100
     access_mode = constants.ACCESS_MODE_RWO
 
-    @pytest.fixture()
-    def namespace(self, project_factory_class):
-        self.proj_obj = project_factory_class()
-        self.proj = self.proj_obj.namespace
-
-    @pytest.fixture()
-    def storageclass(self, lvm_storageclass_factory_class, volume_binding_mode):
-        self.sc_obj = lvm_storageclass_factory_class(volume_binding=volume_binding_mode)
-
-    @pytest.fixture()
-    def pvc(self, pvc_factory_class, volume_mode, volume_binding_mode):
-        self.status = constants.STATUS_PENDING
-        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
-            self.status = constants.STATUS_BOUND
-        self.pvc_obj = pvc_factory_class(
-            project=self.proj_obj,
-            interface=None,
-            storageclass=self.sc_obj,
-            size=self.pvc_size,
-            status=self.status,
-            access_mode=self.access_mode,
-            volume_mode=volume_mode,
-        )
-
-    @pytest.fixture()
-    def pod(self, pod_factory_class, volume_mode):
-        self.block = False
-        if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.block = True
-        self.pod_obj = pod_factory_class(pvc=self.pvc_obj, raw_block_pv=self.block)
-
-    @pytest.fixture()
-    def run_io(self, volume_mode):
-        self.fs = "fs"
-        self.block = False
-        if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.fs = "block"
-            self.block = True
-
-        self.pod_obj.run_io(
-            self.fs,
-            size="5g",
-            rate="1500m",
-            runtime=0,
-            invalidate=0,
-            buffer_compress_percentage=60,
-            buffer_pattern="0xdeadface",
-            bs="1024K",
-            jobs=1,
-            readwrite="readwrite",
-        )
-        self.pod_obj.get_fio_results()
-        if not self.block:
-            self.origin_pod_md5 = cal_md5sum(
-                pod_obj=self.pod_obj, file_name="fio-rand-readwrite", block=self.block
-            )
-
-    @pytest.fixture()
-    def create_clone(self, pvc_clone_factory_class, volume_mode):
-        logger.info(f"Creating clone from {self.pvc_obj.name}")
-        self.clone = pvc_clone_factory_class(
-            pvc_obj=self.pvc_obj, status=self.status, volume_mode=volume_mode
-        )
-
     @tier1
+    @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.10")
     def test_create_clone_from_pvc(
         self,
-        namespace,
-        storageclass,
-        pvc,
-        pod,
-        run_io,
-        create_clone,
+        volume_mode,
+        volume_binding_mode,
+        project_factory,
+        lvm_storageclass_factory,
+        pvc_clone_factory,
+        pvc_factory,
         pod_factory,
     ):
         """
@@ -135,7 +72,7 @@ class TestLvmSnapshot(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM()
+        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"
@@ -144,23 +81,74 @@ class TestLvmSnapshot(ManageTest):
             f"Lvm thin-pool sizePrecent is {lvm.get_lvm_thin_pool_config_size_percent()}"
         )
 
-        logger.info(f"Attaching pod to pvc clone {self.clone.name}")
-        restored_pod_obj = pod_factory(pvc=self.clone, raw_block_pv=self.block)
-        if not self.block:
+        proj_obj = project_factory()
+
+        sc_obj = lvm_storageclass_factory(volume_binding=volume_binding_mode)
+
+        status = constants.STATUS_PENDING
+        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
+            status = constants.STATUS_BOUND
+        pvc_obj = pvc_factory(
+            project=proj_obj,
+            interface=None,
+            storageclass=sc_obj,
+            size=self.pvc_size,
+            status=status,
+            access_mode=self.access_mode,
+            volume_mode=volume_mode,
+        )
+
+        block = False
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            block = True
+        pod_obj = pod_factory(pvc=pvc_obj, raw_block_pv=block)
+
+        fs = "fs"
+        block = False
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            fs = "block"
+            block = True
+
+        pod_obj.run_io(
+            fs,
+            size="5g",
+            rate="1500m",
+            runtime=0,
+            invalidate=0,
+            buffer_compress_percentage=60,
+            buffer_pattern="0xdeadface",
+            bs="1024K",
+            jobs=1,
+            readwrite="readwrite",
+        )
+        pod_obj.get_fio_results()
+        origin_pod_md5 = 0
+        if not block:
+            origin_pod_md5 = cal_md5sum(
+                pod_obj=pod_obj, file_name="fio-rand-readwrite", block=block
+            )
+
+        logger.info(f"Creating clone from {pvc_obj.name}")
+        clone = pvc_clone_factory(
+            pvc_obj=pvc_obj, status=status, volume_mode=volume_mode
+        )
+
+        restored_pod_obj = pod_factory(pvc=clone, raw_block_pv=block)
+        if not block:
             restored_pod_md5 = cal_md5sum(
                 pod_obj=restored_pod_obj,
                 file_name="fio-rand-readwrite",
-                block=self.block,
+                block=block,
             )
-            if restored_pod_md5 != self.origin_pod_md5:
+            if restored_pod_md5 != origin_pod_md5:
                 raise Md5CheckFailed(
-                    f"origin pod {self.pod_obj.name} md5 value {self.origin_pod_md5} "
+                    f"origin pod {pod_obj.name} md5 value {origin_pod_md5} "
                     f"is not the same as restored pod {restored_pod_obj.name} md5 "
                     f"value {restored_pod_md5}"
                 )
 
         restored_pod_obj.run_io(
-            self.fs,
+            fs,
             size="1g",
             rate="1500m",
             runtime=0,
@@ -172,15 +160,15 @@ class TestLvmSnapshot(ManageTest):
             readwrite="readwrite",
         )
         restored_pod_obj.get_fio_results()
-        if not self.block:
+        if not block:
             restored_pod_md5_second = cal_md5sum(
                 pod_obj=restored_pod_obj,
                 file_name="fio-rand-readwrite",
-                block=self.block,
+                block=block,
             )
-            if restored_pod_md5_second == self.origin_pod_md5:
+            if restored_pod_md5_second == origin_pod_md5:
                 raise Md5CheckFailed(
-                    f"origin pod {self.pod_obj.name} md5 value {self.origin_pod_md5} "
+                    f"origin pod {pod_obj.name} md5 value {origin_pod_md5} "
                     f"is not suppose to be the same as restored pod {restored_pod_obj.name} md5 "
                     f"value {restored_pod_md5_second}"
                 )

--- a/tests/lvmo/test_lvm_multi_clone.py
+++ b/tests/lvmo/test_lvm_multi_clone.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import get_ocp_version
 from ocs_ci.ocs.cluster import LVM
@@ -50,68 +50,91 @@ class TestLvmMultiClone(ManageTest):
     access_mode = constants.ACCESS_MODE_RWO
     pvc_num = 5
 
-    @pytest.fixture()
-    def namespace(self, project_factory_class):
-        self.proj_obj = project_factory_class()
-        self.proj = self.proj_obj.namespace
+    @tier1
+    @acceptance
+    @skipif_lvm_not_installed
+    @skipif_ocs_version("<4.10")
+    def test_create_multi_clone_from_pvc(
+        self,
+        volume_mode,
+        volume_binding_mode,
+        project_factory,
+        lvm_storageclass_factory,
+        pvc_clone_factory,
+        pvc_factory,
+        pod_factory,
+    ):
+        """
+        test create delete multi snapshot
+        .* Create 5 PVC
+        .* Create 5 POD
+        .* Run IO
+        .* Create 5 clones
+        .* Create 5 pvc from clone
+        .* Attach 5 pod
+        .* Run IO
 
-    @pytest.fixture()
-    def storageclass(self, lvm_storageclass_factory_class, volume_binding_mode):
-        self.sc_obj = lvm_storageclass_factory_class(volume_binding_mode)
+        """
+        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
+        logger.info(
+            f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"
+        )
+        logger.info(
+            f"Lvm thin-pool sizePercent is {lvm.get_lvm_thin_pool_config_size_percent()}"
+        )
 
-    @pytest.fixture()
-    def pvc(self, pvc_factory_class, volume_mode, volume_binding_mode):
-        self.status = constants.STATUS_PENDING
+        proj_obj = project_factory()
+
+        sc_obj = lvm_storageclass_factory(volume_binding_mode)
+
+        status = constants.STATUS_PENDING
         if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
-            self.status = constants.STATUS_BOUND
+            status = constants.STATUS_BOUND
         futures = []
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         for exec_num in range(0, self.pvc_num):
             futures.append(
                 executor.submit(
-                    pvc_factory_class,
-                    project=self.proj_obj,
+                    pvc_factory,
+                    project=proj_obj,
                     interface=None,
-                    storageclass=self.sc_obj,
+                    storageclass=sc_obj,
                     size=self.pvc_size,
-                    status=self.status,
+                    status=status,
                     access_mode=self.access_mode,
                     volume_mode=volume_mode,
                 )
             )
-        self.pvc_objs = []
+        pvc_objs = []
         for future in concurrent.futures.as_completed(futures):
-            self.pvc_objs.append(future.result())
+            pvc_objs.append(future.result())
 
-    @pytest.fixture()
-    def pod(self, pod_factory_class, volume_mode):
-        self.block = False
+        block = False
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.block = True
+            block = True
         futures_pods = []
-        self.pods_objs = []
-        for pvc in self.pvc_objs:
+        pods_objs = []
+        for pvc in pvc_objs:
             futures_pods.append(
-                executor.submit(pod_factory_class, pvc=pvc, raw_block_pv=self.block)
+                executor.submit(pod_factory, pvc=pvc, raw_block_pv=block)
             )
         for future_pod in concurrent.futures.as_completed(futures_pods):
-            self.pods_objs.append(future_pod.result())
+            pods_objs.append(future_pod.result())
 
-    @pytest.fixture()
-    def run_io(self, volume_mode):
-        self.fs = "fs"
-        self.block = False
+        fs = "fs"
+        block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.fs = "block"
-            self.block = True
+            fs = "block"
+            block = True
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_fio = []
-        for pod in self.pods_objs:
+        for pod in pods_objs:
             futures_fio.append(
                 executor.submit(
                     pod.run_io,
-                    self.fs,
+                    fs,
                     size="5g",
                     rate="1500m",
                     runtime=0,
@@ -128,87 +151,52 @@ class TestLvmMultiClone(ManageTest):
         concurrent.futures.wait(futures_fio)
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_results = []
-        for pod in self.pods_objs:
+        for pod in pods_objs:
             futures_results.append(executor.submit(pod.get_fio_results()))
         for _ in concurrent.futures.as_completed(futures_results):
             logger.info("Just waiting for fio jobs results")
         concurrent.futures.wait(futures_results)
-        if not self.block:
+        origin_pods_md5 = []
+        if not block:
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
             futures_md5 = []
-            self.origin_pods_md5 = []
-            for pod in self.pods_objs:
+            for pod in pods_objs:
                 futures_md5.append(
                     executor.submit(
                         cal_md5sum,
                         pod_obj=pod,
                         file_name="fio-rand-readwrite",
-                        block=self.block,
+                        block=block,
                     )
                 )
             for future_md5 in concurrent.futures.as_completed(futures_md5):
-                self.origin_pods_md5.append(future_md5.result())
+                origin_pods_md5.append(future_md5.result())
 
-    @pytest.fixture()
-    def create_clone(self, pvc_clone_factory, volume_mode):
         logger.info("Creating snapshot from pvc objects")
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_clone = []
-        self.clone_objs = []
-        for pvc in self.pvc_objs:
+        clone_objs = []
+        for pvc in pvc_objs:
             futures_clone.append(
                 executor.submit(
                     pvc_clone_factory,
                     pvc_obj=pvc,
-                    status=self.status,
+                    status=status,
                     volume_mode=volume_mode,
                 )
             )
         for future_clone in concurrent.futures.as_completed(futures_clone):
-            self.clone_objs.append(future_clone.result())
+            clone_objs.append(future_clone.result())
         concurrent.futures.wait(futures_clone)
-
-    @tier1
-    @skipif_lvm_not_installed
-    @skipif_ocs_version("<4.10")
-    def test_create_multi_clone_from_pvc(
-        self,
-        namespace,
-        storageclass,
-        pvc,
-        pod,
-        run_io,
-        create_clone,
-        pod_factory,
-    ):
-        """
-        test create delete multi snapshot
-        .* Create 5 PVC
-        .* Create 5 POD
-        .* Run IO
-        .* Create 5 clones
-        .* Create 5 pvc from clone
-        .* Attach 5 pod
-        .* Run IO
-
-        """
-        lvm = LVM()
-        logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
-        logger.info(
-            f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"
-        )
-        logger.info(
-            f"Lvm thin-pool sizePercent is {lvm.get_lvm_thin_pool_config_size_percent()}"
-        )
 
         logger.info("Attaching pods to pvcs restores")
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_restored_pods = []
         restored_pods_objs = []
 
-        for pvc in self.clone_objs:
+        for pvc in clone_objs:
             futures_restored_pods.append(
-                executor.submit(pod_factory, pvc=pvc, raw_block_pv=self.block)
+                executor.submit(pod_factory, pvc=pvc, raw_block_pv=block)
             )
         for future_restored_pod in concurrent.futures.as_completed(
             futures_restored_pods
@@ -217,7 +205,7 @@ class TestLvmMultiClone(ManageTest):
         concurrent.futures.wait(futures_restored_pods)
         time.sleep(10)
 
-        if not self.block:
+        if not block:
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
             futures_restored_pods_md5 = []
             restored_pods_md5 = []
@@ -227,7 +215,7 @@ class TestLvmMultiClone(ManageTest):
                         cal_md5sum,
                         pod_obj=restored_pod,
                         file_name="fio-rand-readwrite",
-                        block=self.block,
+                        block=block,
                     )
                 )
             for future_restored_pod_md5 in concurrent.futures.as_completed(
@@ -235,9 +223,9 @@ class TestLvmMultiClone(ManageTest):
             ):
                 restored_pods_md5.append(future_restored_pod_md5.result())
             for pod_num in range(0, self.pvc_num):
-                if self.origin_pods_md5[pod_num] != restored_pods_md5[pod_num]:
+                if origin_pods_md5[pod_num] != restored_pods_md5[pod_num]:
                     raise Md5CheckFailed(
-                        f"origin pod {self.pods_objs[pod_num]} md5 value {self.origin_pods_md5[pod_num]} "
+                        f"origin pod {pods_objs[pod_num]} md5 value {origin_pods_md5[pod_num]} "
                         f"is not the same as restored pod {restored_pods_objs[pod_num]} md5 "
                         f"value {restored_pods_md5[pod_num]}"
                     )
@@ -248,7 +236,7 @@ class TestLvmMultiClone(ManageTest):
             futures_restored_pods_fio.append(
                 executor.submit(
                     restored_pod.run_io,
-                    self.fs,
+                    fs,
                     size="1g",
                     rate="1500m",
                     runtime=0,
@@ -273,7 +261,7 @@ class TestLvmMultiClone(ManageTest):
         for _ in concurrent.futures.as_completed(futures_restored_pods_fio_results):
             logger.info("Finished waiting for some pod")
         concurrent.futures.wait(futures_restored_pods_fio_results)
-        if not self.block:
+        if not block:
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
             futures_restored_pods_md5_after_fio = []
             restored_pods_md5_after_fio = []
@@ -283,7 +271,7 @@ class TestLvmMultiClone(ManageTest):
                         cal_md5sum,
                         pod_obj=restored_pod,
                         file_name="fio-rand-readwrite",
-                        block=self.block,
+                        block=block,
                     )
                 )
             for future_restored_pods_md5_after_fio in concurrent.futures.as_completed(
@@ -294,12 +282,9 @@ class TestLvmMultiClone(ManageTest):
                 )
 
             for pod_num in range(0, self.pvc_num):
-                if (
-                    restored_pods_md5_after_fio[pod_num]
-                    == self.origin_pods_md5[pod_num]
-                ):
+                if restored_pods_md5_after_fio[pod_num] == origin_pods_md5[pod_num]:
                     raise Md5CheckFailed(
-                        f"origin pod {self.pods_objs[pod_num].name} md5 value {self.origin_pods_md5[pod_num]} "
+                        f"origin pod {pods_objs[pod_num].name} md5 value {origin_pods_md5[pod_num]} "
                         f"is not suppose to be the same as restored pod {restored_pods_objs[pod_num].name} md5 "
                         f"value {restored_pods_md5_after_fio[pod_num]}"
                     )

--- a/tests/lvmo/test_lvm_multi_snapshot.py
+++ b/tests/lvmo/test_lvm_multi_snapshot.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import get_ocp_version
 from ocs_ci.ocs.cluster import LVM
@@ -50,159 +50,19 @@ class TestLvmMultiSnapshot(ManageTest):
     access_mode = constants.ACCESS_MODE_RWO
     pvc_num = 5
 
-    @pytest.fixture()
-    def namespace(self, project_factory_class):
-        self.proj_obj = project_factory_class()
-        self.proj = self.proj_obj.namespace
-
-    @pytest.fixture()
-    def storageclass(self, lvm_storageclass_factory_class, volume_binding_mode):
-        self.sc_obj = lvm_storageclass_factory_class(volume_binding_mode)
-
-    @pytest.fixture()
-    def pvc(self, pvc_factory_class, volume_mode, volume_binding_mode):
-        self.status = constants.STATUS_PENDING
-        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
-            self.status = constants.STATUS_BOUND
-        futures = []
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        for exec_num in range(0, self.pvc_num):
-            futures.append(
-                executor.submit(
-                    pvc_factory_class,
-                    project=self.proj_obj,
-                    interface=None,
-                    storageclass=self.sc_obj,
-                    size=self.pvc_size,
-                    status=self.status,
-                    access_mode=self.access_mode,
-                    volume_mode=volume_mode,
-                )
-            )
-        self.pvc_objs = []
-        for future in concurrent.futures.as_completed(futures):
-            self.pvc_objs.append(future.result())
-
-    @pytest.fixture()
-    def pod(self, pod_factory_class, volume_mode):
-        self.block = False
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.block = True
-        futures_pods = []
-        self.pods_objs = []
-        for pvc in self.pvc_objs:
-            futures_pods.append(
-                executor.submit(pod_factory_class, pvc=pvc, raw_block_pv=self.block)
-            )
-        for future_pod in concurrent.futures.as_completed(futures_pods):
-            self.pods_objs.append(future_pod.result())
-
-    @pytest.fixture()
-    def run_io(self, volume_mode):
-        self.fs = "fs"
-        self.block = False
-        if volume_mode == constants.VOLUME_MODE_BLOCK:
-            self.fs = "block"
-            self.block = True
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        futures_fio = []
-        for pod in self.pods_objs:
-            futures_fio.append(
-                executor.submit(
-                    pod.run_io,
-                    self.fs,
-                    size="10g",
-                    rate="1500m",
-                    runtime=0,
-                    invalidate=0,
-                    buffer_compress_percentage=60,
-                    buffer_pattern="0xdeadface",
-                    bs="1024K",
-                    jobs=1,
-                    readwrite="readwrite",
-                )
-            )
-        for _ in concurrent.futures.as_completed(futures_fio):
-            logger.info("Some pod submitted FIO")
-        concurrent.futures.wait(futures_fio)
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        futures_results = []
-        for pod in self.pods_objs:
-            futures_results.append(executor.submit(pod.get_fio_results()))
-        for _ in concurrent.futures.as_completed(futures_results):
-            logger.info("Just waiting for fio jobs results")
-        concurrent.futures.wait(futures_results)
-        if not self.block:
-            executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-            futures_md5 = []
-            self.origin_pods_md5 = []
-            for pod in self.pods_objs:
-                futures_md5.append(
-                    executor.submit(
-                        cal_md5sum,
-                        pod_obj=pod,
-                        file_name="fio-rand-readwrite",
-                        block=self.block,
-                    )
-                )
-            for future_md5 in concurrent.futures.as_completed(futures_md5):
-                self.origin_pods_md5.append(future_md5.result())
-
-    @pytest.fixture()
-    def create_snapshot(self, snapshot_factory):
-        logger.info("Creating snapshot from pvc objects")
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        futures_snapshot = []
-        self.snapshots_objs = []
-        for pvc in self.pvc_objs:
-            futures_snapshot.append(
-                executor.submit(
-                    snapshot_factory,
-                    pvc_obj=pvc,
-                )
-            )
-        for future_snapshot in concurrent.futures.as_completed(futures_snapshot):
-            self.snapshots_objs.append(future_snapshot.result())
-        concurrent.futures.wait(futures_snapshot)
-
-    @pytest.fixture()
-    def create_restore(self, snapshot_restore_factory, volume_mode):
-        logger.info("Creating restore from snapshots")
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
-        futures_restore = []
-        self.restore_objs = []
-        for snapshot in self.snapshots_objs:
-            futures_restore.append(
-                executor.submit(
-                    snapshot_restore_factory,
-                    snapshot,
-                    storageclass=self.sc_obj.name,
-                    # restore_pvc_name=f"{snapshot.name}-restore",
-                    size=str(self.pvc_size * 1024 * 1024 * 1024),
-                    volume_mode=volume_mode,
-                    restore_pvc_yaml=constants.CSI_LVM_PVC_RESTORE_YAML,
-                    access_mode=self.access_mode,
-                    status=self.status,
-                )
-            )
-        for future_restore in concurrent.futures.as_completed(futures_restore):
-            self.restore_objs.append(future_restore.result())
-
-        concurrent.futures.wait(futures_restore)
-
     @tier1
+    @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.10")
     def test_create_multi_snapshot_from_pvc(
         self,
-        namespace,
-        storageclass,
-        pvc,
-        pod,
-        run_io,
-        create_snapshot,
-        create_restore,
+        volume_mode,
+        volume_binding_mode,
+        project_factory,
+        lvm_storageclass_factory,
+        snapshot_factory,
+        snapshot_restore_factory,
+        pvc_factory,
         pod_factory,
     ):
         """
@@ -216,7 +76,7 @@ class TestLvmMultiSnapshot(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM()
+        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"
@@ -225,14 +85,140 @@ class TestLvmMultiSnapshot(ManageTest):
             f"Lvm thin-pool sizePercent is {lvm.get_lvm_thin_pool_config_size_percent()}"
         )
 
+        proj_obj = project_factory()
+
+        sc_obj = lvm_storageclass_factory(volume_binding_mode)
+
+        status = constants.STATUS_PENDING
+        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
+            status = constants.STATUS_BOUND
+        futures = []
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        for exec_num in range(0, self.pvc_num):
+            futures.append(
+                executor.submit(
+                    pvc_factory,
+                    project=proj_obj,
+                    interface=None,
+                    storageclass=sc_obj,
+                    size=self.pvc_size,
+                    status=status,
+                    access_mode=self.access_mode,
+                    volume_mode=volume_mode,
+                )
+            )
+        pvc_objs = []
+        for future in concurrent.futures.as_completed(futures):
+            pvc_objs.append(future.result())
+
+        block = False
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            block = True
+        futures_pods = []
+        pods_objs = []
+        for pvc in pvc_objs:
+            futures_pods.append(
+                executor.submit(pod_factory, pvc=pvc, raw_block_pv=block)
+            )
+        for future_pod in concurrent.futures.as_completed(futures_pods):
+            pods_objs.append(future_pod.result())
+
+        fs = "fs"
+        block = False
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            fs = "block"
+            block = True
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        futures_fio = []
+        for pod in pods_objs:
+            futures_fio.append(
+                executor.submit(
+                    pod.run_io,
+                    fs,
+                    size="10g",
+                    rate="1500m",
+                    runtime=0,
+                    invalidate=0,
+                    buffer_compress_percentage=60,
+                    buffer_pattern="0xdeadface",
+                    bs="1024K",
+                    jobs=1,
+                    readwrite="readwrite",
+                )
+            )
+        origin_pods_md5 = []
+        for _ in concurrent.futures.as_completed(futures_fio):
+            logger.info("Some pod submitted FIO")
+        concurrent.futures.wait(futures_fio)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        futures_results = []
+        for pod in pods_objs:
+            futures_results.append(executor.submit(pod.get_fio_results()))
+        for _ in concurrent.futures.as_completed(futures_results):
+            logger.info("Just waiting for fio jobs results")
+        concurrent.futures.wait(futures_results)
+        if not block:
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+            futures_md5 = []
+            for pod in pods_objs:
+                futures_md5.append(
+                    executor.submit(
+                        cal_md5sum,
+                        pod_obj=pod,
+                        file_name="fio-rand-readwrite",
+                        block=block,
+                    )
+                )
+            for future_md5 in concurrent.futures.as_completed(futures_md5):
+                origin_pods_md5.append(future_md5.result())
+
+        logger.info("Creating snapshot from pvc objects")
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        futures_snapshot = []
+        snapshots_objs = []
+        for pvc in pvc_objs:
+            futures_snapshot.append(
+                executor.submit(
+                    snapshot_factory,
+                    pvc_obj=pvc,
+                )
+            )
+        for future_snapshot in concurrent.futures.as_completed(futures_snapshot):
+            snapshots_objs.append(future_snapshot.result())
+        concurrent.futures.wait(futures_snapshot)
+
+        logger.info("Creating restore from snapshots")
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
+        futures_restore = []
+        restore_objs = []
+        for snapshot in snapshots_objs:
+            futures_restore.append(
+                executor.submit(
+                    snapshot_restore_factory,
+                    snapshot,
+                    storageclass=sc_obj.name,
+                    restore_pvc_name=f"{snapshot.name}-restore",
+                    size=str(self.pvc_size * 1024 * 1024 * 1024),
+                    volume_mode=volume_mode,
+                    restore_pvc_yaml=constants.CSI_LVM_PVC_RESTORE_YAML,
+                    access_mode=self.access_mode,
+                    status=status,
+                )
+            )
+        for future_restore in concurrent.futures.as_completed(futures_restore):
+            restore_objs.append(future_restore.result())
+
+        concurrent.futures.wait(futures_restore)
+
         logger.info("Attaching pods to pvcs restores")
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_restored_pods = []
         restored_pods_objs = []
 
-        for pvc in self.restore_objs:
+        for pvc in restore_objs:
             futures_restored_pods.append(
-                executor.submit(pod_factory, pvc=pvc, raw_block_pv=self.block)
+                executor.submit(pod_factory, pvc=pvc, raw_block_pv=block)
             )
         for future_restored_pod in concurrent.futures.as_completed(
             futures_restored_pods
@@ -241,7 +227,7 @@ class TestLvmMultiSnapshot(ManageTest):
         concurrent.futures.wait(futures_restored_pods)
         time.sleep(10)
 
-        if not self.block:
+        if not block:
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
             futures_restored_pods_md5 = []
             restored_pods_md5 = []
@@ -251,7 +237,7 @@ class TestLvmMultiSnapshot(ManageTest):
                         cal_md5sum,
                         pod_obj=restored_pod,
                         file_name="fio-rand-readwrite",
-                        block=self.block,
+                        block=block,
                     )
                 )
             for future_restored_pod_md5 in concurrent.futures.as_completed(
@@ -259,9 +245,9 @@ class TestLvmMultiSnapshot(ManageTest):
             ):
                 restored_pods_md5.append(future_restored_pod_md5.result())
             for pod_num in range(0, self.pvc_num):
-                if self.origin_pods_md5[pod_num] != restored_pods_md5[pod_num]:
+                if origin_pods_md5[pod_num] != restored_pods_md5[pod_num]:
                     raise Md5CheckFailed(
-                        f"origin pod {self.pods_objs[pod_num]} md5 value {self.origin_pods_md5[pod_num]} "
+                        f"origin pod {pods_objs[pod_num]} md5 value {origin_pods_md5[pod_num]} "
                         f"is not the same as restored pod {restored_pods_objs[pod_num]} md5 "
                         f"value {restored_pods_md5[pod_num]}"
                     )
@@ -272,7 +258,7 @@ class TestLvmMultiSnapshot(ManageTest):
             futures_restored_pods_fio.append(
                 executor.submit(
                     restored_pod.run_io,
-                    self.fs,
+                    fs,
                     size="5g",
                     rate="1500m",
                     runtime=0,
@@ -297,7 +283,7 @@ class TestLvmMultiSnapshot(ManageTest):
         for _ in concurrent.futures.as_completed(futures_restored_pods_fio_results):
             logger.info("Finished waiting for some pod")
         concurrent.futures.wait(futures_restored_pods_fio_results)
-        if not self.block:
+        if not block:
             executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
             futures_restored_pods_md5_after_fio = []
             restored_pods_md5_after_fio = []
@@ -307,7 +293,7 @@ class TestLvmMultiSnapshot(ManageTest):
                         cal_md5sum,
                         pod_obj=restored_pod,
                         file_name="fio-rand-readwrite",
-                        block=self.block,
+                        block=block,
                     )
                 )
             for future_restored_pods_md5_after_fio in concurrent.futures.as_completed(
@@ -318,12 +304,9 @@ class TestLvmMultiSnapshot(ManageTest):
                 )
 
             for pod_num in range(0, self.pvc_num):
-                if (
-                    restored_pods_md5_after_fio[pod_num]
-                    == self.origin_pods_md5[pod_num]
-                ):
+                if restored_pods_md5_after_fio[pod_num] == origin_pods_md5[pod_num]:
                     raise Md5CheckFailed(
-                        f"origin pod {self.pods_objs[pod_num].name} md5 value {self.origin_pods_md5[pod_num]} "
+                        f"origin pod {pods_objs[pod_num].name} md5 value {origin_pods_md5[pod_num]} "
                         f"is not suppose to be the same as restored pod {restored_pods_objs[pod_num].name} md5 "
                         f"value {restored_pods_md5_after_fio[pod_num]}"
                     )

--- a/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import tier1, skipif_lvm_not_installed
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
 from ocs_ci.ocs.exceptions import LvSizeWrong
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @tier1
+@acceptance
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.10")
 class TestLvmSnapshotBiggerThanDisk(ManageTest):


### PR DESCRIPTION
In my last PR I've changed the way sampling of product works and didn't test it enough and it is failing.
This is a fix to the fail and also if you check lvmcluster and it is not installed, it will not stdout the errors and only log that cephcluster is installed and the other way if cephcluster is not installed  and lvmcluster is.
Also because of all the fixtures in the test (5-6) on every change the finalizers get mixed. I've flattened all the test not have fixtures. Saw that every test that use more than 3-4 factories is flat in the test.

Fixes: #6227