### PR TITLE
Fixing postgress max connections for test_noobaa_postgres_cm_post_ocs_upgrade

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1688,8 +1688,8 @@ max_wal_size = 8GB
 shared_preload_libraries = 'pg_stat_statements'
 """
 
-# Values from configmap noobaa-postgres-config wrt OCP version 4.10 and above
-NOOBAA_POSTGRES_TUNING_VALUES_4_10 = """
+# Values from configmap noobaa-postgres-config wrt OCP version 4.9 and above
+NOOBAA_POSTGRES_TUNING_VALUES_4_9 = """
 max_connections = 600
 shared_buffers = 1GB
 effective_cache_size = 3GB

--- a/tests/manage/z_cluster/test_ceph_default_values_check.py
+++ b/tests/manage/z_cluster/test_ceph_default_values_check.py
@@ -173,11 +173,12 @@ class TestCephDefaultValuesCheck(ManageTest):
             "match the ones stored in ocs-ci"
         )
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if ocs_version <= version.VERSION_4_9:
+        log.info(f"ocs version----{ocs_version}")
+        if ocs_version <= version.VERSION_4_8:
             stored_values = constants.NOOBAA_POSTGRES_TUNING_VALUES.split("\n")
             stored_values.remove("")
-        elif ocs_version >= version.VERSION_4_10:
-            stored_values = constants.NOOBAA_POSTGRES_TUNING_VALUES_4_10.split("\n")
+        elif ocs_version >= version.VERSION_4_9:
+            stored_values = constants.NOOBAA_POSTGRES_TUNING_VALUES_4_9.split("\n")
             stored_values.remove("")
         assert collections.Counter(config_data) == collections.Counter(stored_values), (
             f"The config set in {constants.NOOBAA_POSTGRES_CONFIGMAP} "


### PR DESCRIPTION
Fix for issue, https://github.com/red-hat-storage/ocs-ci/issues/5738.
Have updated postgres max connections to 600 instead from 300 for ocs version 4.9 and updated the version specific checks.