### PR TITLE
Fixing test_node_replacement tests for Vmware IPI platforms

### DIFF
--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -69,9 +69,12 @@ def check_node_replacement_verification_steps(
             f"of osd nodes. Wait for the new created worker node to appear in the osd nodes"
         )
         timeout = 1500
-        # In vSphere platform, we are creating new node with same name as deleted
+        # In vSphere UPI platform, we are creating new node with same name as deleted
         # node using terraform
-        if config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM:
+        if (
+            config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM
+            and config.ENV_DATA["deployment_type"] == "upi"
+        ):
             new_osd_node_name = old_node_name
         else:
             new_osd_node_name = node.wait_for_new_osd_node(old_osd_node_names, timeout)


### PR DESCRIPTION
Due to regression from #7510 node replacement tests were failing for Vmware IPI platform. This fixes https://github.com/red-hat-storage/ocs-ci/issues/8273