### PR TITLE
Remove redundant use_shell from exec_cmd

### DIFF
--- a/ocs_ci/ocs/rados_utils.py
+++ b/ocs_ci/ocs/rados_utils.py
@@ -362,7 +362,8 @@ def inject_corrupted_dups_into_pg_via_cot(
         osd_pod.exec_sh_cmd_on_pod(
             f"CEPH_ARGS='--no_mon_config --osd_pg_log_dups_tracked=999999999999' "
             f"ceph-objectstore-tool --data-path /var/lib/ceph/osd/ceph-"
-            f"{osd_id} --pgid {pgid} --op pg-log-inject-dups --file {target_path}"
+            f"{osd_id} --pgid {pgid} --op pg-log-inject-dups --file {target_path}",
+            shell=True,
         )
 
 
@@ -401,7 +402,7 @@ def get_pg_log_dups_count_via_cot(osd_deployments, pgid):
         )
         res = exec_cmd(
             f"cat {temp_file.name} | jq  '(.pg_log_t.log|length),(.pg_log_t.dups|length)'",
-            use_shell=True,
+            shell=True,
         )
         total_dups = int(res.stdout.decode("utf-8").split("\n")[1])
         osd_pg_log_dups.append(total_dups)

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -227,7 +227,7 @@ class Pod(OCS):
             str: stdout of the command
         """
         cmd = f"cat {src_path} | oc exec -i {self.name} -n {self.namespace} -- sh -c 'cat > {target_path}'"
-        return exec_cmd(cmd, timeout=timeout, use_shell=True)
+        return exec_cmd(cmd, timeout=timeout, shell=True)
 
     def copy_from_pod_oc_exec(
         self, target_path, src_path, timeout=600, chunk_size=2000
@@ -256,7 +256,7 @@ class Pod(OCS):
                 cmd
                 + f"\"tail -n '+{start_line}' {src_path}| head -n '{chunk_size}'\" >> {target_path}",
                 timeout=timeout,
-                use_shell=True,
+                shell=True,
             )
             start_line += chunk_size
             logger.info(f"size of target file = {os.stat(target_path).st_size}b")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -569,7 +569,6 @@ def exec_cmd(
     ignore_error=False,
     threading_lock=None,
     silent=False,
-    use_shell=False,
     **kwargs,
 ):
     """
@@ -589,7 +588,6 @@ def exec_cmd(
         threading_lock (threading.Lock): threading.Lock object that is used
             for handling concurrent oc commands
         silent (bool): If True will silent errors from the server, default false
-        use_shell (bool): If True will pass the cmd without splitting
     Raises:
         CommandFailed: In case the command execution fails
 
@@ -604,7 +602,7 @@ def exec_cmd(
     """
     masked_cmd = mask_secrets(cmd, secrets)
     log.info(f"Executing command: {masked_cmd}")
-    if isinstance(cmd, str) and not use_shell:
+    if isinstance(cmd, str) and not kwargs.get("shell"):
         cmd = shlex.split(cmd)
     if threading_lock and cmd[0] == "oc":
         threading_lock.acquire()
@@ -614,7 +612,6 @@ def exec_cmd(
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
         timeout=timeout,
-        shell=use_shell,
         **kwargs,
     )
     if threading_lock and cmd[0] == "oc":


### PR DESCRIPTION
Fixes #7263
exec_cmd has **kwargs param. We may use shell=True instead of having use_shell param. Having additional param with same sense is a point of failure for existing and future code