### PR TITLE
Use MCG's internal endpoint at NSFS tests in disconnected and proxy deployments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5326,6 +5326,13 @@ def mcg_account_factory_fixture(request, mcg_obj_session):
         acc_secret_dict = OCP(
             kind="secret", namespace=config.ENV_DATA["cluster_namespace"]
         ).get(f"noobaa-account-{name}")
+
+        endpoint = (
+            mcg_obj_session.s3_internal_endpoint
+            if config.DEPLOYMENT.get("disconnected") or config.DEPLOYMENT.get("proxy")
+            else mcg_obj_session.s3_endpoint
+        )
+
         return {
             "access_key_id": base64.b64decode(
                 acc_secret_dict.get("data").get("AWS_ACCESS_KEY_ID")
@@ -5333,7 +5340,7 @@ def mcg_account_factory_fixture(request, mcg_obj_session):
             "access_key": base64.b64decode(
                 acc_secret_dict.get("data").get("AWS_SECRET_ACCESS_KEY")
             ).decode("utf-8"),
-            "endpoint": mcg_obj_session.s3_endpoint,
+            "endpoint": endpoint,
             "ssl": ssl,
         }
 


### PR DESCRIPTION
Fixes #7339 