### PR TITLE
WIP: Add wait for crash collector in test_add_ocs_node

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2686,7 +2686,9 @@ def delete_all_osd_removal_jobs(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
 
 
 def get_crashcollector_pods(
-    crashcollector_label=constants.CRASHCOLLECTOR_APP_LABEL, namespace=None
+    crashcollector_label=constants.CRASHCOLLECTOR_APP_LABEL,
+    namespace=None,
+    nodes: set = None,
 ):
     """
     Fetches info about crashcollector pods in the cluster
@@ -2696,6 +2698,7 @@ def get_crashcollector_pods(
             (default: defaults.CRASHCOLLECTOR_APP_LABEL)
         namespace (str): Namespace in which ceph cluster lives
             (default: defaults.ROOK_CLUSTER_NAMESPACE)
+        nodes (set): filter result by node names
 
     Returns:
         list : of crashcollector pod objects
@@ -2703,7 +2706,12 @@ def get_crashcollector_pods(
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     crashcollectors = get_pods_having_label(crashcollector_label, namespace)
-    return [Pod(**crashcollector) for crashcollector in crashcollectors]
+    crashcollector_pods = [Pod(**crashcollector) for crashcollector in crashcollectors]
+    if nodes:
+        crashcollector_pods = [
+            pod for pod in crashcollector_pods if pod.get_node() in nodes
+        ]
+    return crashcollector_pods
 
 
 def check_pods_in_statuses(

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2688,7 +2688,7 @@ def delete_all_osd_removal_jobs(namespace=defaults.ROOK_CLUSTER_NAMESPACE):
 def get_crashcollector_pods(
     crashcollector_label=constants.CRASHCOLLECTOR_APP_LABEL,
     namespace=None,
-    nodes: set = None,
+    nodes: list = None,
 ):
     """
     Fetches info about crashcollector pods in the cluster
@@ -2698,7 +2698,7 @@ def get_crashcollector_pods(
             (default: defaults.CRASHCOLLECTOR_APP_LABEL)
         namespace (str): Namespace in which ceph cluster lives
             (default: defaults.ROOK_CLUSTER_NAMESPACE)
-        nodes (set): filter result by node names
+        nodes (list): filter result by the node names
 
     Returns:
         list : of crashcollector pod objects

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -7,6 +7,9 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_flash,
     skipif_managed_service,
 )
+from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.ocs.resources.pod import get_crashcollector_pods
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +27,30 @@ class TestAddNode(ManageTest):
 
     def test_add_ocs_node(self, add_nodes):
         """
-        Test to add ocs nodes and wait till rebalance is completed
+        Test to add ocs nodes, wait till rebalance is completed, verify rook-ceph-crashcollector created
 
         """
-        add_nodes(ocs_nodes=True)
+        nodes_added_num = 3
+
+        worker_nodes_before_add = get_worker_nodes()
+
+        add_nodes(node_count=nodes_added_num, ocs_nodes=True)
         ceph_cluster_obj = CephCluster()
         assert ceph_cluster_obj.wait_for_rebalance(
             timeout=3600
         ), "Data re-balance failed to complete"
+
+        worker_nodes_after_add = get_worker_nodes()
+        new_nodes = set(worker_nodes_before_add) - set(worker_nodes_after_add)
+
+        # to avoid newly created nodes produce crashcollectors in middle of next test, failing leftovers check,
+        # wait until all the new nodes produce crashcollectors in the current test
+        logger.info("verify all new nodes have crashcollectors")
+        for sample in TimeoutSampler(
+            timeout=60 * 5,
+            sleep=5,
+            func=get_crashcollector_pods,
+            func_kwargs={"nodes": new_nodes},
+        ):
+            if len(sample) == nodes_added_num:
+                break

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -41,16 +41,20 @@ class TestAddNode(ManageTest):
         ), "Data re-balance failed to complete"
 
         worker_nodes_after_add = get_worker_nodes()
-        new_nodes = set(worker_nodes_before_add) - set(worker_nodes_after_add)
+        new_nodes = [
+            node
+            for node in worker_nodes_after_add
+            if node not in worker_nodes_before_add
+        ]
 
-        # to avoid newly created nodes produce crashcollectors in middle of next test, failing leftovers check,
-        # wait until all the new nodes produce crashcollectors in the current test
-        logger.info("verify all new nodes have crashcollectors")
+        # to avoid newly created nodes produce crashcollectors in the middle of the next test, failing leftovers check,
+        # do wait until all the new nodes produce crashcollectors in the current test
+        logger.info(f"verify all the new nodes {new_nodes} have crashcollectors")
         for sample in TimeoutSampler(
             timeout=60 * 5,
             sleep=5,
             func=get_crashcollector_pods,
-            func_kwargs={"nodes": new_nodes},
+            nodes=new_nodes,
         ):
             if len(sample) == nodes_added_num:
                 break


### PR DESCRIPTION
Fixes #7085

test_ceph_csidriver_runs_on_non_ocs_nodes fails with msg: failed on teardown with "ocs_ci.ocs.exceptions.ResourceLeftoversException" during environment_checker func

Test tests/manage/z_cluster/cluster_expansion/test_node_expansion.py::TestAddNode::test_add_ocs_node does not have leftovers check on finish and the next test immediately starts with collecting cluster resources configuration, **before all resources created on the new nodes**

Crashcollector pods produced in the middle of the test_ceph_csidriver_runs_on_non_ocs_nodes fail environment_checker on tearDown


* It was taken on consideration 2 options, either remove newly created nodes or wait until resources created
First option has been dropped because remove_node() may fail on ipi deployments.

