### PR TITLE
Test pvc multi snapshot performance - increasing timeout for pod deletion

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -128,7 +128,9 @@ class TestPvcMultiSnapshotPerformance(PASTest):
             try:
                 self.pod_obj.delete()
                 log.info("Wait until the pod is deleted.")
-                self.pod_obj.ocp.wait_for_delete(resource_name=self.pod_obj.name)
+                self.pod_obj.ocp.wait_for_delete(
+                    resource_name=self.pod_obj.name, timeout=180
+                )
             except Exception as ex:
                 log.error(f"Cannot delete the test pod : {ex}")
 

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -411,7 +411,6 @@ class TestPvcMultiSnapshotPerformance(PASTest):
     )
     def test_pvc_multiple_snapshot_performance(
         self,
-        teardown_factory,
         secret_factory,
         interface_type,
         snap_number,
@@ -500,7 +499,6 @@ class TestPvcMultiSnapshotPerformance(PASTest):
         )
         helpers.wait_for_resource_state(self.pvc_obj, constants.STATUS_BOUND)
         self.pvc_obj.reload()
-        teardown_factory(self.pvc_obj)
 
         # Create POD which will attache to the new PVC
         log.info("Creating a Pod")


### PR DESCRIPTION
This PR handles occasional teardown problems by adding teardown factory .
Furthermore, the creation of pod factory and pvc factory was abondoned, in order not to exceed memory usage due to objects. 

