### PR TITLE
Update markers for RDR tests

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -75,7 +75,6 @@ deployment = pytest.mark.deployment
 polarion_id = pytest.mark.polarion_id
 bugzilla = pytest.mark.bugzilla
 acm_import = pytest.mark.acm_import
-rdr_test = pytest.mark.rdr_test
 
 tier_marks = [
     tier1,

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,7 +29,6 @@ markers =
     scale: scale related tests
     scale_long_run: scale tests which has execution time in days
     scale_changed_layout: scale capacity/node tests without teardown
-    rdr_test: Regional Disaster Recovery related tests
     deployment: deployment related tests
     ocs_upgrade: marker for OCS upgrade test
     ocp_upgrade: marker for OCP upgrade test

--- a/tests/disaster-recovery/__init__.py
+++ b/tests/disaster-recovery/__init__.py
@@ -1,0 +1,1 @@
+# This package is for DR team tests

--- a/tests/disaster-recovery/regional-dr/conftest.py
+++ b/tests/disaster-recovery/regional-dr/conftest.py
@@ -1,0 +1,21 @@
+import logging
+from ocs_ci.framework import config
+
+log = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(items):
+    """
+    A pytest hook to filter out RDR tests
+
+    Args:
+        items: list of collected tests
+
+    """
+    if config.MULTICLUSTER.get("multicluster_mode") != "regional-dr":
+        for item in items.copy():
+            if "disaster-recovery/regional-dr" in str(item.fspath):
+                log.debug(
+                    f"Test {item} is removed from the collected items. Test runs only on RDR clusters"
+                )
+                items.remove(item)

--- a/tests/disaster-recovery/regional-dr/conftest.py
+++ b/tests/disaster-recovery/regional-dr/conftest.py
@@ -1,5 +1,6 @@
 import logging
 from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ def pytest_collection_modifyitems(items):
         items: list of collected tests
 
     """
-    if config.MULTICLUSTER.get("multicluster_mode") != "regional-dr":
+    if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         for item in items.copy():
             if "disaster-recovery/regional-dr" in str(item.fspath):
                 log.debug(

--- a/tests/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_failover.py
@@ -4,14 +4,15 @@ import pytest
 from time import sleep
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 
 logger = logging.getLogger(__name__)
 
 
-@rdr_test
+@acceptance
+@tier1
 class TestFailover:
     """
     Test Failover action

--- a/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -4,14 +4,15 @@ import pytest
 from time import sleep
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 
 logger = logging.getLogger(__name__)
 
 
-@rdr_test
+@acceptance
+@tier1
 class TestFailoverAndRelocate:
     """
     Test Failover and Relocate actions

--- a/tests/disaster-recovery/regional-dr/test_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_relocate.py
@@ -3,13 +3,14 @@ import pytest
 
 from time import sleep
 
-from ocs_ci.framework.testlib import rdr_test
+from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 
 logger = logging.getLogger(__name__)
 
 
-@rdr_test
+@acceptance
+@tier1
 @pytest.mark.polarion_id("OCS-4425")
 class TestRelocate:
     """


### PR DESCRIPTION
Update RDR tests to use existing markers and filter out when running on non RDR cluster.