### PR TITLE
[WIP]: Upgrade ocp without --force flag

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1379,19 +1379,20 @@ def confirm_cluster_operator_version(target_version, cluster_operator):
     return False
 
 
-def upgrade_ocp(image_path, image):
+def upgrade_ocp(image_path, image, force=False):
     """
     upgrade OCP version
 
     Args:
         image (str): image to be installed
         image_path (str): path to image
+        force (bool): Allow upgrade with force to disable checks
 
     """
     ocp = OCP()
     ocp.exec_oc_cmd(
         f"adm upgrade --to-image={image_path}:{image} "
-        f"--allow-explicit-upgrade --force "
+        f"--allow-explicit-upgrade --force={force} "
     )
     log.info(f"Upgrading OCP to version: {image} ")
 


### PR DESCRIPTION
Description:

Currently we are upgrading oc with --force flag. "--force" flag was used to perform the upgrade which would cause the upgrade procedure to ignore errors.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)