### PR TITLE
Skip tests in MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -184,6 +184,7 @@ class TestNodesMaintenance(ManageTest):
 
     @tier4a
     @skipif_bm
+    @skipif_managed_service
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[
@@ -462,6 +463,7 @@ class TestNodesMaintenance(ManageTest):
 
     @bugzilla("1861104")
     @bugzilla("1946573")
+    @skipif_managed_service
     @pytest.mark.polarion_id("OCS-2524")
     @tier4a
     def test_pdb_check_simultaneous_node_drains(


### PR DESCRIPTION
 Skip 2 tests in Managed Services platform
 
 Skip
 _tests.manage.z_cluster.nodes.test_nodes_maintenance.TestNodesMaintenance.test_node_maintenance_restart_activate_
which is covered in tests/manage/z_cluster/nodes/test_nodes_restart_ms.py.

Skip the test case given below which is not relevant. 
_tests.manage.z_cluster.nodes.test_nodes_maintenance.TestNodesMaintenance.test_pdb_check_simultaneous_node_drains_
Signed-off-by: Jilju Joy <jijoy@redhat.com>