### PR TITLE
Remove shallow oc get Pod requests

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -54,7 +54,7 @@ class OCP(object):
         silent=False,
     ):
         """
-        Initializer function
+        Initializer function. Avoid shallow request, func is resource consuming
 
         Args:
             api_version (str): TBD


### PR DESCRIPTION
PR is intended to optimize resource consumption. 

For example during the tests/manage/z_cluster/cluster_expansion/test_add_capacity.py:test_add_capacity and tests/manage/z_cluster/cluster_expansion/test_node_expansion.py:test_add_ocs_node we often get "Cannot allocate memory error". During the tests we frequently request pod.get_ceph_tools_pod() -> 'oc get pod -n openshift-storage -o yaml' which produce 30k lines of text in the log each, around 1.35 Mb. This PR replaces such requests with request specified with selector, reduce memory consumption. 
Since shallow requests were called with get_ceph_tools_pod() common routine, changes may have effect not only on the tests test_add_ocs_node and py:test_add_capacity but on many others.

Additionally prevent logs inflation.

Linked issue: https://github.com/red-hat-storage/ocs-ci/issues/6489 and rest of OSError: [Errno 12] Cannot allocate memory  
