### PR TITLE
Make Root Disk size for vmware configurable

### DIFF
--- a/conf/ocsci/root_disk_size_500GB.yaml
+++ b/conf/ocsci/root_disk_size_500GB.yaml
@@ -1,0 +1,4 @@
+---
+# This config will be applicable for VMware Deployment
+ENV_DATA:
+  vmw_root_disk_size: "500"

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1506,7 +1506,7 @@ class VSPHEREUPIFlexy(VSPHEREBASE):
 def change_vm_root_disk_size(machine_file):
     """
     Change the root disk size of VM from constants.CURRENT_VM_ROOT_DISK_SIZE
-    to constants.VM_ROOT_DISK_SIZE
+    to constants.VM_ROOT_DISK_SIZE or from ENV_DATA["vmw_root_disk_size"]
 
     Args:
          machine_file (str): machine file to change the disk size
@@ -1515,7 +1515,13 @@ def change_vm_root_disk_size(machine_file):
     current_vm_root_disk_size = (
         f"{disk_size_prefix}{constants.CURRENT_VM_ROOT_DISK_SIZE}"
     )
-    vm_root_disk_size = f"{disk_size_prefix}{constants.VM_ROOT_DISK_SIZE}"
+
+    if config.ENV_DATA["vmw_root_disk_size"]:
+        root_disk_size = config.ENV_DATA["vmw_root_disk_size"]
+    else:
+        root_disk_size = constants.VM_ROOT_DISK_SIZE
+
+    vm_root_disk_size = f"{disk_size_prefix}{root_disk_size}"
     replace_content_in_file(machine_file, current_vm_root_disk_size, vm_root_disk_size)
 
 


### PR DESCRIPTION
This yaml is basically going to be used for RDR deployment as the default root size is not sufficient when debug log's are enabled 

Signed-off-by: prsurve <prsurve@redhat.com>