### PR TITLE
VM's start/stop using FQDN

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -491,6 +491,20 @@ class VMWareNodes(NodesBase):
             for vm in vms:
                 self.vsphere.wait_for_vm_delete(vm)
 
+    def get_vm_from_ips(self, node_ips, dc):
+        """
+        Fetches VM objects from given IP's
+
+        Args:
+            node_ips (list): List of node IP's
+            dc (str): Datacenter name
+
+        Returns:
+            list: List of VM objects
+
+        """
+        return [self.vsphere.get_vm_by_ip(ip, dc) for ip in node_ips]
+
 
 class AWSNodes(NodesBase):
     """

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -9,6 +9,7 @@ import random
 import re
 import shlex
 import smtplib
+import socket
 import string
 import subprocess
 import time
@@ -3983,3 +3984,17 @@ def wipe_all_disk_partitions_for_node(node):
             if disk_to_wipe != root_disk:
                 disk_path = f"/dev/{disk_to_wipe}"
                 wipe_partition(node, disk_path)
+
+
+def convert_hostnames_to_ips(hostnames):
+    """
+    Gets the IP's from hostname with FQDN
+
+    Args:
+        hostnames (list): List of host names with FQDN
+
+    Returns:
+        list: Host IP's
+
+    """
+    return [socket.gethostbyname(host) for host in hostnames]


### PR DESCRIPTION
How to use start and stop VM's using FQDN
```
node_ips = convert_hostnames_to_ips(node_names)
vms = self.get_vm_from_ips(node_ips, dc)
self.vsphere.stop_vms(vms)
self.vsphere.start_vms(vms)
```


Signed-off-by: vavuthu <vavuthu@redhat.com>