### PR TITLE
cherry-pick for obc_create test, page_has_loaded improve, locators 4.13 for depl 4.12

### DIFF
--- a/ocs_ci/ocs/ui/mcg_ui.py
+++ b/ocs_ci/ocs/ui/mcg_ui.py
@@ -286,15 +286,20 @@ class BucketsUI(PageNavigator):
             resource (str): resource name to delete. It may be Object Bucket Claim name both for OBC or OB,
                 and it may be Object Bucket Name. Object Bucket name consists from Object Bucket Claim and prefix
         """
+        logger.info(f"Find resource by name '{resource}' using search-bar")
+        self.page_has_loaded()
+        self.do_send_keys(self.generic_locators["search_resource_field"], resource)
+
         if delete_via == "Actions":
             logger.info(f"Go to {resource} Page")
             # delete specific resource by its dynamic name. Works both for OBC and OB
             self.do_click(
-                (f"//td[@id='name']//a[contains(text(),'{resource}')]", By.XPATH)
+                (f"//td[@id='name']//a[contains(text(),'{resource}')]", By.XPATH),
+                enable_screenshot=True,
             )
 
             logger.info(f"Click on '{delete_via}'")
-            self.do_click(self.generic_locators["actions"])
+            self.do_click(self.generic_locators["actions"], enable_screenshot=True)
         else:
             logger.info(f"Click on '{delete_via}'")
             # delete specific resource by its dynamic name. Works both for OBC and OB
@@ -303,16 +308,17 @@ class BucketsUI(PageNavigator):
                     f"//td[@id='name']//a[contains(text(), '{resource}')]"
                     "/../../..//button[@aria-label='Actions']",
                     By.XPATH,
-                )
+                ),
+                enable_screenshot=True,
             )
 
         logger.info(f"Click on 'Delete {resource}'")
         # works both for OBC and OB, both from three_dots icon and Actions dropdown list
-        self.do_click(self.obc_loc["delete_resource"])
+        self.do_click(self.obc_loc["delete_resource"], enable_screenshot=True)
 
         logger.info(f"Confirm {resource} Deletion")
         # same PopUp both for OBC and OB
-        self.do_click(self.generic_locators["confirm_action"])
+        self.do_click(self.generic_locators["confirm_action"], enable_screenshot=True)
 
 
 class ObcUI(BucketsUI):
@@ -335,6 +341,8 @@ class ObcUI(BucketsUI):
             bucketclass (str): The bucketclass to be used by the OBC
 
         """
+        # create_obc_ui procedure should start from home page even if prev test failed in the middle
+        self.navigate_OCP_home_page()
         self.navigate_object_bucket_claims_page()
 
         self.select_openshift_storage_project(config.ENV_DATA["cluster_namespace"])

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1157,6 +1157,29 @@ validation_4_11 = {
 
 
 locators = {
+    "4.13": {
+        "login": {**login, **login_4_11},
+        "page": {**page_nav, **page_nav_4_10},
+        "generic": generic_locators,
+        "add_capacity": {**add_capacity, **add_capacity_4_11, **add_capacity_4_12},
+        "deployment": {
+            **deployment,
+            **deployment_4_7,
+            **deployment_4_9,
+            **deployment_4_10,
+            **deployment_4_11,
+            **deployment_4_12,
+        },
+        "validation": {
+            **validation,
+            **validation_4_8,
+            **validation_4_9,
+            **validation_4_10,
+            **validation_4_11,
+        },
+        "obc": obc,
+        "pvc": {**pvc, **pvc_4_7, **pvc_4_8, **pvc_4_9, **pvc_4_12},
+    },
     "4.12": {
         "login": {**login, **login_4_11},
         "page": {**page_nav, **page_nav_4_10},

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -292,6 +292,12 @@ class TestObcUserInterface(object):
         )
 
         obc_ui_obj = ObcUI(setup_ui_class)
+
+        if (
+            config.DEPLOYMENT["external_mode"]
+            and storageclass == "ocs-storagecluster-ceph-rgw"
+        ):
+            storageclass = "ocs-external-storagecluster-ceph-rgw"
         obc_ui_obj.create_obc_ui(obc_name, storageclass, bucketclass)
 
         assert obc_ui_obj.verify_current_page_resource_status(


### PR DESCRIPTION
This is cherry-pick from stable branch (4.13)

during black squad analysis of ODF 4.12 run it was found that we need locators for version 4.13 as some of the tests depend on OCP_version, thus they fail to find locators in views.py when running on OCP 4.13 & ODF 4.12. It is also applicable for upgrade scenarios, so we always should have locators for further version ready.

FIX: https://github.com/red-hat-storage/ocs-ci/issues/7509 for ODF 4.12
FIX: https://github.com/red-hat-storage/ocs-ci/issues/7486 for ODF 4.12
FIX: https://github.com/red-hat-storage/ocs-ci/issues/7605
