### PR TITLE
Fix post install verification for FaaS consumer

### DIFF
--- a/ocs_ci/deployment/fusion_aas.py
+++ b/ocs_ci/deployment/fusion_aas.py
@@ -103,10 +103,12 @@ class FUSIONAAS(rosa_deployment.ROSA):
         """
         Deployment of ODF Managed Service addon on Fusion aaS.
         """
-        ceph_cluster = ocp.OCP(kind="CephCluster", namespace=self.namespace)
+        managed_fusion_offering = ocp.OCP(
+            kind=constants.MANAGED_FUSION_OFFERING, namespace=self.namespace
+        )
         try:
-            ceph_cluster.get().get("items")[0]
-            logger.warning("OCS cluster already exists")
+            managed_fusion_offering.get().get("items")[0]
+            logger.warning("ManagedFusionOffering exists. Skipping installation.")
             return
         except (IndexError, CommandFailed):
             logger.info("Running OCS basic installation")

--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -41,7 +41,13 @@ class Sanity:
         logger.info("Checking cluster and Ceph health")
         node.wait_for_nodes_status(timeout=300)
 
-        if not config.ENV_DATA["mcg_only_deployment"]:
+        if not (
+            config.ENV_DATA["mcg_only_deployment"]
+            or (
+                config.ENV_DATA.get("platform") == constants.FUSIONAAS_PLATFORM
+                and config.ENV_DATA["cluster_type"].lower() == "consumer"
+            )
+        ):
             ceph_health_check(
                 namespace=config.ENV_DATA["cluster_namespace"], tries=tries
             )

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -77,7 +77,10 @@ class CephCluster(object):
         Cluster object initializer, this object needs to be initialized
         after cluster deployment. However its harmless to do anywhere.
         """
-        if config.ENV_DATA["mcg_only_deployment"]:
+        if config.ENV_DATA["mcg_only_deployment"] or (
+            config.ENV_DATA.get("platform") == constants.FUSIONAAS_PLATFORM
+            and config.ENV_DATA["cluster_type"].lower() == "consumer"
+        ):
             return
         # cluster_name is name of cluster in rook of type CephCluster
         self.POD = ocp.OCP(kind="Pod", namespace=config.ENV_DATA["cluster_namespace"])

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -160,6 +160,7 @@ LVMSCLUSTER = "lvmscluster"
 STORAGECLASSCLAIM = "StorageClassClaim"
 MACHINEHEALTHCHECK = "machinehealthcheck"
 STORAGECLIENT = "StorageClient"
+MANAGED_FUSION_OFFERING = "ManagedFusionOffering"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"
@@ -336,6 +337,8 @@ CEPH_FILE_CONTROLLER_DETECT_VERSION_LABEL = "app=ceph-file-controller-detect-ver
 CEPH_OBJECT_CONTROLLER_DETECT_VERSION_LABEL = (
     "app=ceph-object-controller-detect-version"
 )
+CSI_ADDONS_CONTROLLER_MANAGER_LABEL = "app.kubernetes.io/name=csi-addons"
+
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"
 DEFAULT_DEVICESET_LSO_PVC_NAME = "ocs-deviceset-localblock"
 DEFAULT_MON_PVC_NAME = "rook-ceph-mon"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -42,6 +42,7 @@ MCG_OPERATOR = "mcg-operator"
 ODF_CSI_ADDONS_OPERATOR = "odf-csi-addons-operator"
 LOCAL_STORAGE_OPERATOR_NAME = "local-storage-operator"
 LIVE_CONTENT_SOURCE = "redhat-operators"
+OCS_CLIENT_OPERATOR_NAME = "ocs-client-operator"
 
 # Noobaa S3 bucket website configurations
 website_config = {

--- a/ocs_ci/ocs/fusion.py
+++ b/ocs_ci/ocs/fusion.py
@@ -139,12 +139,19 @@ def deploy_odf():
         exec_cmd
     )(offering_check_cmd)
     helpers.create_resource(**template)
+
+    operator_name = (
+        defaults.OCS_OPERATOR_NAME
+        if config.ENV_DATA.get("cluster_type") == "provider"
+        else defaults.OCS_CLIENT_OPERATOR_NAME
+    )
+
     # Sometimes it takes time before ocs operator csv is present
     for sample in TimeoutSampler(
         timeout=1800,
         sleep=15,
         func=get_csvs_start_with_prefix,
-        csv_prefix=defaults.OCS_OPERATOR_NAME,
+        csv_prefix=operator_name,
         namespace=ns_name,
     ):
         if sample:

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -14,6 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.managed_services import (
     verify_provider_topology,
     get_ocs_osd_deployer_version,
+    verify_pods_in_managed_fusion_namespace,
 )
 from ocs_ci.ocs import constants, defaults, ocp, managedservice
 from ocs_ci.ocs.exceptions import (
@@ -173,9 +174,13 @@ def ocs_install_verification(
     external = config.DEPLOYMENT["external_mode"] or (
         managed_service and config.ENV_DATA["cluster_type"].lower() == "consumer"
     )
+    fusion_aas = config.ENV_DATA.get("platform") == constants.FUSIONAAS_PLATFORM
+    fusion_aas_consumer = fusion_aas and consumer_cluster
+    fusion_aas_provider = fusion_aas and provider_cluster
 
     # Basic Verification for cluster
-    basic_verification(ocs_registry_image)
+    if not fusion_aas_consumer:
+        basic_verification(ocs_registry_image)
 
     # Verify pods in running state and proper counts
     log.info("Verifying pod states and counts")
@@ -248,6 +253,10 @@ def ocs_install_verification(
             }
         )
 
+    if fusion_aas_consumer:
+        del resources_dict[constants.OCS_OPERATOR_LABEL]
+        del resources_dict[constants.OPERATOR_LABEL]
+
     if ocs_version >= version.VERSION_4_9:
         resources_dict.update(
             {
@@ -268,7 +277,7 @@ def ocs_install_verification(
         if "mds" in label and disable_cephfs:
             continue
         if label == constants.MANAGED_CONTROLLER_LABEL:
-            if config.ENV_DATA.get("platform") == constants.FUSIONAAS_PLATFORM:
+            if fusion_aas_provider:
                 service_pod = OCP(
                     kind=constants.POD, namespace=config.ENV_DATA["service_namespace"]
                 )
@@ -345,7 +354,13 @@ def ocs_install_verification(
     csi_driver = OCP(kind="CSIDriver")
     csi_drivers = {item["metadata"]["name"] for item in csi_driver.get()["items"]}
     if not provider_cluster:
-        assert defaults.CSI_PROVISIONERS.issubset(csi_drivers)
+        if fusion_aas_consumer:
+            {
+                f"{namespace}.cephfs.csi.ceph.com",
+                f"{namespace}.rbd.csi.ceph.com",
+            }.issubset(csi_drivers)
+        else:
+            assert defaults.CSI_PROVISIONERS.issubset(csi_drivers)
 
     # Verify node and provisioner secret names in storage class
     log.info("Verifying node and provisioner secret names in storage class.")
@@ -448,7 +463,9 @@ def ocs_install_verification(
 
     log.info("Verified node and provisioner secret names in storage class.")
 
-    ct_pod = get_ceph_tools_pod()
+    # TODO: Enable the tools pod check when a solution is identified for tools pod on FaaS consumer
+    if not fusion_aas_consumer:
+        ct_pod = get_ceph_tools_pod()
 
     # https://github.com/red-hat-storage/ocs-ci/issues/3820
     # Verify ceph osd tree output
@@ -545,7 +562,8 @@ def ocs_install_verification(
         log.info("Verified: CSI snapshotter is not present.")
 
     # Verify pool crush rule is with "type": "zone"
-    if utils.get_az_count() == 3:
+    # TODO: Enable the check when a solution is identified for tools pod on FaaS consumer
+    if utils.get_az_count() == 3 and not fusion_aas_consumer:
         log.info("Verifying pool crush rule is with type: zone")
         crush_dump = ct_pod.exec_ceph_cmd(ceph_cmd="ceph osd crush dump", format="")
         pool_names = [
@@ -575,10 +593,18 @@ def ocs_install_verification(
         # health OK. See discussion in BZ:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1817727
         health_check_tries = 180
-    assert utils.ceph_health_check(namespace, health_check_tries, health_check_delay)
+
+    # TODO: Enable the check when a solution is identified for tools pod on FaaS consumer
+    if not fusion_aas_consumer:
+        assert utils.ceph_health_check(
+            namespace, health_check_tries, health_check_delay
+        )
     # Let's wait for storage system after ceph health is OK to prevent fails on
     # Progressing': 'True' state.
-    verify_storage_system()
+
+    if not fusion_aas:
+        verify_storage_system()
+
     if config.ENV_DATA.get("fips"):
         # In case that fips is enabled when deploying,
         # a verification of the installation of it will run
@@ -592,20 +618,30 @@ def ocs_install_verification(
             if config.ENV_DATA.get("VAULT_CA_ONLY", None):
                 verify_kms_ca_only()
 
-    storage_cluster_obj = get_storage_cluster()
-    is_flexible_scaling = (
-        storage_cluster_obj.get()["items"][0].get("spec").get("flexibleScaling", False)
-    )
-    if is_flexible_scaling is True:
-        failure_domain = storage_cluster_obj.data["items"][0]["status"]["failureDomain"]
-        assert failure_domain == "host", (
-            f"The expected failure domain on cluster with flexible scaling is 'host',"
-            f" the actaul failure domain is {failure_domain}"
+    if not fusion_aas_consumer:
+        storage_cluster_obj = get_storage_cluster()
+        is_flexible_scaling = (
+            storage_cluster_obj.get()["items"][0]
+            .get("spec")
+            .get("flexibleScaling", False)
         )
+        if is_flexible_scaling is True:
+            failure_domain = storage_cluster_obj.data["items"][0]["status"][
+                "failureDomain"
+            ]
+            assert failure_domain == "host", (
+                f"The expected failure domain on cluster with flexible scaling is 'host',"
+                f" the actaul failure domain is {failure_domain}"
+            )
 
     if config.ENV_DATA.get("is_multus_enabled"):
         verify_multus_network()
-    if managed_service:
+
+    if fusion_aas:
+        verify_pods_in_managed_fusion_namespace()
+
+    # TODO: Enable the verification for FaaS consumer cluster
+    if managed_service and not fusion_aas_consumer:
         verify_managed_service_resources()
 
 

--- a/tests/ecosystem/deployment/test_deployment.py
+++ b/tests/ecosystem/deployment/test_deployment.py
@@ -69,7 +69,12 @@ def test_deployment(pvc_factory, pod_factory):
                 sanity_helpers.delete_resources()
                 # Verify ceph health
                 log.info("Verifying ceph health after deployment")
-                assert ceph_health_check(tries=10, delay=30)
+                # TODO: Enable the check when a solution is identified for tools pod on FaaS consumer
+                if not (
+                    config.ENV_DATA.get("platform") == constants.FUSIONAAS_PLATFORM
+                    and config.ENV_DATA["cluster_type"].lower() == "consumer"
+                ):
+                    assert ceph_health_check(tries=10, delay=30)
 
     if teardown:
         log.info("Cluster will be destroyed during teardown part of this test.")


### PR DESCRIPTION
Update post installation checks to support FaaS consumer cluster.

1. Checks which require tools pods are skipped because tools pod is not available in consumer cluster. This will be updated when there is a solution to check ceph commands from consumer.
2. Updated deploy_ocs function in ocs_ci/deployment/fusion_aas.py to skip ocs install if managedfusionoffering is present instead of checking cehph cluster.
3. OCS operator, storagecluster, cephcluster will not be present in FaaS consumer cluster. Checks related to this will be skipped.
4. Added verification of pods in managed-fusion namespace.