### PR TITLE
Backlog automation for bz-2096414

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -30,6 +30,7 @@ from ocs_ci.ocs.exceptions import (
     NotSupportedProxyConfiguration,
     TimeoutExpiredError,
     PageNotLoaded,
+    CephHealthException,
 )
 from ocs_ci.ocs.ui.views import OCS_OPERATOR, ODF_OPERATOR
 from ocs_ci.ocs.ocp import get_ocp_url
@@ -383,6 +384,7 @@ class PageNavigator(BaseUI):
         self.ocp_version = get_ocp_version()
         self.ocp_version_full = version.get_semantic_ocp_version_from_config()
         self.page_nav = locators[self.ocp_version]["page"]
+        self.validation_loc = locators[self.ocp_version]["validation"]
         self.ocs_version_semantic = version.get_semantic_ocs_version_from_config()
         self.ocp_version_semantic = version.get_semantic_ocp_version_from_config()
         self.running_ocp_semantic_version = version.get_semantic_ocp_running_version()
@@ -673,6 +675,82 @@ class PageNavigator(BaseUI):
         logger.info("Navigate to block pools page")
         self.navigate_to_ocs_operator_page()
         self.do_click(locator=self.page_nav["block_pool_link"])
+
+    def navigate_cephblockpool(self):
+        """
+        Initial page OCP Home page
+        Navigate to StorageSystem details / ocs-storagecluster-cephblockpool
+
+        """
+        self.navigate_odf_storagesystems()
+        self.navigate_storagecluster_storagesystem()
+        self.navigate_cephblockpool_verify_statusready()
+
+    def navigate_odf_storagesystems(self):
+        """
+        Initial page OCP Home page
+        Navigate to Storage Systems tab
+
+        """
+        self.navigate_odf_overview_page()
+        logger.info("Click on 'Storage Systems' tab")
+        self.do_click(self.validation_loc["storage_systems"], enable_screenshot=True)
+        self.page_has_loaded(retries=15, sleep_time=2)
+
+    def navigate_storagecluster_storagesystem(self):
+        """
+        Initial page - Data Foundation / Storage Systems tab
+        Navigate to StorageSystem details
+
+        """
+        if not config.DEPLOYMENT.get("external_mode"):
+            logger.info(
+                "Click on 'ocs-storagecluster-storagesystem' link from Storage Systems page"
+            )
+            self.do_click(
+                self.validation_loc["ocs-storagecluster-storagesystem"],
+                enable_screenshot=True,
+            )
+        else:
+            logger.info(
+                "Click on 'ocs-external-storagecluster-storagesystem' link "
+                "from Storage Systems page for External Mode Deployment"
+            )
+            self.do_click(
+                self.validation_loc["ocs-external-storagecluster-storagesystem"],
+                enable_screenshot=True,
+            )
+
+    def navigate_cephblockpool_verify_statusready(self):
+        """
+        Initial page - Data Foundation / Storage Systems tab / StorageSystem details
+        Navigate to ocs-storagecluster-cephblockpool
+        Verify cephblockpool status is 'Ready'
+
+        Raises:
+            CephHealthException if cephblockpool_status != 'Ready'
+        """
+        logger.info("Click on 'BlockPools' tab")
+        if (
+            self.ocp_version_semantic == version.VERSION_4_11
+            and self.ocs_version_semantic == version.VERSION_4_10
+        ):
+            self.do_click(
+                self.validation_loc["blockpools-odf-4-10"],
+                enable_screenshot=True,
+            )
+        else:
+            self.do_click(self.validation_loc["blockpools"], enable_screenshot=True)
+        self.page_has_loaded(retries=15, sleep_time=2)
+        logger.info(f"Verifying the status of '{constants.DEFAULT_CEPHBLOCKPOOL}'")
+        cephblockpool_status = self.get_element_text(
+            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}-status"]
+        )
+        if not "Ready" == cephblockpool_status:
+            raise CephHealthException(
+                f"cephblockpool status error | expected status:Ready \n "
+                f"actual status:{cephblockpool_status}"
+            )
 
     def wait_for_namespace_selection(self, project_name):
         """

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -384,7 +384,6 @@ class PageNavigator(BaseUI):
         self.ocp_version = get_ocp_version()
         self.ocp_version_full = version.get_semantic_ocp_version_from_config()
         self.page_nav = locators[self.ocp_version]["page"]
-        self.validation_loc = locators[self.ocp_version]["validation"]
         self.ocs_version_semantic = version.get_semantic_ocs_version_from_config()
         self.ocp_version_semantic = version.get_semantic_ocp_version_from_config()
         self.running_ocp_semantic_version = version.get_semantic_ocp_running_version()
@@ -764,6 +763,7 @@ class StorageSystemNavigator(PageNavigator):
 
     def __init__(self, driver):
         super().__init__(driver)
+        self.validation_loc = locators[self.ocp_version]["validation"]
 
     def navigate_cephblockpool(self):
         """

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -676,82 +676,6 @@ class PageNavigator(BaseUI):
         self.navigate_to_ocs_operator_page()
         self.do_click(locator=self.page_nav["block_pool_link"])
 
