### PR TITLE
support Terraform version 1.0.11

### DIFF
--- a/ocs_ci/deployment/terraform.py
+++ b/ocs_ci/deployment/terraform.py
@@ -79,14 +79,15 @@ class Terraform(object):
         )
         module_param = f"-target={module}" if module else ""
         refresh_param = "-refresh=false" if not refresh else ""
-        chdir_param = (
-            f"-chdir={self.path}"
-            if not self.is_directory_path_supported
-            else f"{self.path}"
-        )
+        if self.is_directory_path_supported:
+            chdir_param = ""
+            dir_path = self.path
+        else:
+            chdir_param = f"-chdir={self.path}"
+            dir_path = ""
         cmd = (
             f"{self.terraform_installer} {chdir_param} apply {module_param} {refresh_param} '-var-file={tfvars}'"
-            f" -auto-approve {bootstrap_complete_param}"
+            f" -auto-approve {bootstrap_complete_param} {dir_path}"
         )
 
         run_cmd(cmd, timeout=1500)
@@ -101,14 +102,15 @@ class Terraform(object):
         """
         logger.info("Destroying the cluster")
         refresh_param = "-refresh=false" if not refresh else ""
-        chdir_param = (
-            f"-chdir={self.path}"
-            if not self.is_directory_path_supported
-            else f"{self.path}"
-        )
+        if self.is_directory_path_supported:
+            chdir_param = ""
+            dir_path = self.path
+        else:
+            chdir_param = f"-chdir={self.path}"
+            dir_path = ""
         cmd = (
             f"{self.terraform_installer} {chdir_param} destroy {refresh_param}"
-            f" '-var-file={tfvars}' -auto-approve"
+            f" '-var-file={tfvars}' -auto-approve {dir_path}"
         )
         run_cmd(cmd, timeout=1200)
 
@@ -144,12 +146,13 @@ class Terraform(object):
 
         """
         logger.info(f"Destroying the module: {module}")
-        chdir_param = (
-            f"-chdir={self.path}"
-            if not self.is_directory_path_supported
-            else f"{self.path}"
-        )
-        cmd = f"terraform {chdir_param} destroy -auto-approve -target={module} '-var-file={tfvars}'"
+        if self.is_directory_path_supported:
+            chdir_param = ""
+            dir_path = self.path
+        else:
+            chdir_param = f"-chdir={self.path}"
+            dir_path = ""
+        cmd = f"terraform {chdir_param} destroy -auto-approve -target={module} '-var-file={tfvars}' {dir_path}"
         run_cmd(cmd, timeout=1200)
 
     def change_statefile(self, module, resource_type, resource_name, instance):

--- a/ocs_ci/deployment/terraform.py
+++ b/ocs_ci/deployment/terraform.py
@@ -6,6 +6,7 @@ import os
 import logging
 
 from ocs_ci.framework import config
+from ocs_ci.utility import version
 from ocs_ci.utility.utils import run_cmd
 
 logger = logging.getLogger(__name__)
@@ -22,13 +23,25 @@ class Terraform(object):
 
         Args:
             path (str): Path to the vSphere modules
-            bin_path (str): Path to the terraform binary installer
+            bin_path (str): Path to terraform binary installer
 
         """
         self.path = path
         self.terraform_installer = bin_path or os.path.expanduser(
             config.ENV_DATA["terraform_installer"]
         )
+        self.is_directory_path_supported = False
+        self.terraform_version = config.DEPLOYMENT["terraform_version"]
+        config.ENV_DATA["terraform_state_file"] = os.path.join(
+            self.path, "terraform.tfstate"
+        )
+        if version.get_semantic_version(
+            self.terraform_version
+        ) <= version.get_semantic_version("0.15"):
+            self.is_directory_path_supported = True
+            config.ENV_DATA["terraform_state_file"] = os.path.join(
+                config.ENV_DATA["cluster_path"], "terraform_data", "terraform.tfstate"
+            )
 
     def initialize(self, upgrade=False):
         """
