### PR TITLE
Add fio parameter direct=1 in the test case test_rbd_block_pvc_snapshot

### DIFF
--- a/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
@@ -76,6 +76,7 @@ class TestRbdBlockPvcSnapshot(ManageTest):
                 size=f"{self.pvc_size - 1}G",
                 io_direction="write",
                 runtime=60,
+                direct=1,
             )
         log.info("IO started on all pods")
 
@@ -203,7 +204,7 @@ class TestRbdBlockPvcSnapshot(ManageTest):
         # Run IO on new pods
         log.info("Starting IO on new pods")
         for pod_obj in restore_pod_objs:
-            pod_obj.run_io(storage_type="block", size="500M", runtime=15)
+            pod_obj.run_io(storage_type="block", size="500M", runtime=15, direct=1)
 
         # Wait for IO completion on new pods
         log.info("Waiting for IO completion on new pods")


### PR DESCRIPTION
Update the test case given below to add the parameter direct=1 in fio command.
tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py::TestRbdBlockPvcSnapshot::test_rbd_block_pvc_snapshot

Fixes #8312 