### PR TITLE
Fix tests to run on external mode

### DIFF
--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -71,9 +71,9 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
             "cephfsplugin_provisioner",
             "cephfsplugin",
             "rbdplugin",
-            "osd",
-            "mgr",
         ]
+        if not config.DEPLOYMENT["external_mode"]:
+            pods_to_delete.extend(["osd", "mgr"])
         executor = ThreadPoolExecutor(max_workers=len(self.pvcs) + len(pods_to_delete))
         disruption_ops = [disruption_helpers.Disruptions() for _ in pods_to_delete]
         file_name = "file_clone"

--- a/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers import disruption_helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
+from ocs_ci.framework import config
 
 log = logging.getLogger(__name__)
 
@@ -56,9 +57,9 @@ class TestResourceDeletionDuringSnapshotRestore(ManageTest):
             "cephfsplugin_provisioner",
             "cephfsplugin",
             "rbdplugin",
-            "osd",
-            "mgr",
         ]
+        if not config.DEPLOYMENT["external_mode"]:
+            pods_to_delete.extend(["osd", "mgr"])
         executor = ThreadPoolExecutor(max_workers=len(self.pvcs) + len(pods_to_delete))
         disruption_ops = [disruption_helpers.Disruptions() for _ in pods_to_delete]
         file_name = "file_snap"


### PR DESCRIPTION
Fix the test cases given below to run on external mode cluster.
1. tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py::TestResourceDeletionDuringPvcClone::test_resource_deletion_during_pvc_clone
2. tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py::TestResourceDeletionDuringSnapshotRestore::test_resource_deletion_during_snapshot_restore

Add osd and mgr to the list "pods_to_delete" only if the cluster is not external mode.

Fixes #7191 
Fixes #7192 