### PR TITLE
skip ui tests for IBM cloud deployment. Authorization to console not …

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -319,6 +319,12 @@ skipif_ibm_cloud = pytest.mark.skipif(
     reason="Test will not run on IBM cloud",
 )
 
+skipif_ibm_cloud_managed = pytest.mark.skipif(
+    config.ENV_DATA["deployment_type"].lower() != "managed"
+    and config.ENV_DATA["platform"].lower() == IBMCLOUD_PLATFORM,
+    reason="Test will not run on IBM Cloud aka ROKS (managed deployment type)",
+)
+
 skipif_ibm_power = pytest.mark.skipif(
     config.ENV_DATA["platform"].lower() == IBM_POWER_PLATFORM,
     reason="Test will not run on IBM Power",

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import skipif_ibm_cloud
+from ocs_ci.framework.pytest_customization.marks import skipif_ibm_cloud_managed
 from ocs_ci.ocs.exceptions import UnexpectedODFAccessException
 from ocs_ci.ocs.ui.mcg_ui import ObcUi
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
@@ -44,7 +44,7 @@ class TestOBCUi(ManageTest):
 
     @ui
     @tier2
-    @skipif_ibm_cloud
+    @skipif_ibm_cloud_managed
     @bugzilla("2031705")
     @polarion_id("OCS-4620")
     def test_create_storageclass_rbd(self, user_factory, login_factory):
@@ -71,7 +71,7 @@ class TestUnprivilegedUserODFAccess(E2ETest):
 
     @ui
     @tier1
-    @skipif_ibm_cloud
+    @skipif_ibm_cloud_managed
     @bugzilla("2103975")
     @polarion_id("OCS-4667")
     def test_unprivileged_user_odf_access(self, user_factory, login_factory):

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import skipif_ibm_cloud
 from ocs_ci.ocs.exceptions import UnexpectedODFAccessException
 from ocs_ci.ocs.ui.mcg_ui import ObcUi
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
@@ -43,6 +44,7 @@ class TestOBCUi(ManageTest):
 
     @ui
     @tier2
+    @skipif_ibm_cloud
     @bugzilla("2031705")
     @polarion_id("OCS-4620")
     def test_create_storageclass_rbd(self, user_factory, login_factory):
@@ -69,6 +71,7 @@ class TestUnprivilegedUserODFAccess(E2ETest):
 
     @ui
     @tier1
+    @skipif_ibm_cloud
     @bugzilla("2103975")
     @polarion_id("OCS-4667")
     def test_unprivileged_user_odf_access(self, user_factory, login_factory):

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     skipif_external_mode,
     skipif_mcg_only,
+    skipif_ibm_cloud,
 )
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
 from ocs_ci.utility import version
@@ -19,6 +20,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
+@skipif_ibm_cloud
 class TestUserInterfaceValidation(object):
     """
     Test User Interface Validation

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -12,7 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     skipif_external_mode,
     skipif_mcg_only,
-    skipif_ibm_cloud,
+    skipif_ibm_cloud_managed,
 )
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
 from ocs_ci.utility import version
@@ -20,7 +20,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
-@skipif_ibm_cloud
+@skipif_ibm_cloud_managed
 class TestUserInterfaceValidation(object):
     """
     Test User Interface Validation


### PR DESCRIPTION
Authorization to console not implemented for IBM Cloud managed deployments. Referring to comments -> Fixes #7119
