### PR TITLE
ocs-osd-removal update job with review fixes

### DIFF
--- a/ocs_ci/ocs/osd_operations.py
+++ b/ocs_ci/ocs/osd_operations.py
@@ -1,10 +1,8 @@
 import random
 import logging
 
-from semantic_version import Version
-
 from ocs_ci.framework import config
-from ocs_ci.utility.utils import get_ocp_version
+from ocs_ci.utility import version
 from ocs_ci.ocs.resources.job import get_job_obj
 from ocs_ci.ocs.resources.pvc import get_deviceset_pvs, get_deviceset_pvcs
 from ocs_ci.ocs import constants, node, ocp
@@ -67,12 +65,13 @@ def osd_device_replacement(nodes):
     ][0]
     logger.info(f"OSD_POD {osd_pod.name}")
     osd_id = get_osd_pod_id(osd_pod)
-
+    if not osd_id:
+        raise ValueError("No osd found to remove")
     # Get the node that has the OSD pod running on
     logger.info(f"Getting the node that has the OSD pod {osd_pod.name} running on")
     osd_node = get_pod_node(osd_pod)
-    ocp_version = get_ocp_version()
-    if Version.coerce(ocp_version) < Version.coerce("4.6"):
+    ocp_version = version.get_semantic_ocp_version_from_config()
+    if ocp_version < version.VERSION_4_6:
         osd_prepare_pods = get_osd_prepare_pods()
         osd_prepare_pod = [
             pod
@@ -128,7 +127,7 @@ def osd_device_replacement(nodes):
 
     osd_pvc_name = osd_pvc.name
 
-    if Version.coerce(ocp_version) < Version.coerce("4.6"):
+    if ocp_version < version.VERSION_4_6:
         # Delete the OSD prepare job
         logger.info(f"Deleting OSD prepare job {osd_prepare_job_name}")
         osd_prepare_job.delete()
@@ -174,7 +173,7 @@ def osd_device_replacement(nodes):
     if cluster.is_lso_cluster():
         node.add_disk_to_node(osd_node)
 
-    if Version.coerce(ocp_version) < Version.coerce("4.6"):
+    if ocp_version < version.VERSION_4_6:
         # Delete the rook ceph operator pod to trigger reconciliation
         rook_operator_pod = get_operator_pods()[0]
         logger.info(f"deleting Rook Ceph operator pod {rook_operator_pod.name}")
@@ -214,7 +213,7 @@ def osd_device_replacement(nodes):
 
     # We need to silence the old osd crash warning due to BZ https://bugzilla.redhat.com/show_bug.cgi?id=1896810
     # This is a workaround - issue for tracking: https://github.com/red-hat-storage/ocs-ci/issues/3438
-    if Version.coerce(ocp_version) >= Version.coerce("4.6"):
+    if ocp_version >= version.VERSION_4_6:
         silence_osd_crash = cluster.wait_for_silence_ceph_osd_crash_warning(
             osd_pod_name
         )

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -33,12 +33,11 @@ from ocs_ci.ocs.exceptions import (
 from ocs_ci.ocs.utils import setup_ceph_toolbox, get_pod_name_by_pattern
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.resources.job import get_job_obj, get_jobs_with_prefix
-from ocs_ci.utility import templating
+from ocs_ci.utility import templating, version
 from ocs_ci.utility.utils import (
     run_cmd,
     check_timeout_reached,
     TimeoutSampler,
-    get_ocp_version,
 )
 from ocs_ci.utility.utils import check_if_executable_in_path
 from ocs_ci.utility.retry import retry
@@ -2116,6 +2115,7 @@ def get_osd_removal_pod_name(osd_id, timeout=60):
         "4.9": "ocs-osd-removal-job",
         "4.10": "ocs-osd-removal-job",
         "4.11": "ocs-osd-removal-job",
+        "4.12": "ocs-osd-removal-job",
     }
 
     ocs_version = config.ENV_DATA["ocs_version"]
@@ -2184,21 +2184,29 @@ def run_osd_removal_job(osd_ids=None):
 
     """
     osd_ids_str = ",".join(map(str, osd_ids))
-    ocp_version = get_ocp_version()
-    ocs_version = config.ENV_DATA["ocs_version"]
+    ocp_version = version.get_semantic_ocp_version_from_config()
+    ocs_version = version.get_semantic_ocs_version_from_config()
 
-    if Version.coerce(ocs_version) >= Version.coerce(
-        "4.10"
-    ) and not check_safe_to_destroy_status(osd_ids_str):
-        cmd = f"process ocs-osd-removal -p FORCE_OSD_REMOVAL=true -p FAILED_OSD_IDS={osd_ids_str} -o yaml"
-    elif Version.coerce(ocp_version) >= Version.coerce("4.6"):
-        cmd = f"process ocs-osd-removal -p FAILED_OSD_IDS={osd_ids_str} -o yaml"
+    # Fixes: #6662
+    # Version OCS 4.6 and above requires FORCE_OSD_REMOVAL set to true in order to not get stuck
+    cmd_params = (
+        "-p FORCE_OSD_REMOVAL=true"
+        if ocs_version >= version.VERSION_4_6
+        and not check_safe_to_destroy_status(osd_ids_str)
+        else ""
+    )
+
+    # Parameter name FAILED_OSD_ID changed to FAILED_OSD_IDS for Version OCP 4.6 and above
+    if ocp_version >= version.VERSION_4_6:
+        cmd_params += f" -p FAILED_OSD_IDS={osd_ids_str}"
     else:
-        cmd = f"process ocs-osd-removal -p FAILED_OSD_ID={osd_ids_str} -o yaml"
+        cmd_params += f" -p FAILED_OSD_ID={osd_ids_str}"
 
     logger.info(f"Executing OSD removal job on OSD ids: {osd_ids_str}")
     ocp_obj = ocp.OCP(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
-    osd_removal_job_yaml = ocp_obj.exec_oc_cmd(cmd)
+    osd_removal_job_yaml = ocp_obj.exec_oc_cmd(
+        f"process ocs-osd-removal {cmd_params} -o yaml"
+    )
     # Add the namespace param, so that the ocs-osd-removal job will be created in the correct namespace
     osd_removal_job_yaml["metadata"]["namespace"] = defaults.ROOK_CLUSTER_NAMESPACE
     osd_removal_job = OCS(**osd_removal_job_yaml)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1757,6 +1757,9 @@ def get_csi_versions():
 
 def get_ocp_version(seperator=None):
     """
+    *The deprecated form of 'get current ocp version'*
+    Use ocs_ci/utility/version.py:get_semantic_ocp_version_from_config()
+
     Get current ocp version
 
     Args:


### PR DESCRIPTION
Fixes: #6662
Add FORCE_OSD_REMOVAL set to true from the OCS 4.6 version in case the ceph osd safe-to-destroy command is not OK
Add v4.12 to ocs_version_pattern_dict