### PR TITLE
Fix validation for namespacestore creation webhook test

### DIFF
--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -157,7 +157,7 @@ class TestAdmissionWebhooks(MCGTest):
                             "secret": {"name": ""},
                         },
                     },
-                    "secret name",
+                    "please provide a valid ARN or secret name",
                 ],
                 marks=[tier3, polarion_id("OCS-2786")],
             ),


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/6782
Signed-off-by: mashetty <mashetty@redhat.com>