### PR TITLE
Increasing the timeout for checking PVC status of compact mode clusters

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4099,5 +4099,7 @@ def verify_quota_resource_exist(quota_name):
 
 def check_cluster_is_compact():
     existing_num_nodes = len(node.get_all_nodes())
-    if existing_num_nodes == 3:
+    worker_n = node.get_worker_nodes()
+    master_n = node.get_master_nodes()
+    if (existing_num_nodes == 3) and (worker_n.sort() == master_n.sort()):
         return True

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -104,6 +104,8 @@ def wait_for_resource_state(resource, state, timeout=60):
             reached the desired state
 
     """
+    if check_cluster_is_compact():
+        timeout = 180
     if (
         resource.name == constants.DEFAULT_STORAGECLASS_CEPHFS
         or resource.name == constants.DEFAULT_STORAGECLASS_RBD
@@ -4093,3 +4095,9 @@ def verify_quota_resource_exist(quota_name):
     return quota_name in [
         quota_resource.get("metadata").get("name") for quota_resource in quota_resources
     ]
+
+
+def check_cluster_is_compact():
+    existing_num_nodes = len(node.get_all_nodes())
+    if existing_num_nodes == 3:
+        return True


### PR DESCRIPTION
This fixes issue https://github.com/red-hat-storage/ocs-ci/issues/6806. Added a function ("check_cluster_is_compact") to check for compact mode in helpers.py and increased PVCs to go to bound state from 60s to 180s