### PR TITLE
PDB verification skip for external mode

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1538,7 +1538,8 @@ class Deployment(object):
         enable_console_plugin()
 
         # validate PDB creation of MON, MDS, OSD pods
-        validate_pdb_creation()
+        if not config.DEPLOYMENT["external_mode"]:
+            validate_pdb_creation()
 
         # Verify health of ceph cluster
         logger.info("Done creating rook resources, waiting for HEALTH_OK")


### PR DESCRIPTION
In external mode deployment, there is no MDS, MON and OSD pods, so there will no PDB's created.

Fixes: #8266 

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)