### PR TITLE
Skip test_check_pod_status_after_two_nodes_shutdown_recovery for External mode

### DIFF
--- a/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_ibm_cloud,
     skipif_managed_service,
+    skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.node import wait_for_nodes_status, get_nodes
@@ -39,6 +40,7 @@ class TestOCSWorkerNodeShutdown(ManageTest):
     @pytest.mark.polarion_id("OCS-2315")
     @skipif_ibm_cloud
     @skipif_managed_service
+    @skipif_external_mode
     def test_check_pod_status_after_two_nodes_shutdown_recovery(
         self, nodes, node_restart_teardown
     ):


### PR DESCRIPTION
fixes #6994 