### PR TITLE
Get the actual replica size of pool in test

### DIFF
--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -65,8 +65,10 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
 
         cbp_name = helpers.default_ceph_block_pool()
 
-        cbp_data = helpers.get_pool_cr(cbp_name)
-        replica_size = int(cbp_data["spec"]["replicated"]["size"])
+        tools_pod = pod.get_ceph_tools_pod()
+        cmd = f"ceph osd pool get {cbp_name} size"
+        size_info = tools_pod.exec_ceph_cmd(ceph_cmd=cmd)
+        replica_size = size_info("size")
 
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL, size=10, status=constants.STATUS_BOUND

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -68,7 +68,7 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         tools_pod = pod.get_ceph_tools_pod()
         cmd = f"ceph osd pool get {cbp_name} size"
         size_info = tools_pod.exec_ceph_cmd(ceph_cmd=cmd)
-        replica_size = size_info("size")
+        replica_size = int(size_info["size"])
 
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL, size=10, status=constants.STATUS_BOUND

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -65,8 +65,8 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
 
         cbp_name = helpers.default_ceph_block_pool()
 
-        # TODO: Get exact value of replica size
-        replica_size = 3
+        cbp_data = helpers.get_pool_cr(cbp_name)
+        replica_size = int(cbp_data["spec"]["replicated"]["size"])
 
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL, size=10, status=constants.STATUS_BOUND


### PR DESCRIPTION
Update the test tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py to get the actual replica size of the pool.
This change will also fixes #6985 
Signed-off-by: Jilju Joy <jijoy@redhat.com>