### PR TITLE
In the test "test_noobaa_sts_host_node_failure" Change how we check the old noobaa operator status

### DIFF
--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -221,7 +221,7 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
         wait_for_pods_to_be_running(timeout=300)
 
         # Check cluster health
-        self.sanity_helpers.health_check()
+        self.sanity_helpers.health_check(tries=30)
 
         # Creates bucket then writes, reads and deletes objects
         # TODO: Reduce timeout in future versions once 2028559 is fixed

--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -12,16 +12,17 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
 from ocs_ci.helpers.helpers import (
-    wait_for_resource_state,
     storagecluster_independent_check,
 )
 from ocs_ci.ocs import constants, node
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
+from ocs_ci.ocs.node import get_nodes, recover_node_to_ready_state
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import (
     get_pod_node,
     get_noobaa_pods,
     wait_for_pods_to_be_running,
+    wait_for_pods_to_be_in_statuses,
 )
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -55,6 +56,19 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
             self.sanity_helpers = SanityExternalCluster()
         else:
             self.sanity_helpers = Sanity()
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request, nodes):
+        """
+        Make sure all the worker nodes are up again
+        """
+
+        def finalizer():
+            wnodes = get_nodes()
+            for n in wnodes:
+                recover_node_to_ready_state(n)
+
+        request.addfinalizer(finalizer)
 
     @pytest.mark.parametrize(
         argnames=["noobaa_sts", "respin_noobaa_operator"],
@@ -132,18 +146,25 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
 
         # Disrupt NooBaa operator
         if respin_noobaa_operator:
-            noobaa_operator_pod.delete(force=True)
+            try:
+                noobaa_operator_pod.delete(force=True)
+            except CommandFailed as e:
+                log.warning(
+                    f"Failed to delete the noobaa operator pod due to the exception: {str(e)}"
+                )
 
         # Check result of 'stop_thread'
         stop_thread.result()
 
-        # Wait for NooBaa operator pod to reach terminating state if on same node
-        # and not respun
-        if operator_on_same_node and not respin_noobaa_operator:
-            wait_for_resource_state(
-                resource=noobaa_operator_pod,
-                state=constants.STATUS_TERMINATING,
-                timeout=360,
+        # Wait for NooBaa operator pod to reach terminating state or to be deleted
+        # if on same node or respun
+        if operator_on_same_node or respin_noobaa_operator:
+            assert wait_for_pods_to_be_in_statuses(
+                [constants.STATUS_TERMINATING],
+                pod_names=[noobaa_operator_pod.name],
+                raise_pod_not_found_error=False,
+                timeout=420,
+                sleep=20,
             )
 
         # Wait for NooBaa operator pod to reach running state
@@ -151,6 +172,8 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
             condition=constants.STATUS_RUNNING,
             selector=self.labels_map[constants.NOOBAA_OPERATOR_DEPLOYMENT],
             resource_count=1,
+            timeout=420,
+            sleep=20,
         )
 
         # Verify NooBaa statefulset pod reschedules on another node

--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -16,7 +16,6 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
-from ocs_ci.ocs.node import get_nodes, recover_node_to_ready_state
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import (
     get_pod_node,
@@ -56,19 +55,6 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
             self.sanity_helpers = SanityExternalCluster()
         else:
             self.sanity_helpers = Sanity()
-
-    @pytest.fixture(autouse=True)
-    def teardown(self, request, nodes):
-        """
-        Make sure all the worker nodes are up again
-        """
-
-        def finalizer():
-            wnodes = get_nodes()
-            for n in wnodes:
-                recover_node_to_ready_state(n)
-
-        request.addfinalizer(finalizer)
 
     @pytest.mark.parametrize(
         argnames=["noobaa_sts", "respin_noobaa_operator"],
@@ -221,7 +207,7 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
         wait_for_pods_to_be_running(timeout=300)
 
         # Check cluster health
-        self.sanity_helpers.health_check(tries=30)
+        self.sanity_helpers.health_check(tries=40)
 
         # Creates bucket then writes, reads and deletes objects
         # TODO: Reduce timeout in future versions once 2028559 is fixed


### PR DESCRIPTION
See the comment here: https://github.com/red-hat-storage/ocs-ci/issues/6689#issuecomment-1372144623, and the following discussion.