### PR TITLE
added new topolvm domain name support

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2420,7 +2420,7 @@ class LVM(object):
         lvmc_cop = OCP(
             namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
             kind="lvmcluster",
-            resource_name="lvmcluster",
+            resource_name=constants.LVMCLUSTER,
         )
         lvmc_ocs = lvmc_cop.data
         self.lvmcluster = lvmc_ocs
@@ -2898,7 +2898,7 @@ def check_clusters():
     try:
         lvmcluster_obj = OCP(
             kind="lvmcluster",
-            resource_name="lvmcluster",
+            resource_name=constants.LVMCLUSTER,
             namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
             silent=True,
         )

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1303,6 +1303,7 @@ OCS_PROVISIONERS = [
     "openshift-storage.cephfs.csi.ceph.com",
     "openshift-storage.noobaa.io/obc",
     "topolvm.cybozu.com",
+    "topolvm.io",
 ]
 RBD_PROVISIONER = "openshift-storage.rbd.csi.ceph.com"
 
@@ -1895,7 +1896,8 @@ LVMO_POD_LABEL = {
         "vg-manager_label": "app.lvm.openshift.io=vg-manager",
     },
 }
-LVM_PROVISIONER = "topolvm.cybozu.com"
+LVM_PROVISIONER_4_11 = "topolvm.cybozu.com"
+LVM_PROVISIONER_4_12 = "topolvm.io"
 TOPOLVM_METRICS = [
     "topolvm_thinpool_data_percent",
     "topolvm_thinpool_metadata_percent",

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -368,6 +368,9 @@ CSI_CEPHFS_STORAGECLASS_YAML = os.path.join(TEMPLATE_CSI_FS_DIR, "storageclass.y
 
 CSI_CEPHFS_PVC_CLONE_YAML = os.path.join(TEMPLATE_CSI_FS_DIR, "pvc-clone.yaml")
 
+CSI_LVM_STORAGECLASS_YAML_4_11 = os.path.join(
+    TEMPLATE_CSI_LVM_DIR, "storageclass_4_11.yaml"
+)
 CSI_LVM_STORAGECLASS_YAML = os.path.join(TEMPLATE_CSI_LVM_DIR, "storageclass.yaml")
 
 ROOK_CSI_CEPHFS_STORAGECLASS_YAML = os.path.join(
@@ -1897,7 +1900,7 @@ LVMO_POD_LABEL = {
     },
 }
 LVM_PROVISIONER_4_11 = "topolvm.cybozu.com"
-LVM_PROVISIONER_4_12 = "topolvm.io"
+LVM_PROVISIONER = "topolvm.io"
 TOPOLVM_METRICS = [
     "topolvm_thinpool_data_percent",
     "topolvm_thinpool_metadata_percent",

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -242,7 +242,9 @@ class PVC(OCS):
             snapshotclass = helpers.default_volumesnapshotclass(
                 constants.CEPHFILESYSTEM
             ).name
-        elif self.provisioner == "topolvm.cybozu.com":
+        elif self.provisioner == (
+            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER_4_12
+        ):
             snap_yaml = constants.CSI_LVM_SNAPSHOT_YAML
             snapshotclass = constants.DEFAULT_VOLUMESNAPSHOTCLASS_LVM
 

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -243,7 +243,7 @@ class PVC(OCS):
                 constants.CEPHFILESYSTEM
             ).name
         elif self.provisioner == (
-            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER_4_12
+            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER
         ):
             snap_yaml = constants.CSI_LVM_SNAPSHOT_YAML
             snapshotclass = constants.DEFAULT_VOLUMESNAPSHOTCLASS_LVM

--- a/ocs_ci/templates/CSI/lvm/storageclass.yaml
+++ b/ocs_ci/templates/CSI/lvm/storageclass.yaml
@@ -8,4 +8,4 @@ volumeBindingMode:
 allowVolumeExpansion: true
 parameters:
   csi.storage.k8s.io/fstype: xfs
-  topolvm.cybozu.com/device-class: vg1
+  topolvm.io/device-class: vg1

--- a/ocs_ci/templates/CSI/lvm/storageclass_4_11.yaml
+++ b/ocs_ci/templates/CSI/lvm/storageclass_4_11.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name:
-provisioner: topolvm.io
+provisioner: topolvm.cybozu.com
 reclaimPolicy: Delete
 volumeBindingMode:
 allowVolumeExpansion: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4152,7 +4152,7 @@ def pvc_clone_factory_fixture(request):
             clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
             interface = constants.CEPHFILESYSTEM
         elif pvc_obj.provisioner == (
-            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER_4_11
+            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER
         ):
             clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
             no_interface = True
@@ -5915,7 +5915,10 @@ def lvm_storageclass_factory_fixture(request, storageclass_factory):
             sc_obj = OCS(**sc_ocp_obj.data)
             log.info(f"Will return default storageclass {sc_obj.name}")
         elif volume_binding == constants.IMMEDIATE_VOLUMEBINDINGMODE:
-            sc_obj = templating.load_yaml(constants.CSI_LVM_STORAGECLASS_YAML)
+            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_11:
+                sc_obj = templating.load_yaml(constants.CSI_LVM_STORAGECLASS_YAML_4_11)
+            elif version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
+                sc_obj = templating.load_yaml(constants.CSI_LVM_STORAGECLASS_YAML)
             sc_obj["metadata"]["name"] = create_unique_resource_name(
                 resource_description="immediate-test",
                 resource_type="storageclass",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4151,7 +4151,9 @@ def pvc_clone_factory_fixture(request):
         elif pvc_obj.provisioner == "openshift-storage.cephfs.csi.ceph.com":
             clone_yaml = constants.CSI_CEPHFS_PVC_CLONE_YAML
             interface = constants.CEPHFILESYSTEM
-        elif pvc_obj.provisioner == constants.LVM_PROVISIONER:
+        elif pvc_obj.provisioner == (
+            constants.LVM_PROVISIONER_4_11 or constants.LVM_PROVISIONER_4_11
+        ):
             clone_yaml = constants.CSI_RBD_PVC_CLONE_YAML
             no_interface = True
         size = size or pvc_obj.get().get("spec").get("resources").get("requests").get(


### PR DESCRIPTION
topolvm domain name changed to "topolvm.io" in 4.12


Signed-off-by: Aviadp <apolak@redhat.com>