### PR TITLE
Increase timeout for EC of submariner install button

### DIFF
--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -129,7 +129,7 @@ class AcmAddClusters(AcmPageNavigator):
         log.info("Click on 'Submariner add-ons' tab")
         self.do_click(self.page_nav["submariner-tab"])
         log.info("Click on 'Install Submariner add-ons' button")
-        self.do_click(self.page_nav["install-submariner-btn"])
+        self.do_click(self.page_nav["install-submariner-btn"], timeout=120)
         log.info("Click on 'Target clusters'")
         self.do_click(self.page_nav["target-clusters"])
         log.info(f"Select 1st cluster which is {cluster_name_a}")


### PR DESCRIPTION
For installing submariner the install button takes time to load.
We can see a timed out execution here (default is 30 sec):
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-dr-setup/52/console

And also a result of passing this through when increased to 120 seconds:
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-dr-setup/54/console