### PR TITLE
Add tests for snapshot and clone using KMIP (Thales)

### DIFF
--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -1941,12 +1941,13 @@ def remove_kmsid(kmsid):
 
     """
     ocp_obj = ocp.OCP()
-    patch = f'\'[{{"op": "remove", "path": "/data/{kmsid}"}}]\''
-    patch_cmd = (
-        f"patch -n {constants.OPENSHIFT_STORAGE_NAMESPACE} cm "
-        f"{constants.VAULT_KMS_CSI_CONNECTION_DETAILS} --type json -p " + patch
-    )
-    ocp_obj.exec_oc_cmd(command=patch_cmd)
+    if kmsid:
+        patch = f'\'[{{"op": "remove", "path": "/data/{kmsid}"}}]\''
+        patch_cmd = (
+            f"patch -n {constants.OPENSHIFT_STORAGE_NAMESPACE} cm "
+            f"{constants.VAULT_KMS_CSI_CONNECTION_DETAILS} --type json -p " + patch
+        )
+        ocp_obj.exec_oc_cmd(command=patch_cmd)
     kmsid_list = get_encryption_kmsid()
     if kmsid in kmsid_list:
         raise KMSResourceCleaneupError(f"KMS ID {kmsid} deletion failed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4540,7 +4540,7 @@ def load_cluster_info_file(request):
     load_cluster_info()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def pv_encryption_kms_setup_factory(request):
     """
     Create vault resources and setup csi-kms-connection-details configMap
@@ -4644,7 +4644,7 @@ def pv_encryption_vault_setup_factory(request):
     return factory
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="class")
 def pv_encryption_kmip_setup_factory(request):
     """
     Create KMIP resources and setup csi-kms-connection-details configMap

--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -21,8 +21,7 @@ from ocs_ci.ocs.exceptions import (
     KMSResourceCleaneupError,
     ResourceNotFoundError,
 )
-from ocs_ci.utility import kms
-from semantic_version import Version
+from ocs_ci.utility import kms, version
 
 
 log = logging.getLogger(__name__)
@@ -55,7 +54,7 @@ else:
                 "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2651")
             ),
         ]
-    if Version.coerce(config.ENV_DATA["ocs_version"]) >= Version.coerce("4.12"):
+    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
         argvalues.append(
             pytest.param(
                 "v1",
@@ -301,9 +300,10 @@ class TestEncryptedRbdClone(ManageTest):
 
         if kms_provider == constants.VAULT_KMS_PROVIDER:
             # Verify if the keys for parent and cloned PVCs are deleted from Vault
-            if kv_version == "v1" or Version.coerce(
-                config.ENV_DATA["ocs_version"]
-            ) >= Version.coerce("4.9"):
+            if (
+                kv_version == "v1"
+                or version.get_semantic_ocs_version_from_config() >= version.VERSION_4_9
+            ):
                 log.info(
                     "Verify whether the keys for cloned PVCs are deleted from vault"
                 )

--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
@@ -23,8 +23,7 @@ from ocs_ci.ocs.exceptions import (
     KMSResourceCleaneupError,
     ResourceNotFoundError,
 )
-from ocs_ci.utility import kms
-from semantic_version import Version
+from ocs_ci.utility import kms, version
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ else:
                 "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2613")
             ),
         ]
-    if Version.coerce(config.ENV_DATA["ocs_version"]) >= Version.coerce("4.12"):
+    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12:
         argvalues.append(
             pytest.param(
                 "v1",
@@ -392,9 +391,10 @@ class TestEncryptedRbdBlockPvcSnapshot(ManageTest):
 
         if kms_provider == constants.VAULT_KMS_PROVIDER:
             # Verify if keys for PVCs and snapshots are deleted from  Vault
-            if kv_version == "v1" or Version.coerce(
-                config.ENV_DATA["ocs_version"]
-            ) >= Version.coerce("4.9"):
+            if (
+                kv_version == "v1"
+                or version.get_semantic_ocs_version_from_config() >= version.VERSION_4_9
+            ):
                 log.info(
                     "Verify whether the keys for PVCs and snapshots are deleted in vault"
                 )


### PR DESCRIPTION
Add tests for PVC snapshot and restore and PVC cloning for encrypted PVCs using KMIP (Thales CipherTrust Manager)

Signed-off-by: rachael-george <rgeorge@redhat.com>