### PR TITLE
Skip access token check in test_pvc_assign_pod_node if platform is FaaS

### DIFF
--- a/ocs_ci/deployment/fusion_aas.py
+++ b/ocs_ci/deployment/fusion_aas.py
@@ -116,7 +116,7 @@ class FUSIONAAS(rosa_deployment.ROSA):
         if config.DEPLOYMENT.get("pullsecret_workaround"):
             # The pull secret may not get updated on all nodes if any node is not updated. Ensure it by checking the
             # status of machineconfigpool
-            wait_for_machineconfigpool_status("all", timeout=2800)
+            wait_for_machineconfigpool_status("all", timeout=1800)
             update_pull_secret()
             wait_for_machineconfigpool_status("all", timeout=900)
         deploy_odf()

--- a/ocs_ci/deployment/fusion_aas.py
+++ b/ocs_ci/deployment/fusion_aas.py
@@ -116,7 +116,7 @@ class FUSIONAAS(rosa_deployment.ROSA):
         if config.DEPLOYMENT.get("pullsecret_workaround"):
             # The pull secret may not get updated on all nodes if any node is not updated. Ensure it by checking the
             # status of machineconfigpool
-            wait_for_machineconfigpool_status("all", timeout=1800)
+            wait_for_machineconfigpool_status("all", timeout=2800)
             update_pull_secret()
             wait_for_machineconfigpool_status("all", timeout=900)
         deploy_odf()

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -102,7 +102,9 @@ class TestPvcAssignPodNode(ManageTest):
         pod.get_fio_rw_iops(pod_obj)
 
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if ocs_version >= version.VERSION_4_12:
+        if (ocs_version >= version.VERSION_4_12) and (
+            config.ENV_DATA.get("platform") != constants.FUSIONAAS_PLATFORM
+        ):
             self.verify_access_token_notin_odf_pod_logs()
 
     @acceptance
@@ -191,5 +193,7 @@ class TestPvcAssignPodNode(ManageTest):
             pod.get_fio_rw_iops(pod_obj)
 
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if ocs_version >= version.VERSION_4_12:
+        if (ocs_version >= version.VERSION_4_12) and (
+            config.ENV_DATA.get("platform") != constants.FUSIONAAS_PLATFORM
+        ):
             self.verify_access_token_notin_odf_pod_logs()


### PR DESCRIPTION
Skip access token check in test_pvc_assign_pod_node if platform is FaaS. ODF operator pod won't be present in FaaS consumer cluster.
Fixes #7639 