### PR TITLE
Add support for ODF clusterwide encryption using KMIP

### DIFF
--- a/conf/ocsci/ciphertrust_kms_deployment.yaml
+++ b/conf/ocsci/ciphertrust_kms_deployment.yaml
@@ -5,7 +5,4 @@ ENV_DATA:
   encryption_at_rest: true
   KMS_PROVIDER: kmip
   KMS_SERVICE_NAME: ciphertrust
-  KMIP_ENDPOINT: ""
-  KMIP_PORT: ""
   KMIP_SECRET_NAME: thales-kmip-ocs
-  TLS_SERVER_NAME: ""

--- a/conf/ocsci/ciphertrust_kms_deployment.yaml
+++ b/conf/ocsci/ciphertrust_kms_deployment.yaml
@@ -1,0 +1,11 @@
+DEPLOYMENT:
+  kms_deployment: true
+
+ENV_DATA:
+  encryption_at_rest: true
+  KMS_PROVIDER: kmip
+  KMS_SERVICE_NAME: ciphertrust
+  KMIP_ENDPOINT: ""
+  KMIP_PORT: ""
+  KMIP_SECRET_NAME: thales-kmip-ocs
+  TLS_SERVER_NAME: ""

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -687,6 +687,7 @@ EXTERNAL_HPCS_CSI_KMS_CONNECTION_DETAILS = os.path.join(
 EXTERNAL_IBM_KP_KMS_SECRET = os.path.join(
     EXTERNAL_HPCS_TEMPLATES, "ibm-kp-kms-secret.yaml"
 )
+
 # KMIP KMS yamls
 KMIP_KMS_TEMPLATES = os.path.join(TEMPLATE_OPENSHIFT_INFRA_DIR, "kmip")
 KMIP_OCS_KMS_CONNECTION_DETAILS = os.path.join(
@@ -697,6 +698,7 @@ KMIP_CSI_KMS_CONNECTION_DETAILS = os.path.join(
 )
 KMIP_OCS_KMS_SECRET = os.path.join(KMIP_KMS_TEMPLATES, "thales-kmip-ocs-secret.yaml")
 KMIP_CSI_KMS_SECRET = os.path.join(TEMPLATE_CSI_RBD_DIR, "thales-kmip-csi-secret.yaml")
+
 # Multicluster related yamls
 ODF_MULTICLUSTER_ORCHESTRATOR = os.path.join(
     TEMPLATE_MULTICLUSTER_DIR, "odf_multicluster_orchestrator.yaml"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -687,6 +687,16 @@ EXTERNAL_HPCS_CSI_KMS_CONNECTION_DETAILS = os.path.join(
 EXTERNAL_IBM_KP_KMS_SECRET = os.path.join(
     EXTERNAL_HPCS_TEMPLATES, "ibm-kp-kms-secret.yaml"
 )
+# KMIP KMS yamls
+KMIP_KMS_TEMPLATES = os.path.join(TEMPLATE_OPENSHIFT_INFRA_DIR, "kmip")
+KMIP_OCS_KMS_CONNECTION_DETAILS = os.path.join(
+    KMIP_KMS_TEMPLATES, "ocs-kms-connection-details.yaml"
+)
+KMIP_CSI_KMS_CONNECTION_DETAILS = os.path.join(
+    TEMPLATE_CSI_RBD_DIR, "csi-kms-connection-details-kmip.yaml"
+)
+KMIP_OCS_KMS_SECRET = os.path.join(KMIP_KMS_TEMPLATES, "thales-kmip-ocs-secret.yaml")
+KMIP_CSI_KMS_SECRET = os.path.join(TEMPLATE_CSI_RBD_DIR, "thales-kmip-csi-secret.yaml")
 # Multicluster related yamls
 ODF_MULTICLUSTER_ORCHESTRATOR = os.path.join(
     TEMPLATE_MULTICLUSTER_DIR, "odf_multicluster_orchestrator.yaml"

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -384,6 +384,10 @@ class KMIPDeploymentError(Exception):
     pass
 
 
+class KMIPOperationError(Exception):
+    pass
+
+
 class KMSNotSupported(Exception):
     pass
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -380,6 +380,10 @@ class HPCSDeploymentError(Exception):
     pass
 
 
+class KMIPDeploymentError(Exception):
+    pass
+
+
 class KMSNotSupported(Exception):
     pass
 

--- a/ocs_ci/templates/openshift-infra/kmip/ocs-kms-connection-details.yaml
+++ b/ocs_ci/templates/openshift-infra/kmip/ocs-kms-connection-details.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  KMS_PROVIDER: kmip
+  KMS_SERVICE_NAME: ciphertrust
+  KMIP_ENDPOINT: ""
+  KMIP_SECRET_NAME: thales-kmip-ocs
+  TLS_SERVER_NAME: ""
+kind: ConfigMap
+metadata:
+  name: ocs-kms-connection-details
+  namespace: openshift-storage

--- a/ocs_ci/templates/openshift-infra/kmip/thales-kmip-ocs-secret.yaml
+++ b/ocs_ci/templates/openshift-infra/kmip/thales-kmip-ocs-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  CA_CERT: <CA_cert from Thales CipherTrust Manager>
+  CLIENT_CERT: <Client cert from Thales CipherTrust Manager>
+  CLIENT_KEY: <Client key from Thales CipherTrust Manager>
+kind: Secret
+metadata:
+  name: thales-kmip-ocs-secret
+  namespace: openshift-storage
+type: Opaque

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -27,6 +27,7 @@ from ocs_ci.ocs.exceptions import (
     NotFoundError,
     KMSConnectionDetailsError,
     HPCSDeploymentError,
+    KMIPDeploymentError,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources import storage_cluster
@@ -1413,7 +1414,298 @@ class HPCS(KMS):
             raise NotFoundError("KMS flag not found")
 
 
-kms_map = {"vault": Vault, "hpcs": HPCS}
+class KMIP(KMS):
+    """
+    A class which handles deployment and other
+    configs related to KMIP (Thales CipherTrust Manager)
+
+    """
+
+    def __init__(self):
+        super().__init__("kmip")
+        self.kmip_endpoint = None
+        self.kmip_port = None
+        self.kmip_ca_cert = None
+        self.kmip_client_cert = None
+        self.kmip_client_key = None
+        self.kmip_secret_name = None
+        self.kmip_tls_server_name = None
+        self.kmip_key_identifier = None
+        self.kmsid = None
+
+    def deploy(self):
+        """
+        This function delegates the deployment of KMS using KMIP.
+        Thales CipherTrust Manager is the only supported vendor for now.
+
+        """
+        ocs_version = Version.get_semantic_ocs_version_from_config()
+        if ocs_version >= Version.VERSION_4_12:
+            self.deploy_kmip_ciphertrust()
+        else:
+            raise KMIPDeploymentError(
+                "Use of KMIP is not supported on clusters below ODF 4.12"
+            )
+
+    def deploy_kmip_ciphertrust(self):
+        """
+        This function configures the resources required to use Thales CipherTrust Manager with ODF
+
+        """
+        self.gather_init_kmip_conf()
+        self.create_odf_kmip_resources()
+
+    def gather_init_kmip_conf(self):
+        """
+        Initialize the variables from the KMIP configuration
+
+        """
+        self.kmip_conf = load_auth_config()["kmip"]
+        self.kmip_endpoint = self.kmip_conf["KMIP_ENDPOINT"]
+        self.kmip_port = self.kmip_conf["KMIP_PORT"]
+        self.kmip_ca_cert = self.kmip_conf["KMIP_CA_CERT"]
+        self.kmip_client_cert = self.kmip_conf["KMIP_CLIENT_CERT"]
+        self.kmip_client_key = self.kmip_conf["KMIP_CLIENT_KEY"]
+        self.kmip_tls_server_name = self.kmip_conf["KMIP_TLS_SERVER_NAME"]
+
+    def create_odf_kmip_resources(self):
+        """
+        Create secret containing certs and the ocs-kms-connection-details confignmap
+
+        """
+
+        self.kmip_secret_name = self.create_kmip_secret()
+        connection_data = templating.load_yaml(
+            constants.KMIP_OCS_KMS_CONNECTION_DETAILS
+        )
+        connection_data["data"][
+            "KMIP_ENDPOINT"
+        ] = f"{self.kmip_endpoint}:{self.kmip_port}"
+        connection_data["data"]["KMIP_SECRET_NAME"] = self.kmip_secret_name
+        connection_data["data"]["TLS_SERVER_NAME"] = self.kmip_tls_server_name
+        self.create_resource(connection_data, prefix="kms-connection")
+
+    def create_kmip_secret(self, type="ocs"):
+        """
+        Create secret containing the certificates and unique identifier (only for PV encryption)
+        from CipherTrust Manager KMS
+
+        Args:
+            type (str): csi, if the secret is being created for PV/Storageclass encryption
+                        ocs, if the secret is for clusterwide encryption
+
+        Returns:
+            (str): name of the kmip secret
+
+        """
+
+        if type == "csi":
+            kmip_kms_secret = templating.load_yaml(constants.KMIP_CSI_KMS_SECRET)
+            self.kmip_key_identifier = self.create_ciphertrust_key()
+            kmip_kms_secret["data"]["UNIQUE_IDENTIFIER"] = self.kmip_key_identifier
+
+        elif type == "ocs":
+            kmip_kms_secret = templating.load_yaml(constants.KMIP_OCS_KMS_SECRET)
+
+        else:
+            raise ValueError("The value should be either 'ocs' or 'csi'")
+
+        kmip_kms_secret["data"]["CA_CERT"] = self.kmip_ca_cert
+        kmip_kms_secret["data"]["CLIENT_CERT"] = self.kmip_client_cert
+        kmip_kms_secret["data"]["CLIENT_KEY"] = self.kmip_client_key
+        kmip_kms_secret["metadata"]["name"] = helpers.create_unique_resource_name(
+            "thales-kmip", type
+        )
+        self.create_resource(kmip_kms_secret, prefix="thales-kmip-secret")
+        return kmip_kms_secret["metadata"]["name"]
+
+    def create_ciphertrust_key(self):
+        """
+        Create a key in Ciphertrust Manager to be used for PV encryption
+
+        """
+        # TO DO
+
+    def delete_ciphertrust_key(self, key_id):
+        """
+        Delete key from CipherTrust Manager
+
+        Args:
+            key_id (str): ID of the key to be deleted
+        """
+
+        # Check if the key is deletable and then proceed with deletion
+        key_info = self.get_key_info_ciphertrust(key_id)
+        if key_info["undeletable"]:
+            logger.warning(
+                f"The key wih ID {key_id} is marked as undeletable. Skipping key deletion"
+            )
+        else:
+            cmd = f"ksctl keys delete --type id --name {key_id}"
+            subprocess.check_output(shlex.split(cmd))
+            if self.check_key_exists_in_ciphertrust(key_id):
+                raise KMSResourceCleaneupError(f"Key deletion failed for ID {key_id}")
+            logger.info(f"Key deletion successful for key ID: {key_id}")
+
+    def check_key_exists_in_ciphertrust(self, key_id):
+        """
+        Check if a key with the key_id is present in CipherTrust Manager
+
+        Args:
+            key_id (str): ID of the key to be checked for
+
+        Returns:
+            (bool): True, if the key exists in CipherTrust Manager
+
+        """
+        cmd = f"ksctl keys get --type id --name {key_id}"
+        proc = subprocess.Popen(
+            shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        out, err = proc.communicate()
+        if proc.returncode:
+            if "Resource not found" in err:
+                return False
+        return True
+
+    def get_key_info_ciphertrust(self, key_id):
+        """
+        Retrieve information about a given key
+
+        Args:
+            key_id (str): ID of the key in CipherTrust
+
+        Returns
+            (dict): Dictionary with key details
+
+        """
+        cmd = f"ksctl keys get info --type id --name {key_id}"
+        proc = subprocess.Popen(
+            shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        out, err = proc.communicate()
+        if proc.returncode:
+            if "Resource not found" in err:
+                raise NotFoundError(f"KMIP: Key with ID {key_id} not found")
+        else:
+            return json.loads(out)
+
+    def get_key_list_ciphertrust(self):
+        """
+        Lists all keys in CipherTrust Manager
+
+        Returns:
+            (list): list containing the IDs of the keys
+
+        """
+        key_id_list = []
+        cmd = "ksctl key list"
+        out = subprocess.check_output(shlex.split(cmd))
+        json_out = json.loads(out)
+        if json_out["total"] == 0:
+            raise NotFoundError("No keys found")
+        else:
+            for key in json_out["resources"]:
+                key_id_list.append(key["id"])
+            return key_id_list
+
+    def get_osd_key_ids(self):
+        """
+        Retrieve the key ID used for OSD encryption stored in their respective secrets
+
+        Returns:
+            (list): list of key IDs from all OSDs
+
+        """
+        key_ids = []
+        osds = pod.get_osd_pods()
+        for osd in osds:
+            pvc = (
+                osd.get()
+                .get("metadata")
+                .get("labels")
+                .get(constants.CEPH_ROOK_IO_PVC_LABEL)
+            )
+            cmd = (
+                rf"oc get secret rook-ceph-osd-encryption-key-{pvc} -o jsonpath=\"{{.data[\'dmcrypt-key\']}}\""
+                f" -n {constants.OPENSHIFT_STORAGE_NAMESPACE}"
+            )
+            key_ids.append(base64.b64decode(run_cmd(cmd=cmd)).decode())
+        return key_ids
+
+    def get_noobaa_key_id(self):
+        """
+        Retrieve the key ID used for encryption by Noobaa
+
+        Returns:
+            (str): Key ID used by NooBaa for encryption
+
+        """
+        cmd = (
+            rf"oc get cm ocs-kms-connection-details -o jsonpath=\"{{.data[\'KMIP_SECRET_NAME\']}}\""
+            f" -n {constants.OPENSHIFT_STORAGE_NAMESPACE}"
+        )
+        secret_name = run_cmd(cmd=cmd)
+
+        cmd = (
+            rf"oc get secret {secret_name} -o jsonpath=\"{{.data[\'UniqueIdentifier\']}}\""
+            f" -n {constants.OPENSHIFT_STORAGE_NAMESPACE}"
+        )
+        noobaa_key_id = base64.b64decode(run_cmd(cmd=cmd)).decode()
+        return noobaa_key_id
+
+    def post_deploy_verification(self):
+        """
+        Verify ODF deployment using KMIP
+
+        """
+        self.validate_ciphertrust_deployment()
+
+    def validate_ciphertrust_deployment(self):
+        """
+        Verify whether OSD and NooBaa keys are stored in CipherTrust Manager
+
+        """
+        self.gather_init_kmip_conf()
+        key_id_list = self.get_key_list_ciphertrust()
+
+        # Check for OSD keys
+        osd_key_ids = self.get_osd_key_ids()
+        if all(id in key_id_list for id in osd_key_ids):
+            logger.info("KMIP: All OSD keys found in CipherTrust Manager")
+        else:
+            logger.error(
+                "KMIP: Only some or no OSD keys found in CipherTrust Manager"
+                f"Keys found in CipherTrust Manager: {key_id_list}"
+                f"OSD keys from the ODF cluster: {osd_key_ids}"
+            )
+            raise NotFoundError(
+                "KMIP: Only some or no OSD keys found in CipherTrust Manager"
+            )
+
+        # Check for NOOBAA key
+        noobaa_key_id = self.noobaa_key_id()
+        if noobaa_key_id in key_id_list:
+            logger.info("KMIP: Noobaa encryption key found in CipherTrust Manager")
+        else:
+            raise NotFoundError(
+                "KMIP: Noobaa encryption key found in CipherTrust Manager"
+            )
+
+        # Check kms enabled
+        if not is_kms_enabled():
+            logger.error("KMS not enabled on storage cluster")
+            raise NotFoundError("KMS flag not found")
+
+    def cleanup(self):
+        """
+        Cleanup for KMIP
+
+        """
+        logger.warning("Nothing to cleanup in CipherTrust Manager")
+
+
+kms_map = {"vault": Vault, "hpcs": HPCS, "kmip": KMIP}
 
 
 def update_csi_kms_vault_connection_details(update_config):

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -1695,7 +1695,7 @@ class KMIP(KMS):
         Verify whether OSD and NooBaa keys are stored in CipherTrust Manager
 
         """
-
+        self.update_kmip_env_vars()
         key_id_list = self.get_key_list_ciphertrust()
 
         # Check for OSD keys

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -1425,15 +1425,19 @@ class KMIP(KMS):
 
     def __init__(self):
         super().__init__("kmip")
-        self.kmip_endpoint = None
-        self.kmip_port = None
-        self.kmip_ca_cert_base64 = None
-        self.kmip_client_cert_base64 = None
-        self.kmip_client_key_base64 = None
         self.kmip_secret_name = None
-        self.kmip_tls_server_name = None
         self.kmip_key_identifier = None
         self.kmsid = None
+        logger.info("Loading KMIP details from auth config")
+        self.kmip_conf = load_auth_config()["kmip"]
+        self.kmip_endpoint = self.kmip_conf["KMIP_ENDPOINT"]
+        self.kmip_ciphertrust_user = self.kmip_conf["KMIP_CTM_USER"]
+        self.kmip_ciphertrust_pwd = self.kmip_conf["KMIP_CTM_PWD"]
+        self.kmip_port = self.kmip_conf["KMIP_PORT"]
+        self.kmip_ca_cert_base64 = self.kmip_conf["KMIP_CA_CERT_BASE64"]
+        self.kmip_client_cert_base64 = self.kmip_conf["KMIP_CLIENT_CERT_BASE64"]
+        self.kmip_client_key_base64 = self.kmip_conf["KMIP_CLIENT_KEY_BASE64"]
+        self.kmip_tls_server_name = self.kmip_conf["KMIP_TLS_SERVER_NAME"]
 
     def deploy(self):
         """
@@ -1453,26 +1457,9 @@ class KMIP(KMS):
         This function configures the resources required to use Thales CipherTrust Manager with ODF
 
         """
-        self.gather_init_kmip_conf()
         self.update_kmip_env_vars()
         get_ksctl_cli()
         self.create_odf_kmip_resources()
-
-    def gather_init_kmip_conf(self):
-        """
-        Initialize the variables from the KMIP configuration
-
-        """
-        logger.info("Loading KMIP details from auth config")
-        self.kmip_conf = load_auth_config()["kmip"]
-        self.kmip_endpoint = self.kmip_conf["KMIP_ENDPOINT"]
-        self.kmip_ciphertrust_user = self.kmip_conf["KMIP_CTM_USER"]
-        self.kmip_ciphertrust_pwd = self.kmip_conf["KMIP_CTM_PWD"]
-        self.kmip_port = self.kmip_conf["KMIP_PORT"]
-        self.kmip_ca_cert_base64 = self.kmip_conf["KMIP_CA_CERT_BASE64"]
-        self.kmip_client_cert_base64 = self.kmip_conf["KMIP_CLIENT_CERT_BASE64"]
-        self.kmip_client_key_base64 = self.kmip_conf["KMIP_CLIENT_KEY_BASE64"]
-        self.kmip_tls_server_name = self.kmip_conf["KMIP_TLS_SERVER_NAME"]
 
     def update_kmip_env_vars(self):
         """
@@ -1704,7 +1691,7 @@ class KMIP(KMS):
         Verify whether OSD and NooBaa keys are stored in CipherTrust Manager
 
         """
-        self.gather_init_kmip_conf()
+
         key_id_list = self.get_key_list_ciphertrust()
 
         # Check for OSD keys
@@ -1740,8 +1727,6 @@ class KMIP(KMS):
         Cleanup for KMIP
 
         """
-        if not self.kmip_endpoint:
-            self.gather_init_kmip_conf()
         self.update_kmip_env_vars()
 
         # Retrieve OSD and NooBaa keys for deletion and delete

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3964,16 +3964,16 @@ def wipe_all_disk_partitions_for_node(node):
                 wipe_partition(node, disk_path)
 
 
-def get_ksctl_cli(bind_dir=None):
+def get_ksctl_cli(bin_dir=None):
     """
     Download ksctl to interact with CipherTrust Manager via CLI
 
     Args:
-        bind_dir (str): Path to bin directory (default: config.RUN['bin_dir'])
+        bin_dir (str): Path to bin directory (default: config.RUN['bin_dir'])
 
     """
 
-    bin_dir = os.path.expanduser(bind_dir or config.RUN["bin_dir"])
+    bin_dir = os.path.expanduser(bin_dir or config.RUN["bin_dir"])
     system = platform.system()
     if "Darwin" not in system and "Linux" not in system:
         raise UnsupportedOSType("Not a supported platform")
@@ -3989,13 +3989,11 @@ def get_ksctl_cli(bind_dir=None):
     else:
         log.info("Downloading ksctl cli")
         prepare_bin_dir()
-        previous_dir = os.getcwd()
-        os.chdir(bin_dir)
         url = f"https://{load_auth_config()['kmip']['KMIP_ENDPOINT']}/downloads/{zip_file}"
         download_file(url, zip_file, verify=False)
-        run_cmd(f"unzip {zip_file}")
+        run_cmd(f"tar -xzC {bin_dir} -f {zip_file}")
         run_cmd(f"mv ksctl-{system}-amd64 {ksctl_cli_filename}")
         delete_file(zip_file)
-        os.chdir(previous_dir)
+
     ksctl_ver = run_cmd(f"{ksctl_binary_path} version")
     log.info(f"ksctl cli version: {ksctl_ver}")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3962,38 +3962,3 @@ def wipe_all_disk_partitions_for_node(node):
             if disk_to_wipe != root_disk:
                 disk_path = f"/dev/{disk_to_wipe}"
                 wipe_partition(node, disk_path)
-
-
-def get_ksctl_cli(bin_dir=None):
-    """
-    Download ksctl to interact with CipherTrust Manager via CLI
-
-    Args:
-        bin_dir (str): Path to bin directory (default: config.RUN['bin_dir'])
-
-    """
-
-    bin_dir = os.path.expanduser(bin_dir or config.RUN["bin_dir"])
-    system = platform.system()
-    if "Darwin" not in system and "Linux" not in system:
-        raise UnsupportedOSType("Not a supported platform")
-
-    system = system.lower()
-    zip_file = "ksctl_images.zip"
-    ksctl_cli_filename = "ksctl"
-    ksctl_binary_path = os.path.join(bin_dir, ksctl_cli_filename)
-    if os.path.isfile(ksctl_binary_path):
-        log.info(
-            f"ksctl CLI binary already exists {ksctl_binary_path}, skipping download."
-        )
-    else:
-        log.info("Downloading ksctl cli")
-        prepare_bin_dir()
-        url = f"https://{load_auth_config()['kmip']['KMIP_ENDPOINT']}/downloads/{zip_file}"
-        download_file(url, zip_file, verify=False)
-        run_cmd(f"tar -xzC {bin_dir} -f {zip_file}")
-        run_cmd(f"mv ksctl-{system}-amd64 {ksctl_cli_filename}")
-        delete_file(zip_file)
-
-    ksctl_ver = run_cmd(f"{ksctl_binary_path} version")
-    log.info(f"ksctl cli version: {ksctl_ver}")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3962,3 +3962,15 @@ def wipe_all_disk_partitions_for_node(node):
             if disk_to_wipe != root_disk:
                 disk_path = f"/dev/{disk_to_wipe}"
                 wipe_partition(node, disk_path)
+
+
+def get_ksctl_cli(bind_dir=None, force_download=False):
+    """
+    Download ksctl to interact with CipherTrust Manager via CLI
+
+    Args:
+        bind_dir (str): Path to bin directory (default: config.RUN['bin_dir'])
+        force_download (bool): Force vault cli download even if already present
+
+    """
+    # TODO:


### PR DESCRIPTION
Add support for clusterwide encryption using KMIP (Thales CipherTrust Manager)
Epic link: https://issues.redhat.com/browse/RHSTOR-2179

Signed-off-by: rachael-george <rgeorge@redhat.com>