### PR TITLE
Skip test_resource_deletion_during_pvc_pod_deletion_and_io tests in external mode

### DIFF
--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     tier4,
     tier4c,
     ignore_leftover_label,
+    skipif_external_mode,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
@@ -48,25 +49,32 @@ log = logging.getLogger(__name__)
     argnames=["interface", "resource_to_delete"],
     argvalues=[
         pytest.param(
-            *[constants.CEPHBLOCKPOOL, "mgr"], marks=pytest.mark.polarion_id("OCS-810")
+            *[constants.CEPHBLOCKPOOL, "mgr"],
+            marks=[pytest.mark.polarion_id("OCS-810"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHBLOCKPOOL, "mon"], marks=pytest.mark.polarion_id("OCS-811")
+            *[constants.CEPHBLOCKPOOL, "mon"],
+            marks=[pytest.mark.polarion_id("OCS-811"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHBLOCKPOOL, "osd"], marks=pytest.mark.polarion_id("OCS-812")
+            *[constants.CEPHBLOCKPOOL, "osd"],
+            marks=[pytest.mark.polarion_id("OCS-812"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "mgr"], marks=pytest.mark.polarion_id("OCS-813")
+            *[constants.CEPHFILESYSTEM, "mgr"],
+            marks=[pytest.mark.polarion_id("OCS-813"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "mon"], marks=pytest.mark.polarion_id("OCS-814")
+            *[constants.CEPHFILESYSTEM, "mon"],
+            marks=[pytest.mark.polarion_id("OCS-814"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "osd"], marks=pytest.mark.polarion_id("OCS-815")
+            *[constants.CEPHFILESYSTEM, "osd"],
+            marks=[pytest.mark.polarion_id("OCS-815"), skipif_external_mode],
         ),
         pytest.param(
-            *[constants.CEPHFILESYSTEM, "mds"], marks=pytest.mark.polarion_id("OCS-816")
+            *[constants.CEPHFILESYSTEM, "mds"],
+            marks=[pytest.mark.polarion_id("OCS-816"), skipif_external_mode],
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, "cephfsplugin"],


### PR DESCRIPTION
The pods mgr, mon, osd and mds are not present in external cluster. So the test cases given below are skipped in external mode cluster.

```
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_and_io[CephBlockPool-mgr]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_a nd_io[CephBlockPool-mon]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_and_io[CephBlockPool-osd]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_and_io[CephFileSystem-mgr]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_and_io[CephFileSystem-mon]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOperations::test_disruptive_during_pod_pvc_deletion_and_io[CephFileSystem-osd]
tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py::TestResourceDeletionDuringMultipleDeleteOp erations::test_disruptive_during_pod_pvc_deletion_and_io[CephFileSystem-mds]
```
Fixes #7189