### PR TITLE
Switch to the correct cluster index at setup

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -366,28 +366,28 @@ class MultiClusterConfig:
         cluster_types = [cluster.ENV_DATA["cluster_type"] for cluster in self.clusters]
         return cluster_type in cluster_types
 
-    def get_cluster_type_indexes_list(self, cluster_type):
+    def get_cluster_type_indices_list(self, cluster_type):
         """
-        Get the cluster type indexes
+        Get the cluster type indices
 
         Returns:
-            list: the cluster type indexes
+            list: the cluster type indices
 
         Raises:
             ClusterNotFoundException: In case it didn't find any cluster with the cluster type
 
         """
-        cluster_type_indexes_list = []
+        cluster_type_indices_list = []
         for i, cluster in enumerate(self.clusters):
             if cluster.ENV_DATA["cluster_type"] == cluster_type:
-                cluster_type_indexes_list.append(i)
+                cluster_type_indices_list.append(i)
 
-        if not cluster_type_indexes_list:
+        if not cluster_type_indices_list:
             raise ClusterNotFoundException(
                 f"Didn't find any cluster with the cluster type '{cluster_type}'"
             )
 
-        return cluster_type_indexes_list
+        return cluster_type_indices_list
 
     def switch_to_cluster_by_cluster_type(self, cluster_type, num_of_cluster=0):
         """
@@ -403,7 +403,7 @@ class MultiClusterConfig:
 
         """
         self.switch_ctx(
-            self.get_cluster_type_indexes_list(cluster_type)[num_of_cluster]
+            self.get_cluster_type_indices_list(cluster_type)[num_of_cluster]
         )
 
 

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -352,5 +352,59 @@ class MultiClusterConfig:
         cluster_types = [cluster.ENV_DATA["cluster_type"] for cluster in self.clusters]
         return "consumer" in cluster_types
 
+    def is_cluster_type_exist(self, cluster_type):
+        """
+        Check if the given cluster type exists in the clusters
+
+        Args:
+            cluster_type (str): The cluster type
+
+        Returns:
+            bool: True, if the given cluster type exists in the clusters. False, otherwise.
+
+        """
+        cluster_types = [cluster.ENV_DATA["cluster_type"] for cluster in self.clusters]
+        return cluster_type in cluster_types
+
+    def get_cluster_type_indexes_list(self, cluster_type):
+        """
+        Get the cluster type indexes
+
+        Returns:
+            list: the cluster type indexes
+
+        Raises:
+            ClusterNotFoundException: In case it didn't find any cluster with the cluster type
+
+        """
+        cluster_type_indexes_list = []
+        for i, cluster in enumerate(self.clusters):
+            if cluster.ENV_DATA["cluster_type"] == cluster_type:
+                cluster_type_indexes_list.append(i)
+
+        if not cluster_type_indexes_list:
+            raise ClusterNotFoundException(
+                f"Didn't find any cluster with the cluster type '{cluster_type}'"
+            )
+
+        return cluster_type_indexes_list
+
+    def switch_to_cluster_by_cluster_type(self, cluster_type, num_of_cluster=0):
+        """
+        Switch to the cluster with the given cluster type
+
+        Args:
+            cluster_type (str): The cluster type
+            num_of_cluster (int): The cluster index to switch to. The default cluster number
+                is 0 - which means it will switch to the first cluster.
+                1 - is the second, 2 - is the third, and so on.
+        Raises:
+            ClusterNotFoundException: In case it didn't find any cluster with the cluster type
+
+        """
+        self.switch_ctx(
+            self.get_cluster_type_indexes_list(cluster_type)[num_of_cluster]
+        )
+
 
 config = MultiClusterConfig()

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -204,6 +204,10 @@ END = "END"
 LEAK_LIMIT = 100 * 1024 * 1024  # 100 MB
 RAM = "rss"
 VIRT = "vms"
+# cluster types
+MS_CONSUMER_TYPE = "consumer"
+MS_PROVIDER_TYPE = "provider"
+NON_MS_CLUSTER_TYPE = "non_ms"
 
 OCP_QE_MISC_REPO = "https://gitlab.cee.redhat.com/aosqe/flexy-templates.git"
 CRITICAL_ERRORS = ["core dumped", "oom_reaper"]

