### PR TITLE
Skipping s3cli pod from respin in test_toleration.py

### DIFF
--- a/tests/manage/z_cluster/nodes/test_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_toleration.py
@@ -57,5 +57,8 @@ class TestTaintAndTolerations(E2ETest):
         # Respin all pods and check it if is still running
         pod_list = get_all_pods(namespace=defaults.ROOK_CLUSTER_NAMESPACE)
         for pod in pod_list:
-            pod.delete(wait=False)
+            if "s3cli" in pod.name:
+                continue
+            else:
+                pod.delete(wait=False)
         assert wait_for_pods_to_be_running(timeout=300)


### PR DESCRIPTION
We need to skip s3cli pod from respin in test_toleration.py as this pod doesnt have the toleration set to "http://node.ocs.openshift.io/storage"

Signed-off-by: pintojoy <jopinto@redhat.com>