### PR TITLE
Change pod.py::cal_md5sum to use oc exec instead of oc rsh

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1013,7 +1013,7 @@ def cal_md5sum(pod_obj, file_name, block=False, raw_path=False):
     else:
         file_path = file_name
 
-    md5sum_cmd_out = OCP().exec_oc_cmd(
+    md5sum_cmd_out = pod_obj.ocp.exec_oc_cmd(
         command=f"exec {pod_obj.name} -- md5sum {file_path}"
     )
     md5sum = md5sum_cmd_out.split()[0]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1012,10 +1012,12 @@ def cal_md5sum(pod_obj, file_name, block=False, raw_path=False):
         )
     else:
         file_path = file_name
-    md5sum_cmd_out = pod_obj.exec_cmd_on_pod(
-        command=f'bash -c "md5sum {file_path}"', out_yaml_format=False
+
+    md5sum_cmd_out = OCP().exec_oc_cmd(
+        command=f"exec {pod_obj.name} -- md5sum {file_path}"
     )
     md5sum = md5sum_cmd_out.split()[0]
+
     logger.info(f"md5sum of file {file_name}: {md5sum}")
     return md5sum
 


### PR DESCRIPTION
Fixes: #5463

This change allows running md5sum regardless of which type of shell is installed on the pod, as long as it's available in the desired path.

This should be compatible with all platforms, but testing on platforms other than vSphere is still needed to confirm.

Signed-off-by: Sagi Hirshfeld <shirshfe@redhat.com>