### PR TITLE
Skipping 'test_pdb_check_simultaneous_node_drains' for more than three worker nodes

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -148,6 +148,11 @@ skip_inconsistent = pytest.mark.skip(
     reason="Currently the reduction is too inconsistent leading to inconsistent test results"
 )
 
+skipif_more_than_three_workers = pytest.mark.skipif(
+    config.ENV_DATA["worker_replicas"] > 3,
+    reason="This test cannot run on setup having more than three worker nodes",
+)
+
 # Skipif marks
 skipif_aws_creds_are_missing = pytest.mark.skipif(
     (

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -493,7 +493,6 @@ class TestNodesMaintenance(ManageTest):
         - Check cluster and Ceph health
 
         """
-        log.info(config.ENV_DATA)
         # Validate OSD PDBs before drain operation
         assert (
             not validate_existence_of_blocking_pdb()

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -493,6 +493,7 @@ class TestNodesMaintenance(ManageTest):
         - Check cluster and Ceph health
 
         """
+
         # Validate OSD PDBs before drain operation
         assert (
             not validate_existence_of_blocking_pdb()

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -39,6 +39,7 @@ from ocs_ci.framework.testlib import (
     skipif_bm,
     bugzilla,
     skipif_managed_service,
+    skipif_more_than_three_workers,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
 from ocs_ci.ocs.resources import pod
@@ -467,6 +468,7 @@ class TestNodesMaintenance(ManageTest):
     @bugzilla("1861104")
     @bugzilla("1946573")
     @skipif_managed_service
+    @skipif_more_than_three_workers
     @pytest.mark.polarion_id("OCS-2524")
     @tier4a
     def test_pdb_check_simultaneous_node_drains(
@@ -491,7 +493,7 @@ class TestNodesMaintenance(ManageTest):
         - Check cluster and Ceph health
 
         """
-
+        log.info(config.ENV_DATA)
         # Validate OSD PDBs before drain operation
         assert (
             not validate_existence_of_blocking_pdb()


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/7216