### PR TITLE
Skip volume detach tests in MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_ibm_cloud,
     skipif_external_mode,
+    skipif_managed_service,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import (
@@ -119,6 +120,7 @@ class TestDiskFailures(ManageTest):
         """
         self.sanity_helpers = Sanity()
 
+    @skipif_managed_service
     @cloud_platform_required
     @pytest.mark.polarion_id("OCS-1085")
     @bugzilla("1825675")
@@ -166,6 +168,7 @@ class TestDiskFailures(ManageTest):
         # TODO: Remove 'tries=100'
         self.sanity_helpers.health_check(tries=100)
 
+    @skipif_managed_service
     @cloud_platform_required
     @pytest.mark.polarion_id("OCS-1086")
     @skipif_ibm_cloud


### PR DESCRIPTION
Skip the test cases given below which is not currently relevant in Managed Service platform.
tests/manage/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_detach_attach_worker_volume
tests/manage/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_detach_attach_2_data_volumes

Signed-off-by: Jilju Joy <jijoy@redhat.com>