### PR TITLE
`test_noobaa_kms_validation` - Also check the logs with --previous if the noobaa-operator pod restarted

### DIFF
--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -22,28 +22,32 @@ class TestNoobaaKMS(MCGTest):
         """
         Validate from logs that there is successfully used NooBaa with KMS integration.
         """
-        # Collect the current logs from the noobaa-operator pod
+        # Define which records to look for based on the version
+        target_records = []
+        if version.get_semantic_ocs_version_from_config() < version.VERSION_4_10:
+            target_records.append("found root secret in external KMS successfully")
+        else:
+            target_records.append("setKMSConditionStatus Init")
+            target_records.append("setKMSConditionStatus Sync")
+
+        # Get the noobaa-operator pod and it's relevant metadata
         operator_pod = pod.get_pods_having_label(
             label=constants.NOOBAA_OPERATOR_POD_LABEL,
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
         )[0]
         operator_pod_name = operator_pod["metadata"]["name"]
-        operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
-
-        # If the pod restarted, collect the previous logs as well
         restart_count = operator_pod["status"]["containerStatuses"][0]["restartCount"]
-        if restart_count > 0:
-            previous_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
-            operator_logs = "".join(
-                (
-                    operator_logs,
-                    previous_logs,
-                )
-            )
 
-        # Check whether the logs contain a positive record of the integration
-        if version.get_semantic_ocs_version_from_config() < version.VERSION_4_10:
-            assert "found root secret in external KMS successfully" in operator_logs
-        else:
-            assert "setKMSConditionStatus Init" in operator_logs
-            assert "setKMSConditionStatus Sync" in operator_logs
+        # Look for the target records in the logs of the pod
+        targets_found = False
+        operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
+        targets_found = all(target in operator_logs for target in target_records)
+
+        # Also check the logs before the last pod restart
+        if not targets_found and restart_count > 0:
+            operator_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
+            targets_found = all(target in operator_logs for target in target_records)
+
+        assert (
+            targets_found
+        ), "No records were found of the integration of NooBaa and KMS"

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -26,7 +26,19 @@ class TestNoobaaKMS(MCGTest):
             label=constants.NOOBAA_OPERATOR_POD_LABEL,
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
         )[0]
-        operator_logs = pod.get_pod_logs(pod_name=operator_pod["metadata"]["name"])
+        operator_pod_name = operator_pod["metadata"]["name"]
+        operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
+
+        restart_count = operator_pod["status"]["containerStatuses"][0]["restartCount"]
+        if restart_count > 0:
+            previous_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
+            operator_logs = "".join(
+                (
+                    operator_logs,
+                    previous_logs,
+                )
+            )
+
         if version.get_semantic_ocs_version_from_config() < version.VERSION_4_10:
             assert "found root secret in external KMS successfully" in operator_logs
         else:

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -22,6 +22,7 @@ class TestNoobaaKMS(MCGTest):
         """
         Validate from logs that there is successfully used NooBaa with KMS integration.
         """
+        # Collect the current logs from the noobaa-operator pod
         operator_pod = pod.get_pods_having_label(
             label=constants.NOOBAA_OPERATOR_POD_LABEL,
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
@@ -29,6 +30,7 @@ class TestNoobaaKMS(MCGTest):
         operator_pod_name = operator_pod["metadata"]["name"]
         operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
 
+        # If the pod restarted, collect the previous logs as well
         restart_count = operator_pod["status"]["containerStatuses"][0]["restartCount"]
         if restart_count > 0:
             previous_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
@@ -39,6 +41,7 @@ class TestNoobaaKMS(MCGTest):
                 )
             )
 
+        # Check whether the logs contain a positive record of the integration
         if version.get_semantic_ocs_version_from_config() < version.VERSION_4_10:
             assert "found root secret in external KMS successfully" in operator_logs
         else:


### PR DESCRIPTION
Fixes: #6575 

Signed-off-by: Sagi Hirshfeld <shirshfe@redhat.com>