### PR TITLE
external mode does not have osds, add skip-mark

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import tier3, skipif_managed_service
+from ocs_ci.framework.testlib import tier3, skipif_managed_service, skipif_external_mode
 from ocs_ci.ocs import metrics
 from ocs_ci.utility.prometheus import PrometheusAPI, check_query_range_result_enum
 
@@ -90,6 +90,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
 @tier3
 @pytest.mark.polarion_id("OCS-1307")
 @skipif_managed_service
+@skipif_external_mode
 def test_monitoring_shows_osd_down(measure_stop_ceph_osd):
     """
     Make sure simple problems with OSD daemons are reported via OCP Prometheus.

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @tier3
 @pytest.mark.polarion_id("OCS-1306")
 @skipif_managed_service
+@skipif_external_mode
 def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
     """
     Make sure simple problems with MON daemons are reported via OCP Prometheus.


### PR DESCRIPTION
Addressing the issue 

Message: failed on setup with "IndexError: list index out of range"
Type: None


Text:
measurement_dir = '/tmp/pytest-of-jenkins/pytest-0/measurement_results'
threading_lock = <unlocked _thread.lock object at 0x7f1e59e67b10>


@pytest.fixture
def measure_stop_ceph_osd(measurement_dir, threading_lock):
    """
    Downscales Ceph osd deployment, measures the time when it was
    downscaled and alerts that were triggered during this event.

    Returns:
        dict: Contains information about `start` and `stop` time for stopping
            Ceph osd pod
    """
    oc = ocp.OCP(
        kind=constants.DEPLOYMENT,
        namespace=config.ENV_DATA.get("cluster_namespace"),
        threading_lock=threading_lock,
    )
    osd_deployments = oc.get(selector=constants.OSD_APP_LABEL).get("items")
    osds = [deployment.get("metadata").get("name") for deployment in osd_deployments]

    # get osd deployments to stop, leave even number of osd

  osd_to_stop = osds[-1]
E       IndexError: list index out of range

=================
Report Portal 
https://url.corp.redhat.com/report-portal