### PR TITLE
Fix the check for storageclassclaims and sc in FaaS consumer

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -306,6 +306,10 @@ def ocs_install_verification(
             timeout=timeout,
         )
 
+    # Checks for FaaS
+    if fusion_aas:
+        verify_faas_resources()
+
     # Verify StorageClasses (1 ceph-fs, 1 ceph-rbd)
     log.info("Verifying storage classes")
     storage_class = OCP(kind=constants.STORAGECLASS, namespace=namespace)
@@ -659,9 +663,6 @@ def ocs_install_verification(
 
     if config.ENV_DATA.get("is_multus_enabled"):
         verify_multus_network()
-
-    if fusion_aas:
-        verify_faas_resources()
 
     # validation in case of openshift-cert-manager installed
     if config.DEPLOYMENT.get("install_cert_manager"):


### PR DESCRIPTION
Fix the check for storageclassclaims and storageclass in FaaS consumer install verification.
Moved the storageclient check before storageclass check because the storage client should be verified first.
The check for storageclassclaim is updated. Retry is required because the storageclassclaim won't be in Ready state immediately after the storageclient is connected.

Fixes #7693 