### PR TITLE
Minor fix on Quay workload

### DIFF
--- a/ocs_ci/ocs/quay_operator.py
+++ b/ocs_ci/ocs/quay_operator.py
@@ -191,6 +191,10 @@ def get_super_user_token(endpoint):
         data=data,
         verify=False,
     )
+    if r.status_code != 200:
+        raise Exception(
+            f"Error code [{r.status_code}]: Failed to fetch super user token!!"
+        )
     return r.json()["access_token"]
 
 

--- a/tests/e2e/workloads/app/quay/test_quay_operator.py
+++ b/tests/e2e/workloads/app/quay/test_quay_operator.py
@@ -94,12 +94,11 @@ class TestQuayWorkload(E2ETest):
         # Create quay registry
         quay_operator.create_quay_registry()
         log.info("Waiting for quay endpoint to start serving")
-        sleep(90)
+        sleep(120)
         endpoint = quay_operator.get_quay_endpoint()
 
         log.info("Pulling test image")
         exec_cmd(f"podman pull {constants.COSBENCH_IMAGE}")
-
         log.info("Getting the Super user token")
         token = get_super_user_token(endpoint)
 


### PR DESCRIPTION
- Failing tests with correct message, if API calls to Quay endpoint fails
- Added +30 seconds of wait for the Quay endpoint to start serving to avoid unnecessary failures

Signed-off-by: mashetty <mashetty@redhat.com>