### PR TITLE
WIP: Update `exec_mcg_cmd` to use the new `use_shell` param of `exec_cmd` instead of using kwargs

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -868,7 +868,7 @@ class MCG:
         if use_yes:
             result = exec_cmd(
                 [f"yes | {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH} {cmd} {namespace}"],
-                shell=True,
+                use_shell=True,
                 **kwargs,
             )
         else:


### PR DESCRIPTION
Fixes: #7263