-    def navigate_cephblockpool(self):
-        """
-        Initial page OCP Home page
-        Navigate to StorageSystem details / ocs-storagecluster-cephblockpool
-
-        """
-        self.navigate_odf_storagesystems()
-        self.navigate_storagecluster_storagesystem()
-        self.navigate_cephblockpool_verify_statusready()
-
-    def navigate_odf_storagesystems(self):
-        """
-        Initial page OCP Home page
-        Navigate to Storage Systems tab
-
-        """
-        self.navigate_odf_overview_page()
-        logger.info("Click on 'Storage Systems' tab")
-        self.do_click(self.validation_loc["storage_systems"], enable_screenshot=True)
-        self.page_has_loaded(retries=15, sleep_time=2)
-
-    def navigate_storagecluster_storagesystem(self):
-        """
-        Initial page - Data Foundation / Storage Systems tab
-        Navigate to StorageSystem details
-
-        """
-        if not config.DEPLOYMENT.get("external_mode"):
-            logger.info(
-                "Click on 'ocs-storagecluster-storagesystem' link from Storage Systems page"
-            )
-            self.do_click(
-                self.validation_loc["ocs-storagecluster-storagesystem"],
-                enable_screenshot=True,
-            )
-        else:
-            logger.info(
-                "Click on 'ocs-external-storagecluster-storagesystem' link "
-                "from Storage Systems page for External Mode Deployment"
-            )
-            self.do_click(
-                self.validation_loc["ocs-external-storagecluster-storagesystem"],
-                enable_screenshot=True,
-            )
-
-    def navigate_cephblockpool_verify_statusready(self):
-        """
-        Initial page - Data Foundation / Storage Systems tab / StorageSystem details
-        Navigate to ocs-storagecluster-cephblockpool
-        Verify cephblockpool status is 'Ready'
-
-        Raises:
-            CephHealthException if cephblockpool_status != 'Ready'
-        """
-        logger.info("Click on 'BlockPools' tab")
-        if (
-            self.ocp_version_semantic == version.VERSION_4_11
-            and self.ocs_version_semantic == version.VERSION_4_10
-        ):
-            self.do_click(
-                self.validation_loc["blockpools-odf-4-10"],
-                enable_screenshot=True,
-            )
-        else:
-            self.do_click(self.validation_loc["blockpools"], enable_screenshot=True)
-        self.page_has_loaded(retries=15, sleep_time=2)
-        logger.info(f"Verifying the status of '{constants.DEFAULT_CEPHBLOCKPOOL}'")
-        cephblockpool_status = self.get_element_text(
-            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}-status"]
-        )
-        if not "Ready" == cephblockpool_status:
-            raise CephHealthException(
-                f"cephblockpool status error | expected status:Ready \n "
-                f"actual status:{cephblockpool_status}"
-            )
-
     def wait_for_namespace_selection(self, project_name):
         """
         If you have already navigated to namespace drop-down, this function waits for namespace selection on UI.
@@ -830,6 +754,92 @@ class PageNavigator(BaseUI):
                 "The resource did not reach the expected state within the time limit."
             )
             return False
+
+
+class StorageSystemNavigator(PageNavigator):
+    """
+    Storage Navigator Class
+
+    """
+
+    def __init__(self, driver):
+        super().__init__(driver)
+
+    def navigate_cephblockpool(self):
+        """
+        Initial page OCP Home page
+        Navigate to StorageSystem details / ocs-storagecluster-cephblockpool
+
+        """
+        self.navigate_odf_storagesystems()
+        self.navigate_storagecluster_storagesystem()
+        self.navigate_cephblockpool_verify_statusready()
+
+    def navigate_odf_storagesystems(self):
+        """
+        Initial page OCP Home page
+        Navigate to Storage Systems tab
+
+        """
+        self.navigate_odf_overview_page()
+        logger.info("Click on 'Storage Systems' tab")
+        self.do_click(self.validation_loc["storage_systems"], enable_screenshot=True)
+        self.page_has_loaded(retries=15, sleep_time=2)
+
+    def navigate_storagecluster_storagesystem(self):
+        """
+        Initial page - Data Foundation / Storage Systems tab
+        Navigate to StorageSystem details
+
+        """
+        if not config.DEPLOYMENT.get("external_mode"):
+            logger.info(
+                "Click on 'ocs-storagecluster-storagesystem' link from Storage Systems page"
+            )
+            self.do_click(
+                self.validation_loc["ocs-storagecluster-storagesystem"],
+                enable_screenshot=True,
+            )
+        else:
+            logger.info(
+                "Click on 'ocs-external-storagecluster-storagesystem' link "
+                "from Storage Systems page for External Mode Deployment"
+            )
+            self.do_click(
+                self.validation_loc["ocs-external-storagecluster-storagesystem"],
+                enable_screenshot=True,
+            )
+
+    def navigate_cephblockpool_verify_statusready(self):
+        """
+        Initial page - Data Foundation / Storage Systems tab / StorageSystem details
+        Navigate to ocs-storagecluster-cephblockpool
+        Verify cephblockpool status is 'Ready'
+
+        Raises:
+            CephHealthException if cephblockpool_status != 'Ready'
+        """
+        logger.info("Click on 'BlockPools' tab")
+        if (
+            self.ocp_version_semantic == version.VERSION_4_11
+            and self.ocs_version_semantic == version.VERSION_4_10
+        ):
+            self.do_click(
+                self.validation_loc["blockpools-odf-4-10"],
+                enable_screenshot=True,
+            )
+        else:
+            self.do_click(self.validation_loc["blockpools"], enable_screenshot=True)
+        self.page_has_loaded(retries=15, sleep_time=2)
+        logger.info(f"Verifying the status of '{constants.DEFAULT_CEPHBLOCKPOOL}'")
+        cephblockpool_status = self.get_element_text(
+            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}-status"]
+        )
+        if not "Ready" == cephblockpool_status:
+            raise CephHealthException(
+                f"cephblockpool status error | expected status:Ready \n "
+                f"actual status:{cephblockpool_status}"
+            )
 
 
 def screenshot_dom_location(type_loc="screenshot"):

--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -465,7 +465,11 @@ class ValidationUI(StorageSystemNavigator):
                 self.do_click(
                     self.validation_loc["blockandfile"], enable_screenshot=True
                 )
-        self.navigate_cephblockpool_verify_statusready()
+        if not (
+            config.DEPLOYMENT.get("external_mode")
+            or config.ENV_DATA["mcg_only_deployment"]
+        ):
+            self.navigate_cephblockpool_verify_statusready()
 
     def check_capacity_breakdown(self, project_name, pod_name):
         """

