### PR TITLE
OCSCI containe, Added DEBUG_NEW_REQUIRES parm

### DIFF
--- a/Docker_files/ocsci_container/README.md
+++ b/Docker_files/ocsci_container/README.md
@@ -46,6 +46,7 @@ The containers are expected to run with a service account that has admin credent
 
 ### Debug ODF tests
   * In this mode we can develop new tests/code on our local machine and run the local-code via container
+  * DEBUG_NEW_REQUIRES : there is option to reinstall python requirements [by default is False]
   * In this example we added a new test in our local machine `test_new_code.py`:
   ```
   make debug-odf CLUSTER_PATH=~/ClusterPath \
@@ -53,7 +54,8 @@ The containers are expected to run with a service account that has admin credent
   ENGINE=podman \
   PULL_IMAGE=quay.io/ocsci/ocs-ci-container:release-4.12 \
   IMAGE_NAME=quay.io/ocsci/ocs-ci-container:release-4.12 \
-  AWS_PATH=~/.aws
+  AWS_PATH=~/.aws \
+  DEBUG_NEW_REQUIRES = True
   ```
 
 ### Run Managed Service
@@ -94,6 +96,11 @@ The containers are expected to run with a service account that has admin credent
 **Login to quay.io**
 ```
 docker/podman login -u <user-name> quay.io
+```
+
+**Login to registry.redhat.io**
+```
+docker/podman login registry.redhat.io
 ```
 
 **Tag Image**

--- a/Docker_files/ocsci_container/scripts/common.sh
+++ b/Docker_files/ocsci_container/scripts/common.sh
@@ -11,6 +11,8 @@ PIP_VERSION_ARG="${PIP_VERSION:-"pip3.8"}"
 
 BRANCH_ARG="${BRANCH:-"stable"}"
 
+DEBUG_NEW_REQUIRES_ARG="${DEBUG_NEW_REQUIRES:-""}"
+
 if [ "$PULL_IMAGE" != "" ]
 then
       $ENGINE_ARG image pull $PULL_IMAGE

--- a/Docker_files/ocsci_container/scripts/debug-odf.sh
+++ b/Docker_files/ocsci_container/scripts/debug-odf.sh
@@ -5,7 +5,14 @@ PWD=$(pwd)
 
 source Docker_files/ocsci_container/scripts/common.sh
 
-$ENGINE_ARG run -v $CLUSTER_PATH:/opt/cluster -v $PWD:/opt/ocs-ci-debug \
- $IMAGE_NAME_ARG --debug-- $RUN_CI
+if [ "$DEBUG_NEW_REQUIRES_ARG" == "" ];
+then
+  $ENGINE_ARG run -v $CLUSTER_PATH:/opt/cluster -v $PWD:/opt/ocs-ci-debug \
+   $IMAGE_NAME_ARG $RUN_CI
+else
+  $ENGINE_ARG run -v $CLUSTER_PATH:/opt/cluster -v $PWD:/opt/ocs-ci-debug \
+   $IMAGE_NAME_ARG --debug-- $RUN_CI
+fi
+
 
 #make debug-odf CLUSTER_PATH=~/ClusterPath RUN_CI="run-ci --cluster-path /opt/cluster --ocp-version 4.12 --ocs-version 4.12 --cluster-name oviner6-jun tests/e2e/workloads/app/jenkins/test_oded.py"


### PR DESCRIPTION
There is an issue to install ocs-ci requirements on M1 [mac]
I added option to skip on "new requiremnts" installtion on debug mode
So developers using MAC must pull the image from https://quay.io/repository/ocsci/ocs-ci-container?tab=tags and not build a local image