### PR TITLE
BaseUI: added module_loc to page_has_loaded

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -637,7 +637,7 @@ class PageNavigator(BaseUI):
         """
         logger.info("Navigate to OCP Home Page")
         self.driver.get(get_ocp_url())
-        self.page_has_loaded(retries=10, sleep_time=5)
+        self.page_has_loaded(retries=10, sleep_time=1)
 
     def navigate_storage(self):
         logger.info("Navigate to ODF tab under Storage section")

--- a/ocs_ci/ocs/ui/mcg_ui.py
+++ b/ocs_ci/ocs/ui/mcg_ui.py
@@ -529,5 +529,5 @@ class ObUI(BucketsUI):
 
             _check_three_dots_disabled("check three dots inactive automatically")
             self.driver.refresh()
-            self.page_has_loaded(sleep_time=10)
+            self.page_has_loaded(sleep_time=2)
             _check_three_dots_disabled("check three dots inactive after refresh")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -453,6 +453,7 @@ pvc_4_12 = {
     "resize-value": ("//input[@data-test='pvc-expand-size-input']", By.XPATH),
 }
 page_nav = {
+    "page_navigator_sidebar": ("page-sidebar", By.ID),
     "Home": ("//button[text()='Home']", By.XPATH),
     "overview_page": ("Overview", By.LINK_TEXT),
     "projects_page": ("Projects", By.LINK_TEXT),


### PR DESCRIPTION
FIXES: #7743

added an optional argument to page_has_loaded.
Should not affect on tests using method page_has_loaded and not using module_loc as it still uses default root HTML loc ("html", By.TAG_NAME)

