### PR TITLE
Increase timeout for pods to reach running state in test_check_pods_status_after_node_failure

### DIFF
--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -156,7 +156,7 @@ class TestCheckPodsAfterNodeFailure(ManageTest):
 
         log.info("Check the rook ceph pods are in 'Running' or 'Completed' state")
         previous_timeout = 480
-        timeout = 600
+        timeout = 900
         are_pods_running = wait_for_pods_to_be_running(
             pod_names=rook_ceph_pod_names_not_in_node, timeout=timeout, sleep=30
         )


### PR DESCRIPTION
The test has been repeatedly failing with 
Message: AssertionError: Increased timeout from 480 to 600 seconds, The pods are not 'Running' even after 600 seconds
assert False
RP- https://url.corp.redhat.com/

But the Pods reach running state in collected must gather and ceph is also healthy. We should allow some more time for the checks to ensure Pods reaching running state before failing the test.

