### PR TITLE
Fix for the common tox issue: 'isinstance instead of type(obj) == type'

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -172,7 +172,7 @@ def wait_for_job_completion(namespace, timeout, error_msg):
         )
     except Exception as ex:
         # report some high level error as well in case of a timeout error
-        if type(ex) == TimeoutExpiredError:
+        if isinstance(ex, TimeoutExpiredError):
             logger.error(error_msg)
             ex.message = error_msg
         # fetch log(s) of any fio pod(s) in the job namespace

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1307,7 +1307,7 @@ def get_images(data, images=None):
         # Check if we have those keys: 'name' and 'value' in the data dict.
         # If yes and the value ends with '_IMAGE' we found the image.
         if set(("name", "value")) <= data.keys() and (
-            type(data["name"]) == str and data["name"].endswith("_IMAGE")
+            isinstance(data["name"], str) and data["name"].endswith("_IMAGE")
         ):
             image_name = data["name"].rstrip("_IMAGE").lower()
             image = data["value"]

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -182,9 +182,9 @@ class ObjectBucket(ABC):
         return hash(self.name)
 
     def __eq__(self, other):
-        if type(other) == str:
+        if isinstance(other, str):
             return self.name == other
-        elif type(other) == ObjectBucket:
+        elif isinstance(other, ObjectBucket):
             return self.name == other.name
 
     def delete(self, verify=True):

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -72,7 +72,7 @@ class PackageManifest(OCP):
         selector = selector if selector else self.selector
 
         data = super(PackageManifest, self).get(**kwargs)
-        if type(data) == dict and (data.get("kind") == "List"):
+        if isinstance(data, dict) and (data.get("kind") == "List"):
             items = data["items"]
             data_len = len(items)
             if data_len == 0 and selector and resource_name:

--- a/ocs_ci/ocs/tests/test_fiojob.py
+++ b/ocs_ci/ocs/tests/test_fiojob.py
@@ -63,13 +63,13 @@ def test_fio_to_dict_empty():
 
 def test_fio_to_dict_without_error(fio_json_output):
     fio_dict = fiojob.fio_to_dict(fio_json_output)
-    assert type(fio_dict) == dict
+    assert isinstance(fio_dict, dict)
     assert len(fio_dict["jobs"]) == 1
 
 
 def test_fio_to_dict_with_error(fio_json_output_with_error):
     fio_dict = fiojob.fio_to_dict(fio_json_output_with_error)
-    assert type(fio_dict) == dict
+    assert isinstance(fio_dict, dict)
     assert len(fio_dict["jobs"]) == 1
 
 

--- a/ocs_ci/ocs/ui/odf_topology.py
+++ b/ocs_ci/ocs/ui/odf_topology.py
@@ -338,7 +338,9 @@ class OdfTopologyHelper:
         """
         try:
             resource_list = self.topology_cli_df[node_name][deployment_name]
-            delp_obj = [resource for resource in resource_list if type(resource) == OCP]
+            delp_obj = [
+                resource for resource in resource_list if isinstance(resource, OCP)
+            ]
             if len(delp_obj) == 0:
                 logger.error(f"no deployment '{deployment_name}' in node '{node_name}'")
             return delp_obj[0]
@@ -417,7 +419,7 @@ class OdfTopologyHelper:
         pod_objs = [
             resource
             for resource in resource_list
-            if type(resource) == Pod and resource.name == pod_name
+            if isinstance(resource, Pod) and resource.name == pod_name
         ]
         if len(pod_objs) == 0:
             logger.error(

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3224,7 +3224,7 @@ def convert_bytes_to_unit(bytes_to_convert):
         str: The converted bytes as biggest unit possible
 
     """
-    if type(bytes_to_convert) != str:
+    if not isinstance(bytes_to_convert, str):
         log.error("Unable to convert, expected string")
     if float(bytes_to_convert) < constants.BYTES_IN_KB:
         return f"{bytes_to_convert}B"
@@ -3256,7 +3256,7 @@ def prepare_customized_pull_secret(images=None):
 
     """
     log.debug(f"Prepare customized pull-secret for images: {images}")
-    if type(images) == str:
+    if isinstance(images, str):
         images = [images]
     # load pull-secret file to pull_secret dict
     pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")


### PR DESCRIPTION
remove flake8 errors from tox logs

tox: flake8
  flake8: commands[0]> flake8 ocs_ci tests
  ocs_ci/ocs/fiojob.py:175:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/ocp.py:1309:55: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/resources/objectbucket.py:185:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/resources/objectbucket.py:187:14: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/resources/packagemanifest.py:75:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/tests/test_fiojob.py:66:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/tests/test_fiojob.py:72:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/ui/odf_topology.py:341:67: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/ocs/ui/odf_topology.py:420:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/utility/utils.py:3227:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  ocs_ci/utility/utils.py:3259:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
  flake8: exit 1 (13.70 seconds) /home/runner/work/ocs-ci/ocs-ci> flake8 ocs_ci tests pid=[402](https://github.com/red-hat-storage/ocs-ci/actions/runs/5706426266/job/15462095420#step:6:404)4
flake8: FAIL ✖ in 17.66 seconds

-------------
Requires to backward support

- [ ] 4.13
- [ ]  4.12
- [ ]  4.11
- [ ]  4.10
