### PR TITLE
test_ceph_capacity_recovery.py - adding retries for pulling perf image, adding skips for external and disconnected clusters 

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -25,7 +25,7 @@ from ocs_ci.helpers.proxy import (
     update_container_with_proxy_env,
 )
 from ocs_ci.ocs.utils import mirror_image
-from ocs_ci.ocs import constants, defaults, node, ocp
+from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     ResourceWrongStatusException,
@@ -1095,6 +1095,7 @@ def get_cephfs_name():
     return result[0]["name"]
 
 
+@retry(exceptions.CommandFailed, tries=5, delay=10, backoff=1)
 def pull_images(image_name):
     """
     Function to pull images on all nodes

--- a/tests/manage/pv_services/test_ceph_capacity_recovery.py
+++ b/tests/manage/pv_services/test_ceph_capacity_recovery.py
@@ -2,7 +2,12 @@ import logging
 import time
 
 from ocs_ci.ocs.perftests import PASTest
-from ocs_ci.framework.testlib import tier2, skipif_ocs_version
+from ocs_ci.framework.testlib import (
+    tier2,
+    skipif_ocs_version,
+    skipif_disconnected_cluster,
+    skipif_external_mode,
+)
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.helpers import helpers
@@ -46,6 +51,8 @@ def check_health_status():
 
 
 @tier2
+@skipif_external_mode
+@skipif_disconnected_cluster
 @skipif_ocs_version("<4.12")
 class TestCephCapacityRecovery(PASTest):
     def setup(self):
@@ -210,7 +217,7 @@ class TestCephCapacityRecovery(PASTest):
         get_used_capacity("Before PVCs deletion")
         check_health_status()
 
-        for (pod_obj, pvc_obj) in zip(pod_list, pvc_list):
+        for pod_obj, pvc_obj in zip(pod_list, pvc_list):
             log.info(f"Deleting the test POD : {pod_obj.name}")
             try:
                 pod_obj.delete()


### PR DESCRIPTION
This PR is a fix following https://github.com/red-hat-storage/ocs-ci/issues/7195  and https://github.com/red-hat-storage/ocs-ci/issues/7200. 

The changes which are implemented: 
 - added retries for pulling perf image. 
 - added skip for disconnected cluster
 - added skip for external cluster 
