### PR TITLE
Allow to overwrite DATA_DIR via environment variable

### DIFF
--- a/conf/ocsci/README.md
+++ b/conf/ocsci/README.md
@@ -1,4 +1,4 @@
-# OCSCI related config directory
+# OCS-CI related config directory
 
 In this directory we will have common config files which we will use in our
 automation for example for different platforms like AWS or VmWare and so on.
@@ -6,7 +6,7 @@ automation for example for different platforms like AWS or VmWare and so on.
 See the documentation from [conf dir](../README.md) for more details!
 
 
-##Specific config directories
+## Specific config directories
 
 ### openshift-console
 

--- a/ocs_ci/deployment/aws.py
+++ b/ocs_ci/deployment/aws.py
@@ -631,7 +631,7 @@ class AWSUPI(AWSBase):
             self.cluster_path, config.RUN.get("kubeconfig_location")
         )
         pod.upload(rhel_pod_obj.name, kubeconfig, "/")
-        pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         pod.upload(rhel_pod_obj.name, pull_secret_path, "/tmp/")
         host_file = self.build_ansible_inventory(hosts)
         pod.upload(rhel_pod_obj.name, host_file, "/")

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -103,7 +103,7 @@ def mirror_images_from_mapping_file(mapping_file, icsp=None, ignore_image=None):
     # ignore errors, because some of the images might be already mirrored
     # via the `oc adm catalog mirror ...` command and not available on the
     # mirror
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
     exec_cmd(
         f"oc image mirror --filter-by-os='.*' -f {mapping_file} "
         f"--insecure --registry-config={pull_secret_path} "
@@ -137,7 +137,7 @@ def prune_and_mirror_index_image(
 
     """
     get_opm_tool()
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
 
     # prune an index image
     logger.info(
@@ -232,7 +232,7 @@ def mirror_index_image_via_oc_mirror(index_image, packages, icsp=None):
 
     """
     get_oc_mirror_tool()
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
 
     # login to mirror registry
     login_to_mirror_registry(pull_secret_path)
@@ -357,7 +357,7 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
     # Disable the default OperatorSources
     disable_default_sources()
 
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
 
     # login to mirror registry
     login_to_mirror_registry(pull_secret_path)
@@ -468,7 +468,7 @@ def mirror_ocp_release_images(ocp_image_path, ocp_version):
             or checksum
     """
     ocp_image = f"{ocp_image_path}:{ocp_version}"
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
     # login to mirror registry
     login_to_mirror_registry(pull_secret_path)
 

--- a/ocs_ci/deployment/ibmcloud.py
+++ b/ocs_ci/deployment/ibmcloud.py
@@ -139,7 +139,7 @@ class IBMCloudIPI(CloudDeploymentBase):
         self.installer = None
         super(IBMCloudIPI, self).__init__()
         self.credentials_requests_dir = os.path.join(self.cluster_path, "creds_reqs")
-        self.pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        self.pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
 
     def deploy_ocp(self, log_cli_level="DEBUG"):
         """

--- a/ocs_ci/deployment/install_ocp_on_rhel.py
+++ b/ocs_ci/deployment/install_ocp_on_rhel.py
@@ -57,7 +57,7 @@ class OCPINSTALLRHEL(object):
             config.ENV_DATA["cluster_path"], config.RUN.get("kubeconfig_location")
         )
         self.pod_name = "rhelpod"
-        self.pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        self.pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         self.pod_pull_secret_path = os.path.join(
             constants.POD_UPLOADPATH, "pull-secret"
         )

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -60,7 +60,7 @@ class OCPDeployment:
         Returns:
             dict: content of pull secret
         """
-        pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         with open(pull_secret_path, "r") as f:
             # Parse, then unparse, the JSON file.
             # We do this for two reasons: to ensure it is well-formatted, and

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -67,7 +67,7 @@ TEMPLATE_DEPLOYMENT_CLO = os.path.join(
 )
 TEMPLATE_AUTHENTICATION_DIR = os.path.join(TEMPLATE_DIR, "authentication")
 KREW_INSTALL_DIR = os.path.join(TEMPLATE_DIR, "krew_plugin")
-DATA_DIR = os.path.join(TOP_DIR, "data")
+DATA_DIR = os.getenv("OCSCI_DATA_DIR") or os.path.join(TOP_DIR, "data")
 ROOK_REPO_DIR = os.path.join(DATA_DIR, "rook")
 ROOK_EXAMPLES_DIR = os.path.join(
     ROOK_REPO_DIR, "cluster", "examples", "kubernetes", "ceph"

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -1069,7 +1069,7 @@ class AWSNodes(NodesBase):
             self.cluster_path, config.RUN.get("kubeconfig_location")
         )
         pod.upload(rhel_pod_obj.name, kubeconfig, "/")
-        pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         pod.upload(rhel_pod_obj.name, pull_secret_path, "/tmp/")
         host_file = self.build_ansible_inventory(hosts)
         pod.upload(rhel_pod_obj.name, host_file, "/")

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -932,7 +932,7 @@ class MCG:
                 constants.NOOBAA_OPERATOR_POD_CLI_PATH
             )
             # The MCG CLI retrieval process is known to be flaky
-            # and there's an active BZ regardaing it -
+            # and there's an active BZ regarding it -
             # https://bugzilla.redhat.com/show_bug.cgi?id=2011845
             # rsync should be more reliable than cp, thus the use of oc rsync.
             if version.get_semantic_ocs_version_from_config() > version.VERSION_4_5:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2448,7 +2448,7 @@ def load_auth_config():
 
     """
     log.info("Retrieving the authentication config dictionary")
-    auth_file = os.path.join(constants.TOP_DIR, "data", constants.AUTHYAML)
+    auth_file = os.path.join(constants.DATA_DIR, constants.AUTHYAML)
     try:
         with open(auth_file) as f:
             return yaml.safe_load(f)
@@ -3195,7 +3195,7 @@ def prepare_customized_pull_secret(images=None):
     if type(images) == str:
         images = [images]
     # load pull-secret file to pull_secret dict
-    pull_secret_path = os.path.join(constants.TOP_DIR, "data", "pull-secret")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
     with open(pull_secret_path) as pull_secret_fo:
         pull_secret = json.load(pull_secret_fo)
 


### PR DESCRIPTION
This patch will allow overwriting the DATA_DIR, which was hardcoded in the code, 
this will allow us to better use this image in the Openshift-CI tests.

See this log for example, 
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/39363/rehearse-39363-periodic-ci-RedHatQE-interop-testing-main-ocp-cnv-odf-4.12-cnv-odf-tests-aws-upi-ocp412/1658776923427311616/artifacts/cnv-odf-tests-aws-upi-ocp412/interop-tests-ocs-tests/build-log.txt

Verified: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/39363/rehearse-39363-periodic-ci-RedHatQE-interop-testing-main-ocp-cnv-odf-4.12-cnv-odf-tests-aws-upi-ocp412/1658854402775060480/artifacts/cnv-odf-tests-aws-upi-ocp412/interop-tests-ocs-tests/build-log.txt