### PR TITLE
Increase the number of workloads in sequential failover, relocate tests

### DIFF
--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -44,7 +44,7 @@ class TestSequentialFailover:
         when primary cluster is Up/Down
 
         """
-        workloads = dr_workload(num_of_subscription=3)
+        workloads = dr_workload(num_of_subscription=5)
 
         primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
             workloads[0].workload_namespace

--- a/tests/disaster-recovery/regional-dr/test_sequential_relocate.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_relocate.py
@@ -24,7 +24,7 @@ class TestSequentialRelocate:
         Test to verify relocate action for multiple workloads one after another from primary to secondary cluster
 
         """
-        workloads = dr_workload(num_of_subscription=3)
+        workloads = dr_workload(num_of_subscription=5)
 
         primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
             workloads[0].workload_namespace


### PR DESCRIPTION
Increase the number of workloads from 3 to 5 in sequential failover, relocate tests

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>