### PR TITLE
RHSTOR-3506: Qualify "Support resource modification for MCG PV pool pods - Test and Docs only"

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -712,7 +712,7 @@ def cli_create_pv_backingstore(
     if req_mem:
         cmd += f" --request-memory {req_mem}"
     if lim_cpu:
-        cmd += f" --limit-cpu {lim_mem}"
+        cmd += f" --limit-cpu {lim_cpu}"
     if lim_mem:
         cmd += f" --limit-memory {lim_mem}"
     mcg_obj.exec_mcg_cmd(cmd)

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -677,7 +677,15 @@ def oc_create_pv_backingstore(backingstore_name, vol_num, size, storage_class):
 
 
 def cli_create_pv_backingstore(
-    mcg_obj, backingstore_name, vol_num, size, storage_class
+    mcg_obj,
+    backingstore_name,
+    vol_num,
+    size,
+    storage_class,
+    req_cpu=None,
+    req_mem=None,
+    lim_cpu=None,
+    lim_mem=None,
 ):
     """
     Create a new backingstore with pv underlying storage using noobaa cli command
@@ -687,6 +695,10 @@ def cli_create_pv_backingstore(
         vol_num (int): number of pv volumes
         size (int): each volume size in GB
         storage_class (str): which storage class to use
+        req_cpu (str): requested cpu value
+        req_mem (str): requested memory value
+        lim_cpu (str): limit cpu value
+        lim_mem (str): limit memory value
 
     """
     cmd = (
@@ -695,6 +707,14 @@ def cli_create_pv_backingstore(
     )
     if storage_class:
         cmd += f" --storage-class {storage_class}"
+    if req_cpu:
+        cmd += f" --request-cpu {req_cpu}"
+    if req_mem:
+        cmd += f" --request-memory {req_mem}"
+    if lim_cpu:
+        cmd += f" --limit-cpu {lim_mem}"
+    if lim_mem:
+        cmd += f" --limit-memory {lim_mem}"
     mcg_obj.exec_mcg_cmd(cmd)
     wait_for_pv_backingstore(backingstore_name, config.ENV_DATA["cluster_namespace"])
 

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -279,7 +279,19 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                         f'available types: {", ".join(cmdMap[method.lower()].keys())}'
                     )
                 if cloud == "pv":
-                    vol_num, size, storagecluster = uls_tup
+                    if len(uls_tup) == 3:
+                        vol_num, size, storagecluster = uls_tup
+                        req_cpu, req_mem, lim_cpu, lim_mem = (None, None, None, None)
+                    else:
+                        (
+                            vol_num,
+                            size,
+                            storagecluster,
+                            req_cpu,
+                            req_mem,
+                            lim_cpu,
+                            lim_mem,
+                        ) = uls_tup
                     if (
                         storagecluster == constants.DEFAULT_STORAGECLASS_RBD
                         and storagecluster_independent_check()
@@ -302,7 +314,15 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
                     created_backingstores.append(backingstore_obj)
                     if method.lower() == "cli":
                         cmdMap[method.lower()][cloud.lower()](
-                            mcg_obj, backingstore_name, vol_num, size, storagecluster
+                            mcg_obj,
+                            backingstore_name,
+                            vol_num,
+                            size,
+                            storagecluster,
+                            req_cpu=req_cpu,
+                            req_mem=req_mem,
+                            lim_cpu=lim_cpu,
+                            lim_mem=lim_mem,
                         )
                     else:
                         cmdMap[method.lower()][cloud.lower()](

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -166,6 +166,7 @@ class TestPvPool:
                     tier2,
                     pytest.mark.polarion_id("OCS-3932"),
                     pytest.mark.bugzilla("2064599"),
+                    pytest.mark.skipif_ocs_version("<4.11"),
                 ],
             ),
             pytest.param(
@@ -185,7 +186,11 @@ class TestPvPool:
                         ]
                     },
                 },
