### PR TITLE
Skip mcg tests in FaaS test runs

### DIFF
--- a/tests/manage/mcg/conftest.py
+++ b/tests/manage/mcg/conftest.py
@@ -1,10 +1,6 @@
 import logging
 from ocs_ci.framework import config
-from ocs_ci.ocs.constants import (
-    OPENSHIFT_DEDICATED_PLATFORM,
-    ROSA_PLATFORM,
-    CLOUD_PLATFORMS,
-)
+from ocs_ci.ocs.constants import CLOUD_PLATFORMS, MANAGED_SERVICE_PLATFORMS
 
 log = logging.getLogger(__name__)
 
@@ -19,10 +15,7 @@ def pytest_collection_modifyitems(items):
 
     """
     # Need to update the condition when MCG will get supported
-    if (
-        config.ENV_DATA["platform"].lower() == OPENSHIFT_DEDICATED_PLATFORM
-        or config.ENV_DATA["platform"].lower() == ROSA_PLATFORM
-    ):
+    if config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS:
         for item in items.copy():
             if "manage/mcg" in str(item.fspath):
                 log.debug(


### PR DESCRIPTION
MCG tests were skipped in MS test runs. With the new name of the platform for FaaS, the MCG test skip condition required update to include FaaS platform config name as well.