--- a/ocs_ci/ocs/managedservice.py
+++ b/ocs_ci/ocs/managedservice.py
@@ -385,8 +385,8 @@ def check_switch_to_correct_cluster_at_setup(cluster_type=None):
     logger.info(f"The cluster type is: {cluster_type}")
     if not cluster_type:
         assert check_default_cluster_context_index_equal_to_current_index(), (
-            "The default cluster ctx index should be equal to the current index in case the cluster type "
-            "param is not provider"
+            "The default cluster ctx index should be equal to the current index, if we don't pass "
+            "the cluster type param "
         )
         return
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -23,6 +23,7 @@ import pandas as pd
 from scipy.stats import tmean, scoreatpercentile
 from shutil import which, move, rmtree
 import pexpect
+import pytest
 
 import hcl2
 import requests
@@ -4104,3 +4105,60 @@ def string_chunkify(cstring, csize):
         yield cstring[i : i + csize]
         i += csize
     yield cstring[i:]
+
+
+def get_pytest_fixture_value(request, fixture_name):
+    """
+    Get the value of a fixture name from the request
+
+    Args:
+        request (_pytest.fixtures.SubRequest'): The pytest request fixture
+        fixture_name: Fixture for which this request is being performed
+
+    Returns:
+        Any: The fixture value
+
+    """
+    if fixture_name not in request.fixturenames:
+        return None
+
+    return request.getfixturevalue(fixture_name)
+
+
+def switch_to_correct_cluster_at_setup(request):
+    """
+    Switch to the correct cluster index at setup, according to the 'cluster_type' fixture parameter
+    provided in the test.
+
+    Args:
+        request (_pytest.fixtures.SubRequest'): The pytest request fixture
+
+    """
+    from ocs_ci.ocs.cluster import is_managed_service_cluster
+
+    cluster_type = get_pytest_fixture_value(request, "cluster_type")
+    if not cluster_type:
+        log.info(
+            "The cluster type is not provided in the request params. "
+            "Continue the test with the current cluster"
+        )
+        return
+
+    if not is_managed_service_cluster():
+        if cluster_type == constants.NON_MS_CLUSTER_TYPE:
+            log.info(
+                "The cluster is a non-MS cluster. Continue the test with the current cluster"
+            )
+            return
+        else:
+            pytest.skip(
+                f"The test will not run on a non-MS cluster with the cluster type '{cluster_type}'"
+            )
+
+    # If the cluster is an MS cluster
+    if not config.is_cluster_type_exist(cluster_type):
+        pytest.skip(f"The cluster type '{cluster_type}' is not exist in the run")
+
+    # Switch to the correct cluster type
+    log.info(f"Switching to the cluster with the cluster type '{cluster_type}'")
+    config.switch_to_cluster_by_cluster_type(cluster_type)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4157,7 +4157,7 @@ def switch_to_correct_cluster_at_setup(request):
 
     # If the cluster is an MS cluster
     if not config.is_cluster_type_exist(cluster_type):
-        pytest.skip(f"The cluster type '{cluster_type}' is not exist in the run")
+        pytest.skip(f"The cluster type '{cluster_type}' does not exist in the run")
 
     # Switch to the correct cluster type
     log.info(f"Switching to the cluster with the cluster type '{cluster_type}'")

