### PR TITLE
Skip test case in external mode

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
     skipif_managed_service,
+    skipif_external_mode,
 )
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2595")
 @skipif_managed_service
+@skipif_external_mode
 class TestVerifyRbdTrashPurge(ManageTest):
     """
     Verify RBD trash purge command when the RBD image have snapshots


### PR DESCRIPTION
Skip the test case given below if the the cluster is external mode. The test case creates CephBlockPool and storageclass.
tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py

Signed-off-by: Jilju Joy <jijoy@redhat.com>