### PR TITLE
test_nsfs.py: Wait for the nooba-endpoint pods to reset and mount the PVC at setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5429,6 +5429,17 @@ def nsfs_bucket_factory_fixture(
             )[0]
         )
         wait_for_pods_to_be_running(pod_names=[nsfs_interface_pod.name])
+
+        # Wait for the nooba-endpoint pods to reset and mount the PVC
+        nb_endpoint_pods = [
+            Pod(**pod_dict)
+            for pod_dict in get_pods_having_label(
+                constants.NOOBAA_ENDPOINT_POD_LABEL,
+                config.ENV_DATA["cluster_namespace"],
+            )
+        ]
+        wait_for_pods_to_be_running(pod_names=[pod.name for pod in nb_endpoint_pods])
+
         # Apply the necessary permissions on the filesystem
         nsfs_interface_pod.exec_cmd_on_pod(f"chmod -R 777 {nsfs_obj.mount_path}")
         nsfs_interface_pod.exec_cmd_on_pod(f"groupadd -g {nsfs_obj.gid} nsfs-group")


### PR DESCRIPTION
Fixes: #7716

Adds a wait period for the noobaa-endpoint pods to stabilize before attempting to modify the PVC they're mounting