### PR TITLE
Use the ingress cert for IBM Cloud deployments

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1172,9 +1172,7 @@ def obc_io_create_delete(mcg_obj, awscli_pod, bucket_factory):
 
 
 def retrieve_verification_mode():
-    if config.ENV_DATA["platform"].lower() == "ibm_cloud":
-        verify = True
-    elif config.DEPLOYMENT.get("use_custom_ingress_ssl_cert"):
+    if config.DEPLOYMENT.get("use_custom_ingress_ssl_cert"):
         verify = get_root_ca_cert()
     else:
         verify = constants.DEFAULT_INGRESS_CRT_LOCAL_PATH

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1172,7 +1172,12 @@ def obc_io_create_delete(mcg_obj, awscli_pod, bucket_factory):
 
 
 def retrieve_verification_mode():
-    if config.DEPLOYMENT.get("use_custom_ingress_ssl_cert"):
+    if (
+        config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
+        and config.ENV_DATA["deployment_type"] == "managed"
+    ):
+        verify = True
+    elif config.DEPLOYMENT.get("use_custom_ingress_ssl_cert"):
         verify = get_root_ca_cert()
     else:
         verify = constants.DEFAULT_INGRESS_CRT_LOCAL_PATH


### PR DESCRIPTION
Up until now the default CA bundle was used; Now, it leads to an SSL error.
This PR changes the behavior of MCG tests and fixtures running over IBM Cloud clusters to use the cluster's ingress certificate.