### PR TITLE
Ignore the post-validation storagecluster version keyError when using MS

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -885,12 +885,21 @@ def verify_storage_cluster():
         "upgrade_ocs_version"
     ):
         log.info("Verifying storage cluster version")
-        storage_cluster_version = storage_cluster.get()["status"]["version"]
-        ocs_csv = get_ocs_csv()
-        csv_version = ocs_csv.data["spec"]["version"]
-        assert (
-            storage_cluster_version in csv_version
-        ), f"storage cluster version {storage_cluster_version} is not same as csv version {csv_version}"
+        try:
+            storage_cluster_version = storage_cluster.get()["status"]["version"]
+            ocs_csv = get_ocs_csv()
+            csv_version = ocs_csv.data["spec"]["version"]
+            assert (
+                storage_cluster_version in csv_version
+            ), f"storage cluster version {storage_cluster_version} is not same as csv version {csv_version}"
+        except KeyError as e:
+            if (
+                config.ENV_DATA.get("platform", "").lower()
+                in constants.MANAGED_SERVICE_PLATFORMS
+            ):
+                log.warning(f"Can't get the sc version due to the error: {str(e)}")
+            else:
+                raise e
 
 
 def verify_storage_device_class(device_class):

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -897,6 +897,8 @@ def verify_storage_cluster():
                 config.ENV_DATA.get("platform", "").lower()
                 in constants.MANAGED_SERVICE_PLATFORMS
             ):
+                # This is a workaround. The issue for tracking is
+                # https://github.com/red-hat-storage/ocs-ci/issues/8390
                 log.warning(f"Can't get the sc version due to the error: {str(e)}")
             else:
                 raise e


### PR DESCRIPTION
With the new ocs-qe-addon, we don't see the version of the ocs-storagecluster. See, for example, the error here https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/28929/console:

> 2023-08-31 19:19:47  16:19:47 - MainThread - ocs_ci.ocs.resources.storage_cluster - INFO  - Verifying storage cluster version
2023-08-31 19:19:47  16:19:47 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-storage get StorageCluster ocs-storagecluster -n openshift-storage -o yaml
2023-08-31 19:19:48  FAILED

> 2023-08-31 19:19:48              log.info("Verifying storage cluster version")
2023-08-31 19:19:48  >           storage_cluster_version = storage_cluster.get()["status"]["version"]
2023-08-31 19:19:48  E           KeyError: 'version'

This is not a product bug but something that should be fixed. In the meantime, we can skip the ocs-storagecluster version when using MS.