### PR TITLE
[release-4.13 backport] Ignore the noobaa-endpoint pods leftovers at `test_nsfs.py`

### DIFF
--- a/tests/manage/mcg/test_nsfs.py
+++ b/tests/manage/mcg/test_nsfs.py
@@ -6,9 +6,12 @@ from ocs_ci.framework.testlib import MCGTest, tier1, tier3
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     skipif_ocs_version,
+    ignore_leftover_label,
 )
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
 from ocs_ci.ocs.exceptions import CommandFailed
+
 
 from ocs_ci.ocs.resources.mcg_params import NSFS
 from ocs_ci.utility.retry import retry
@@ -18,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 @skipif_mcg_only
 @skipif_ocs_version("<4.10")
+@ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)
 class TestNSFSObjectIntegrity(MCGTest):
     """
     Test the integrity of IO operations on NSFS buckets


### PR DESCRIPTION
4.13 backport of #7872