### PR TITLE
remove wait parameter in stop_node since its not exists on all platforms

### DIFF
--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -320,7 +320,7 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
         temp_osd = get_node_pods(self.osd_worker_node.name, pods_to_search=osd_pods)[0]
         osd_real_name = "-".join(temp_osd.name.split("-")[:-1])
 
-        nodes.stop_nodes([self.osd_worker_node], wait=True)
+        nodes.stop_nodes([self.osd_worker_node])
         log.info(f"Successfully powered off node: {self.osd_worker_node.name}")
 
         timeout = 420


### PR DESCRIPTION
Fixes: #6861

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)