### PR TITLE
Tier2 snapshot with node reboot and tier4 multiple reboot to test catalogsource presence

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -562,3 +562,11 @@ class LvThinUtilNotChanged(Exception):
 
 class ThinPoolUtilityWrong(Exception):
     pass
+
+
+class CatalogSourceNotFoundAfterReboot(Exception):
+    pass
+
+
+class PodDidNotReachRunningState(Exception):
+    pass

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1886,7 +1886,11 @@ def check_pods_in_running_state(
     ret_val = True
 
     if pod_names:
-        list_of_pods = get_pod_objs(pod_names, raise_pod_not_found_error)
+        list_of_pods = get_pod_objs(
+            pod_names,
+            namespace=namespace,
+            raise_pod_not_found_error=raise_pod_not_found_error,
+        )
     else:
         list_of_pods = get_all_pods(namespace)
 
@@ -2739,3 +2743,29 @@ def get_mon_label(mon_pod_obj):
 
     """
     return mon_pod_obj.get().get("metadata").get("labels").get("mon")
+
+
+def get_lvm_pods_objs():
+    """
+    Get lvm pods name (without operator)
+    Returns:
+        list(POD): list of pods objects.
+    """
+    lvm_pods = get_pods_having_label(
+        label="app.kubernetes.io/managed-by=lvm-operator",
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+    return lvm_pods
+
+
+def wait_for_lvm_pod_running():
+    """
+    Wait for all lvm pods to be running.
+    """
+
+    pod_name_list = []
+    for lvm_pod in get_lvm_pods_objs():
+        pod_name_list.append(lvm_pod["metadata"]["name"])
+    wait_for_pods_to_be_running(
+        pod_names=pod_name_list, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+    )

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -219,14 +219,14 @@ class PVC(OCS):
                 attached_pods.append(pod_obj)
         return attached_pods
 
-    def create_snapshot(self, snapshot_name=None, wait=False):
+    def create_snapshot(self, snapshot_name=None, wait=False, time_to_wait=60):
         """
         Take snapshot of the PVC
 
         Args:
             snapshot_name (str): Name to be provided for snapshot
             wait (bool): True to wait for snapshot to be ready, False otherwise
-
+            time_to_wait (int): The number of seconds to wait for status
         Returns:
             OCS: Kind Snapshot
 
@@ -254,6 +254,7 @@ class PVC(OCS):
             namespace=self.namespace,
             sc_name=snapshotclass,
             wait=wait,
+            time_to_wait=time_to_wait,
         )
         snapshot_obj.parent_access_mode = self.get_pvc_access_mode
         snapshot_obj.parent_sc = self.backed_sc
@@ -411,7 +412,7 @@ def get_deviceset_pvs():
 
 
 def create_pvc_snapshot(
-    pvc_name, snap_yaml, snap_name, namespace, sc_name=None, wait=False
+    pvc_name, snap_yaml, snap_name, namespace, sc_name=None, wait=False, time_to_wait=60
 ):
     """
     Create snapshot of a PVC
@@ -423,6 +424,7 @@ def create_pvc_snapshot(
         namespace (str): The namespace for the snapshot creation
         sc_name (str): The name of the snapshot class
         wait (bool): True to wait for snapshot to be ready, False otherwise
+        time_to_wait (int): The number of seconds to wait for status
 
     Returns:
         OCS object
@@ -444,7 +446,7 @@ def create_pvc_snapshot(
             condition="true",
             resource_name=ocs_obj.name,
             column=constants.STATUS_READYTOUSE,
-            timeout=60,
+            timeout=time_to_wait,
         )
     return ocs_obj
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3619,18 +3619,20 @@ def snapshot_factory_fixture(request):
     """
     instances = []
 
-    def factory(pvc_obj, wait=True, snapshot_name=None):
+    def factory(pvc_obj, wait=True, snapshot_name=None, time_to_wait=60):
         """
         Args:
             pvc_obj (PVC): PVC object from which snapshot has to be created
             wait (bool): True to wait for snapshot to be ready, False otherwise
             snapshot_name (str): Name to be provided for snapshot
-
+            time_to_wait (int): The number of seconds to wait for restore to get to state
         Returns:
             OCS: OCS instance of kind VolumeSnapshot
 
         """
-        snap_obj = pvc_obj.create_snapshot(snapshot_name=snapshot_name, wait=wait)
+        snap_obj = pvc_obj.create_snapshot(
+            snapshot_name=snapshot_name, wait=wait, time_to_wait=time_to_wait
+        )
         instances.append(snap_obj)
         return snap_obj
 

