### PR TITLE
Adding reclaim space cron job tc and refactoring

### DIFF
--- a/ocs_ci/templates/CSI/addons/ReclaimSpaceCronJob.yaml
+++ b/ocs_ci/templates/CSI/addons/ReclaimSpaceCronJob.yaml
@@ -1,7 +1,7 @@
 apiVersion: csiaddons.openshift.io/v1alpha1
 kind: ReclaimSpaceCronJob
 metadata:
-  name: reclaimspacecronjob-sample
+  name: reclaim-space-cron-job-sample
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1

--- a/ocs_ci/templates/CSI/addons/ReclaimSpaceJob.yaml
+++ b/ocs_ci/templates/CSI/addons/ReclaimSpaceJob.yaml
@@ -1,7 +1,7 @@
 apiVersion: csiaddons.openshift.io/v1alpha1
 kind: ReclaimSpaceJob
 metadata:
-  name: sample-1
+  name: reclaim-space-job-sample
 spec:
   target:
      persistentVolumeClaim: pvc-1

--- a/ocs_ci/templates/CSI/addons/volumeReplicationCR.yaml
+++ b/ocs_ci/templates/CSI/addons/volumeReplicationCR.yaml
@@ -4,10 +4,12 @@ metadata:
   name: volume-replication-sample
   namespace: default
 spec:
-  volumeReplicationClass: volumereplicationclass-sample
+  volumeReplicationClass: volume-replication-class-sample
   replicationState: primary
+  replicationHandle: ""
   autoResync: false
   dataSource:
+    apiGroup: ""
     kind: PersistentVolumeClaim
     name: myPersistentVolumeClaim
 

--- a/ocs_ci/templates/CSI/addons/volumeReplicationCR.yaml
+++ b/ocs_ci/templates/CSI/addons/volumeReplicationCR.yaml
@@ -1,7 +1,7 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplication
 metadata:
-  name: volumereplication-sample
+  name: volume-replication-sample
   namespace: default
 spec:
   volumeReplicationClass: volumereplicationclass-sample

--- a/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
+++ b/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
@@ -3,9 +3,9 @@ kind: VolumeReplicationClass
 metadata:
   name: volume-replication-class-sample
 spec:
-  mirroringMode: snapshot
   provisioner: example.provisioner.io
   parameters:
+    mirroringMode: snapshot
     replication.storage.openshift.io/replication-secret-name: secret-name
     replication.storage.openshift.io/replication-secret-namespace: secret-namespace
     schedulingInterval: 1m

--- a/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
+++ b/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
@@ -3,6 +3,7 @@ kind: VolumeReplicationClass
 metadata:
   name: volume-replication-class-sample
 spec:
+  mirroringMode: snapshot
   provisioner: example.provisioner.io
   parameters:
     replication.storage.openshift.io/replication-secret-name: secret-name

--- a/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
+++ b/ocs_ci/templates/CSI/addons/volumeReplicationClass.yaml
@@ -1,7 +1,7 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplicationClass
 metadata:
