### PR TITLE
Skip the test 'test_all_worker_nodes_short_network_failure' when we use Managed Service

### DIFF
--- a/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_i3,
     skipif_vsphere_ipi,
     skipif_ibm_power,
+    skipif_managed_service,
     bugzilla,
 )
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier4b
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 @skipif_aws_i3
 @skipif_vsphere_ipi
 @skipif_ibm_power
+@skipif_managed_service
 @ignore_leftovers
 @bugzilla("2029690")
 class TestWorkerNodesFailure(ManageTest):


### PR DESCRIPTION
Currently, we need to skip the test "test_all_worker_nodes_short_network_failure" is not applicable for MS, as it is not applicable for the Managed Service and can cause errors in the tier4b runs.

When we have more capacity, we should adjust the test to run on Managed Service.
Issue for tracking: https://issues.redhat.com/browse/ODFMS-363.
