### PR TITLE
Increase timeout waiting for pod to reach running in test test_resource_deletion_during_pvc_pod_creation_and_io

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -427,7 +427,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Verify pods are Running
         for pod_obj in pod_objs_re:
             helpers.wait_for_resource_state(
-                resource=pod_obj, state=constants.STATUS_RUNNING
+                resource=pod_obj, state=constants.STATUS_RUNNING, timeout=120
             )
             pod_obj.reload()
         log.info("Successfully created new pods using all PVCs.")


### PR DESCRIPTION
Increasing the wait time for the pods to reach the state Running.
Fixes #7088 

Signed-off-by: Jilju Joy <jijoy@redhat.com>