-                marks=[tier2, pytest.mark.polarion_id("OCS-4643")],
+                marks=[
+                    tier2,
+                    pytest.mark.polarion_id("OCS-4643"),
+                    pytest.mark.skipif_ocs_version("<4.12"),
+                ],
             ),
         ],
     )

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -199,20 +199,13 @@ class TestPvPool:
         bucketclass_dict,
     ):
         """
-        Test to modify the CPU and Memory resource limits for BS and see if its reflecting
+        Objective of the test are:
+            1) See if the CLI options to add resource parameters works while creating
+            Pv based backingstore.
+            2) Modifying the backingstores resource, reflects in the pv based backingstore
+            pods.
+
         """
-        # bucketclass_dict = {
-        #     "interface": "OC",
-        #     "backingstore_dict": {
-        #         "pv": [
-        #             (
-        #                 3,
-        #                 MIN_PV_BACKINGSTORE_SIZE_IN_GB,
-        #                 "ocs-storagecluster-ceph-rbd",
-        #             )
-        #         ]
-        #     },
-        # }
         bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
         bucket_name = bucket.name
         pv_backingstore = bucket.bucketclass.backingstores[0]
@@ -222,9 +215,7 @@ class TestPvPool:
         for pod in get_pods_having_label(
             label=pv_pod_label, namespace=config.ENV_DATA["cluster_namespace"]
         ):
-            pv_pod_obj.extend(Pod(**pod))
-        # pv_pod_obj = Pod(**pv_pod_info)
-        # logger.info(f"Pod created for PV Backingstore {pv_bs_name}: {pv_pod_name}")
+            pv_pod_obj.append(Pod(**pod))
         req_cpu = "400m"
         req_mem = "600Mi"
         lim_cpu = "500m"

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier2, tier3, bugzilla
+from ocs_ci.framework.pytest_customization.marks import tier2, tier3
 from ocs_ci.ocs.bucket_utils import (
     wait_for_pv_backingstore,
     check_pv_backingstore_status,
@@ -146,56 +146,100 @@ class TestPvPool:
         ), "Scale out PV Pool failed. "
         logger.info("Scale out was successful")
 
