### PR TITLE
Remove TimeoutExpiredError's arguments and class members

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -43,18 +43,7 @@ class ObjectsStillBeingDeletedException(Exception):
 
 
 class TimeoutExpiredError(Exception):
-    message = "Timed Out"
-
-    def __init__(self, value, custom_message=None):
-        self.value = value
-        self.custom_message = custom_message
-
-    def __str__(self):
-        if self.custom_message is None:
-            self.message = f"{self.__class__.message}: {self.value}"
-        else:
-            self.message = self.custom_message
-        return self.message
+    pass
 
 
 class TimeoutException(Exception):


### PR DESCRIPTION
There are multiple cases where we're using this class without providing any arguments, and when a test fails due to a timeout expiration error and no arguments are given, the result is this unhelpful error message:

```
Message: TypeError: init() missing 1 required positional argument: 'value'
```

Example:
https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/493/10848/481918/481947/481951/log

We're currently not using this exception's arguments/class members when creating or catching it, so this change wouldn't break any working use of it.