--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -4,7 +4,7 @@ import time
 
 from selenium.common.exceptions import TimeoutException
 from ocs_ci.ocs.exceptions import UnexpectedODFAccessException
-from ocs_ci.ocs.ui.base_ui import PageNavigator
+from ocs_ci.ocs.ui.base_ui import StorageSystemNavigator
 from ocs_ci.ocs.ui.views import locators
 from ocs_ci.utility import version
 from ocs_ci.utility.utils import get_ocp_version, TimeoutSampler
@@ -14,14 +14,14 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
-class ValidationUI(PageNavigator):
+class ValidationUI(StorageSystemNavigator):
     """
     User Interface Validation Selenium
 
     """
 
     def __init__(self, driver):
-        super().__init__(driver)
+        StorageSystemNavigator.__init__(self, driver=driver)
         self.dep_loc = locators[self.ocp_version]["deployment"]
         self.ocp_version = get_ocp_version()
         self.err_list = list()
@@ -540,7 +540,6 @@ class ValidationUI(PageNavigator):
             String representation of 'Compression status' from ocs-storagecluster-cephblockpool page
 
         """
-
         self.navigate_cephblockpool()
         logger.info(
             f"Get the 'Compression status' of '{constants.DEFAULT_CEPHBLOCKPOOL}'"
@@ -552,7 +551,7 @@ class ValidationUI(PageNavigator):
             f"Click on '{constants.DEFAULT_CEPHBLOCKPOOL}' link under BlockPools tab"
         )
         self.do_click(
-            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}"],
+            self.validation_loc[constants.DEFAULT_CEPHBLOCKPOOL],
             enable_screenshot=True,
         )
         compression_status_blockpools_details = self.get_element_text(

--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -21,7 +21,7 @@ class ValidationUI(StorageSystemNavigator):
     """
 
     def __init__(self, driver):
