### PR TITLE
In the test "test_nodes_restart" use "SanityExternalCluster" in case we use the external mode

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -17,8 +17,12 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs, get_nodes
 from ocs_ci.ocs.resources import pod
-from ocs_ci.helpers.sanity_helpers import Sanity
-from ocs_ci.helpers.helpers import wait_for_ct_pod_recovery, get_pv_names
+from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
+from ocs_ci.helpers.helpers import (
+    wait_for_ct_pod_recovery,
+    get_pv_names,
+    storagecluster_independent_check,
+)
 from ocs_ci.ocs.ocp import OCP
 
 
@@ -39,7 +43,10 @@ class TestNodesRestart(ManageTest):
         Initialize Sanity instance
 
         """
-        self.sanity_helpers = Sanity()
+        if storagecluster_independent_check():
+            self.sanity_helpers = SanityExternalCluster()
+        else:
+            self.sanity_helpers = Sanity()
 
     @pytest.fixture(autouse=True)
     def teardown(self, request, nodes):


### PR DESCRIPTION
We can see in the test https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster-prod/4875/testReport/tests.manage.z_cluster.nodes.test_nodes_restart/TestNodesRestart/test_nodes_restart_True_/, that when we use the external mode cluster, it searches for the wrong pods. That's why we should use the "SanityExternalCluster" in case we use the external mode in the test "test_nodes_restart".