### PR TITLE
Fix login UI urllib3 exceptions MaxRetryError

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -846,7 +846,7 @@ def garbage_collector_webdriver():
     for obj in collected_objs:
         if str(type(obj)) == constants.WEB_DRIVER_CHROME_OBJ_TYPE:
             try:
-                obj.close()
+                obj.quit()
             except WebDriverException as e:
                 logger.error(e)
 
@@ -1027,7 +1027,8 @@ def close_browser(driver):
     logger.info("Close browser")
     take_screenshot(driver)
     copy_dom(driver)
-    driver.close()
+    driver.quit()
+    time.sleep(10)
     garbage_collector_webdriver()
 
 


### PR DESCRIPTION
Changed the closing method from `close` to `quit`

```
failed on setup with "urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='127.0.0.1', port=45301): Max retries exceeded with url: /session/58d5027e5219c9c63704113e78e2b2ca/window (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f8ae7195fd0>: Failed to establish a new connection: [Errno 111] Connection refused'))"
```

https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster-prod/6664/testReport/tests.ui.test_validation_ui/TestUserInterfaceValidation/test_dashboard_validation_ui/

https://stackoverflow.com/questions/63944480/maxretryerror-selenium

Signed-off-by: OdedViner <oviner@redhat.com>