### PR TITLE
Use provider cluster to get StorageCluster in FaaS

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -24,7 +24,6 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
-from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 from ocs_ci.ocs.utils import mirror_image
 from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
@@ -2934,6 +2933,7 @@ def storagecluster_independent_check():
         bool: True if storagecluster is running on external mode False otherwise
 
     """
+    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 
     storage_cluster = get_storage_cluster()
 

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -24,6 +24,7 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
+from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 from ocs_ci.ocs.utils import mirror_image
 from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
@@ -2933,14 +2934,14 @@ def storagecluster_independent_check():
         bool: True if storagecluster is running on external mode False otherwise
 
     """
-    storage_cluster = (
-        OCP(kind="StorageCluster", namespace=config.ENV_DATA["cluster_namespace"])
-        .get()
-        .get("items")[0]
-    )
+
+    storage_cluster = get_storage_cluster()
 
     return bool(
-        storage_cluster.get("spec", {}).get("externalStorage", {}).get("enable", False)
+        storage_cluster.get()
+        .get("spec", {})
+        .get("externalStorage", {})
+        .get("enable", False)
     )
 
 

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -4,6 +4,7 @@ StorageCluster related functionalities
 import copy
 import ipaddress
 import logging
+import os
 import re
 import tempfile
 import json
@@ -1302,7 +1303,23 @@ def get_storage_cluster(namespace=config.ENV_DATA["cluster_namespace"]):
         storage cluster (obj) : Storage cluster object handler
 
     """
-    sc_obj = OCP(kind=constants.STORAGECLUSTER, namespace=namespace)
+    # In FaaS platform, the StorageCluster CR is only present in the provider cluster
+    if (
+        config.multicluster
+        and config.ENV_DATA.get("platform", "").lower() == constants.FUSIONAAS_PLATFORM
+    ):
+        provider_kubeconfig = os.path.join(
+            config.clusters[config.get_provider_index()].ENV_DATA["cluster_path"],
+            config.clusters[config.get_provider_index()].RUN.get("kubeconfig_location"),
+        )
+        cluster_kubeconfig = provider_kubeconfig
+    else:
+        cluster_kubeconfig = ""
+    sc_obj = OCP(
+        kind=constants.STORAGECLUSTER,
+        namespace=namespace,
+        cluster_kubeconfig=cluster_kubeconfig,
+    )
     return sc_obj
 
 


### PR DESCRIPTION
In FaaS platform, StorageCluster CR is present in provider cluster only. Issues like #8027  will be seen due to this. Using provider cluster to fetch StorageCluster will be a solution for this. Currently, the function storagecluster_independent_check is updated to use get_storage_cluster function. 
get_storage_cluster can be used in other places to solve such issues issue when it arises.

Fixes #8027