### PR TITLE
use new version of ocp-network-split - v0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.2.0#egg=ocp-network-split
+-e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.3.0#egg=ocp-network-split
 -e .


### PR DESCRIPTION
The v0.2.0 is ~2 months old and doesn't contain important fixes like: https://gitlab.com/mbukatov/ocp-network-split/-/issues/14