### PR TITLE
[RDR] Change default workload repo and support new directory structure of ocs-workloads repository

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -1,6 +1,8 @@
 ENV_DATA:
-  dr_workload_repo_url: "https://github.com/shylesh/ocm-ramen-samples.git"
+  dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
   dr_workload_repo_branch: "master"
-  dr_workload_pod_count: 1
-  dr_workload_pvc_count: 1
+  dr_workload_pod_count: 20
+  dr_workload_pvc_count: 20
+  dr_workload_subscription_dir: "rdr/busybox/app-busybox-1/subscriptions"
+  # dr_policy_name: PLACEHOLDER
   # preferred_primary_cluster: PLACEHOLDER

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -535,3 +535,17 @@ def wait_for_all_resources_deletion(
         pvc_obj.ocp.wait_for_delete(
             resource_name=pvc_obj.name, timeout=timeout, sleep=5
         )
+
+
+def get_all_drpolicy():
+    """
+    Gets all DRPolicy from hub cluster
+
+    Returns:
+        list: List of all DRPolicy
+
+    """
+    config.switch_acm_ctx()
+    drpolicy_obj = ocp.OCP(kind=constants.DRPOLICY)
+    drpolicy_list = drpolicy_obj.get(all_namespaces=True).get("items")
+    return drpolicy_list


### PR DESCRIPTION
This PR includes required changes in ocs-ci to use the ocs-workloads as default repo and also supports it's new directory structure introduced in https://github.com/red-hat-storage/ocs-workloads/pull/14

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>