@@ -42,8 +55,10 @@ class Terraform(object):
         logger.info("Initializing terraform work directory")
         if upgrade:
             cmd = f"{self.terraform_installer} init -upgrade {self.path}"
-        else:
+        elif self.is_directory_path_supported:
             cmd = f"{self.terraform_installer} init {self.path}"
+        else:
+            cmd = f"{self.terraform_installer} -chdir={self.path} init"
         run_cmd(cmd, timeout=1200)
 
     def apply(self, tfvars, bootstrap_complete=False, module=None, refresh=True):
@@ -64,9 +79,14 @@ class Terraform(object):
         )
         module_param = f"-target={module}" if module else ""
         refresh_param = "-refresh=false" if not refresh else ""
+        chdir_param = (
+            f"-chdir={self.path}"
+            if not self.is_directory_path_supported
+            else f"{self.path}"
+        )
         cmd = (
-            f"{self.terraform_installer} apply {module_param} {refresh_param} '-var-file={tfvars}'"
-            f" -auto-approve {bootstrap_complete_param} '{self.path}'"
+            f"{self.terraform_installer} {chdir_param} apply {module_param} {refresh_param} '-var-file={tfvars}'"
+            f" -auto-approve {bootstrap_complete_param}"
         )
 
         run_cmd(cmd, timeout=1500)
@@ -81,9 +101,14 @@ class Terraform(object):
         """
         logger.info("Destroying the cluster")
         refresh_param = "-refresh=false" if not refresh else ""
+        chdir_param = (
+            f"-chdir={self.path}"
+            if not self.is_directory_path_supported
+            else f"{self.path}"
+        )
         cmd = (
-            f"{self.terraform_installer} destroy {refresh_param}"
-            f" '-var-file={tfvars}' -auto-approve {self.path}"
+            f"{self.terraform_installer} {chdir_param} destroy {refresh_param}"
+            f" '-var-file={tfvars}' -auto-approve"
         )
         run_cmd(cmd, timeout=1200)
 
@@ -119,7 +144,12 @@ class Terraform(object):
 
         """
         logger.info(f"Destroying the module: {module}")
-        cmd = f"terraform destroy -auto-approve -target={module} '-var-file={tfvars}' '{self.path}'"
+        chdir_param = (
+            f"-chdir={self.path}"
+            if not self.is_directory_path_supported
+            else f"{self.path}"
+        )
+        cmd = f"terraform {chdir_param} destroy -auto-approve -target={module} '-var-file={tfvars}'"
         run_cmd(cmd, timeout=1200)
 
     def change_statefile(self, module, resource_type, resource_name, instance):

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1591,13 +1591,15 @@ def clone_openshift_installer():
         else:
             # due to failure domain changes in 4.13, use 4.12 branch till
             # we incorporate changes
