### PR TITLE
Skip the test 'test_check_pods_status_after_node_failure' when using MS

### DIFF
--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -7,7 +7,7 @@ from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
     skipif_ibm_cloud,
-    skipif_ms_consumer,
+    skipif_managed_service,
     skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -78,7 +78,7 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 
 @ignore_leftovers
 @tier4a
-@skipif_ms_consumer
+@skipif_managed_service
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2552")
 class TestCheckPodsAfterNodeFailure(ManageTest):


### PR DESCRIPTION
Skip the test 'test_check_pods_status_after_node_failure' when using MS because the functionality in the test is not relevant to the Managed Service.