### PR TITLE
test_pvc_creation_deletion_performance.py - fixing deletion measurements

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -103,7 +103,8 @@ def run_command(cmd, timeout=600, out_format="string", **kwargs):
 
     if out_format == "list":
         output = output.split("\n")  # convert output to list
-        output.pop()  # remove last empty element from the list
+        if len(output) > 1:
+            output.pop()  # remove last empty element from the list
     return output
 
 

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -9,7 +9,6 @@ import ocs_ci.ocs.exceptions as ex
 import statistics
 import tempfile
 import yaml
-import time
 
 from ocs_ci.framework.testlib import performance
 from ocs_ci.ocs.perftests import PASTest

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -9,6 +9,7 @@ import ocs_ci.ocs.exceptions as ex
 import statistics
 import tempfile
 import yaml
+import time
 
 from ocs_ci.framework.testlib import performance
 from ocs_ci.ocs.perftests import PASTest
@@ -308,7 +309,8 @@ class TestPVCCreationDeletionPerformance(PASTest):
             f'get sc {Interface_Info[self.interface]["sc"]} -o jsonpath="'
             + '{.reclaimPolicy}"'
         )
-        if rec_policy == constants.RECLAIM_POLICY_DELETE:
+
+        if rec_policy[0].strip('"') == constants.RECLAIM_POLICY_DELETE:
             log.info("Wait for all PVC(s) backed PV(s) to be deleted")
             # Timeout for each PV to be deleted is 20 sec.
             performance_lib.wait_for_resource_bulk_status(


### PR DESCRIPTION
Previous version of the test was measuring Deletion and CSI Deletion times as None. 
Following the current fix Deletion and CSI deletion times will be measured. 

Example from test log: 

17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 1 was created in 0.087 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 1 was deleted in 0.078 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 1 was csi_created in 0.082 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 1 was csi_deleted in 0.066 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 2 was created in 0.079 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 2 was deleted in 0.08 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 2 was csi_created in 0.074 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 2 was csi_deleted in 0.07 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 3 was created in 0.081 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 3 was deleted in 0.078 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 3 was csi_created in 0.075 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 3 was csi_deleted in 0.069 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 4 was created in 0.08 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 4 was deleted in 0.079 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 4 was csi_created in 0.072 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 4 was csi_deleted in 0.065 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 5 was created in 0.081 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 5 was deleted in 0.084 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 5 was csi_created in 0.077 seconds.
17:44:58 - MainThread - test_pvc_creation_deletion_performance - INFO  - Interface: CephBlockPool, PVC size: 5Gi. PVC number 5 was csi_deleted in 0.073 seconds.

Signed-off-by: Yulia Persky <ypersky@redhat.com>