### PR TITLE
Adjust send_rpc_query to send RPC requests via the NooBaa CLI

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -62,7 +62,7 @@ class MCG:
         noobaa_user,
         noobaa_password,
         noobaa_token,
-    ) = (None,) * 11
+    ) = (None,) * 12
 
     def __init__(self, *args, **kwargs):
         """

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -332,6 +332,8 @@ class MCG:
 
         """
 
+        logger.info(f"Sending MCG RPC query:\n{api} {method} {params}")
+
         # This version comparison is a workaround to make sure we still cover
         # the usage of the noobaa mgmt-endpoint via RPC calls
         # Once the release-4.13 branch is created we should remove the unused logic per version
@@ -349,8 +351,6 @@ class MCG:
             )
 
         else:
-            logger.info(f"Sending MCG RPC query:\n{api} {method} {params}")
-
             cli_output = self.exec_mcg_cmd(
                 f"api {api} {method} '{json.dumps(params)}' -ojson"
             )

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -328,7 +328,7 @@ class MCG:
             f"api {api} {method} '{json.dumps(params)}' -ojson"
         )
 
-        # This class is needed to json method to the response dict
+        # This class is needed to add a json method to the response dict
         # which is needed to support existing usage
         class CLIResponseDict(dict):
             def json(self):

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -60,7 +60,7 @@ class MCG:
         noobaa_user,
         noobaa_password,
         noobaa_token,
-    ) = (None,) * 12
+    ) = (None,) * 11
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
In 4.14 the URL that was used to make NooBaa RPC requests has been removed, so this PR adjusts the method that was used to make these calls, so it uses the NooBaa CLI instead.

See this google chat thread for details:
https://url.corp.redhat.com/c4c3508