-        StorageSystemNavigator.__init__(self, driver=driver)
+        super().__init__(driver)
         self.dep_loc = locators[self.ocp_version]["deployment"]
         self.ocp_version = get_ocp_version()
         self.err_list = list()

--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -429,29 +429,9 @@ class ValidationUI(PageNavigator):
         Function to verify changes and validate elements on ODF Storage Systems tab for ODF 4.9
 
         """
-
         self.odf_console_plugin_check()
-        self.navigate_odf_overview_page()
-        logger.info("Click on 'Storage Systems' tab")
-        self.do_click(self.validation_loc["storage_systems"], enable_screenshot=True)
-        self.page_has_loaded(retries=15, sleep_time=2)
-        if not config.DEPLOYMENT.get("external_mode"):
-            logger.info(
-                "Click on 'ocs-storagecluster-storagesystem' link from Storage Systems page"
-            )
-            self.do_click(
-                self.validation_loc["ocs-storagecluster-storagesystem"],
-                enable_screenshot=True,
-            )
-        else:
-            logger.info(
-                "Click on 'ocs-external-storagecluster-storagesystem' link "
-                "from Storage Systems page for External Mode Deployment"
-            )
-            self.do_click(
-                self.validation_loc["ocs-external-storagecluster-storagesystem"],
-                enable_screenshot=True,
-            )
+        self.navigate_odf_storagesystems()
+        self.navigate_storagecluster_storagesystem()
         logger.info("Click on Overview tab")
         if (
             self.ocp_version_semantic == version.VERSION_4_11
@@ -485,40 +465,7 @@ class ValidationUI(PageNavigator):
                 self.do_click(
                     self.validation_loc["blockandfile"], enable_screenshot=True
                 )
-        if not config.DEPLOYMENT.get("external_mode"):
-            if not config.ENV_DATA["mcg_only_deployment"]:
-                logger.info("Click on 'BlockPools' tab")
-                if (
-                    self.ocp_version_semantic == version.VERSION_4_11
-                    and self.ocs_version_semantic == version.VERSION_4_10
-                ):
-                    self.do_click(
-                        self.validation_loc["blockpools-odf-4-10"],
-                        enable_screenshot=True,
-                    )
-                else:
-                    self.do_click(
-                        self.validation_loc["blockpools"], enable_screenshot=True
-                    )
-                logger.info(
-                    "Click on 'ocs-storagecluster-cephblockpool' link under BlockPools tab"
-                )
-                self.do_click(
-                    self.validation_loc["ocs-storagecluster-cephblockpool"],
-                    enable_screenshot=True,
-                )
-                self.page_has_loaded(retries=15, sleep_time=2)
-                logger.info(
-                    "Verifying the status of 'ocs-storagecluster-cephblockpool'"
-                )
-                cephblockpool_status = self.get_element_text(
-                    self.validation_loc["ocs-storagecluster-cephblockpool-status"]
-                )
-                assert "Ready" == cephblockpool_status, (
-                    f"cephblockpool status error | expected status:Ready \n "
-                    f"actual status:{cephblockpool_status}"
-                )
-                logger.info("Verification of cephblockpool status is successful!")
+        self.navigate_cephblockpool_verify_statusready()
 
     def check_capacity_breakdown(self, project_name, pod_name):
         """
@@ -582,3 +529,33 @@ class ValidationUI(PageNavigator):
             )
         else:
             raise UnexpectedODFAccessException