--- a/tests/lvmo/test_lvm_node_reboot_catalogsource.py
+++ b/tests/lvmo/test_lvm_node_reboot_catalogsource.py
@@ -1,0 +1,78 @@
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import tier4a, skipif_lvm_not_installed
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, bugzilla
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import LVM
+from ocs_ci.ocs.resources.pod import wait_for_lvm_pod_running
+from ocs_ci.ocs.exceptions import CommandFailed, CatalogSourceNotFoundAfterReboot
+from ocs_ci.ocs.node import wait_for_nodes_status
+from ocs_ci.deployment.deployment import create_catalog_source
+from ocs_ci.utility.utils import run_cmd
+from ocs_ci.ocs.node import get_node_objs
+
+logger = logging.getLogger(__name__)
+
+
+@bugzilla("2122785")
+@tier4a
+@skipif_lvm_not_installed
+@skipif_ocs_version("<4.11")
+class TestLvmCatalogSourceNodeReboot(ManageTest):
+    """
+    Test lvm snapshot bigger than disk
+
+    """
+
+    number_of_reboots = 10
+
+    def test_node_reboot_sno_catalogsource(
+        self,
+        nodes,
+    ):
+        """
+        test reboot multiple time to check catalogsource existence
+        .* Reboot node
+        .* Check that catalogsource exists
+        .* repeat number_of_reboots
+
+        """
+        lvm = LVM()
+
+        image = lvm.image
+        catalogsource_not_found_occurrences = 0
+        nodes_ocs = get_node_objs()
+        nodes_names = []
+        for reboot in range(1, (self.number_of_reboots + 1)):
+            for node in nodes_ocs:
+                nodes_names.append(node.data["metadata"]["name"])
+            nodes.restart_nodes(nodes_ocs, force=False, wait=False)
+
+            wait_for_nodes_status(node_names=nodes_names)
+
+            wait_for_lvm_pod_running()
+            logger.info(f"++++++++++++++++++ In reboot {reboot} ++++++++++++++++++")
+            try:
+                LVM()
+            except CommandFailed as er:
+                logger.error(
+                    f"CatalogSource "
+                    f"{constants.OPERATOR_CATALOG_SOURCE_NAME} not found in reboot {reboot}. {er}"
+                    f" Re-creating and continuing for statistics. Gathering events"
+                )
+                retrieve = run_cmd(
+                    cmd="oc get events --all-namespaces --sort-by='.metadata.creationTimestamp'"
+                )
+                splitted = retrieve.split("\n")
+                for line in splitted:
+                    if "redhat-oper" in line and "Normal" not in line:
+                        logger.info(f"** {line}")
+
+                create_catalog_source(image=image)
+                catalogsource_not_found_occurrences += 1
+        if catalogsource_not_found_occurrences > 0:
+            raise CatalogSourceNotFoundAfterReboot(
+                f"Catalogsource {constants.OPERATOR_CATALOG_SOURCE_NAME} not found"
+                f"in {catalogsource_not_found_occurrences} "
+                f"out of {self.number_of_reboots} reboots"
+            )