-    @pytest.mark.polarion_id("OCS-3932")
-    @tier2
-    @bugzilla("2064599")
-    def test_pvpool_cpu_and_memory_modifications(
+    @pytest.mark.parametrize(
+        argnames=["bucketclass_dict"],
+        argvalues=[
+            pytest.param(
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {
+                        "pv": [
+                            (
+                                3,
+                                MIN_PV_BACKINGSTORE_SIZE_IN_GB,
+                                "ocs-storagecluster-ceph-rbd",
+                            )
+                        ]
+                    },
+                },
+                marks=[
+                    tier2,
+                    pytest.mark.polarion_id("OCS-3932"),
+                    pytest.mark.bugzilla("2064599"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "CLI",
+                    "backingstore_dict": {
+                        "pv": [
+                            (
+                                3,
+                                MIN_PV_BACKINGSTORE_SIZE_IN_GB,
+                                "ocs-storagecluster-ceph-rbd",
+                                "300m",
+                                "500Mi",
+                                "400m",
+                                "600Mi",
+                            )
+                        ]
+                    },
+                },
+                marks=[tier2, pytest.mark.polarion_id("OCS-3932")],
+            ),
+        ],
+    )
+    def test_pvpool_resource_modifications(
         self,
         awscli_pod_session,
         backingstore_factory,
         bucket_factory,
         test_directory_setup,
         mcg_obj_session,
+        bucketclass_dict,
     ):
         """
         Test to modify the CPU and Memory resource limits for BS and see if its reflecting
         """
-        bucketclass_dict = {
-            "interface": "OC",
-            "backingstore_dict": {
-                "pv": [
-                    (
-                        1,
-                        MIN_PV_BACKINGSTORE_SIZE_IN_GB,
-                        "ocs-storagecluster-ceph-rbd",
-                    )
-                ]
-            },
-        }
+        # bucketclass_dict = {
+        #     "interface": "OC",
+        #     "backingstore_dict": {
+        #         "pv": [
+        #             (
+        #                 3,
+        #                 MIN_PV_BACKINGSTORE_SIZE_IN_GB,
+        #                 "ocs-storagecluster-ceph-rbd",
+        #             )
+        #         ]
+        #     },
+        # }
         bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
         bucket_name = bucket.name
         pv_backingstore = bucket.bucketclass.backingstores[0]
         pv_bs_name = pv_backingstore.name
         pv_pod_label = f"pool={pv_bs_name}"
-        pv_pod_info = get_pods_having_label(
+        pv_pod_obj = list()
+        for pod in get_pods_having_label(
             label=pv_pod_label, namespace=config.ENV_DATA["cluster_namespace"]
-        )[0]
-        pv_pod_obj = Pod(**pv_pod_info)
-        pv_pod_name = pv_pod_obj.name
-        logger.info(f"Pod created for PV Backingstore {pv_bs_name}: {pv_pod_name}")
-        new_cpu = "500m"
-        new_mem = "500Mi"
+        ):
+            pv_pod_obj.extend(Pod(**pod))
+        # pv_pod_obj = Pod(**pv_pod_info)
+        # logger.info(f"Pod created for PV Backingstore {pv_bs_name}: {pv_pod_name}")
+        req_cpu = "400m"
+        req_mem = "600Mi"
+        lim_cpu = "500m"
+        lim_mem = "700Mi"
         new_resource_patch = {
             "spec": {
                 "pvPool": {
                     "resources": {
                         "limits": {
-                            "cpu": f"{new_cpu}",
-                            "memory": f"{new_mem}",
+                            "cpu": f"{lim_cpu}",
+                            "memory": f"{lim_mem}",
                         },
                         "requests": {
-                            "cpu": f"{new_cpu}",
-                            "memory": f"{new_mem}",
+                            "cpu": f"{req_cpu}",
+                            "memory": f"{req_mem}",
                         },
                     }
                 }
@@ -212,19 +256,23 @@ class TestPvPool:
         else:
             logger.info("Patched new resource limits")
         wait_for_pods_to_be_running(
-            namespace=config.ENV_DATA["cluster_namespace"], pod_names=[pv_pod_name]
+            namespace=config.ENV_DATA["cluster_namespace"],
+            pod_names=[pod.name for pod in pv_pod_obj],
         )
-        pv_pod_ocp_obj = OCP(
-            namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
-        ).get(resource_name=pv_pod_name)
-        resource_dict = pv_pod_ocp_obj["spec"]["containers"][0]["resources"]
-        assert (
-            resource_dict["limits"]["cpu"] == new_cpu
-            and resource_dict["limits"]["memory"] == new_mem
-            and resource_dict["requests"]["cpu"] == new_cpu
-            and resource_dict["requests"]["memory"] == new_mem
-        ), "New resource modification in Backingstore is not reflected in PV Backingstore Pod!!"
-        logger.info("Resource modification reflected in the PV Backingstore Pod!!")
+
+        for pod in pv_pod_obj:
+            resource_dict = OCP(
+                namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
+            ).get(resource_name=pod.name)["spec"]["containers"][0]["resources"]
+            assert (
+                resource_dict["limits"]["cpu"] == lim_cpu
+                and resource_dict["limits"]["memory"] == lim_mem
+                and resource_dict["requests"]["cpu"] == req_cpu
+                and resource_dict["requests"]["memory"] == req_mem
+            ), f"New resource modification in Backingstore is not reflected in PV Backingstore Pod {pod.name}!!"
+        logger.info(
+            f"Resource modification reflected in the PV Backingstore Pods {[pod.name for pod in pv_pod_obj]}!!"
+        )
 
         # push some data to the bucket
         file_dir = test_directory_setup.origin_dir

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -185,7 +185,7 @@ class TestPvPool:
                         ]
                     },
                 },
-                marks=[tier2, pytest.mark.polarion_id("OCS-3932")],
+                marks=[tier2, pytest.mark.polarion_id("OCS-4643")],
             ),
         ],
     )


### PR DESCRIPTION
This PR modifies the already existing test to cover additional scenarios:

1. Increased number of volumes for Pv pool based backingstores
2. Setting the resource parameters while creating the backingstore through CLI

Links:
https://issues.redhat.com/browse/RHSTOR-3506
https://issues.redhat.com/browse/RHSTOR-3725