### PR TITLE
Fix #6953 test_node_maintenence. Add wait ceph plugin provisioner ready

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -146,14 +146,19 @@ class TestNodesMaintenance(ManageTest):
         # Maintenance the node (unschedule and drain)
         drain_nodes([typed_node_name])
 
-        # check csi-cephfsplugin-provisioner's are ready, see BZ #2162504
-        ceph_provis_pods = get_pods_having_label(
+        # check csi-cephfsplugin-provisioner's and csi-rbdplugin-provisioner's
+        # are ready, see BZ #2162504
+        provis_pods = get_pods_having_label(
             constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
             defaults.ROOK_CLUSTER_NAMESPACE,
         )
-        ceph_provis_pod_names = [p["metadata"]["name"] for p in ceph_provis_pods]
+        provis_pods += get_pods_having_label(
+            constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+            defaults.ROOK_CLUSTER_NAMESPACE,
+        )
+        provis_pod_names = [p["metadata"]["name"] for p in provis_pods]
         wait_for_pods_to_be_running(
-            pod_names=ceph_provis_pod_names, raise_pod_not_found_error=True
+            pod_names=provis_pod_names, raise_pod_not_found_error=True
         )
 
         # Check basic cluster functionality by creating resources

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -143,6 +143,9 @@ class TestNodesMaintenance(ManageTest):
         assert typed_nodes, f"Failed to find a {node_type} node for the test"
         typed_node_name = typed_nodes[0].name
 
+        # Maintenance the node (unschedule and drain)
+        drain_nodes([typed_node_name])
+
         # check csi-cephfsplugin-provisioner's are ready, see BZ #2162504
         ceph_provis_pods = get_pods_having_label(
             constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -5,7 +5,12 @@ import time
 
 from subprocess import TimeoutExpired
 
-from ocs_ci.ocs.exceptions import CephHealthException, ResourceWrongStatusException
+from ocs_ci.ocs.exceptions import (
+    CephHealthException,
+    ResourceWrongStatusException,
+    ResourceNotFoundError,
+)
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check_base, TimeoutSampler
 
 from ocs_ci.ocs import constants, machine, ocp, defaults
@@ -143,9 +148,6 @@ class TestNodesMaintenance(ManageTest):
         assert typed_nodes, f"Failed to find a {node_type} node for the test"
         typed_node_name = typed_nodes[0].name
 
-        # Maintenance the node (unschedule and drain)
-        drain_nodes([typed_node_name])
-
         # check csi-cephfsplugin-provisioner's and csi-rbdplugin-provisioner's
         # are ready, see BZ #2162504
         provis_pods = get_pods_having_label(
@@ -157,9 +159,14 @@ class TestNodesMaintenance(ManageTest):
             defaults.ROOK_CLUSTER_NAMESPACE,
         )
         provis_pod_names = [p["metadata"]["name"] for p in provis_pods]
-        wait_for_pods_to_be_running(
-            pod_names=provis_pod_names, raise_pod_not_found_error=True
-        )
+
+        # Maintenance the node (unschedule and drain)
+        drain_nodes([typed_node_name])
+
+        # avoid scenario when provisioners yet not been created (6 sec for creation)
+        retry(ResourceNotFoundError, tries=2, delay=2, backoff=2)(
+            wait_for_pods_to_be_running
+        )(pod_names=provis_pod_names, raise_pod_not_found_error=True)
 
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),


### PR DESCRIPTION
It was decided to wait until cephfs provisioner pod ready after node drain and before create new resources. 

Details in comments to BZ #2162504
