### PR TITLE
Scale s3 delete bucket for buckets having huge number of objects

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -392,7 +392,6 @@ class MCGS3Bucket(ObjectBucket):
         """
         response = self.s3client.get_bucket_versioning(Bucket=self.name)
         if "Status" in response.keys():
-            logger.info(f"bucket versioning: {response}")
             self.s3resource.Bucket(self.name).object_versions.delete()
         else:
             self.s3resource.Bucket(self.name).objects.all().delete()

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -383,14 +383,19 @@ class MCGS3Bucket(ObjectBucket):
             self.s3resource = kwargs["s3resource"]
         else:
             self.s3resource = self.mcg.s3_resource
-
+        self.s3client = self.mcg.s3_client
         self.s3resource.create_bucket(Bucket=self.name)
 
     def internal_delete(self):
         """
         Deletes the bucket using the S3 API
         """
-        self.s3resource.Bucket(self.name).object_versions.delete()
+        response = self.s3client.get_bucket_versioning(Bucket=self.name)
+        if "Status" in response.keys():
+            logger.info(f"bucket versioning: {response}")
+            self.s3resource.Bucket(self.name).object_versions.delete()
+        else:
+            self.s3resource.Bucket(self.name).objects.all().delete()
         self.s3resource.Bucket(self.name).delete()
 
     @property


### PR DESCRIPTION
This PR fixes https://github.com/red-hat-storage/ocs-ci/issues/6459

1.  Scales s3 delete objects for buckets having huge number of objects
2. Handle versioning enabled and disabled bucket deletion differently

Signed-off-by: mashetty <mashetty@redhat.com>