### PR TITLE
Disable managed ODF topology check

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1334,8 +1334,9 @@ def verify_managed_service_resources():
     if config.ENV_DATA["cluster_type"].lower() == "provider":
         verify_provider_storagecluster(sc_data)
         verify_provider_resources()
-        if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11"):
-            verify_provider_topology()
+        # TODO: adjust topology check when the final version is known
+        # if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11"):
+        #    verify_provider_topology()
     else:
         verify_consumer_storagecluster(sc_data)
         verify_consumer_resources()

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -10,10 +10,11 @@ import yaml
 from jsonschema import validate
 
 from ocs_ci.framework import config
-from ocs_ci.helpers.managed_services import (
-    verify_provider_topology,
-    get_ocs_osd_deployer_version,
-)
+
+# from ocs_ci.helpers.managed_services import (
+#    verify_provider_topology,
+#    get_ocs_osd_deployer_version,
+# )
 from ocs_ci.ocs import constants, defaults, ocp, managedservice
 from ocs_ci.ocs.exceptions import (
     CommandFailed,


### PR DESCRIPTION
Topology of managed ODF clusters is changing due to Pricing epic. The final version is yet unknown. We need to disable the check so that deployments are not marked as failed.

Signed-off-by: Elena Bondarenko <ebondare@redhat.com>