### PR TITLE
Add new functionality to wait for stop and terminate nodes

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1205,9 +1205,10 @@ class AWSNodes(NodesBase):
 
         """
         instances = self.get_ec2_instances(nodes)
-        assert (
-            instances
-        ), f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+        if not instances:
+            raise ValueError(
+                f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+            )
         try:
             self.aws.wait_for_instances_to_stop(instances=instances)
         except WaiterError as e:
@@ -1226,9 +1227,10 @@ class AWSNodes(NodesBase):
 
         """
         instances = self.get_ec2_instances(nodes)
-        assert (
-            instances
-        ), f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+        if not instances:
+            raise ValueError(
+                f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+            )
         try:
             self.aws.wait_for_instances_to_terminate(instances=instances)
         except WaiterError as e:
@@ -1248,9 +1250,10 @@ class AWSNodes(NodesBase):
 
         """
         instances = self.get_ec2_instances(nodes)
-        assert (
-            instances
-        ), f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+        if not instances:
+            raise ValueError(
+                f"Failed to get the EC2 instances for nodes {[n.name for n in nodes]}"
+            )
         try:
             self.aws.wait_for_instances_to_stop_or_terminate(instances=instances)
         except WaiterError as e:

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -6,7 +6,7 @@ import random
 import traceback
 import re
 
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import ClientError, NoCredentialsError, WaiterError
 
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import get_infra_id
@@ -1692,6 +1692,65 @@ class AWS(object):
 
         """
         return self.get_hosted_zone_details(zone_id)["DelegationSet"]["NameServers"]
+
+    def wait_for_instances_to_stop(self, instances):
+        """
+        Wait for the instances to reach status stopped
+
+        Args:
+            instances: A dictionary of instance IDs and names
+
+        Raises:
+            botocore.exceptions.WaiterError: If it failed to reach the expected status stopped
+
+        """
+        for instance_id, instance_name in instances.items():
+            logger.info(f"Waiting for instance {instance_name} to reach status stopped")
+            instance = self.get_ec2_instance(instance_id)
+            instance.wait_until_stopped()
+
+    def wait_for_instances_to_terminate(self, instances):
+        """
+        Wait for the instances to reach status terminated
+
+        Args:
+            instances: A dictionary of instance IDs and names
+
+        Raises:
+            botocore.exceptions.WaiterError: If it failed to reach the expected status terminated
+
+        """
+        for instance_id, instance_name in instances.items():
+            logger.info(
+                f"Waiting for instance {instance_name} to reach status terminated"
+            )
+            instance = self.get_ec2_instance(instance_id)
+            instance.wait_until_terminated()
+
+    def wait_for_instances_to_stop_or_terminate(self, instances):
+        """
+        Wait for the instances to reach statuses stopped or terminated
+
+        Args:
+            instances: A dictionary of instance IDs and names
+
+        Raises:
+            botocore.exceptions.WaiterError: If it failed to reach the expected statuses stopped or terminated
+
+        """
+        for instance_id, instance_name in instances.items():
+            logger.info(f"Waiting for instance {instance_name} to reach status stopped")
+            instance = self.get_ec2_instance(instance_id)
+            try:
+                instance.wait_until_stopped()
+            except WaiterError as e:
+                logger.warning(
+                    f"Failed to reach the status stopped due to the error {str(e)}"
+                )
+                logger.info(
+                    f"Waiting for instance {instance_name} to reach status terminated"
+                )
+                instance.wait_until_terminated()
 
 
 def get_instances_ids_and_names(instances):

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -1739,7 +1739,9 @@ class AWS(object):
 
         """
         for instance_id, instance_name in instances.items():
-            logger.info(f"Waiting for instance {instance_name} to reach status stopped")
+            logger.info(
+                f"Waiting for instance {instance_name} to reach status stopped or terminated"
+            )
             instance = self.get_ec2_instance(instance_id)
             try:
                 instance.wait_until_stopped()

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -87,7 +87,8 @@ def check_automated_recovery_from_stopped_node(nodes):
         osd_node_name
     )
 
-    nodes.stop_nodes([osd_node], wait=True)
+    nodes.stop_nodes([osd_node], wait=False)
+    nodes.wait_for_nodes_to_stop_or_terminate([osd_node])
     log.info(f"Successfully powered off node: {osd_node_name}")
 
     log.info("Verify the node rook ceph pods go into a Terminating state")

--- a/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery_ms.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery_ms.py
@@ -97,7 +97,8 @@ class TestRollingWorkerNodeShutdownAndRecoveryMS(ManageTest):
 
         # Start rolling shutdown and recovery of OCS worker nodes
         for node_obj in ocs_node_objs:
-            nodes.stop_nodes(nodes=[node_obj])
+            nodes.stop_nodes(nodes=[node_obj], wait=False)
+            nodes.wait_for_nodes_to_stop_or_terminate(nodes=[node_obj])
             # When we use the managed service, the worker node should recover automatically
             # by starting the node, or removing it and creating a new one
             log.info("Waiting for all the worker nodes to be ready...")


### PR DESCRIPTION
Fix issue https://issues.redhat.com/browse/ODFMS-326.
When shutting down a worker node using MS, the node usually goes into a Terminating state.
The current "stop nodes" MS tests expect the node to reach the status stopped(and not terminated). This can cause the following error: https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-odf-multicluster/1600/testReport/tests.manage.z_cluster.nodes.test_rolling_shutdown_and_recovery_ms/TestRollingWorkerNodeShutdownAndRecoveryMS/test_rolling_shutdown_and_recovery_in_controlled_fashion_provider_/.
To fix the issue above, I implemented the following:

- Add new functionality to wait for stop and terminate nodes. This functionality implemented in the pr is currently for the AWS platform. But it can be extended later to the other platforms if needed.
- Instead of stopping nodes and waiting for the nodes to stop - Stop the nodes first, and then wait for the nodes to reach the status stopped or terminated(using the functionality above).