### PR TITLE
Increasing 'wait_for_pods_to_be_running' timeout to address intermittent failures in test_toleration.py

### DIFF
--- a/tests/manage/z_cluster/nodes/test_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_toleration.py
@@ -61,4 +61,4 @@ class TestTaintAndTolerations(E2ETest):
                 continue
             else:
                 pod.delete(wait=False)
-        assert wait_for_pods_to_be_running(timeout=300)
+        assert wait_for_pods_to_be_running(timeout=360)


### PR DESCRIPTION
This fixes https://github.com/red-hat-storage/ocs-ci/issues/7857