### PR TITLE
test_encrypted_rbd_block_pvc_snapshot I/O enhancement

### DIFF
--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
@@ -190,6 +190,8 @@ class TestEncryptedRbdBlockPvcSnapshot(ManageTest):
                 size=f"{self.pvc_size - 1}G",
                 io_direction="write",
                 runtime=60,
+                end_fsync=1,
+                direct=1,
             )
         log.info("IO started on all pods")
 


### PR DESCRIPTION
Add fio parameters direct=1 and end_fsync=1 in test_encrypted_rbd_block_pvc_snapshot
Based on discussions in PR #5193 and [Bug 2028757](https://bugzilla.redhat.com/show_bug.cgi?id=2028757) to make the test more stable.

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>