### PR TITLE
Skip test_overprovision_level_policy_control_with_capacity on external mode

### DIFF
--- a/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
+++ b/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     skipif_managed_service,
+    skipif_external_mode,
 )
 
 
@@ -27,6 +28,7 @@ def setup_sc(storageclass_factory_class):
 
 @tier1
 @pytest.mark.polarion_id("OCS-3778")
+@skipif_external_mode
 @skipif_managed_service
 class TestOverProvisionLevelPolicyControlWithCapacity(ManageTest):
     """


### PR DESCRIPTION
Fixes: #6933 

Signed-off-by: rachael-george <rgeorge@redhat.com>