### PR TITLE
test_obc_creation_and_deletion fix

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -743,11 +743,21 @@ class PageNavigator(BaseUI):
 
         from ocs_ci.ocs.ui.helpers_ui import format_locator
 
-        if self.ocp_version_full >= version.VERSION_4_10:
+        if version.VERSION_4_10 <= self.ocp_version_full < version.VERSION_4_12:
             default_projects_is_checked = self.driver.find_element_by_xpath(
                 "//span[@class='pf-c-switch__toggle']"
             )
 
+            if (
+                default_projects_is_checked.get_attribute("data-checked-state")
+                == "false"
+            ):
+                logger.info("Show default projects")
+                self.do_click(self.page_nav["show-default-projects"])
+        else:
+            default_projects_is_checked = self.driver.find_element_by_css_selector(
+                "input[class='pf-c-switch__input']"
+            )
             if (
                 default_projects_is_checked.get_attribute("data-checked-state")
                 == "false"

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -187,7 +187,8 @@ deployment_4_12 = {
 
 generic_locators = {
     "project_selector": (
-        'button[class="pf-c-dropdown__toggle pf-m-plain"]',
+        'button[class="pf-c-dropdown__toggle pf-m-plain"],'
+        'button[class="pf-c-menu-toggle co-namespace-dropdown__menu-toggle"]',
         By.CSS_SELECTOR,
     ),
     "select_openshift-storage_project": (
@@ -200,8 +201,19 @@ generic_locators = {
         'a[data-test="dropdown-menu-item-link"]',
         By.CSS_SELECTOR,
     ),
-    "actions": ('button[data-test-id="actions-menu-button"]', By.CSS_SELECTOR),
-    "confirm_action": ("confirm-action", By.ID),
+    "second_dropdown_option": (
+        '//a[@data-test="dropdown-menu-item-link"]/../../li[2]',
+        By.XPATH,
+    ),
+    "actions": (
+        '//span[@class="pf-c-dropdown__toggle-text" and text()="Actions"]/..',
+        By.XPATH,
+    ),
+    "three_dots": ('//button[@aria-label="Actions"]', By.XPATH),
+    "confirm_action": (
+        'button[id="confirm-action"],button[data-test="delete-action"]',
+        By.CSS_SELECTOR,
+    ),
     "submit_form": ('button[type="submit"]', By.CSS_SELECTOR),
     "ocs_operator": ('//h1[text()="OpenShift Container Storage"]', By.XPATH),
     "kebab_button": ('button[data-test-id="kebab-button"', By.CSS_SELECTOR),
@@ -281,14 +293,18 @@ obc = {
     ),
     "bucketclass_dropdown": ("bc-dropdown", By.ID),
     "bucketclass_text_field": (
-        'input[placeholder="Select BucketClass"]',
+        'input[placeholder="Select BucketClass"],input[class="pf-c-form-control pf-m-search"]',
         By.CSS_SELECTOR,
+    ),
+    "resource_name": (
+        '//td[@id="name"]//a[@class="co-resource-item__resource-name"]',
+        By.XPATH,
     ),
     "default_bucketclass": ("noobaa-default-bucket-class-link", By.ID),
     "obc_name": ("obc-name", By.ID),
     "first_obc_link": ('a[class="co-resource-item__resource-name"]', By.CSS_SELECTOR),
     "delete_obc": (
-        'button[data-test-action="Delete Object Bucket Claim"]',
+        'button[data-test-action="Delete Object Bucket Claim"], li[id="Delete"] a[role="menuitem"]',
         By.CSS_SELECTOR,
     ),
 }
@@ -1168,6 +1184,7 @@ locators = {
             **acm_configuration,
             **acm_configuration_4_12,
         },
+        "obc": obc,
     },
     "4.11": {
         "login": {**login, **login_4_11},

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -240,20 +240,30 @@ class TestObcUserInterface(object):
 
     @ui
     @tier1
-    @skipif_ocs_version("!=4.8")
     @pytest.mark.parametrize(
-        argnames=["storageclass", "bucketclass"],
+        argnames=["storageclass", "bucketclass", "delete_via"],
         argvalues=[
             pytest.param(
                 *[
                     "openshift-storage.noobaa.io",
                     "noobaa-default-bucket-class",
+                    "three_dots",
                 ],
                 marks=pytest.mark.polarion_id("OCS-2542"),
-            )
+            ),
+            pytest.param(
+                *[
+                    "openshift-storage.noobaa.io",
+                    "noobaa-default-bucket-class",
+                    "Actions",
+                ],
+                marks=pytest.mark.polarion_id("OCS-4698"),
+            ),
         ],
     )
-    def test_obc_creation_and_deletion(self, setup_ui_class, storageclass, bucketclass):
+    def test_obc_creation_and_deletion(
+        self, setup_ui_class, storageclass, bucketclass, delete_via
+    ):
         """
         Test creation and deletion of an OBC via the UI
 
@@ -289,6 +299,6 @@ class TestObcUserInterface(object):
         ), f"BucketClass mismatch. Expected: {bucketclass}, found: {obc_bucketclass}"
 
         logger.info(f"Delete {obc_name}")
-        obc_ui_obj.delete_obc_ui(obc_name)
+        obc_ui_obj.delete_obc_ui(obc_name, delete_via)
 
         assert test_obc.check_resource_existence(should_exist=False)


### PR DESCRIPTION
Adjust test test_obc_creation_and_deletion for 4.12 and add new functionality ~~so BZ #2097772 is covered~~

Description:
now test is runnable for 4.12
test is splited to deletion via "three_dots" and via "Actions"