### PR TITLE
Fix pd.DataFrame call in teardown

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1558,7 +1558,7 @@ def add_mem_stats(soup):
     Add performance summary to the soup to print the table:
     columns = ['TC name', 'Peak RAM consumed', 'Peak VMS consumed', 'RAM leak']
     """
-    if "memory" in config.RUN and isinstance(config.RUN["memory"], pd.Dataframe):
+    if "memory" in config.RUN and isinstance(config.RUN["memory"], pd.DataFrame):
         mem_table = config.RUN["memory"]
         mem_table["Peak RAM consumed"] = mem_table["Peak RAM consumed"].apply(
             bytes2human


### PR DESCRIPTION
Fix error: Dataframe ---> DataFrame

2023-02-02 20:22:22    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/utils.py", line 1561, in add_mem_stats
2023-02-02 20:22:22      if "memory" in config.RUN and isinstance(config.RUN["memory"], pd.Dataframe):
2023-02-02 20:22:22    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.8/site-packages/pandas/__init__.py", line 264, in __getattr__
2023-02-02 20:22:22      raise AttributeError(f"module 'pandas' has no attribute '{name}'")
2023-02-02 20:22:22  AttributeError: module 'pandas' has no attribute 'Dataframe'