### PR TITLE
avoid race condition after login

### DIFF
--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -736,6 +736,7 @@ def workload_idle(measurement_dir):
     the workload in such case.
     """
 
+    @retry(CommandFailed, text_in_exception="failed to get OSD and MON pods")
     def count_ceph_components():
         ceph_osd_ls_list = get_osd_pods()
         osd_num = len(ceph_osd_ls_list)


### PR DESCRIPTION
Fixes #7415 

add retry decorator to address possible race condition, more may be seen bellow: 

![image](https://user-images.githubusercontent.com/61454420/229528620-4dcc8d09-6ae0-4ba8-a945-c344b19f991d.png)
