### PR TITLE
update benchmark_operator* modules for disconnected env

### DIFF
--- a/ocs_ci/ocs/benchmark_operator.py
+++ b/ocs_ci/ocs/benchmark_operator.py
@@ -17,11 +17,12 @@ import re
 from subprocess import run, CalledProcessError
 
 # Local modules
+from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.node import get_worker_nodes
 from ocs_ci.ocs.ocp import OCP, switch_to_default_rook_cluster_project
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import mirror_image, TimeoutSampler
 
 # BMO stand for : BenchMark Operator
 # The benchmark operator name used for path / namespace etc.
@@ -149,8 +150,11 @@ class BenchmarkOperator(object):
         """
         log.info("Deploy the benchmark-operator project")
         try:
+            bmo_img = "quay.io/ocsci/benchmark-operator:testing"
+            if config.DEPLOYMENT.get("disconnected"):
+                bmo_img = mirror_image(bmo_img)
             run(
-                "make deploy IMG=quay.io/ocsci/benchmark-operator:testing",
+                f"make deploy IMG={bmo_img}",
                 shell=True,
                 check=True,
                 cwd=self.dir,

--- a/ocs_ci/ocs/benchmark_operator_fio.py
+++ b/ocs_ci/ocs/benchmark_operator_fio.py
@@ -5,6 +5,7 @@ import git
 import tempfile
 from subprocess import run
 
+from ocs_ci.framework import config
 from ocs_ci.ocs.ocp import OCP, switch_to_default_rook_cluster_project
 from ocs_ci.ocs.cluster import get_percent_used_capacity, CephCluster
 from ocs_ci.ocs.resources.ocs import OCS
@@ -13,7 +14,7 @@ from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
 from ocs_ci.ocs.node import get_worker_nodes
 from ocs_ci.ocs import constants
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import mirror_image, TimeoutSampler
 from ocs_ci.utility import templating
 from ocs_ci.helpers import helpers
 
@@ -121,8 +122,11 @@ class BenchmarkOperatorFIO(object):
 
         """
         log.info("Run make deploy command")
+        bmo_img = "quay.io/ocsci/benchmark-operator:testing"
+        if config.DEPLOYMENT.get("disconnected"):
+            bmo_img = mirror_image(bmo_img)
         run(
-            "make deploy IMG=quay.io/ocsci/benchmark-operator:testing",
+            f"make deploy IMG={bmo_img}",
             shell=True,
             check=True,
             cwd=self.local_repo,


### PR DESCRIPTION
Mirror `quay.io/ocsci/benchmark-operator:testing` image for benchmark operator on disconnected cluster.