### PR TITLE
Add memory monitoring for process/subprocesses

### DIFF
--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -109,7 +109,7 @@ def get_ocsci_conf(upgrade_run=False, pre_upgrade=False):
         conf_obj["REPORTING"]["us_ds"] = "DS"
     if env.get("SMTP_SERVER"):
         conf_obj["REPORTING"]["email"] = dict(smtp_server=env["SMTP_SERVER"])
-    if env.get("SAVE_MEM_REPORT") == "true":
+    if env.get("SAVE_MEM_REPORT").lower() == "true":
         conf_obj["REPORTING"]["save_mem_report"] = True
     if upgrade_run:
         version = Version.coerce(env["OCS_REGISTRY_IMAGE"].split(":")[1]).truncate(

--- a/.functional_ci_setup.py
+++ b/.functional_ci_setup.py
@@ -3,7 +3,6 @@ import argparse
 import base64
 import binascii
 import os
-import re
 import yaml
 
 from os import environ as env
@@ -110,6 +109,8 @@ def get_ocsci_conf(upgrade_run=False, pre_upgrade=False):
         conf_obj["REPORTING"]["us_ds"] = "DS"
     if env.get("SMTP_SERVER"):
         conf_obj["REPORTING"]["email"] = dict(smtp_server=env["SMTP_SERVER"])
+    if env.get("SAVE_MEM_REPORT") == "true":
+        conf_obj["REPORTING"]["save_mem_report"] = True
     if upgrade_run:
         version = Version.coerce(env["OCS_REGISTRY_IMAGE"].split(":")[1]).truncate(
             "minor"

--- a/conf/README.md
+++ b/conf/README.md
@@ -145,6 +145,8 @@ Reporting related config. (Do not store secret data in the repository!).
 * `must_gather_timeout` - Time (in seconds) to wait before timing out during must-gather
 * `post_upgrade` - If True, post-upgrade will be reported in the test suite
   name in the mail subject.
+* `save_mem_report` - If True, test run memory report CSV file will be saved in <$WORKSPACE>/logs/stats_log_dir_<run_id>
+  directory along with <test name>.peak_rss_table, <test name>.peak_vms_table reports.
 
 #### ENV_DATA
 

--- a/conf/README.md
+++ b/conf/README.md
@@ -146,7 +146,8 @@ Reporting related config. (Do not store secret data in the repository!).
 * `post_upgrade` - If True, post-upgrade will be reported in the test suite
   name in the mail subject.
 * `save_mem_report` - If True, test run memory report CSV file will be saved in <$WORKSPACE>/logs/stats_log_dir_<run_id>
-  directory along with <test name>.peak_rss_table, <test name>.peak_vms_table reports.
+  directory along with <test name>.peak_rss_table, <test name>.peak_vms_table reports. The option may be enforced by
+* exporting env variable: export SAVE_MEM_REPORT=true
 
 #### ENV_DATA
 

--- a/conf/README.md
+++ b/conf/README.md
@@ -145,9 +145,9 @@ Reporting related config. (Do not store secret data in the repository!).
 * `must_gather_timeout` - Time (in seconds) to wait before timing out during must-gather
 * `post_upgrade` - If True, post-upgrade will be reported in the test suite
   name in the mail subject.
-* `save_mem_report` - If True, test run memory report CSV file will be saved in <$WORKSPACE>/logs/stats_log_dir_<run_id>
+* `save_mem_report` - If True, test run memory report CSV file will be saved in `RUN["log_dir"]/stats_log_dir_<run_id>`
   directory along with <test name>.peak_rss_table, <test name>.peak_vms_table reports. The option may be enforced by
-* exporting env variable: export SAVE_MEM_REPORT=true
+  exporting env variable: export SAVE_MEM_REPORT=true
 
 #### ENV_DATA
 

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -749,11 +749,10 @@ def pytest_runtest_setup(item):
         start_monitor_memory()
 
         global consumed_ram_start_test
-        consumed_memory = get_consumed_ram()
         consumed_ram_start_test = get_consumed_ram()
 
         log.debug(
-            f"Consumed memory at the start of TC {item.nodeid}: {bytes2human(consumed_memory)}"
+            f"Consumed memory at the start of TC {item.nodeid}: {bytes2human(consumed_ram_start_test)}"
         )
     except Exception:
         log.exception("Got exception while start to monitor memory")

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -8,7 +8,6 @@ pytest which proccess config and passes all params to pytest.
 """
 import logging
 import os
-import traceback
 import pandas as pd
 import pytest
 from junitparser import JUnitXml
@@ -757,9 +756,7 @@ def pytest_runtest_setup(item):
             f"Consumed memory at the start of TC {item.nodeid}: {bytes2human(consumed_memory)}"
         )
     except Exception:
-        log.warning(
-            f"Got exception while start monitor memory \n{traceback.format_exc()}"
-        )
+        log.exception("Got exception while start to monitor memory")
 
 
 @pytest.hookimpl(trylast=True)
@@ -842,9 +839,7 @@ def pytest_runtest_teardown(item):
             )
         )
     except Exception:
-        log.warning(
-            f"Got exception while stop monitor memory \n{traceback.format_exc()}"
-        )
+        log.exception("Got exception while stop to monitor memory")
     finally:
         if hasattr(ocs_ci.utility.memory, "mon"):
             mon = ocs_ci.utility.memory.mon

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import logging
 from py.xml import html
-from ocs_ci.utility.utils import email_reports
+from ocs_ci.utility.utils import email_reports, save_reports
 from ocs_ci.framework import config as ocsci_config
 
 
@@ -72,7 +72,9 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     """
-    send email report
+    save session's report files and send email report
     """
+    if ocsci_config.REPORTING.get("save_mem_report"):
+        save_reports()
     if ocsci_config.RUN["cli_params"].get("email"):
         email_reports(session)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -197,6 +197,11 @@ MOUNT_POINT = "/var/lib/www/html"
 TOLERATION_KEY = "node.ocs.openshift.io/storage"
 CLUSTERLOGGING_SUBSCRIPTION = "cluster-logging"
 ELASTICSEARCH_SUBSCRIPTION = "elasticsearch-operator"
+START = "START"
+END = "END"
+LEAK_LIMIT = 100 * 1024 * 1024  # 100 MB
+RAM = "rss"
+VIRT = "vms"
 
 OCP_QE_MISC_REPO = "https://gitlab.cee.redhat.com/aosqe/flexy-templates.git"
 CRITICAL_ERRORS = ["core dumped", "oom_reaper"]

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -74,9 +74,9 @@ def _rec_memory(proc: Process):
             ]
         )
     except ZombieProcess:
-        pass
+        log.exception("Cannot access ZombieProcess. Recording skipped")
     except NoSuchProcess:
-        pass
+        log.exception("Process is unavailable. Recording skipped")
     except ValueError:
         pass
 

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -137,7 +137,7 @@ def stop_monitor_memory(save_csv: bool = False) -> tuple:
 
     Args:
         save_csv (bool):  saves csv temporarily, until main process is dead if save_csv = True;
-            reauire create_csv=True at start_monitor_memory(...)
+            require create_csv=True at start_monitor_memory(...)
 
      Returns:
          tuple: (path to csv file with memory stats,

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -10,8 +10,7 @@ from collections import namedtuple
 from itertools import groupby
 import numpy as np
 import pandas as pd
-import psutil
-from psutil import Process
+from psutil import Process, ZombieProcess, NoSuchProcess
 from psutil._common import bytes2human
 from ocs_ci.ocs import constants
 from threading import Timer
@@ -67,9 +66,9 @@ def _rec_memory(proc: Process):
             get_consumed_virt_mem(proc),
             proc.status(),
         ]
-    except psutil.ZombieProcess:
+    except ZombieProcess:
         pass
-    except psutil.NoSuchProcess:
+    except NoSuchProcess:
         pass
 
 

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -88,10 +88,10 @@ def get_consumed_virt_mem(proc: Process = Process(os.getpid())):
 
     ! Important notice !
     'vms' will be larger than physical memory capacity:
-        Shared libraries and frameworks are counted as part of the virtual memory for
-        every application that uses them, e.g. if you have 100 processes
-        running on a computer, and a 5 MB library used by all those processes,
-        then that library is counted as 500 MB of virtual memory.
+    Shared libraries and frameworks are counted as part of the virtual memory for
+    every application that uses them, e.g. if you have 100 processes
+    running on a computer, and a 5 MB library used by all those processes,
+    then that library is counted as 500 MB of virtual memory.
     """
     return proc.memory_info().vms
 
@@ -171,7 +171,7 @@ def read_peak_mem_stats(
                         will be ignored in case if df != None
 
     Returns: DataFrame similar to:
-                         name                  proc_start                    proc_end           rss_peak
+    name                                     proc_start                    proc_end           rss_peak
     0                    Google Chrome  2022-12-23 14:25:36.301757  2022-12-23 14:27:32.194759  156 MB
     1  Google Chrome Helper (Renderer)  2022-12-23 14:25:39.451159  2022-12-23 14:27:32.214615  784 MB
     2                           Python  2022-12-23 14:25:22.814883  2022-12-23 14:27:32.151046  228 MB

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -1,0 +1,197 @@
+# -*- coding: utf8 -*-
+"""
+Module for memory related util functions.
+"""
+
+import os
+import logging
+import tempfile
+from collections import namedtuple
+from itertools import groupby
+import numpy as np
+import pandas as pd
+import psutil
+from psutil import Process
+from psutil._common import bytes2human
+from ocs_ci.ocs import constants
+from threading import Timer
+
+from ocs_ci.utility.utils import get_testrun_name
+
+current_factory = logging.getLogRecordFactory()
+log = logging.getLogger(__name__)
+
+ConsumedRamLogEntry = namedtuple(
+    "ConsumedRamLogEntry", ("nodeid", "on", "consumed_ram")
+)
+
+
+class MemoryMonitor(Timer):
+    """
+    class to implement threading.Timer running func in a background
+    """
+
+    def run(self):
+        while not self.finished.wait(self.interval):
+            self.function(*self.args, **self.kwargs)
+
+
+consumed_ram_log = []
+_proc = Process(os.getpid())
+_df = pd.DataFrame(columns=["pid", "name", "ts", "rss", "vms", "status"])
+_mon: MemoryMonitor
+_mem_csv: str
+
+
+def _get_memory_per_process():
+    """
+    Function to add memory rss and vms of current process and all subprocesses to dataframe obj (_df)
+    """
+    _rec_memory(_proc)
+    children = _proc.children(recursive=True)
+    for child in children:
+        _rec_memory(child)
+
+
+def _rec_memory(proc: Process):
+    """
+    Helper func to update _df DataFrame object with proc stats, accordingly
+    to structure: "pid", "name", "ts", "rss", "vms", "status"
+    """
+    try:
+        _df.loc[len(_df)] = [
+            proc.pid,
+            proc.name(),
+            pd.Timestamp.now(),
+            get_consumed_ram(proc),
+            get_consumed_virt_mem(proc),
+            proc.status(),
+        ]
+    except psutil.ZombieProcess:
+        pass
+    except psutil.NoSuchProcess:
+        pass
+
+
+def get_consumed_ram(proc: Process = Process(os.getpid())):
+    """
+    Get consumed RAM(rss) for the process
+    rss is the Resident Set Size, which is the actual physical memory the process is using
+    """
+    return proc.memory_info().rss
+
+
+def get_consumed_virt_mem(proc: Process = Process(os.getpid())):
+    """
+    Get consumed Virtual mem for the process
+    vms is the Virtual Memory Size which is the virtual memory that process is using
+
+    ! Important notice !
+    'vms' will be larger than physical memory capacity:
+        Shared libraries and frameworks are counted as part of the virtual memory for
+        every application that uses them, e.g. if you have 100 processes
+        running on a computer, and a 5 MB library used by all those processes,
+        then that library is counted as 500 MB of virtual memory.
+    """
+    return proc.memory_info().vms
+
+
+def start_monitor_memory(interval: int = 3, create_csv: bool = False) -> MemoryMonitor:
+    """
+    Start memory monitor Timer process
+
+    Args:
+        interval (int): interval in sec to read measurements
+        create_csv (bool): create csv during test run. With this option it is possible
+            to upload file as artifact (to be done) or preserve csv file in the system
+    Returns:
+         MemoryMonitor: monitor object MemoryMonitor(Timer)
+    """
+    global _mem_csv
+    global _mon
+    _mem_csv_path = f"mem-data-{get_testrun_name()}"
+    if create_csv:
+        _mem_csv = tempfile.mktemp(prefix=_mem_csv_path)
+    _mon = MemoryMonitor(interval, _get_memory_per_process)
+    _mon.start()
+    return _mon
+
+
+def stop_monitor_memory(save_csv: bool = False) -> tuple:
+    """
+    Stop MemoryMonitor(Timer) and read memory stats
+
+    Args:
+        save_csv (bool):  saves csv temporarily, until main process is dead if save_csv = True;
+            reauire create_csv=True at start_monitor_memory(...)
+
+     Returns:
+         tuple: (path to csv file with memory stats,
+                table with results for rss peak memory processes,
+                table with results for vms peak memory processes)
+    """
+    global _mon
+    global _mem_csv
+    _mon.cancel()
+    if save_csv:
+        _df.to_csv(_mem_csv)
+    else:
+        _mem_csv = None
+    table_rss = read_peak_mem_stats(constants.RAM, _df)
+    table_vms = read_peak_mem_stats(constants.VIRT, _df)
+    del _mon
+    return _mem_csv, table_rss, table_vms
+
+
+def get_memory_consumption_report() -> list:
+    """
+    Get the memory consumption report data
+    Returns:
+        list: lines of the report with consumed memory by TC
+    """
+    report_data = []
+    grouped = groupby(consumed_ram_log, lambda entry: entry.nodeid)
+    for nodeid, (start_entry, end_entry) in grouped:
+        leaked = end_entry.consumed_ram - start_entry.consumed_ram
+        if leaked > constants.LEAK_LIMIT:
+            report_data.append("LEAKED {}MB in {}".format(bytes2human(leaked), nodeid))
+    return report_data
+
+
+def read_peak_mem_stats(
+    stat: constants, df: pd.DataFrame = None, csv_path: str = None
+) -> pd.DataFrame:
+    """
+    Read peak memory stats from Dataframe or csv file. Processes with stat above avg will be taken
+
+    Args:
+        stat (constants): stat either 'rss' or 'vms' (constants.RAM | constants.VIRT)
+        df (pd.DataFrame): dataframe object with structure: index,pid,name,ts,rss,vms,status
+        csv_path (str): path to csv file with structure: index,pid,name,ts,rss,vms,status;
+                        will be ignored in case if df != None
+
+    Returns: DataFrame similar to:
+                         name                  proc_start                    proc_end           rss_peak
+    0                    Google Chrome  2022-12-23 14:25:36.301757  2022-12-23 14:27:32.194759  156 MB
+    1  Google Chrome Helper (Renderer)  2022-12-23 14:25:39.451159  2022-12-23 14:27:32.214615  784 MB
+    2                           Python  2022-12-23 14:25:22.814883  2022-12-23 14:27:32.151046  228 MB
+    """
+    excluded_stat = list(filter(lambda x: x != stat, [constants.RAM, constants.VIRT]))[
+        0
+    ]
+    if df is None:
+        df = pd.read_csv(csv_path)
+    df.reset_index(drop=True)
+    stat_high = df.loc[df[stat] > (df[stat].mean())]
+    high_pid = stat_high.pid.unique()
+    stat_high_full = df[df.pid.isin(high_pid)]
+    table = (
+        stat_high_full.drop(["status", excluded_stat], axis=1)
+        .groupby("name", as_index=False)
+        .agg({"ts": [np.min, np.max], stat: [np.max]})
+    )
+    table = pd.DataFrame(
+        table.values, columns=["name", "proc_start", "proc_end", f"{stat}_peak"]
+    )
+    table[f"{stat}_peak"] = table[f"{stat}_peak"].apply(bytes2human)
+    return table

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1651,7 +1651,7 @@ def save_reports():
         else:
             log.info("Memory performance report not saved - no data")
     except Exception:
-        log.info(f"Failed save reports to slave \n{traceback.format_exc()}")
+        log.exception("Failed save reports to slave")
 
 
 def get_cluster_version_info():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1635,7 +1635,7 @@ def email_reports(session):
 
 def save_reports():
     """
-    Save reports of test run to slave
+    Save reports of test run to logs directory
 
     """
     try:
@@ -1651,7 +1651,7 @@ def save_reports():
         else:
             log.info("Memory performance report not saved - no data")
     except Exception:
-        log.exception("Failed save reports to slave")
+        log.exception("Failed save reports to logs directory")
 
 
 def get_cluster_version_info():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1639,11 +1639,17 @@ def save_reports():
 
     """
     try:
-        if "memory" in config.RUN and isinstance(config.RUN["memory"], pd.DataFrame):
+        if (
+            "memory" in config.RUN
+            and isinstance(config.RUN["memory"], pd.DataFrame)
+            and not config.RUN["memory"].empty
+        ):
             stats_dir = create_stats_dir()
             mem_report_file = os.path.join(stats_dir, "session_mem_report_file")
             config.RUN["memory"].to_csv(mem_report_file, index=False)
-        log.info(f"Memory performance report saved to '{mem_report_file}'")
+            log.info(f"Memory performance report saved to '{mem_report_file}'")
+        else:
+            log.info(f"Memory performance report not saved - no data")
     except Exception:
         log.info(f"Failed save reports to slave \n{traceback.format_exc()}")
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1649,7 +1649,7 @@ def save_reports():
             config.RUN["memory"].to_csv(mem_report_file, index=False)
             log.info(f"Memory performance report saved to '{mem_report_file}'")
         else:
-            log.info(f"Memory performance report not saved - no data")
+            log.info("Memory performance report not saved - no data")
     except Exception:
         log.info(f"Failed save reports to slave \n{traceback.format_exc()}")
 

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,7 @@ setup(
         "pytest_marker_bugzilla>=0.9.3",
         "pyvmomi==7.0",
         "python-hcl2==3.0.1",
-        # issue opened for botocore
-        # https://github.com/boto/botocore/issues/1872
-        # till above issue fixed, manually pointing python-dateutil to 2.8.0
-        "python-dateutil==2.8.0",
+        "python-dateutil==2.8.2",
         "pytest-ordering==0.6",
         "funcy==1.14",
         "semantic-version==2.8.5",
@@ -53,6 +50,8 @@ setup(
         "google-auth==2.14.1",
         "elasticsearch==7.14.0",
         "numpy==1.22.0",
+        "pandas==1.5.2",
+        "tabulate==0.9.0",
         "python-ipmi==0.4.2",
         "scipy==1.8.1",
         "PrettyTable==0.7.2",
@@ -87,6 +86,7 @@ setup(
         # googleapis-common-protos 1.56.2 needs to have protobuf<4.0.0>=3.15.0
         "protobuf==4.21.7",
         "ping3>=4.0.3",
+        "psutil==5.9.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Added memory helper util based on https://github.com/red-hat-storage/ocs-ci/pull/5622

New functionality: during the test run consumed memory is monitored and results with memory peak processes printed into the log:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/61454420/209473298-466dc7f1-57d2-46f1-9712-39d6db534a84.png">
Leaked memory will be printed in a debug level.

Necessary libraries were added:
"pandas==1.5.2", "tabulate==0.9.0", "psutil==5.9.0"
Library version updated:
"python-dateutil==2.8.2"
Previously opened issue [link](https://github.com/boto/botocore/issues/1872) has been resolved and closed; python-dateutil update is dependancy for pandas version>=2.8.1 [link](https://pandas.pydata.org/docs/getting_started/install.html#:~:text=python%2Ddateutil,2.8.1)
