### PR TITLE
Fix test_recovery_from_volume_deletion to fetch vol id as per pv yaml change

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -272,9 +272,7 @@ class VMWareNodes(NodesBase):
         """
         if not pvs:
             pvs = get_deviceset_pvs()
-        return [
-            pv.get().get("spec").get("vsphereVolume").get("volumePath") for pv in pvs
-        ]
+        return [pv.get().get("spec").get("csi").get("volumeHandle") for pv in pvs]
 
     def get_node_by_attached_volume(self, volume):
         """


### PR DESCRIPTION
In test_recovery_from_volume_deletion, we see a failure in fetching volumePath due to changes in PV yamls.

return [
  pv.get().get("spec").get("vsphereVolume").get("volumePath") for pv in pvs
]
E   AttributeError: 'NoneType' object has no attribute 'get'

4.12 PV yaml- http://magna002.ceph.redhat.com/ocsci-jenkins/openshift-clusters/j-137vukv11cs33-t1/j-137vukv11cs33-t1_20230717T152243/logs/failed_testcase_ocs_logs_1689610546/test_ceph_csidriver_runs_on_non_ocs_nodes_ocs_logs/ocs_must_gather/quay-io-rhceph-dev-ocs-must-gather-sha256-76e0eaf8e458f3653cfae160ea8368e6cbedd7d419be2672677fcc7b60fa9889/cluster-scoped-resources/core/persistentvolumes/pvc-ff241165-e3e3-4107-9236-e6038c52069b.yaml

4.13 PV yaml- http://magna002.ceph.redhat.com/ocsci-jenkins/openshift-clusters/j-303vuf1cs36-t4a/j-303vuf1cs36-t4a_20230706T070701/logs/failed_testcase_ocs_logs_1688631432/test_recovery_from_volume_deletion_ocs_logs/j-303vuf1cs36-t4a/ocs_must_gather/quay-io-rhceph-dev-ocs-must-gather-sha256-3bca8d4b745fbb94c9fce66fef923795a809d65c933d4eef9b91e9127e0ab51b/cluster-scoped-resources/core/persistentvolumes/pvc-e7875c47-fda8-49d1-b65e-ad06a9defae9.yaml