### PR TITLE
Enable external mode using SSL with RGW - backport of PR#7645 to release-4.12

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -286,6 +286,8 @@ Configuration specific to external Ceph cluster
 * `admin_keyring`
     * `key` - Admin keyring value used for the external Ceph cluster
 * `external_cluster_details` - base64 encoded data of json output from exporter script
+* `rgw_secure` - boolean parameter which defines if external Ceph cluster RGW is secured using SSL
+* `rgw_cert_ca` - url pointing to CA certificate used to sign certificate for RGW with SSL
 
 ##### login
 


### PR DESCRIPTION
* ssl_cert: add function configure_trusted_ca_bundle
- separate configuration of cluster-wide trusted CA bundle in Proxy object to new function (and handle situation with existing config map) to be able to re-use it in other modules

* external cluster - enable rgw with ssl
- add functionality to be able to connect to external cluster with secured RGW with SSL

this is backport of https://github.com/red-hat-storage/ocs-ci/pull/7645/files