### PR TITLE
Fix AWS cleanUp

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1005,8 +1005,8 @@ def get_openshift_client(
             extract_ocp_binary_from_image("oc", custom_ocp_image, bin_dir)
         try:
             client_version = run_cmd(f"{client_binary_path} version --client")
-        except CommandFailed:
-            log.error("Unable to get version from downloaded client.")
+        except Exception as e:
+            log.error(f"Unable to get version from downloaded client. {e}")
         if client_version:
             try:
                 delete_file(client_binary_backup)


### PR DESCRIPTION
AWS_Cleanup jobs failed because the command `./bin/oc version --client` return `No such file or directory: './bin/oc'`
https://url.corp.redhat.com/bbd9745

```
2023-07-26 15:47:28  2023-07-26 12:47:28,532 - MainThread - ocs_ci.utility.utils - INFO - Executing command: ./bin/oc version --client
2023-07-26 15:47:28  Traceback (most recent call last):
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/.venv/bin/aws-cleanup", line 11, in <module>
2023-07-26 15:47:28      load_entry_point('ocs-ci', 'console_scripts', 'aws-cleanup')()
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/ocs_ci/cleanup/aws/cleanup.py", line 401, in aws_cleanup
2023-07-26 15:47:28      get_openshift_installer()
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/ocs_ci/utility/utils.py", line 762, in get_openshift_installer
2023-07-26 15:47:28      get_openshift_client()
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/ocs_ci/utility/utils.py", line 1007, in get_openshift_client
2023-07-26 15:47:28      client_version = run_cmd(f"{client_binary_path} version --client")
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/ocs_ci/utility/utils.py", line 480, in run_cmd
2023-07-26 15:47:28      completed_process = exec_cmd(
2023-07-26 15:47:28    File "/home/jenkins/workspace/qe-aws-cleanup/ocs-ci/ocs_ci/utility/utils.py", line 629, in exec_cmd
2023-07-26 15:47:28      completed_process = subprocess.run(
2023-07-26 15:47:28    File "/usr/lib64/python3.8/subprocess.py", line 493, in run
2023-07-26 15:47:28      with Popen(*popenargs, **kwargs) as process:
2023-07-26 15:47:28    File "/usr/lib64/python3.8/subprocess.py", line 858, in __init__
2023-07-26 15:47:28      self._execute_child(args, executable, preexec_fn, close_fds,
2023-07-26 15:47:28    File "/usr/lib64/python3.8/subprocess.py", line 1704, in _execute_child
2023-07-26 15:47:28      raise child_exception_type(errno_num, err_msg, err_filename)
2023-07-26 15:47:28  FileNotFoundError: [Errno 2] No such file or directory: './bin/oc'
2023-07-26 15:47:28  + aws_cleanup_rc=1
2023-07-26 15:47:28  + exit 1
```