### PR TITLE
Change variable fs to storage_type and increase snap and clone tests version to 4.11 

### DIFF
--- a/tests/lvmo/test_lvm_clone_base.py
+++ b/tests/lvmo/test_lvm_clone_base.py
@@ -49,7 +49,7 @@ class TestLvmSnapshot(ManageTest):
     @tier1
     @acceptance
     @skipif_lvm_not_installed
-    @skipif_ocs_version("<4.10")
+    @skipif_ocs_version("<4.11")
     def test_create_clone_from_pvc(
         self,
         volume_mode,
@@ -103,14 +103,14 @@ class TestLvmSnapshot(ManageTest):
             block = True
         pod_obj = pod_factory(pvc=pvc_obj, raw_block_pv=block)
 
-        fs = "fs"
+        storage_type = "fs"
         block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            fs = "block"
+            storage_type = "block"
             block = True
 
         pod_obj.run_io(
-            fs,
+            storage_type,
             size="5g",
             rate="1500m",
             runtime=0,
@@ -148,7 +148,7 @@ class TestLvmSnapshot(ManageTest):
                 )
 
         restored_pod_obj.run_io(
-            fs,
+            storage_type,
             size="1g",
             rate="1500m",
             runtime=0,

--- a/tests/lvmo/test_lvm_multi_clone.py
+++ b/tests/lvmo/test_lvm_multi_clone.py
@@ -53,7 +53,7 @@ class TestLvmMultiClone(ManageTest):
     @tier1
     @acceptance
     @skipif_lvm_not_installed
-    @skipif_ocs_version("<4.10")
+    @skipif_ocs_version("<4.11")
     def test_create_multi_clone_from_pvc(
         self,
         volume_mode,
@@ -123,10 +123,10 @@ class TestLvmMultiClone(ManageTest):
         for future_pod in concurrent.futures.as_completed(futures_pods):
             pods_objs.append(future_pod.result())
 
-        fs = "fs"
+        storage_type = "fs"
         block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            fs = "block"
+            storage_type = "block"
             block = True
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_fio = []
@@ -134,7 +134,7 @@ class TestLvmMultiClone(ManageTest):
             futures_fio.append(
                 executor.submit(
                     pod.run_io,
-                    fs,
+                    storage_type,
                     size="5g",
                     rate="1500m",
                     runtime=0,
@@ -236,7 +236,7 @@ class TestLvmMultiClone(ManageTest):
             futures_restored_pods_fio.append(
                 executor.submit(
                     restored_pod.run_io,
-                    fs,
+                    storage_type,
                     size="1g",
                     rate="1500m",
                     runtime=0,

--- a/tests/lvmo/test_lvm_multi_snapshot.py
+++ b/tests/lvmo/test_lvm_multi_snapshot.py
@@ -53,7 +53,7 @@ class TestLvmMultiSnapshot(ManageTest):
     @tier1
     @acceptance
     @skipif_lvm_not_installed
-    @skipif_ocs_version("<4.10")
+    @skipif_ocs_version("<4.11")
     def test_create_multi_snapshot_from_pvc(
         self,
         volume_mode,
@@ -124,10 +124,10 @@ class TestLvmMultiSnapshot(ManageTest):
         for future_pod in concurrent.futures.as_completed(futures_pods):
             pods_objs.append(future_pod.result())
 
-        fs = "fs"
+        storage_type = "fs"
         block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            fs = "block"
+            storage_type = "block"
             block = True
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.pvc_num)
         futures_fio = []
@@ -135,7 +135,7 @@ class TestLvmMultiSnapshot(ManageTest):
             futures_fio.append(
                 executor.submit(
                     pod.run_io,
-                    fs,
+                    storage_type,
                     size="10g",
                     rate="1500m",
                     runtime=0,
@@ -258,7 +258,7 @@ class TestLvmMultiSnapshot(ManageTest):
             futures_restored_pods_fio.append(
                 executor.submit(
                     restored_pod.run_io,
-                    fs,
+                    storage_type,
                     size="5g",
                     rate="1500m",
                     runtime=0,

--- a/tests/lvmo/test_lvm_snapshot_base.py
+++ b/tests/lvmo/test_lvm_snapshot_base.py
@@ -49,7 +49,7 @@ class TestLvmSnapshot(ManageTest):
     @tier1
     @acceptance
     @skipif_lvm_not_installed
-    @skipif_ocs_version("<4.10")
+    @skipif_ocs_version("<4.11")
     def test_create_snapshot_from_pvc(
         self,
         volume_mode,
@@ -103,13 +103,13 @@ class TestLvmSnapshot(ManageTest):
             block = True
         pod_obj = pod_factory(pvc=pvc_obj, raw_block_pv=block)
         origin_pod_md5 = ""
-        fs = "fs"
+        storage_type = "fs"
         block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            fs = "block"
+            storage_type = "block"
             block = True
         pod_obj.run_io(
-            fs,
+            storage_type,
             size="5g",
             rate="1500m",
             runtime=0,
@@ -157,7 +157,7 @@ class TestLvmSnapshot(ManageTest):
                 )
 
         restored_pod_obj.run_io(
-            fs,
+            storage_type,
             size="1g",
             rate="1500m",
             runtime=0,

--- a/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @acceptance
 @skipif_lvm_not_installed
-@skipif_ocs_version("<4.10")
+@skipif_ocs_version("<4.11")
 class TestLvmSnapshotBiggerThanDisk(ManageTest):
     """
     Test lvm snapshot bigger than disk
@@ -125,13 +125,13 @@ class TestLvmSnapshotBiggerThanDisk(ManageTest):
                 f"❌Lv size {lv_size} is not the same as pvc size {pvc_size}"
             )
 
-        fs = "fs"
+        storage_type = "fs"
         block = False
         if volume_mode == constants.VOLUME_MODE_BLOCK:
-            fs = "block"
+            storage_type = "block"
             block = True
         pod_obj.run_io(
-            fs,
+            storage_type,
             size=f"{fio_size}g",
             rate="1500M",
             fio_filename=filename,
@@ -188,7 +188,7 @@ class TestLvmSnapshotBiggerThanDisk(ManageTest):
         )
 
         restored_pod_obj.run_io(
-            fs,
+            storage_type,
             size=f"{second_fio_size}g",
             rate="1500M",
             runtime=0,


### PR DESCRIPTION
Change varible fs to storage_type and increase snap and clone tests version to 4.11 
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>