### PR TITLE
4.12. Cherry-pick. test_obc_creation_and_deletion added RGW sc

### DIFF
--- a/ocs_ci/ocs/ui/mcg_ui.py
+++ b/ocs_ci/ocs/ui/mcg_ui.py
@@ -9,6 +9,7 @@ from ocs_ci.ocs.ocp import OCP, get_ocp_url
 from ocs_ci.framework import config
 from selenium.webdriver.support.wait import WebDriverWait
 from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.utility import version
 from ocs_ci.ocs.ui.base_ui import PageNavigator
 from ocs_ci.ocs.ui.views import locators
@@ -346,16 +347,10 @@ class ObcUI(BucketsUI):
 
         logger.info("Select Storage Class")
         self.do_click(self.obc_loc["storageclass_dropdown"])
-
-        if self.ocp_version_full <= version.VERSION_4_8:
-            self.do_send_keys(self.obc_loc["storageclass_text_field"], storageclass)
-
-        if self.ocp_version_full <= version.VERSION_4_8 or (
-            self.ocp_version_full > version.VERSION_4_8 and not bucketclass
-        ):
-            self.do_click(self.generic_locators["first_dropdown_option"])
-        else:
-            self.do_click(self.generic_locators["second_dropdown_option"])
+        self.do_send_keys(self.obc_loc["storageclass_text_field"], storageclass)
+        self.do_click(
+            locator=format_locator(self.generic_locators["storage_class"], storageclass)
+        )
 
         if bucketclass:
             logger.info("Select BucketClass")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -46,6 +46,7 @@ deployment = {
     ),
     "search_operator_installed": ('input[data-test-id="item-filter"]', By.CSS_SELECTOR),
     "thin_sc": ('a[id="thin-link"]', By.CSS_SELECTOR),
+    "thin-csi_sc": ("//span[text()='(default) | csi.vsphere.vmware.com']", By.XPATH),
     "gp2_sc": ('a[id="gp2-link"]', By.CSS_SELECTOR),
     "standard_sc": ('a[id="standard-link"]', By.CSS_SELECTOR),
     "standard_csi_sc": ('a[id="standard-csi-link"]', By.CSS_SELECTOR),
@@ -201,6 +202,7 @@ generic_locators = {
         'a[data-test="dropdown-menu-item-link"]',
         By.CSS_SELECTOR,
     ),
+    "storage_class": ("//span[contains(text(), '{}')]", By.XPATH),
     "second_dropdown_option": (
         '//a[@data-test="dropdown-menu-item-link"]/../../li[2]',
         By.XPATH,
@@ -287,10 +289,7 @@ obc = {
     ),
     "obc_menu_name": ("//a[normalize-space()='Object Bucket Claims']", By.XPATH),
     "storageclass_dropdown": ("sc-dropdown", By.ID),
-    "storageclass_text_field": (
-        'input[placeholder="Select StorageClass"]',
-        By.CSS_SELECTOR,
-    ),
+    "storageclass_text_field": ("//input[@id='search-bar']", By.XPATH),
     "bucketclass_dropdown": ("bc-dropdown", By.ID),
     "bucketclass_text_field": (
         'input[placeholder="Select BucketClass"],input[class="pf-c-form-control pf-m-search"]',

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -274,7 +274,7 @@ class TestObcUserInterface(object):
                     "three_dots",
                     True,
                 ],
-                marks=[pytest.mark.polarion_id("OCS-4698"), on_prem_platform_required],
+                marks=[pytest.mark.polarion_id("OCS-4845"), on_prem_platform_required],
             ),
         ],
     )


### PR DESCRIPTION
cherry-pick from [#7386](https://github.com/red-hat-storage/ocs-ci/pull/7386)
1. add cloud vers support for test_obc_creation_and_deletion
2. added a test to support ocs-storagecluster-ceph-rgw Storage Class