### PR TITLE
use SC with vSAN Default Storage Policy as default for ODF deployment

### DIFF
--- a/conf/ocsci/vsphere_disable_custom_sc_in_deployment.yaml
+++ b/conf/ocsci/vsphere_disable_custom_sc_in_deployment.yaml
@@ -1,0 +1,4 @@
+---
+# This configuration file is used for using default storage class ( thin-csi ) in ODF deployment.
+ENV_DATA:
+  use_custom_sc_in_deployment: false

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -92,7 +92,12 @@ class VSPHEREBASE(Deployment):
 
     # default storage class for StorageCluster CRD on VmWare platform
     if version.get_semantic_ocp_version_from_config() >= version.VERSION_4_13:
-        DEFAULT_STORAGECLASS = "thin-csi"
+        if config.ENV_DATA.get("use_custom_sc_in_deployment"):
+            CUSTOM_STORAGE_CLASS_PATH = os.path.join(
+                constants.TEMPLATE_DEPLOYMENT_DIR, "storageclass_thin-csi-odf.yaml"
+            )
+        else:
+            DEFAULT_STORAGECLASS = "thin-csi"
     else:
         DEFAULT_STORAGECLASS = "thin"
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -237,6 +237,11 @@ ENV_DATA:
   # used in heterogeneous architecture
   num_workers_additional: 0
 
+  # Below parameter is used for using custom storage class ( thin-csi-odf ) in vSphere ODF deployment.
+  # thin-csi-odf is clone of thin-csi but with storage policy as "vSAN Default Storage Policy"
+  # This is used to save the storage in vSphere environment.
+  use_custom_sc_in_deployment: true
+
   # Multus settings
   multus_create_public_net: true
   multus_public_net_name: "public-net"

--- a/ocs_ci/templates/ocs-deployment/storageclass_thin-csi-odf.yaml
+++ b/ocs_ci/templates/ocs-deployment/storageclass_thin-csi-odf.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  name: thin-csi-odf
+parameters:
+  StoragePolicyName: "vSAN Default Storage Policy"
+provisioner: csi.vsphere.vmware.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Description:

Since OCP deployment comes with thin-csi as default SC and it has StoragePolicyName as "openshift-storage-policy-<clustername>". ODF deployment uses thin-csi for deployment which inturn creaes RAID 1 disks for osd and mon. To save storage on vSphere, create new SC which has same param as thin-csi and use that for ODF deployment.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)