### PR TITLE
[RDR] Additional health checks, validation for PV and backend image deletion

### DIFF
--- a/tests/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_failover.py
@@ -7,6 +7,8 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import rdr_test
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +58,7 @@ class TestFailover:
 
         # Stop primary cluster nodes
         if primary_cluster_down:
+            logger.info("Stopping primary cluster nodes")
             nodes_multicluster[primary_cluster_index].stop_nodes(node_objs)
 
         # Failover action
@@ -84,6 +87,14 @@ class TestFailover:
             sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(node_objs)
             wait_for_nodes_status([node.name for node in node_objs])
+            logger.info(
+                "Wait for all the pods in openshift-storage to be in running state"
+            )
+            assert wait_for_pods_to_be_running(
+                timeout=720
+            ), "Not all the pods reached running state"
+            logger.info("Checking for Ceph Health OK")
+            ceph_health_check()
         dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
 
         dr_helpers.wait_for_mirroring_status_ok()

--- a/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -7,6 +7,8 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import rdr_test
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +60,7 @@ class TestFailoverAndRelocate:
 
         # Stop primary cluster nodes
         if primary_cluster_down:
+            logger.info("Stopping primary cluster nodes")
             nodes_multicluster[primary_cluster_index].stop_nodes(node_objs)
 
         # Failover action
@@ -86,6 +89,14 @@ class TestFailoverAndRelocate:
             sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(node_objs)
             wait_for_nodes_status([node.name for node in node_objs])
+            logger.info(
+                "Wait for all the pods in openshift-storage to be in running state"
+            )
+            assert wait_for_pods_to_be_running(
+                timeout=720
+            ), "Not all the pods reached running state"
+            logger.info("Checking for Ceph Health OK")
+            ceph_health_check()
         dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
 
         dr_helpers.wait_for_mirroring_status_ok()


### PR DESCRIPTION
Few enhancements for RDR tests
 - Added checks for OCS pods and Ceph health after nodes power ON in failover tests
 - Added validation for PV deletion
 - Added validation for backend RBD image deletion 
  
 Related bugs for above enhancements
 -  [2140550](https://bugzilla.redhat.com/show_bug.cgi?id=2140550)
 -  [2155976](https://bugzilla.redhat.com/show_bug.cgi?id=2155976)

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>