### PR TITLE
Skip test cases in external mode

### DIFF
--- a/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     E2ETest,
     tier2,
+    skipif_external_mode,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import (
@@ -99,6 +100,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
             log.info(f"Expanding size of PVC {pvc_obj.name} to {pvc_size_new}G")
             pvc_obj.resize_pvc(pvc_size_new, True)
 
+    @skipif_external_mode
     @skipif_ocs_version("<4.6")
     @skipif_ocp_version("<4.6")
     @pytest.mark.parametrize(
@@ -157,6 +159,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
             multi_pvc_clone_factory,
         )
 
+    @skipif_external_mode
     @skipif_ocs_version("<4.9")
     @skipif_ocp_version("<4.9")
     @pytest.mark.parametrize(

--- a/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -3,7 +3,12 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import E2ETest, tier2, ignore_leftovers
+from ocs_ci.framework.testlib import (
+    E2ETest,
+    tier2,
+    ignore_leftovers,
+    skipif_external_mode,
+)
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
 )
@@ -13,6 +18,7 @@ from ocs_ci.ocs import flowtest
 log = logging.getLogger(__name__)
 
 
+@skipif_external_mode
 @ignore_leftovers
 @tier2
 class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):


### PR DESCRIPTION
Skip the test case given below if the the cluster is external mode. The test case creates CephBlockPool and storageclass.
tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py

Signed-off-by: vkathole <vkathole@redhat.com>