### PR TITLE
Create a new function to check if the rados connect error is in the exception

### DIFF
--- a/ocs_ci/ocs/managedservice.py
+++ b/ocs_ci/ocs/managedservice.py
@@ -132,7 +132,7 @@ def patch_consumer_toolbox(ceph_admin_key=None):
         consumer_tools_pod.exec_ceph_cmd("ceph health")
         return
     except Exception as exc:
-        if "RADOS permission error" not in str(exc):
+        if not is_rados_connect_error_in_ex(exc):
             logger.warning(
                 f"Ceph command on rook-ceph-tools deployment is failing with error {str(exc)}. "
                 "This error cannot be fixed by patching the rook-ceph-tools deployment with ceph admin key."
@@ -345,3 +345,18 @@ def get_managedocs_component_state(component):
         namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
     )
     return managedocs_obj.get()["status"]["components"][component]["state"]
+
+
+def is_rados_connect_error_in_ex(ex):
+    """
+    Check if the RADOS connect error is found in the exception
+
+    Args:
+        ex (Exception): The exception to check if the RADOS connect error is found
+
+    Returns:
+        bool: True, if the RADOS connect error is found in the exception. False otherwise
+
+    """
+    rados_errors = ("RADOS permission error", "RADOS I/O error")
+    return any([rados_error in str(ex) for rados_error in rados_errors])

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2072,7 +2072,10 @@ def ceph_health_check_base(namespace=None):
     """
     # Import here to avoid circular loop
     from ocs_ci.ocs.cluster import is_ms_consumer_cluster
-    from ocs_ci.ocs.managedservice import patch_consumer_toolbox
+    from ocs_ci.ocs.managedservice import (
+        patch_consumer_toolbox,
+        is_rados_connect_error_in_ex,
+    )
 
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     run_cmd(
@@ -2085,7 +2088,7 @@ def ceph_health_check_base(namespace=None):
     try:
         health = run_cmd(ceph_health_cmd)
     except CommandFailed as ex:
-        if "RADOS permission error" in str(ex) and is_ms_consumer_cluster():
+        if is_rados_connect_error_in_ex(ex) and is_ms_consumer_cluster():
             log.info("Patch the consumer rook-ceph-tools deployment")
             patch_consumer_toolbox()
             # get the new tool box pod since patching creates the new tool box pod


### PR DESCRIPTION
Currently, we patch the consumer rook-ceph-tool deployment when we get the RADOS error "RADOS permission error". Recently, when running a test, I saw that there is another optional error, "RADOS I/O error" that can occur. So we need to create a new function to check all the RADOS connect errors in the exception.