### PR TITLE
Skip the test 'test_recovery_from_volume_deletion' when using external mode

### DIFF
--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     vsphere_platform_required,
     bugzilla,
     skipif_ibm_cloud,
+    skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import (
@@ -206,6 +207,7 @@ class TestDiskFailures(ManageTest):
     @bugzilla("1830702")
     @vsphere_platform_required
     @pytest.mark.polarion_id("OCS-2172")
+    @skipif_external_mode
     def test_recovery_from_volume_deletion(
         self, nodes, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
     ):


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/6256