### PR TITLE
Update pre-commit-config with new repository of flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.7.9
   hooks:
     - id: flake8


### PR DESCRIPTION
Fixes: #6678
Flake8 migrated from https://gitlab.com/pycqa/flake8 to https://github.com/pycqa/flake8 
