### PR TITLE
Fix test_ceph_pg_log_dups_trim. Replace oc cp calls (Updated)

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -249,16 +249,16 @@ class Pod(OCS):
 
         timestamp_end = datetime.now() + timedelta(seconds=timeout)
 
-        x = 1
+        start_line = 1
         cmd = f"oc exec -i {self.name} -n {self.namespace} -- bash -c "
         while os.path.exists(target_path) and datetime.now() <= timestamp_end:
             exec_cmd(
                 cmd
-                + f"\"tail -n '+{x}' {src_path}| head -n '{chunk_size}'\" >> {target_path}",
+                + f"\"tail -n '+{start_line}' {src_path}| head -n '{chunk_size}'\" >> {target_path}",
                 timeout=timeout,
                 use_shell=True,
             )
-            x += chunk_size
+            start_line += chunk_size
             logger.info(f"size of target file = {os.stat(target_path).st_size}b")
             if os.stat(target_path).st_size == file_size:
                 logger.info(f"file '{target_path}' copied")

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -3,6 +3,7 @@ Pod related functionalities and context info
 
 Each pod in the openshift cluster will have a corresponding pod object
 """
+from datetime import datetime, timedelta
 import logging
 import os
 import re
@@ -29,6 +30,7 @@ from ocs_ci.ocs.exceptions import (
     UnavailableResourceException,
     ResourceNotFoundError,
     NotFoundError,
+    TimeoutException,
 )
 from ocs_ci.ocs.utils import setup_ceph_toolbox, get_pod_name_by_pattern
 from ocs_ci.ocs.resources.ocs import OCS
@@ -38,6 +40,7 @@ from ocs_ci.utility.utils import (
     run_cmd,
     check_timeout_reached,
     TimeoutSampler,
+    exec_cmd,
 )
 from ocs_ci.utility.utils import check_if_executable_in_path
 from ocs_ci.utility.retry import retry
@@ -194,7 +197,7 @@ class Pod(OCS):
             else None,
         )
 
-    def copy_to_pod(self, src_path, target_path, container=None):
+    def copy_to_pod_rsync(self, src_path, target_path, container=None):
         """
         Copies to pod path from the local path
 
@@ -211,6 +214,60 @@ class Pod(OCS):
         if container:
             cmd = cmd + f" -c {container}"
         return self.ocp.exec_oc_cmd(cmd, out_yaml_format=False)
+
+    def copy_to_pod_cat(self, src_path, target_path, timeout=60):
+        """
+        Copies to pod path from the local path file using standard output stream
+
+        Args:
+            src_path (str): local path
+            target_path (str): path within pod where you want to copy
+            timeout (int): timeout in seconds
+        Returns:
+            str: stdout of the command
+        """
+        cmd = f"cat {src_path} | oc exec -i {self.name} -n {self.namespace} -- sh -c 'cat > {target_path}'"
+        return exec_cmd(cmd, timeout=timeout, use_shell=True)
+
+    def copy_from_pod_oc_exec(
+        self, target_path, src_path, timeout=600, chunk_size=2000
+    ):
+        """
+        Copies to local path file from the pod using standard output stream via 'oc exec'. Good for log/json/yaml/text
+        files, not good for large files/binaries with one-line plain string
+        * Hand data from the pod over `oc exec cat`, other standard output ways will fail for the files > 1 Mb
+
+        Args:
+            target_path (str): local path
+            src_path (str): path within pod what you want to copy
+            timeout (int): timeout in seconds
+                until size of the local file will not reach the initial file size.
+                2000 lines is a maximum chunk size tested successfully
+            chunk_size (int): file will be copied by chunks, by number of lines
+        """
+        file_size = int(self.exec_cmd_on_pod(f"stat -c %s {src_path}"))
+
+        timestamp_end = datetime.now() + timedelta(seconds=timeout)
+
+        x = 1
+        cmd = f"oc exec -i {self.name} -n {self.namespace} -- bash -c "
+        while os.path.exists(target_path) and datetime.now() <= timestamp_end:
+            exec_cmd(
+                cmd
+                + f"\"tail -n '+{x}' {src_path}| head -n '{chunk_size}'\" >> {target_path}",
+                timeout=timeout,
+                use_shell=True,
+            )
+            x += chunk_size
+            logger.info(f"size of target file = {os.stat(target_path).st_size}b")
+            if os.stat(target_path).st_size == file_size:
+                logger.info(f"file '{target_path}' copied")
+                break
+        else:
+            raise TimeoutException(
+                f"Failed to copy file from pod {self.name}:{src_path} to local path '{target_path}'\n"
+                f"src file size = {src_path}b, target file size = {os.stat(target_path).st_size}b"
+            )
 
     def exec_sh_cmd_on_pod(self, command, sh="bash", timeout=600, **kwargs):
         """

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -73,10 +73,13 @@ def _rec_memory(proc: Process):
                 ),
             ]
         )
+    # ZombieProcess's, NoSuchProcess's come too often within a test run,
+    # we're polling each process once per 3 sec. ZombieProcess and NoSuchProcess
+    # appear due to concurrency. Failed polls are not valuable information
     except ZombieProcess:
-        log.exception("Cannot access ZombieProcess. Recording skipped")
+        pass
     except NoSuchProcess:
-        log.exception("Process is unavailable. Recording skipped")
+        pass
     except ValueError:
         pass
 

--- a/ocs_ci/utility/memory.py
+++ b/ocs_ci/utility/memory.py
@@ -73,13 +73,10 @@ def _rec_memory(proc: Process):
                 ),
             ]
         )
-    # ZombieProcess's, NoSuchProcess's come too often within a test run,
-    # we're polling each process once per 3 sec. ZombieProcess and NoSuchProcess
-    # appear due to concurrency. Failed polls are not valuable information
     except ZombieProcess:
-        pass
+        log.exception("Cannot access ZombieProcess. Recording skipped")
     except NoSuchProcess:
-        pass
+        log.exception("Process is unavailable. Recording skipped")
     except ValueError:
         pass
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -569,6 +569,7 @@ def exec_cmd(
     ignore_error=False,
     threading_lock=None,
     silent=False,
+    use_shell=False,
     **kwargs,
 ):
     """
