### PR TITLE
Disconnected ODF deployment: apply icsp rules when mirroring images - backport for 4.13

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -92,7 +92,10 @@ from ocs_ci.ocs.utils import (
     get_all_acm_indexes,
     get_active_acm_index,
 )
-from ocs_ci.utility.deployment import create_external_secret
+from ocs_ci.utility.deployment import (
+    create_external_secret,
+    get_and_apply_icsp_from_catalog,
+)
 from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility import (
     templating,
@@ -110,7 +113,6 @@ from ocs_ci.utility.ssl_certs import (
 from ocs_ci.utility.utils import (
     ceph_health_check,
     clone_repo,
-    create_directory_path,
     enable_huge_pages,
     exec_cmd,
     get_latest_ds_olm_tag,
@@ -2011,48 +2013,6 @@ def setup_persistent_monitoring():
     retry((CommandFailed, AssertionError), tries=3, delay=15)(
         validate_pvc_are_mounted_on_monitoring_pods
     )(pods_list)
-
-
-def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
-    """
-    Get ICSP from catalog image (if exists) and apply it on the cluster (if
-    requested).
-
-    Args:
-        image (str): catalog image of ocs registry.
-        apply (bool): controls if the ICSP should be applied or not
-            (default: true)
-        insecure (bool): If True, it allows push and pull operations to registries to be made over HTTP
-
-    Returns:
-        str: path to the icsp.yaml file or empty string, if icsp not available
-            in the catalog image
-
-    """
-
-    icsp_file_location = "/icsp.yaml"
-    icsp_file_dest_dir = os.path.join(
-        config.ENV_DATA["cluster_path"], f"icsp-{config.RUN['run_id']}"
-    )
-    icsp_file_dest_location = os.path.join(icsp_file_dest_dir, "icsp.yaml")
-    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-    create_directory_path(icsp_file_dest_dir)
-    cmd = (
-        f"oc image extract --filter-by-os linux/amd64 --registry-config {pull_secret_path} "
-        f"{image} --confirm "
-        f"--path {icsp_file_location}:{icsp_file_dest_dir}"
-    )
-    if insecure:
-        cmd = f"{cmd} --insecure"
-    exec_cmd(cmd)
-    if not os.path.exists(icsp_file_dest_location):
-        return ""
-
-    if apply:
-        exec_cmd(f"oc apply -f {icsp_file_dest_location}")
-        wait_for_machineconfigpool_status("all")
-
-    return icsp_file_dest_location
 
 
 class RBDDRDeployOps(object):

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -2,6 +2,7 @@
 Utility functions that are used as a part of OCP or OCS deployments
 """
 import logging
+import os
 import re
 import tempfile
 
@@ -11,7 +12,12 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ExternalClusterDetailsException
 from ocs_ci.utility import templating
-from ocs_ci.utility.utils import run_cmd
+from ocs_ci.utility.utils import (
+    create_directory_path,
+    exec_cmd,
+    run_cmd,
+    wait_for_machineconfigpool_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +105,45 @@ def get_cluster_prefix(cluster_name, special_rules):
     if prefix.startswith("-"):
         prefix = prefix[1:]
     return prefix
+
+
+def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
+    """
+    Get ICSP from catalog image (if exists) and apply it on the cluster (if
+    requested).
+
+    Args:
+        image (str): catalog image of ocs registry.
+        apply (bool): controls if the ICSP should be applied or not
+            (default: true)
+        insecure (bool): If True, it allows push and pull operations to registries to be made over HTTP
+
+    Returns:
+        str: path to the icsp.yaml file or empty string, if icsp not available
+            in the catalog image
+
+    """
+
+    icsp_file_location = "/icsp.yaml"
+    icsp_file_dest_dir = os.path.join(
+        config.ENV_DATA["cluster_path"], f"icsp-{config.RUN['run_id']}"
+    )
+    icsp_file_dest_location = os.path.join(icsp_file_dest_dir, "icsp.yaml")
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+    create_directory_path(icsp_file_dest_dir)
+    cmd = (
+        f"oc image extract --filter-by-os linux/amd64 --registry-config {pull_secret_path} "
+        f"{image} --confirm "
+        f"--path {icsp_file_location}:{icsp_file_dest_dir}"
+    )
+    if insecure:
+        cmd = f"{cmd} --insecure"
+    exec_cmd(cmd)
+    if not os.path.exists(icsp_file_dest_location):
+        return ""
+
+    if apply and not config.DEPLOYMENT.get("disconnected"):
+        exec_cmd(f"oc apply -f {icsp_file_dest_location}")
+        wait_for_machineconfigpool_status("all")
+
+    return icsp_file_dest_location


### PR DESCRIPTION
- use icsp rules from ocs-registry image for mirroring images for disconnected deployment
- do not apply icsp rules from ocs-registry image on disconnected cluster
- moving get_and_apply_icsp_from_catalog() to ocs_ci/utility/deployment.py to avoid circular imports

backporting https://github.com/red-hat-storage/ocs-ci/pull/8106