### PR TITLE
Add ceph health check for the Faas consumer cluster in the utility "ceph_health_check_base"

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2299,6 +2299,36 @@ def is_vsphere_ipi_cluster():
     )
 
 
+def is_faas_consumer_cluster():
+    """
+    Check if the cluster is a Fusion Service consumer cluster
+
+    Returns:
+        bool: True, if the cluster is a Fusion Service consumer cluster. False, otherwise.
+
+    """
+    return (
+        config.ENV_DATA.get("platform", "").lower() == constants.FUSIONAAS_PLATFORM
+        and config.ENV_DATA.get("cluster_type", "").lower()
+        == constants.MS_CONSUMER_TYPE
+    )
+
+
+def is_faas_provider_cluster():
+    """
+    Check if the cluster is a Fusion Service provider cluster
+
+    Returns:
+        bool: True, if the cluster is a Fusion Service provider cluster. False, otherwise.
+
+    """
+    return (
+        config.ENV_DATA.get("platform", "").lower() == constants.FUSIONAAS_PLATFORM
+        and config.ENV_DATA.get("cluster_type", "").lower()
+        == constants.MS_PROVIDER_TYPE
+    )
+
+
 class CephClusterExternal(CephCluster):
     """
     Handle all external ceph cluster related functionalities


### PR DESCRIPTION
In the pr, I implement the following:

- Create two functions to check if the cluster is a Faas provider or consumer cluster.
- Divide the utility function `ceph_health_check_base` into small parts, making the code more clean and easy to modify. The basic ceph health check commands are still the same.
- Add ceph health check for the Faas consumer cluster because it behaves differently than a regular cluster.