### PR TITLE
Skip MCG tests that make external requests in disconnected deployments

### DIFF
--- a/tests/manage/mcg/test_cached_buckets.py
+++ b/tests/manage/mcg/test_cached_buckets.py
@@ -10,12 +10,20 @@ from ocs_ci.ocs.bucket_utils import (
     write_random_objects_in_pod,
     sync_object_directory,
 )
-from ocs_ci.framework.pytest_customization.marks import bugzilla, polarion_id, tier2
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    polarion_id,
+    skipif_disconnected_cluster,
+    skipif_aws_creds_are_missing,
+    tier2,
+)
 from ocs_ci.framework.testlib import MCGTest
 
 logger = logging.getLogger(__name__)
 
 
+@skipif_disconnected_cluster
+@skipif_aws_creds_are_missing
 class TestCachedBuckets(MCGTest):
     """
     Tests Noobaa cache bucket caching mechanism

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.bucket_utils import (
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 @skipif_managed_service
+@skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 class TestMultiRegion(MCGTest):
     """

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.testlib import (
     MCGTest,
     on_prem_platform_required,
     skipif_ocs_version,
+    skipif_disconnected_cluster,
     tier1,
     tier2,
     tier4c,
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 @skipif_managed_service
 @skipif_aws_creds_are_missing
+@skipif_disconnected_cluster
 @skipif_ocs_version("<4.7")
 class TestNamespace(MCGTest):
     """

--- a/tests/manage/mcg/test_noobaa_secret.py
+++ b/tests/manage/mcg/test_noobaa_secret.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     bugzilla,
     skipif_ocs_version,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.aws import update_config_from_s3
@@ -59,6 +60,7 @@ def cleanup(request):
 
 @tier2
 @skipif_ocs_version("<4.11")
+@skipif_disconnected_cluster
 class TestNoobaaSecrets:
     @bugzilla("1992090")
     @polarion_id("OCS-4466")

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -13,6 +13,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_ocs_version,
+    skipif_disconnected_cluster,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ class TestObjectIntegrity(MCGTest):
     Test data integrity of various objects
     """
 
+    @skipif_disconnected_cluster
     @pytest.mark.polarion_id("OCS-1321")
     @pytest.mark.parametrize(
         argnames="bucketclass_dict",


### PR DESCRIPTION
Fixes: #6855 

Implemented by adding the `@skipif_disconnected_cluster` PyTest mark to tests that make external requests.

These requests are mostly to AWS, as evident by the current `@skipif_aws_creds_are_missing` flag in most of these tests.