### PR TITLE
Extract the pull-secret and place it under /data dir

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -965,8 +965,18 @@ class MCG:
                 image = f"registry.redhat.io/odf4/mcg-cli-rhel9:v{semantic_version}"
             else:
                 image = f"quay.io/rhceph-dev/mcg-cli:{get_ocs_build_number()}"
+
             pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
 
+            if not os.path.isfile(pull_secret_path):
+                logger.info(
+                    f"Extracting pull-secret and placing it under {pull_secret_path}"
+                )
+                exec_cmd(
+                    f"oc get secret pull-secret -n {constants.OPENSHIFT_CONFIG_NAMESPACE} -ojson | "
+                    f"jq -r '.data.\".dockerconfigjson\"|@base64d' > {pull_secret_path}",
+                    shell=True,
+                )
             exec_cmd(
                 f"oc image extract --registry-config {pull_secret_path} "
                 f"{image} --confirm "


### PR DESCRIPTION
Fixes #8109 

With this PR we extract the pull-secret (if not already present) from the pullsecret secret in openshift-config namespace and then place it under /data directory