### PR TITLE
Post installation verifications for FaaS

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -224,6 +224,7 @@ ENV_DATA:
   rosa_billing_model: 'standard'
   appliance_mode: true
   ms_osd_pod_memory: "6Gi"
+  ms_osd_pod_cpu: "1650m"
 
   # used in external mode deployment
   restricted-auth-permission: false

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -392,8 +392,7 @@ def verify_faas_resources():
         sc_data = sc_obj.get()["items"][0]
         verify_faas_provider_storagecluster(sc_data)
         verify_faas_provider_resources()
-        if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11-0"):
-            verify_provider_topology()
+        verify_provider_topology()
     else:
         verify_storageclient()
         verify_faas_consumer_resources()

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -8,7 +8,6 @@ from ocs_ci.helpers.helpers import create_ocs_object_from_kind_and_name
 from ocs_ci.ocs import managedservice
 from ocs_ci.ocs.resources import csv
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 from ocs_ci.utility.managedservice import get_storage_provider_endpoint
 from ocs_ci.utility.version import get_semantic_version
 from ocs_ci.framework import config
@@ -387,9 +386,12 @@ def verify_faas_resources():
 
     # Verify attributes specific to cluster types
     if config.ENV_DATA["cluster_type"].lower() == "provider":
-        sc = get_storage_cluster()
-        sc_data = sc.get()["items"][0]
-        verify_provider_storagecluster(sc_data)
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        sc_data = sc_obj.get()["items"][0]
+        verify_faas_provider_storagecluster(sc_data)
         verify_faas_provider_resources()
         if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11-0"):
             verify_provider_topology()

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -120,8 +120,8 @@ def verify_provider_topology():
     log.info(f"Verified that the OSD count is {size_map[size]['osd_count']}")
 
     # Verify OSD CPU and memory
-    osd_cpu_limit = "1750m"
-    osd_cpu_request = "1750m"
+    osd_cpu_limit = config.ENV_DATA["ms_osd_pod_cpu"]
+    osd_cpu_request = config.ENV_DATA["ms_osd_pod_cpu"]
     osd_pods = get_osd_pods()
     osd_memory_size = config.ENV_DATA["ms_osd_pod_memory"]
     log.info("Verifying OSD CPU and memory")

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -5,7 +5,6 @@ import logging
 import re
 
 from ocs_ci.helpers.helpers import create_ocs_object_from_kind_and_name
