### PR TITLE
Skipping test cases that are not relevant for external mode cluster

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
@@ -4,6 +4,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework.testlib import ignore_leftovers, tier4c, skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @skipif_managed_service
+@skipif_external_mode
 @ignore_leftovers
 @tier4c
 class TestAddCapacityWithResourceDelete:

--- a/tests/manage/z_cluster/test_restart_mgr_while_two_mons_down.py
+++ b/tests/manage/z_cluster/test_restart_mgr_while_two_mons_down.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
 from ocs_ci.ocs.resources.pod import get_deployments_having_label
+from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 @tier2
 @bugzilla("1990031")
 @polarion_id("OCS-2696")
+@skipif_external_mode
 class TestRestartMgrWhileTwoMonsDown(ManageTest):
     """
     Restart mgr pod while two mon pods are down


### PR DESCRIPTION
Few test cases are not relevant for external mode cluster

https://github.com/red-hat-storage/ocs-ci/issues/6847 and https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/362/8246/363236/363317/363319/log

Signed-off-by: pintojoy <jopinto@redhat.com>