### PR TITLE
Test automation of mon failure scenarios with intransit encryption.

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3048,22 +3048,3 @@ def get_mds_standby_replay_info():
         "mds_daemon": ceph_daemon_name,
         "standby_replay_pod": standby_replay_pod.name,
     }
-
-
-def scale_ceph_mon(replica_count, mon_name, ignore_error=False):
-    """
-    Scaling up/down mon deployment.
-
-    Args:
-        replica_count (int): number of replicas to scale
-        mon_name (str): mon deployment name
-        ignore_errors (bool, optional): Ignore errors. Defaults to False.
-
-    Returns:
-        None
-    """
-    logger.info(f"Scaling mon {mon_name} to replica count {replica_count}")
-    run_cmd(
-        f"oc scale --replicas={replica_count} deploy/{mon_name} -n {constants.OPENSHIFT_STORAGE_NAMESPACE}",
-        ignore_error=ignore_error,
-    )

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3048,3 +3048,22 @@ def get_mds_standby_replay_info():
         "mds_daemon": ceph_daemon_name,
         "standby_replay_pod": standby_replay_pod.name,
     }
+
+
+def scale_ceph_mon(replica_count, mon_name, ignore_error=False):
+    """
+    Scaling up/down mon deployment.
+
+    Args:
+        replica_count (int): number of replicas to scale
+        mon_name (str): mon deployment name
+        ignore_errors (bool, optional): Ignore errors. Defaults to False.
+
+    Returns:
+        None
+    """
+    logger.info(f"Scaling mon {mon_name} to replica count {replica_count}")
+    run_cmd(
+        f"oc scale --replicas={replica_count} deploy/{mon_name} -n {constants.OPENSHIFT_STORAGE_NAMESPACE}",
+        ignore_error=ignore_error,
+    )

