### PR TITLE
Update bugzilla marker in the test test_connection_time_out

### DIFF
--- a/tests/managed-service/test_post_installation_state.py
+++ b/tests/managed-service/test_post_installation_state.py
@@ -157,7 +157,7 @@ class TestPostInstallationState(ManageTest):
         assert len(log_lines) > 100
 
     @tier1
-    @bugzilla("2073025")
+    @bugzilla("2117312")
     @runs_on_provider
     @pytest.mark.polarion_id("OCS-2695")
     @managed_service_required


### PR DESCRIPTION
The bug 2073025 was recently closed as a duplicate of 2117312. The bugzilla marker is be updated to skip the test.
Fixes #6448
Signed-off-by: Jilju Joy <jijoy@redhat.com>