### PR TITLE
In the test "test_delete_rook_ceph_osd_deployment" ignore the "rook-ceph-osd" labels in the leftovers #7790

### DIFF
--- a/tests/manage/z_cluster/test_delete_osd_deployment.py
+++ b/tests/manage/z_cluster/test_delete_osd_deployment.py
@@ -4,6 +4,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
     skipif_ocs_version,
+    ignore_leftover_label,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources.pod import get_osd_deployments
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 @tier4c
 @skipif_ocs_version("<4.10")
+@ignore_leftover_label(constants.OSD_APP_LABEL)
 @pytest.mark.polarion_id("OCS-3731")
 @pytest.mark.bugzilla("2032656")
 class TestDeleteOSDDeployment(ManageTest):

--- a/tests/manage/z_cluster/test_delete_osd_deployment.py
+++ b/tests/manage/z_cluster/test_delete_osd_deployment.py
@@ -59,7 +59,10 @@ class TestDeleteOSDDeployment(ManageTest):
 
             # Wait for new OSD deployment to be Ready
             deployment_obj.wait_for_resource(
-                condition="1/1", resource_name=osd_deployment_name, column="READY"
+                condition="1/1",
+                resource_name=osd_deployment_name,
+                column="READY",
+                timeout=120,
             )
 
             # Check if a new OSD pod is created

--- a/tests/manage/z_cluster/test_delete_osd_deployment.py
+++ b/tests/manage/z_cluster/test_delete_osd_deployment.py
@@ -62,7 +62,8 @@ class TestDeleteOSDDeployment(ManageTest):
                 condition="1/1",
                 resource_name=osd_deployment_name,
                 column="READY",
-                timeout=120,
+                timeout=180,
+                sleep=10,
             )
 
             # Check if a new OSD pod is created
@@ -86,4 +87,4 @@ class TestDeleteOSDDeployment(ManageTest):
         if config.ENV_DATA.get("encryption_at_rest"):
             osd_encryption_verification()
 
-        assert ceph_health_check(delay=120, tries=50), "Ceph health check failed"
+        assert ceph_health_check(delay=60, tries=50), "Ceph health check failed"


### PR DESCRIPTION
fix #7784 