### PR TITLE
In the function "wait_for_silence_ceph_osd_crash_warning" change the exception from "TimeoutError" to "TimeoutExpiredError"

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1961,7 +1961,7 @@ def wait_for_silence_ceph_osd_crash_warning(osd_pod_name, timeout=900):
         ):
             if silence_old_osd_crash_warning:
                 return True
-    except TimeoutError:
+    except TimeoutExpiredError:
         return False
 
 


### PR DESCRIPTION
fix #7048 