### PR TITLE
Update fio_dc.yaml - to suppress debconf messages | Fixes: #7711

### DIFF
--- a/ocs_ci/templates/workloads/fio/fio_dc.yaml
+++ b/ocs_ci/templates/workloads/fio/fio_dc.yaml
@@ -20,6 +20,11 @@ spec:
           volumeDevices:
             - devicePath: /dev/rbdblock
               name: my-volume
+          env:
+            - name: DEBIAN_FRONTEND
+              value: noninteractive
+            - name: DEBCONF_NOWARNINGS
+              value: yes
           command: ["/usr/bin/fio"]
           args: ["--name=fio-rand-readwrite",
                  "--filename=/dev/rbdblock",


### PR DESCRIPTION
Add 2 environment variables to suppress debconf messages

Fixes: #7711 

```
WARNING  - Command stderr: debconf: delaying package configuration, since apt-utils is not installed
```