### PR TITLE
Disable lb test 4.12 fix

### DIFF
--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     skipif_external_mode,
     skipif_ibm_cloud,
+    skipif_managed_service,
 )
 from ocs_ci.ocs import defaults, constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
@@ -188,9 +189,10 @@ class TestS3Routes:
         request.addfinalizer(finalizer)
 
     @tier3
-    @bugzilla("1954708")
     @skipif_external_mode
     @skipif_ibm_cloud
+    @skipif_managed_service
+    @bugzilla("1954708")
     @pytest.mark.polarion_id("OCS-4653")
     @skipif_ocs_version("<4.10")
     def test_disable_nb_lb(self, revert_lb_service):

--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -9,9 +9,11 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     tier3,
     skipif_external_mode,
+    skipif_ibm_cloud,
 )
 from ocs_ci.ocs import defaults, constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
+from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
@@ -163,13 +165,18 @@ class TestS3Routes:
             )
             sleep(10)
             logger.info("Validating service type reverted to LoadBalancer")
-            assert (
-                nb_mgmt_svc_obj.data["spec"]["type"]
-                and nb_s3_svc_obj.data["spec"]["type"] == "LoadBalancer"
-            ), (
-                f'Failed, noobaa-mgmt type: {nb_mgmt_svc_obj.data["spec"]["type"]}, '
-                f's3 type: {nb_s3_svc_obj.data["spec"]["type"]}'
-            )
+            if version.get_semantic_ocs_version_from_config() < version.VERSION_4_12:
+                assert (
+                    nb_mgmt_svc_obj.data["spec"]["type"]
+                    and nb_s3_svc_obj.data["spec"]["type"] == "LoadBalancer"
+                ), (
+                    f'Failed, noobaa-mgmt type: {nb_mgmt_svc_obj.data["spec"]["type"]}, '
+                    f's3 type: {nb_s3_svc_obj.data["spec"]["type"]}'
+                )
+            else:
+                assert (
+                    nb_s3_svc_obj.data["spec"]["type"] == "LoadBalancer"
+                ), f'Failed, s3 type: {nb_s3_svc_obj.data["spec"]["type"]}'
             nb_route_obj = ocp.OCP(
                 kind=constants.ROUTE,
                 namespace=defaults.ROOK_CLUSTER_NAMESPACE,
@@ -183,6 +190,7 @@ class TestS3Routes:
     @tier3
     @bugzilla("1954708")
     @skipif_external_mode
+    @skipif_ibm_cloud
     @pytest.mark.polarion_id("OCS-4653")
     @skipif_ocs_version("<4.10")
     def test_disable_nb_lb(self, revert_lb_service):
@@ -212,10 +220,15 @@ class TestS3Routes:
         )
         sleep(10)
         logger.info("Validating service type changed to ClusterIP")
-        assert (
-            nb_mgmt_svc_obj.data["spec"]["type"]
-            and nb_s3_svc_obj.data["spec"]["type"] == "ClusterIP"
-        ), (
-            f'Failed: noobaa-mgmt type: {nb_mgmt_svc_obj.data["spec"]["type"]}, '
-            f's3 type {nb_s3_svc_obj.data["spec"]["type"]}'
-        )
+        if version.get_semantic_ocs_version_from_config() < version.VERSION_4_12:
+            assert (
+                nb_mgmt_svc_obj.data["spec"]["type"]
+                and nb_s3_svc_obj.data["spec"]["type"] == "ClusterIP"
+            ), (
+                f'Failed: noobaa-mgmt type: {nb_mgmt_svc_obj.data["spec"]["type"]}, '
+                f's3 type {nb_s3_svc_obj.data["spec"]["type"]}'
+            )
+        else:
+            assert (
+                nb_s3_svc_obj.data["spec"]["type"] == "ClusterIP"
+            ), f'Failed: s3 type {nb_s3_svc_obj.data["spec"]["type"]}'


### PR DESCRIPTION
nb mgmt is by default clusterIP as per https://github.com/noobaa/noobaa-operator/pull/941#discussion_r920850680
Signed-off-by: Parikshith Byregowda <pbyregow@redhat.com>