### PR TITLE
[Release-4.11 cherry pick] Fix the expeced error for test_namespacestore_creation_webhook[Empty secret name]

### DIFF
--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -157,7 +157,7 @@ class TestAdmissionWebhooks(MCGTest):
                             "secret": {"name": ""},
                         },
                     },
-                    "please provide a valid ARN or secret name",
+                    "secret name",
                 ],
                 marks=[tier3, polarion_id("OCS-2786")],
             ),


### PR DESCRIPTION
Fixes: #6838 