### PR TITLE
Fixing OBC bound list count mismatch

### DIFF
--- a/ocs_ci/ocs/scale_noobaa_lib.py
+++ b/ocs_ci/ocs/scale_noobaa_lib.py
@@ -120,16 +120,18 @@ def check_all_obc_reached_bound_state_in_kube_job(
     return obc_bound_list
 
 
-def cleanup(namespace, obc_count=None):
+def cleanup(namespace, obc_list=None):
     """
     Delete all OBCs created in the cluster
 
     Args:
         namespace (str): Namespace of OBC's deleting
+        obc_list (string): List of OBCs to be deleted
 
     """
-    if obc_count is not None:
-        obc_name_list = obc_count
+    obc_name_list = list()
+    if obc_list is not None:
+        obc_name_list = obc_list
     else:
         obc_name_list = oc_get_all_obc_names()
     log.info(f"Deleting {len(obc_name_list)} OBCs")
@@ -359,7 +361,7 @@ def noobaa_running_node_restart(pod_name):
     helpers.wait_for_resource_state(nb_pod_obj, constants.STATUS_RUNNING, timeout=180)
 
 
-def check_all_obcs_status(namespace=None, timeout=120):
+def check_all_obcs_status(namespace=None):
     """
     Check all OBCs status in given namespace
 
@@ -380,7 +382,6 @@ def check_all_obcs_status(namespace=None, timeout=120):
             obc_bound_list.append(status)
         else:
             obc_not_bound_list.append(status)
-    time.sleep(timeout)
     return obc_bound_list, obc_not_bound_list
 
 
@@ -511,3 +512,23 @@ def hsbench_cleanup():
     """
     hsbenchs3.delete_test_user()
     hsbenchs3.cleanup()
+
+
+def create_namespace():
+    """
+    Create and set namespace for obcs to be created
+    """
+    namespace_list = list()
+    namespace_list.append(helpers.create_project())
+    namespace = namespace_list[-1].namespace
+    return namespace
+
+
+def delete_namespace(namespace=None):
+    """
+    Delete namespace which was created for OBCs
+    Args:
+        namespace (str): Namespace where OBCs were created
+    """
+    ocp = OCP(kind=constants.NAMESPACE)
+    ocp.delete(resource_name=namespace)

--- a/ocs_ci/ocs/scale_noobaa_lib.py
+++ b/ocs_ci/ocs/scale_noobaa_lib.py
@@ -359,7 +359,7 @@ def noobaa_running_node_restart(pod_name):
     helpers.wait_for_resource_state(nb_pod_obj, constants.STATUS_RUNNING, timeout=180)
 
 
-def check_all_obcs_status(namespace=None):
+def check_all_obcs_status(namespace=None, timeout=120):
     """
     Check all OBCs status in given namespace
 
@@ -380,6 +380,7 @@ def check_all_obcs_status(namespace=None):
             obc_bound_list.append(status)
         else:
             obc_not_bound_list.append(status)
+    time.sleep(timeout)
     return obc_bound_list, obc_not_bound_list
 
 

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -102,7 +102,7 @@ def test_scale_obc_post_upgrade():
         namespace
     )
     log.info(f"OBC Bound list === {obc_bound_list}")
-    log.info(f"OBC Bound list === {obc_not_bound_list}")
+    log.info(f"OBC Not Bound list === {obc_not_bound_list}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -22,8 +22,7 @@ log = logging.getLogger(__name__)
 namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
-# scale_obc_count = 500
-scale_obc_count = 50
+scale_obc_count = 500
 # Number of obc creating by batch
 num_obc_batch = 50
 # Scale data file

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
-scale_obc_count = 500
+# scale_obc_count = 500
+scale_obc_count = 50
 # Number of obc creating by batch
 num_obc_batch = 50
 # Scale data file

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
-scale_obc_count = 500
+# scale_obc_count = 500
+scale_obc_count = 50
 # Number of obc creating by batch
 num_obc_batch = 50
 # Scale data file
@@ -101,9 +102,8 @@ def test_scale_obc_post_upgrade():
     obc_bound_list, obc_not_bound_list = scale_noobaa_lib.check_all_obcs_status(
         namespace
     )
-    log.info(f"OBC Bound list === {obc_bound_list}")
-    log.info(f"OBC Not Bound list === {obc_not_bound_list}")
-    log.info(f" OBC scale list === {obc_scale_list}")
+    log.info(f"OBC Bound list === {len(obc_bound_list)}")
+    log.info(f" OBC scale list === {len(obc_scale_list)}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -18,8 +18,7 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 log = logging.getLogger(__name__)
 
-# Namespace and noobaa storage class
-namespace = scale_noobaa_lib.create_namespace()
+# Noobaa storage class
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
 scale_obc_count = 500
@@ -40,6 +39,7 @@ def test_scale_obc_pre_upgrade(tmp_path, timeout=60):
     Create scaled MCG OBC using Noobaa storage class before upgrade
     Save scaled obc data in a file for post upgrade validation
     """
+    namespace = scale_noobaa_lib.create_namespace()
     obc_scaled_list = []
     log.info(f"Start creating  {scale_obc_count} " f"OBC in a batch of {num_obc_batch}")
     for i in range(int(scale_obc_count / num_obc_batch)):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -103,6 +103,7 @@ def test_scale_obc_post_upgrade():
     )
     log.info(f"OBC Bound list === {obc_bound_list}")
     log.info(f"OBC Not Bound list === {obc_not_bound_list}")