+            # Once https://github.com/openshift/installer/issues/6810 issue is fixed,
+            # we need to revert the changes
             if version.get_semantic_version(
                 ocp_version
             ) >= version.get_semantic_version("4.13"):
                 clone_repo(
                     constants.VSPHERE_INSTALLER_REPO,
                     upi_repo_path,
-                    f"release-4.12",
+                    "release-4.12",
                 )
             else:
                 clone_repo(

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -992,10 +992,16 @@ class VSPHEREUPI(VSPHEREBASE):
                 # remove bootstrap node
                 if not config.DEPLOYMENT["preserve_bootstrap_node"]:
                     logger.info("removing bootstrap node")
+                    bootstrap_module_to_remove = constants.BOOTSTRAP_MODULE_413
+                    if (
+                        version.get_semantic_ocp_version_from_config()
+                        < version.VERSION_4_13
+                    ):
+                        bootstrap_module_to_remove = constants.BOOTSTRAP_MODULE
                     os.chdir(self.terraform_data_dir)
                     if self.folder_structure:
                         self.terraform.destroy_module(
-                            self.terraform_var, constants.BOOTSTRAP_MODULE
+                            self.terraform_var, bootstrap_module_to_remove
                         )
                     else:
                         self.terraform.apply(

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1589,11 +1589,22 @@ def clone_openshift_installer():
                 clone_type="normal",
             )
         else:
-            clone_repo(
-                constants.VSPHERE_INSTALLER_REPO,
-                upi_repo_path,
-                f"release-{ocp_version}",
-            )
+            # due to failure domain changes in 4.13, use 4.12 branch till
+            # we incorporate changes
+            if version.get_semantic_version(
+                ocp_version
+            ) >= version.get_semantic_version("4.13"):
+                clone_repo(
+                    constants.VSPHERE_INSTALLER_REPO,
+                    upi_repo_path,
+                    f"release-4.12",
+                )
+            else:
+                clone_repo(
+                    constants.VSPHERE_INSTALLER_REPO,
+                    upi_repo_path,
+                    f"release-{ocp_version}",
+                )
     elif Version.coerce(ocp_version) == Version.coerce("4.4"):
         clone_repo(
             constants.VSPHERE_INSTALLER_REPO,

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.12-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.12-config.yaml
@@ -4,7 +4,7 @@ RUN:
   client_version: "4.12.0-0.nightly"
 DEPLOYMENT:
   installer_version: "4.12.0-0.nightly"
-  terraform_version: "1.0.11"
+  terraform_version: "0.12.26"
   # ignition_version can be found here
   # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.12-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.12-config.yaml
@@ -4,7 +4,7 @@ RUN:
   client_version: "4.12.0-0.nightly"
 DEPLOYMENT:
   installer_version: "4.12.0-0.nightly"
-  terraform_version: "0.12.26"
+  terraform_version: "1.0.11"
   # ignition_version can be found here
   # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.13-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.13-config.yaml
@@ -4,7 +4,7 @@ RUN:
   client_version: "4.13.0-0.nightly"
 DEPLOYMENT:
   installer_version: "4.13.0-0.nightly"
-  terraform_version: "0.12.26"
+  terraform_version: "1.0.11"
   # ignition_version can be found here
   # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1506,6 +1506,7 @@ FILE_PATH = "/tmp/ceph.tar.gz"
 
 # terraform tfstate modules
 BOOTSTRAP_MODULE = "module.ipam_bootstrap"
+BOOTSTRAP_MODULE_413 = "module.bootstrap"
 LOAD_BALANCER_MODULE = "module.ipam_lb"
 COMPUTE_MODULE = "module.ipam_compute"
 CONTROL_PLANE = "module.ipam_control_plane"

--- a/ocs_ci/utility/load_balancer.py
+++ b/ocs_ci/utility/load_balancer.py
@@ -45,9 +45,7 @@ class LoadBalancer(object):
              str: IP Address of load balancer
 
         """
-        self.terraform_state_file = os.path.join(
-            config.ENV_DATA["cluster_path"], "terraform_data", "terraform.tfstate"
-        )
+        self.terraform_state_file = config.ENV_DATA["terraform_state_file"]
 
         if not os.path.isfile(self.terraform_state_file):
             raise FileNotFoundError(

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -45,6 +45,7 @@ VERSION_4_9 = get_semantic_version("4.9", True)
 VERSION_4_10 = get_semantic_version("4.10", True)
 VERSION_4_11 = get_semantic_version("4.11", True)
 VERSION_4_12 = get_semantic_version("4.12", True)
+VERSION_4_13 = get_semantic_version("4.13", True)
 
 
 def get_semantic_ocs_version_from_config():


### PR DESCRIPTION
Fixes: #6906 

This PR contains below important changes

80bf74b1a155d64e9b204987549c04ffd1bd692b : support terraform version 1.0.11 in terraform module
2ea95d8d8780a204920425017e2a7200423a542b : donot remove lb node along with bootstrap node
0d0a129e1138de15866f34ba9fc2f57bcbeaaf7f : support terraform 1.0.11 version in destroy cluster
016cf163414d8a25aa49e6d3b99863412661c920 : use installer 4.12 branch due to failure domain changes in 4.13 branch
ade03ae671f0a9efdc1f8d32d33823e5e6a61b28 : use terraform version 1.0.11 for OCP 4.13
