### PR TITLE
pause MachineHealthCheck during OCP upgrade

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -156,6 +156,7 @@ RECLAIMSPACECRONJOB = "reclaimspacecronjob"
 LVMCLUSTER = "odf-lvmcluster"
 LVMSCLUSTER = "lvmscluster"
 STORAGECLASSCLAIM = "StorageClassClaim"
+MACHINEHEALTHCHECK = "machinehealthcheck"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1096,7 +1096,7 @@ class OCP(object):
         resource_name = resource_name or self.resource_name
         cmd = f"annotate {self.kind} {resource_name} {annotation}"
         if overwrite:
-            cmd += f" --overwrite"
+            cmd += " --overwrite"
         log.info(f"Annotate {self.kind} {resource_name} with '{annotation}'")
         result = self.exec_oc_cmd(cmd)
         return result

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1081,6 +1081,26 @@ class OCP(object):
             )
             return False
 
+    def annotate(self, annotation, resource_name="", overwrite=True):
+        """
+        Update the annotations on resource.
+
+        Args:
+            annotation (str): Annotation string (key=value pair or key- for
+                removing annotation) E.g: 'cluster.x-k8s.io/paused=""'
+            resource_name (str): Name of the resource you want to label
+
+        Returns:
+            dict: Dictionary represents a returned yaml file
+        """
+        resource_name = resource_name or self.resource_name
+        cmd = f"annotate {self.kind} {resource_name} {annotation}"
+        if overwrite:
+            cmd += f" --overwrite"
+        log.info(f"Annotate {self.kind} {resource_name} with '{annotation}'")
+        result = self.exec_oc_cmd(cmd)
+        return result
+
 
 def get_all_resource_names_of_a_kind(kind):
     """

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1089,6 +1089,8 @@ class OCP(object):
             annotation (str): Annotation string (key=value pair or key- for
                 removing annotation) E.g: 'cluster.x-k8s.io/paused=""'
             resource_name (str): Name of the resource you want to label
+            overwrite (bool): Overwrite existing annotation with the same key,
+                (default: True)
 
         Returns:
             dict: Dictionary represents a returned yaml file

--- a/ocs_ci/utility/ocp_upgrade.py
+++ b/ocs_ci/utility/ocp_upgrade.py
@@ -1,0 +1,35 @@
+from ocs_ci.ocs import constants
+
+from ocs_ci.ocs.ocp import OCP
+
+
+def pause_machinehealthcheck():
+    """
+    During the upgrade process, nodes in the cluster might become temporarily
+    unavailable. In the case of worker nodes, the machine health check might
+    identify such nodes as unhealthy and reboot them. To avoid rebooting such
+    nodes, pause all the MachineHealthCheck resources before updating the
+    cluster.
+    This step is based on OCP documentation for OCP 4.9 and above.
+    """
+    ocp = OCP(
+        kind=constants.MACHINEHEALTHCHECK,
+        namespace=constants.OPENSHIFT_MACHINE_API_NAMESPACE,
+    )
+    mhcs = ocp.get()
+    for mhc in mhcs["items"]:
+        ocp.annotate("cluster.x-k8s.io/paused=''", mhc["metadata"]["name"])
+
+
+def resume_machinehealthcheck():
+    """
+    Resume the machine health checks after updating the cluster. To resume the
+    check, remove the pause annotation from the MachineHealthCheck resource.
+    """
+    ocp = OCP(
+        kind=constants.MACHINEHEALTHCHECK,
+        namespace=constants.OPENSHIFT_MACHINE_API_NAMESPACE,
+    )
+    mhcs = ocp.get()
+    for mhc in mhcs["items"]:
+        ocp.annotate("cluster.x-k8s.io/paused-", mhc["metadata"]["name"])

--- a/tests/ecosystem/upgrade/test_upgrade_ocp.py
+++ b/tests/ecosystem/upgrade/test_upgrade_ocp.py
@@ -17,6 +17,14 @@ from ocs_ci.utility.utils import (
 )
 from ocs_ci.framework.testlib import ManageTest, ocp_upgrade, ignore_leftovers
 from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
+from ocs_ci.utility.ocp_upgrade import (
+    pause_machinehealthcheck,
+    resume_machinehealthcheck,
+)
+from ocs_ci.utility.version import (
+    get_semantic_ocp_running_version,
+    VERSION_4_8,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +118,10 @@ class TestUpgradeOCP(ManageTest):
                     logger.info(f"OCP Channel:{ocp_channel}")
                     break
 
+            # pause a MachineHealthCheck resource
+            if get_semantic_ocp_running_version() > VERSION_4_8:
+                pause_machinehealthcheck()
+
             # Upgrade OCP
             logger.info(f"full upgrade path: {image_path}:{target_image}")
             ocp.upgrade_ocp(image=target_image, image_path=image_path)
@@ -140,6 +152,10 @@ class TestUpgradeOCP(ManageTest):
                         break
                     else:
                         logger.info(f"{ocp_operator} upgrade did not completed yet!")
+
+            # resume a MachineHealthCheck resource
+            if get_semantic_ocp_running_version() > VERSION_4_8:
+                resume_machinehealthcheck()
 
             # post upgrade validation: check cluster operator status
             cluster_operators = ocp.get_all_cluster_operators()


### PR DESCRIPTION
This step is  recommended in [OCP documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/updating_clusters/index#machine-health-checks-pausing_updating-cluster-cli) for OCP 4.9 and above.

Signed-off-by: Daniel Horak <dahorak@redhat.com>