### PR TITLE
Fix the expected error message when providing an empty secret name at TestAdmissionWebhooks::test_namespacestore_creation_webhook[Empty secret name]

### DIFF
--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -155,7 +155,7 @@ class TestAdmissionWebhooks(MCGTest):
                             "secret": {"name": ""},
                         },
                     },
-                    "please provide a valid ARN or secret name",
+                    "secret name",
                 ],
                 marks=[tier3, polarion_id("OCS-2786")],
             ),

--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -155,7 +155,7 @@ class TestAdmissionWebhooks(MCGTest):
                             "secret": {"name": ""},
                         },
                     },
-                    "please provide secret name",
+                    "please provide a valid ARN or secret name",
                 ],
                 marks=[tier3, polarion_id("OCS-2786")],
             ),


### PR DESCRIPTION
Fixes: #6838 

Signed-off-by: Sagi Hirshfeld <shirshfe@redhat.com>