### PR TITLE
Adding sleep to avoid flakiness in the MCG test

### DIFF
--- a/ocs_ci/ocs/ui/mcg_ui.py
+++ b/ocs_ci/ocs/ui/mcg_ui.py
@@ -154,8 +154,11 @@ class BucketClassUI(PageNavigator):
     def set_multi_namespacestore_policy(self, nss_name_lst):
         for nss_name in nss_name_lst:
             self.do_send_keys(self.generic_locators["search_resource_field"], nss_name)
+            sleep(1)
             self.do_click(self.generic_locators["check_first_row_checkbox"])
+            sleep(1)
             self.do_click(self.generic_locators["remove_search_filter"])
+            sleep(2)
 
         self.do_click(self.bucketclass["nss_dropdown"])
         self.do_click_by_id(nss_name_lst[0])


### PR DESCRIPTION
Signed-off-by: am-agrawa <amagrawa@redhat.com>

This test was repeatedly failing, so after debugging a couple of times, it seems the code is perfectly fine but it's flaky because sometimes the clicks are too fast and console is unable to match the timing. So as a temp. fix, I added a few sleeps and ran the PR validation which passed.

For the long term, we would need to design a function to handle such scenarios as using sleep is not recommended in UI automation.