### PR TITLE
Edit multiple Red Squad tests' decorators

### DIFF
--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -9,6 +9,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
+    skipif_mcg_only,
     ignore_leftovers,
     tier3,
     polarion_id,
@@ -367,6 +368,7 @@ class TestAdmissionWebhooks(MCGTest):
         else:
             assert False, "Store patch succeeded unexpectedly"
 
+    @skipif_mcg_only
     @polarion_id("OCS-2792")
     def test_pvpool_downscaling(self, backingstore_factory_session):
         """

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     tier3,
     skipif_managed_service,
+    skipif_mcg_only,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -31,6 +32,7 @@ def setup(request):
 
 
 @ignore_leftovers()
+@skipif_mcg_only
 @pytest.mark.usefixtures(setup.__name__)
 class TestMCGResourcesDisruptions(MCGTest):
     """

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -12,7 +12,6 @@ from ocs_ci.ocs.bucket_utils import (
 )
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
-    skipif_ocs_version,
     skipif_disconnected_cluster,
 )
 
@@ -31,7 +30,6 @@ class TestObjectIntegrity(MCGTest):
     Test data integrity of various objects
     """
 
-    @skipif_disconnected_cluster
     @pytest.mark.polarion_id("OCS-1321")
     @pytest.mark.parametrize(
         argnames="bucketclass_dict",
@@ -49,19 +47,19 @@ class TestObjectIntegrity(MCGTest):
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"azure": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier1, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier1, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier1, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier1, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {
@@ -79,7 +77,7 @@ class TestObjectIntegrity(MCGTest):
                         ]
                     },
                 },
-                marks=[tier1, skipif_ocs_version("<4.7")],
+                marks=[tier1, skipif_disconnected_cluster],
             ),
         ],
         ids=[

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -4,11 +4,13 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    polarion_id,
+    skipif_mcg_only,
     tier2,
     tier3,
-    polarion_id,
-    bugzilla,
 )
+
 from ocs_ci.ocs.bucket_utils import (
     wait_for_pv_backingstore,
     check_pv_backingstore_status,
@@ -33,6 +35,7 @@ logger = logging.getLogger(__name__)
 LOCAL_DIR_PATH = "/awsfiles"
 
 
+@skipif_mcg_only
 class TestPvPool:
     """
     Test pv pool related operations
@@ -300,7 +303,6 @@ class TestPvPool:
     @bugzilla("2187789")
     @polarion_id("OCS-4862")
     def test_ephemeral_for_pv_bs(self, backingstore_factory):
-
         """
         Test if ephemeral storage on pv backingstore pod node is getting consumed
         """

--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ibm_cloud,
     skipif_managed_service,
+    skipif_mcg_only,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
@@ -89,6 +90,7 @@ class TestS3Routes:
     @skipif_external_mode
     @pytest.mark.polarion_id("OCS-4648")
     @skipif_ocs_version("<4.11")
+    @skipif_mcg_only
     def test_s3_routes_reconcile(self, revert_routes):
         """
         Tests:


### PR DESCRIPTION
1. Fixes #7913: Add the skipif_mcg_only decorator to the listed tests
2. Make sure test_check_object_integrity[DEFAULT-BACKINGSTORE]  is not skipped in disconnected deployments