### PR TITLE
Fix the condition to get file path on pod

### DIFF
--- a/tests/manage/pv_services/pvc_clone/test_node_restart_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_node_restart_during_pvc_clone.py
@@ -168,9 +168,9 @@ class TestNodeRestartDuringPvcClone(ManageTest):
         # Verify md5sum
         for pod_obj in clone_pod_objs:
             file_name_pod = (
-                file_name
-                if (pod_obj.pvc.volume_mode == constants.VOLUME_MODE_FILESYSTEM)
-                else pod_obj.get_storage_path(storage_type="block")
+                pod_obj.get_storage_path(storage_type="block")
+                if (pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK)
+                else file_name
             )
             pod.verify_data_integrity(
                 pod_obj,


### PR DESCRIPTION
Fixes #6284 
The check for volume mode is needed only when the volume mode is "Block". Modified the condition to check volume mode "Block" instead of volume mode "FileSystem".

Signed-off-by: Jilju Joy <jijoy@redhat.com>