### PR TITLE
Temporarily disable all format generation for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,7 +24,7 @@ sphinx:
    configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats: all
+# formats: all
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Backport to 4.12