### PR TITLE
Create new markers for checking if we use the Managed Service with provider and consumer clusters

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -330,5 +330,27 @@ class MultiClusterConfig:
         """
         return self.ENV_DATA.get("cluster_name")
 
+    def is_provider_exist(self):
+        """
+        Check if the provider cluster exists in the clusters
+
+        Returns:
+            bool: True, if the provider cluster exists in the clusters. False, otherwise.
+
+        """
+        cluster_types = [cluster.ENV_DATA["cluster_type"] for cluster in self.clusters]
+        return "provider" in cluster_types
+
+    def is_consumer_exist(self):
+        """
+        Check if the consumer cluster exists in the clusters
+
+        Returns:
+            bool: True, if the consumer cluster exists in the clusters. False, otherwise.
+
+        """
+        cluster_types = [cluster.ENV_DATA["cluster_type"] for cluster in self.clusters]
+        return "consumer" in cluster_types
+
 
 config = MultiClusterConfig()

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -231,6 +231,15 @@ ms_consumer_required = pytest.mark.skipif(
     reason="Test runs ONLY on managed service consumer cluster",
 )
 
+ms_provider_and_consumer_required = pytest.mark.skipif(
+    not (
+        config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS
+        and config.is_provider_exist()
+        and config.is_consumer_exist()
+    ),
+    reason="Test runs ONLY on Managed service with provider and consumer clusters",
+)
+
 kms_config_required = pytest.mark.skipif(
     (
         config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER
@@ -285,6 +294,13 @@ skipif_ms_consumer = pytest.mark.skipif(
     config.default_cluster_ctx.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS
     and config.default_cluster_ctx.ENV_DATA["cluster_type"].lower() == "consumer",
     reason="Test will not run on Managed service consumer cluster",
+)
+
+skipif_ms_provider_and_consumer = pytest.mark.skipif(
+    config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS
+    and config.is_provider_exist()
+    and config.is_consumer_exist(),
+    reason="Test will not run on Managed service with provider and consumer clusters",
 )
 
 skipif_rosa = pytest.mark.skipif(

--- a/tests/e2e/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
+++ b/tests/e2e/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
@@ -12,7 +12,9 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     ipi_deployment_required,
-    managed_service_required,
+    ms_provider_and_consumer_required,
+    skipif_ms_provider_and_consumer,
+    ms_consumer_required,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
@@ -60,7 +62,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         ceph_health_check()
         log.info("The resources created successfully using the kube job")
 
-    @managed_service_required
+    @ms_provider_and_consumer_required
     def test_create_scale_pods_and_pvcs_using_kube_job_ms(
         self, create_scale_pods_and_pvcs_using_kube_job
     ):
@@ -88,10 +90,32 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         config.switch_to_consumer()
         log.info("The resources created successfully using the kube job")
 
+    @skipif_ms_provider_and_consumer
+    @ms_consumer_required
+    def test_create_scale_pods_and_pvcs_with_ms_consumer(
+        self, create_scale_pods_and_pvcs_using_kube_job
+    ):
+        """
+        Test create scale pods and PVCs using a kube job with MS consumer
+        when we don't have a provider in the run
+        """
+        log.info("Start creating resources using kube job with MS consumer...")
+        create_scale_pods_and_pvcs_using_kube_job()
+        time_to_wait_for_io_running = 60
+        log.info(
+            f"Wait {time_to_wait_for_io_running} seconds for checking "
+            f"that the IO running as expected"
+        )
+        sleep(time_to_wait_for_io_running)
+        ceph_health_check()
+        log.info(
+            "The resources created successfully using the kube job with MS consumer"
+        )
+
 
 @tier1
 @ignore_leftovers
-@managed_service_required
+@ms_provider_and_consumer_required
 class TestCreateScalePodsAndPvcsUsingKubeJobWithMSConsumers(ManageTest):
     """
     Test create scale pods and PVCs using a kube job with MS consumers


### PR DESCRIPTION
I implement the following in the pr:
  1. Create new markers for checking if we use the Managed Service with provider and consumer clusters:
  
        - **ms_provider_and_consumer_required**
        - **skipif_ms_provider_and_consumer**
  
  2. Use these markers in the test "test_create_scale_pods_and_pvcs_using_kube_job".
