### PR TITLE
latency setup for a single cluster

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_arbiter.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_arbiter.yaml
@@ -12,6 +12,7 @@ DEPLOYMENT:
   arbiter_autodetect: false
   dummy_zone_node_labels: true
   network_split_setup: true
+  network_zone_latency: 5
 ENV_DATA:
   platform: 'vsphere'
   deployment_type: 'upi'

--- a/ocs_ci/ocs/resources/machineconfig.py
+++ b/ocs_ci/ocs/resources/machineconfig.py
@@ -1,0 +1,67 @@
+# -*- coding: utf8 -*-
+
+
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
+
+
+logger = logging.getLogger(__name__)
+
+
+def deploy_machineconfig(tmp_path, mc_name, mc_dict, mcp_num=2):
+    """
+    Deploy given ``MachineConfig`` dict and wait for the configuration to be
+    deployed on all MachineConfigPools. By default we assume there are
+    just two pools.
+
+    Args:
+        tmp_path (pathlib.Path): Directory where a temporary yaml file will
+            be created. In test context, use pytest fixture `tmp_path`_.
+        mc_name (str): name prefix for object config yaml file which will be
+            created for the machineconfig before it's deployment
+        mc_dict (list): list of dictionaries with MachineConfig resource(s)
+            to deploy
+        mcp_num (int): number of MachineConfigPool resources in the cluster
+
+    .. _`tmp_path`: https://docs.pytest.org/en/latest/tmpdir.html#the-tmp-path-fixture
+    """
+    # deploy the machine config within openshift-config namespace
+    mc_file = ObjectConfFile(mc_name, mc_dict, None, tmp_path)
+    mc_file.create(namespace=constants.OPENSHIFT_CONFIG_NAMESPACE)
+    # now let's make sure the MCO (machine config operator) noticed just
+    # deployed givne machine config and started to process it
+    logger.info(
+        "waiting for both machineconfigpools to be updating "
+        "as a result of deployment of given machineconfig"
+    )
+    mcp_h = OCP(
+        kind=constants.MACHINECONFIGPOOL, namespace=constants.OPENSHIFT_CONFIG_NAMESPACE
+    )
+    mcp_h.wait_for_resource(
+        resource_count=mcp_num,
+        condition="True",
+        column="UPDATING",
+        sleep=5,
+        timeout=120,
+    )
+    # and now wait for MachineConfigPools to be updated and ready
+    logger.info("waiting for %d machineconfigpools to be updated and ready", mcp_num)
+    mcp_h.wait_for_resource(
+        resource_count=mcp_num,
+        condition="True",
+        column="UPDATED",
+        sleep=60,
+        timeout=1800,
+    )
+    # also check that no pools are degraded
+    mcp_h.wait_for_resource(
+        resource_count=mcp_num,
+        condition="False",
+        column="DEGRADED",
+        sleep=10,
+        timeout=120,
+    )
+    logger.info("MachineConfig %s has been deployed", mc_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.1.0#egg=ocp-network-split
+-e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.2.0#egg=ocp-network-split
 -e .


### PR DESCRIPTION
Overview:

- implementing https://github.com/red-hat-storage/ocs-ci/issues/4575
- using [ocp-network-split #3](https://gitlab.com/mbukatov/ocp-network-split/-/issues/3) feature, see [Single Cluster Usage](https://mbukatov.gitlab.io/ocp-network-split/usage.html#single-cluster-usage)
- use the latency in `upi_1az_rhcos_vsan_lso_vmdk_3m_6w_arbiter.yaml` config

Verification/Status:

- [X] latency is deployed when the arbiter cluster conf is used
- [X] tweak production latency value for arbiter: 5ms latency (10ms RTT)
- [x] check missing net splits and weird ZONE_X values (fix passing values)
- [x] testing latency via https://gitlab.com/mbukatov/ocp-network-split/-/raw/5db1aa58dc1e13bf2939a39106533b373811afad/ocpnetsplit/network-pingtest.sh
