### PR TITLE
Update ms_osd_pod_memory value

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -218,7 +218,7 @@ ENV_DATA:
   ms_env_type: 'staging'
   rosa_cli_version: '1.2.6'
   appliance_mode: true
-  ms_osd_pod_memory: "7Gi"
+  ms_osd_pod_memory: "5700Mi"
 
   # used in external mode deployment
   restricted-auth-permission: false


### PR DESCRIPTION
OSD pod memory in Managed Services provider cluster is changed to 5700Mi  in v2.0.11.
Fixes #6872 
Signed-off-by: Jilju Joy <jijoy@redhat.com>