### PR TITLE
Fixes purge bucket with versioning at the teardown of test_versioning_parallel_ops #6849

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -397,8 +397,10 @@ class MCGS3Bucket(ObjectBucket):
         Deletes the bucket using the S3 API
         """
         response = self.s3client.get_bucket_versioning(Bucket=self.name)
-        if "Status" in response.keys():
-            self.s3resource.Bucket(self.name).object_versions.delete()
+        logger.info(response)
+        if "Status" in response and response["Status"] == "Enabled":
+            for obj_version in self.s3resource.Bucket(self.name).object_versions.all():
+                obj_version.delete()
         else:
             self.s3resource.Bucket(self.name).objects.all().delete()
         self.s3resource.Bucket(self.name).delete()


### PR DESCRIPTION
This fixes #6849 But we may have to monitor the test run for couple of runs since failure observed in #6849 is not consistent. 