+
+    def get_blockpools_compression_status_from_storagesystem(self) -> tuple:
+        """
+        Initial page - Data Foundation / Storage Systems tab / StorageSystem details / ocs-storagecluster-cephblockpool
+        Get compression status from storagesystem details and ocs-storagecluster-cephblockpool
+
+        Returns:
+            tuple: String representation of 'Compression status' from StorageSystem details page and
+            String representation of 'Compression status' from ocs-storagecluster-cephblockpool page
+
+        """
+
+        self.navigate_cephblockpool()
+        logger.info(
+            f"Get the 'Compression status' of '{constants.DEFAULT_CEPHBLOCKPOOL}'"
+        )
+        compression_status_blockpools_tab = self.get_element_text(
+            self.validation_loc["storagesystem-details-compress-state"]
+        )
+        logger.info(
+            f"Click on '{constants.DEFAULT_CEPHBLOCKPOOL}' link under BlockPools tab"
+        )
+        self.do_click(
+            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}"],
+            enable_screenshot=True,
+        )
+        compression_status_blockpools_details = self.get_element_text(
+            self.validation_loc["storagecluster-blockpool-details-compress-status"]
+        )
+        return compression_status_blockpools_tab, compression_status_blockpools_details

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1031,6 +1031,14 @@ validation_4_9 = {
         "//li[normalize-space()='StorageSystem details']",
         By.XPATH,
     ),
+    "storagesystem-details-compress-state": (
+        "#compressionStatus",
+        By.CSS_SELECTOR,
+    ),
+    "storagecluster-blockpool-details-compress-status": (
+        "article[data-test-id='compression-details-card'] dd[class='co-overview-details-card__item-value']",
+        By.CSS_SELECTOR,
+    ),
     "performance-card": ("//h2[normalize-space()='Performance']", By.XPATH),
     "backingstore": ("//a[normalize-space()='Backing Store']", By.XPATH),
     "backingstore-link": (

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -52,7 +52,6 @@ class TestUserInterfaceValidation(object):
     @polarion_id("OCS-4642")
     @skipif_ocs_version("<4.9")
     @skipif_ui_not_support("validation")
-    @skipif_external_mode
     @skipif_mcg_only
     def test_odf_storagesystems_ui(self, setup_ui_class):
         """

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -69,6 +69,7 @@ class TestUserInterfaceValidation(object):
     @skipif_external_mode
     @skipif_mcg_only
     @pytest.mark.bugzilla("2096414")
+    @polarion_id("OCS-4685")
     def test_odf_cephblockpool_compression_status(self, setup_ui_class):
         """
         Validate Compression status for cephblockpool at StorageSystem details and ocs-storagecluster-cephblockpool

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -93,6 +93,6 @@ class TestUserInterfaceValidation(object):
         ), (
             "Compression status validation failed:\n"
             f"'Compression status' from StorageSystem details page = {compression_statuses[0]};\n"
-            f"'Compression status' from ocs-storagecluster-cephblockpool = {compression_statuses[0]}\n"
-            f"Expected: "
+            f"'Compression status' from ocs-storagecluster-cephblockpool = {compression_statuses[1]}\n"
+            f"Expected: {compression_status_expected}"
         )

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -51,7 +51,6 @@ class TestUserInterfaceValidation(object):
     @polarion_id("OCS-4642")
     @skipif_ocs_version("<4.9")
     @skipif_ui_not_support("validation")
-    @skipif_mcg_only
     def test_odf_storagesystems_ui(self, setup_ui_class):
         """
         Validate User Interface for ODF Storage Systems Tab for ODF 4.9

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -10,7 +10,6 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
-    brown_squad,
     skipif_external_mode,
     skipif_mcg_only,
 )
@@ -66,7 +65,7 @@ class TestUserInterfaceValidation(object):
 
     @ui
     @tier1
-    @brown_squad
+    @black_squad
     @skipif_ocs_version("<4.9")
     @skipif_external_mode
     @skipif_mcg_only


### PR DESCRIPTION
New automation script for https://bugzilla.redhat.com/show_bug.cgi?id=2096414 test_odf_cephblockpool_compression_status

Validate Compression status for cephblockpool at StorageSystem details and ocs-storagecluster-cephblockpool are matching.
Some refactoring at ocs_ci/ocs/ui/validation_ui.py done in order to have more dry code