--- a/tests/managed-service/test_switch_to_correct_index_at_setup.py
+++ b/tests/managed-service/test_switch_to_correct_index_at_setup.py
@@ -1,0 +1,153 @@
+import logging
+import pytest
+
+from ocs_ci.framework.testlib import (
+    libtest,
+    ManageTest,
+    managed_service_required,
+)
+from ocs_ci.ocs.cluster import (
+    is_managed_service_cluster,
+)
+from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup
+from ocs_ci.helpers.sanity_helpers import Sanity, SanityManagedService
+from ocs_ci.ocs.constants import MS_CONSUMER_TYPE, MS_PROVIDER_TYPE, NON_MS_CLUSTER_TYPE
+
+from ocs_ci.ocs.managedservice import (
+    check_switch_to_correct_cluster_at_setup,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@libtest
+class TestSwitchToCorrectIndexAtSetup(ManageTest):
+    """
+    Test switch to the correct cluster index at setup.
+    The class contains test examples of switching to the correct cluster index at setup using the param
+    'cluster_type'.
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers, request):
+        switch_to_correct_cluster_at_setup(request)
+        # Adding the sanity helpers here to make it similar to a regular test.
+        if is_managed_service_cluster():
+            self.sanity_helpers = SanityManagedService(
+                create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
+            )
+        else:
+            self.sanity_helpers = Sanity()
+
+    @managed_service_required
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [MS_PROVIDER_TYPE, MS_CONSUMER_TYPE],
+    )
+    def test_switch_to_correct_cluster_with_ms_cluster_types(self, cluster_type):
+        """
+        Test switch to the correct cluster index at setup, when we have MS cluster types
+
+        """
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    @managed_service_required
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [MS_PROVIDER_TYPE],
+    )
+    def test_switch_to_correct_cluster_with_provider_cluster_type(self, cluster_type):
+        """
+        Test switch to the correct cluster index at setup, when we have MS provider cluster type
+
+        """
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [MS_PROVIDER_TYPE, MS_CONSUMER_TYPE, NON_MS_CLUSTER_TYPE],
+    )
+    def test_switch_to_correct_cluster_with_all_cluster_types(self, cluster_type):
+        """
+        Test switch to the correct cluster index at setup, when we have all the cluster types
+
+        """
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [MS_PROVIDER_TYPE, NON_MS_CLUSTER_TYPE],
+    )
+    def test_switch_to_correct_cluster_with_provider_and_non_ms_cluster_types(
+        self, cluster_type
+    ):
+        """
+        Test switch to the correct cluster index at setup,
+        when we have MS provider and non-MS cluster types
+
+        """
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [MS_CONSUMER_TYPE, NON_MS_CLUSTER_TYPE],
+    )
+    def test_switch_to_correct_cluster_with_consumer_and_non_ms_cluster_types(
+        self, cluster_type
+    ):
+        """
+        Test switch to the correct cluster index at setup,
+        when we have MS consumer and non-MS cluster types
+
+        """
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    def test_switch_to_correct_cluster_without_cluster_type_param(self):
+        """
+        Test switch to the correct cluster index at setup, when we don't pass the cluster type param
+
+        """
+        check_switch_to_correct_cluster_at_setup()
+
+    @pytest.mark.parametrize(
+        argnames=["cluster_type", "additional_param"],
+        argvalues=[
+            pytest.param(*[MS_PROVIDER_TYPE, "common_value"]),
+            pytest.param(*[MS_CONSUMER_TYPE, "common_value"]),
+            pytest.param(*[NON_MS_CLUSTER_TYPE, "common_value"]),
+            pytest.param(*[MS_PROVIDER_TYPE, "provider_value"]),
+            pytest.param(*[MS_CONSUMER_TYPE, "consumer_value"]),
+        ],
+    )
+    def test_switch_to_correct_cluster_with_all_cluster_types_with_additional_param(
+        self, cluster_type, additional_param
+    ):
+        """
+        Test switch to the correct cluster index at setup when we have all cluster types, and we also pass
+        an additional parameter. Some param values we use for all the cluster types, and some we use only
+        for specific clusters.
+
+        """
+        logger.info(f"additional value = {additional_param}")
+        check_switch_to_correct_cluster_at_setup(cluster_type)
+
+    @pytest.mark.parametrize(
+        argnames=["cluster_type", "additional_param"],
+        argvalues=[
+            pytest.param(*[MS_PROVIDER_TYPE, "common_value"]),
+            pytest.param(*[MS_CONSUMER_TYPE, "common_value"]),
+            pytest.param(*[MS_CONSUMER_TYPE, "consumer_value"]),
+        ],
+    )
+    def test_switch_to_correct_cluster_with_ms_cluster_types_with_additional_param(
+        self, cluster_type, additional_param
+    ):
+        """
+        Test switch to the correct cluster index at setup when we have all cluster types, and we also pass
+        an additional parameter. Some param values we use for all the cluster types, and some we use only
+        for specific clusters.
+
+        """
+        logger.info(f"additional value = {additional_param}")
+        check_switch_to_correct_cluster_at_setup(cluster_type)


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/6881.
The purpose of the pr is to fix the problem described in the issue above.

In the pr, I implemented a functionality to switch to the correct cluster index at the test setup.
I had three goals in the implementation:

1. Stability - means that we can be sure that in every test, it switches to the correct cluster index in the setup method. That's why I preferred creating a function `check_switch_to_correct_cluster_at_setup`, rather than a fixture or decorator.
2. Clean - means that we have a minimum change in the tests. That's why the change is implemented only in the `setup` method and not in the test methods.
3. Easy to analyze - we can quickly look at the test runs and see if the cluster was a provider, consumer, or non-MS cluster type. I used the pytest `parametrize` with the `cluster_type` param.

I also added the test file `tests/managed-service/test_switch_to_correct_index_at_setup.py` to demonstrate the functionality mentioned above.