### PR TITLE
Verify that the OSD pods are running on the correct nodes after OSD disruption in tests

### DIFF
--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -233,3 +233,24 @@ def verify_osd_used_capacity_greater_than_expected(expected_used_capacity):
             )
             return True
     return False
+
+
+def verify_osds_are_on_correct_machinepool():
+    """
+    Verify that the OSD pods are running on nodes which are part of the correct machinepool.
+    Applicable for Managed Services.
+
+    """
+    osd_nodes = get_osd_running_nodes()
+    osd_node_objs = get_node_objs(osd_nodes)
+    for node_obj in osd_node_objs:
+        annotation = (
+            node_obj.get()
+            .get("metadata")
+            .get("annotations")
+            .get("machine.openshift.io/machine")
+        )
+        assert (
+            "ceph-osd-nodepool" in annotation
+        ), f"OSD running node {node_obj.name} is not part of the machinepool {constants.OSD_NODE_POOL}"
+    log.info(f"OSD running nodes are part of the machinepool {constants.OSD_NODE_POOL}")

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -251,6 +251,6 @@ def verify_osds_are_on_correct_machinepool():
             .get("machine.openshift.io/machine")
         )
         assert (
-            "ceph-osd-nodepool" in annotation
+            constants.OSD_NODE_POOL in annotation
         ), f"OSD running node {node_obj.name} is not part of the machinepool {constants.OSD_NODE_POOL}"
     log.info(f"OSD running nodes are part of the machinepool {constants.OSD_NODE_POOL}")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -197,6 +197,7 @@ MOUNT_POINT = "/var/lib/www/html"
 TOLERATION_KEY = "node.ocs.openshift.io/storage"
 CLUSTERLOGGING_SUBSCRIPTION = "cluster-logging"
 ELASTICSEARCH_SUBSCRIPTION = "elasticsearch-operator"
+OSD_NODE_POOL = "ceph-osd-nodepool"
 
 OCP_QE_MISC_REPO = "https://gitlab.cee.redhat.com/aosqe/flexy-templates.git"
 CRITICAL_ERRORS = ["core dumped", "oom_reaper"]

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     ignore_leftover_label,
 )
+from ocs_ci.helpers.managed_services import verify_osds_are_on_correct_machinepool
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods,
@@ -370,6 +371,14 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
             f"{initial_pods_num}. Total number of pods present now: "
             f"{final_pods_num}"
         )
+
+        # If platform is MS and resource_to_delete is osd, verify that the OSD pods are running on nodes which are
+        # part of the correct machinepool.
+        if (
+            config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
+            and resource_to_delete == "osd"
+        ):
+            verify_osds_are_on_correct_machinepool()
 
         if switch_to_provider_needed:
             # Switch back to consumer cluster context

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.helpers.managed_services import verify_osds_are_on_correct_machinepool
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import is_managed_service_cluster
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods,
     get_mon_pods,
@@ -374,10 +375,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
 
         # If platform is MS and resource_to_delete is osd, verify that the OSD pods are running on nodes which are
         # part of the correct machinepool.
-        if (
-            config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
-            and resource_to_delete == "osd"
-        ):
+        if is_managed_service_cluster() and resource_to_delete == "osd":
             verify_osds_are_on_correct_machinepool()
 
         if switch_to_provider_needed:

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftover_label,
 )
 from ocs_ci.framework import config
+from ocs_ci.helpers.managed_services import verify_osds_are_on_correct_machinepool
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
 from ocs_ci.ocs.resources.pod import (
@@ -528,6 +529,14 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
             f"{num_of_resource_to_delete}. Total number of pods present now: "
             f"{final_num_resource_to_delete}"
         )
+
+        # If platform is MS and resource_to_delete is osd, verify that the OSD pods are running on nodes which are
+        # part of the correct machinepool.
+        if (
+            config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
+            and resource_to_delete == "osd"
+        ):
+            verify_osds_are_on_correct_machinepool()
 
         if switch_to_provider_needed:
             # Switch back to consumer cluster context

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.framework import config
 from ocs_ci.helpers.managed_services import verify_osds_are_on_correct_machinepool
 from ocs_ci.ocs import constants, node
+from ocs_ci.ocs.cluster import is_managed_service_cluster
 from ocs_ci.ocs.resources.pvc import get_all_pvcs, delete_pvcs
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods,
@@ -532,10 +533,7 @@ class TestResourceDeletionDuringMultipleDeleteOperations(ManageTest):
 
         # If platform is MS and resource_to_delete is osd, verify that the OSD pods are running on nodes which are
         # part of the correct machinepool.
-        if (
-            config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS
-            and resource_to_delete == "osd"
-        ):
+        if is_managed_service_cluster() and resource_to_delete == "osd":
             verify_osds_are_on_correct_machinepool()
 
         if switch_to_provider_needed:


### PR DESCRIPTION
In the test cases given below, verify that the OSD pods are running on nodes which are part of the correct machinepool.
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py

Created a function to verify that the OSD pods are running on nodes which are part of the correct machinepool.

Signed-off-by: Jilju Joy <jijoy@redhat.com>