### PR TITLE
[Release-4.11 cherry pick] Fix template_pvc to specify the PVC's capacity units

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -338,7 +338,7 @@ def template_pvc(
     namespace=config.ENV_DATA["cluster_namespace"],
     storageclass=constants.CEPHFILESYSTEM_SC,
     access_mode=constants.ACCESS_MODE_RWX,
-    size="20Gi",
+    size=20,
 ):
     """
     Create a PVC using the MCG CLI
@@ -354,7 +354,7 @@ def template_pvc(
     pvc_data["metadata"]["name"] = name
     pvc_data["metadata"]["namespace"] = namespace
     pvc_data["spec"]["accessModes"] = [access_mode]
-    pvc_data["spec"]["resources"]["requests"]["storage"] = size
+    pvc_data["spec"]["resources"]["requests"]["storage"] = f"{size}Gi"
     pvc_data["spec"]["storageClassName"] = (
         constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_CEPHFS
         if storagecluster_independent_check()


### PR DESCRIPTION
4.11 Cherry pick of #7359. 

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/7358

