### PR TITLE
properly parse version from rc and upgrade images

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2979,7 +2979,13 @@ def get_ocs_version_from_image(image):
 
     """
     try:
-        version = image.rsplit(":", 1)[1].lstrip("latest-").lstrip("stable-")
+        version = (
+            image.rsplit(":", 1)[1]
+            .lstrip("latest-")
+            .lstrip("stable-")
+            .lstrip("rc-")
+            .lstrip("upgrade-")
+        )
         version = Version.coerce(version)
         return "{major}.{minor}".format(major=version.major, minor=version.minor)
     except ValueError:


### PR DESCRIPTION
This should fix following issues:
`OCS_REGISTRY_IMAGE: quay.io/rhceph-dev/ocs-registry:latest-rc-4.12.4`
```
2023-07-20 14:32:08  The version: rc-4.12.4 couldn't be parsed!
2023-07-20 14:32:08  Traceback (most recent call last):
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/bin/run-ci", line 11, in <module>
2023-07-20 14:32:08      load_entry_point('ocs-ci', 'console_scripts', 'run-ci')()
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/main.py", line 286, in main
2023-07-20 14:32:08      init_ocsci_conf(arguments)
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/main.py", line 90, in init_ocsci_conf
2023-07-20 14:32:08      process_ocsci_conf(arguments)
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/main.py", line 150, in process_ocsci_conf
2023-07-20 14:32:08      ocs_version_from_image = utils.get_ocs_version_from_image(ocs_registry_image)
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/utils.py", line 2956, in get_ocs_version_from_image
2023-07-20 14:32:08      version = Version.coerce(version)
2023-07-20 14:32:08    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.8/site-packages/semantic_version/base.py", line 236, in coerce
2023-07-20 14:32:08      raise ValueError(
2023-07-20 14:32:08  ValueError: Version string lacks a numerical component: 'rc-4.12.4'
```

