### PR TITLE
Fix the deletion of the underlying storage of GCP BackingStores and minor refactor regarding CloudClient.delete_uls

### DIFF
--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -412,7 +412,7 @@ class GoogleClient(CloudClient):
             try:
                 bucket = GCPBucket(client=self.client, name=name)
                 blobs = self.client.list_blobs(bucket)
-                bucket.delete_blobs(blobs)
+                bucket.delete_blobs(list(blobs))
                 bucket.delete()
                 break
             except GoogleExceptions.NotFound:

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -126,7 +126,7 @@ class CloudClient(ABC):
         """
         if self.verify_uls_exists(name) is False:
             logger.warning(
-                f"Underlying Storage {name} does not exist, hence was not deleted."
+                f"Underlying Storage {name} does not exist, hence it can't be deleted."
             )
             return
 

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -126,7 +126,7 @@ class CloudClient(ABC):
         """
         if self.verify_uls_exists(name) is False:
             logger.warning(
-                f"Underlying Storage {name} does not exist, and was not deleted."
+                f"Underlying Storage {name} does not exist, hence was not deleted."
             )
             return
 

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -134,7 +134,7 @@ class CloudClient(ABC):
 
         try:
             for deletion_result in TimeoutSampler(
-                60, 5, self.internal_delete_uls, self, name
+                60, 5, self.internal_delete_uls, name
             ):
                 if deletion_result:
                     logger.info("ULS deleted.")

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -411,7 +411,8 @@ class GoogleClient(CloudClient):
         for _ in range(10):
             try:
                 bucket = GCPBucket(client=self.client, name=name)
-                bucket.delete_blobs(bucket.list_blobs())
+                blobs = self.client.list_blobs(bucket)
+                bucket.delete_blobs(blobs)
                 bucket.delete()
                 break
             except GoogleExceptions.NotFound:


### PR DESCRIPTION
Fixes: #6837 

`GCPBucket.delete_blobs` in `GoogleClient.delete_uls` could not parse the blobs in HTTPIterator which is the default output of `GCPBucket.list_blobs`, causing an `HTTPIterator has no len` error. This issue is resolved by passing these blobs via a Python List instead.

In addition to solving this issue, this PR includes a minor refactor regarding the way that CloudClients and it's inheritors S3Client, GoogleClient, and AzureClient are deleting ULS':

The TimeoutSampler logic that was used in `S3Client.delete_uls` has been elevated to the abstract parent class and the abstract method `CloudClient.internal_delete_uls`, which is implemented by each inheritor, is the function that is used by the TimeoutSampler.