@@ -588,7 +589,7 @@ def exec_cmd(
         threading_lock (threading.Lock): threading.Lock object that is used
             for handling concurrent oc commands
         silent (bool): If True will silent errors from the server, default false
-
+        use_shell (bool): If True will pass the cmd without splitting
     Raises:
         CommandFailed: In case the command execution fails
 
@@ -603,7 +604,7 @@ def exec_cmd(
     """
     masked_cmd = mask_secrets(cmd, secrets)
     log.info(f"Executing command: {masked_cmd}")
-    if isinstance(cmd, str):
+    if isinstance(cmd, str) and not use_shell:
         cmd = shlex.split(cmd)
     if threading_lock and cmd[0] == "oc":
         threading_lock.acquire()
@@ -613,6 +614,7 @@ def exec_cmd(
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
         timeout=timeout,
+        shell=use_shell,
         **kwargs,
     )
     if threading_lock and cmd[0] == "oc":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2379,7 +2379,7 @@ def javasdk_pod_fixture(request, scope_name):
     # push java code to the pod created
     java_src_code_path = constants.JAVA_SRC_CODE_PATH
     target_path = "/app/"
-    assert javas3_pod_obj.copy_to_pod(
+    assert javas3_pod_obj.copy_to_pod_rsync(
         src_path=java_src_code_path, target_path=target_path
     ), "Failed to copy java source code!!"
 


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/7140
Commit fixes the test tests/manage/z_cluster/test_ceph_pg_log_dups_trim.py::TestCephPgLogDupsTrimming::test_ceph_pg_log_dups_trim
and 'oc cp' to the pod references.

Due to implemented https://url.corp.redhat.com/RHSTOR-3411 task 'tar', 'yum' utilities were remove from ceph pods to trim an image size.
oc cp command depends on 'tar' utility, see https://linuxhint.com/use-kubectl-cp-command/ and oc cp --help

!!!Important Note!!!
Requires that the 'tar' binary is present in your container
image. If 'tar' is not present, 'oc cp' will fail.

therefore it fails, hence func copy_to_pod_cat and copy_from_pod_oc_exec added to the framework.

Copy to rook-ceph-osd with oc rsync also fails with error:

WARNING: cannot use rsync: rsync not available in container
WARNING: cannot use tar: tar not available in container
error: No available strategies to copy.

~~Minor improvements: exec_cmd - parameter added 'use_shell=False' ; ZombieProcess's, NoSuchProcess's stack trace print removed~~

High Priority: Test has longstanding failure history, has a recently opened bug and should run to close bug and trace failures.

merge conflict resolved, all commits are signed