### PR TITLE
Fix the use of TimeoutExpiredError in `bucket_utils.py::wait_for_pv_backingstore`

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -767,8 +767,9 @@ def wait_for_pv_backingstore(backingstore_name, namespace=None):
         namespace=namespace,
     )
     if not sample.wait_for_func_status(result=True):
-        logger.error(f"Backing Store {backingstore_name} never reached OPTIMAL state")
-        raise TimeoutExpiredError
+        raise TimeoutExpiredError(
+            f"Backing Store {backingstore_name} never reached OPTIMAL state"
+        )
     else:
         logger.info(f"Backing Store {backingstore_name} created successfully")
 


### PR DESCRIPTION
Currently, if we reach timeout expiration, then we get the following unhelpful message in RP:

```
Message: TypeError: init() missing 1 required positional argument: 'value'
Type: None
``` 

The reason is that's we're attempting to raise the class of the exception instead of an instance of it:

```
...
...
    if not sample.wait_for_func_status(result=True):
        logger.error(f"Backing Store {backingstore_name} never reached OPTIMAL state")
        raise TimeoutExpiredError
...
...
```