### PR TITLE
[release-4.13 backport] s3cli-sts: runAsUser 0 with image 2.0

### DIFF
--- a/ocs_ci/templates/mcg/s3cli-sts.yaml
+++ b/ocs_ci/templates/mcg/s3cli-sts.yaml
@@ -25,7 +25,7 @@ spec:
             name: awscli-service-ca
       containers:
         - name: s3cli
-          image: quay.io/ocsci/s3-cli-with-test-objects-multiarch:1.0
+          image: quay.io/ocsci/s3-cli-with-test-objects-multiarch:2.0
           command: ['/bin/sh']
           stdin: true
           tty: true


### PR DESCRIPTION
release-4.13 backport of #8175