### PR TITLE
cherry-pick. SeleniumDriver attribute error fix

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -2059,9 +2059,14 @@ class SeleniumDriver(WebDriver):
 
     # noinspection PyUnresolvedReferences
     def __new__(cls):
-        if not hasattr(cls, "instance"):
+        if not hasattr(cls, "instance") or not hasattr(cls.instance, "driver"):
+            logger.debug("Creating instance of Selenium Driver")
             cls.instance = super(SeleniumDriver, cls).__new__(cls)
             cls.instance.driver = cls._set_driver()
+        else:
+            logger.debug(
+                "SeleniumDriver instance already exists, driver created earlier"
+            )
         return cls.instance.driver
 
     @classmethod


### PR DESCRIPTION
Backport.

Fix case when SeleniumDriver exists and driver attribute not.

ISSUE: https://github.com/red-hat-storage/ocs-ci/issues/7859