### PR TITLE
Update the test "test_simultaneous_drain_of_two_ocs_nodes" when we have 1az and 3 racks 4.13 #7987

### DIFF
--- a/ocs_ci/ocs/machine.py
+++ b/ocs_ci/ocs/machine.py
@@ -11,6 +11,7 @@ from ocs_ci.ocs.exceptions import (
     ResourceNotFoundError,
     UnexpectedBehaviour,
     ResourceWrongStatusException,
+    CommandFailed,
 )
 
 log = logging.getLogger(__name__)
@@ -1244,3 +1245,105 @@ def wait_for_current_replica_count_to_reach_expected_value(
         res = False
 
     return res
+
+
+def delete_machines(machine_names):
+    """
+    Delete the machines
+
+    Args:
+        machine_names (list): List of the machine names you want to delete
+
+    Raises:
+        CommandFailed: In case yaml_file and resource_name wasn't provided
+
+    """
+    machine_obj = OCP(
+        kind="machine", namespace=constants.OPENSHIFT_MACHINE_API_NAMESPACE
+    )
+    for machine_name in machine_names:
+        log.info(f"Deleting machine {machine_name}")
+        machine_obj.delete(resource_name=machine_name)
+
+
+def get_machines_in_statuses(
+    statuses, machine_objs=None, machine_type=constants.WORKER_MACHINE
+):
+    """
+    Get all machines in specific statuses
+
+    Args:
+        statuses (list): List of the statuses to search for the machines
+        machine_objs (list): The machine objects to check their statues. If not specified,
+            it gets all the machines.
+        machine_type (str): The machine type (e.g. worker, master)
+
+    Returns:
+        list: OCP objects representing the machines in the specific statuses
+
+    """
+    machines = machine_objs or get_machines(machine_type)
+    machine_obj = OCP(
+        kind="machine", namespace=constants.OPENSHIFT_MACHINE_API_NAMESPACE
+    )
+
+    machines_in_statuses = []
+    for m in machines:
+        try:
+            machine_status = machine_obj.get_resource(
+                resource_name=m.name, column="PHASE"
+            )
+        except CommandFailed as e:
+            log.warning(f"Failed to get the machine status due to the error: {str(e)}")
+            continue
+
+        if machine_status in statuses:
+            machines_in_statuses.append(m)
+
+    return machines_in_statuses
+
+
+def wait_for_machines_count_to_reach_status(
+    machine_count,
+    machine_type=constants.WORKER_MACHINE,
+    expected_status=constants.STATUS_RUNNING,
+    timeout=600,
+    sleep=20,
+):
+    """
+    Wait for a machine count to reach the expected status
+
+    Args:
+        machine_count (int): The machine count
+        machine_type (str): The machine type (e.g. worker, master)
+        expected_status (str): The expected status. Default value is "Running".
+        timeout (int): Time to wait for the machine count to reach the expected status.
+        sleep (int): Time in seconds to wait between attempts.
+
+    Raise:
+        TimeoutExpiredError: In case the machine count didn't reach the expected status in the given timeout.
+
+    """
+    log.info(
+        f"Wait for {machine_count} of the machines to reach the expected status {expected_status}"
+    )
+
+    for machine_objs in TimeoutSampler(
+        timeout=timeout, sleep=sleep, func=get_machines, machine_type=machine_type
+    ):
+        machines_in_expected_statuses = get_machines_in_statuses(
+            [expected_status], machine_objs
+        )
+        machines_names_in_expected_status = [
+            n.name for n in machines_in_expected_statuses
+        ]
+        if len(machines_names_in_expected_status) == machine_count:
+            log.info(
+                f"{machine_count} of the machines reached the expected status: {expected_status}"
+            )
+            break
+        else:
+            log.info(
+                f"The machines {machines_names_in_expected_status} reached the expected status {expected_status}, "
+                f"but we were waiting for {machine_count} of them to reach status {expected_status}"
+            )

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -24,7 +24,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants, exceptions, ocp, defaults
 from ocs_ci.utility import version
-from ocs_ci.utility.utils import TimeoutSampler, convert_device_size
+from ocs_ci.utility.utils import TimeoutSampler, convert_device_size, get_az_count
 from ocs_ci.ocs import machine
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.utils import set_selinux_permissions, get_ocp_version
@@ -197,12 +197,13 @@ def schedule_nodes(node_names):
     wait_for_nodes_status(node_names)
 
 
-def drain_nodes(node_names):
+def drain_nodes(node_names, timeout=1800):
     """
     Drain nodes
 
     Args:
         node_names (list): The names of the nodes
+        timeout (int): Time to wait for the drain nodes 'oc' command
 
     Raises:
         TimeoutExpired: in case drain command fails to complete in time
@@ -221,7 +222,7 @@ def drain_nodes(node_names):
         ocp.exec_oc_cmd(
             f"adm drain {node_names_str} --force=true --ignore-daemonsets "
             f"{drain_deletion_flag}",
-            timeout=1800,
+            timeout=timeout,
         )
     except TimeoutExpired:
         ct_pod = pod.get_ceph_tools_pod()
@@ -2716,3 +2717,80 @@ def gracefully_reboot_nodes():
         time.sleep(waiting_time)
         schedule_nodes([node_name])
     wait_for_nodes_status(status=constants.NODE_READY, timeout=180)
+
+
+def get_num_of_racks():
+    """
+    Get the number of racks in the cluster
+
+    Returns:
+        int: The number of racks in the cluster
+
+    """
+    node_racks = get_node_rack_dict().values()
+    node_racks = [rack for rack in node_racks if rack]
+    return len(set(node_racks))
+
+
+def generate_new_nodes_and_osd_running_nodes_ipi(
+    osd_running_worker_nodes=None, num_of_nodes=2
+):
+    """
+    Create new nodes and generate osd running worker nodes in the same machinesets as the new nodes,
+    or if it's a 1AZ cluster, it generates osd running worker nodes in the same rack or zone as the new nodes.
+    This function is only for an IPI deployment
+
+    Args:
+        osd_running_worker_nodes: The list to use in the function for generate osd running worker nodes.
+            If not provided, it generates all the osd running worker nodes.
+        num_of_nodes (int): The number of the new nodes to create and generate. The default value is 2.
+
+    Returns:
+        list: The list of the generated osd running worker nodes
+
+    """
+    osd_running_worker_nodes = osd_running_worker_nodes or get_osd_running_nodes()
+
+    # Get the machine name using the node name
+    machine_names = [
+        machine.get_machine_from_node_name(osd_running_worker_node)
+        for osd_running_worker_node in osd_running_worker_nodes[:num_of_nodes]
+    ]
+    log.info(f"{osd_running_worker_nodes} associated " f"machine are {machine_names}")
+
+    # Get the machineset name using machine name
+    machineset_names = [
+        machine.get_machineset_from_machine_name(machine_name)
+        for machine_name in machine_names
+    ]
+    log.info(
+        f"{osd_running_worker_nodes[:num_of_nodes]} associated machineset is {machineset_names}"
+    )
+
+    # Add a new nodes and label it
+    new_node_names = []
+    machineset_names = machineset_names[:num_of_nodes]
+    for mset in machineset_names:
+        new_node_names.extend(add_new_node_and_label_it(mset))
+    log.info(f"New added nodes: {new_node_names}")
+
+    num_of_racks = get_num_of_racks()
+    num_of_zones = get_az_count()
+
+    if num_of_zones == 1 and num_of_racks >= 3:
+        log.info(
+            f"We have 1 AZ and {num_of_racks} racks in the cluster. "
+            f"Get the osd worker nodes in the same racks as the newly added nodes"
+        )
+        new_nodes = get_node_objs(new_node_names)
+        failure_domain = "rack"
+        osd_running_worker_nodes = []
+        for n in new_nodes:
+            osd_node = get_another_osd_node_in_same_rack_or_zone(
+                failure_domain, node_obj=n
+            )
+            osd_running_worker_nodes.append(osd_node.name)
+
+        log.info(f"osd running worker nodes: {osd_running_worker_nodes}")
+
+    return osd_running_worker_nodes[:num_of_nodes]

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
-    add_new_node_and_label_it,
+    generate_new_nodes_and_osd_running_nodes_ipi,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework import config
@@ -390,31 +390,11 @@ class TestNodesMaintenance(ManageTest):
             pod.run_io_in_bg(dc_pod, fedora_dc=True)
             dc_pod_obj.append(dc_pod)
 
-        # Get the machine name using the node name
-        machine_names = [
-            machine.get_machine_from_node_name(osd_running_worker_node)
-            for osd_running_worker_node in osd_running_worker_nodes[:2]
-        ]
-        log.info(
-            f"{osd_running_worker_nodes} associated " f"machine are {machine_names}"
+        osd_running_worker_nodes = generate_new_nodes_and_osd_running_nodes_ipi(
+            num_of_nodes=2
         )
-
-        # Get the machineset name using machine name
-        machineset_names = [
-            machine.get_machineset_from_machine_name(machine_name)
-            for machine_name in machine_names
-        ]
-        log.info(
-            f"{osd_running_worker_nodes} associated machineset "
-            f"is {machineset_names}"
-        )
-
-        # Add a new node and label it
-        add_new_node_and_label_it(machineset_names[0])
-        add_new_node_and_label_it(machineset_names[1])
-
         # Drain 2 nodes
-        drain_nodes(osd_running_worker_nodes[:2])
+        drain_nodes(osd_running_worker_nodes, timeout=2100)
 
         # Check the pods should be in running state
         all_pod_obj = pod.get_all_pods(wait=True)
@@ -445,13 +425,24 @@ class TestNodesMaintenance(ManageTest):
         pod.wait_for_dc_app_pods_to_reach_running_state(dc_pod_obj, timeout=1200)
         log.info("All the dc pods reached running state")
 
+        # Save the machine count of the worker nodes and the machine names of the osd nodes
+        machine_count = len(machine.get_machines())
+        machine_names_of_osd_nodes = [
+            machine.get_machine_from_node_name(n) for n in osd_running_worker_nodes
+        ]
         # Remove unscheduled nodes
         # In scenarios where the drain is attempted on >3 worker setup,
         # post completion of drain we are removing the unscheduled nodes so
         # that we maintain 3 worker nodes.
-        log.info(f"Removing scheduled nodes {osd_running_worker_nodes[:2]}")
-        remove_node_objs = get_node_objs(osd_running_worker_nodes[:2])
+        log.info(f"Removing scheduled nodes {osd_running_worker_nodes}")
+        remove_node_objs = get_node_objs(osd_running_worker_nodes)
         remove_nodes(remove_node_objs)
+
+        log.info(
+            f"Deleting the machines associated with the osd nodes: {machine_names_of_osd_nodes}"
+        )
+        machine.delete_machines(machine_names_of_osd_nodes)
+        machine.wait_for_machines_count_to_reach_status(machine_count)
 
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),


### PR DESCRIPTION
The pr fixes three small issues in the test "test_simultaneous_drain_of_two_ocs_nodes": 

- fix #7866 - Increase the timeout when draining the osd nodes.
- fix #7868 -  Generate the correct osd nodes for 1AZ deployment. This is implemented in the function `generate_new_nodes_and_osd_running_nodes_ipi`, which generates the right osd nodes.
- fix #8045 - Ensure that the current replica count equals the ready replica count - this is implemented when we delete the machines of the deleted osd nodes and wait for the new machines to come up with new nodes.