### PR TITLE
test error message improvements for name inputs. new feature

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2094,3 +2094,54 @@ TOPOLVM_ALERTS = {
 
 
 WARP_CLIENT_PORT = 7761
+
+UI_INPUT_RULES_GENERAL = {
+    "rule1": "Starts and ends with a lowercase letter or number",
+    "rule2": "Only lowercase letters, numbers, non-consecutive periods, or hyphens",
+    "rule3": "A unique name for the BackingStore within the project",
+    "rule4": "Cannot be used before",
+    "rule5": "No more than 253 characters",
+}
+
+UI_INPUT_RULES_BACKING_STORE = {
+    "rule1": "No more than 43 characters",
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": "A unique name for the BackingStore within the project",
+}
+
+UI_INPUT_RULES_BUCKET_CLASS = {
+    "rule1": "3-63 characters",
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": "Avoid using the form of an IP address",
+    "rule5": "Cannot be used before",
+}
+
+UI_INPUT_RULES_OBJECT_BUCKET_CLAIM = {
+    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+}
+
+UI_INPUT_RULES_NAMESPACE_STORE = {
+    "rule1": "No more than 43 characters",
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": "A unique name for the NamespaceStore within the project",
+}
+
+UI_INPUT_RULES_BLOCKING_POOL = {
+    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+}
+
+UI_INPUT_RULES_STORAGE_SYSTEM = {
+    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule2": UI_INPUT_RULES_GENERAL["rule1"],
+    "rule3": UI_INPUT_RULES_GENERAL["rule2"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+}

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2098,9 +2098,8 @@ WARP_CLIENT_PORT = 7761
 UI_INPUT_RULES_GENERAL = {
     "rule1": "Starts and ends with a lowercase letter or number",
     "rule2": "Only lowercase letters, numbers, non-consecutive periods, or hyphens",
-    "rule3": "A unique name for the BackingStore within the project",
-    "rule4": "Cannot be used before",
-    "rule5": "No more than 253 characters",
+    "rule3": "Cannot be used before",
+    "rule4": "No more than 253 characters",
 }
 
 UI_INPUT_RULES_BACKING_STORE = {
@@ -2119,10 +2118,10 @@ UI_INPUT_RULES_BUCKET_CLASS = {
 }
 
 UI_INPUT_RULES_OBJECT_BUCKET_CLAIM = {
-    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule1": UI_INPUT_RULES_GENERAL["rule4"],
     "rule2": UI_INPUT_RULES_GENERAL["rule1"],
     "rule3": UI_INPUT_RULES_GENERAL["rule2"],
-    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule3"],
 }
 
 UI_INPUT_RULES_NAMESPACE_STORE = {
@@ -2133,15 +2132,15 @@ UI_INPUT_RULES_NAMESPACE_STORE = {
 }
 
 UI_INPUT_RULES_BLOCKING_POOL = {
-    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule1": UI_INPUT_RULES_GENERAL["rule4"],
     "rule2": UI_INPUT_RULES_GENERAL["rule1"],
     "rule3": UI_INPUT_RULES_GENERAL["rule2"],
-    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule3"],
 }
 
 UI_INPUT_RULES_STORAGE_SYSTEM = {
-    "rule1": UI_INPUT_RULES_GENERAL["rule5"],
+    "rule1": UI_INPUT_RULES_GENERAL["rule4"],
     "rule2": UI_INPUT_RULES_GENERAL["rule1"],
     "rule3": UI_INPUT_RULES_GENERAL["rule2"],
-    "rule4": UI_INPUT_RULES_GENERAL["rule4"],
+    "rule4": UI_INPUT_RULES_GENERAL["rule3"],
 }

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -606,3 +606,7 @@ class UnknownOperationForTerraformVariableUpdate(Exception):
 
 class TerrafromFileNotFoundException(Exception):
     pass
+
+
+class IncorrectUiOptionRequested(Exception):
+    pass

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -608,5 +608,5 @@ class TerrafromFileNotFoundException(Exception):
     pass
 
 
-class IncorrectUiOptionRequested(Exception):
+class IncorrectUIOptionRequested(Exception):
     pass

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -39,7 +39,7 @@ from ocs_ci.ocs.exceptions import (
     NotSupportedProxyConfiguration,
     TimeoutExpiredError,
     CephHealthException,
-    IncorrectUiOptionRequested,
+    IncorrectUIOptionRequested,
 )
 from ocs_ci.ocs.ui.views import OCS_OPERATOR, ODF_OPERATOR
 from ocs_ci.ocs.ocp import get_ocp_url, OCP
@@ -1021,6 +1021,9 @@ class CreateResourceForm(PageNavigator):
         Method to proceed to resource creation form, when Create button is visible
         """
         self.page_has_loaded()
+        self.wait_for_element_to_be_visible(
+            self.generic_locators["create_resource_button"]
+        )
         self.do_click(self.generic_locators["create_resource_button"])
 
     def check_error_messages(self):
@@ -1558,7 +1561,7 @@ class StorageSystemTab(DataFoundationTabBar, CreateResourceForm):
         option_2 = "Create a new StorageClass using local storage devices"
         option_3 = "Connect an external storage platform"
         if backing_store_type not in [option_1, option_2, option_3]:
-            raise IncorrectUiOptionRequested(
+            raise IncorrectUIOptionRequested(
                 f"Choose one of the existed option: '{[option_1, option_2, option_3]}'"
             )
 
@@ -1572,7 +1575,7 @@ class StorageSystemTab(DataFoundationTabBar, CreateResourceForm):
         btn_2 = "Back"
         btn_3 = "Cancel"
         if btn_text not in [btn_1, btn_2, btn_3]:
-            raise IncorrectUiOptionRequested(
+            raise IncorrectUIOptionRequested(
                 f"Choose one of the existed option: '{[btn_1, btn_2, btn_3]}'"
             )
 

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -1,3 +1,7 @@
+import ipaddress
+import random
+import re
+import string
 from pathlib import Path
 import datetime
 import logging
@@ -7,6 +11,7 @@ import time
 import zipfile
 from functools import reduce
 
+import pytest
 from selenium import webdriver
 from selenium.common.exceptions import (
     TimeoutException,
@@ -14,6 +19,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     StaleElementReferenceException,
 )
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
@@ -32,9 +38,10 @@ from ocs_ci.ocs.exceptions import (
     NotSupportedProxyConfiguration,
     TimeoutExpiredError,
     CephHealthException,
+    IncorrectUiOptionRequested,
 )
 from ocs_ci.ocs.ui.views import OCS_OPERATOR, ODF_OPERATOR
-from ocs_ci.ocs.ocp import get_ocp_url
+from ocs_ci.ocs.ocp import get_ocp_url, OCP
 from ocs_ci.ocs.ui.views import locators
 from ocs_ci.utility.templating import Templating
 from ocs_ci.utility.retry import retry
@@ -233,6 +240,7 @@ class BaseUI:
             raise TimeoutException(
                 f"Failed to find the element ({locator[1]},{locator[0]})"
             )
+        return element
 
     def is_expanded(self, locator, timeout=30):
         """
@@ -337,7 +345,7 @@ class BaseUI:
         """
         return self.driver.find_elements(by=locator[1], value=locator[0])
 
-    def wait_for_element_to_be_visible(self, locator, timeout):
+    def wait_for_element_to_be_visible(self, locator, timeout=30):
         """
         Wait for element to be visible. Use when Web element is not have to be clickable (icons, disabled btns, etc.)
         Method does not fail when Web element not found
@@ -840,6 +848,9 @@ class PageNavigator(BaseUI):
         self.do_click(
             locator=self.page_nav["object_bucket_claims_page"], enable_screenshot=False
         )
+        from ocs_ci.ocs.ui.mcg_ui import ObcUI
+
+        return ObcUI()
 
     def navigate_alerting_page(self):
         """
@@ -983,6 +994,398 @@ class PageNavigator(BaseUI):
             return False
 
 
+class CreateResourceForm(PageNavigator):
+    def __init__(self):
+        self.status_error = "error status"
+        self.status_indeterminate = "indeterminate status"
+        self.status_success = "success status"
+        super().__init__()
+
+    def _report_failed(self, error_text):
+        """
+        Reports a failed test by logging an error message,
+        taking a screenshot of the page and copying the DOM.
+
+        Args:
+            error_text (str): The error message to log.
+        """
+        logger.error(error_text)
+        self.take_screenshot()
+        self.copy_dom()
+
+    def proceed_resource_creation(self):
+        """
+        Method to proceed to resource creation form, when Create button is visible
+        """
+        self.do_click(self.generic_locators["create_resource_button"])
+
+    def check_error_messages(self):
+        """
+        Performs a series of checks to verify if the error messages for the input fields
+        meet the expected requirements. It clicks on the "create resource" button and verifies
+        the existence of all expected rules in the input field. It then checks the error messages
+        for each input field based on the expected rules and raises a failure if the actual
+        error message does not match the expected message.
+        Finally, it navigates back to the previous page.
+        """
+        self._verify_input_requirements()
+        self.navigate_backward()
+        logger.info("all error improvements checks done")
+
+    def _verify_input_requirements(self):
+        """
+        Verify that all input requirements are met.
+        """
+        rules_texts_ok = self._check_all_rules_exist(
+            self.generic_locators["text_input_popup_rules"]
+        )
+
+        rule_check_statuses = {rule: func(rule) for rule, func in self.rules.items()}
+
+        if not all(rule_check_statuses.values()):
+            pytest.fail(
+                "Error message improvements check failed, trace issue from the log and artifacts"
+            )
+        if not rules_texts_ok:
+            pytest.fail(
+                "Error message improvements check failed. Not all expected rules exist"
+            )
+
+    def _check_all_rules_exist(self, input_loc: tuple):
+        """
+        Clicks on the input validator icon, retrieves the rules from the input location,
+        and checks whether they match the list of expected rules. Returns True if they match,
+        False otherwise.
+
+        Args:
+            input_loc (tuple): The locator of the input field containing the rules.
+
+        Returns:
+            bool: True if the list of rules in the input field matches the expected list,
+            False otherwise.
+        """
+        self.do_click(self.validation_loc["input_value_validator_icon"])
+        rules_elements = self.get_elements(input_loc)
+        rules_texts_statuses = [rule.text for rule in rules_elements]
+        rules_texts = [rule.split("\n: ")[0] for rule in rules_texts_statuses]
+        if sorted(rules_texts) != sorted(self.rules.keys()):
+            self._report_failed(
+                f"Rules are not identical to the list of expected rules\n"
+                f"Expected: {self.rules.keys()}\n"
+                f"Actual: {rules_texts}"
+            )
+            return False
+        return True
+
+    def _check_rule_case(self, rule: str, input_text: str, status_exp: str) -> bool:
+        """
+        Check if a rule case passes for a given input text and expected status.
+
+        Args:
+            rule (str): The expected rule to be checked.
+            input_text (str): The input text to be tested.
+            status_exp (str): The expected status for the rule.
+
+        Returns:
+            bool: True if the check passed, False otherwise.
+        """
+        logger.info(f"check rule case with input '{input_text}'")
+        self._send_input_and_update_popup(input_text)
+        check_pass = self._check_input_rule_and_status(rule, status_exp)
+        self._remove_text_from_input()
+
+        return check_pass
+
+    def _remove_text_from_input(self) -> bool:
+        """
+        Remove all text from a specified input element.
+
+        Returns:
+            bool: True if the input element is successfully cleared, False otherwise.
+        """
+        self.wait_for_element_to_be_visible(self.name_input_loc, 30)
+        elements = self.get_elements(self.name_input_loc)
+        input_el = elements[0]
+        input_len = len(str(input_el.get_attribute("value")))
+
+        # timeout in seconds will be equal no a number of symbols to be removed, but not less than 30s
+        timeout = input_len if input_len > 30 else 30
+        timeout = time.time() + timeout
+        if len(elements):
+            while len(str(input_el.get_attribute("value"))) != 0:
+                if time.time() < timeout:
+                    # to remove text from the input independently where the caret is use both delete and backspace
+                    input_el.send_keys(Keys.BACKSPACE, Keys.DELETE)
+                    time.sleep(0.05)
+                else:
+                    logger.error("time to clear input os out")
+                    return False
+        else:
+            logger.error("test input locator not found")
+            return False
+        return True
+
+    def _check_input_text_length(
+        self, rule_exp: str, text_length: int, status_expected: str
+    ) -> bool:
+        """
+        A method that checks the length of the input text based on a rule and expected status.
+
+        Args:
+            rule_exp (str): the expected rule to be applied to the input text.
+            text_length (int): the number of characters of the input text to be generated and tested.
+            status_expected (str): the expected status after applying the rule on the input text.
+        Returns:
+            check_pass (bool): a boolean value indicating whether the input text satisfies the expected rule and status.
+        """
+        random_text_input = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=text_length)
+        )
+        self._send_input_and_update_popup(random_text_input)
+        logger.info(
+            f"rule '{rule_exp}'. "
+            f"number of characters '{text_length}'. "
+            f"status verify '{status_expected}'. "
+            f"input '{random_text_input}. "
+            f"check starts...'"
+        )
+        check_pass = self._check_input_rule_and_status(rule_exp, status_expected)
+
+        self._remove_text_from_input()
+        return check_pass
+
+    def _send_input_and_update_popup(self, text_input: str):
+        """
+        Sends an input to the name input field, updates the validation popup, and reloads it.
+
+        Args:
+            text_input (str): The text input to send to the name input field.
+        """
+        try:
+            self.do_send_keys(self.name_input_loc, text_input)
+        except TimeoutException:
+            logger.warning(
+                "failed to send text to input. repeat send keys and update validation popup"
+            )
+            self._remove_text_from_input()
+            self.do_send_keys(self.name_input_loc, text_input)
+        # reload popup to process all input, but not a part
+        self.do_click(self.validation_loc["input_value_validator_icon"])
+        self.do_click(self.validation_loc["input_value_validator_icon"])
+
+    def _check_input_rule_and_status(self, rule_exp, status_expected) -> bool:
+        """
+        Check the input rule and status against the expected values.
+
+        Args:
+            rule_exp (str): The expected input rule.
+            status_expected (str): The expected status of the input rule.
+
+        Returns:
+            bool: True if the check passes, False otherwise.
+        """
+        check_pass = True
+
+        def get_rule_actual():
+            time_sleep = 2
+            logger.debug(f"sleep {time_sleep} get browser render new popup")
+            time.sleep(time_sleep)
+            for _ in range(3):
+                _rules_elements = self.get_elements(
+                    self.generic_locators["text_input_popup_rules"]
+                )
+                logger.debug(f"sleep {time_sleep} get browser render new popup")
+                time.sleep(time_sleep)
+                if len(_rules_elements) > 0:
+                    break
+            else:
+                logger.error("no rules found after 3 attempts")
+            return [rule.text for rule in _rules_elements if rule_exp in rule.text]
+
+        rule_actual = get_rule_actual()
+
+        if len(rule_actual) > 1:
+            self._report_failed(f"rule duplicated -> {rule_actual}'")
+            check_pass = False
+        elif len(rule_actual) < 1:
+            self.page_has_loaded(retries=5, sleep_time=5)
+            # reload popup to process all input one more time. May not appear if input is large - automation issue
+            self.do_click(self.validation_loc["input_value_validator_icon"])
+            if not len(get_rule_actual()):
+                self.do_click(self.validation_loc["input_value_validator_icon"])
+            rule_actual = get_rule_actual()
+            if len(rule_actual) < 1:
+                self._report_failed(f"rule not found -> {rule_actual}'")
+                check_pass = False
+        status_actual = rule_actual[0].split("\n: ")[1].replace(";", "")
+        if status_expected not in status_actual:
+            self._report_failed(
+                f"status expected '{status_expected}'. status actual '{status_actual}'. check failed"
+            )
+            check_pass = False
+        else:
+            logger.info(
+                f"status expected '{status_expected}'. status actual '{status_actual}'. check passed"
+            )
+        return check_pass
+
+    def _check_start_end_char_rule(self, rule_exp) -> bool:
+        """
+        Check that the input field follows the rule that only alphanumeric lowercase characters are allowed and
+        the first and last characters of the input field are also alphanumeric lowercase characters.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if all the checks pass, False otherwise.
+        """
+        alphanumeric_lowercase = string.ascii_lowercase + string.digits
+        params_list = [
+            (
+                rule_exp,
+                random.choice(string.ascii_uppercase),
+                random.choice(string.ascii_uppercase),
+                self.status_error,
+            ),
+            (
+                rule_exp,
+                random.choice(string.ascii_uppercase),
+                random.choice(alphanumeric_lowercase),
+                self.status_error,
+            ),
+            (
+                rule_exp,
+                random.choice(alphanumeric_lowercase),
+                random.choice(string.ascii_uppercase),
+                self.status_error,
+            ),
+            (
+                rule_exp,
+                random.choice(string.punctuation),
+                random.choice(alphanumeric_lowercase),
+                self.status_error,
+            ),
+            (
+                rule_exp,
+                random.choice(alphanumeric_lowercase),
+                random.choice(string.punctuation),
+                self.status_error,
+            ),
+            (
+                rule_exp,
+                random.choice(alphanumeric_lowercase),
+                random.choice(alphanumeric_lowercase),
+                self.status_success,
+            ),
+        ]
+
+        return all(self._check_start_end_char_case(*params) for params in params_list)
+
+    def _check_start_end_char_case(
+        self, rule: str, start_letter: str, end_letter: str, status_exp: str
+    ) -> bool:
+        """Checks that an input string with a specific start and end character meets a given input rule.
+
+        Args:
+            rule (str): The input rule to check.
+            start_letter (str): The start character for the input string.
+            end_letter (str): The end character for the input string.
+            status_exp (str): The expected status of the input string, either 'success' or 'error'.
+
+        Returns:
+            bool: True if the input string meets the input rule and has the expected status, False otherwise.
+        """
+        random_name = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=8)
+        )
+        text_input = start_letter + random_name + end_letter
+        self._send_input_and_update_popup(text_input)
+        check_pass = self._check_input_rule_and_status(rule, status_exp)
+        self._remove_text_from_input()
+        if not check_pass:
+            logger.error(f"check failed with input '{text_input}'")
+        else:
+            logger.info(f"check passed with input '{text_input}'")
+        return check_pass
+
+    def _check_only_lower_case_numbers_periods_hyphens_rule(self, rule_exp) -> bool:
+        """
+        Check if only the input text containing lowercase letters, digits, periods,
+        and hyphens allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: indicating whether all test cases passed.
+        """
+        allowed_chars = string.ascii_lowercase + string.digits + "-"
+
+        random_name = "".join(random.choices(allowed_chars, k=10))
+        random_name = "a" + random_name + "z"
+        name_with_consecutive_period = random_name[:4] + ".." + random_name[6:]
+
+        uppercase_letters = "".join(random.choices(string.ascii_uppercase, k=2))
+        name_with_uppercase_letters = (
+            random_name[:4] + uppercase_letters + random_name[6:]
+        )
+
+        name_with_no_ascii = random_name[:4] + "æå" + random_name[6:]
+
+        param_list = [
+            (rule_exp, name_with_consecutive_period, self.status_error),
+            (rule_exp, name_with_uppercase_letters, self.status_error),
+            (rule_exp, name_with_no_ascii, self.status_error),
+            (rule_exp, random_name, self.status_success),
+        ]
+
+        return all(self._check_rule_case(*params) for params in param_list)
+
+    def _check_max_length_backing_store_rule(self, rule_exp):
+        """
+        Check if the length of the backing store name is less than or equal to the maximum allowed length.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if the rule was not violated, False otherwise.
+        """
+
+        logger.info(f"checking the input rule '{rule_exp}'")
+        max_length_exp = int(re.search(r"\d+(\.\d+)?", rule_exp).group())
+        params_list = [
+            (rule_exp, max_length_exp - 1, self.status_success),
+            (rule_exp, max_length_exp, self.status_success),
+            (rule_exp, max_length_exp + 1, self.status_error),
+        ]
+
+        return all(self._check_input_text_length(*params) for params in params_list)
+
+    def _check_resource_name_not_exists_rule(
+        self, existing_resource_names: str, rule_exp: str
+    ) -> bool:
+        """
+        Checks that an existing resource name cannot be used.
+
+        Args:
+            existing_resource_names (str): A string containing a list of existing resource names.
+            rule_exp (str): A string representing a rule to be checked.
+
+        Returns:
+            bool: True if not allowed to use duplicated resource name, False otherwise.
+        """
+        name_exist = existing_resource_names.split()[0]
+        random_char = random.choice(string.ascii_lowercase + string.digits)
+        name_does_not_exist = random_char + name_exist[1:]
+        params_list = [
+            (rule_exp, name_exist, self.status_error),
+            (rule_exp, name_does_not_exist, self.status_success),
+        ]
+        return all(self._check_rule_case(*params) for params in params_list)
+
+
 class DataFoundationTabBar(PageNavigator):
     def __init__(self):
         super().__init__()
@@ -1027,7 +1430,7 @@ class DataFoundationTabBar(PageNavigator):
         """
         logger.info("Navigate to Data Foundation - Namespace Store tab")
         self.do_click(locator=self.validation_loc["namespacestore_page"])
-        return NameStoreTab()
+        return NameSpaceStoreTab()
 
     # noinspection PyUnreachableCode
     def nav_topology_tab(self):
@@ -1041,7 +1444,6 @@ class DataFoundationTabBar(PageNavigator):
 
 
 class DataFoundationDefaultTab(DataFoundationTabBar):
-
     """
     Default Foundation default Tab: TopologyTab | OverviewTab
     """
@@ -1062,7 +1464,7 @@ class TopologyTab(DataFoundationDefaultTab):
 
 class OverviewTab(DataFoundationDefaultTab):
     """
-    Overiview tab Class
+    Overview tab Class
     Content of Data Foundation/Overview tab (default for ODF bellow 4.12)
     """
 
@@ -1085,7 +1487,7 @@ class OverviewTab(DataFoundationDefaultTab):
         )
 
 
-class StorageSystemTab(DataFoundationTabBar):
+class StorageSystemTab(DataFoundationTabBar, CreateResourceForm):
     """
     Storage System tab Class
     Content of Data Foundation/Storage Systems tab
@@ -1094,6 +1496,80 @@ class StorageSystemTab(DataFoundationTabBar):
 
     def __init__(self):
         DataFoundationTabBar.__init__(self)
+        CreateResourceForm.__init__(self)
+        self.rules = {
+            constants.UI_INPUT_RULES_STORAGE_SYSTEM[
+                "rule1"
+            ]: self._check_max_length_backing_store_rule,
+            constants.UI_INPUT_RULES_STORAGE_SYSTEM[
+                "rule2"
+            ]: self._check_start_end_char_rule,
+            constants.UI_INPUT_RULES_STORAGE_SYSTEM[
+                "rule3"
+            ]: self._check_only_lower_case_numbers_periods_hyphens_rule,
+            constants.UI_INPUT_RULES_STORAGE_SYSTEM[
+                "rule4"
+            ]: self._check_storage_system_not_used_before_rule,
+        }
+        self.name_input_loc = self.sc_loc["sc-name"]
+
+    def fill_backing_storage_form(self, backing_store_type: str, btn_text: str):
+        """
+        Storage system creation form consists from several forms, showed one after another when mandatory fields filled
+        and Next btn clicked.
+        Function to fill first form in order to create new Backing store.
+
+
+        Args:
+            backing_store_type (str): options available when filling backing store form (1-st form)
+            btn_text (str): text of the button to be clicked after the form been filled ('Next', 'Back', 'Cancel')
+        """
+        option_1 = "Use an existing StorageClass"
+        option_2 = "Create a new StorageClass using local storage devices"
+        option_3 = "Connect an external storage platform"
+        if backing_store_type not in [option_1, option_2, option_3]:
+            raise IncorrectUiOptionRequested(
+                f"Choose one of the existed option: '{[option_1, option_2, option_3]}'"
+            )
+
+        from ocs_ci.ocs.ui.helpers_ui import format_locator
+
+        self.do_click(
+            format_locator(self.sc_loc["backing_store_type"], backing_store_type)
+        )
+
+        btn_1 = "Next"
+        btn_2 = "Back"
+        btn_3 = "Cancel"
+        if btn_text not in [btn_1, btn_2, btn_3]:
+            raise IncorrectUiOptionRequested(
+                f"Choose one of the existed option: '{[btn_1, btn_2, btn_3]}'"
+            )
+
+        self.do_click(format_locator(self.sc_loc["button_with_txt"], btn_text))
+
+    def _check_storage_system_not_used_before_rule(self, rule_exp) -> bool:
+        """
+        Checks whether the storage system name allowed to use again.
+
+        This function executes an OpenShift command to retrieve the names of all existing storage systems
+        in all namespaces.
+        It then checks whether the name of the existed storage system would be allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if not allowed to use duplicated storage system name, False otherwise.
+        """
+        existing_storage_systems_names = str(
+            OCP().exec_oc_cmd(
+                "get storageclass --all-namespaces -o custom-columns=':metadata.name'"
+            )
+        )
+        return self._check_resource_name_not_exists_rule(
+            existing_storage_systems_names, rule_exp
+        )
 
     def nav_storagecluster_storagesystem_details(self):
         """
@@ -1195,18 +1671,7 @@ class StorageSystemDetails(StorageSystemTab):
         else:
             self.do_click(self.validation_loc["blockpools"], enable_screenshot=True)
         self.page_has_loaded(retries=15, sleep_time=2)
-
-    def verify_cephblockpool_status(self, status_exp: str = "Ready"):
-
-        logger.info(f"Verifying the status of '{constants.DEFAULT_CEPHBLOCKPOOL}'")
-        cephblockpool_status = self.get_element_text(
-            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}-status"]
-        )
-        if not status_exp == cephblockpool_status:
-            raise CephHealthException(
-                f"cephblockpool status error | expected status:Ready \n "
-                f"actual status:{cephblockpool_status}"
-            )
+        return BlockPools()
 
     def get_blockpools_compression_status_from_storagesystem(self) -> tuple:
         """
@@ -1242,19 +1707,244 @@ class StorageSystemDetails(StorageSystemTab):
         return StorageSystemTab()
 
 
-class BackingStoreTab(DataFoundationDefaultTab):
+class BlockPools(StorageSystemDetails, CreateResourceForm):
+    def __init__(self):
+        StorageSystemTab.__init__(self)
+        CreateResourceForm.__init__(self)
+        self.name_input_loc = self.validation_loc["blockpool_name"]
+        self.rules = {
+            constants.UI_INPUT_RULES_BLOCKING_POOL[
+                "rule1"
+            ]: self._check_max_length_backing_store_rule,
+            constants.UI_INPUT_RULES_BLOCKING_POOL[
+                "rule2"
+            ]: self._check_start_end_char_rule,
+            constants.UI_INPUT_RULES_BLOCKING_POOL[
+                "rule3"
+            ]: self._check_only_lower_case_numbers_periods_hyphens_rule,
+            constants.UI_INPUT_RULES_BLOCKING_POOL[
+                "rule4"
+            ]: self._check_blockpool_not_used_before_rule,
+        }
+
+    def _check_blockpool_not_used_before_rule(self, rule_exp) -> bool:
+        """
+        Checks whether the blockpool name allowed to use again.
+
+        This function executes an OpenShift command to retrieve the names of all existing blockpools in all namespaces.
+        It then checks whether the name of the existed namespace store would be allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if not allowed to use duplicated blockpool name, False otherwise.
+        """
+
+        existing_blockpool_names = str(
+            OCP().exec_oc_cmd(
+                "get CephBlockPool --all-namespaces -o custom-columns=':metadata.name'"
+            )
+        )
+        return self._check_resource_name_not_exists_rule(
+            existing_blockpool_names, rule_exp
+        )
+
+    def verify_cephblockpool_status(self, status_exp: str = "Ready"):
+
+        logger.info(f"Verifying the status of '{constants.DEFAULT_CEPHBLOCKPOOL}'")
+        cephblockpool_status = self.get_element_text(
+            self.validation_loc[f"{constants.DEFAULT_CEPHBLOCKPOOL}-status"]
+        )
+        if not status_exp == cephblockpool_status:
+            raise CephHealthException(
+                f"cephblockpool status error | expected status:Ready \n "
+                f"actual status:{cephblockpool_status}"
+            )
+
+
+class BackingStoreTab(DataFoundationDefaultTab, CreateResourceForm):
+    def __init__(self):
+        DataFoundationDefaultTab.__init__(self)
+        CreateResourceForm.__init__(self)
+        self.rules = {
+            constants.UI_INPUT_RULES_BACKING_STORE[
+                "rule1"
+            ]: self._check_max_length_backing_store_rule,
+            constants.UI_INPUT_RULES_BACKING_STORE[
+                "rule2"
+            ]: self._check_start_end_char_rule,
+            constants.UI_INPUT_RULES_BACKING_STORE[
+                "rule3"
+            ]: self._check_only_lower_case_numbers_periods_hyphens_rule,
+            constants.UI_INPUT_RULES_BACKING_STORE[
+                "rule4"
+            ]: self._check_backingstore_name_not_used_before_per_namespace_rule,
+        }
+        self.name_input_loc = self.validation_loc["backingstore_name"]
+
+    def _check_backingstore_name_not_used_before_per_namespace_rule(self, rule_exp):
+        """
+        Checks if a backing store name per namespace is not allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            A boolean value indicating whether the check passed or not.
+        """
+        existing_backingstore_names = str(
+            OCP().exec_oc_cmd(
+                f"get backingstore -n {config.ENV_DATA['cluster_namespace']} -o custom-columns=':metadata.name'"
+            )
+        )
+        return self._check_resource_name_not_exists_rule(
+            existing_backingstore_names, rule_exp
+        )
+
+
+class BucketClassTab(DataFoundationDefaultTab, CreateResourceForm):
     def __init__(self):
         DataFoundationTabBar.__init__(self)
+        CreateResourceForm.__init__(self)
+        self.rules = {
+            constants.UI_INPUT_RULES_BUCKET_CLASS["rule1"]: self._check_3_63_char_rule,
+            constants.UI_INPUT_RULES_BUCKET_CLASS[
+                "rule2"
+            ]: self._check_start_end_char_rule,
+            constants.UI_INPUT_RULES_BUCKET_CLASS[
+                "rule3"
+            ]: self._check_only_lower_case_numbers_periods_hyphens_rule,
+            constants.UI_INPUT_RULES_BUCKET_CLASS[
+                "rule4"
+            ]: self._check_no_ip_address_rule,
+            constants.UI_INPUT_RULES_BUCKET_CLASS[
+                "rule5"
+            ]: self._check_bucketclass_name_not_used_before_rule,
+        }
+        self.name_input_loc = self.bucketclass["bucketclass_name"]
+
+    def _check_3_63_char_rule(self, rule_exp) -> bool:
+        """
+        Check if the input text length between 3 and 63 characters only can be used.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if the input text length not violated, False otherwise.
+        """
+        logger.info(f"checking the input rule '{rule_exp}'")
+        numbers = re.findall(r"\d+", rule_exp)
+        min_len, max_len = map(int, numbers)
+        params_list = [
+            (rule_exp, min_len - 1, self.status_error),
+            (rule_exp, min_len, self.status_success),
+            (rule_exp, min_len + 1, self.status_success),
+            (rule_exp, max_len - 1, self.status_success),
+            (rule_exp, max_len, self.status_success),
+            (rule_exp, max_len + 1, self.status_error),
+        ]
+
+        return all(self._check_input_text_length(*params) for params in params_list)
+
+    def _check_no_ip_address_rule(self, rule_exp) -> bool:
+        """
+        Check if the input does not contain a valid IPv4 address.
+
+        This function generates a random IPv4 address and a random string that is not an IP address.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if the rule is satisfied for the random string that is not an IP address, False otherwise.
+        """
+
+        def _generate_ipv4_address_str():
+            octets = [random.randint(0, 255) for _ in range(4)]
+            ipv4_address_str = ".".join(map(str, octets))
+            ipv4_address = ipaddress.IPv4Address(ipv4_address_str)
+            return str(ipv4_address)
+
+        random_ip = str(_generate_ipv4_address_str())
+        not_ip = "".join(
+            random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+        )
+
+        params_list = [
+            (rule_exp, random_ip, self.status_error),
+            (rule_exp, not_ip, self.status_success),
+        ]
+
+        return all(self._check_rule_case(*params) for params in params_list)
+
+    def _check_bucketclass_name_not_used_before_rule(self, rule_exp) -> bool:
+        """
+        Checks whether the existed bucket class name allowed to use again.
+
+        This function executes an OpenShift command to retrieve the names of all existing bucket classes
+        in all namespaces.
+        It then checks whether the name of the existed bucket class would be allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if the bucket class name has not been used before, False otherwise.
+        """
+        existing_backingstore_names = str(
+            OCP().exec_oc_cmd(
+                "get bucketclass --all-namespaces -o custom-columns=':metadata.name'"
+            )
+        )
+        return self._check_resource_name_not_exists_rule(
+            existing_backingstore_names, rule_exp
+        )
 
 
-class BucketClassTab(DataFoundationDefaultTab):
+class NameSpaceStoreTab(DataFoundationDefaultTab, CreateResourceForm):
     def __init__(self):
         DataFoundationTabBar.__init__(self)
+        CreateResourceForm.__init__(self)
+        self.rules = {
+            constants.UI_INPUT_RULES_NAMESPACE_STORE[
+                "rule1"
+            ]: self._check_max_length_backing_store_rule,
+            constants.UI_INPUT_RULES_NAMESPACE_STORE[
+                "rule2"
+            ]: self._check_start_end_char_rule,
+            constants.UI_INPUT_RULES_NAMESPACE_STORE[
+                "rule3"
+            ]: self._check_only_lower_case_numbers_periods_hyphens_rule,
+            constants.UI_INPUT_RULES_NAMESPACE_STORE[
+                "rule4"
+            ]: self._check_namespace_store_not_used_before_rule,
+        }
+        self.name_input_loc = self.validation_loc["namespacestore_name"]
 
+    def _check_namespace_store_not_used_before_rule(self, rule_exp) -> bool:
+        """
+        Checks whether the namespace store name allowed to use again.
 
-class NameStoreTab(DataFoundationDefaultTab):
-    def __init__(self):
-        DataFoundationTabBar.__init__(self)
+        This function executes an OpenShift command to retrieve the names of all existing namespace stores
+        in all namespaces.
+        It then checks whether the name of the existed namespace store would be allowed to use.
+
+        Args:
+            rule_exp (str): the rule requested to be checked. rule_exp text should match the text from validation popup
+
+        Returns:
+            bool: True if the namespace name has not been used before, False otherwise.
+        """
+        existing_namespace_store_names = str(
+            OCP().exec_oc_cmd(
+                "get namespacestore --all-namespaces -o custom-columns=':metadata.name'"
+            )
+        )
+        return self._check_resource_name_not_exists_rule(
+            existing_namespace_store_names, rule_exp
+        )
 
 
 def screenshot_dom_location(type_loc="screenshot"):

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -228,6 +228,7 @@ generic_locators = {
     "check_first_row_checkbox": ('input[name="checkrow0"]', By.CSS_SELECTOR),
     "remove_search_filter": ('button[aria-label="close"]', By.CSS_SELECTOR),
     "delete_resource_kebab_button": ('//*[contains(text(), "Delete")]', By.XPATH),
+    "text_input_popup_rules": ("//*[@class='pf-c-helper-text__item-text']", By.XPATH),
 }
 
 ocs_operator_locators = {
@@ -954,6 +955,11 @@ storageclass = {
         By.CSS_SELECTOR,
     ),
     "approve-storage-class-deletion": ("#confirm-action", By.CSS_SELECTOR),
+    "backing_store_type": (
+        "//*[text()='{}']/preceding-sibling::input[@name='backing-storage-radio-group']",
+        By.XPATH,
+    ),
+    "button_with_txt": ("//button[text()=('{}')]", By.XPATH),
 }
 
 storageclass_4_9 = {
@@ -1008,6 +1014,14 @@ validation = {
     ),
     "capacity_breakdown_projects": ("//button[text()='Projects']", By.XPATH),
     "capacity_breakdown_pods": ("//button[text()='Pods']", By.XPATH),
+    "backingstore_name": ("input[placeholder='my-backingstore']", By.CSS_SELECTOR),
+    "namespacestore_name": ("input[placeholder='my-namespacestore']", By.CSS_SELECTOR),
+    "blockpool_name": ("input[placeholder='my-block-pool']", By.CSS_SELECTOR),
+    "input_value_validator_icon": (".pf-c-icon", By.CSS_SELECTOR),
+    "text_input_field_error_improvements": (
+        "input[data-ouia-component-id='OUIA-Generated-TextInputBase-1']",
+        By.CSS_SELECTOR,
+    ),
 }
 
 validation_4_7 = {
@@ -1260,6 +1274,7 @@ locators = {
         },
         "block_pool": {**block_pool, **block_pool_4_12, **block_pool_4_13},
         "storageclass": {**storageclass, **storageclass_4_9},
+        "bucketclass": bucketclass,
     },
     "4.12": {
         "login": {**login, **login_4_11},

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -1,0 +1,131 @@
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import (
+    ui,
+    skipif_ibm_cloud_managed,
+    skipif_managed_service,
+    black_squad,
+    polarion_id,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.ui.base_ui import PageNavigator
+
+logger = logging.getLogger(__name__)
+
+
+@ui
+@black_squad
+@skipif_ibm_cloud_managed
+@skipif_managed_service
+class TestErrorMessageImprovements(ManageTest):
+    @polarion_id("OCS-4865")
+    def test_backing_store_create_rules(self, setup_ui_class):
+        """
+        Test to verify error rules for the name when creating a new backing store
+            No more than 43 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            A unique name for the BackingStore within the project
+        """
+        backing_store_tab = (
+            PageNavigator().nav_odf_default_page().nav_backing_store_tab()
+        )
+        backing_store_tab.proceed_resource_creation()
+        backing_store_tab.check_error_messages()
+
+    @polarion_id("OCS-4867")
+    def test_obc_create_rules(self, setup_ui_class):
+        """
+        Test to verify error rules for the name when creating a new object bucket claim
+            No more than 253 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            Cannot be used before
+        """
+        object_bucket_claim_create_tab = (
+            PageNavigator().nav_odf_default_page().navigate_object_bucket_claims_page()
+        )
+        object_bucket_claim_create_tab.proceed_resource_creation()
+        object_bucket_claim_create_tab.check_error_messages()
+
+    @polarion_id("OCS-4869")
+    def test_bucket_class_create_rules(self, setup_ui_class):
+        """
+        Test to verify error rules for the name when creating a new bucket class
+            3-63 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            Avoid using the form of an IP address
+            Cannot be used before
+        """
+        bucket_class_create_tab = (
+            PageNavigator().nav_odf_default_page().nav_bucket_class_tab()
+        )
+        bucket_class_create_tab.proceed_resource_creation()
+        bucket_class_create_tab.check_error_messages()
+
+    @polarion_id("OCS-4871")
+    def test_namespace_store_create_rules(
+        self, cld_mgr, namespace_store_factory, setup_ui_class
+    ):
+        """
+        Test to verify error rules for the name when creating a new namespace store
+            No more than 43 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            A unique name for the NamespaceStore within the project
+
+        * check_error_messages function requires 1 existing namespacestore as pre-condition for checking rule
+        'A unique name for the NamespaceStore within the project'
+        """
+        existing_namespace_store_names = OCP().exec_oc_cmd(
+            "get namespacestore --all-namespaces -o custom-columns=':metadata.name'"
+        )
+        if not existing_namespace_store_names:
+            logger.info("Create namespace resource")
+            nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
+            namespace_store_factory(*nss_tup)
+
+        namespace_store_tab = (
+            PageNavigator().nav_odf_default_page().nav_namespace_store_tab()
+        )
+        namespace_store_tab.proceed_resource_creation()
+        namespace_store_tab.check_error_messages()
+
+    @polarion_id("OCS-4873")
+    def test_blocking_pool_create_rules(self, setup_ui_class):
+        """
+        Test to verify error rules for the name when creating a new blocking pool
+            No more than 253 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            Cannot be used before
+        """
+        blocking_pool_tab = (
+            PageNavigator()
+            .nav_odf_default_page()
+            .nav_storage_systems_tab()
+            .nav_storagecluster_storagesystem_details()
+            .nav_ceph_blockpool()
+        )
+        blocking_pool_tab.proceed_resource_creation()
+        blocking_pool_tab.check_error_messages()
+
+    @polarion_id("OCS-4875")
+    def test_storage_class_create_rules(self, setup_ui_class):
+        """
+        Test to verify error rules for the name when creating a new storage class
+            No more than 253 characters
+            Starts and ends with a lowercase letter or number
+            Only lowercase letters, numbers, non-consecutive periods, or hyphens
+            Cannot be used before
+        """
+        storage_systems_tab = (
+            PageNavigator().nav_odf_default_page().nav_storage_systems_tab()
+        )
+        storage_systems_tab.proceed_resource_creation()
+        storage_systems_tab.fill_backing_storage_form(
+            "Use an existing StorageClass", "Next"
+        )
+        storage_systems_tab.check_error_messages()

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -1,11 +1,12 @@
 import logging
 
 from ocs_ci.framework.pytest_customization.marks import (
-    ui,
     skipif_ibm_cloud_managed,
     skipif_managed_service,
     black_squad,
     polarion_id,
+    tier3,
+    bugzilla,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.ocp import OCP
@@ -14,11 +15,12 @@ from ocs_ci.ocs.ui.base_ui import PageNavigator
 logger = logging.getLogger(__name__)
 
 
-@ui
+@tier3
 @black_squad
 @skipif_ibm_cloud_managed
 @skipif_managed_service
 class TestErrorMessageImprovements(ManageTest):
+    @bugzilla("2193109")
     @polarion_id("OCS-4865")
     def test_backing_store_create_rules(self, setup_ui_class):
         """
@@ -34,6 +36,7 @@ class TestErrorMessageImprovements(ManageTest):
         backing_store_tab.proceed_resource_creation()
         backing_store_tab.check_error_messages()
 
+    @bugzilla("2193109")
     @polarion_id("OCS-4867")
     def test_obc_create_rules(self, setup_ui_class):
         """
@@ -49,6 +52,7 @@ class TestErrorMessageImprovements(ManageTest):
         object_bucket_claim_create_tab.proceed_resource_creation()
         object_bucket_claim_create_tab.check_error_messages()
 
+    @bugzilla("2193109")
     @polarion_id("OCS-4869")
     def test_bucket_class_create_rules(self, setup_ui_class):
         """
@@ -65,6 +69,7 @@ class TestErrorMessageImprovements(ManageTest):
         bucket_class_create_tab.proceed_resource_creation()
         bucket_class_create_tab.check_error_messages()
 
+    @bugzilla("2193109")
     @polarion_id("OCS-4871")
     def test_namespace_store_create_rules(
         self, cld_mgr, namespace_store_factory, setup_ui_class
@@ -93,6 +98,7 @@ class TestErrorMessageImprovements(ManageTest):
         namespace_store_tab.proceed_resource_creation()
         namespace_store_tab.check_error_messages()
 
+    @bugzilla("2193109")
     @polarion_id("OCS-4873")
     def test_blocking_pool_create_rules(self, setup_ui_class):
         """
@@ -112,6 +118,7 @@ class TestErrorMessageImprovements(ManageTest):
         blocking_pool_tab.proceed_resource_creation()
         blocking_pool_tab.check_error_messages()
 
+    @bugzilla("2193109")
     @polarion_id("OCS-4875")
     def test_storage_class_create_rules(self, setup_ui_class):
         """

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class TestErrorMessageImprovements(ManageTest):
     @bugzilla("2193109")
     @polarion_id("OCS-4865")
-    def test_backing_store_create_rules(self, setup_ui_class):
+    def test_backing_store_creation_rules(self, setup_ui_class):
         """
         Test to verify error rules for the name when creating a new backing store
             No more than 43 characters
@@ -38,7 +38,7 @@ class TestErrorMessageImprovements(ManageTest):
 
     @bugzilla("2193109")
     @polarion_id("OCS-4867")
-    def test_obc_create_rules(self, setup_ui_class):
+    def test_obc_creation_rules(self, setup_ui_class):
         """
         Test to verify error rules for the name when creating a new object bucket claim
             No more than 253 characters
@@ -54,7 +54,7 @@ class TestErrorMessageImprovements(ManageTest):
 
     @bugzilla("2193109")
     @polarion_id("OCS-4869")
-    def test_bucket_class_create_rules(self, setup_ui_class):
+    def test_bucket_class_creation_rules(self, setup_ui_class):
         """
         Test to verify error rules for the name when creating a new bucket class
             3-63 characters
@@ -71,7 +71,7 @@ class TestErrorMessageImprovements(ManageTest):
 
     @bugzilla("2193109")
     @polarion_id("OCS-4871")
-    def test_namespace_store_create_rules(
+    def test_namespace_store_creation_rules(
         self, cld_mgr, namespace_store_factory, setup_ui_class
     ):
         """
@@ -100,7 +100,7 @@ class TestErrorMessageImprovements(ManageTest):
 
     @bugzilla("2193109")
     @polarion_id("OCS-4873")
-    def test_blocking_pool_create_rules(self, setup_ui_class):
+    def test_blocking_pool_creation_rules(self, setup_ui_class):
         """
         Test to verify error rules for the name when creating a new blocking pool
             No more than 253 characters
@@ -120,7 +120,7 @@ class TestErrorMessageImprovements(ManageTest):
 
     @bugzilla("2193109")
     @polarion_id("OCS-4875")
-    def test_storage_class_create_rules(self, setup_ui_class):
+    def test_storage_class_creation_rules(self, setup_ui_class):
         """
         Test to verify error rules for the name when creating a new storage class
             No more than 253 characters


### PR DESCRIPTION
Tests cover error message improvements feature https://issues.redhat.com/browse/RHSTOR-4117  for Bucket class name, NamespaceStore name, System storage class name, Object bucket claim name, Blocking pool name, Backing store name.

Tests are UI only.

Known bug fails the test run - https://bugzilla.redhat.com/show_bug.cgi?id=2193109

Multiple tests performed to evaluate performance with given boundary values for the input rules:


OBC

'No more than 253 characters											
'Starts and ends with a lowercase letter or number					
'Only lowercase letters, numbers, non-consecutive periods, or hyphens	
'Cannot be used before												


Backing store

No more than 43 characters											
Starts and ends with a lowercase letter or number					
Only lowercase letters, numbers, non-consecutive periods, or hyphens	
A unique name for the BackingStore within the project				


Bucket class

3-63 characters														
Starts and ends with a lowercase letter or number					
Only lowercase letters, numbers, non-consecutive periods, or hyphens	
Avoid using the form of an IP address								
Cannot be used before												


Namespace store

No more than 43 characters											
Starts and ends with a lowercase letter or number					
Only lowercase letters, numbers, non-consecutive periods, or hyphens	
A unique name for the NamespaceStore within the project				


Blocking pool

No more than 253 characters											
Starts and ends with a lowercase letter or number					
Only lowercase letters, numbers, non-consecutive periods, or hyphens	
Cannot be used before												


StorageSystem name 

No more than 253 characters											
Starts and ends with a lowercase letter or number					
Only lowercase letters, numbers, non-consecutive periods, or hyphens	
Cannot be used before												
