### PR TITLE
fix removal of MS tests from skiped list

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -719,10 +719,9 @@ def pytest_collection_modifyitems(items):
     ]
     if not config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
         for item in items.copy():
-            for testname in skip_list:
-                if testname in str(item.fspath):
-                    logger.debug(
-                        f"Test {item} is removed from the collected items"
-                        f" since it requires Managed service platform"
-                    )
-                    items.remove(item)
+            if str(item.name) in skip_list:
+                logger.debug(
+                    f"Test {item} is removed from the collected items"
+                    f" since it requires Managed service platform"
+                )
+                items.remove(item)


### PR DESCRIPTION
- this fixes issue in PR#7862 - `fspath` contains path to the file with tests, not the test name
- also the original condition in the code `if testname in str(item....)` would remove also tests with partial match - e.g. `test_foo` testname will match also with `test_foo_bar` test.