### PR TITLE
Add the skipif_mcg_only mark to MCG PVPool tests

### DIFF
--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     acceptance,
     performance,
+    skipif_mcg_only,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -101,7 +102,7 @@ class TestBucketCreation(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, pytest.mark.polarion_id("OCS-2331")],
+                marks=[tier1, skipif_mcg_only, pytest.mark.polarion_id("OCS-2331")],
             ),
             pytest.param(
                 *[
@@ -114,7 +115,7 @@ class TestBucketCreation(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, pytest.mark.polarion_id("OCS-2331")],
+                marks=[tier1, skipif_mcg_only, pytest.mark.polarion_id("OCS-2331")],
             ),
         ],
         ids=[

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     bugzilla,
     skipif_ocs_version,
+    skipif_mcg_only,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -93,7 +94,7 @@ class TestBucketDeletion(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, pytest.mark.polarion_id("OCS-2354")],
+                marks=[tier1, skipif_mcg_only, pytest.mark.polarion_id("OCS-2354")],
             ),
             pytest.param(
                 *[
@@ -106,7 +107,7 @@ class TestBucketDeletion(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, pytest.mark.polarion_id("OCS-2354")],
+                marks=[tier1, skipif_mcg_only, pytest.mark.polarion_id("OCS-2354")],
             ),
         ],
         ids=[


### PR DESCRIPTION
Fixes: #6348

Signed-off-by: sagihirshfeld <shirshfe@redhat.com>