### PR TITLE
Fix a mismatch between the PyTest param and it's ID at test_unidirectional_namespace_bucket_replication

### DIFF
--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -161,7 +161,7 @@ class TestReplication(MCGTest):
             ),
         ],
         ids=[
-            "AZUREtoAWS-NS-Hybrid",
+            "AWStoAZURE-NS-Hybrid",
         ],
     )
     def test_unidirectional_namespace_bucket_replication(

--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -381,7 +381,7 @@ class TestReplication(MCGTest):
             ),
         ],
         ids=[
-            "AWStoAZURE-BS-OC",
+            "AZUREtoAWS-BS-OC",
         ],
     )
     def test_unidirectional_bucket_object_change_replication(

--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -381,7 +381,7 @@ class TestReplication(MCGTest):
             ),
         ],
         ids=[
-            "AZUREtoAWS-BS-OC",
+            "AWStoAZURE-BS-OC",
         ],
     )
     def test_unidirectional_bucket_object_change_replication(


### PR DESCRIPTION
Fixes: #6799 

Signed-off-by: sagihirshfeld [shirshfe@redhat.com](mailto:shirshfe@redhat.com)