### PR TITLE
Switch to the default cluster index at the "create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers" fixture finalizer

### DIFF
--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -25,3 +25,26 @@ def switch_to_orig_index_at_last(func):
                 config.switch_ctx(orig_index)
 
     return inner
+
+
+def switch_to_default_cluster_index_at_last(func):
+    """
+    A decorator for switching to the default cluster index after the function execution.
+    This decorator will primarily be used in the 'teardown' and 'finalizer' methods when we want to make sure
+    that the next test will start with the default cluster index.
+
+    Args:
+        func (function): The function we want to decorate
+
+    """
+
+    def inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        finally:
+            default_cluster_index = config.ENV_DATA["default_cluster_context_index"]
+            if config.cur_index != default_cluster_index:
+                logger.info("Switching back to the default cluster index")
+                config.switch_ctx(default_cluster_index)
+
+    return inner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ from ocs_ci.helpers.longevity_helpers import (
     _multi_obc_lifecycle_factory,
 )
 from ocs_ci.ocs.longevity import start_app_workload
+from ocs_ci.utility.decorators import switch_to_default_cluster_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -5952,15 +5953,13 @@ def create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers(
         config.switch_ctx(orig_index)
         return consumer_index_per_fio_scale_dict
 
+    @switch_to_default_cluster_index_at_last
     def finalizer():
         log.info("Cleaning the fio_scale instances")
         for consumer_i, fio_scale in consumer_index_per_fio_scale_dict.items():
             config.switch_ctx(consumer_i)
             if not fio_scale.is_cleanup:
                 fio_scale.cleanup()
-
-        if orig_index is not None:
-            config.switch_ctx(orig_index)
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
Fix issue https://issues.redhat.com/browse/ODFMS-388.