-  name: volumereplicationclass-sample
+  name: volume-replication-class-sample
 spec:
   provisioner: example.provisioner.io
   parameters:

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -143,7 +143,7 @@ class TestCRRsourcesValidation(E2ETest):
 
     def test_network_fence_not_editable(self):
         """
-        Test case to check that network fence object is not editable once created
+        Test case to check that some properties of network fence object are not editable once object is created
         """
 
         patches_non_editable = {  # dictionary: patch_name --> patch
@@ -169,7 +169,7 @@ class TestCRRsourcesValidation(E2ETest):
 
     def test_reclaim_space_cron_job_editable(self):
         """
-        Test case to check that reclaim space cron job object is not editable once created
+        Test case to check that some properties reclaim space cron job object are not editable once object is created
         """
 
         non_editable_patches = {  # dictionary: patch_name --> patch
@@ -179,6 +179,43 @@ class TestCRRsourcesValidation(E2ETest):
         self.cr_resource_not_editable(
             "Reclaim space cron job",
             "ReclaimSpaceCronJob.yaml",
+            non_editable_patches,
+            {},
+        )
+
+    def test_reclaim_space_job_editable(self):
+        """
+        Test case to check that some properties of reclaim space job object are not editable once object is created
+        """
+
+        non_editable_patches = {  # dictionary: patch_name --> patch
+            "persistentVolumeClaim": '{"spec": {"target" :{"persistentVolumeClaim": "pv"}}}',
+        }
+
+        self.cr_resource_not_editable(
+            "Reclaim space job",
+            "ReclaimSpaceJob.yaml",
+            non_editable_patches,
+            {},
+        )
+
+    def test_volume_replication_class_editable(self):
+        """
+        Test case to check that some properties of volume replication class object are not editable
+        once object is created
+        """
+
+        non_editable_patches = {  # dictionary: patch_name --> patch
+            "persistentVolumeClaim": '{"spec": {"provisioner": "edited.provisioner.io"}}}',
+            "persistentVolumeClaim": '{"spec": {"parameters" : '
+            '{"replication.storage.openshift.io/replication-secret-name": "my-secret"}}}',
+            "persistentVolumeClaim": '{"spec": {"parameters" :'
+            '{"replication.storage.openshift.io/replication-secret-namespace": "my-name"}}}',
+        }
+
+        self.cr_resource_not_editable(
+            "Volume Replication Class",
+            "volumeReplicationClass.yaml",
             non_editable_patches,
             {},
         )

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -154,7 +154,7 @@ class TestCRRsourcesValidation(E2ETest):
                 editable_properties_errors[patch] = cr_resource_modified_yaml
                 continue  # just continue to the next property
 
-        assert editable_properties_errors, (
+        assert not editable_properties_errors, (
             f"{cr_object_kind} object has not been edited but it should be. \n"
             f"Unchanged properties: {list(editable_properties_errors.keys())}"
         )

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -116,7 +116,8 @@ class TestCRRsourcesValidation(E2ETest):
 
             detailed_err_msg = f"Original object yaml is {cr_resource_original_yaml}\n."
             for prop in non_editable_properties_errors:
-                detailed_err_msg += f"Changed property is {prop}. \nEdited object yaml is {non_editable_properties_errors[prop]}\n"
+                detailed_err_msg += f"Changed property is {prop}. \nEdited object yaml is " \
+                                    f"{non_editable_properties_errors[prop]}\n"
                 logger.error(detailed_err_msg)
 
             raise Exception(err_msg)

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -206,10 +206,10 @@ class TestCRRsourcesValidation(E2ETest):
         """
 
         non_editable_patches = {  # dictionary: patch_name --> patch
-            "persistentVolumeClaim": '{"spec": {"provisioner": "edited.provisioner.io"}}}',
-            "persistentVolumeClaim": '{"spec": {"parameters" : '
+            "provisioner": '{"spec": {"provisioner": "edited.provisioner.io"}}}',
+            "replication-secret-name": '{"spec": {"parameters" : '
             '{"replication.storage.openshift.io/replication-secret-name": "my-secret"}}}',
-            "persistentVolumeClaim": '{"spec": {"parameters" :'
+            "replication-secret-namespace": '{"spec": {"parameters" :'
             '{"replication.storage.openshift.io/replication-secret-namespace": "my-name"}}}',
         }
 

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -9,7 +9,6 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     tier3,
 )
-from ocs_ci.framework.pytest_customization.marks import system_test
 from ocs_ci.helpers.performance_lib import run_oc_command
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import run_cmd

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -116,8 +116,10 @@ class TestCRRsourcesValidation(E2ETest):
 
             detailed_err_msg = f"Original object yaml is {cr_resource_original_yaml}\n."
             for prop in non_editable_properties_errors:
-                detailed_err_msg += f"Changed property is {prop}. \nEdited object yaml is " \
-                                    f"{non_editable_properties_errors[prop]}\n"
+                detailed_err_msg += (
+                    f"Changed property is {prop}. \nEdited object yaml is "
+                    f"{non_editable_properties_errors[prop]}\n"
+                )
                 logger.error(detailed_err_msg)
 
             raise Exception(err_msg)

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -22,26 +22,82 @@ class TestCRRsourcesValidation(E2ETest):
     Test that check that csi addons resources are not editable after creation
     """
 
+    def setup(self):
+        self.temp_files_list = []
+        self.object_name_to_delete = ""
+
+    def cr_resource_not_editable(self, cr_object_kind, yaml_name, patches):
+        """
+        Test that cr object is not editable once created
+
+        Args:
+            cr_object_kind (str): cr object kind
+            yaml_name (str): name of the yaml file from which the object is to be created
+            patches (dict, of str: str): patches to be applied by 'oc patch' command
+
+        """
+        cr_resource_yaml = os.path.join(constants.TEMPLATE_CSI_ADDONS_DIR, yaml_name)
+        res = run_oc_command(cmd=f"create -f {cr_resource_yaml}")
+        assert (
+            ERRMSG not in res[0]
+        ), f"Failed to create resource {cr_object_kind} from yaml file {cr_resource_yaml}, got result {res}"
+
+        cr_resource_name = res[0].split()[0]
+        self.object_name_to_delete = cr_resource_name
+
+        cr_resource_original_yaml = run_oc_command(f"get {cr_resource_name} -o yaml")
+
+        editable_properties = {}
+        cr_resource_prev_yaml = cr_resource_original_yaml
+        for patch in patches:
+            params = "'" + f"{patches[patch]}" + "'"
+            command = f"oc -n openshift-storage patch {cr_resource_name} -p {params} --type merge"
+
+            temp_file = NamedTemporaryFile(
+                mode="w+", prefix="cr_resource_modification", suffix=".sh"
+            )
+            with open(temp_file.name, "w") as t_file:
+                t_file.writelines(command)
+            self.temp_files_list.append(temp_file.name)
+            run_cmd(f"chmod 777 {temp_file.name}")
+            logger.info(f"Trying to edit property {patch}")
+
+            try:
+                run_cmd(f"sh {temp_file.name}")
+                cr_resource_modified_yaml = run_oc_command(
+                    f"get {cr_resource_name} -o yaml"
+                )
+
+                if cr_resource_prev_yaml != cr_resource_modified_yaml:
+                    editable_properties[patch] = cr_resource_modified_yaml
+                    # reset prev yaml to the modified one to track further modifications
+                    cr_resource_prev_yaml = cr_resource_modified_yaml
+            except (
+                CommandFailed
+            ):  # some properties are not editable and CommandFailed exception is thrown
+                continue  # just continue to the next property
+
+        if editable_properties:
+            err_msg = (
+                f"{cr_object_kind} object has been edited but it should not be. \n"
+                f"Changed properties: {list(editable_properties.keys())}"
+            )
+            logger.error(err_msg)
+
+            detailed_err_msg = f"Original object yaml is {cr_resource_original_yaml}\n."
+            for prop in editable_properties:
+                detailed_err_msg += f"Changed property is {prop}. "
+                detailed_err_msg += (
+                    f"Edited object yaml is {editable_properties[prop]}\n"
+                )
+            logger.error(detailed_err_msg)
+
+            raise Exception(err_msg)
+
     def test_network_fence_not_editable(self):
         """
         Test case to check that network fence object is not editable once created
         """
-        self.temp_files_list = []
-        self.object_name_to_delete = ""
-        network_fence_yaml = os.path.join(
-            constants.TEMPLATE_CSI_ADDONS_DIR, "NetworkFence.yaml"
-        )
-        res = run_oc_command(cmd=f"create -f {network_fence_yaml}")
-        assert (
-            ERRMSG not in res[0]
-        ), f"Failed to create resource Network Fence from yaml file {network_fence_yaml}, got result {res}"
-
-        network_fence_name = res[0].split()[0]
-        self.object_name_to_delete = network_fence_name
-
-        network_fence_original_yaml = run_oc_command(
-            f"get {network_fence_name} -o yaml"
-        )
 
         patches = {  # dictionary: patch_name --> patch
             "apiVersion": {"apiVersion": "csiaddons.openshift.io/v1alpha2"},
@@ -52,43 +108,39 @@ class TestCRRsourcesValidation(E2ETest):
             "uid": '{"metadata": {"uid": "897b3c9c-c1ce-40e3-95e6-7f3dadeb3e83" }}',
             "secret": '{"spec": {"secret": {"name": "new_secret"}}}',
             "cidrs": '{"spec": {"cidrs": {"10.90.89.66/32", "11.67.12.42/32"}}}',
-            "fenceState": '{"spec": {"fenceState": "NotFenced"}}',
+            "fenceState": '{"spec": {"fenceState": "Unfenced"}}',
             "driver": '{"spec": {"driver": "example.new_driver"}}',
             "new_property": '{"spec": {"new_property": "new_value"}}',
         }
 
-        for patch in patches:
-            params = "'" + f"{patches[patch]}" + "'"
-            command = f"oc -n openshift-storage patch {network_fence_name} -p {params} --type merge"
+        self.cr_resource_not_editable("Network fence", "NetworkFence.yaml", patches)
 
-            temp_file = NamedTemporaryFile(
-                mode="w+", prefix="network_fence_modification", suffix=".sh"
-            )
-            with open(temp_file.name, "w") as t_file:
-                t_file.writelines(command)
-            self.temp_files_list.append(temp_file.name)
-            run_cmd(f"chmod 777 {temp_file.name}")
-            logger.info(f"Trying to edit property {patch}")
+    def test_reclaim_space_cron_job_editable(self):
+        """
+        Test case to check that reclaim space cron job object is not editable once created
+        """
 
-            try:
-                run_cmd(f"sh {temp_file.name}")
-                network_fence_modified_yaml = run_oc_command(
-                    f"get {network_fence_name} -o yaml"
-                )
+        patches = {  # dictionary: patch_name --> patch
+            "apiVersion": {"apiVersion": "csiaddons.openshift.io/v1alpha2"},
+            "kind": {"kind": "newReclainSpaceCronJob"},
+            "generation": '{"metadata": {"generation": 6456456 }}',
+            "creationTime": '{"metadata": {"creationTimestamp": "2022-04-24T19:39:54Z" }}',
+            "name": '{"metadata": {"name": "newName" }}',
+            "resourceVersion": '{"metadata": {"resourceVersion": "21332" }}',
+            "uid": '{"metadata": {"uid": "897b3c9c-c1ce-40e3-95e6-7f3dadeb3e83" }}',
+            "concurrencyPolicy": '{"spec": {"concurrencyPolicy": "Replace"}}',
+            "failedJobsHistoryLimit": '{"spec": {"failedJobsHistoryLimit": 50}}',
+            "backoffLimit": '{"spec": {"jobTemplate": {"spec": {"backOffLimit": 111}}}}',
+            "retryDeadlineSeconds": '{"spec": {"jobTemplate": {"spec": {"retryDeadlineSeconds": 20}}}}',
+            "persistentVolumeClaim": '{"spec": {"jobTemplate": {"spec": {"target" :{"persistentVolumeClaim": "pv"}}}}}',
+            "successfulJobsHistoryLimit": '{"spec": {"successfulJobsHistoryLimit": 300}}',
+            "new_property": '{"spec": {"new_property": "new_value"}}',
+            "schedule": '{"spec": {"schedule": "@daily"}}',
+        }
 
-                if network_fence_original_yaml != network_fence_modified_yaml:
-                    err_msg = (
-                        f"Network fence object has been edited but it should not be. \n"
-                        f"Property {patch} was changed. \n"
-                        f"Original object yaml is {network_fence_original_yaml}\n."
-                        f"Edited object yaml is {network_fence_modified_yaml}"
-                    )
-                    logger.error(err_msg)
-                    raise Exception(err_msg)
-            except (
-                CommandFailed
-            ):  # some properties are not editable and CommandFailed exception is thrown
-                continue  # just continue to the next property
+        self.cr_resource_not_editable(
+            "Reclaim space cron job", "ReclaimSpaceCronJob.yaml", patches
+        )
 
     @pytest.fixture(autouse=True)
     def teardown(self, request):


### PR DESCRIPTION
This PR implements the following: 

1) Refactoring the existing code to make a function called with different parameters for different resources
2) Network fence and reclaim space cron job are made different testcases
3) Changing resources names in the yaml files to meaningful ones. 

Please note that changing an exiting cr ( oc edit ...) is done the following way: 
For each property that should be tested for editability, a temporary shell file is created and the appropriate 'oc patch' command is written into it. Then this file is run and the command is executed. I tried different approaches and this one seems to be the only one that works.