### PR TITLE
Consume KUBEADMIN_PASSWORD and KUBECONFIG environment variables

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -497,7 +497,12 @@ def process_cluster_cli_params(config):
     suffix = ocsci_config.cur_index + 1 if ocsci_config.multicluster else ""
     cluster_path = get_cli_param(config, f"cluster_path{suffix}")
     if not cluster_path:
-        raise ClusterPathNotProvidedError()
+        if "KUBECONFIG" in os.environ:
+            cluster_path = os.path.dirname(os.environ["KUBECONFIG"])
+            ocsci_config.RUN["kubeconfig_location"] = "kubeconfig"
+            ocsci_config.RUN["password_location"] = "kubeadmin-password"
+        else:
+            raise ClusterPathNotProvidedError()
     cluster_path = os.path.expanduser(cluster_path)
     if not os.path.exists(cluster_path):
         os.makedirs(cluster_path)

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -497,7 +497,7 @@ def process_cluster_cli_params(config):
     suffix = ocsci_config.cur_index + 1 if ocsci_config.multicluster else ""
     cluster_path = get_cli_param(config, f"cluster_path{suffix}")
     if not cluster_path:
-        if "KUBECONFIG" in os.environ:
+        if os.getenv("KUBECONFIG"):
             cluster_path = os.path.dirname(os.environ["KUBECONFIG"])
             ocsci_config.RUN["kubeconfig_location"] = "kubeconfig"
             ocsci_config.RUN["password_location"] = "kubeadmin-password"


### PR DESCRIPTION
Added option to remove `cluster-path` parameter [from `run-ci` entrypoint], if there is an environment var named KUBECONFIG

#7498

