### PR TITLE
Skiping the logging upgrade tyestcase due to changes in upgrade process

### DIFF
--- a/tests/ecosystem/upgrade/test_logging_upgrade.py
+++ b/tests/ecosystem/upgrade/test_logging_upgrade.py
@@ -18,7 +18,6 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import get_ocp_version, run_cmd
 from tests.conftest import install_logging
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -146,6 +145,9 @@ def upgrade_info(channel):
     )
 
 
+@pytest.mark.skip(
+    reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/6610"
+)
 @post_ocp_upgrade
 @magenta_squad
 @pytest.mark.usefixtures(install_logging.__name__)


### PR DESCRIPTION
issue- https://github.com/red-hat-storage/ocs-ci/issues/6610 