### PR TITLE
Skip the test "test_rolling_shutdown_and_recovery" when using MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_external_mode,
     skipif_ibm_cloud,
+    skipif_managed_service,
 )
 from ocs_ci.ocs.node import get_ocs_nodes
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 @bugzilla("1895819")
 @skipif_ibm_cloud
 @skipif_external_mode
+@skipif_managed_service
 @ignore_leftovers
 class TestRollingWorkerNodeShutdownAndRecovery(ManageTest):
     """


### PR DESCRIPTION
Skip the test "test_rolling_shutdown_and_recovery" when using the Managed Service. I will implement a new test in the pr https://github.com/red-hat-storage/ocs-ci/pull/6328.