### PR TITLE
Added skipif_external_mode tag for test_mon_log_trimming testcase

### DIFF
--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -3,7 +3,7 @@ import random
 import threading
 import pytest
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import E2ETest, bugzilla, tier2
+from ocs_ci.framework.testlib import E2ETest, bugzilla, tier2, skipif_external_mode
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_mon_pods
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 
 
 @tier2
+@skipif_external_mode
 @bugzilla("1941939")
 @pytest.mark.polarion_id("OCS-2526")
 class TestMonLogTrimming(E2ETest):


### PR DESCRIPTION
Signed-off-by: Amrita Mahapatra <49347640+amr1ta@users.noreply.github.com>

In External mode there will be no any mon,osd,mds,mgr,rgw pods. [Reference](https://docs.google.com/presentation/d/1H_2D2f9LUWRqQTGbYcPVA3z3YIhEE-4hm3yUEb9WNC0/edit#slide=id.g900445dfe9_0_178)

Deployment: OCS4-12-Downstream-OCP4-12-VSPHERE6-UPI-1AZ-RHCOS-EXTERNAL-3M-3W-tier2-jenkins

Test: [tests.manage.z_cluster.test_mon_log_trimming.TestMonLogTrimming](https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/362/6898/286901/287073)

Failure message:
Message: failed on setup with "IndexError: Cannot choose from an empty sequence"
Type: None


Text:
self = <tests.manage.z_cluster.test_mon_log_trimming.TestMonLogTrimming object at 0x7f4167ae4040>
request = <SubRequest 'setup' for >
pod_factory = <function pod_factory_fixture..factory at 0x7f41845d83a0>

