### PR TITLE
Create a new helper function to verify the provider machine pools

### DIFF
--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -3,11 +3,16 @@ Managed Services related functionalities
 """
 import logging
 
-from ocs_ci.utility.rosa import get_machine_pool_info_list, get_ceph_osd_nodepool_info
+from ocs_ci.utility.rosa import get_ceph_osd_nodepool_info
 from ocs_ci.utility.version import get_semantic_version
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
+from ocs_ci.ocs.node import (
+    get_worker_nodes,
+    get_node_objs,
+    get_node_pods,
+    get_osd_running_nodes,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
@@ -68,6 +73,7 @@ def verify_provider_topology():
     5. Verify worker node instance count
     6. Verify OSD count
     7. Verify OSD cpu
+    8. Verify OSD running nodes are part of the correct machine pool
 
     """
     # importing here to avoid circular import
@@ -166,6 +172,9 @@ def verify_provider_topology():
                     f"Request is {container['resources']['requests']['cpu']}"
                 )
     log.info("Verified OSD CPU")
+
+    # Verify OSD running nodes are part of the correct machine pool
+    verify_provider_osd_nodes_on_correct_machine_pools()
 
 
 def get_used_capacity(msg):

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -38,6 +38,9 @@ from ocs_ci.ocs.node import (
     consumers_verification_steps_after_provider_node_replacement,
 )
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
+from ocs_ci.helpers.managed_services import (
+    verify_provider_osd_nodes_on_correct_machine_pools,
+)
 
 log = logging.getLogger(__name__)
 
@@ -303,6 +306,8 @@ class TestAutomatedRecoveryFromFailedNodeReactiveMS(ManageTest):
 
         log.info("Checking that the ceph health is ok on the provider")
         ceph_health_check()
+
+        verify_provider_osd_nodes_on_correct_machine_pools()
 
         log.info("Checking that the ceph health is ok on the consumers")
         consumer_indexes = config.get_consumer_indexes_list()

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -33,6 +33,9 @@ from ocs_ci.ocs.resources.pod import (
     check_pods_after_node_replacement,
 )
 from ocs_ci.ocs.cluster import is_managed_service_cluster
+from ocs_ci.helpers.managed_services import (
+    verify_provider_osd_nodes_on_correct_machine_pools,
+)
 
 log = logging.getLogger(__name__)
 
@@ -205,6 +208,7 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
             wait_for_node_count_to_reach_status(node_count=len(wnodes), timeout=900)
             log.info("Waiting for all the pods to be running")
             assert check_pods_after_node_replacement(), "Not all the pods are running"
+            verify_provider_osd_nodes_on_correct_machine_pools()
         else:
             log.info(f"Starting the node '{node_name}' again...")
             nodes.start_nodes(nodes=[ocs_node])

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -36,6 +36,9 @@ from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.helpers.managed_services import (
+    verify_provider_osd_nodes_on_correct_machine_pools,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -124,6 +127,7 @@ class TestNodesRestartMS(ManageTest):
 
         logger.info("Verify the worker nodes security groups on the provider...")
         assert verify_worker_nodes_security_groups()
+        verify_provider_osd_nodes_on_correct_machine_pools()
 
     @tier4a
     @pytest.mark.parametrize(
@@ -293,5 +297,6 @@ class TestNodesRestartMS(ManageTest):
                 cephcluster_yaml["status"]["phase"] == expected_phase
             ), f"Status of cephcluster {cephcluster_yaml['metadata']['name']} is {cephcluster_yaml['status']['phase']}"
 
+        verify_provider_osd_nodes_on_correct_machine_pools()
         # Create PVCs and pods
         self.sanity_helpers.create_resources_on_ms_consumers()

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -303,6 +303,7 @@ class TestNodesRestartMS(ManageTest):
         # Create PVCs and pods
         self.sanity_helpers.create_resources_on_ms_consumers()
 
+    @tier4a
     @polarion_id("OCS-3982")
     def test_provider_worker_nodes_restart(self, nodes):
         """
@@ -333,6 +334,7 @@ class TestNodesRestartMS(ManageTest):
         verify_provider_osd_nodes_on_correct_machine_pools()
         self.sanity_helpers.create_resources_on_ms_consumers()
 
+    @tier4b
     @pytest.mark.polarion_id("OCS-2015")
     def test_rolling_provider_worker_nodes_restart(self, nodes):
         """


### PR DESCRIPTION
According to the recent changes described in the Jira issue https://issues.redhat.com/browse/ODFMS-352, the OSD and ceph pods of the MS provider cluster are now segregated on a different set of nodes which will run on two machine pools.

In the pr, I implemented the following:

- Create a new function `verify_provider_osd_nodes_on_correct_machine_pools` to Verify the following on the MS provider cluster: 1. OSD running nodes are part of the correct machine pool, 2. Other pods are not running on OSD nodes.

- Create a new function to rand nodes from different racks or zones.

- Create a new test for restarting one osd and one mon node in the provider cluster. The nodes will pick up randomly.

- Create a new test for restarting provider worker nodes one after the other and check the health status in between.
The test will pick up two osd nodes from different zones, one mgr node and one mon node. The nodes will pick up randomly.

- Add the function `verify_provider_osd_nodes_on_correct_machine_pools` in the tests above and other relevant tests.