### PR TITLE
Split add capacity test on tier1 suite [ui] and acceptance test [cli]

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -956,7 +956,7 @@ def add_capacity(osd_size_capacity_requested, add_extra_disk_to_existing_worker=
     return new_storage_devices_sets_count
 
 
-def add_capacity_lso():
+def add_capacity_lso(ui_flag=False):
     """
     Add capacity on LSO cluster.
 
@@ -964,6 +964,8 @@ def add_capacity_lso():
     Because the UI backend check the pv and available state and base on it
     change the count param on StorageCluster.
 
+    Args:
+        ui_flag(bool): add capacity via ui [true] or via cli [false]
     """
     from ocs_ci.ocs.cluster import (
         is_flexible_scaling_enabled,
@@ -985,15 +987,9 @@ def add_capacity_lso():
         num_available_pv = 3
         set_count = deviceset_count + 1
     localstorage.check_pvs_created(num_pvs_required=num_available_pv)
-    if ui_add_capacity_conditions():
-        try:
-            osd_size = get_osd_size()
-            ui_add_capacity(osd_size)
-        except Exception as e:
-            log.error(
-                f"Add capacity via UI is not applicable and CLI method will be done. The error is {e}"
-            )
-            set_deviceset_count(set_count)
+    if ui_add_capacity_conditions() and ui_flag:
+        osd_size = get_osd_size()
+        ui_add_capacity(osd_size)
     else:
         set_deviceset_count(set_count)
 

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -19,7 +19,7 @@ class AddReplaceDeviceUI(PageNavigator):
 
     def add_capacity_ui(self):
         """
-        Add Capacity via UI.
+        Add Capacity via UI
 
         """
         self.add_capacity_ui = locators[self.ocp_version]["add_capacity"]

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -33,10 +33,6 @@ class AddReplaceDeviceUI(PageNavigator):
         self.do_click(self.add_capacity_ui["kebab_storage_cluster"])
         self.do_click(self.add_capacity_ui["add_capacity_button"])
         self.do_click(
-            self.add_capacity_ui["select_sc_add_capacity"], enable_screenshot=True
-        )
-        self.do_click(self.add_capacity_ui[self.storage_class], enable_screenshot=True)
-        self.do_click(
             self.add_capacity_ui["confirm_add_capacity"], enable_screenshot=True
         )
 

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from ocs_ci.ocs.ui.base_ui import PageNavigator
 from ocs_ci.ocs.ui.views import locators
@@ -31,6 +32,7 @@ class AddReplaceDeviceUI(PageNavigator):
             self.do_click(self.add_capacity_ui["ocs_operator"])
             self.do_click(self.add_capacity_ui["storage_cluster_tab"])
         self.do_click(self.add_capacity_ui["kebab_storage_cluster"])
+        time.sleep(4)
         self.take_screenshot()
         self.do_click(self.add_capacity_ui["add_capacity_button"])
         self.take_screenshot()

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -31,8 +31,8 @@ class AddReplaceDeviceUI(PageNavigator):
         else:
             self.do_click(self.add_capacity_ui["ocs_operator"])
             self.do_click(self.add_capacity_ui["storage_cluster_tab"])
+        time.sleep(3)
         self.do_click(self.add_capacity_ui["kebab_storage_cluster"])
-        time.sleep(4)
         self.take_screenshot()
         self.do_click(self.add_capacity_ui["add_capacity_button"])
         self.take_screenshot()

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -31,7 +31,9 @@ class AddReplaceDeviceUI(PageNavigator):
             self.do_click(self.add_capacity_ui["ocs_operator"])
             self.do_click(self.add_capacity_ui["storage_cluster_tab"])
         self.do_click(self.add_capacity_ui["kebab_storage_cluster"])
+        self.take_screenshot()
         self.do_click(self.add_capacity_ui["add_capacity_button"])
+        self.take_screenshot()
         self.do_click(
             self.add_capacity_ui["confirm_add_capacity"], enable_screenshot=True
         )

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -37,7 +37,6 @@ class AddReplaceDeviceUI(PageNavigator):
         self.do_click(
             self.add_capacity_ui["confirm_add_capacity"], enable_screenshot=True
         )
-        self.take_screenshot()
 
     def verify_pod_status(self, pod_names, pod_state="Running"):
         """

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from ocs_ci.ocs.ui.base_ui import PageNavigator
 from ocs_ci.ocs.ui.views import locators
@@ -31,8 +30,12 @@ class AddReplaceDeviceUI(PageNavigator):
         else:
             self.do_click(self.add_capacity_ui["ocs_operator"])
             self.do_click(self.add_capacity_ui["storage_cluster_tab"])
-        time.sleep(3)
         self.do_click(self.add_capacity_ui["kebab_storage_cluster"])
+        self.wait_until_expected_text_is_found(
+            locator=self.add_capacity_ui["add_capacity_button"],
+            timeout=10,
+            expected_text="Add Capacity",
+        )
         self.take_screenshot()
         self.do_click(self.add_capacity_ui["add_capacity_button"])
         self.take_screenshot()

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -37,6 +37,7 @@ class AddReplaceDeviceUI(PageNavigator):
         self.do_click(
             self.add_capacity_ui["confirm_add_capacity"], enable_screenshot=True
         )
+        self.take_screenshot()
 
     def verify_pod_status(self, pod_names, pod_state="Running"):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -20,6 +20,7 @@ login = {
     ),
     "skip_tour": (By.CSS_SELECTOR, 'button[data-test="tour-step-footer-secondary"]'),
 }
+
 login_4_11 = {
     "ocp_page": "Overview · Red Hat OpenShift",
     "login_page_title": "Log in · Red Hat OpenShift",
@@ -689,7 +690,6 @@ acm_ui_specific = {
     "acm_2_4": {"cc_create_cluster_endswith_url": "create-cluster"},
 }
 
-
 acm_configuration_4_11 = {
     "install-submariner-btn": ("install-submariner", By.ID),
     "nat-t-checkbox": ("natt-enable", By.ID),
@@ -738,9 +738,6 @@ add_capacity_4_11 = {
     "managed-csi_sc": ("managed-csi-link", By.ID),
     "standard_sc": ("standard-link", By.ID),
     "localblock_sc": ("localblock-link", By.ID),
-}
-add_capacity_4_12 = {
-    "standard_csi_sc": ("standard-csi-link", By.ID),
 }
 
 add_capacity_4_12 = {
@@ -1092,6 +1089,7 @@ validation_4_10 = {
         By.XPATH,
     ),
 }
+
 validation_4_11 = {
     "overview": ("//span[normalize-space()='Overview']", By.XPATH),
     "overview_odf_4_10": ("//a[@data-test-id='horizontal-link-Overview']", By.XPATH),
@@ -1171,7 +1169,7 @@ locators = {
             **acm_configuration,
             **acm_configuration_4_11,
         },
-        "add_capacity": {**add_capacity, **add_capacity_4_11, **add_capacity_4_12},
+        "add_capacity": {**add_capacity, **add_capacity_4_11},
         "obc": obc,
     },
     "4.10": {

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -730,6 +730,7 @@ add_capacity = {
 }
 
 add_capacity_4_11 = {
+    "confirm_add_capacity": ('button[data-test-id="confirm-action"]', By.CSS_SELECTOR),
     "thin_sc": ("thin-link", By.ID),
     "gp2_sc": ("gp2-link", By.ID),
     "gp2-csi_sc": ("gp2-csi-link", By.ID),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -730,7 +730,6 @@ add_capacity = {
 }
 
 add_capacity_4_11 = {
-    "confirm_add_capacity": ('button[data-test-id="confirm-action"]', By.CSS_SELECTOR),
     "thin_sc": ("thin-link", By.ID),
     "gp2_sc": ("gp2-link", By.ID),
     "gp2-csi_sc": ("gp2-csi-link", By.ID),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -725,7 +725,7 @@ add_capacity = {
     "standard_sc": ('a[id="standard-link"]', By.CSS_SELECTOR),
     "localblock_sc": ('a[id="localblock-link"]', By.CSS_SELECTOR),
     "managed-premium_sc": ('a[id="managed-premium-link"]', By.CSS_SELECTOR),
-    "confirm_add_capacity": ('button[data-test="confirm-action"', By.CSS_SELECTOR),
+    "confirm_add_capacity": ('button[data-test="confirm-action"]', By.CSS_SELECTOR),
     "filter_pods": ('input[data-test-id="item-filter"]', By.CSS_SELECTOR),
 }
 
@@ -741,6 +741,7 @@ add_capacity_4_11 = {
 
 add_capacity_4_12 = {
     "add_capacity_button": ("//span[text()='Add Capacity']", By.XPATH),
+    "confirm_add_capacity": ('button[data-test-id="confirm-action"]', By.CSS_SELECTOR),
 }
 
 block_pool = {


### PR DESCRIPTION
We are using `try exception`  method for add capacity test.
 https://github.com/red-hat-storage/ocs-ci/blob/master/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py#L45-L51

When the add capacity process fails via UI, we perform the process via CLI.
In this situtaion, we cant catche bugs like this  https://bugzilla.redhat.com/show_bug.cgi?id=2137616 [there is an option to check the screenshots]


The developers change the locators frequtly, so the test fails even though there is no real bug. 

So I think the method is to split add capacity test to acceptance [cli] and tier1 [ui] 

Signed-off-by: OdedViner <oviner@redhat.com>