### PR TITLE
Fixed cal_md5sum function for bucket replacation testing on IBMZ build

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1004,7 +1004,7 @@ def cal_md5sum(pod_obj, file_name, block=False, raw_path=False):
     else:
         file_path = file_name
     md5sum_cmd_out = pod_obj.exec_cmd_on_pod(
-        command=f'bash -c "md5sum {file_path}"', out_yaml_format=False
+        command=f'sh -c "md5sum {file_path}"', out_yaml_format=False
     )
     md5sum = md5sum_cmd_out.split()[0]
     logger.info(f"md5sum of file {file_name}: {md5sum}")


### PR DESCRIPTION
Changed 'bash' to 'sh' so bucket rep testing wont fail on s390x build,
regarding [issue5463](https://github.com/red-hat-storage/ocs-ci/issues/5463)
Signed-off-by: hmeir <hmeir@redhat.com>