### PR TITLE
BZ 2139037 Coverage - `test_rgw_routes`

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1470,6 +1470,7 @@ RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjec
 
 # Routes
 RGW_ROUTE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
+RGW_ROUTE_INTERNAL_MODE_SECURE = "ocs-storagecluster-cephobjectstore-secure"
 RGW_ROUTE_EXTERNAL_MODE = "ocs-external-storagecluster-cephobjectstore"
 
 # Miscellaneous

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1465,7 +1465,7 @@ NOOBAA_DB_SERVICE_ACCOUNT = NB_SERVICE_ACCOUNT_BASE.format(
 
 
 # Services
-RGW_SERVICE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
+RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
 RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
 
 # Routes

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -64,7 +64,7 @@ class RGW(object):
                 kind=constants.ROUTE, namespace=config.ENV_DATA["cluster_namespace"]
             )
             endpoint = route_ocp_obj.get(
-                resource_name=constants.RGW_SERVICE_INTERNAL_MODE
+                resource_name=constants.RGW_ROUTE_INTERNAL_MODE
             )
             endpoint = f"http://{endpoint['status']['ingress'][0]['host']}"
 

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -1,0 +1,105 @@
+import logging
+
+import boto3
+
+from ocs_ci.ocs import ocp, constants
+from ocs_ci.ocs.resources.objectbucket import OBC
+from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    skipif_external_mode,
+)
+from ocs_ci.ocs.bucket_utils import (
+    s3_put_object,
+    s3_get_object,
+    s3_delete_object,
+)
+
+log = logging.getLogger(__name__)
+
+
+class TestRGWRoutes:
+    """
+    Test the RGW routes in an ODF cluster
+
+    """
+
+    @skipif_external_mode
+    @bugzilla("2139037")
+    def test_rgw_routes(self, rgw_bucket_factory):
+        """
+        Test the availability of RGW routes in an ODF cluster
+
+        1. Assert that RGW's service is exposed by both http and https routes
+        2. Assert that both endpoints use a TLS termination policy
+        3. Test basic I.O functionality using both endpoints
+
+        """
+        route_obj = ocp.OCP(kind="Route", namespace=self.namespace)
+
+        log.info("Getting RGW's HTTP and HTTPS routes")
+        try:
+            http_route = route_obj.get(resource_name=constants.RGW_ROUTE_INTERNAL_MODE)
+        except CommandFailed as ex:
+            log.error("Failed to get RGW's HTTP route!")
+            raise UnavailableResourceException(ex)
+
+        try:
+            https_route = route_obj.get(
+                resource_name=constants.RGW_ROUTE_INTERNAL_MODE_SECURE
+            )
+        except CommandFailed as ex:
+            log.error("Failed to get RGW's HTTPS route!")
+            raise UnavailableResourceException(ex)
+
+        log.info(
+            "Asserting that RGW's service is exposed by both http and https routes"
+        )
+        assert http_route["spec"]["to"]["name"] == constants.RGW_SERVICE_INTERNAL_MODE
+        assert (
+            https_route[["spec"]["to"]["name"]] == constants.RGW_SERVICE_INTERNAL_MODE
+        )
+        assert http_route["spec"]["port"]["targetPort"] == "http"
+        assert https_route["spec"]["port"]["targetPort"] == "https"
+
+        log.info("Asserting that both endpoints use a TLS termination policy")
+        assert http_route["spec"]["tls"]["insecureEdgeTerminationPolicy"] is not None
+        assert https_route["spec"]["tls"]["insecureEdgeTerminationPolicy"] is not None
+
+        log.info("Testing basic I.O functionality using both endpoints")
+        rgw_bucket_name = rgw_bucket_factory(amount=1, interface="RGW-OC")[0].name
+        rgw_obc = OBC(rgw_bucket_name)
+
+        for route in http_route, https_route:
+            # Apply the current route to the OBC s3_client
+            route_name = route["metadata"]["name"]
+            url_prefix = route["spec"]["port"]["targetPort"]
+            current_route_endpoint_url = f"{url_prefix}://{route['spec']['host']}"
+            rgw_obc.s3_resource = boto3.resource(
+                "s3",
+                endpoint_url=current_route_endpoint_url,
+                aws_access_key_id=rgw_obc.access_key_id,
+                aws_secret_access_key=rgw_obc.access_key,
+            )
+            rgw_obc.s3_client = rgw_obc.s3_resource.meta.client
+
+            # Test basic I.O functionality
+            assert s3_put_object(
+                s3_obj=rgw_obc,
+                bucketname=rgw_bucket_name,
+                object_key=f"test-route-{route_name}",
+                object_data="A simple test object string",
+                content_type="text/html",
+            ), f"s3_put_object failed via route {route_name}!"
+
+            assert s3_get_object(
+                s3_obj=rgw_obc,
+                bucketname=rgw_bucket_name,
+                object_key=f"test-route-{route_name}",
+            ), f"s3_get_object failed via route {route_name}!"
+
+            assert s3_delete_object(
+                s3_obj=rgw_obc,
+                bucketname=rgw_bucket_name,
+                object_key=f"test-route-{route_name}",
+            ), f"s3_delete_object failed via route {route_name}!"

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -72,7 +72,7 @@ class TestRGWRoutes:
         log.info(
             "Asserting that RGW's service is exposed by both http and https routes"
         )