--- a/tests/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/encryption/test_mon_failure_in_intransit_encryption.py
@@ -14,7 +14,8 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 
-from ocs_ci.ocs.cluster import CephCluster, scale_ceph_mon
+from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.helpers.helpers import modify_deployment_replica_count
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class TestMonFailuresWithIntransitEncryption:
             Restoring the mon replicasets
             """
             for mon in self.mons:
-                scale_ceph_mon(1, mon, ignore_error=True)
+                modify_deployment_replica_count(mon, 1)
 
         request.addfinalizer(scale_up_mons_at_teardown)
 
@@ -72,10 +73,11 @@ class TestMonFailuresWithIntransitEncryption:
 
         # Select Two mons
         self.mons = ceph_obj.get_mons_from_cluster()[:2]
+        # self.mons = get_mon_deployments()[:2]
 
         # Scale Down Mon Count to replica=0
         for mon in self.mons:
-            scale_ceph_mon(0, mon)
+            modify_deployment_replica_count(mon, 0)
 
         # Sleeping for 10 seconds to emulate a condition where the 2 mons is inaccessibe  for 10 seconds.
         time.sleep(10)
@@ -89,7 +91,7 @@ class TestMonFailuresWithIntransitEncryption:
 
         log.info(f"Scaling up mons {','.join(self.mons)}")
         for mon in self.mons:
-            scale_ceph_mon(1, mon)
+            modify_deployment_replica_count(mon, 1)
 
         log.info("Waiting for mgr pod move to Running state")
         ceph_obj.scan_cluster()

--- a/tests/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/encryption/test_mon_failure_in_intransit_encryption.py
@@ -1,0 +1,120 @@
+import logging
+import pytest
+import time
+
+from ocs_ci.ocs.resources.storage_cluster import (
+    in_transit_encryption_verification,
+    set_in_transit_encryption,
+    get_in_transit_encryption_config_state,
+)
+from ocs_ci.framework.pytest_customization.marks import (
+    tier4a,
+    skipif_ocs_version,
+)
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import run_cmd
+
+from ocs_ci.ocs.cluster import CephCluster
+
+log = logging.getLogger(__name__)
+
+
+@tier4a
+@skipif_ocs_version("<4.13")
+class TestMonFailuresWithIntransitEncryption:
+    @pytest.fixture(autouse=True)
+    def teardown_fixture(self, request):
+        """
+        Teardown operations.
+        """
+
+        def scale_up_mons_at_teardown():
+            """
+            Restoring the mon replicasets
+            """
+            for mon in self.mons:
+                self.scale_ceph_mon(1, mon, ignore_error=True)
+
+        request.addfinalizer(scale_up_mons_at_teardown)
+
+    def scale_ceph_mon(self, replica_count, mon_name, ignore_error=False):
+        """
+        Scaling up/down mon deployment.
+
+        Args:
+            replica_count (int): number of replicas to scale
+            mon_name (str): mon deployment name
+            ignore_errors (bool, optional): Ignore errors. Defaults to False.
+
+        Returns:
+            None
+        """
+        log.info(f"Scaling mon {mon_name} to replica count {replica_count}")
+        run_cmd(
+            f"oc scale --replicas={replica_count} deploy/{mon_name} -n {constants.OPENSHIFT_STORAGE_NAMESPACE}",
+            ignore_error=ignore_error,
+        )
+
+    def test_mon_failures_with_intransit_encryption(self):
+        """
+        Test case to ensure the proper functioning of mon failures with in-transit encryption.
+
+        Steps:
+            1. Ensure that in-transit encryption is enabled on the setup.
+            2. Scale down two mons.
+            3. Restart Mgr pod.
+            4. Sleep for 5 seconds.
+            5. Scale up mons.
+            6. Sleep for 10 seconds.
+            7. Wait for mgr pod to move to the running state.
+            8. Verify the in-transit encryption configuration after scaling up mons and restarting mgr pod.
+        """
+
+        if not get_in_transit_encryption_config_state():
+            if config.ENV_DATA.get("in_transit_encryption"):
+                pytest.fail("In-transit encryption is not enabled on the setup")
+            else:
+                set_in_transit_encryption()
+
+        ceph_obj = CephCluster()
+
+        log.info("Verifying the in-transit encryption is enable on setup.")
+        assert in_transit_encryption_verification()
+
+        # Select Two mons
+        self.mons = ceph_obj.get_mons_from_cluster()[:2]
+
+        # Scale Down Mon Count to replica=0
+        for mon in self.mons:
+            self.scale_ceph_mon(0, mon)
+
+        time.sleep(10)
+
+        # Restart Mgr pod
+        mgr_pod = ceph_obj.mgrs[0]
+        mgr_pod.delete(wait=True)
+
+        time.sleep(5)
+
+        log.info(f"Scaling up mons {','.join(self.mons)}")
+        for mon in self.mons:
+            self.scale_ceph_mon(1, mon)
+
+        log.info("Waiting for mgr pod move to Running state")
+        ceph_obj.scan_cluster()
+        mgr_pod = ceph_obj.mgrs[0]
+
+        assert ceph_obj.POD.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector=constants.MGR_APP_LABEL,
+            resource_count=1,
+            timeout=100,
+        ), "Mgr pod did'nt move to Running state after 100 seconds"
+
+        log.info(
+            "Verifying the in-transit encryption config "
+            "After scaling up mon and restarting mgr pod"
+        )
+
+        assert in_transit_encryption_verification()

--- a/tests/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/encryption/test_mon_failure_in_intransit_encryption.py
@@ -13,15 +13,15 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.utility.utils import run_cmd
 
-from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.cluster import CephCluster, scale_ceph_mon
 
 log = logging.getLogger(__name__)
 
 
 @tier4a
 @skipif_ocs_version("<4.13")
+@pytest.mark.polarion_id("OCS-4919")
 class TestMonFailuresWithIntransitEncryption:
     @pytest.fixture(autouse=True)
     def teardown_fixture(self, request):
@@ -34,31 +34,14 @@ class TestMonFailuresWithIntransitEncryption:
             Restoring the mon replicasets
             """
             for mon in self.mons:
