### PR TITLE
Check for an existing pod before calling `awscli_pod_fixture`, and leverage the retry decorator in it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2237,7 +2237,11 @@ def mcg_obj_fixture(request, *args, **kwargs):
 
 @pytest.fixture(scope="session")
 def awscli_pod_session(request):
-    return awscli_pod_fixture(request, scope_name="session")
+    awscli_pods = get_pods_having_label(
+        constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
+    )
+    existing_pod = Pod(**awscli_pods[0]) if len(awscli_pods) > 0 else None
+    return existing_pod or awscli_pod_fixture(request, scope_name="session")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2282,10 +2282,12 @@ def awscli_pod_fixture(request, scope_name):
     s3cli_sts_obj = helpers.create_resource(**awscli_sts_dict)
     assert s3cli_sts_obj, "Failed to create S3CLI STS"
 
-    awscli_pod_obj = Pod(
-        **get_pods_having_label(
-            constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
-        )[0]
+    awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
+        lambda _: Pod(
+            **get_pods_having_label(
+                constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
+            )[0]
+        )
     )
 
     OCP(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2283,12 +2283,12 @@ def awscli_pod_fixture(request, scope_name):
     assert s3cli_sts_obj, "Failed to create S3CLI STS"
 
     awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
-        lambda _: Pod(
+        lambda: Pod(
             **get_pods_having_label(
                 constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
             )[0]
         )
-    )
+    )()
 
     OCP(
         namespace=config.ENV_DATA["cluster_namespace"], kind="ConfigMap"


### PR DESCRIPTION
Fixes: #7313