### PR TITLE
Update OSD expected state in test_automated_recovery_from_failed_nodes_reactive_ms[drain_node]

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1034,7 +1034,7 @@ MASTER_LABEL = "node-role.kubernetes.io/master"
 WORKER_LABEL = "node-role.kubernetes.io/worker"
 APP_LABEL = "node-role.kubernetes.io/app"
 S3CLI_APP_LABEL = "s3cli"
-OSD_NODE_LABEL = "node.ocs.openshift.io/ocd=''"
+OSD_NODE_LABEL = "node.ocs.openshift.io/osd=''"
 
 # well known topologies
 ZONE_LABEL = "topology.kubernetes.io/zone"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1034,6 +1034,7 @@ MASTER_LABEL = "node-role.kubernetes.io/master"
 WORKER_LABEL = "node-role.kubernetes.io/worker"
 APP_LABEL = "node-role.kubernetes.io/app"
 S3CLI_APP_LABEL = "s3cli"
+OSD_NODE_LABEL = "node.ocs.openshift.io/ocd=''"
 
 # well known topologies
 ZONE_LABEL = "topology.kubernetes.io/zone"

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -170,6 +170,9 @@ def check_automated_recovery_from_drain_node(nodes):
     log.info(f"osd pod ids: {old_osd_pod_ids}")
     node_osd_pods = get_osd_pods_having_ids(old_osd_pod_ids)
 
+    osd_labelled_nodes = set(machine.get_labeled_nodes(constants.OSD_NODE_LABEL))
+    osd_running_nodes = set(get_osd_running_nodes())
+
     unschedule_nodes([osd_node_name])
     log.info(f"Successfully unschedule the node: {osd_node_name}")
 
@@ -178,9 +181,6 @@ def check_automated_recovery_from_drain_node(nodes):
 
     new_osd_pods = wait_for_osd_pods_having_ids(osd_ids=old_osd_pod_ids)
     new_osd_pod_names = [p.name for p in new_osd_pods]
-
-    osd_labelled_nodes = set(machine.get_labeled_nodes(constants.OSD_NODE_LABEL))
-    osd_running_nodes = set(get_osd_running_nodes())
 
     wnodes = get_worker_nodes()
     if len(wnodes) <= 3 or osd_labelled_nodes == osd_running_nodes:

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import machine, constants
+from ocs_ci.ocs.machine import get_labeled_nodes
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_in_statuses,
     check_pods_after_node_replacement,
@@ -179,8 +180,11 @@ def check_automated_recovery_from_drain_node(nodes):
     new_osd_pods = wait_for_osd_pods_having_ids(osd_ids=old_osd_pod_ids)
     new_osd_pod_names = [p.name for p in new_osd_pods]
 
+    osd_labelled_nodes = set(get_labeled_nodes(constants.OSD_NODE_LABEL))
+    osd_running_nodes = set(get_osd_running_nodes())
+
     wnodes = get_worker_nodes()
-    if len(wnodes) <= 3:
+    if len(wnodes) <= 3 or osd_labelled_nodes == osd_running_nodes:
         expected_pods_status = constants.STATUS_PENDING
     else:
         expected_pods_status = constants.STATUS_RUNNING
@@ -199,7 +203,7 @@ def check_automated_recovery_from_drain_node(nodes):
     schedule_nodes([osd_node_name])
     log.info(f"Successfully scheduled the node {osd_node_name}")
 
-    if len(wnodes) <= 3:
+    if len(wnodes) <= 3 or osd_labelled_nodes == osd_running_nodes:
         assert wait_for_osd_ids_come_up_on_node(osd_node_name, old_osd_pod_ids)
         log.info(
             f"the osd ids {old_osd_pod_ids} Successfully come up on the node {osd_node_name}"

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -11,7 +11,6 @@ from ocs_ci.framework.testlib import (
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import machine, constants
-from ocs_ci.ocs.machine import get_labeled_nodes
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_in_statuses,
     check_pods_after_node_replacement,
@@ -180,7 +179,7 @@ def check_automated_recovery_from_drain_node(nodes):
     new_osd_pods = wait_for_osd_pods_having_ids(osd_ids=old_osd_pod_ids)
     new_osd_pod_names = [p.name for p in new_osd_pods]
 
-    osd_labelled_nodes = set(get_labeled_nodes(constants.OSD_NODE_LABEL))
+    osd_labelled_nodes = set(machine.get_labeled_nodes(constants.OSD_NODE_LABEL))
     osd_running_nodes = set(get_osd_running_nodes())
 
     wnodes = get_worker_nodes()


### PR DESCRIPTION
Update the test given below to expect OSD in pending state after node drain if the the OSDs are running on dedicated nodes only. This is the change related to pricing and topology changes. OSDs cannot run on worker nodes which does not have the label ```node.ocs.openshift.io/ocd=''```

tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py::TestAutomatedRecoveryFromFailedNodeReactiveMS::test_automated_recovery_from_failed_nodes_reactive_ms[drain_node]

Fixes #6558 

Signed-off-by: Jilju Joy <jijoy@redhat.com>