### PR TITLE
test_monitoring_negative__resolve_concurrent_oc_cmds

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1306")
 @skipif_managed_service
 @skipif_external_mode
-def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
+def test_monitoring_shows_mon_down(measure_stop_ceph_mon, threading_lock):
     """
     Make sure simple problems with MON daemons are reported via OCP Prometheus.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     # time (in seconds) for monitoring to notice the change
     expected_delay = 60
     # query resolution step used in this test case (number of seconds)
@@ -97,11 +97,11 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon):
 @pytest.mark.polarion_id("OCS-1307")
 @skipif_managed_service
 @skipif_external_mode
-def test_monitoring_shows_osd_down(measure_stop_ceph_osd):
+def test_monitoring_shows_osd_down(measure_stop_ceph_osd, threading_lock):
     """
     Make sure simple problems with OSD daemons are reported via OCP Prometheus.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     # time (in seconds) for monitoring to notice the change
     expected_delay = 60
 
@@ -168,14 +168,14 @@ def test_monitoring_shows_osd_down(measure_stop_ceph_osd):
 @bugzilla("2203795")
 @pytest.mark.polarion_id("OCS-2734")
 @skipif_managed_service
-def test_ceph_metrics_presence_when_osd_down(measure_stop_ceph_osd):
+def test_ceph_metrics_presence_when_osd_down(measure_stop_ceph_osd, threading_lock):
     """
     Since ODF 4.9 ceph metrics covering disruptions will be available only
     when there are some disruptions to report, as noted in BZ 2028649.
 
     This test case covers this behaviour for one stopped/disabled OSD.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     metrics_expected = list(metrics.ceph_metrics_healthy)
     # metrics which should be present with one OSD down
     for mtr in ("ceph_pg_degraded", "ceph_pg_undersized"):


### PR DESCRIPTION
Fix the issue faced here: https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/465/11656/531560/531624/531625/log

Problem: constant 'oc login' necessary for Prometheus api and any other exec_cmd will have collision if will be ran same time. Only one cmd will have an action.

