### PR TITLE
Update the RPC payload at `test_buckets_before_upgrade`

### DIFF
--- a/tests/ecosystem/upgrade/conftest.py
+++ b/tests/ecosystem/upgrade/conftest.py
@@ -550,9 +550,11 @@ def upgrade_buckets(bucket_factory_session, awscli_pod_session, mcg_obj_session)
         "quota": {
             "size": {
                 "unit": "P",
+                # The size value here refers to how many Petabytes are allowed
                 "value": 1,
             },
-            "quantity": {"value": 1},
+            # The quantity value here refers to max number of objects
+            "quantity": {"value": 1000},
         },
     }
 

--- a/tests/ecosystem/upgrade/conftest.py
+++ b/tests/ecosystem/upgrade/conftest.py
@@ -544,10 +544,22 @@ def upgrade_buckets(bucket_factory_session, awscli_pod_session, mcg_obj_session)
     buckets = bucket_factory_session(amount=3)
 
     # add quota to the first bucket
+
+    update_quota_payload = {
+        "name": buckets[0].name,
+        "quota": {
+            "size": {
+                "unit": "P",
+                "value": 1,
+            },
+            "quantity": {"value": 1},
+        },
+    }
+
     mcg_obj_session.send_rpc_query(
         "bucket_api",
         "update_bucket",
-        {"name": buckets[0].name, "quota": {"unit": "PETABYTE", "size": 1}},
+        update_quota_payload,
     )
 
     # add some data to the first pod


### PR DESCRIPTION
Fixes: #8072 

Required backports:

- [ ] - 4.13
- [ ] - 4.12