### PR TITLE
Verify provider topology based on deployer version in MS

### DIFF
--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -3,8 +3,8 @@ Managed Services related functionalities
 """
 import logging
 import yaml
-from semantic_version import Version
 
+from ocs_ci.utility.version import get_semantic_version
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import (
@@ -251,4 +251,4 @@ def get_ocs_osd_deployer_version():
         "ocs-osd-deployer" in deployer_csv["items"][0]["metadata"]["name"]
     ), "Couldn't find ocs-osd-deployer CSV"
     deployer_version = deployer_csv["items"][0]["spec"]["version"]
-    return Version.coerce(deployer_version)
+    return get_semantic_version(deployer_version)

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -3,6 +3,7 @@ Managed Services related functionalities
 """
 import logging
 import yaml
+from semantic_version import Version
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -12,6 +13,7 @@ from ocs_ci.ocs.node import (
     get_node_objs,
     get_node_pods,
 )
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
 from ocs_ci.utility.utils import convert_device_size, run_cmd
@@ -233,3 +235,20 @@ def verify_osd_used_capacity_greater_than_expected(expected_used_capacity):
             )
             return True
     return False
+
+
+def get_ocs_osd_deployer_version():
+    """
+    Get OCS OSD deployer version from CSV
+
+    Returns:
+         Version: OCS OSD deployer version
+
+    """
+    csv_kind = OCP(kind="ClusterServiceVersion", namespace="openshift-storage")
+    deployer_csv = csv_kind.get(selector=constants.OCS_OSD_DEPLOYER_CSV_LABEL)
+    assert (
+        "ocs-osd-deployer" in deployer_csv["items"][0]["metadata"]["name"]
+    ), "Couldn't find ocs-osd-deployer CSV"
+    deployer_version = deployer_csv["items"][0]["spec"]["version"]
+    return Version.coerce(deployer_version)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1053,6 +1053,7 @@ WORKER_LABEL = "node-role.kubernetes.io/worker"
 APP_LABEL = "node-role.kubernetes.io/app"
 S3CLI_APP_LABEL = "s3cli"
 OSD_NODE_LABEL = "node.ocs.openshift.io/osd=''"
+OCS_OSD_DEPLOYER_CSV_LABEL = "operators.coreos.com/ocs-osd-deployer.openshift-storage"
 
 # well known topologies
 ZONE_LABEL = "topology.kubernetes.io/zone"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -8,9 +8,13 @@ import tempfile
 import yaml
 
 from jsonschema import validate
+from semantic_version import Version
 
 from ocs_ci.framework import config
-from ocs_ci.helpers.managed_services import verify_provider_topology
+from ocs_ci.helpers.managed_services import (
+    verify_provider_topology,
+    get_ocs_osd_deployer_version,
+)
 from ocs_ci.ocs import constants, defaults, ocp, managedservice
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -1335,8 +1339,7 @@ def verify_managed_service_resources():
     if config.ENV_DATA["cluster_type"].lower() == "provider":
         verify_provider_storagecluster(sc_data)
         verify_provider_resources()
-        # TODO: Update the condition based on the deployer version when the feature is available in a particular version
-        if config.ENV_DATA["addon_name"] == "ocs-provider-dev":
+        if get_ocs_osd_deployer_version() >= Version("2.0.11"):
             verify_provider_topology()
     else:
         verify_consumer_storagecluster(sc_data)

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -8,7 +8,6 @@ import tempfile
 import yaml
 
 from jsonschema import validate
-from semantic_version import Version
 
 from ocs_ci.framework import config
 from ocs_ci.helpers.managed_services import (
@@ -1339,7 +1338,7 @@ def verify_managed_service_resources():
     if config.ENV_DATA["cluster_type"].lower() == "provider":
         verify_provider_storagecluster(sc_data)
         verify_provider_resources()
-        if get_ocs_osd_deployer_version() >= Version("2.0.11"):
+        if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11"):
             verify_provider_topology()
     else:
         verify_consumer_storagecluster(sc_data)


### PR DESCRIPTION
Update the condition for checking the provider topology based on the deployer version. Provider topology verification is relevant if deployer version is 2.0.11 or above.

Signed-off-by: Jilju Joy <jijoy@redhat.com>