### PR TITLE
Choose to use only the MCG-CLI for RPC calls elsewhere

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -9,7 +9,6 @@ import tempfile
 from time import sleep
 
 import boto3
-import requests
 from botocore.client import ClientError
 
 from ocs_ci.framework import config
@@ -344,36 +343,19 @@ class MCG:
 
         """
 
-        logger.info(f"Sending MCG RPC query:\n{api} {method} {params}")
+        logger.info(f"Sending MCG RPC query via mcg-cli:\n{api} {method} {params}")
 
-        # This version comparison is a workaround to make sure we still cover
-        # the usage of the noobaa mgmt-endpoint via RPC calls
-        # Once the release-4.13 branch is created we should remove the unused logic per version
-        if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_10:
-            payload = {
-                "api": api,
-                "method": method,
-                "params": params,
-                "auth_token": self.noobaa_token,
-            }
-            return requests.post(
-                url=self.mgmt_endpoint,
-                data=json.dumps(payload),
-                verify=retrieve_verification_mode(),
-            )
+        cli_output = self.exec_mcg_cmd(
+            f"api {api} {method} '{json.dumps(params)}' -ojson"
+        )
 
-        else:
-            cli_output = self.exec_mcg_cmd(
-                f"api {api} {method} '{json.dumps(params)}' -ojson"
-            )
+        # This class is needed to add a json method to the response dict
+        # which is needed to support existing usage
+        class CLIResponseDict(dict):
+            def json(self):
+                return self
 
-            # This class is needed to add a json method to the response dict
-            # which is needed to support existing usage
-            class CLIResponseDict(dict):
-                def json(self):
-                    return self
-
-            return CLIResponseDict({"reply": json.loads(cli_output.stdout)})
+        return CLIResponseDict({"reply": json.loads(cli_output.stdout)})
 
     def check_data_reduction(self, bucketname, expected_reduction_in_bytes):
         """

--- a/tests/manage/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/manage/mcg/test_nb_mgmt_endpoint.py
@@ -1,0 +1,50 @@
+import json
+import requests
+import logging
+
+from ocs_ci.framework.testlib import tier1
+
+from ocs_ci.framework.testlib import MCGTest
+from ocs_ci.framework.testlib import skipif_ocs_version
+
+logger = logging.getLogger(name=__file__)
+
+
+@tier1
+@skipif_ocs_version("<4.14")
+class TestNoobaaMgmtEndpoint(MCGTest):
+    """
+    Test the noobaa mgmt route functionality
+    """
+
+    def test_noobaa_mgmt_route(self, mcg_obj_session):
+        """
+        Test the noobaa mgmt route via an RPC call
+        """
+        rpc_response = send_rpc_request_to_mgmt_endpoint(
+            mcg_obj_session, "system_api", "read_system"
+        )
+        assert rpc_response
+
+
+def send_rpc_request_to_mgmt_endpoint(mcg_obj, api, method, params):
+    """
+    Send an RPC request to the noobaa mgmt route
+    """
+
+    logger.info(
+        f"Sending MCG RPC query to the noobaa-mgmt endpoint:\n{api} {method} {params}"
+    )
+
+    payload = {
+        "api": api,
+        "method": method,
+        "params": params,
+        "auth_token": mcg_obj.noobaa_token,
+    }
+
+    return requests.post(
+        url=mcg_obj.mgmt_endpoint,
+        data=json.dumps(payload),
+        verify=mcg_obj.retrieve_verification_mode(),
+    ).json()

--- a/tests/manage/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/manage/mcg/test_nb_mgmt_endpoint.py
@@ -30,9 +30,12 @@ class TestNoobaaMgmtEndpoint(MCGTest):
         assert (
             rpc_response.ok
         ), f"RPC to {mcg_obj_session.mgmt_endpoint} failed with {rpc_response.status_code} status code"
+
+        json_response = rpc_response.json()
+
         assert (
-            "error" not in rpc_response.json()
-        ), f"RPC failed with message: {rpc_response.json()['error']['message']}"
+            "error" not in json_response
+        ), f"RPC failed with message: {json_response['error']['message']}"
 
         logger.info("RPC to the noobaa-mgmt endpoint was successful")
 


### PR DESCRIPTION
In 4.14 RPCs are only possible via the MCG-CLI, but in #7795 we kept making RPCs against the noobaa-endpoint in lower versions just to keep covering the noobaa-mgmt route.

This PR separates the functionality issue from the coverage issue by introducing a dedicated test for the noobaa-mgmt route, and choosing to use the MCG-CLI for RPCs in all other cases.