### PR TITLE
Increase timeout of "refresh pop-up"

### DIFF
--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -77,7 +77,6 @@ class DeploymentUI(PageNavigator):
                 self.navigate_installed_operators_page()
                 self.do_click(locator=self.dep_loc["refresh_popup"], timeout=500)
             except Exception as e:
-                self.take_screenshot()
                 logger.error(f"Refresh pop-up does not exist: {e}")
                 self.refresh_page()
         self.verify_operator_succeeded(operator=self.operator_name)

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -75,9 +75,11 @@ class DeploymentUI(PageNavigator):
         if self.operator_name is ODF_OPERATOR:
             try:
                 self.navigate_installed_operators_page()
-                self.do_click(locator=self.dep_loc["refresh_popup"], timeout=300)
+                self.do_click(locator=self.dep_loc["refresh_popup"], timeout=500)
             except Exception as e:
+                self.take_screenshot()
                 logger.error(f"Refresh pop-up does not exist: {e}")
+                self.refresh_page()
         self.verify_operator_succeeded(operator=self.operator_name)
 
     def refresh_popup(self, timeout=30):


### PR DESCRIPTION
We did not click on `Refresh Page`. So I increased the timeout and add "manual refresh"

![image](https://user-images.githubusercontent.com/61982127/221163971-ccfb0709-83ea-4766-8a3a-9f897bf3e7f8.png)


https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster-prod/6963/testReport/tests.ecosystem.deployment/test_deployment/test_deployment_2/

http://magna002.ceph.redhat.com/ocsci-jenkins/openshift-clusters/j-267vuf1cs36-t4a/j-267vuf1cs36-t4a_20230223T011221/logs/ui_logs_dir_1677117064/screenshots_ui/test_deployment/2023-02-23T01-55-04.155443.png