### PR TITLE
Remove SYS_ADMIN capability for fedora DC workload to comply with pod security profiles

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -316,10 +316,6 @@ def create_pod(
                 del pod_data["spec"]["template"]["spec"]["containers"][0][
                     "volumeMounts"
                 ]
-                security_context = {"capabilities": {"add": ["SYS_ADMIN"]}}
-                pod_data["spec"]["template"]["spec"]["containers"][0][
-                    "securityContext"
-                ] = security_context
 
             pod_data["spec"]["template"]["spec"]["containers"][0][
                 "volumeDevices"


### PR DESCRIPTION
Fixes: #6982 

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>