### PR TITLE
[Release-4.12 cherry pick] Fix test_noobaa_kms to look for the same record on all versions

### DIFF
--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -1,11 +1,12 @@
 import logging
-
 import pytest
+import re
 
 from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms
-from ocs_ci.framework.testlib import MCGTest, version
+from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.resources import pod
+
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +23,9 @@ class TestNoobaaKMS(MCGTest):
         """
         Validate from logs that there is successfully used NooBaa with KMS integration.
         """
-        # Define which records to look for based on the version
-        target_records = []
-        if version.get_semantic_ocs_version_from_config() < version.VERSION_4_10:
-            target_records.append("found root secret in external KMS successfully")
-        else:
-            target_records.append("setKMSConditionStatus Init")
-            target_records.append("setKMSConditionStatus Sync")
 
-        # Get the noobaa-operator pod and it's relevant metadata
+        logger.info("Getting the noobaa-operator pod and it's relevant metadata")
+
         operator_pod = pod.get_pods_having_label(
             label=constants.NOOBAA_OPERATOR_POD_LABEL,
             namespace=defaults.ROOK_CLUSTER_NAMESPACE,
@@ -38,16 +33,18 @@ class TestNoobaaKMS(MCGTest):
         operator_pod_name = operator_pod["metadata"]["name"]
         restart_count = operator_pod["status"]["containerStatuses"][0]["restartCount"]
 
-        # Look for the target records in the logs of the pod
-        targets_found = False
-        operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
-        targets_found = all(target in operator_logs for target in target_records)
+        logger.info("Looking for evidence of KMS integration in the logs of the pod")
 
-        # Also check the logs before the last pod restart
-        if not targets_found and restart_count > 0:
+        target_re = r"Exists:.*ocs-kms-token"
+        target_found = False
+        operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
+        target_found = re.search(target_re, operator_logs) is not None
+
+        if not target_found and restart_count > 0:
+            logger.info("Checking the logs before the last pod restart")
             operator_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
-            targets_found = all(target in operator_logs for target in target_records)
+            target_found = re.search(target_re, operator_logs) is not None
 
         assert (
-            targets_found
+            target_found
         ), "No records were found of the integration of NooBaa and KMS"


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/6966

- Look for the message ✅ Exists: Secret \"ocs-kms-token\"\n" on all versions instead of the current targets.
- Replace the comments with logs to ease future debugging.