### PR TITLE
Skip test_verify_new_cbp_creation_not_blocked_by_invalid_cbp in external mode

### DIFF
--- a/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -1,7 +1,12 @@
 import logging
 
 from ocs_ci.helpers import helpers
-from ocs_ci.framework.testlib import polarion_id, skipif_ocs_version, tier2
+from ocs_ci.framework.testlib import (
+    polarion_id,
+    skipif_ocs_version,
+    tier2,
+    skipif_external_mode,
+)
 
 log = logging.getLogger(__name__)
 
@@ -9,6 +14,7 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_ocs_version("<4.3")
 @polarion_id("OCS-2130")
+@skipif_external_mode
 def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(teardown_factory):
     """
     Test to verify new ceph block pool can be created without deleting


### PR DESCRIPTION
Skip the test case given below if the the cluster is external mode. The test case creates CephBlockPool.
tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py::test_verify_new_cbp_creation_not_blocked_by_invalid_cbp
Fixes #6827 

Signed-off-by: Jilju Joy <jijoy@redhat.com>