### PR TITLE
Ypersky multi clones used capacity enhancement

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -165,10 +165,20 @@ def get_logfile_names(interface, provisioning=True):
     """
     log_names = []
 
-    pods = run_oc_command(cmd="get pod", namespace="openshift-storage")
+    num_of_tries = (
+        5  # to overcome network glitches try a few times if the command fails
+    )
+    for i in range(num_of_tries):
+        pods = run_oc_command(cmd="get pod", namespace="openshift-storage")
 
-    if "Error in command" in pods:
-        raise Exception("Cannot get csi controller pod")
+        if "Error in command" in pods or "Unable to connect" in pods:
+            if i == num_of_tries - 1:
+                raise Exception("Cannot get csi controller pod")
+            else:
+                time.sleep(3)
+                continue
+
+        break  # if we are here, no errors in command, exit the loop
 
     provisioning_name = interface_data[interface]["prov"]
     csi_name = interface_data[interface]["csi_cnt"]

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -623,23 +623,17 @@ class CephCluster(object):
 
         Returns:
             int : Total storage capacity in GiB (GiB is for development environment)
-                  if the replica is '0', return 0.
 
         """
         replica = int(self.get_ceph_default_replica())
-        if replica > 0:
-            logger.info(f"Number of replica : {replica}")
-            ceph_pod = pod.get_ceph_tools_pod()
-            ceph_status = ceph_pod.exec_ceph_cmd(ceph_cmd="ceph df")
-            usable_capacity = (
-                int(ceph_status["stats"]["total_bytes"]) / replica / constant.GB
-            )
+        logger.info(f"Number of replica : {replica}")
+        ceph_pod = pod.get_ceph_tools_pod()
+        ceph_status = ceph_pod.exec_ceph_cmd(ceph_cmd="ceph df")
+        usable_capacity = (
+            int(ceph_status["stats"]["total_bytes"]) / replica / constant.GB
+        )
 
-            return usable_capacity
-        else:
-            # if the replica number is 0, usable capacity can not be calculate
-            # so, return 0 as usable capacity.
-            return 0
+        return usable_capacity
 
     def get_ceph_free_capacity(self):
         """

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1599,22 +1599,6 @@ def get_percent_used_capacity():
     return 100.0 * total_used / total_avail
 
 
-# def get_ceph_free_capacity():
-#     """
-#     Function to calculate the free capacity of a cluster
-#
-#     Returns:
-#         float: The free capacity of a cluster (in GB)
-#
-#     """
-#     ct_pod = pod.get_ceph_tools_pod()
-#     output = ct_pod.exec_ceph_cmd(ceph_cmd="ceph df")
-#     total_avail = output.get("stats").get("total_bytes")
-#     total_used = output.get("stats").get("total_used_raw_bytes")
-#     total_free = total_avail - total_used
-#     return total_free / constants.BYTES_IN_GB
-
-
 def get_osd_pods_memory_sum():
     """
     Get the sum of memory of all OSD pods. This is used to determine the size

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -641,6 +641,28 @@ class CephCluster(object):
             # so, return 0 as usable capacity.
             return 0
 
+    def get_ceph_free_capacity(self):
+        """
+        Function to calculate the free capacity of a cluster
+
+        Returns:
+            float: The free capacity of a cluster (in GB)
+
+        """
+        replica = int(self.get_ceph_default_replica())
+        if replica > 0:
+            logger.info(f"Number of replica : {replica}")
+            ct_pod = pod.get_ceph_tools_pod()
+            output = ct_pod.exec_ceph_cmd(ceph_cmd="ceph df")
+            total_avail = output.get("stats").get("total_bytes")
+            total_used = output.get("stats").get("total_used_raw_bytes")
+            total_free = total_avail - total_used
+            return total_free / replica / constants.BYTES_IN_GB
+        else:
+            # if the replica number is 0, usable capacity can not be calculate
+            # so, return 0 as usable capacity.
+            return 0
+
     def get_ceph_cluster_iops(self):
         """
         The function gets the IOPS from the ocs cluster
@@ -1575,6 +1597,22 @@ def get_percent_used_capacity():
     total_used = output.get("stats").get("total_used_raw_bytes")
     total_avail = output.get("stats").get("total_bytes")
     return 100.0 * total_used / total_avail
+
+
+# def get_ceph_free_capacity():
+#     """
+#     Function to calculate the free capacity of a cluster
+#
+#     Returns:
+#         float: The free capacity of a cluster (in GB)
+#
+#     """
+#     ct_pod = pod.get_ceph_tools_pod()
+#     output = ct_pod.exec_ceph_cmd(ceph_cmd="ceph df")
+#     total_avail = output.get("stats").get("total_bytes")
+#     total_used = output.get("stats").get("total_used_raw_bytes")
+#     total_free = total_avail - total_used
+#     return total_free / constants.BYTES_IN_GB
 
 
 def get_osd_pods_memory_sum():
@@ -2750,7 +2788,6 @@ class LVM(object):
         if type(pvc_obj) is PVC:
             raw_size = pvc_obj.data["spec"]["resources"]["requests"]["storage"]
             if raw_size.isdigit():
