### PR TITLE
skip quay operator test cases

### DIFF
--- a/tests/e2e/workloads/app/quay/test_quay_operator.py
+++ b/tests/e2e/workloads/app/quay/test_quay_operator.py
@@ -45,6 +45,9 @@ def _exec_cmd(cmd):
 
 
 @workloads
+@pytest.mark.skip(
+    reason="Skipped because of issue https://github.com/red-hat-storage/ocs-ci/issues/7419"
+)
 class TestQuayWorkload(E2ETest):
     """
     Tests Quay operator


### PR DESCRIPTION
Skip due to https://github.com/red-hat-storage/ocs-ci/issues/7419
Create QuayRegistry is failing with status 'Condition: RolloutBlocked' on  OCP 4.13 with ODF 4.13. 
Quay operator pod can not deploy quay pods when set horizontalpodautoscaler as managed in OCP 4.13
Root cause is autoscaling/v2beta2 isn't available on OCP 4.13
Bug is reported at https://issues.redhat.com/browse/PROJQUAY-5079