### PR TITLE
Change pod label dictionary above 4.11 to default and add pod security label to openshift-storage

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1269,8 +1269,9 @@ class Deployment(object):
             f"lvm-cluster-{file_version}.yaml",
         )
 
-        if int(lvmo_version_without_period) >= 411:
+        if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_11:
             lvmo_version_without_period = "default"
+
         # this is a workaround for 2101343
         if 110 > int(minor) > 98 and major == "4.11.0":
             rolebinding_config_file = os.path.join(

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1268,6 +1268,9 @@ class Deployment(object):
             constants.TEMPLATE_DEPLOYMENT_DIR_LVMO,
             f"lvm-cluster-{file_version}.yaml",
         )
+
+        if int(lvmo_version_without_period) >= 411:
+            lvmo_version_without_period = "default"
         # this is a workaround for 2101343
         if 110 > int(minor) > 98 and major == "4.11.0":
             rolebinding_config_file = os.path.join(
@@ -1288,6 +1291,7 @@ class Deployment(object):
             resource_count=1,
             timeout=300,
         )
+        label_pod_security_admission(namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
         run_cmd(f"oc create -f {cluster_config_file} -n {self.namespace}")
         assert pod.wait_for_resource(
             condition="Running",

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1852,7 +1852,7 @@ LVMO_POD_LABEL = {
         "topolvm-node_label": "app=topolvm-node",
         "vg-manager_label": "app=vg-manager",
     },
-    "411": {
+    "default": {
         "controller_manager_label": "app.kubernetes.io/name=lvm-operator",
         "topolvm-controller_label": "app.kubernetes.io/name=topolvm-controller",
         "topolvm-node_label": "app.kubernetes.io/name=topolvm-node",

--- a/ocs_ci/templates/lvmo-deployment/lvm-cluster-412.yaml
+++ b/ocs_ci/templates/lvmo-deployment/lvm-cluster-412.yaml
@@ -1,0 +1,12 @@
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      thinPoolConfig:
+        name: thin-pool-1
+        overprovisionRatio: 50


### PR DESCRIPTION
Change pod label dictionary above 4.11 to default and add pod security label to openshift-storage
Fixes: #6393 
Signed-off-by: Shay Rozen <shay.rozen@gmail.com>