-
                 pvc_size = (
                     float(pvc_obj.data["spec"]["resources"]["requests"]["storage"])
                     / 1024

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -342,7 +342,9 @@ class OCP(object):
         log.debug(f"{yaml.dump(output)}")
         return output
 
-    def delete(self, yaml_file=None, resource_name="", wait=True, force=False):
+    def delete(
+        self, yaml_file=None, resource_name="", wait=True, force=False, timeout=600
+    ):
         """
         Deletes a resource
 
@@ -354,6 +356,7 @@ class OCP(object):
                 completion
             force (bool): True for force deletion with --grace-period=0,
                 False otherwise
+            timeout (int): timeout for the oc_cmd, defaults to 600 seconds
 
         Returns:
             dict: Dictionary represents a returned yaml file
@@ -376,7 +379,7 @@ class OCP(object):
         # oc default for wait is True
         if not wait:
             command += " --wait=false"
-        return self.exec_oc_cmd(command)
+        return self.exec_oc_cmd(command, timeout=timeout)
 
     def apply(self, yaml_file):
         """
@@ -619,7 +622,6 @@ class OCP(object):
             for sample in TimeoutSampler(
                 timeout, sleep, self.get, resource_name, True, selector
             ):
-
                 # Only 1 resource expected to be returned
                 if resource_name:
                     retry = int(timeout / sleep if sleep else timeout / 1)

--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -955,7 +955,7 @@ class PASTest(BaseTest):
             raise PVCNotCreated("PVC did not reach BOUND state.")
         # Wait for the PVC to be Bound
         performance_lib.wait_for_resource_bulk_status(
-            "pvc", 1, self.namespace, constants.STATUS_BOUND, 120, 5
+            "pvc", 1, self.namespace, constants.STATUS_BOUND, 600, 5
         )
         log.info(f"The PVC {self.pvc_obj.name} was created and in Bound state.")
 

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -62,6 +62,7 @@ class TestPvcMultiClonePerformance(PASTest):
 
         # Getting the total Storage capacity
         self.ceph_capacity = int(self.ceph_cluster.get_ceph_capacity())
+        # Getting the free Storage capacity
         self.ceph_free_capacity = int(self.ceph_cluster.get_ceph_free_capacity())
         # Use 70% of the free storage capacity in the test
         self.capacity_to_use = int(self.ceph_free_capacity * 0.7)

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -233,6 +233,7 @@ class TestPvcMultiClonePerformance(PASTest):
                     "name": Interfaces_info[self.interface]["sc"],
                 },
             )
+            self.pool_name = "ocs-storagecluster-cephfilesystem"
 
         # Create a PVC
         self.create_testing_pvc_and_wait_for_bound()

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -4,7 +4,6 @@ The test is supposed to create the maximum number of clones for one PVC
 """
 
 import logging
-import time
 import statistics
 
 import pytest

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -96,6 +96,10 @@ class TestPvcMultiClonePerformance(PASTest):
         """
         Cleanup the test environment
         """
+
+        # Deleting the namespace used by the test
+        self.delete_test_project()
+
         if not self.teardown_needed:
             return
 
@@ -115,9 +119,6 @@ class TestPvcMultiClonePerformance(PASTest):
 
         # Delete the test PVC
         self.cleanup_testing_pvc()
-
-        # Deleting the namespace used by the test
-        self.delete_test_project()
 
         # Delete the test StorageClass
         try:

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -130,13 +130,14 @@ class TestPvcMultiClonePerformance(PASTest):
             log.error(f"Can not delete the test sc : {ex}")
 
         # Delete the test storage pool
-        if self.interface == constants.CEPHBLOCKPOOL:
-            log.info(f"Try to delete the Storage pool {self.pool_name}")
-            try:
-                self.delete_ceph_pool(self.pool_name)
-            except Exception:
-                pass
-            finally:
+
+        log.info(f"Try to delete the Storage pool {self.pool_name}")
+        try:
+            self.delete_ceph_pool(self.pool_name)
+        except Exception:
+            pass
+        finally:
+            if self.interface == constants.CEPHBLOCKPOOL:
                 # Verify deletion by checking the backend CEPH pools using the toolbox
                 results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
                 log.debug(f"Existing pools are : {results}")
@@ -150,17 +151,6 @@ class TestPvcMultiClonePerformance(PASTest):
                     )
                 else:
                     log.info(f"The pool {self.pool_name} was deleted successfully")
-        else:
-            log.info("Deleting the default ceph filesystem")
-            self.ceph_cluster.CEPHFS.delete(
-                resource_name="ocs-storagecluster-cephfilesystem", timeout=3600
-            )
-            log.info("Wait until the ceph filesystem re-created")
-            time.sleep(60)
-            log.info("re-create the ceph filesystem csi subvolumegroup")
-            self.ceph_cluster.toolbox.exec_cmd_on_pod(
-                "ceph fs subvolumegroup create ocs-storagecluster-cephfilesystem csi"
-            )
 
         super(TestPvcMultiClonePerformance, self).teardown()
 

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -153,7 +153,7 @@ class TestPvcMultiClonePerformance(PASTest):
         else:
             log.info("Deleting the default ceph filesystem")
             self.ceph_cluster.CEPHFS.delete(
-                resource_name="ocs-storagecluster-cephfilesystem", timeout=1200
+                resource_name="ocs-storagecluster-cephfilesystem", timeout=3600
             )
             log.info("Wait until the ceph filesystem re-created")
             time.sleep(60)


### PR DESCRIPTION
This PR contains the following enhancements: 

1) Free ceph capacity calculation is added and the PVC/clones sizes are calculated by diving the free capacity be the required number of maximal PVCs in the cluster ( instead of the total capacity) 

2) Teardown problems should be resolved  

3) Added retries to overcome network glitches during which the test is unable to read data from logs. 