### PR TITLE
Bz 2111895 automation - PVC resize on lvm cluster

### DIFF
--- a/tests/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/lvmo/test_lvmo_pvc_resize.py
@@ -1,6 +1,5 @@
-import logging
-
 import pytest
+import logging
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
@@ -9,7 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs.cluster import LVM
-from ocs_ci.utility.utils import TimeoutSampler
+
 
 log = logging.getLogger(__name__)
 
@@ -24,17 +23,83 @@ log = logging.getLogger(__name__)
                 constants.STATUS_PENDING,
             ],
         ),
+        pytest.param(
+            *[
+                constants.VOLUME_MODE_BLOCK,
+                constants.WFFC_VOLUMEBINDINGMODE,
+                constants.STATUS_PENDING,
+            ],
+        ),
+        pytest.param(
+            *[
+                constants.VOLUME_MODE_FILESYSTEM,
+                constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                constants.STATUS_BOUND,
+            ],
+        ),
+        pytest.param(
+            *[
+                constants.VOLUME_MODE_BLOCK,
+                constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                constants.STATUS_BOUND,
+            ],
+        ),
     ],
 )
 class TestLVMPVCResize(ManageTest):
+    """
+    Testing PVC resize on LVM cluster
+
+    """
+
     access_mode = constants.ACCESS_MODE_RWO
     block = False
 
-    init_lvm = LVM()
-    sample = TimeoutSampler()
+    @pytest.fixture()
+    def init_lvm(self):
+        self.lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        disk1 = self.lvm.pv_data["pv_list"][0]
+        log.info(f"PV List: {self.lvm.pv_data['pv_list']}")
+        self.disk_size = self.lvm.pv_data[disk1]["pv_size"]
+        self.thin_pool_size = float(self.lvm.get_thin_pool1_size())
+        self.int_tp_size = int(self.thin_pool_size)
+
+    @pytest.fixture()
+    def storageclass(self, lvm_storageclass_factory_class, volume_binding_mode):
+        self.sc_obj = lvm_storageclass_factory_class(volume_binding=volume_binding_mode)
+
+    @pytest.fixture()
+    def namespace(self, project_factory):
+        self.proj_obj = project_factory()
+        self.proj = self.proj_obj.namespace
 
     @tier1
     @skipif_ocs_version("<4.11")
     @skipif_lvm_not_installed
-    def test_pvc_resive(self):
-        pass
+    def test_pvc_resize(
+        self,
+        init_lvm,
+        status,
+        volume_mode,
+        storageclass,
+        namespace,
+        pvc_factory,
+        pod_factory,
+    ):
+        if volume_mode == constants.VOLUME_MODE_BLOCK:
+            self.block = True
+        self.pvc_size_at_start = self.int_tp_size * 0.7
+        self.pvc_size_resize = int(self.int_tp_size * 0.9)
+        pvc_obj = pvc_factory(
+            project=self.proj_obj,
+            interface=None,
+            storageclass=self.sc_obj,
+            size=self.pvc_size_at_start,
+            status=status,
+            access_mode=self.access_mode,
+            volume_mode=volume_mode,
+        )
+        pod_obj = pod_factory(pvc=pvc_obj, raw_block_pv=self.block)
+        log.info(f"{pod_obj} created")
+
+        pvc_obj.resize_pvc(self.pvc_size_resize, True)

--- a/tests/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/lvmo/test_lvmo_pvc_resize.py
@@ -48,7 +48,7 @@ log = logging.getLogger(__name__)
 )
 class TestLVMPVCResize(ManageTest):
     """
-    Testing PVC resize on LVM cluster
+    Testing PVC resize on LVM cluster beyond thinpool size, but within overprovisioning rate
 
     """
 
@@ -89,7 +89,7 @@ class TestLVMPVCResize(ManageTest):
         if volume_mode == constants.VOLUME_MODE_BLOCK:
             self.block = True
         self.pvc_size_at_start = self.int_tp_size * 0.7
-        self.pvc_size_resize = int(self.int_tp_size * 0.9)
+        self.pvc_size_resize = int(self.int_tp_size * 1.1)
         pvc_obj = pvc_factory(
             project=self.proj_obj,
             interface=None,

--- a/tests/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/lvmo/test_lvmo_pvc_resize.py
@@ -1,0 +1,40 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_lvm_not_installed,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
+from ocs_ci.ocs.cluster import LVM
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    argnames=["volume_mode", "volume_binding_mode", "status"],
+    argvalues=[
+        pytest.param(
+            *[
+                constants.VOLUME_MODE_FILESYSTEM,
+                constants.WFFC_VOLUMEBINDINGMODE,
+                constants.STATUS_PENDING,
+            ],
+        ),
+    ],
+)
+class TestLVMPVCResize(ManageTest):
+    access_mode = constants.ACCESS_MODE_RWO
+    block = False
+
+    init_lvm = LVM()
+    sample = TimeoutSampler()
+
+    @tier1
+    @skipif_ocs_version("<4.11")
+    @skipif_lvm_not_installed
+    def test_pvc_resive(self):
+        pass


### PR DESCRIPTION
resize pvc beyond thin-pool size, but within thinpool over-provisioning rate

https://bugzilla.redhat.com/show_bug.cgi?id=2111895 