### PR TITLE
Fix snapshot apiVersion based on OCP version

### DIFF
--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -429,8 +429,8 @@ def create_pvc_snapshot(
     """
     ocp_version = version.get_semantic_ocp_version_from_config()
     snapshot_data = templating.load_yaml(snap_yaml)
-    if ocp_version >= version.VERSION_4_11:
-        snapshot_data["apiVersion"] = "snapshot.storage.k8s.io/v1"
+    if ocp_version < version.VERSION_4_9:
+        snapshot_data["apiVersion"] = "snapshot.storage.k8s.io/v1beta1"
     snapshot_data["metadata"]["name"] = snap_name
     snapshot_data["metadata"]["namespace"] = namespace
     if sc_name:


### PR DESCRIPTION
Use snapshot apiVersion "snapshot.storage.k8s.io/v1beta1" if OCP version is below 4.9.

Fixes #6416

Signed-off-by: Jilju Joy <jijoy@redhat.com>