### PR TITLE
Create a new sanity helper class for the Managed Sevice

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -10,8 +10,7 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs.bucket_utils import s3_delete_object, s3_get_object, s3_put_object
 from ocs_ci.helpers.pvc_ops import create_pvcs
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.ocs.cluster import CephCluster, CephClusterExternal
-
+from ocs_ci.ocs.cluster import CephCluster, CephClusterExternal, is_ms_consumer_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -183,3 +182,144 @@ class SanityExternalCluster(Sanity):
         self.pod_objs = list()
         self.obc_objs = list()
         self.ceph_cluster = CephClusterExternal()
+
+
+class SanityManagedService(Sanity):
+    """
+    Class for cluster health and functional validations for the Managed Service
+    """
+
+    def __init__(self):
+        """
+        Init the sanity managed service class
+        """
+        super(Sanity, self).__init__()
+        # Save the original index
+        self.orig_index = config.cur_index
+        # A dictionary of a consumer index per the fio_scale object
+        self.consumer_i_per_fio_scale = {}
+        # The 'create resources on MS consumers' factory. Will be initialized with the
+        # 'create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers' factory using the method
+        # 'init_create_resources_on_ms_factory'
+        self.create_resources_on_ms_consumers_factory = None
+        # All the variables below will be initialized in the method 'init_create_resources_on_ms_factory'.
+        self.scale_count = None
+        self.pvc_per_pod_count = None
+        self.start_io = None
+        self.io_runtime = None
+        self.pvc_size = None
+        self.max_pvc_size = None
+        self.consumer_indexes = None
+
+    def init_create_resources_on_ms_factory(
+        self,
+        create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers,
+        scale_count=None,
+        pvc_per_pod_count=5,
+        start_io=True,
+        io_runtime=None,
+        pvc_size=None,
+        max_pvc_size=30,
+        consumer_indexes=None,
+    ):
+        """
+        Init the 'create resources on MS consumers' factory.
+        This function uses the factory 'create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers'.
+        Note: You need to use this method before using the method 'create_resources_on_ms_consumers'
+
+        Args:
+           create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers (function): Factory for creating scale
+               pods and PVCs using k8s on MS consumers fixture.
+           scale_count (int): No of PVCs to be Scaled. Should be one of the values in the dict
+               "constants.SCALE_PVC_ROUND_UP_VALUE".
+           pvc_per_pod_count (int): Number of PVCs to be attached to single POD
+               Example, If 20 then 20 PVCs will be attached to single POD
+           start_io (bool): Binary value to start IO default it's True
+           io_runtime (seconds): Runtime in Seconds to continue IO
+           pvc_size (int): Size of PVC to be created
+           max_pvc_size (int): The max size of the pvc
+           consumer_indexes (list): The list of the consumer indexes to create scale pods and PVCs.
+               If not specified - if it's a consumer cluster, it creates scale pods and PVCs only
+               on the current consumer. And if it's a provider it creates scale pods and PVCs on
+               all the consumers.
+        """
+        if consumer_indexes:
+            self.consumer_indexes = consumer_indexes
+        elif is_ms_consumer_cluster():
+            self.consumer_indexes = [config.cur_index]
+        else:
+            self.consumer_indexes = config.get_consumer_indexes_list()
+
+        self.create_resources_on_ms_consumers_factory = (
+            create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
+        )
+        self.scale_count = scale_count
+        self.pvc_per_pod_count = pvc_per_pod_count
+        self.start_io = start_io
+        self.io_runtime = io_runtime
+        self.pvc_size = pvc_size
+        self.max_pvc_size = max_pvc_size
+
+    def create_resources_on_ms_consumers(self):
+        """
+        Create resources on MS consumers.
+        This function uses the factory "create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers"
+        for creating the resources - Create scale pods, PVCs, and run IO using a Kube job on MS consumers.
+        Note: Before using this method, you need to first init the 'Create resources on MS consumers' factory
+        using the method 'init_create_resources_on_ms_factory'.
+
+        """
+        if not self.create_resources_on_ms_consumers_factory:
+            raise ValueError(
+                "You need to first init the 'Create resources on MS consumers' factory"
+                "using the method 'init_create_resources_on_ms_factory'"
+            )
+        # Create the scale pods and PVCs using k8s on MS consumers factory
+        self.consumer_i_per_fio_scale = self.create_resources_on_ms_consumers_factory(
+            scale_count=self.scale_count,
+            pvc_per_pod_count=self.pvc_per_pod_count,
+            start_io=self.start_io,
+            io_runtime=self.io_runtime,
+            pvc_size=self.pvc_size,
+            max_pvc_size=self.max_pvc_size,
+            consumer_indexes=self.consumer_indexes,
+        )
+
+    def delete_resources_on_ms_consumers(self):
+        """
+        Delete the resources from the MS consumers
+
+        """
+        logger.info("Clean up the pods and PVCs from all consumers")
+        for consumer_i, fio_scale in self.consumer_i_per_fio_scale.items():
+            config.switch_ctx(consumer_i)
+            fio_scale.cleanup()
+
+        # Switch back to the original index
+        config.switch_ctx(self.orig_index)
+
+    def health_check_ms(
+        self,
+        cluster_check=True,
+        tries=20,
+        consumers_ceph_health_check=True,
+        consumers_tries=10,
+    ):
+        """
+        Perform Ceph and cluster health checks on Managed Service cluster
+
+        Args:
+            cluster_check (bool): If true, perform the cluster check. False, otherwise.
+            tries (int): The number of tries to perform ceph health check
+            consumers_ceph_health_check (bool): If true and the cluster is an MS provider cluster,
+                perform ceph health check on the ms consumer clusters.
+            consumers_tries: The number of tries to perform ceph health check on the MS consumer clusters
+
+        """
+        self.health_check(cluster_check=cluster_check, tries=tries)
+        if consumers_ceph_health_check and not is_ms_consumer_cluster():
+            # Check the ceph health on the consumers
+            consumer_indexes = config.get_consumer_indexes_list()
+            for consumer_i in consumer_indexes:
+                config.switch_ctx(consumer_i)
+                ceph_health_check(tries=consumers_tries)

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -247,9 +247,6 @@ class SanityManagedService(Sanity):
         Create resources on MS consumers.
         This function uses the factory "create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers"
         for creating the resources - Create scale pods, PVCs, and run IO using a Kube job on MS consumers.
