### PR TITLE
discon. cl.: ensure that metadata.json file exists

### DIFF
--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -10,6 +10,7 @@ import yaml
 
 import io
 import configparser
+from pathlib import Path
 from semantic_version import Version
 import subprocess
 from subprocess import CalledProcessError
@@ -594,6 +595,10 @@ class FlexyBase(object):
         # only works with 'debug' option
         if log_level:
             pass
+        # create empty metadata.json file in cluster dir, to ensure, that
+        # destroy job will be properly triggered even when the deployment fails
+        # and metadata.json file will not be created
+        Path(os.path.join(self.cluster_path, "metadata.json")).touch()
         cmd = self.build_install_cmd()
         # Ensure that flexy workdir will be copied to cluster dir even when
         # Flexy itself fails.


### PR DESCRIPTION
- if disconnected deployment using flexy fails before the OCP cluster deployment start (e.g. during images mirroring), the metadata.json file is not created and Destroy job is not properly triggered. This change ensures that at least empty metadata.json file exists and full Destroy job is properly triggerd and all resources are cleaned up.