### PR TITLE
Added skipif_external_mode tag for the nfs testsuite

### DIFF
--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.testlib import (
     skipif_proxy_cluster,
     polarion_id,
     aws_platform_required,
+    skipif_external_mode,
 )
 
 from ocs_ci.ocs.resources import pod, ocs
@@ -63,6 +64,7 @@ class TestDefaultNfsDisabled(ManageTest):
             log.error("nfs feature is enabled by default")
 
 
+@skipif_external_mode
 @aws_platform_required
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")


### PR DESCRIPTION
Added skipif_external_mode tag for the nfs enabled test suite as external mode support is out of scope

Signed-off-by: Amrita Mahapatra <49347640+amr1ta@users.noreply.github.com>