### PR TITLE
Adding a new test case for VolumeReplication CR edit 

### DIFF
--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -49,7 +49,7 @@ class TestCRRsourcesValidation(ManageTest):
 
             if self.object_name_to_delete != "":
                 res = run_oc_command(
-                    cmd=f"delete -n {self.namespace} {self.object_name_to_delete}"
+                    cmd=f"delete {self.object_name_to_delete}", namespace=self.namespace
                 )
                 assert ERRMSG not in res[0], (
                     f"Failed to delete {self.object_kind_to_delete} resource with name: {self.object_name_to_delete}, "
@@ -82,7 +82,7 @@ class TestCRRsourcesValidation(ManageTest):
             namespace (str): namespace in which cr object should be created
 
         """
-        res = run_oc_command(cmd=f"create -n {namespace} -f {cr_resource_yaml}")
+        res = run_oc_command(cmd=f"create -f {cr_resource_yaml}", namespace=namespace)
         assert (
             ERRMSG not in res[0]
         ), f"Failed to create resource {cr_object_kind} from yaml file {cr_resource_yaml}, got result {res}"
@@ -92,7 +92,9 @@ class TestCRRsourcesValidation(ManageTest):
         self.object_kind_to_delete = cr_object_kind
         self.namespace = namespace
 
-        cr_resource_original_yaml = run_oc_command(f"get {cr_resource_name} -o yaml")
+        cr_resource_original_yaml = run_oc_command(
+            f"get {cr_resource_name} -o yaml", namespace=namespace
+        )
 
         # test that all non editable properties are really not editable
         non_editable_properties_errors = {}
@@ -115,7 +117,7 @@ class TestCRRsourcesValidation(ManageTest):
             try:
                 run_cmd(f"sh {temp_file.name}")
                 cr_resource_modified_yaml = run_oc_command(
-                    f"get -n {namespace} {cr_resource_name} -o yaml"
+                    f"get {cr_resource_name} -o yaml", namespace=namespace
                 )
 
                 if cr_resource_prev_yaml != cr_resource_modified_yaml:
@@ -168,7 +170,7 @@ class TestCRRsourcesValidation(ManageTest):
             try:
                 run_cmd(f"sh {temp_file.name}")
                 cr_resource_modified_yaml = run_oc_command(
-                    f"get -n {namespace} {cr_resource_name} -o yaml"
+                    f"get {cr_resource_name} -o yaml", namespace=namespace
                 )
 
                 if cr_resource_prev_yaml == cr_resource_modified_yaml:

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -126,7 +126,7 @@ class TestCRRsourcesValidation(ManageTest):
                 CommandFailed
             ):  # some properties are not editable and CommandFailed exception is thrown
                 logger.info(
-                    f"Properyy {patch} is not editable, patch command failed, continue to the next"
+                    f"Property {patch} is not editable, patch command failed, continue to the next"
                 )
                 continue  # just continue to the next property
 

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -180,7 +180,7 @@ class TestCRRsourcesValidation(ManageTest):
                 CommandFailed
             ):  # some properties are not editable and CommandFailed exception is thrown
                 logger.info(
-                    f"Properyy {patch} should be editable, but patch command failed, continue to the next"
+                    f"Property {patch} should be editable, but patch command failed, continue to the next"
                 )
                 editable_properties_errors[patch] = cr_resource_modified_yaml
                 continue  # just continue to the next property

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -2,8 +2,9 @@ import logging
 import os
 import pytest
 import yaml
-from tempfile import NamedTemporaryFile
 
+from tempfile import NamedTemporaryFile
+from ocs_ci.framework.pytest_customization.marks import bugzilla
 from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     skipif_ocs_version,
@@ -274,6 +275,7 @@ class TestCRRsourcesValidation(ManageTest):
             {},
         )
 
+    @bugzilla("2207780")
     def test_volume_replication_cr_editable(self):
         """
         Test case to check that some properties of volume replication class object are not editable


### PR DESCRIPTION
1) This PR contains a new test case for VolumeReplication CR edit 
2) In order to support creation of CR in other than openshift-storage namespace the cr_resource_not_editable function was enhanced. 
3) This PR also contain fixes of remarks by Karthick from previous pr https://github.com/red-hat-storage/ocs-ci/pull/7593