### PR TITLE
add cluster_dir_full_path to result xml

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -42,6 +42,7 @@ run it belongs here.
 * `password_location` - Filepath (under the cluster path) where the kubeadmin password is located
 * `log_dir` - Directory where logs are placed
 * `logs_url` - URL where the logs will be available for remote access, used for Jenkins runs and configured by Jenkins
+* `cluster_dir_full_path` - cluster dir full path on NFS share starting with `/mnt/`
 * `run_id` - Timestamp ID that is used for log directory naming
 * `kubeconfig_location` - Filepath (under the cluster path) where the kubeconfig is located
 * `cli_params` - Dict that holds onto all CLI parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1372,6 +1372,13 @@ def additional_testsuite_properties(record_testsuite_property, pytestconfig):
     # add run_id
     record_testsuite_property("run_id", config.RUN["run_id"])
 
+    # add cluster dir full path (on NFS share, if configured, it should contain
+    # full path to cluster dir on NFS share, starting with `/mnt/`)
+    if config.RUN.get("cluster_dir_full_path"):
+        record_testsuite_property(
+            "cluster_dir_full_path", config.RUN.get("cluster_dir_full_path")
+        )
+
     # Report Portal
     launch_name = reporting.get_rp_launch_name()
     record_testsuite_property("rp_launch_name", launch_name)


### PR DESCRIPTION
Add `cluster_dir_full_path` to xunit result xml, which could point to the cluster dir on the NFS share (starting with `/mnt`).