### PR TITLE
`test_noobaa_kms_validation`: Remove the use of RE and generalize the search based on environment config

### DIFF
--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -37,7 +37,7 @@ class TestNoobaaKMS(MCGTest):
 
         target_log = "setKMSConditionType " + config.ENV_DATA["KMS_PROVIDER"]
         operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
-        target_log_found = target_log not in operator_logs
+        target_log_found = target_log in operator_logs
 
         if not target_log_found and restart_count > 0:
             logger.info("Checking the logs before the last pod restart")

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import re
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms
@@ -36,16 +35,15 @@ class TestNoobaaKMS(MCGTest):
 
         logger.info("Looking for evidence of KMS integration in the logs of the pod")
 
-        target_re = r"Exists:.*ocs-kms-token"
-        target_found = False
+        target_log = "setKMSConditionType " + config.ENV_DATA["KMS_PROVIDER"]
         operator_logs = pod.get_pod_logs(pod_name=operator_pod_name)
-        target_found = re.search(target_re, operator_logs) is not None
+        target_log_found = target_log not in operator_logs
 
-        if not target_found and restart_count > 0:
+        if not target_log_found and restart_count > 0:
             logger.info("Checking the logs before the last pod restart")
             operator_logs = pod.get_pod_logs(pod_name=operator_pod_name, previous=True)
-            target_found = re.search(target_re, operator_logs) is not None
+            target_log_found = target_log in operator_logs
 
         assert (
-            target_found
+            target_log_found
         ), "No records were found of the integration of NooBaa and KMS"


### PR DESCRIPTION
Fixes: #7659

Looking for "setKMSConditionType <KM type>" should be sufficient, based on the printed logs from past runs and the following code from the noopaa-operator project:
https://github.com/noobaa/noobaa-operator/blob/b45e8b619bca06f91586fdbd523ecbcf55203824/pkg/system/phase2_creating.go#LL830C1-L852C1

And since we're specifying this type under ENV_DATA.KMS_PROVIDER in our conf files, looking for `setKMSConditionType + config.ENV_DATA["KMS_PROVIDER"]` should work for both of the current KM providers as well as future ones.