### PR TITLE
Wait more time for the nodes recovery in the test "test_rolling_nodes_restart" for MS

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -262,13 +262,42 @@ class SanityManagedService(Sanity):
             f"The consumer indexes for creating resources are: {self.consumer_indexes}"
         )
 
-    def create_resources_on_ms_consumers(self):
+    def create_resources_on_ms_consumers(self, tries=1, delay=30):
+        """
+        Try creates resources for MS consumers 'tries' times with delay 'delay' between the iterations
+        using the method 'base_create_resources_on_ms_consumers'. If not specified, the default value of
+        'tries' is 1 - which means that by default, it only tries to create the resources once.
+        In every iteration, if it fails to generate the resources, it cleans up the current resources
+        before continuing to the next iteration.
+
+        Args:
+            tries (int): The number of tries to create the resources on MS consumers
+            delay (int): The delay in seconds between retries
+
+        Raises:
+            ocs_ci.ocs.exceptions.CommandFailed: In case of a command failed
+
+        """
+        retry(
+            (FileNotFoundError, CommandFailed),
+            tries=tries,
+            delay=delay,
+            backoff=1,
+        )(self.base_create_resources_on_ms_consumers)()
+
+    def base_create_resources_on_ms_consumers(self):
         """
         Create resources on MS consumers.
         This function uses the factory "create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers"
         for creating the resources - Create scale pods, PVCs, and run IO using a Kube job on MS consumers.
+        If it fails to create the resources, it cleans up the current resources.
+
+        Raises:
+            ocs_ci.ocs.exceptions.CommandFailed: In case of a command failed
+
         """
         orig_index = config.cur_index
+        is_success = False
 
         try:
             # Create the scale pods and PVCs using k8s on MS consumers factory
@@ -283,9 +312,16 @@ class SanityManagedService(Sanity):
                     consumer_indexes=self.consumer_indexes,
                 )
             )
+            is_success = True
+            logger.info("Successfully create the resources on MS consumers")
         finally:
             # Switch back to the original index
             config.switch_ctx(orig_index)
+            if not is_success:
+                logger.info(
+                    "Failed to create the resources on MS consumers. Deleting the leftovers..."
+                )
+                self.delete_resources_on_ms_consumers()
 
     def delete_resources_on_ms_consumers(self):
         """
@@ -332,47 +368,3 @@ class SanityManagedService(Sanity):
 
         finally:
             config.switch_ctx(orig_index)
-
-    def retry_create_resources_on_ms_consumers(self, tries=3, delay=60):
-        """
-        Retry creates resources for MS consumers multiple times until it succeeds.
-        In every iteration, if it fails to create the resources, it cleans up the current resources
-        before continuing to the next iteration.
-
-        Args:
-            tries (int): The number of tries to create the resources on MS consumers
-            delay (int): The delay in seconds between retries
-
-        Raises:
-            FileNotFoundError, ocs_ci.ocs.exceptions.CommandFailed: In case of file not found,
-                or in case of a command failed after the number of the given tries
-
-        """
-        retry(
-            (FileNotFoundError, CommandFailed),
-            tries=tries,
-            delay=delay,
-            backoff=1,
-        )(self.base_retry_create_resources_on_ms_consumers)()
-
-    def base_retry_create_resources_on_ms_consumers(self):
-        """
-        Try to create resources on MS consumers. If it fails to create the resources,
-        it cleans up the current resources.
-
-        Raises:
-            FileNotFoundError, ocs_ci.ocs.exceptions.CommandFailed: In case of file not found,
-                or in case of a command failed
-
-        """
-        is_success = False
-        try:
-            self.create_resources_on_ms_consumers()
-            is_success = True
-            logger.info("Successfully create the resources on MS consumers")
-        finally:
-            if not is_success:
-                logger.info(
-                    "Failed to create the resources on MS consumers. Deleting the leftovers..."
-                )
-                self.delete_resources_on_ms_consumers()

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -184,7 +184,18 @@ class TestNodesRestartMS(ManageTest):
         ocp_nodes = get_nodes(node_type=node_type)
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
+            wait_for_node_count_to_reach_status(
+                node_count=len(ocp_nodes), node_type=node_type
+            )
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
+
+        if is_ms_consumer_cluster():
+            logger.info(
+                "Verify that the nodes are ready before start creating resources"
+            )
+            wait_for_node_count_to_reach_status(
+                node_count=len(ocp_nodes), node_type=node_type
+            )
 
         self.create_resources()
 

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -174,7 +174,7 @@ class TestNodesRestartMS(ManageTest):
             wait_for_node_count_to_reach_status(
                 node_count=len(ocp_nodes), node_type=node_type
             )
-            self.sanity_helpers.health_check(cluster_check=False, tries=60)
+            ceph_health_check(tries=40)
 
         if is_ms_consumer_cluster():
             # When we use the MS consumer cluster, we sometimes need to wait a little more time after

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -95,7 +95,7 @@ class TestNodesRestartMS(ManageTest):
             )
             config.switch_to_provider()
 
-        self.sanity_helpers.delete_resources_on_ms_consumers()
+        self.sanity_helpers.create_resources_on_ms_consumers()
 
         osd_node_name = random.choice(get_osd_running_nodes())
         osd_node = get_node_objs([osd_node_name])[0]
@@ -179,9 +179,10 @@ class TestNodesRestartMS(ManageTest):
         if is_ms_consumer_cluster():
             # When we use the MS consumer cluster, we sometimes need to wait a little more time after
             # restarting the nodes before start creating resources
-            self.sanity_helpers.retry_create_resources_on_ms_consumers()
+            tries = 3
         else:
-            self.sanity_helpers.create_resources()
+            tries = 1
+        self.sanity_helpers.create_resources_on_ms_consumers(tries=tries)
 
     @tier4a
     @polarion_id("OCS-4482")

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -27,7 +27,7 @@ from ocs_ci.ocs.node import (
     schedule_nodes,
 )
 from ocs_ci.ocs.resources import pod
-from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.helpers.sanity_helpers import SanityManagedService
 from ocs_ci.ocs.cluster import (
     ceph_health_check,
     is_ms_consumer_cluster,
@@ -55,22 +55,9 @@ class TestNodesRestartMS(ManageTest):
 
         """
         self.orig_index = config.cur_index
