### PR TITLE
Try to create multiple namespacestores only if nss_tup fits

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -407,7 +407,7 @@ def namespace_store_factory(
         current_call_created_nss = []
         for platform, nss_lst in nss_dict.items():
             for nss_tup in nss_lst:
-                for _ in range(nss_tup[0]):
+                for _ in range(nss_tup[0] if isinstance(nss_tup[0], int) else 1):
                     if platform.lower() == "nsfs":
                         uls_name = nss_tup[0] or create_unique_resource_name(
                             constants.PVC.lower(), platform


### PR DESCRIPTION
Currently, the NSFS tuple's first value is its name - since the NSFS infrastructure assumes the creation of a single one for each test.
The new code will only try to iterate over `nss_tup[0]` if it's an int.

The problem should be fixed fundamentally though #5594 