### PR TITLE
Increase wait time for pod to reach running state

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -343,7 +343,7 @@ class TestResourceDeletionDuringCreationOperations(ManageTest):
         # Verify new pods are Running
         for pod_obj in pod_objs_new:
             helpers.wait_for_resource_state(
-                resource=pod_obj, state=constants.STATUS_RUNNING
+                resource=pod_obj, state=constants.STATUS_RUNNING, timeout=120
             )
             pod_obj.reload()
         log.info("Verified: All new pods are Running.")


### PR DESCRIPTION
Increase the timeout value waiting for pod to reach the state Running in the test given below.
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py::TestResourceDeletionDuringCreationOperations::test_resource_deletion_during_pvc_pod_creation_and_io 
Fixes #7136