-        assert route_dict["spec"]["to"]["name"] == route_name
+        assert route_dict["spec"]["to"]["name"] == constants.RGW_SERVICE_INTERNAL_MODE
         assert route_dict["spec"]["port"]["targetPort"] == url_prefix
 
         log.info("Asserting that the endpoint uses a TLS termination policy")

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_external_mode,
+    on_prem_platform_required,
 )
 from ocs_ci.ocs.bucket_utils import (
     s3_put_object,
@@ -18,6 +19,7 @@ from ocs_ci.ocs.bucket_utils import (
 log = logging.getLogger(__name__)
 
 
+@on_prem_platform_required
 class TestRGWRoutes:
     """
     Test the RGW routes in an ODF cluster

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -1,21 +1,23 @@
 import logging
 
 import boto3
+import pytest
 
-from ocs_ci.ocs import ocp, constants
 from ocs_ci.framework import config
-from ocs_ci.ocs.resources.objectbucket import OBC
-from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
-    skipif_external_mode,
     on_prem_platform_required,
+    skipif_external_mode,
+    tier1,
 )
+from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.bucket_utils import (
-    s3_put_object,
-    s3_get_object,
     s3_delete_object,
+    s3_get_object,
+    s3_put_object,
 )
+from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
+from ocs_ci.ocs.resources.objectbucket import OBC
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +31,8 @@ class TestRGWRoutes:
 
     @skipif_external_mode
     @bugzilla("2139037")
+    @pytest.mark.polarion_id("OCS-5168")
+    @tier1
     def test_rgw_routes(self, rgw_bucket_factory):
         """
         Test the availability of RGW routes in an ODF cluster

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -31,83 +31,85 @@ class TestRGWRoutes:
 
     @skipif_external_mode
     @bugzilla("2139037")
-    @pytest.mark.polarion_id("OCS-5168")
-    @tier1
-    def test_rgw_routes(self, rgw_bucket_factory):
+    @tier1  # TODO: tier2 instead?
+    @pytest.mark.parametrize(
+        argnames="route_data",
+        argvalues=[
+            pytest.param(
+                (constants.RGW_ROUTE_INTERNAL_MODE, "http"),
+                marks=pytest.mark.polarion_id("OCS-5168"),
+            ),
+            pytest.param(
+                (constants.RGW_ROUTE_INTERNAL_MODE_SECURE, "https"),
+                marks=pytest.mark.polarion_id("OCS-5169"),
+            ),
+        ],
+        ids=[
+            "HTTP",
+            "HTTPS",
+        ],
+    )
+    def test_rgw_route(self, rgw_bucket_factory, route_data):
         """
         Test the availability of RGW routes in an ODF cluster
 
-        1. Assert that RGW's service is exposed by both http and https routes
-        2. Assert that both endpoints use a TLS termination policy
-        3. Test basic I.O functionality using both endpoints
+        1. Assert that RGW's service is exposed by the route
+        2. Assert that the route uses a TLS termination policy
+        3. Test basic I.O functionality using the endpoint
 
         """
+        route_name, url_prefix = route_data
         route_obj = ocp.OCP(
             kind="Route", namespace=config.ENV_DATA["cluster_namespace"]
         )
 
-        log.info("Getting RGW's HTTP and HTTPS routes")
         try:
-            http_route = route_obj.get(resource_name=constants.RGW_ROUTE_INTERNAL_MODE)
+            route_dict = route_obj.get(resource_name=route_name)
         except CommandFailed as ex:
-            log.error("Failed to get RGW's HTTP route!")
-            raise UnavailableResourceException(ex)
-
-        try:
-            https_route = route_obj.get(
-                resource_name=constants.RGW_ROUTE_INTERNAL_MODE_SECURE
-            )
-        except CommandFailed as ex:
-            log.error("Failed to get RGW's HTTPS route!")
+            log.error(f"Failed to get {route_name}")
             raise UnavailableResourceException(ex)
 
         log.info(
             "Asserting that RGW's service is exposed by both http and https routes"
         )
-        assert http_route["spec"]["to"]["name"] == constants.RGW_SERVICE_INTERNAL_MODE
-        assert https_route["spec"]["to"]["name"] == constants.RGW_SERVICE_INTERNAL_MODE
-        assert http_route["spec"]["port"]["targetPort"] == "http"
-        assert https_route["spec"]["port"]["targetPort"] == "https"
+        assert route_dict["spec"]["to"]["name"] == route_name
+        assert route_dict["spec"]["port"]["targetPort"] == url_prefix
 
-        log.info("Asserting that both endpoints use a TLS termination policy")
-        assert http_route["spec"]["tls"]["insecureEdgeTerminationPolicy"] is not None
-        assert https_route["spec"]["tls"]["insecureEdgeTerminationPolicy"] is not None
+        log.info("Asserting that the endpoint uses a TLS termination policy")
+        assert route_dict["spec"]["tls"]["insecureEdgeTerminationPolicy"] is not None
 
-        log.info("Testing basic I.O functionality using both endpoints")
+        log.info("Testing basic I.O functionality using the endpoint")
         rgw_bucket_name = rgw_bucket_factory(amount=1, interface="RGW-OC")[0].name
         rgw_obc = OBC(rgw_bucket_name)
 
-        for route in http_route, https_route:
-            # Apply the current route to the OBC s3_client
-            route_name = route["metadata"]["name"]
-            url_prefix = route["spec"]["port"]["targetPort"]
-            current_route_endpoint_url = f"{url_prefix}://{route['spec']['host']}"
-            rgw_obc.s3_resource = boto3.resource(
-                "s3",
-                verify=False,
-                endpoint_url=current_route_endpoint_url,
-                aws_access_key_id=rgw_obc.access_key_id,
-                aws_secret_access_key=rgw_obc.access_key,
-            )
-            rgw_obc.s3_client = rgw_obc.s3_resource.meta.client
+        # Apply the current route to the OBC s3_client
+        current_route_endpoint_url = f"{url_prefix}://{route_dict['spec']['host']}"
+        rgw_obc.s3_resource = boto3.resource(
+            "s3",
+            verify=False,
+            endpoint_url=current_route_endpoint_url,
+            aws_access_key_id=rgw_obc.access_key_id,
+            aws_secret_access_key=rgw_obc.access_key,
+        )
+        rgw_obc.s3_client = rgw_obc.s3_resource.meta.client
 
-            # Test basic I.O functionality
-            assert s3_put_object(
-                s3_obj=rgw_obc,
-                bucketname=rgw_bucket_name,
-                object_key=f"test-route-{route_name}",
-                data="A simple test object string",
-                content_type="text/html",
-            ), f"s3_put_object failed via route {route_name}!"
+        # Test basic I.O functionality
+        assert s3_put_object(
+            s3_obj=rgw_obc,
+            bucketname=rgw_bucket_name,
+            object_key=f"test-route-{route_name}",
+            data="A simple test object string",
+            content_type="text/html",
+        ), f"s3_put_object failed via route {route_name}!"
 
-            assert s3_get_object(
-                s3_obj=rgw_obc,
-                bucketname=rgw_bucket_name,
-                object_key=f"test-route-{route_name}",
-            ), f"s3_get_object failed via route {route_name}!"
+        assert s3_get_object(
+            s3_obj=rgw_obc,
+            bucketname=rgw_bucket_name,
+            object_key=f"test-route-{route_name}",
+        ), f"s3_get_object failed via route {route_name}!"
 
-            assert s3_delete_object(
-                s3_obj=rgw_obc,
-                bucketname=rgw_bucket_name,
-                object_key=f"test-route-{route_name}",
-            ), f"s3_delete_object failed via route {route_name}!"
+        assert s3_delete_object(
+            s3_obj=rgw_obc,
+            bucketname=rgw_bucket_name,
+            object_key=f"test-route-{route_name}",
+        ), f"s3_delete_object failed via route {route_name}!"


### PR DESCRIPTION
Covers  [BZ #2139037](https://bugzilla.redhat.com/show_bug.cgi?id=2139037) by testing the following:

1. RGW's service is exposed by both http and https routes
2. Both endpoints use a TLS termination policy
3. Basic I.O functionality is working properly using both endpoints