### PR TITLE
Fix `template_pvc` to specify the PVC's capacity units

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -338,7 +338,7 @@ def template_pvc(
     namespace=config.ENV_DATA["cluster_namespace"],
     storageclass=constants.CEPHFILESYSTEM_SC,
     access_mode=constants.ACCESS_MODE_RWX,
-    size="20Gi",
+    size=20,
 ):
     """
     Create a PVC using the MCG CLI
@@ -354,7 +354,7 @@ def template_pvc(
     pvc_data["metadata"]["name"] = name
     pvc_data["metadata"]["namespace"] = namespace
     pvc_data["spec"]["accessModes"] = [access_mode]
-    pvc_data["spec"]["resources"]["requests"]["storage"] = size
+    pvc_data["spec"]["resources"]["requests"]["storage"] = f"{size}Gi"
     pvc_data["spec"]["storageClassName"] = (
         constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_CEPHFS
         if storagecluster_independent_check()


### PR DESCRIPTION
Fixes: #7358

The "Gi" units were hard coded since this is one of the function's assumptions:

```
def template_pvc(
    name,
    namespace=config.ENV_DATA["cluster_namespace"],
    storageclass=constants.CEPHFILESYSTEM_SC,
    access_mode=constants.ACCESS_MODE_RWX,
    size=20,
):
    """
    Create a PVC using the MCG CLI

    Args:
        name (str): Name of the PVC
        namespace (str): Namespace to create the PVC in
        access_mode (str): Access mode for the PVC
        size (str): Size of the PVC in GiB

    """
```
Once merged we need to backport this to 4.12, 4.11 and 4.10.