### PR TITLE
Skip the testcase test_nodereplacement_twice in MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -283,7 +283,7 @@ class TestNodeReplacement(ManageTest):
 @bugzilla("1840539")
 @pytest.mark.polarion_id("OCS-2535")
 @skipif_external_mode
-@skipif_ms_consumer
+@skipif_managed_service
 class TestNodeReplacementTwice(ManageTest):
     """
     Node replacement twice:


### PR DESCRIPTION
Skip the testcase test_nodereplacement_twice which is not relevant for Managed Services.