### PR TITLE
Splitting the performance suite to 3

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -64,6 +64,9 @@ workloads = pytest.mark.workloads
 flowtests = pytest.mark.flowtests
 system_test = pytest.mark.system_test
 performance = pytest.mark.performance
+performance_a = pytest.mark.performance_a
+performance_b = pytest.mark.performance_b
+performance_c = pytest.mark.performance_c
 performance_extended = pytest.mark.performance_extended
 scale = pytest.mark.scale
 scale_long_run = pytest.mark.scale_long_run
@@ -83,6 +86,9 @@ tier_marks = [
     tier4c,
     tier_after_upgrade,
     performance,
+    performance_a,
+    performance_b,
+    performance_c,
     scale,
     scale_long_run,
     scale_changed_layout,

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,9 @@ markers =
     flowtests: flowbased related tests
     system_test: Tests related to system level scenarios where the test scenarios exercise multiple features together
     performance: performance related tests
+    performance_a: performance related tests - first group
+    performance_b: performance related tests - second group
+    performance_c: performance related tests - third group
     performance_extended: non regression performance tests
     scale: scale related tests
     scale_long_run: scale tests which has execution time in days

--- a/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
@@ -8,7 +8,7 @@ import pytest
 import pathlib
 import time
 
-from ocs_ci.framework.testlib import performance, polarion_id
+from ocs_ci.framework.testlib import performance, performance_a, polarion_id
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants, scale_lib
 from ocs_ci.ocs.perftests import PASTest
@@ -25,6 +25,7 @@ Interfaces_info = {
 
 
 @performance
+@performance_a
 class TestBulkPodAttachPerformance(PASTest):
     """
     Test to measure performance of attaching pods to pvc in a bulk

--- a/tests/e2e/performance/csi_tests/test_pod_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_attachtime.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import statistics
 
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
 import ocs_ci.ocs.exceptions as ex
@@ -45,6 +45,7 @@ class ResultsAnalyse(PerfResult):
 
 
 @performance
+@performance_a
 class TestPodStartTime(PASTest):
     """
     Measure time to start pod with PVC attached

--- a/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
@@ -6,7 +6,7 @@ import time
 import statistics
 import os
 
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import constants, node
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @performance
+@performance_a
 class TestPodReattachTimePerformance(PASTest):
     """
     Test to verify Pod Reattach Time Performance

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
@@ -10,7 +10,7 @@ import pytest
 
 from ocs_ci.utility import utils, templating
 from ocs_ci.ocs.perftests import PASTest
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import performance_lib
 from ocs_ci.helpers.helpers import (
     create_unique_resource_name,
@@ -41,6 +41,7 @@ Interfaces_info = {
 
 
 @performance
+@performance_b
 class TestBulkCloneCreation(PASTest):
     """
     Base class for bulk creation of PVC clones

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
@@ -10,7 +10,7 @@ import datetime
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework.testlib import performance, polarion_id
+from ocs_ci.framework.testlib import performance, performance_a, polarion_id
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.perftests import PASTest
@@ -22,6 +22,7 @@ Interface_Types = {constants.CEPHFILESYSTEM: "CephFS", constants.CEPHBLOCKPOOL: 
 
 
 @performance
+@performance_a
 class TestPVCCreationPerformance(PASTest):
     """
     Test to verify PVC creation and deletion performance

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -7,7 +7,7 @@ import pytest
 import statistics
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.utility.utils import convert_device_size
 from ocs_ci.ocs.perfresult import ResultsAnalyse
@@ -95,6 +95,7 @@ class ClonesResultsAnalyse(ResultsAnalyse):
 
 
 @performance
+@performance_b
 class TestPVCClonePerformance(PASTest):
     """
     Test to verify clone creation and deletion performance for PVC with data written to it.

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -10,7 +10,7 @@ import statistics
 import tempfile
 import yaml
 
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
@@ -36,6 +36,7 @@ Operations_Mesurment = ["create", "delete", "csi_create", "csi_delete"]
 
 
 @performance
+@performance_a
 class TestPVCCreationDeletionPerformance(PASTest):
     """
     Test(s) to verify performance of PVC creation and deletion

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
     performance,
+    performance_b,
 )
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import constants, exceptions
@@ -42,6 +43,7 @@ ERR_MSG = "Error in command"
 
 
 @performance
+@performance_b
 @skipif_ocp_version("<4.6")
 @skipif_ocs_version("<4.6")
 class TestPvcMultiClonePerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
     performance,
+    performance_b,
 )
 
 from ocs_ci.helpers.helpers import get_full_test_logs_path
@@ -37,6 +38,7 @@ ERRMSG = "Error in command"
 
 
 @performance
+@performance_b
 @skipif_ocp_version("<4.6")
 @skipif_ocs_version("<4.6")
 class TestPvcMultiSnapshotPerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -23,6 +23,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     skipif_ocs_version,
     performance,
+    performance_b,
 )
 from ocs_ci.utility.utils import ceph_health_check
 
@@ -30,6 +31,7 @@ log = logging.getLogger(__name__)
 
 
 @performance
+@performance_b
 @skipif_ocp_version("<4.6")
 @skipif_ocs_version("<4.6")
 class TestPvcSnapshotPerformance(PASTest):

--- a/tests/e2e/performance/io_workload/test_fio_benchmark.py
+++ b/tests/e2e/performance/io_workload/test_fio_benchmark.py
@@ -12,7 +12,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import performance, skipif_ocs_version
+from ocs_ci.framework.testlib import performance, performance_c, skipif_ocs_version
 from ocs_ci.ocs.perfresult import PerfResult
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs.perftests import PASTest
@@ -129,6 +129,7 @@ class FIOResultsAnalyse(PerfResult):
 
 
 @performance
+@performance_c
 class TestFIOBenchmark(PASTest):
     """
     Run FIO perf test using benchmark operator

--- a/tests/e2e/performance/io_workload/test_perf_pgsql.py
+++ b/tests/e2e/performance/io_workload/test_perf_pgsql.py
@@ -6,7 +6,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.perf_pgsql import PerfPGSQL
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.node import get_node_resource_utilization_from_adm_top
 
@@ -27,6 +27,7 @@ def pgsql(request):
 
 
 @performance
+@performance_c
 @pytest.mark.polarion_id("OCS-2725")
 class TestPGSQLPodPerf(PASTest):
     """

--- a/tests/e2e/performance/io_workload/test_small_file_workload.py
+++ b/tests/e2e/performance/io_workload/test_small_file_workload.py
@@ -25,7 +25,7 @@ import pytest
 
 # Local modules
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import benchmark_operator, constants
 from ocs_ci.ocs.elasticsearch import ElasticSearch
@@ -361,6 +361,7 @@ class SmallFileResultsAnalyse(PerfResult):
 
 
 @performance
+@performance_a
 class TestSmallFileWorkload(PASTest):
     """
     Deploy benchmark operator and run SmallFile workload

--- a/tests/e2e/performance/mcg/test_mcg_cosbench.py
+++ b/tests/e2e/performance/mcg/test_mcg_cosbench.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import performance
+from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.perfresult import ResultsAnalyse
 from ocs_ci.helpers.helpers import get_full_test_logs_path
@@ -23,6 +23,7 @@ def cosbench(request):
 
 
 @performance
+@performance_c
 @pytest.mark.polarion_id("OCS-3694")
 class TestMCGCosbench(PASTest):
     """


### PR DESCRIPTION
The porpoise of this PR is to split the Performance test suite, since, currently the suite doesn't completed because of memory consumption (memory Leak).

In this way each part of the suite consume less memory and less time to complete, so the running of the full suite will finish and in less time.

the PR was tested locally - 3 different runs, and it finish.


Signed-off-by: Avi Layani <alayani@redhat.com>