### PR TITLE
Run the nodes restart tests with vSphere IPI

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2285,6 +2285,20 @@ def get_osd_pg_log_dups_tracked():
     return int(osd_pg_log_dups_count)
 
 
+def is_vsphere_ipi_cluster():
+    """
+    Check if the cluster is a vSphere IPI cluster
+
+    Returns:
+        bool: True, if the cluster is a vSphere IPI cluster. False, otherwise
+
+    """
+    return (
+        config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM
+        and config.ENV_DATA["deployment_type"] == "ipi"
+    )
+
+
 class CephClusterExternal(CephCluster):
     """
     Handle all external ceph cluster related functionalities

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -10,7 +10,6 @@ from ocs_ci.framework.testlib import (
     cloud_platform_required,
     bugzilla,
     skipif_no_lso,
-    skipif_vsphere_ipi,
     skipif_ibm_cloud,
     skipif_managed_service,
 )
@@ -32,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 @ignore_leftovers
-@skipif_vsphere_ipi
 @skipif_managed_service
 class TestNodesRestart(ManageTest):
     """

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     cloud_platform_required,
     bugzilla,
     skipif_no_lso,
+    skipif_vsphere_ipi,
     skipif_ibm_cloud,
     skipif_managed_service,
 )
@@ -124,6 +125,7 @@ class TestNodesRestart(ManageTest):
         ],
     )
     @skipif_ibm_cloud
+    @skipif_vsphere_ipi
     def test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node(
         self,
         nodes,
@@ -269,6 +271,7 @@ class TestNodesRestart(ManageTest):
         ],
     )
     @skipif_ibm_cloud
+    @skipif_vsphere_ipi
     def test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node(
         self,
         nodes,


### PR DESCRIPTION
fix #7737 
In the pr, I implemented the following:
- Run the tests `test_nodes_restart` and `test_rolling_nodes_restart` with vSphere IPI.
- Adjust the test `test_nodes_restart` to run on vSphere IPI.
- Still skip the tests `test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node`, `test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node` because with vSphere IPI when stopping a node it behaves differently. We may reimplement them in the future if necessary.
    
