### PR TITLE
Verify MS provider topology based on version

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -219,7 +219,7 @@ ENV_DATA:
   rosa_cli_version: '1.2.11'
   rosa_billing_model: 'standard'
   appliance_mode: true
-  ms_osd_pod_memory: "5700Mi"
+  ms_osd_pod_memory: "7Gi"
 
   # used in external mode deployment
   restricted-auth-permission: false

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -11,7 +11,10 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from ocs_ci.framework import config
 
-from ocs_ci.helpers.managed_services import verify_provider_topology
+from ocs_ci.helpers.managed_services import (
+    verify_provider_topology,
+    get_ocs_osd_deployer_version,
+)
 from ocs_ci.ocs import constants, defaults, ocp, managedservice
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -1349,9 +1352,7 @@ def verify_managed_service_resources():
     if config.ENV_DATA["cluster_type"].lower() == "provider":
         verify_provider_storagecluster(sc_data)
         verify_provider_resources()
-        # TODO: adjust topology check when the final version is known
-        # if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11"):
-        if config.ENV_DATA["addon_name"] == "ocs-provider-dev":
+        if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11"):
             verify_provider_topology()
     else:
         verify_consumer_storagecluster(sc_data)


### PR DESCRIPTION
Verify provider topology in Managed Services cluster if the deployer version is 2.0.11 or higher.
Fixes #7000 
Signed-off-by: Jilju Joy <jijoy@redhat.com>