### PR TITLE
[4.12]: MachineConfigPool skip for IBM Managed cloud

### DIFF
--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -152,6 +152,11 @@ def get_and_apply_icsp_from_catalog(image, apply=True, insecure=False):
 
     if apply and not config.DEPLOYMENT.get("disconnected"):
         exec_cmd(f"oc apply -f {icsp_file_dest_location}")
-        wait_for_machineconfigpool_status("all")
+        managed_ibmcloud = (
+            config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
+            and config.ENV_DATA["deployment_type"] == "managed"
+        )
+        if not managed_ibmcloud:
+            wait_for_machineconfigpool_status("all")
 
     return icsp_file_dest_location


### PR DESCRIPTION
Back-port: https://github.com/red-hat-storage/ocs-ci/pull/8292

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)