-        Note: Before using this method, you need to first init the 'Create resources on MS consumers' factory
-        using the method 'init_create_resources_on_ms_factory'.
-
         """
         orig_index = config.cur_index
 

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -189,27 +189,7 @@ class SanityManagedService(Sanity):
     Class for cluster health and functional validations for the Managed Service
     """
 
-    def __init__(self):
-        """
-        Init the sanity managed service class
-        """
-        super(Sanity, self).__init__()
-        # A dictionary of a consumer index per the fio_scale object
-        self.consumer_i_per_fio_scale = {}
-        # The 'create resources on MS consumers' factory. Will be initialized with the
-        # 'create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers' factory using the method
-        # 'init_create_resources_on_ms_factory'
-        self.create_resources_on_ms_consumers_factory = None
-        # All the variables below will be initialized in the method 'init_create_resources_on_ms_factory'.
-        self.scale_count = None
-        self.pvc_per_pod_count = None
-        self.start_io = None
-        self.io_runtime = None
-        self.pvc_size = None
-        self.max_pvc_size = None
-        self.consumer_indexes = None
-
-    def init_create_resources_on_ms_factory(
+    def __init__(
         self,
         create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers,
         scale_count=None,
@@ -221,9 +201,9 @@ class SanityManagedService(Sanity):
         consumer_indexes=None,
     ):
         """
+        Init the sanity managed service class.
         Init the 'create resources on MS consumers' factory.
-        This function uses the factory 'create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers'.
-        Note: You need to use this method before using the method 'create_resources_on_ms_consumers'
+        This method uses the 'create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers' factory.
 
         Args:
            create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers (function): Factory for creating scale
@@ -241,12 +221,9 @@ class SanityManagedService(Sanity):
                on the current consumer. And if it's a provider it creates scale pods and PVCs on
                all the consumers.
         """
-        if consumer_indexes:
-            self.consumer_indexes = consumer_indexes
-        elif is_ms_consumer_cluster():
-            self.consumer_indexes = [config.cur_index]
-        else:
-            self.consumer_indexes = config.get_consumer_indexes_list()
+        super(SanityManagedService, self).__init__()
+        # A dictionary of a consumer index per the fio_scale object
+        self.consumer_i_per_fio_scale = {}
 
         self.create_resources_on_ms_consumers_factory = (
             create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
@@ -258,6 +235,13 @@ class SanityManagedService(Sanity):
         self.pvc_size = pvc_size
         self.max_pvc_size = max_pvc_size
 
+        if consumer_indexes:
+            self.consumer_indexes = consumer_indexes
+        elif is_ms_consumer_cluster():
+            self.consumer_indexes = [config.cur_index]
+        else:
+            self.consumer_indexes = config.get_consumer_indexes_list()
+
     def create_resources_on_ms_consumers(self):
         """
         Create resources on MS consumers.
@@ -268,11 +252,7 @@ class SanityManagedService(Sanity):
 
         """
         orig_index = config.cur_index
-        if not self.create_resources_on_ms_consumers_factory:
-            raise ValueError(
-                "You need to first init the 'Create resources on MS consumers' factory"
-                "using the method 'init_create_resources_on_ms_factory'"
-            )
+
         try:
             # Create the scale pods and PVCs using k8s on MS consumers factory
             self.consumer_i_per_fio_scale = (

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -236,11 +236,29 @@ class SanityManagedService(Sanity):
         self.max_pvc_size = max_pvc_size
 
         if consumer_indexes:
+            logger.info(
+                f"The consumer indexes for creating resources passed to the method are: {consumer_indexes}"
+            )
             self.consumer_indexes = consumer_indexes
-        elif is_ms_consumer_cluster():
-            self.consumer_indexes = [config.cur_index]
         else:
-            self.consumer_indexes = config.get_consumer_indexes_list()
+            logger.info(
+                "The consumer indexes were not passed to the method. Checking the cluster type..."
+            )
+            if is_ms_consumer_cluster():
+                logger.info(
+                    "The cluster is a consumer cluster. We will create the resources only for this cluster"
+                )
+                self.consumer_indexes = [config.cur_index]
+            else:
+                logger.info(
+                    "The cluster is a provider cluster. We will create the resources for "
+                    "all the consumer clusters"
+                )
+                self.consumer_indexes = config.get_consumer_indexes_list()
+
+        logger.info(
+            f"The consumer indexes for creating resources are: {self.consumer_indexes}"
+        )
 
     def create_resources_on_ms_consumers(self):
         """

--- a/tests/managed-service/test_sanity_ms.py
+++ b/tests/managed-service/test_sanity_ms.py
@@ -7,7 +7,6 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     libtest,
     ManageTest,
-    ignore_leftovers,
     managed_service_required,
 )
 
@@ -15,7 +14,6 @@ log = logging.getLogger(__name__)
 
 
 @libtest
-@ignore_leftovers
 @managed_service_required
 class TestSanityManagedServiceWithDefaultParams(ManageTest):
     """
@@ -65,7 +63,6 @@ class TestSanityManagedServiceWithDefaultParams(ManageTest):
 
 
 @libtest
-@ignore_leftovers
 @managed_service_required
 class TestSanityManagedServiceWithOptionalParams(ManageTest):
     """

--- a/tests/managed-service/test_santiy_ms.py
+++ b/tests/managed-service/test_santiy_ms.py
@@ -1,0 +1,124 @@
+import logging
+from time import sleep
+import pytest
+
+from ocs_ci.helpers.sanity_helpers import SanityManagedService
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import (
+    libtest,
+    ManageTest,
+    ignore_leftovers,
+    managed_service_required,
+)
+
+log = logging.getLogger(__name__)
+
+
+@libtest
+@ignore_leftovers
+@managed_service_required
+class TestSanityManagedServiceWithDefaultParams(ManageTest):
+    """
+    Test the usage of the 'SanityManagedService' class when using the default params
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+        self.sanity_helpers = SanityManagedService()
+        # Init the 'create resources' factory with the default params
+        self.sanity_helpers.init_create_resources_on_ms_factory(
+            create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
+        )
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request, nodes):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_ms(self):
+        log.info("Start creating resources for the MS consumers")
+        self.sanity_helpers.create_resources_on_ms_consumers()
+        timeout = 60
+        log.info(f"Waiting {timeout} seconds for the IO to be running")
+        sleep(timeout)
+
+        log.info("Deleting the resources from the MS consumers")
+        self.sanity_helpers.delete_resources_on_ms_consumers()
+        log.info("Check the cluster health")
+        self.sanity_helpers.health_check_ms()
+
+        assert (
+            config.cur_index == self.orig_index
+        ), "The current index is different from the original index"
+        log.info("The The current index is equal to the original index")
+
+
+@libtest
+@ignore_leftovers
+@managed_service_required
+class TestSanityManagedServiceWithOptionalParams(ManageTest):
+    """
+    Test the usage of the 'SanityManagedService' class when passing optional params
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+        self.sanity_helpers = SanityManagedService()
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request, nodes):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_ms_with_optional_params(
+        self, create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
+    ):
+        consumer_i = config.get_consumer_indexes_list()[0]
+        # Init the 'create resources' factory with the optional params
+        self.sanity_helpers.init_create_resources_on_ms_factory(
+            create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers,
+            scale_count=40,
+            pvc_per_pod_count=10,
+            start_io=True,
+            io_runtime=600,
+            max_pvc_size=25,
+            consumer_indexes=[consumer_i],
+        )
+
+        log.info("Start creating resources for the MS consumers")
+        self.sanity_helpers.create_resources_on_ms_consumers()
+        timeout = 60
+        log.info(f"Waiting {timeout} seconds for the IO to be running")
+        sleep(timeout)
+
+        log.info("Deleting the resources from the MS consumers")
+        self.sanity_helpers.delete_resources_on_ms_consumers()
+        log.info("Check the cluster health")
+        self.sanity_helpers.health_check_ms()
+
+        assert (
+            config.cur_index == self.orig_index
+        ), "The current index is different from the original index"
+        log.info("The The current index is equal to the original index")


### PR DESCRIPTION
I created a new sanity helper class to efficiently run IO on multiple consumers and check the functionality of the Managed Service cluster/s. To run IO I use the fixture `create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers` defined here https://github.com/red-hat-storage/ocs-ci/blob/master/tests/conftest.py#L5647.
Before we create the resources on the MS consumers, we need to pass an instance of the fixture `create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers` to the `init_create_resources_on_ms_factory` method.
Also, we can specify extra parameters in the method - if not, it uses the default parameters.

After adding this new class, we can quickly modify or create new tests with the Managed Service.

The implementation is a little complicated, but the usage is easy and flexible, as you can see in the added test https://github.com/red-hat-storage/ocs-ci/pull/6362/files#diff-69a3460a68a96af51b4b130b9501ec3e2c1e47f761960a686a62e5f1937e8e89.