### PR TITLE
Add FORCE_OSD_REMOVAL for ocs>=4.6 at run_osd_removal_job

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1034,6 +1034,7 @@ def delete_and_create_osd_node_vsphere_upi_lso(osd_node_name, use_existing_node=
     )
 
     osd_id = osd_ids[0]
+    assert osd_id, "osd ids not found"
     log.info(f"osd ids to remove = {osd_ids}")
     # Save the node hostname before deleting the node
     osd_node_hostname_label = get_node_hostname_label(osd_node)

--- a/ocs_ci/ocs/osd_operations.py
+++ b/ocs_ci/ocs/osd_operations.py
@@ -120,6 +120,7 @@ def osd_device_replacement(nodes):
         osd_pod.ocp.wait_for_delete(resource_name=osd_pod_name)
 
     # Run ocs-osd-removal job
+    assert osd_id, "No osd found to remove"
     osd_removal_job = run_osd_removal_job([osd_id])
     assert osd_removal_job, "ocs-osd-removal failed to create"
     is_completed = verify_osd_removal_job_completed_successfully(osd_id)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
         "apache-libcloud==3.1.0",
         "cryptography==38.0.1",
         "docopt==0.6.2",
-        "gevent==20.9.0",
+        # https://pypi.org/project/gevent/ the latest version resolves problem for Mac M1 chips
+        # This issue is caused by a program attempting to load an x86_64-only library from a native arm64 process.
+        # More https://stackoverflow.com/questions/71443345/gevent-cant-be-installed-on-m1-mac-using-poetry
+        "gevent==21.12.0",
         "reportportal-client==3.2.3",
         "requests==2.23.0",
         "paramiko==2.11.0",
@@ -68,7 +71,10 @@ setup(
         "webdriver-manager==3.2.2",
         # greenlet 1.0.0 is broken on ppc64le
         # https://github.com/python-greenlet/greenlet/issues/230
-        "greenlet<1.0.0",
+        # by default program attempting to load an x86_64-only library from a native arm64 process
+        # Beginning with gevent 20.12.0, 64-bit ARM binaries are distributed on PyPI for aarch64 manylinux2014
+        # compatible systems. Resolves problem for m1 Mac chips
+        "greenlet==1.1.2",
         "ovirt-engine-sdk-python==4.4.11",
         "junitparser",
         "flaky==3.7.0",


### PR DESCRIPTION
Fix for 6662: adding FORCE_OSD_REMOVAL set to true from the OCS 4.6 version in case the ceph osd safe-to-destroy command is not OK

Update modules gevent and greenlet at setup.py to make initial setup work on computers with M1 chip
