### PR TITLE
Add the skipif_disconnected_cluster flag to test_s3_with_java_sdk.py::TestS3WithJavaSDK

### DIFF
--- a/tests/manage/mcg/test_s3_with_java_sdk.py
+++ b/tests/manage/mcg/test_s3_with_java_sdk.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
+    skipif_disconnected_cluster,
     tier1,
 )
 from ocs_ci.ocs.bucket_utils import upload_objects_with_javasdk
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @skipif_ocs_version("<4.9")
+@skipif_disconnected_cluster
 class TestS3WithJavaSDK:
     @bugzilla("2064304")
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: #6845

Signed-off-by: Sagi Hirshfeld <shirshfe@redhat.com>