### PR TITLE
Introduce wait time before creating resources for test_rolling_nodes_restart

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 
 from ocs_ci.framework.testlib import (
@@ -99,6 +100,7 @@ class TestNodesRestart(ManageTest):
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
+        time.sleep(120)
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
         )

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -100,7 +100,7 @@ class TestNodesRestart(ManageTest):
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
-        # Wait for 2 minutes before creating resources to avoid server timeout errors
+        # Wait for 2 minutes before creating resources to avoid server timeout error
         time.sleep(120)
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -100,6 +100,7 @@ class TestNodesRestart(ManageTest):
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
+        # Wait for 2 minutes before creating resources to avoid server timeout errors
         time.sleep(120)
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory


### PR DESCRIPTION
Test fails with-
```
Message: ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc new-project namespace-test-a166037ce3714829bd8cb2e39.
Error is Error from server (ServiceUnavailable): the server is currently unable to handle the request (get projectrequests.project.openshift.io)
```

Run ID: 1676239998 || Suite: tier4b || ODF 4.12.1-11, OCP 4.12, vsphere