-from ocs_ci.ocs import managedservice
 from ocs_ci.ocs.resources import csv
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility.managedservice import get_storage_provider_endpoint

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -2,14 +2,23 @@
 Managed Services related functionalities
 """
 import logging
+import re
 
 from ocs_ci.helpers.helpers import create_ocs_object_from_kind_and_name
+from ocs_ci.ocs import managedservice
+from ocs_ci.ocs.resources import csv
 from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 from ocs_ci.utility.managedservice import get_storage_provider_endpoint
 from ocs_ci.utility.version import get_semantic_version
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.node import get_worker_nodes, get_node_objs, get_node_zone_dict
+from ocs_ci.ocs.node import (
+    get_worker_nodes,
+    get_node_objs,
+    get_node_zone_dict,
+    verify_worker_nodes_security_groups,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_pod_node
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs
@@ -363,3 +372,232 @@ def verify_pods_in_managed_fusion_namespace():
     log.info(
         f"Verified the status of the pods in the namespace {constants.MANAGED_FUSION_NAMESPACE}"
     )
+
+
+def verify_faas_resources():
+    """
+    Verify the presence and status of resources in FaaS clusters
+
+    """
+    # Verify pods in managed-fusion namespace
+    verify_pods_in_managed_fusion_namespace()
+
+    # Verify secrets
+    verify_faas_cluster_secrets()
+
+    # Verify attributes specific to cluster types
+    if config.ENV_DATA["cluster_type"].lower() == "provider":
+        sc = get_storage_cluster()
+        sc_data = sc.get()["items"][0]
+        verify_provider_storagecluster(sc_data)
+        verify_faas_provider_resources()
+        if get_ocs_osd_deployer_version() >= get_semantic_version("2.0.11-0"):
+            verify_provider_topology()
+    else:
+        verify_storageclient()
+        verify_faas_consumer_resources()
+
+    # Verify security
+    if config.ENV_DATA["cluster_type"].lower() == "consumer":
+        verify_client_operator_security()
+
+
+def verify_faas_provider_resources():
+    """
+    Verify resources specific to FaaS provider cluster
+
+    1. Verify CSV phase
+    2. Verify ocs-provider-server pod is Running
+    3. Verify that Cephcluster is Ready and hostNetworking is True
+    4. Verify that the security groups are set up correctly
+
+    """
+    # Verify CSV phase
+    for csv_prefix in {
+        constants.MANAGED_FUSION_AGENT,
+        constants.OCS_CSV_PREFIX,
+        constants.OSE_PROMETHEUS_OPERATOR,
+    }:
+        csvs = csv.get_csvs_start_with_prefix(
+            csv_prefix, config.ENV_DATA["cluster_namespace"]
+        )
+        assert (
+            len(csvs) == 1
+        ), f"Unexpected number of CSVs with name prefix {csv_prefix}: {len(csvs)}"
+        csv_name = csvs[0]["metadata"]["name"]
+        csv_obj = csv.CSV(
+            resource_name=csv_name, namespace=config.ENV_DATA["cluster_namespace"]
+        )
+        log.info(f"Verify that the CSV {csv_name} is in Succeeded phase.")
+        csv_obj.wait_for_phase(phase="Succeeded", timeout=600)
+
+    # Verify ocs-provider-server pod is Running
+    pod_obj = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
+    pod_obj.wait_for_resource(
+        condition="Running", selector=constants.PROVIDER_SERVER_LABEL, resource_count=1
+    )
+
+    # Verify that Cephcluster is Ready and hostNetworking is True
+    cephcluster = OCP(
+        kind=constants.CEPH_CLUSTER, namespace=config.ENV_DATA["cluster_namespace"]
+    )
+    cephcluster_yaml = cephcluster.get().get("items")[0]
+    log.info("Verifying that Cephcluster is Ready and hostNetworking is True")
+    assert (
+        cephcluster_yaml["status"]["phase"] == "Ready"
+    ), f"Status of cephcluster {cephcluster_yaml['metadata']['name']} is {cephcluster_yaml['status']['phase']}"
+    assert cephcluster_yaml["spec"]["network"][
+        "hostNetwork"
+    ], f"hostNetwork is {cephcluster_yaml['spec']['network']['hostNetwork']} in Cephcluster"
+
+    # Verify that the security groups are set up correctly
+    assert verify_worker_nodes_security_groups()
+
+
+def verify_faas_consumer_resources():
+    """
+    Verify resources specific to FaaS consumer
+
+    1. Verify CSV phase
+    2. Verify client endpoint
+
+    """
+
+    # Verify CSV phase
+    for csv_prefix in {
+        constants.MANAGED_FUSION_AGENT,
+        constants.OCS_CLIENT_OPERATOR,
+        constants.ODF_CSI_ADDONS_OPERATOR,
+        constants.OSE_PROMETHEUS_OPERATOR,
+    }:
+        csvs = csv.get_csvs_start_with_prefix(
+            csv_prefix, config.ENV_DATA["cluster_namespace"]
+        )
+        assert (
+            len(csvs) == 1
+        ), f"Unexpected number of CSVs with name prefix {csv_prefix}: {len(csvs)}"
+        csv_name = csvs[0]["metadata"]["name"]
+        csv_obj = csv.CSV(
+            resource_name=csv_name, namespace=config.ENV_DATA["cluster_namespace"]
+        )
+        log.info(f"Verify that the CSV {csv_name} is in Succeeded phase.")
+        csv_obj.wait_for_phase(phase="Succeeded", timeout=600)
+
+    # Verify client endpoint
+    client_endpoint = OCP(
+        kind=constants.ENDPOINTS,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        selector="operators.coreos.com/ocs-client-operator.fusion-storage",
+    )
+    client_ep_yaml = client_endpoint.get().get("items")[0]
+    log.info("Verifying that The client endpoint has an IP address")
+    ep_ip = client_ep_yaml["subsets"][0]["addresses"][0]["ip"]
+    log.info(f"Client endpoint IP is {ep_ip}")
+    assert re.match("\\d+(\\.\\d+){3}", ep_ip)
+
+
+def verify_faas_cluster_secrets():
+    """
+    Verify the secrets present in FaaS cluster
+
+    """
+    secret_cluster_namespace_obj = OCP(
+        kind=constants.SECRET, namespace=config.ENV_DATA["cluster_namespace"]
+    )
+    secret_service_namespace_obj = OCP(
+        kind=constants.SECRET, namespace=config.ENV_DATA["service_namespace"]
+    )
+    managed_fusion_secret_names = [
+        "alertmanager-managed-fusion-alertmanager-generated",
+        "managed-fusion-agent-config",
+        "managed-fusion-alertmanager-secret",
+        "prometheus-managed-fusion-prometheus",
+    ]
+    for secret_name in managed_fusion_secret_names:
+        assert secret_service_namespace_obj.is_exist(
+            resource_name=secret_name
+        ), f"Secret {secret_name} does not exist in {config.ENV_DATA['service_namespace']} namespace"
+
+    if config.ENV_DATA["cluster_type"].lower() == "provider":
+        secret_names = [
+            constants.MANAGED_ONBOARDING_SECRET,
+            constants.MANAGED_PROVIDER_SERVER_SECRET,
+            constants.MANAGED_MON_SECRET,
+        ]
+        for secret_name in secret_names:
+            assert secret_cluster_namespace_obj.is_exist(
+                resource_name=secret_name
+            ), f"Secret {secret_name} does not exist in {config.ENV_DATA['cluster_namespace']} namespace"
+
+
+def verify_faas_provider_storagecluster(sc_data):
+    """
+    Verify provider storagecluster
+
+    1. allowRemoteStorageConsumers: true
+    2. hostNetwork: true
+    3. matchExpressions:
+    key: node-role.kubernetes.io/worker
+    operator: Exists
+    key: node-role.kubernetes.io/infra
+    operator: DoesNotExist
+    4. storageProviderEndpoint
+    5. annotations:
+    uninstall.ocs.openshift.io/cleanup-policy: delete
+    uninstall.ocs.openshift.io/mode: graceful
+
+    Args:
+        sc_data (dict): storagecluster data dictionary
+
+    """
+    log.info(
+        f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
+    )
+    assert sc_data["spec"]["allowRemoteStorageConsumers"]
+    log.info(f"hostNetwork: {sc_data['spec']['hostNetwork']}")
+    assert sc_data["spec"]["hostNetwork"]
+    expressions = sc_data["spec"]["labelSelector"]["matchExpressions"]
+    for item in expressions:
+        log.info(f"Verifying {item}")
+        if item["key"] == "node-role.kubernetes.io/worker":
+            assert item["operator"] == "Exists"
+        else:
+            assert item["operator"] == "DoesNotExist"
+    log.info(f"storageProviderEndpoint: {sc_data['status']['storageProviderEndpoint']}")
+    assert re.match(
+        "(\\w+\\-\\w+\\.\\w+\\-\\w+\\-\\w+\\.elb.amazonaws.com):50051",
+        sc_data["status"]["storageProviderEndpoint"],
+    )
+    annotations = sc_data["metadata"]["annotations"]
+    log.info(f"Annotations: {annotations}")
+    assert annotations["uninstall.ocs.openshift.io/cleanup-policy"] == "delete"
+    assert annotations["uninstall.ocs.openshift.io/mode"] == "graceful"
+
+
+def verify_client_operator_security():
+    """
+    Check ocs-client-operator-controller-manager permissions
+
+    1. Verify `runAsUser` is not 0
+    2. Verify `SecurityContext.allowPrivilegeEscalation` is set to false
+    3. Verify `SecurityContext.capabilities.drop` contains ALL
+
+    """
+    pod_obj = OCP(
+        kind=constants.POD,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        selector=constants.MANAGED_CONTROLLER_LABEL,
+    )
+    client_operator_yaml = pod_obj.get().get("items")[0]
+    containers = client_operator_yaml["spec"]["containers"]
+    for container in containers:
+        log.info(f"Checking container {container['name']}")
+        userid = container["securityContext"]["runAsUser"]
+        log.info(f"runAsUser is {userid}. Verifying it is not 0")
+        assert userid > 0
+        escalation = container["securityContext"]["allowPrivilegeEscalation"]
+        log.info("Verifying allowPrivilegeEscalation is False")
+        assert not escalation
+        dropped_capabilities = container["securityContext"]["capabilities"]["drop"]
+        log.info(f"Dropped capabilities: {dropped_capabilities}")
+        assert "ALL" in dropped_capabilities

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -538,14 +538,14 @@ def verify_faas_provider_storagecluster(sc_data):
     1. allowRemoteStorageConsumers: true
     2. hostNetwork: true
     3. matchExpressions:
-    key: node-role.kubernetes.io/worker
-    operator: Exists
-    key: node-role.kubernetes.io/infra
-    operator: DoesNotExist
+        key: node-role.kubernetes.io/worker
+        operator: Exists
+        key: node-role.kubernetes.io/infra
+        operator: DoesNotExist
     4. storageProviderEndpoint
     5. annotations:
-    uninstall.ocs.openshift.io/cleanup-policy: delete
-    uninstall.ocs.openshift.io/mode: graceful
+        uninstall.ocs.openshift.io/cleanup-policy: delete
+        uninstall.ocs.openshift.io/mode: graceful
 
     Args:
         sc_data (dict): storagecluster data dictionary

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -161,6 +161,8 @@ STORAGECLASSCLAIM = "StorageClassClaim"
 MACHINEHEALTHCHECK = "machinehealthcheck"
 STORAGECLIENT = "StorageClient"
 MANAGED_FUSION_OFFERING = "ManagedFusionOffering"
+CEPH_CLUSTER = "CephCluster"
+ENDPOINTS = "Endpoints"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"
@@ -1076,6 +1078,9 @@ MIRROR_OPENSHIFT_PASSWORD_FILE = "mirror_openshift_password"
 NOOBAA_POSTGRES_CONFIGMAP = "noobaa-postgres-config"
 ROOK_CEPH_OPERATOR = "rook-ceph-operator"
 ROOK_CEPH_CSI_CONFIG = "rook-ceph-csi-config"
+MANAGED_FUSION_AGENT = "managed-fusion-agent"
+OCS_CLIENT_OPERATOR = "ocs-client-operator"
+ODF_CSI_ADDONS_OPERATOR = "odf-csi-addons-operator"
 
 # UI Deployment constants
 HTPASSWD_SECRET_NAME = "htpass-secret"

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1635,6 +1635,8 @@ def verify_all_nodes_created():
     # when DEPLOYMENT["pullsecret_workaround"] is True
     if config.ENV_DATA["platform"].lower() == constants.FUSIONAAS_PLATFORM:
         wait_time = 2400
+    else:
+        wait_time = 1200
 
     if expected_num_nodes != existing_num_nodes:
         platforms_to_wait = [

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1629,6 +1629,13 @@ def verify_all_nodes_created():
         expected_num_nodes += config.ENV_DATA.get("infra_replicas", 0)
 
     existing_num_nodes = len(get_all_nodes())
+
+    # Some nodes will take time to create due to the issue https://issues.redhat.com/browse/SDA-6346
+    # Increasing the wait time for FaaS where the presence of all nodes are important
+    # when DEPLOYMENT["pullsecret_workaround"] is True
+    if config.ENV_DATA["platform"].lower() == constants.FUSIONAAS_PLATFORM:
+        wait_time = 2400
+
     if expected_num_nodes != existing_num_nodes:
         platforms_to_wait = [
             constants.VSPHERE_PLATFORM,
@@ -1652,7 +1659,7 @@ def verify_all_nodes_created():
             try:
 
                 for node_list in TimeoutSampler(
-                    timeout=1200, sleep=60, func=get_all_nodes
+                    timeout=wait_time, sleep=60, func=get_all_nodes
                 ):
                     if len(node_list) == expected_num_nodes:
                         log.info(

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1643,8 +1643,8 @@ def verify_all_nodes_created():
             constants.VSPHERE_PLATFORM,
             constants.IBMCLOUD_PLATFORM,
             constants.AZURE_PLATFORM,
-            constants.MANAGED_SERVICE_PLATFORMS,
         ]
+        platforms_to_wait.extend(constants.MANAGED_SERVICE_PLATFORMS)
         if config.ENV_DATA[
             "platform"
         ].lower() in constants.MANAGED_SERVICE_PLATFORMS and not config.DEPLOYMENT.get(

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -14,7 +14,7 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.managed_services import (
     verify_provider_topology,
     get_ocs_osd_deployer_version,
-    verify_pods_in_managed_fusion_namespace,
+    verify_faas_resources,
 )
 from ocs_ci.ocs import constants, defaults, ocp, managedservice
 from ocs_ci.ocs.exceptions import (
@@ -638,11 +638,7 @@ def ocs_install_verification(
         verify_multus_network()
 
     if fusion_aas:
-        verify_pods_in_managed_fusion_namespace()
-
-    # TODO: Enable the verification for FaaS consumer cluster
-    if managed_service and not fusion_aas_consumer:
-        verify_managed_service_resources()
+        verify_faas_resources()
 
 
 def mcg_only_install_verification(ocs_registry_image=None):


### PR DESCRIPTION
Creted new functions for FaaS provider and consumer verification.
Movied the verification of pods in managed-fusion namespace to the new function.
Verify security in ocs-client-operator pod on consumer.
Verifiy storage client on consumer.

Consumer:
    1. Verify CSV phase
    2. Verify client endpoint

Provider:
    1. Verify CSV phase
    2. Verify ocs-provider-server pod is Running
    4. Verify that Cephcluster is Ready and hostNetworking is True
    5. Verify that the security groups are set up correctly