### PR TITLE
Disconected deployment: extend time for mirroring images (for 4.10)

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -173,7 +173,7 @@ def prune_and_mirror_index_image(
         f"oc adm catalog mirror {mirrored_index_image} -a {pull_secret_path} --insecure "
         f"{config.DEPLOYMENT['mirror_registry']} --index-filter-by-os='.*' --max-per-registry=2"
     )
-    oc_acm_result = exec_cmd(cmd, timeout=7200)
+    oc_acm_result = exec_cmd(cmd, timeout=10800)
 
     for line in oc_acm_result.stdout.decode("utf-8").splitlines():
         if "wrote mirroring manifests to" in line:


### PR DESCRIPTION
```
2023-08-09 16:14:45  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-08-09 16:14:45  ocs_ci/deployment/deployment.py:318: in deploy_cluster
2023-08-09 16:14:45      self.do_deploy_ocs()
2023-08-09 16:14:45  ocs_ci/deployment/deployment.py:215: in do_deploy_ocs
2023-08-09 16:14:45      self.deploy_ocs()
2023-08-09 16:14:45  ocs_ci/deployment/deployment.py:1157: in deploy_ocs
2023-08-09 16:14:45      image = prepare_disconnected_ocs_deployment()
2023-08-09 16:14:45  ocs_ci/deployment/disconnected.py:414: in prepare_disconnected_ocs_deployment
2023-08-09 16:14:45      prune_and_mirror_index_image(
2023-08-09 16:14:45  ocs_ci/deployment/disconnected.py:176: in prune_and_mirror_index_image
2023-08-09 16:14:45      oc_acm_result = exec_cmd(cmd, timeout=7200)
2023-08-09 16:14:45  ocs_ci/utility/utils.py:610: in exec_cmd
2023-08-09 16:14:45      completed_process = subprocess.run(
2023-08-09 16:14:45  /usr/lib64/python3.8/subprocess.py:495: in run
2023-08-09 16:14:45      stdout, stderr = process.communicate(input, timeout=timeout)
2023-08-09 16:14:45  /usr/lib64/python3.8/subprocess.py:1028: in communicate
2023-08-09 16:14:45      stdout, stderr = self._communicate(input, endtime, timeout)
2023-08-09 16:14:45  /usr/lib64/python3.8/subprocess.py:1869: in _communicate
2023-08-09 16:14:45      self._check_timeout(endtime, orig_timeout, stdout, stderr)
2023-08-09 16:14:45  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-08-09 16:14:45  
2023-08-09 16:14:45  self = <subprocess.Popen object at 0x7fea2c91c8e0>, endtime = 12616.797880524
2023-08-09 16:14:45  orig_timeout = 7200
2023-08-09 16:14:45  stdout_seq = [b'src image has index label for database path: /database/index.db\nusing index path mapping: /database/index.db:/tmp/...2-3-137-190-156.us-east-2.compute.amazonaws.com:5000/openshift-logging/cluster-logging-operator-bundle:4a179ef\n', ...]
2023-08-09 16:14:45  stderr_seq = [b'\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n!! DEPRECATION NOTICE:\n!!   Sq....redhat.io/odf4/cephcsi-rhel8 sha256:2a96e1d491e04d05a4dae0554c2052186ffec9c62fb256bb53515b99340c29fd 4.445KiB\n', ...]
2023-08-09 16:14:45  skip_check_and_raise = False
2023-08-09 16:14:45  
2023-08-09 16:14:45      def _check_timeout(self, endtime, orig_timeout, stdout_seq, stderr_seq,
2023-08-09 16:14:45                         skip_check_and_raise=False):
2023-08-09 16:14:45          """Convenience for checking if a timeout has expired."""
2023-08-09 16:14:45          if endtime is None:
2023-08-09 16:14:45              return
2023-08-09 16:14:45          if skip_check_and_raise or _time() > endtime:
2023-08-09 16:14:45  >           raise TimeoutExpired(
2023-08-09 16:14:45                      self.args, orig_timeout,
2023-08-09 16:14:45                      output=b''.join(stdout_seq) if stdout_seq else None,
2023-08-09 16:14:45                      stderr=b''.join(stderr_seq) if stderr_seq else None)
2023-08-09 16:14:45  E           subprocess.TimeoutExpired: Command '['oc', 'adm', 'catalog', 'mirror', '.....amazonaws.com:5000/olm-mirror/redhat-operator-index:v4.10', '-a', '/home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/pull-secret', '--insecure', '...amazonaws.com:5000', '--index-filter-by-os=.*', '--max-per-registry=2']' timed out after 7200 seconds
2023-08-09 16:14:45  
2023-08-09 16:14:45  /usr/lib64/python3.8/subprocess.py:1072: TimeoutExpired
```

https://url.corp.redhat.com/58f5605