### PR TITLE
Automation analysis backlog. Skip test for external mode. Test is not designed…

### DIFF
--- a/tests/manage/z_cluster/test_hugepages.py
+++ b/tests/manage/z_cluster/test_hugepages.py
@@ -17,6 +17,7 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.framework.testlib import (
     bugzilla,
+    skipif_external_mode,
     skipif_ocs_version,
     ignore_leftovers,
     E2ETest,
@@ -67,6 +68,7 @@ class TestHugePages(E2ETest):
 
         request.addfinalizer(finalizer)
 
+    @skipif_external_mode
     def test_hugepages_post_odf_deployment(
         self,
         pvc_factory,

--- a/tests/manage/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/manage/z_cluster/test_mon_data_avail_warn.py
@@ -8,7 +8,13 @@ import random
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import E2ETest, tier2, bugzilla, skipif_ocs_version
+from ocs_ci.framework.testlib import (
+    E2ETest,
+    tier2,
+    bugzilla,
+    skipif_ocs_version,
+    skipif_external_mode,
+)
 from ocs_ci.ocs import node, defaults
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.cluster import CephCluster
@@ -119,6 +125,7 @@ class TestMonDataAvailWarn(E2ETest):
             self.mon_pod.exec_sh_cmd_on_pod(command=write_cmd, sh="sh")
         self.dd_seek_count += 1
 
+    @skipif_external_mode
     @pytest.mark.usefixtures(workloads_dir_setup.__name__)
     def test_mon_data_avail_warn(self):
         """


### PR DESCRIPTION
Fixes: #6817 
Backlog analysis. Skip test for external mode. Test is not designed for this deployment. Feature is unavailable at post deployment stage.