### PR TITLE
Skip UI tests in FaaS test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,10 +276,7 @@ def pytest_collection_modifyitems(session, items):
                     items.remove(item)
                     continue
     # skip UI test on openshift dedicated ODF-MS platform
-    if (
-        config.ENV_DATA["platform"].lower() == constants.OPENSHIFT_DEDICATED_PLATFORM
-        or config.ENV_DATA["platform"].lower() == constants.ROSA_PLATFORM
-    ):
+    if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
         for item in items.copy():
             if "/ui/" in str(item.fspath):
                 log.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,7 +275,7 @@ def pytest_collection_modifyitems(session, items):
                     )
                     items.remove(item)
                     continue
-    # skip UI test on openshift dedicated ODF-MS platform
+    # Skip UI test on openshift dedicated, ODF-MS, FaaS platform
     if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
         for item in items.copy():
             if "/ui/" in str(item.fspath):


### PR DESCRIPTION
UI tests were skipped in MS test runs. With the new name of the platform for FaaS, the UI test skip condition required update to include FaaS platform config name as well.