+    log.info(f" OBC scale list === {obc_scale_list}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -101,6 +101,8 @@ def test_scale_obc_post_upgrade():
     obc_bound_list, obc_not_bound_list = scale_noobaa_lib.check_all_obcs_status(
         namespace
     )
+    log.info(f"OBC Bound list === {obc_bound_list}")
+    log.info(f"OBC Bound list === {obc_not_bound_list}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -19,11 +19,10 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 log = logging.getLogger(__name__)
 
 # Namespace and noobaa storage class
-namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+namespace = scale_noobaa_lib.create_namespace()
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
-# scale_obc_count = 500
-scale_obc_count = 50
+scale_obc_count = 500
 # Number of obc creating by batch
 num_obc_batch = 50
 # Scale data file
@@ -102,8 +101,6 @@ def test_scale_obc_post_upgrade():
     obc_bound_list, obc_not_bound_list = scale_noobaa_lib.check_all_obcs_status(
         namespace
     )
-    log.info(f"OBC Bound list === {len(obc_bound_list)}")
-    log.info(f" OBC scale list === {len(obc_scale_list)}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):
@@ -118,4 +115,7 @@ def test_scale_obc_post_upgrade():
     utils.ceph_health_check()
 
     # Clean up all scaled obc
-    scale_noobaa_lib.cleanup(namespace=namespace)
+    scale_noobaa_lib.cleanup(namespace=namespace, obc_list=obc_scale_list)
+
+    # Delete namespace
+    scale_noobaa_lib.delete_namespace(namespace=namespace)

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -20,17 +20,14 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 log = logging.getLogger(__name__)
 
 # Namespace and noobaa storage class
-namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+namespace = scale_noobaa_lib.create_namespace()
 sc_name = constants.DEFAULT_STORAGECLASS_RGW
 # Number of scaled obc count
-# scale_obc_count = 100
-scale_obc_count = 10
+scale_obc_count = 100
 # Number of obc creating by batch
-# num_obc_batch = 50
-num_obc_batch = 10
+num_obc_batch = 50
 # Number of objects
-# num_objs = 150000
-num_objs = 1500
+num_objs = 150000
 # Scale data file
 log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
@@ -135,9 +132,6 @@ def test_scale_obc_rgw_post_upgrade():
         namespace
     )
 
-    log.info(f"OBC Bound list === {len(obc_bound_list)}")
-    log.info(f" OBC scale list === {len(obc_scale_list)}")
-
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):
         raise UnexpectedBehaviour(
@@ -186,7 +180,10 @@ def test_scale_obc_rgw_post_upgrade():
     utils.ceph_health_check()
 
     # Clean up all scaled obcs
-    scale_noobaa_lib.cleanup(namespace=namespace)
+    scale_noobaa_lib.cleanup(namespace=namespace, obc_list=obc_scale_list)
 
     # Cleanup hsbench resources
     scale_noobaa_lib.hsbench_cleanup()
+
+    # Delete namespace
+    scale_noobaa_lib.delete_namespace(namespace=namespace)

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -6,8 +6,8 @@ import os
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
-    pre_upgrade,
-    post_upgrade,
+    # pre_upgrade,
+    # post_upgrade,
     skipif_managed_service,
     skipif_bm,
     skipif_external_mode,
@@ -33,7 +33,6 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
 
 
-@pre_upgrade
 @vsphere_platform_required
 @skipif_external_mode
 @skipif_bm
@@ -108,7 +107,6 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
-@post_upgrade
 @vsphere_platform_required
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -23,11 +23,14 @@ log = logging.getLogger(__name__)
 namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
 sc_name = constants.DEFAULT_STORAGECLASS_RGW
 # Number of scaled obc count
-scale_obc_count = 100
+# scale_obc_count = 100
+scale_obc_count = 10
 # Number of obc creating by batch
-num_obc_batch = 50
+# num_obc_batch = 50
+num_obc_batch = 10
 # Number of objects
-num_objs = 150000
+# num_objs = 150000
+num_objs = 1500
 # Scale data file
 log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
@@ -131,6 +134,9 @@ def test_scale_obc_rgw_post_upgrade():
     obc_bound_list, obc_not_bound_list = scale_noobaa_lib.check_all_obcs_status(
         namespace
     )
+
+    log.info(f"OBC Bound list === {len(obc_bound_list)}")
+    log.info(f" OBC scale list === {len(obc_scale_list)}")
 
     # Check status of OBC scaled in pre-upgrade
     if not len(obc_bound_list) == len(obc_scale_list):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -6,8 +6,8 @@ import os
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
-    # pre_upgrade,
-    # post_upgrade,
+    pre_upgrade,
+    post_upgrade,
     skipif_managed_service,
     skipif_bm,
     skipif_external_mode,
@@ -30,9 +30,10 @@ num_obc_batch = 50
 num_objs = 150000
 # Scale data file
 log_path = ocsci_log_path()
-obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
+obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
+@pre_upgrade
 @vsphere_platform_required
 @skipif_external_mode
 @skipif_bm
@@ -107,6 +108,7 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@post_upgrade
 @vsphere_platform_required
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -19,8 +19,7 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 log = logging.getLogger(__name__)
 
-# Namespace and noobaa storage class
-namespace = scale_noobaa_lib.create_namespace()
+# Noobaa storage class
 sc_name = constants.DEFAULT_STORAGECLASS_RGW
 # Number of scaled obc count
 scale_obc_count = 100
@@ -48,6 +47,7 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
     """
     # Running hsbench to create buckets with objects before upgrade.
     #  PUT, GET and LIST objects of a bucket.
+    namespace = scale_noobaa_lib.create_namespace()
     scale_noobaa_lib.hsbench_setup()
     scale_noobaa_lib.hsbench_io(
         namespace=namespace,


### PR DESCRIPTION
Fixing scale [issue # 6942](https://github.com/red-hat-storage/ocs-ci/issues/6942):
* Using 2 different data files to store obc status
* Using separate namespace to create scaled obcs 