### PR TITLE
'SeleniumDriver' object has no attribute 'driver' - fix

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -725,9 +725,14 @@ class SeleniumDriver(WebDriver):
 
     # noinspection PyUnresolvedReferences
     def __new__(cls):
-        if not hasattr(cls, "instance"):
+        if not hasattr(cls, "instance") or not hasattr(cls.instance, "driver"):
+            logger.debug("Creating instance of Selenium Driver")
             cls.instance = super(SeleniumDriver, cls).__new__(cls)
             cls.instance.driver = cls._set_driver()
+        else:
+            logger.debug(
+                "SeleniumDriver instance already exists, driver created earlier"
+            )
         return cls.instance.driver
 
     @classmethod


### PR DESCRIPTION
### Fix case when driver removed and selenium class not
class constructor failing to return 'driver' attribute.
assumption is that python garbage collector deletes the driver when not referred for a long time .

fix creates SeleniumDriver class and sets the driver again if 'driver' attribute not found

FIXES: https://github.com/red-hat-storage/ocs-ci/issues/7859

Verified by specifically added test - https://github.com/red-hat-storage/ocs-ci/pull/8073
https://url.corp.redhat.com/no-driver-attribute
-> all failures analyzed, part of them caused by bad health of the cluster and another part anticipated to fail to check behavior and driver recreation for the test failure

need to be backported:

- [ ] 4.13
- [ ] 4.12
