### PR TITLE
In the test "rolling_terminate_and_recovery_of_ocs_worker_nodes" with AWS and vSphere IPI delete the machine associated with the terminated worker node

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2661,7 +2661,7 @@ def check_pods_after_node_replacement():
     # Import here to avoid circular loop
     from ocs_ci.ocs.cluster import is_ms_provider_cluster
 
-    are_pods_running = wait_for_pods_to_be_running(timeout=180)
+    are_pods_running = wait_for_pods_to_be_running(timeout=240)
     if are_pods_running:
         return True
 

--- a/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -31,7 +31,11 @@ from ocs_ci.ocs.resources.pod import (
     check_pods_after_node_replacement,
 )
 from ocs_ci.helpers.sanity_helpers import SanityManagedService, Sanity
-from ocs_ci.ocs.cluster import is_ms_provider_cluster, is_managed_service_cluster
+from ocs_ci.ocs.cluster import (
+    is_ms_provider_cluster,
+    is_managed_service_cluster,
+    is_vsphere_ipi_cluster,
+)
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import MS_PROVIDER_TYPE, MS_CONSUMER_TYPE
 from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup
@@ -143,7 +147,10 @@ class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
                     sleep=10,
                 )
                 delete_machine(machine_name)
-                new_ocs_node = wait_for_new_worker_node_ipi(machineset, old_wnodes)
+                timeout = 1500 if is_vsphere_ipi_cluster() else 900
+                new_ocs_node = wait_for_new_worker_node_ipi(
+                    machineset, old_wnodes, timeout
+                )
                 label_nodes([new_ocs_node])
 
             log.info(f"The new ocs node is: {new_ocs_node.name}")

--- a/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -96,13 +96,10 @@ class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
         4. Terminate the worker node.
         5. If we use an MS cluster, we will wait for the new worker node associated with the old node machine set
         to come up automatically.
-        If we use a non-MS cluster, the recovery process does not always happen automatically, so we will perform
-        the following steps:
-            5.1. Ensure that the ready replica count of the old machine set is decreased by 1.
-            5.2. Set the current replica count of the old machine set to the new ready replica count(reducing
-            it by one also).
-            5.3. Add a new worker node for the old machine set(which means we increase the
-            current replica count again by 1), and label it with the OCS label.
+        If we use a non-MS cluster, we will perform the following steps:
+            5.1. Delete the machine associated with the terminated worker node.
+            5.2. Wait for the new worker node associated with the old node machine set to come up automatically.
+            5.3. Label the new worker node with the OCS label.
         6. Wait for the OCS pods to be running and Ceph health to be OK before the next iteration.
 
         Args:
@@ -142,7 +139,7 @@ class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
                     condition=constants.STATUS_FAILED,
                     resource_name=machine_name,
                     column="PHASE",
-                    timeout=120,
+                    timeout=240,
                     sleep=10,
                 )
                 delete_machine(machine_name)


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/8191