### PR TITLE
use dry-run with client

### DIFF
--- a/ocs_ci/utility/pagerduty.py
+++ b/ocs_ci/utility/pagerduty.py
@@ -26,7 +26,7 @@ def set_pagerduty_integration_secret(integration_key):
     cmd = (
         f"oc create secret generic {managedservice.get_pagerduty_secret_name()} "
         f"--from-literal=PAGERDUTY_KEY={integration_key} -n openshift-storage "
-        f"--kubeconfig {kubeconfig} --dry-run -o yaml"
+        f"--kubeconfig {kubeconfig} --dry-run=client -o yaml"
     )
     secret_data = exec_cmd(
         cmd,

--- a/ocs_ci/utility/users.py
+++ b/ocs_ci/utility/users.py
@@ -46,7 +46,7 @@ def create_htpasswd_secret(htpasswd_path, replace=False):
         f"--kubeconfig {kubeconfig}"
     )
     if replace:
-        secret_data = exec_cmd(f"{cmd} --dry-run -o yaml").stdout
+        secret_data = exec_cmd(f"{cmd} --dry-run=client -o yaml").stdout
         with NamedTemporaryFile(prefix="htpasswd_secret_") as secret_file:
             secret_file.write(secret_data)
             secret_file.flush()


### PR DESCRIPTION
-dry-run is deprecated and can be replaced with --dry-run=client

Signed-off-by: vavuthu <vavuthu@redhat.com>