### PR TITLE
Remove peer ready check and allow option to select subscription if not auto-selected

### DIFF
--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -258,6 +258,18 @@ def failover_relocate_ui(
                 ),
                 enable_screenshot=True,
             )
+        if not move_workloads_to_same_cluster:
+            log.info("Click on subscription dropdown")
+            acm_obj.do_click(acm_loc["subscription-dropdown"], enable_screenshot=True)
+            clear_selection = acm_obj.find_an_element_by_xpath(
+                "//button[@class='pf-c-button pf-m-plain pf-c-select__toggle-clear']"
+            )
+            aria_label = clear_selection.get_attribute("aria-label")
+            if aria_label == "Clear all":
+                log.info("Subscription is already selected")
+            else:
+                log.info("Subscription is not selected, click on it to select")
+                acm_obj.do_click(acm_loc["select-subscription"], enable_screenshot=True)
         log.info("Check operation readiness")
         if action == constants.ACTION_FAILOVER:
             if move_workloads_to_same_cluster:
@@ -302,15 +314,6 @@ def failover_relocate_ui(
                 )
                 acm_obj.take_screenshot()
                 return True
-        log.info("Click on subscription dropdown")
-        acm_obj.do_click(acm_loc["subscription-dropdown"], enable_screenshot=True)
-        # TODO: Commented below lines due to Regression BZ2208637
-        # log.info("Check peer readiness")
-        # assert acm_obj.wait_until_expected_text_is_found(
-        #     locator=acm_loc["peer-ready"],
-        #     expected_text=constants.PEER_READY,
-        # ), f"Peer is not ready, can not initiate {action}"
-        acm_obj.take_screenshot()
         if aria_disabled == "true":
             log.error("Initiate button in not enabled to failover/relocate")
             return False

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -750,6 +750,7 @@ acm_configuration_4_12 = {
     "failover-preferred-cluster-name": ("//button[text()='{}']", By.XPATH),
     "operation-readiness": ("//*[contains(text(), 'Ready')]", By.XPATH),
     "subscription-dropdown": (".pf-c-select__toggle.pf-m-typeahead", By.CSS_SELECTOR),
+    "select-subscription": ("//input[@class='pf-c-check__input']", By.XPATH),
     "peer-ready": ("//i[normalize-space()='Peer ready']", By.XPATH),
     "initiate-action": ("#modal-intiate-action", By.CSS_SELECTOR),
     "close-action-modal": ("//button[normalize-space()='Close']", By.XPATH),


### PR DESCRIPTION
This PR fixes issue #7667, the bug was closed as not a bug so the existing validation for Peer ready is being removed.
Also, ACM UI auto-selects subscription to trigger failover/relocate. ​If auto-selection is not enabled, the PR allows ability to first select the subscription and then triggers the operation. 