-        self.sanity_helpers = Sanity()
-        self.create_pods_and_pvcs_factory = (
+        self.sanity_helpers = SanityManagedService(
             create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
         )
-
-    def create_resources(self):
-        """
-        Create resources on the consumers and run IO
-
-        """
-        if is_ms_consumer_cluster():
-            consumer_indexes = [config.cur_index]
-        else:
-            consumer_indexes = config.get_consumer_indexes_list()
-
-        self.create_pods_and_pvcs_factory(consumer_indexes=consumer_indexes)
 
     @pytest.fixture(autouse=True)
     def teardown(self, request, nodes):
@@ -108,7 +95,7 @@ class TestNodesRestartMS(ManageTest):
             )
             config.switch_to_provider()
 
-        self.create_resources()
+        self.sanity_helpers.delete_resources_on_ms_consumers()
 
         osd_node_name = random.choice(get_osd_running_nodes())
         osd_node = get_node_objs([osd_node_name])[0]
@@ -164,7 +151,7 @@ class TestNodesRestartMS(ManageTest):
         nodes.restart_nodes(nodes=ocp_nodes, wait=False)
         wait_for_node_count_to_reach_status(node_count=node_count, node_type=node_type)
         self.sanity_helpers.health_check()
-        self.create_resources()
+        self.sanity_helpers.create_resources_on_ms_consumers()
 
     @tier4b
     @bugzilla("1754287")
@@ -190,14 +177,11 @@ class TestNodesRestartMS(ManageTest):
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
 
         if is_ms_consumer_cluster():
-            logger.info(
-                "Verify that the nodes are ready before start creating resources"
-            )
-            wait_for_node_count_to_reach_status(
-                node_count=len(ocp_nodes), node_type=node_type
-            )
-
-        self.create_resources()
+            # When we use the MS consumer cluster, we sometimes need to wait a little more time after
+            # restarting the nodes before start creating resources
+            self.sanity_helpers.retry_create_resources_on_ms_consumers()
+        else:
+            self.sanity_helpers.create_resources()
 
     @tier4a
     @polarion_id("OCS-4482")
@@ -221,7 +205,7 @@ class TestNodesRestartMS(ManageTest):
             )
             config.switch_to_provider()
 
-        self.create_resources()
+        self.sanity_helpers.create_resources_on_ms_consumers()
 
         # Get 1 worker node
         typed_nodes = get_nodes(node_type=constants.WORKER_MACHINE, num_of_nodes=1)
@@ -241,7 +225,7 @@ class TestNodesRestartMS(ManageTest):
         drain_nodes([typed_node_name])
 
         # Create PVCs and pods
-        self.create_resources()
+        self.sanity_helpers.create_resources_on_ms_consumers()
 
         # Restart the node
         nodes.restart_nodes(nodes=typed_nodes, wait=False)
@@ -309,4 +293,4 @@ class TestNodesRestartMS(ManageTest):
             ), f"Status of cephcluster {cephcluster_yaml['metadata']['name']} is {cephcluster_yaml['status']['phase']}"
 
         # Create PVCs and pods
-        self.create_resources()
+        self.sanity_helpers.create_resources_on_ms_consumers()


### PR DESCRIPTION
In the test "test_rolling_nodes_restart" for MS, wait more time for the nodes recovery before checking cluster health and before creating resources. See more details in the issue https://issues.redhat.com/browse/ODFMS-324.