### PR TITLE
Add verification steps on the MS consumers after a provider node replacement

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2500,6 +2500,14 @@ def get_provider_internal_node_ips(
 def consumer_verification_steps_after_provider_node_replacement():
     """
     Check the consumer verification steps after a provider node replacement
+    The steps are as follows:
+
+    1. Check if the consumer "storageProviderEndpoint" IP is found in the provider worker node ips
+        1.1 If not found, edit the rosa addon installation - modify the param 'storage-provider-endpoint'
+            with the first provider worker node IP.
+        1.2 Wait and check again if the consumer "storageProviderEndpoint" IP is found in the
+            provider worker node IPs.
+    2. If found, also check that the rook ceph mon endpoint IPs are found in the provider worker node IPs.
 
     Returns:
         bool: True, if the consumer verification steps finished successfully. False, otherwise.
@@ -2540,7 +2548,9 @@ def consumer_verification_steps_after_provider_node_replacement():
 @switch_to_orig_index_at_last
 def consumers_verification_steps_after_provider_node_replacement():
     """
-    Check all the consumers verification steps after a provider node replacement
+    Check all the consumers verification steps after a provider node replacement.
+    On every consumer we will check the steps described in the function
+    'consumer_verification_steps_after_provider_node_replacement'.
 
     Returns:
         bool: True, if all the consumers verification steps finished successfully. False, otherwise.

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -42,7 +42,7 @@ from ocs_ci.ocs.node import (
     verify_worker_nodes_security_groups,
     add_disk_to_node,
     get_nodes,
-    get_node_internal_ip,
+    get_provider_internal_node_ips,
 )
 from ocs_ci.ocs.version import get_ocp_version
 from ocs_ci.utility.version import get_semantic_version, VERSION_4_11
@@ -1624,15 +1624,10 @@ def check_consumer_rook_ceph_mon_endpoints_in_provider_wnodes():
     """
     rook_ceph_mon_per_endpoint_ip = get_rook_ceph_mon_per_endpoint_ip()
     log.info(f"rook ceph mon per endpoint ip: {rook_ceph_mon_per_endpoint_ip}")
-
-    log.info("Switching to the provider cluster to get the provider worker node ips")
-    config.switch_to_provider()
-    provider_wnodes = get_nodes()
-    provider_wnode_ips = [get_node_internal_ip(n) for n in provider_wnodes]
-    log.info(f"Provider worker node ips: {provider_wnode_ips}")
+    provider_wnode_ips = get_provider_internal_node_ips()
 
     for mon_name, endpoint_ip in rook_ceph_mon_per_endpoint_ip.items():
-        if endpoint_ip not in provider_wnodes:
+        if endpoint_ip not in provider_wnode_ips:
             log.warning(
                 f"The endpoint ip {endpoint_ip} of mon {mon_name} is not found "
                 f"in the provider worker node ips"
@@ -1674,21 +1669,16 @@ def check_consumer_storage_provider_endpoint_in_provider_wnodes():
     log.info(
         f"The consumer 'storageProviderEndpoint' ip is: {storage_provider_endpoint_ip}"
     )
-
-    log.info("Switching to the provider cluster to get the provider worker node ips")
-    config.switch_to_provider()
-    provider_wnodes = get_nodes()
-    provider_wnode_ips = [get_node_internal_ip(n) for n in provider_wnodes]
-    log.info(f"Provider worker node ips: {provider_wnode_ips}")
+    provider_wnode_ips = get_provider_internal_node_ips()
 
     if storage_provider_endpoint_ip in provider_wnode_ips:
         log.info(
-            "The consumer 'storageProviderEndpoint' ip found in the provider node ips"
+            "The consumer 'storageProviderEndpoint' ip found in the provider worker node ips"
         )
         return True
     else:
         log.warning(
-            "The consumer 'storageProviderEndpoint' ip was not found in the provider node ips"
+            "The consumer 'storageProviderEndpoint' ip was not found in the provider worker node ips"
         )
         return False
 

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -42,6 +42,7 @@ from ocs_ci.ocs.node import (
     verify_worker_nodes_security_groups,
     add_disk_to_node,
     get_nodes,
+    get_node_internal_ip,
 )
 from ocs_ci.ocs.version import get_ocp_version
 from ocs_ci.utility.version import get_semantic_version, VERSION_4_11
@@ -56,6 +57,7 @@ from ocs_ci.utility import (
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.rgwutils import get_rgw_count
 from ocs_ci.utility.utils import run_cmd, TimeoutSampler
+from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -1590,3 +1592,126 @@ def get_storage_cluster_state(sc_name, namespace=defaults.ROOK_CLUSTER_NAMESPACE
         namespace=namespace,
     )
     return sc_obj.get_resource(resource_name=sc_name, column="PHASE")
+
+
+def get_rook_ceph_mon_per_endpoint_ip():
+    """
+    Get a dictionary of the rook ceph mon per endpoint ip
+
+    Returns:
+        dict: A dictionary of the rook ceph mon per endpoint ip
+
+    """
+    configmap_obj = ocp.OCP(
+        kind=constants.CONFIGMAP,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        resource_name=constants.ROOK_CEPH_MON_ENDPOINTS,
+    )
+    cm_data = configmap_obj.get().get("data").get("data")
+    cm_data_list = cm_data.split(sep=",")
+    return {d[0]: d[2 : d.index(":")] for d in cm_data_list}
+
+
+@switch_to_orig_index_at_last
+def check_consumer_rook_ceph_mon_endpoints_in_provider_wnodes():
+    """
+    Check that the rook ceph mon endpoint ips are found in the provider worker node ips
+
+    Returns:
+        bool: True, If all the rook ceph mon endpoint ips are found in the
+            provider worker nodes. False, otherwise.
+
+    """
+    rook_ceph_mon_per_endpoint_ip = get_rook_ceph_mon_per_endpoint_ip()
+    log.info(f"rook ceph mon per endpoint ip: {rook_ceph_mon_per_endpoint_ip}")
+
+    log.info("Switching to the provider cluster to get the provider worker node ips")
+    config.switch_to_provider()
+    provider_wnodes = get_nodes()
+    provider_wnode_ips = [get_node_internal_ip(n) for n in provider_wnodes]
+    log.info(f"Provider worker node ips: {provider_wnode_ips}")
+
+    for mon_name, endpoint_ip in rook_ceph_mon_per_endpoint_ip.items():
+        if endpoint_ip not in provider_wnodes:
+            log.warning(
+                f"The endpoint ip {endpoint_ip} of mon {mon_name} is not found "
+                f"in the provider worker node ips"
+            )
+            return False
+
+    log.info("All the mon endpoint ips are found in the provider worker node ips")
+    return True
+
+
+def get_consumer_storage_provider_endpoint():
+    """
+    Get the consumer "storageProviderEndpoint" from the ocs storage cluster
+
+    Returns:
+        str: The consumer "storageProviderEndpoint"
+
+    """
+    sc_obj = ocp.OCP(
+        kind=constants.STORAGECLUSTER,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        resource_name=constants.DEFAULT_CLUSTERNAME,
+    )
+    return sc_obj.get()["spec"]["externalStorage"]["storageProviderEndpoint"]
+
+
+@switch_to_orig_index_at_last
+def check_consumer_storage_provider_endpoint_in_provider_wnodes():
+    """
+    Check that the consumer "storageProviderEndpoint" ip is found in the provider worker node ips
+
+    Returns:
+        bool: True, if the consumer "storageProviderEndpoint" ip is found in the
+            provider worker node ips. False, otherwise.
+
+    """
+    storage_provider_endpoint = get_consumer_storage_provider_endpoint()
+    storage_provider_endpoint_ip = storage_provider_endpoint.split(":")[0]
+    log.info(
+        f"The consumer 'storageProviderEndpoint' ip is: {storage_provider_endpoint_ip}"
+    )
+
+    log.info("Switching to the provider cluster to get the provider worker node ips")
+    config.switch_to_provider()
+    provider_wnodes = get_nodes()
+    provider_wnode_ips = [get_node_internal_ip(n) for n in provider_wnodes]
+    log.info(f"Provider worker node ips: {provider_wnode_ips}")
+
+    if storage_provider_endpoint_ip in provider_wnode_ips:
+        log.info(
+            "The consumer 'storageProviderEndpoint' ip found in the provider node ips"
+        )
+        return True
+    else:
+        log.warning(
+            "The consumer 'storageProviderEndpoint' ip was not found in the provider node ips"
+        )
+        return False
+
+
+def wait_for_consumer_storage_provider_endpoint_in_provider_wnodes(
+    timeout=180, sleep=10
+):
+    """
+    Wait for the consumer "storageProviderEndpoint" ip to be found in the provider worker node ips
+
+    Args:
+        timeout (int): timeout in seconds to wait for the consumer "storageProviderEndpoint" ip
+            to be found in the provider worker node ips
+        sleep (int): Time in seconds to sleep between attempts
+
+    Returns:
+        True, if the consumer "storageProviderEndpoint" ip is found in the
+            provider worker node ips. False, otherwise.
+
+    """
+    sample = TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=check_consumer_storage_provider_endpoint_in_provider_wnodes,
+    )
+    return sample.wait_for_func_status(result=True)

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -1,0 +1,26 @@
+import logging
+
+from ocs_ci.framework import config
+
+
+logger = logging.getLogger(__name__)
+
+
+def switch_to_orig_index_at_last(func):
+    """
+    A decorator for switching to the original index after the function execution
+
+    Args:
+        func (function): The function we want to decorate
+
+    """
+
+    def inner(*args, **kwargs):
+        orig_index = config.cur_index
+        try:
+            return func(*args, **kwargs)
+        finally:
+            logger.info("Switching back to the original cluster")
+            config.switch_ctx(orig_index)
+
+    return inner

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -20,7 +20,8 @@ def switch_to_orig_index_at_last(func):
         try:
             return func(*args, **kwargs)
         finally:
-            logger.info("Switching back to the original cluster")
-            config.switch_ctx(orig_index)
+            if config.cur_index != orig_index:
+                logger.info("Switching back to the original cluster")
+                config.switch_ctx(orig_index)
 
     return inner

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -12,7 +12,7 @@ from ocs_ci.framework.testlib import (
     ipi_deployment_required,
 )
 from ocs_ci.ocs import constants, node
-from ocs_ci.ocs.cluster import CephCluster, is_lso_cluster
+from ocs_ci.ocs.cluster import CephCluster, is_lso_cluster, is_ms_provider_cluster
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
@@ -98,6 +98,10 @@ def check_node_replacement_verification_steps(
     assert node.node_replacement_verification_steps_user_side(
         old_node_name, new_node_name, new_osd_node_name, old_osd_ids
     )
+
+    # If the cluster is an MS provider cluster, and we also have MS consumer clusters in the run
+    if is_ms_provider_cluster() and config.is_consumer_exist():
+        assert node.consumers_verification_steps_after_provider_node_replacement()
 
 
 def delete_and_create_osd_node(osd_node_name):

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -117,6 +117,14 @@ def delete_and_create_osd_node(osd_node_name):
 
     old_osd_node_names = node.get_osd_running_nodes()
 
+    # If the cluster is an MS provider cluster, and we also have MS consumer clusters in the run
+    if is_ms_provider_cluster() and config.is_consumer_exist():
+        pytest.skip(
+            "The test will not run with an MS provider and MS consumer clusters due to the BZ "
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2131581. issue for tracking: "
+            "https://github.com/red-hat-storage/ocs-ci/issues/6540"
+        )
+
     # error message for invalid deployment configuration
     msg_invalid = (
         "ocs-ci config 'deployment_type' value "


### PR DESCRIPTION
The pr is for the Managed Service when using a provider and consumers. 
I added in the pr the verification steps on the MS consumers after a provider node replacement. 
The steps are as follows:

1. Check if the consumer "storageProviderEndpoint" IP is found in the provider worker node ips
1.1 If not found, edit the rosa addon installation - modify the param `storage-provider-endpoint` with the first provider worker node IP.
1.2 Wait and check again if the  consumer "storageProviderEndpoint" IP is found in the provider worker node ips
2. If found, also check that the rook ceph mon endpoint IPs are found in the provider worker node ips


I also implemented a new decorator for wrapping a function related to the Managed Service to ensure we use the original index after the execution.