### PR TITLE
Fixing OBC bound list count mismatch (#7021)

### DIFF
--- a/ocs_ci/ocs/scale_noobaa_lib.py
+++ b/ocs_ci/ocs/scale_noobaa_lib.py
@@ -120,16 +120,18 @@ def check_all_obc_reached_bound_state_in_kube_job(
     return obc_bound_list
 
 
-def cleanup(namespace, obc_count=None):
+def cleanup(namespace, obc_list=None):
     """
     Delete all OBCs created in the cluster
 
     Args:
         namespace (str): Namespace of OBC's deleting
+        obc_list (string): List of OBCs to be deleted
 
     """
-    if obc_count is not None:
-        obc_name_list = obc_count
+    obc_name_list = list()
+    if obc_list is not None:
+        obc_name_list = obc_list
     else:
         obc_name_list = oc_get_all_obc_names()
     log.info(f"Deleting {len(obc_name_list)} OBCs")
@@ -510,3 +512,23 @@ def hsbench_cleanup():
     """
     hsbenchs3.delete_test_user()
     hsbenchs3.cleanup()
+
+
+def create_namespace():
+    """
+    Create and set namespace for obcs to be created
+    """
+    namespace_list = list()
+    namespace_list.append(helpers.create_project())
+    namespace = namespace_list[-1].namespace
+    return namespace
+
+
+def delete_namespace(namespace=None):
+    """
+    Delete namespace which was created for OBCs
+    Args:
+        namespace (str): Namespace where OBCs were created
+    """
+    ocp = OCP(kind=constants.NAMESPACE)
+    ocp.delete(resource_name=namespace)

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -18,8 +18,7 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 log = logging.getLogger(__name__)
 
-# Namespace and noobaa storage class
-namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+# Noobaa storage class
 sc_name = constants.NOOBAA_SC
 # Number of scaled obc count
 scale_obc_count = 500
@@ -40,6 +39,7 @@ def test_scale_obc_pre_upgrade(tmp_path, timeout=60):
     Create scaled MCG OBC using Noobaa storage class before upgrade
     Save scaled obc data in a file for post upgrade validation
     """
+    namespace = scale_noobaa_lib.create_namespace()
     obc_scaled_list = []
     log.info(f"Start creating  {scale_obc_count} " f"OBC in a batch of {num_obc_batch}")
     for i in range(int(scale_obc_count / num_obc_batch)):
@@ -115,4 +115,7 @@ def test_scale_obc_post_upgrade():
     utils.ceph_health_check()
 
     # Clean up all scaled obc
-    scale_noobaa_lib.cleanup(namespace=namespace)
+    scale_noobaa_lib.cleanup(namespace=namespace, obc_list=obc_scale_list)
+
+    # Delete namespace
+    scale_noobaa_lib.delete_namespace(namespace=namespace)

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -19,8 +19,7 @@ from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 
 log = logging.getLogger(__name__)
 
-# Namespace and noobaa storage class
-namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+# Noobaa storage class
 sc_name = constants.DEFAULT_STORAGECLASS_RGW
 # Number of scaled obc count
 scale_obc_count = 100
@@ -30,7 +29,7 @@ num_obc_batch = 50
 num_objs = 150000
 # Scale data file
 log_path = ocsci_log_path()
-obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
+obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
 @pre_upgrade
@@ -48,6 +47,7 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
     """
     # Running hsbench to create buckets with objects before upgrade.
     #  PUT, GET and LIST objects of a bucket.
+    namespace = scale_noobaa_lib.create_namespace()
     scale_noobaa_lib.hsbench_setup()
     scale_noobaa_lib.hsbench_io(
         namespace=namespace,
@@ -180,7 +180,10 @@ def test_scale_obc_rgw_post_upgrade():
     utils.ceph_health_check()
 
     # Clean up all scaled obcs
-    scale_noobaa_lib.cleanup(namespace=namespace)
+    scale_noobaa_lib.cleanup(namespace=namespace, obc_list=obc_scale_list)
 
     # Cleanup hsbench resources
     scale_noobaa_lib.hsbench_cleanup()
+
+    # Delete namespace
+    scale_noobaa_lib.delete_namespace(namespace=namespace)


### PR DESCRIPTION
Fixing scale issue # 6942:
    Using 2 different data files to store obc status
    Using separate namespace to create scaled obcs