### PR TITLE
Change network interface for multus deployment

### DIFF
--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_cluster_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_cluster_nvme_intel_3m_3w.yaml
@@ -11,7 +11,7 @@ ENV_DATA:
   osd_type: 'nvme'
   disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
-  multus_cluster_net_interface: 'enp1s0f0'
+  multus_cluster_net_interface: 'enp1s0f1'
   multus_create_public_net: false
   multus_create_cluster_net: true
   multus_cluster_net_namespace: "default"

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w.yaml
@@ -11,8 +11,8 @@ ENV_DATA:
   osd_type: 'nvme'
   disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
-  multus_public_net_interface: 'enp1s0f0'
-  multus_cluster_net_interface: 'enp1s0f0'
+  multus_public_net_interface: 'enp1s0f1'
+  multus_cluster_net_interface: 'enp1s0f1'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2510'

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_public_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_public_nvme_intel_3m_3w.yaml
@@ -11,7 +11,7 @@ ENV_DATA:
   osd_type: 'nvme'
   disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
-  multus_public_net_interface: 'enp1s0f0'
+  multus_public_net_interface: 'enp1s0f1'
   multus_create_public_net: true
   multus_create_cluster_net: false
   multus_public_net_namespace: "default"


### PR DESCRIPTION
On our BM there are 2 NICs [1G,10G]
We need to work on 10G
```
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
 name: public-net
 namespace: openshift-storage
 labels: {}
 annotations: {}
spec:
 config: '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "enp1s0f1", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.20.0/24" } }'
---
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
 name: cluster-net
 namespace: openshift-storage
 labels: {}
 annotations: {}
spec:
  config: '{ "cniVersion": "0.3.1", "type": "macvlan", "master": "enp1s0f1", "mode": "bridge", "ipam": { "type": "whereabouts", "range": "192.168.30.0/24" } }'
```

In addition, I verified traffic on enp1s0f1: https://url.corp.redhat.com/4eaeddf

![image](https://github.com/red-hat-storage/ocs-ci/assets/61982127/7de9729f-c0f2-4975-9573-680cc0e50c7e)





