### PR TITLE
Add _get_bucket_name() method to query the bucket name

### DIFF
--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -49,7 +49,7 @@ class HsBench(object):
         Args:
             bucket_num (int): Number of bucket
         Returns:
-            bucket_name (str): Name of bucket
+            str : Name of bucket
 
         """
 

--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -42,6 +42,14 @@ class HsBench(object):
         self.result = self.hsbench_cr["output_file"]
         self.hsbench_dir = mkdtemp(prefix="hsbench-")
 
+    def _get_bucket_name(self, bucket_num):
+        # bucket_str = "00000000000"
+        # bucket_name = self.bucket_prefix + bucket_str + str(bucket_num)
+        bucket_postfix = str("{:d}".format(bucket_num).zfill(12))
+        log.info(f"===bucket_postfix=== {bucket_postfix}")
+        bucket_name = self.bucket_prefix + bucket_postfix
+        return bucket_name
+
     def create_resource_hsbench(self):
         """
         Create resource for hsbench mark test:
@@ -209,7 +217,7 @@ class HsBench(object):
 
         """
         for i in range(self.num_bucket):
-            bucket_name = self.bucket_prefix + "00000000000" + str(i)
+            bucket_name = self._get_bucket_name(i)
             num_objects = self.toolbox.exec_sh_cmd_on_pod(
                 f"radosgw-admin bucket stats --bucket={bucket_name} | grep num_objects"
             )
@@ -358,7 +366,7 @@ class HsBench(object):
             CommandFailed: If reshard process fails
 
         """
-        bucket_name = self.bucket_prefix + "000000000000"
+        bucket_name = self._get_bucket_name(bucket_num=0)
         log.info("Starting checking bucket limit and start reshard process")
         try:
             self.toolbox.exec_cmd_on_pod(

--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -43,10 +43,16 @@ class HsBench(object):
         self.hsbench_dir = mkdtemp(prefix="hsbench-")
 
     def _get_bucket_name(self, bucket_num):
-        # bucket_str = "00000000000"
-        # bucket_name = self.bucket_prefix + bucket_str + str(bucket_num)
+        """
+        Get bucket name from bucket number.
+        Args:
+            bucket_num (int): Number of bucket
+        Returns:
+            bucket_name (str): Name of bucket
+
+        """
+
         bucket_postfix = str("{:d}".format(bucket_num).zfill(12))
-        log.info(f"===bucket_postfix=== {bucket_postfix}")
         bucket_name = self.bucket_prefix + bucket_postfix
         return bucket_name
 
@@ -187,7 +193,7 @@ class HsBench(object):
         """
         Validate if workload was running on the app-pod
 
-        Raise:
+        Raises:
             UnexpectedBehaviour: if result.csv file doesn't contain output data.
 
         """
@@ -210,9 +216,9 @@ class HsBench(object):
         Validate S3 objects using 'radosgw-admin' on single bucket
         Validate objects in buckets after completed upgrade
 
-        Agr:
+        Args:
             upgrade (str): Upgrade status
-        Raise:
+        Raises:
             UnexpectedBehaviour: If objects pre-upgrade and post-upgrade are not identical.
 
         """
@@ -263,7 +269,7 @@ class HsBench(object):
         """
         Validate PUT, GET, LIST objects from previous hsbench operation
 
-        Agr:
+        Args:
             result (str): Result file name
             num_objs (str): Number of objects to validate
             put (Boolean): Validate PUT operation
@@ -314,7 +320,7 @@ class HsBench(object):
         """
         Delete objects in a bucket
 
-        Agr:
+        Args:
             bucket_name (str): Name of bucket
 
         """
@@ -337,7 +343,7 @@ class HsBench(object):
         """
         Delete bucket
 
-        Agr:
+        Args:
             bucket_name (str): Name of bucket
 
         """

--- a/ocs_ci/ocs/hsbench.py
+++ b/ocs_ci/ocs/hsbench.py
@@ -45,6 +45,7 @@ class HsBench(object):
     def _get_bucket_name(self, bucket_num):
         """
         Get bucket name from bucket number.
+
         Args:
             bucket_num (int): Number of bucket
         Returns:

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -60,8 +60,7 @@ class TestHsBench(E2ETest):
         """
 
         # Running hsbench
-        # hsbenchs3.run_benchmark(num_obj=1000000, timeout=7200)
-        hsbenchs3.run_benchmark(num_obj=100, timeout=7200)
+        hsbenchs3.run_benchmark(num_obj=1000000, timeout=7200)
 
         # Validate hsbench created objects
         hsbenchs3.validate_s3_objects()

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -60,7 +60,8 @@ class TestHsBench(E2ETest):
         """
 
         # Running hsbench
-        hsbenchs3.run_benchmark(num_obj=1000000, timeout=7200)
+        # hsbenchs3.run_benchmark(num_obj=1000000, timeout=7200)
+        hsbenchs3.run_benchmark(num_obj=100, timeout=7200)
 
         # Validate hsbench created objects
         hsbenchs3.validate_s3_objects()


### PR DESCRIPTION
Fixed: # [6974](https://github.com/red-hat-storage/ocs-ci/issues/6974)

Added _get_bucket_name() method to query the bucket name.