--- a/tests/lvmo/test_lvm_snapshot_node_reboot.py
+++ b/tests/lvmo/test_lvm_snapshot_node_reboot.py
@@ -1,0 +1,301 @@
+import logging
+import time
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import tier2, skipif_lvm_not_installed
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import LVM
+from ocs_ci.ocs.exceptions import (
+    LvSizeWrong,
+    CommandFailed,
+    PodDidNotReachRunningState,
+)
+from ocs_ci.ocs.node import wait_for_nodes_status
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.ocs.ocp import switch_to_project
+from ocs_ci.utility.retry import retry
+from ocs_ci.ocs.node import get_node_objs
+
+logger = logging.getLogger(__name__)
+
+
+@tier2
+@skipif_lvm_not_installed
+@skipif_ocs_version("<4.11")
+class TestLvmSnapshotNodeReboot(ManageTest):
+    """
+    Test lvm snapshot with node reboot
+
+    """
+
+    @pytest.mark.parametrize(
+        argnames=["volume_mode", "volume_binding_mode"],
+        argvalues=[
+            pytest.param(
+                *[constants.VOLUME_MODE_FILESYSTEM, constants.WFFC_VOLUMEBINDINGMODE],
+                marks=pytest.mark.polarion_id("OCS-3991"),
+            ),
+            pytest.param(
+                *[constants.VOLUME_MODE_BLOCK, constants.WFFC_VOLUMEBINDINGMODE],
+                marks=pytest.mark.polarion_id("OCS-3991"),
+            ),
+            pytest.param(
+                *[
+                    constants.VOLUME_MODE_FILESYSTEM,
+                    constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                ],
+                marks=pytest.mark.polarion_id("OCS-3991"),
+            ),
+            pytest.param(
+                *[constants.VOLUME_MODE_BLOCK, constants.IMMEDIATE_VOLUMEBINDINGMODE],
+                marks=pytest.mark.polarion_id("OCS-3991"),
+            ),
+        ],
+    )
+    def test_create_snapshot_with_node_reboot(
+        self,
+        nodes,
+        volume_mode,
+        volume_binding_mode,
+        project_factory,
+        lvm_storageclass_factory,
+        snapshot_factory,
+        snapshot_restore_factory,
+        pvc_factory,
+        pod_factory,
+    ):
+        """
+        test create snapshot reboot
+        .* Create PVC
+        .* Create POD
+        .* Run IO PVC
+        .* Create Snapshot
+        .* Create pvc from Snapshot
+        .* Attach pod
+        .* Reboot node
+        .* Check LV size
+        .* Run IO
+        .* Create another restore
+        .* Attach Pod and check utilization
+
+        """
+
+        access_mode = constants.ACCESS_MODE_RWO
+
+        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=False)
+        disk1 = lvm.pv_data["pv_list"][0]
+        disk_size = lvm.pv_data[disk1]["pv_size"]
+        pvc_size = int(float(disk_size)) * 2
+        thin_pool_size = lvm.get_thin_pool1_size()
+        first_io_ratio = 0.1
+        second_io_ratio = 0.05
+
+        fio_size = round(float(pvc_size) * first_io_ratio)
+        second_fio_size = round(float(pvc_size) * second_io_ratio)
+
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            readwrite = "write"
+            filename = "/dev/rbdblock"
+
+        else:
+            readwrite = "readwrite"
+            filename = "fio.txt"
+
+        proj_obj = project_factory()
+
+        sc_obj = lvm_storageclass_factory(volume_binding_mode)
+
+        status = constants.STATUS_PENDING
+        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
+            status = constants.STATUS_BOUND
+        pvc_obj = pvc_factory(
+            project=proj_obj,
+            interface=None,
+            storageclass=sc_obj,
+            size=pvc_size,
+            status=status,
+            access_mode=access_mode,
+            volume_mode=volume_mode,
+        )
+
+        block = False
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            block = True
+        pod_name_list = []
+        pod_1_start_time = time.time()
+        pod_obj = pod_factory(pvc=pvc_obj, raw_block_pv=block)
+        pod_1_end_time = time.time()
+        pod_1_elapsed = pod_1_end_time - pod_1_start_time
+        logger.info(f"Pod {pod_obj.name} elapsed time to running is {pod_1_elapsed}")
+        pod_name_list.append(pod_obj.name)
+        lv_size = lvm.get_lv_size_of_pvc(pvc_obj)
+        if int(float(lv_size)) != pvc_size:
+            raise LvSizeWrong(
+                f"❌ Lv size {lv_size} is not the same as pvc size {pvc_size}"
+            )
+
+        storage_type = "fs"
+        block = False
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            storage_type = "block"
+            block = True
+        pod_obj.run_io(
+            storage_type,
+            size=f"{fio_size}g",
+            rate="1500M",
+            fio_filename=filename,
+            direct=1,
+            invalidate=0,
+            rate_process=None,
+            buffer_pattern="0xdeadface",
+            bs="100M",
+            jobs=1,
+            runtime=0,
+            readwrite=readwrite,
+            rw_ratio=50,
+        )
+        pod_obj.get_fio_results()
+        lvm.compare_percent_data_from_pvc(pvc_obj, fio_size)
+
+        logger.info(f"ℹ️ Creating snapshot from {pvc_obj.name}")
+        snapshot = snapshot_factory(pvc_obj)
+        lvm.compare_percent_data_from_pvc(snapshot, fio_size)
+
+        logger.info(f"ℹ ️Creating restore from snapshot {snapshot.name}")
+        pvc_restore = snapshot_restore_factory(
+            snapshot,
+            storageclass=sc_obj.name,
+            restore_pvc_name=f"{pvc_obj.name}-restore",
+            size=str(pvc_size * 1024 * 1024 * 1024),
+            volume_mode=volume_mode,
+            restore_pvc_yaml=constants.CSI_LVM_PVC_RESTORE_YAML,
+            access_mode=access_mode,
+            status=status,
+        )
+        if volume_binding_mode == constants.IMMEDIATE_VOLUMEBINDINGMODE:
+            lvm.compare_percent_data_from_pvc(pvc_restore, fio_size)
+
+        pod_2_start_time = time.time()
+        restored_pod_obj = pod_factory(pvc=pvc_restore, raw_block_pv=block)
+        pod_2_end_time = time.time()
+        pod_2_elapsed_time_to_running = pod_2_end_time - pod_2_start_time
+        logger.info(
+            f"Pod {restored_pod_obj.name} got to running time in {pod_2_elapsed_time_to_running}"
+        )
+        pod_name_list.append(restored_pod_obj.name)
+
+        logger.info(f"ℹ ️LVMCluster version is {lvm.get_lvm_version()}")
+        logger.info(
+            f"ℹ️ Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"
+        )
+        logger.info(
+            f"ℹ️ Lvm thin-pool sizePercent is {lvm.get_lvm_thin_pool_config_size_percent()}"
+        )
+
+        logger.info(f"ℹ️Attaching pod to pvc restore {pvc_restore.name}")
+
+        if volume_binding_mode == constants.WFFC_VOLUMEBINDINGMODE:
+            lvm.compare_percent_data_from_pvc(pvc_restore, fio_size)
+        lv_name = lvm.get_lv_name_from_pvc(pvc_restore)
+
+        before_fio_thin_pool_util = lvm.get_thin_pool1_data_percent()
+        logger.info(
+            f"ℹ️ lv {lv_name} from pvc {pvc_restore.name} utilization after fio is {before_fio_thin_pool_util}"
+        )
+
+        nodes_ocs = get_node_objs()
+        nodes_names = []
+        for node in nodes_ocs:
+            nodes_names.append(node.data["metadata"]["name"])
+        logger.info(f"Rebooting {nodes_names}")
+        nodes.restart_nodes(nodes_ocs, force=False, wait=False)
+        logger.info(f"Waiting for nodes {nodes_names} to be in READY state")
+        wait_for_nodes_status(node_names=nodes_names, timeout=300)
+        logger.info(f"Nodes {nodes_names} in ready state")
+        lvm.wait_for_lvm_pod_running()
+
+        @retry(CommandFailed, tries=30, delay=3)
+        def switch_project_after_reboot():
+            switch_to_project(project_name=proj_obj.namespace)
+
+        switch_project_after_reboot()
+
+        if not wait_for_pods_to_be_running(
+            pod_names=pod_name_list, sleep=3, namespace=proj_obj.namespace
+        ):
+            raise PodDidNotReachRunningState
+
+        lvm.compare_percent_data_from_pvc(pvc_restore, fio_size)
+
+        restored_pod_obj.run_io(
+            storage_type,
+            size=f"{second_fio_size}g",
+            rate="1500M",
+            runtime=0,
+            rate_process=None,
+            fio_filename=f"second-{filename}",
+            buffer_pattern="0xdeadface",
+            direct=1,
+            invalidate=0,
+            bs="100M",
+            jobs=1,
+            readwrite=readwrite,
+        )
+
+        restored_pod_obj.get_fio_results()
+
+        if block:
+            if fio_size > second_fio_size:
+                after_expected_util = (
+                    float(fio_size + second_fio_size) / float(thin_pool_size) * 100
+                )
+
+                lv_util_after_second_fio = float(fio_size)
+            else:
+                after_expected_util = (
+                    float(second_fio_size + fio_size) / float(thin_pool_size) * 100
+                )
+
+                lv_util_after_second_fio = float(second_fio_size)
+
+        else:
+            after_expected_util = (
+                float(fio_size + second_fio_size) / float(thin_pool_size)
+            ) * 100
+            lv_util_after_second_fio = float(fio_size + second_fio_size)
+
+        lvm.compare_percent_data_from_pvc(pvc_restore, lv_util_after_second_fio)
+        lvm.compare_thin_pool_data_percent(
+            data_percent=after_expected_util,
+            sampler=True,
+            timeout=10,
+            wait=1,
+        )
+        pvc_restore_second_start_time = time.time()
+        pvc_restore_second = snapshot_restore_factory(
+            snapshot,
+            storageclass=sc_obj.name,
+            restore_pvc_name=f"{pvc_obj.name}-second-restore",
+            size=str(pvc_size * 1024 * 1024 * 1024),
+            volume_mode=volume_mode,
+            restore_pvc_yaml=constants.CSI_LVM_PVC_RESTORE_YAML,
+            access_mode=access_mode,
+            status=status,
+            timeout=300,
+        )
+        pvc_restore_second_end_time = time.time()
+        logger.info(
+            f"Pvc creation time is {(pvc_restore_second_end_time - pvc_restore_second_start_time)}"
+        )
+        pod_3_start_time = time.time()
+        restored_pod_obj_second = pod_factory(
+            pvc=pvc_restore_second, raw_block_pv=block
+        )
+        pod_3_end_time = time.time()
+        pod_3_elapsed_time = pod_3_end_time - pod_3_start_time
+        logger.info(
+            f"Pod {restored_pod_obj_second.name} got to running state after {pod_3_elapsed_time}"
+        )
+        logger.info(f"Second pod {restored_pod_obj_second.name} was created")
+        lvm.compare_percent_data_from_pvc(pvc_restore_second, fio_size)


### PR DESCRIPTION
Tier 2 testcase Iterates over volume mode and volume binding mode for snapshot with node reboot.
Tier 4 is doing multiple reboot, check lvm init (and this checks catalog). In case of failure with catalogsource it repairs it and count the failure within 10 reboot. Raise if there was a failure.
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>