### PR TITLE
Fix deploy pod status value for DeploymentConfig workload in pod_factory_fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1081,7 +1081,6 @@ def pod_factory_fixture(request, pvc_factory):
                 command=command,
                 command_args=command_args,
                 subpath=subpath,
-                deploy_pod_status=status,
             )
             assert pod_obj, "Failed to create pod"
         if deployment_config:


### PR DESCRIPTION
Fixes: #7240

PR #6124 added `deploy_pod_status=status` when calling `create_pod()` in pod_factory_fixture
The status value which it was being set is same as other pods desired status (constants.STATUS_RUNNING).
This assumption that deploy pod status will be same as other pod status is not True and appears that it was added by mistake.
Also see this example output from ODF 4.13 setup where deploy pod goes to Completed state:
```
pod-test-cephfs-ed710c8134b6414ba84a2ff5-1-75rbh    1/1     Running     0          91s
pod-test-cephfs-ed710c8134b6414ba84a2ff5-1-deploy   0/1     Completed   0          92s
pod-test-rbd-2aaee60d8d0840d9a146af0e7d8-1-4p2pk    1/1     Running     0          29s
pod-test-rbd-2aaee60d8d0840d9a146af0e7d8-1-deploy   0/1     Completed   0          30s
```

Hence removing the param from inside the fixture. The `create_pod()` in helpers.py already uses correct value ,i.e., `deploy_pod_status=constants.STATUS_COMPLETED`

