### PR TITLE
Test_pvc_clone_performance - skipping multiple files test cases due to 2101874

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -128,7 +128,6 @@ ignore_leftover_label = pytest.mark.ignore_leftover_label
 run_this = pytest.mark.run_this
 
 # Skip marks
-skip = pytest.mark.skip
 
 skip_inconsistent = pytest.mark.skip(
     reason="Currently the reduction is too inconsistent leading to inconsistent test results"

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -128,6 +128,8 @@ ignore_leftover_label = pytest.mark.ignore_leftover_label
 run_this = pytest.mark.run_this
 
 # Skip marks
+skip = pytest.mark.skip
+
 skip_inconsistent = pytest.mark.skip(
     reason="Currently the reduction is too inconsistent leading to inconsistent test results"
 )

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -6,8 +6,6 @@ import logging
 import pytest
 import statistics
 
-from ocs_ci.framework.testlib import skip, bugzilla
-
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import helpers, performance_lib
@@ -50,7 +48,6 @@ class ClonesResultsAnalyse(ResultsAnalyse):
     """
 
     def analyse_results(self, test_times, speed=False, total_data=0):
-
         op_types = ["create", "csi_create", "delete", "csi_delete"]
         all_data = {}
         avg_data = {}
@@ -63,7 +60,6 @@ class ClonesResultsAnalyse(ResultsAnalyse):
 
         # Print the results into the log.
         for clone in test_times:
-
             logger.info(f"Test report for clone {clone} :")
             for op in op_types:
                 data = test_times[clone][op]["time"]
@@ -164,7 +160,6 @@ class TestPVCClonePerformance(PASTest):
         super(TestPVCClonePerformance, self).teardown()
 
     def create_new_pool_and_sc(self, secret_factory):
-
         self.pool_name = (
             f"pas-test-pool-{Interfaces_info[self.interface]['name'].lower()}"
         )
@@ -417,11 +412,11 @@ class TestPVCClonePerformance(PASTest):
         argnames=["interface", "copies", "timeout"],
         argvalues=[
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 13, 1800],
+                *[constants.CEPHBLOCKPOOL, 7, 1800],
                 marks=pytest.mark.polarion_id("OCS-2673"),
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 13, 1800],
+                *[constants.CEPHFILESYSTEM, 7, 1800],
                 marks=[
                     pytest.mark.polarion_id("OCS-2674"),
                     pytest.mark.bugzilla("2101874"),
@@ -429,8 +424,6 @@ class TestPVCClonePerformance(PASTest):
             ),
         ],
     )
-    @skip
-    @bugzilla("2101874")
     def test_pvc_clone_performance_multiple_files(
         self,
         secret_factory,

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -6,6 +6,8 @@ import logging
 import pytest
 import statistics
 
+from ocs_ci.framework.testlib import skip, bugzilla
+
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import helpers, performance_lib
@@ -427,6 +429,8 @@ class TestPVCClonePerformance(PASTest):
             ),
         ],
     )
+    @skip
+    @bugzilla("2101874")
     def test_pvc_clone_performance_multiple_files(
         self,
         secret_factory,
@@ -551,10 +555,10 @@ class TestPVCClonePerformance(PASTest):
             test_count=8,
             test_name="PVC Clone",
         )
-        self.add_test_to_results_check(
-            test="test_pvc_clone_performance_multiple_files",
-            # TODO: after BZ-2101874 will fix, change the test_count to 2
-            test_count=1,
-            test_name="PVC Clone Multiple Files",
-        )
+        # TODO: after BZ-2101874 is fixed, add this code
+        # self.add_test_to_results_check(
+        #     test="test_pvc_clone_performance_multiple_files",
+        #     test_count=2,
+        #     test_name="PVC Clone Multiple Files",
+        # )
         self.check_results_and_push_to_dashboard()


### PR DESCRIPTION
The reason for this PR is to skip running multiple files test cases until BZ 2101874 is resolved. 
Those test cases keep failing on all the platforms without an exception. 
Link to the BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2101874 

Signed-off-by: Yulia Persky <ypersky@redhat.com>