### PR TITLE
Revert back to use default fio timeout value in get_fio_rw_iops()

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1316,7 +1316,7 @@ def get_fio_rw_iops(pod_obj):
     Args:
         pod_obj (Pod): The object of the pod
     """
-    fio_result = pod_obj.get_fio_results(120)
+    fio_result = pod_obj.get_fio_results()
     logger.info(f"FIO output: {fio_result}")
     logger.info("IOPs after FIO:")
     logger.info(f"Read: {fio_result.get('jobs')[0].get('read').get('iops')}")


### PR DESCRIPTION
Fixes #8311 
In PR #7669, fio timeout value in `get_fio_rw_iops()` was reduced from default value (600) to 120.
Due to this change, tests are failing with TimeoutError. See #8311 for more details.
Hence reverting back to default timeout value.