### PR TITLE
MS: Move OSD memory check to verify_provider_topology function

### DIFF
--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -26,7 +26,7 @@ def verify_provider_topology():
     4. Verify worker node instance type
     5. Verify worker node instance count
     6. Verify OSD count
-    7. Verify OSD cpu
+    7. Verify OSD CPU and memory
 
     """
     # importing here to avoid circular import
@@ -108,11 +108,12 @@ def verify_provider_topology():
     ), f"OSD count is not as expected. Actual:{osd_count}. Expected:{size_map[size]['osd_count']}"
     log.info(f"Verified that the OSD count is {size_map[size]['osd_count']}")
 
-    # Verify OSD cpu
+    # Verify OSD CPU and memory
     osd_cpu_limit = "1750m"
     osd_cpu_request = "1750m"
     osd_pods = get_osd_pods()
-    log.info("Verifying OSD cpu")
+    osd_memory_size = config.ENV_DATA["ms_osd_pod_memory"]
+    log.info("Verifying OSD CPU and memory")
     for osd_pod in osd_pods:
         for container in osd_pod.data["spec"]["containers"]:
             if container["name"] == "osd":
@@ -124,7 +125,13 @@ def verify_provider_topology():
                     f"OSD pod {osd_pod.name} container osd doesn't have cpu request {osd_cpu_request}. "
                     f"Request is {container['resources']['requests']['cpu']}"
                 )
-    log.info("Verified OSD CPU")
+                assert (
+                    container["resources"]["limits"]["memory"] == osd_memory_size
+                ), f"OSD pod {osd_pod.name} container osd doesn't have memory limit {osd_memory_size}"
+                assert (
+                    container["resources"]["requests"]["memory"] == osd_memory_size
+                ), f"OSD pod {osd_pod.name} container osd doesn't have memory request {osd_memory_size}"
+    log.info("Verified OSD CPU and memory")
 
 
 def get_used_capacity(msg):

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1357,7 +1357,6 @@ def verify_provider_resources():
     1. Ocs-provider-server pod is Running
     2. cephcluster is Ready and its hostNetworking is set to True
     3. Security groups are set up correctly
-    4. verify memory limit of OSD pods are set to 7Gi
     """
     # Verify ocs-provider-server pod is Running
     pod_obj = OCP(
@@ -1380,20 +1379,6 @@ def verify_provider_resources():
     ], f"hostNetwork is {cephcluster_yaml['spec']['network']['hostNetwork']}"
 
     assert verify_worker_nodes_security_groups()
-
-    # verify OSD pod memory size
-    osd_memory_size = config.ENV_DATA["ms_osd_pod_memory"]
-    osd_pods = get_osd_pods()
-    log.info("verifying OSD pod memory size")
-    for osd_pod in osd_pods:
-        for each_container in osd_pod.data["spec"]["containers"]:
-            if "osd" in each_container["name"]:
-                assert (
-                    each_container["resources"]["limits"]["memory"] == osd_memory_size
-                ), f"OSD pod {osd_pod.name} container osd doesn't have limits memory of 7Gi"
-                assert (
-                    each_container["resources"]["requests"]["memory"] == osd_memory_size
-                ), f"OSD pod {osd_pod.name} container osd doesn't have requests memory of 7Gi"
 
 
 def verify_consumer_resources():


### PR DESCRIPTION
The memory of OSD is changed as part of topology changes. Moving the verification of OSD memory to the function verify_provider_topology will keep the verification of topology changes in on place.
Closes #6957
Signed-off-by: Jilju Joy <jijoy@redhat.com>