### PR TITLE
make test_log_reader_writer_paraller more error resilient

### DIFF
--- a/tests/e2e/workloads/test_data_consistency.py
+++ b/tests/e2e/workloads/test_data_consistency.py
@@ -178,7 +178,6 @@ def test_log_reader_writer_parallel(project, tmp_path):
                 ocp_pod.wait_for_resource(
                     resource_count=deploy_dict["spec"]["replicas"],
                     condition=constants.STATUS_RUNNING,
-                    error_condition=constants.STATUS_ERROR,
                     timeout=300,
                     sleep=30,
                 )


### PR DESCRIPTION
Dropping error_condition=constants.STATUS_ERROR from
ocp_pod.wait_for_resource() call in the logwriter test to make the error
handling more resilient.

If the pod is able to recover from the error, the test will continue and
will check the feature under test, and if not, the error won't go
unnoticed as it will fail after allowed_failures counter is breached.

fixing https://github.com/red-hat-storage/ocs-ci/issues/6382

Signed-off-by: Martin Bukatovič <mbukatov@redhat.com>