### PR TITLE
Remove the `rgw_endpoint` fixture

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1374,7 +1374,7 @@ NOOBAA_DB_SERVICE_ACCOUNT = NB_SERVICE_ACCOUNT_BASE.format(
 
 
 # Services
-RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
+RGW_SERVICE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
 RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
 
 # Routes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2088,7 +2088,7 @@ def ec2_instances(request, aws_obj):
 
 
 @pytest.fixture(scope="session")
-def cld_mgr(request, rgw_endpoint):
+def cld_mgr(request):
     """
     Returns a cloud manager instance that'll be used throughout the session
 

--- a/tests/manage/rgw/test_bucket_creation.py
+++ b/tests/manage/rgw/test_bucket_creation.py
@@ -41,7 +41,7 @@ class TestRGWBucketCreation:
         ],
     )
     def test_duplicate_bucket_creation(
-        self, rgw_endpoint, rgw_obj, rgw_bucket_factory, amount, interface
+        self, rgw_obj, rgw_bucket_factory, amount, interface
     ):
         """
         Negative test with duplicate bucket creation using OC commands

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -47,7 +47,7 @@ class TestBucketDeletion:
     )
     @flaky
     def test_bucket_delete_with_objects(
-        self, rgw_endpoint, rgw_bucket_factory, interface, awscli_pod_session
+        self, rgw_bucket_factory, interface, awscli_pod_session
     ):
         """
         Negative test with deletion of bucket has objects stored in.

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -56,7 +56,7 @@ class TestS3MultipartUpload(ManageTest):
     @tier1
     @pytest.mark.polarion_id("OCS-2245")
     def test_multipart_upload_operations(
-        self, rgw_endpoint, awscli_pod_session, rgw_bucket_factory, test_directory_setup
+        self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """
         Test Multipart upload operations on bucket and verifies the integrity of the downloaded object

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -24,7 +24,7 @@ class TestObjectIntegrity(ManageTest):
     @flaky
     @pytest.mark.polarion_id("OCS-2246")
     def test_check_object_integrity(
-        self, rgw_endpoint, awscli_pod_session, rgw_bucket_factory, test_directory_setup
+        self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """
         Test object integrity using md5sum
@@ -56,7 +56,7 @@ class TestObjectIntegrity(ManageTest):
     @pytest.mark.polarion_id("OCS-2243")
     @tier2
     def test_empty_file_integrity(
-        self, rgw_endpoint, awscli_pod_session, rgw_bucket_factory, test_directory_setup
+        self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """
         Test write empty files to bucket and check integrity


### PR DESCRIPTION
Fixes: #7024

Since 4.7 the RGW service is exposed by default, and after the recent fix of https://url.corp.redhat.com/0769663 in 4.13 
there shouldn't be any issues using this default HTTP endpoint