### PR TITLE
Support new MCG replication rules schema for OBC patches and bucketclasses

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1674,27 +1674,21 @@ def patch_replication_policy_to_bucket(bucket_name, rule_id, destination_bucket_
         rule_id (str): The ID of the replication rule
         destination_bucket_name (str): The name of the replication destination bucket
     """
+    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
+        replication_policy = {
+            "rules": [
+                {"rule_id": rule_id, "destination_bucket": destination_bucket_name}
+            ]
+        }
+    else:
+        replication_policy = [
+            {"rule_id": rule_id, "destination_bucket": destination_bucket_name}
+        ]
     replication_policy_patch_dict = {
         "spec": {
-            "additionalConfig": {
-                "replicationPolicy": json.dumps(
-                    [
-                        {
-                            "rule_id": rule_id,
-                            "destination_bucket": destination_bucket_name,
-                        }
-                    ]
-                )
-            }
+            "additionalConfig": {"replicationPolicy": json.dumps(replication_policy)}
         }
     }
-    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
-        rep_policy_dict = replication_policy_patch_dict["spec"]["additionalConfig"][
-            "replicationPolicy"
-        ]
-        replication_policy_patch_dict["spec"]["additionalConfig"][
-            "replicationPolicy"
-        ] = {"rules": rep_policy_dict}
     OCP(
         kind="obc",
         namespace=config.ENV_DATA["cluster_namespace"],

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -14,7 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.utility import templating
+from ocs_ci.utility import templating, version
 from ocs_ci.utility.ssl_certs import get_root_ca_cert
 from ocs_ci.utility.utils import TimeoutSampler, run_cmd
 from ocs_ci.helpers.helpers import create_resource
@@ -1688,6 +1688,13 @@ def patch_replication_policy_to_bucket(bucket_name, rule_id, destination_bucket_
             }
         }
     }
+    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
+        rep_policy_dict = replication_policy_patch_dict["spec"]["additionalConfig"][
+            "replicationPolicy"
+        ]
+        replication_policy_patch_dict["spec"]["additionalConfig"][
+            "replicationPolicy"
+        ] = {"rules": rep_policy_dict}
     OCP(
         kind="obc",
         namespace=config.ENV_DATA["cluster_namespace"],

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -677,7 +677,7 @@ class MCG:
                 "replicationPolicy",
                 json.dumps(replication_policy)
                 if version.get_semantic_ocs_version_from_config() < version.VERSION_4_12
-                else {"rules": json.dumps(replication_policy)},
+                else json.dumps({"rules": replication_policy}),
             )
 
         return create_resource(**bc_data)

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -674,7 +674,10 @@ class MCG:
 
         if replication_policy:
             bc_data["spec"].setdefault(
-                "replicationPolicy", json.dumps(replication_policy)
+                "replicationPolicy",
+                json.dumps(replication_policy)
+                if version.get_semantic_ocs_version_from_config() < version.VERSION_4_12
+                else {"rules": json.dumps(replication_policy)},
             )
 
         return create_resource(**bc_data)

--- a/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
+++ b/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
@@ -1,14 +1,14 @@
 import logging
 import pytest
-import json
 import time
 
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs import hsbench
-from ocs_ci.framework import config
-from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.bucket_utils import compare_bucket_object_list
+from ocs_ci.ocs.bucket_utils import (
+    compare_bucket_object_list,
+    patch_replication_policy_to_bucket,
+)
 from ocs_ci.ocs import scale_noobaa_lib
 
 log = logging.getLogger(__name__)
@@ -177,26 +177,8 @@ class TestScaleBucketReplication(E2ETest):
                 replication_policy=replication_policy,
                 verify_health=False,
             )[0]
-            replication_policy_patch_dict = {
-                "spec": {
-                    "additionalConfig": {
-                        "replicationPolicy": json.dumps(
-                            [
-                                {
-                                    "rule_id": "basic-replication-rule-2",
-                                    "destination_bucket": second_bucket.name,
-                                }
-                            ]
-                        )
-                    }
-                }
-            }
-            OCP(
-                kind="obc",
-                namespace=config.ENV_DATA["cluster_namespace"],
-                resource_name=bucket.name,
-            ).patch(
-                params=json.dumps(replication_policy_patch_dict), format_type="merge"
+            patch_replication_policy_to_bucket(
+                bucket.name, "basic-replication-rule-2", second_bucket.name
             )
             first_end_point = (
                 "http://"


### PR DESCRIPTION
#6570 took care of the standard OBC creation schema, but not of these two cases.