-                self.scale_ceph_mon(1, mon, ignore_error=True)
+                scale_ceph_mon(1, mon, ignore_error=True)
 
         request.addfinalizer(scale_up_mons_at_teardown)
 
-    def scale_ceph_mon(self, replica_count, mon_name, ignore_error=False):
-        """
-        Scaling up/down mon deployment.
-
-        Args:
-            replica_count (int): number of replicas to scale
-            mon_name (str): mon deployment name
-            ignore_errors (bool, optional): Ignore errors. Defaults to False.
-
-        Returns:
-            None
-        """
-        log.info(f"Scaling mon {mon_name} to replica count {replica_count}")
-        run_cmd(
-            f"oc scale --replicas={replica_count} deploy/{mon_name} -n {constants.OPENSHIFT_STORAGE_NAMESPACE}",
-            ignore_error=ignore_error,
-        )
-
     def test_mon_failures_with_intransit_encryption(self):
         """
-        Test case to ensure the proper functioning of mon failures with in-transit encryption.
+        The test case ensures the proper functioning of in-transit encryption
+        after mon and mgr failures case.
 
         Steps:
             1. Ensure that in-transit encryption is enabled on the setup.
@@ -68,38 +51,45 @@ class TestMonFailuresWithIntransitEncryption:
             5. Scale up mons.
             6. Sleep for 10 seconds.
             7. Wait for mgr pod to move to the running state.
-            8. Verify the in-transit encryption configuration after scaling up mons and restarting mgr pod.
+            8. Verify the in-transit encryption configuration after
+            scaling up mons and restarting mgr pod.
         """
 
         if not get_in_transit_encryption_config_state():
             if config.ENV_DATA.get("in_transit_encryption"):
-                pytest.fail("In-transit encryption is not enabled on the setup")
+                pytest.fail(
+                    "In-transit encryption is not enabled on the setup while it was supposed to be."
+                )
             else:
                 set_in_transit_encryption()
 
         ceph_obj = CephCluster()
 
         log.info("Verifying the in-transit encryption is enable on setup.")
-        assert in_transit_encryption_verification()
+        assert (
+            in_transit_encryption_verification()
+        ), "In transit encryption verification failed"
 
         # Select Two mons
         self.mons = ceph_obj.get_mons_from_cluster()[:2]
 
         # Scale Down Mon Count to replica=0
         for mon in self.mons:
-            self.scale_ceph_mon(0, mon)
+            scale_ceph_mon(0, mon)
 
+        # Sleeping for 10 seconds to emulate a condition where the 2 mons is inaccessibe  for 10 seconds.
         time.sleep(10)
 
         # Restart Mgr pod
         mgr_pod = ceph_obj.mgrs[0]
         mgr_pod.delete(wait=True)
 
+        # Sleeping for 5 seconds to rejoin the manager's pod.
         time.sleep(5)
 
         log.info(f"Scaling up mons {','.join(self.mons)}")
         for mon in self.mons:
-            self.scale_ceph_mon(1, mon)
+            scale_ceph_mon(1, mon)
 
         log.info("Waiting for mgr pod move to Running state")
         ceph_obj.scan_cluster()
@@ -117,4 +107,6 @@ class TestMonFailuresWithIntransitEncryption:
             "After scaling up mon and restarting mgr pod"
         )
 
-        assert in_transit_encryption_verification()
+        assert (
+            in_transit_encryption_verification()
+        ), "In transit encryption verification failed"


### PR DESCRIPTION
       Test case to ensure the proper functioning of mon failures with in-transit encryption.

        Steps:
            1. Ensure that in-transit encryption is enabled on the setup.
            2. Scale down two mons.
            3. Restart Mgr pod.
            4. Sleep for 5 seconds.
            5. Scale up mons.
            6. Sleep for 10 seconds.
            7. Wait for mgr pod to move to the running state.
            8. Verify the in-transit encryption configuration after scaling up mons and restarting mgr pod.