### PR TITLE
Added aws_platform_required tag for the suite to run it only for AWS clusters

### DIFF
--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.testlib import (
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
     polarion_id,
+    aws_platform_required,
 )
 
 from ocs_ci.ocs.resources import pod, ocs
@@ -62,6 +63,7 @@ class TestDefaultNfsDisabled(ManageTest):
             log.error("nfs feature is enabled by default")
 
 
+@aws_platform_required
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")
 @skipif_managed_service


### PR DESCRIPTION
Added aws_platform_required tag for the suite to run it only for AWS clusters.

Signed-off-by: Amrita Mahapatra <49347640+amr1ta@users.noreply.github.com>