### PR TITLE
Adding hook to create a timing report for the tests run

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -433,6 +433,6 @@ class MultiClusterConfig:
 config = MultiClusterConfig()
 
 
-class globalVariables:
+class GlobalVariables:
     # Test time report
     TIMEREPORT_DICT: dict = dict()

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -36,8 +36,6 @@ class Config:
     COMPONENTS: dict = field(default_factory=dict)
     # Used for multicluster only
     MULTICLUSTER: dict = field(default_factory=dict)
-    # Test time report
-    TIMEREPORT_DICT: dict = field(default_factory=dict)
 
     def __post_init__(self):
         self.reset()
@@ -433,3 +431,8 @@ class MultiClusterConfig:
 
 
 config = MultiClusterConfig()
+
+
+class globalVariables:
+    # Test time report
+    TIMEREPORT_DICT: dict = dict()

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -36,6 +36,8 @@ class Config:
     COMPONENTS: dict = field(default_factory=dict)
     # Used for multicluster only
     MULTICLUSTER: dict = field(default_factory=dict)
+    # Test time report
+    TIMEREPORT_DICT: dict = field(default_factory=dict)
 
     def __post_init__(self):
         self.reset()

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -78,3 +78,58 @@ def pytest_sessionfinish(session, exitstatus):
         save_reports()
     if ocsci_config.RUN["cli_params"].get("email"):
         email_reports(session)
+
+    # creating report of test cases with total time in ascending order
+    data = ocsci_config.TIMEREPORT_DICT
+    sorted_data = dict(sorted(data.items(), key=lambda item: item[1]["total"]))
+    with open("time_report.txt", "a") as f:
+        f.write("testName\tsetup\tcall\tteardown\ttotal\n")
+        for test, values in sorted_data.items():
+            row = (
+                f"{test}\t{values.get('setup', 'NA')}\t"
+                f"{values.get('call', 'NA')}\t"
+                f"{values.get('teardown', 'NA')}\t"
+                f"{values.get('total', 'NA'):.2f}\n"
+            )
+            f.write(row)
+
+
+def pytest_report_teststatus(report, config):
+    """
+    This function checks the status of the test at which stage it is at an calculates
+    the time take by each stage to complete it.
+    There are three stages:
+    setup : when the test case is setup
+    call : when the test case is run
+    teardown: when the teardown of the test case happens.
+    """
+    ocsci_config.TIMEREPORT_DICT[report.nodeid] = ocsci_config.TIMEREPORT_DICT.get(
+        report.nodeid, {}
+    )
+
+    if report.when == "setup":
+        print(
+            f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
+        )
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["setup"] = round(report.duration, 2)
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] = round(report.duration, 2)
+
+    if report.when == "call":
+        print(
+            f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
+        )
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["call"] = round(report.duration, 2)
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] += round(
+            report.duration, 2
+        )
+
+    if report.when == "teardown":
+        print(
+            f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
+        )
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(
+            report.duration, 2
+        )
+        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] += round(
+            report.duration, 2
+        )

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -78,6 +78,8 @@ def pytest_sessionfinish(session, exitstatus):
     """
     save session's report files and send email report
     """
+    import csv
+
     if ocsci_config.REPORTING.get("save_mem_report"):
         save_reports()
     if ocsci_config.RUN["cli_params"].get("email"):
@@ -93,19 +95,20 @@ def pytest_sessionfinish(session, exitstatus):
             ocsci_log_path(), "session_test_time_report_file.csv"
         )
         with open(time_report_file, "a") as fil:
-            fil.write("testName\tsetup\tcall\tteardown\ttotal\n")
+            c = csv.writer(fil)
+            c.writerow(["testName", "setup", "call", "teardown", "total"])
             for test, values in sorted_data.items():
-                row = (
-                    f"{test}\t"
-                    f"{values.get('setup', 'NA')}\t"
-                    f"{values.get('call', 'NA')}\t"
-                    f"{values.get('teardown', 'NA')}\t"
-                    f"{values.get('total', 'NA')}\n"
-                )
-                fil.write(row)
+                row = [
+                    f"{test}",
+                    f"{values.get('setup', 'NA')}",
+                    f"{values.get('call', 'NA')}",
+                    f"{values.get('teardown', 'NA')}",
+                    f"{values.get('total', 'NA')}",
+                ]
+                c.writerow(row)
         logger.info(f"Test Time report saved to '{time_report_file}'")
     except Exception:
-        logger.exception("Failed save report to logs directory")
+        logger.exception("Failed to save Test Time report to logs directory")
 
 
 def pytest_report_teststatus(report, config):

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -6,7 +6,6 @@ from ocs_ci.utility.utils import email_reports, save_reports, ocsci_log_path
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework import GlobalVariables as GV
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -99,11 +98,11 @@ def pytest_sessionfinish(session, exitstatus):
             c.writerow(["testName", "setup", "call", "teardown", "total"])
             for test, values in sorted_data.items():
                 row = [
-                    f"{test}",
-                    f"{values.get('setup', 'NA')}",
-                    f"{values.get('call', 'NA')}",
-                    f"{values.get('teardown', 'NA')}",
-                    f"{values.get('total', 'NA')}",
+                    test,
+                    values.get("setup", "NA"),
+                    values.get("call", "NA"),
+                    values.get("teardown", "NA"),
+                    values.get("total", "NA"),
                 ]
                 c.writerow(row)
         logger.info(f"Test Time report saved to '{time_report_file}'")

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import logging
 from py.xml import html
-from ocs_ci.utility.utils import email_reports, save_reports
+from ocs_ci.utility.utils import email_reports, save_reports, ocsci_log_path
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework import GlobalVariables as GV
 
@@ -88,16 +88,22 @@ def pytest_sessionfinish(session, exitstatus):
     sorted_data = dict(
         sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
     )
-    with open("time_report.txt", "a") as f:
-        f.write("testName\tsetup\tcall\tteardown\ttotal\n")
-        for test, values in sorted_data.items():
-            row = (
-                f"{test}\t{values.get('setup', 'NA')}\t"
-                f"{values.get('call', 'NA')}\t"
-                f"{values.get('teardown', 'NA')}\t"
-                f"{values.get('total', 'NA'):.2f}\n"
-            )
-            f.write(row)
+    try:
+        time_report_file = os.path.join(ocsci_log_path, "session_test_time_report_file")
+        with open(time_report_file, "a") as fil:
+            fil.write("testName\tsetup\tcall\tteardown\ttotal\n")
+            for test, values in sorted_data.items():
+                row = (
+                    f"{test}\t"
+                    f"{values.get('setup', 'NA')}\t"
+                    f"{values.get('call', 'NA')}\t"
+                    f"{values.get('teardown', 'NA')}\t"
+                    f"{values.get('total', 'NA')}\n"
+                )
+                fil.write(row)
+        logger.info(f"Test Time report saved to '{time_report_file}'")
+    except Exception:
+        logger.exception("Failed save report to logs directory")
 
 
 def pytest_report_teststatus(report, config):

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -4,6 +4,7 @@ import logging
 from py.xml import html
 from ocs_ci.utility.utils import email_reports, save_reports
 from ocs_ci.framework import config as ocsci_config
+from ocs_ci.framework import globalVariables as globalVariables
 
 
 @pytest.mark.optionalhook
@@ -80,7 +81,7 @@ def pytest_sessionfinish(session, exitstatus):
         email_reports(session)
 
     # creating report of test cases with total time in ascending order
-    data = ocsci_config.TIMEREPORT_DICT
+    data = globalVariables.TIMEREPORT_DICT
     sorted_data = dict(sorted(data.items(), key=lambda item: item[1]["total"]))
     with open("time_report.txt", "a") as f:
         f.write("testName\tsetup\tcall\tteardown\ttotal\n")
@@ -103,23 +104,29 @@ def pytest_report_teststatus(report, config):
     call : when the test case is run
     teardown: when the teardown of the test case happens.
     """
-    ocsci_config.TIMEREPORT_DICT[report.nodeid] = ocsci_config.TIMEREPORT_DICT.get(
-        report.nodeid, {}
-    )
+    globalVariables.TIMEREPORT_DICT[
+        report.nodeid
+    ] = globalVariables.TIMEREPORT_DICT.get(report.nodeid, {})
 
     if report.when == "setup":
         print(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["setup"] = round(report.duration, 2)
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] = round(report.duration, 2)
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["setup"] = round(
+            report.duration, 2
+        )
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] = round(
+            report.duration, 2
+        )
 
     if report.when == "call":
         print(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["call"] = round(report.duration, 2)
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] += round(
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["call"] = round(
+            report.duration, 2
+        )
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] += round(
             report.duration, 2
         )
 
@@ -127,9 +134,9 @@ def pytest_report_teststatus(report, config):
         print(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(
             report.duration, 2
         )
-        ocsci_config.TIMEREPORT_DICT[report.nodeid]["total"] += round(
+        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] += round(
             report.duration, 2
         )

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -89,7 +89,9 @@ def pytest_sessionfinish(session, exitstatus):
         sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
     )
     try:
-        time_report_file = os.path.join(ocsci_log_path, "session_test_time_report_file")
+        time_report_file = os.path.join(
+            ocsci_log_path(), "session_test_time_report_file.csv"
+        )
         with open(time_report_file, "a") as fil:
             fil.write("testName\tsetup\tcall\tteardown\ttotal\n")
             for test, values in sorted_data.items():

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -4,7 +4,7 @@ import logging
 from py.xml import html
 from ocs_ci.utility.utils import email_reports, save_reports
 from ocs_ci.framework import config as ocsci_config
-from ocs_ci.framework import globalVariables as globalVariables
+from ocs_ci.framework import GlobalVariables as GV
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ def pytest_sessionfinish(session, exitstatus):
         email_reports(session)
 
     # creating report of test cases with total time in ascending order
-    data = globalVariables.TIMEREPORT_DICT
+    data = GV.TIMEREPORT_DICT
     sorted_data = dict(
         sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
     )
@@ -109,39 +109,25 @@ def pytest_report_teststatus(report, config):
     call : when the test case is run
     teardown: when the teardown of the test case happens.
     """
-    globalVariables.TIMEREPORT_DICT[
-        report.nodeid
-    ] = globalVariables.TIMEREPORT_DICT.get(report.nodeid, {})
+    GV.TIMEREPORT_DICT[report.nodeid] = GV.TIMEREPORT_DICT.get(report.nodeid, {})
 
     if report.when == "setup":
         logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["setup"] = round(
-            report.duration, 2
-        )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] = round(
-            report.duration, 2
-        )
+        GV.TIMEREPORT_DICT[report.nodeid]["setup"] = round(report.duration, 2)
+        GV.TIMEREPORT_DICT[report.nodeid]["total"] = round(report.duration, 2)
 
     if report.when == "call":
         logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["call"] = round(
-            report.duration, 2
-        )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] += round(
-            report.duration, 2
-        )
+        GV.TIMEREPORT_DICT[report.nodeid]["call"] = round(report.duration, 2)
+        GV.TIMEREPORT_DICT[report.nodeid]["total"] += round(report.duration, 2)
 
     if report.when == "teardown":
         logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(
-            report.duration, 2
-        )
-        globalVariables.TIMEREPORT_DICT[report.nodeid]["total"] += round(
-            report.duration, 2
-        )
+        GV.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(report.duration, 2)
+        GV.TIMEREPORT_DICT[report.nodeid]["total"] += round(report.duration, 2)

--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -6,6 +6,9 @@ from ocs_ci.utility.utils import email_reports, save_reports
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework import globalVariables as globalVariables
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 @pytest.mark.optionalhook
 def pytest_html_results_table_header(cells):
@@ -82,7 +85,9 @@ def pytest_sessionfinish(session, exitstatus):
 
     # creating report of test cases with total time in ascending order
     data = globalVariables.TIMEREPORT_DICT
-    sorted_data = dict(sorted(data.items(), key=lambda item: item[1]["total"]))
+    sorted_data = dict(
+        sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
+    )
     with open("time_report.txt", "a") as f:
         f.write("testName\tsetup\tcall\tteardown\ttotal\n")
         for test, values in sorted_data.items():
@@ -109,7 +114,7 @@ def pytest_report_teststatus(report, config):
     ] = globalVariables.TIMEREPORT_DICT.get(report.nodeid, {})
 
     if report.when == "setup":
-        print(
+        logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
         globalVariables.TIMEREPORT_DICT[report.nodeid]["setup"] = round(
@@ -120,7 +125,7 @@ def pytest_report_teststatus(report, config):
         )
 
     if report.when == "call":
-        print(
+        logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
         globalVariables.TIMEREPORT_DICT[report.nodeid]["call"] = round(
@@ -131,7 +136,7 @@ def pytest_report_teststatus(report, config):
         )
 
     if report.when == "teardown":
-        print(
+        logger.info(
             f"duration reported by {report.nodeid} immediately after test execution: {round(report.duration, 2)}"
         )
         globalVariables.TIMEREPORT_DICT[report.nodeid]["teardown"] = round(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2313,3 +2313,6 @@ NOOBAA_REGIONS_CODE_URL = (
     "https://github.com/noobaa/noobaa-operator/blob/master/pkg/util/util.go#L1108"
 )
 AWS_REGIONS_DOC_URL = "https://docs.aws.amazon.com/general/latest/gr/rande.html"
+
+# dir of template for html reports
+HTML_REPORT_TEMPLATE_DIR = "ocs_ci/templates/html_reports/"

--- a/ocs_ci/templates/html_reports/test_time_table.html.j2
+++ b/ocs_ci/templates/html_reports/test_time_table.html.j2
@@ -1,0 +1,42 @@
+<table style="border-collapse: collapse; width: 100%; border: 1px solid #ddd;font-size:small">
+    <caption style="font-size:medium; text-align:left; font-weight:bold">
+        Most Time-Consuming Test Cases in seconds
+    </caption>
+    <thead>
+        <tr>
+            <th scope="col"
+            style="border: 1px solid #ddd;padding: 8px;text-align: left;background-color: #f2f2f2;white-space:nowrap">
+            Test Name
+            </th>
+            <th scope="col"
+            style="border: 1px solid #ddd;padding: 8px;text-align: left;background-color: #f2f2f2;white-space:nowrap">
+            Setup Time</th>
+            <th scope="col"
+            style="border: 1px solid #ddd;padding: 8px;text-align: left;background-color: #f2f2f2;white-space:nowrap">
+            Call Time</th>
+            <th scope="col"
+            style="border: 1px solid #ddd;padding: 8px;text-align: left;background-color: #f2f2f2;white-space:nowrap">
+            Teardown Time</th>
+            <th scope="col"
+            style="border: 1px solid #ddd;padding: 8px;text-align: left;background-color: #f2f2f2;white-space:nowrap">
+            Total Time</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for test, values in sorted_data %}
+            <tr>
+                <td scope="row"
+                style="border: 1px solid #ddd;padding: 8px;text-align: left">
+                {{test}}</td>
+                <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
+                {{values.get("setup", 'NA')}}</td>
+                <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
+                {{values.get("call", 'NA')}}</td>
+                <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
+                {{values.get("teardown", 'NA')}}</td>
+                <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
+                {{values.get("total", 'NA')}}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4455,9 +4455,9 @@ def add_time_report_to_email(session, soup):
             break
         table_body_html += f"""
         <tr>
-            <th scope="row"
+            <td scope="row"
             style="border: 1px solid #ddd;padding: 8px;text-align: left">
-            {test}</th>
+            {test}</td>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
             {values.get("setup", 'NA')}</td>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
@@ -4472,7 +4472,7 @@ def add_time_report_to_email(session, soup):
 
     table_html_template = f"""
     <table style="border-collapse: collapse; width: 100%; border: 1px solid #ddd;font-size:small">
-        <caption style="font-size:medium">
+        <caption style="font-size:medium text-align: left font-weight: bold">
             Test cases that took most amount of time to run in seconds
         </caption>
         <thead>

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4473,7 +4473,7 @@ def add_time_report_to_email(session, soup):
     table_html_template = f"""
     <table style="border-collapse: collapse; width: 100%; border: 1px solid #ddd;font-size:small">
         <caption style="font-size:medium; text-align:left; font-weight:bold">
-            Test cases that took most amount of time to run in seconds
+            Most Time-Consuming Test Cases in seconds
         </caption>
         <thead>
             <tr>

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4449,7 +4449,10 @@ def add_time_report_to_email(session, soup):
     sorted_data = dict(
         sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
     )
+    count = 1
     for test, values in sorted_data.items():
+        if count > 5:
+            break
         table_body_html += f"""
         <tr>
             <th scope="row"
@@ -4465,6 +4468,8 @@ def add_time_report_to_email(session, soup):
             {values.get("total", 'NA')}</td>
         </tr>
         """
+        count += 1
+
     table_html_template = f"""
     <table style="border-collapse: collapse; width: 100%; border: 1px solid #ddd;font-size:small">
         <caption style="font-size:medium">
@@ -4497,7 +4502,6 @@ def add_time_report_to_email(session, soup):
     """
     summary_tag = soup.find("h2", string="Summary")
     time_div = soup.new_tag("div")
-    time_div.append(table_html_template)
+    table = BeautifulSoup(table_html_template, "html.parser")
+    time_div.append(table)
     summary_tag.insert_after(time_div)
-    with open("time.html", "a", encoding="utf-8") as f:
-        f.write(str(soup))

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1735,12 +1735,12 @@ def email_reports(session):
     with open(os.path.expanduser(html)) as fd:
         html_data = fd.read()
     soup = BeautifulSoup(html_data, "html.parser")
-    add_time_report_to_email(session, soup)
 
     parse_html_for_email(soup)
     if config.RUN["cli_params"].get("squad_analysis"):
         add_squad_analysis_to_email(session, soup)
     move_summary_to_top(soup)
+    add_time_report_to_email(session, soup)
     part1 = MIMEText(soup, "html")
     add_mem_stats(soup)
     msg.attach(part1)
@@ -4495,5 +4495,9 @@ def add_time_report_to_email(session, soup):
         </tbody>
     </table>
     """
-    with open("time.html", "a") as f:
-        f.write(table_html_template)
+    summary_tag = soup.find("h2", string="Summary")
+    time_div = soup.new_tag("div")
+    time_div.append(table_html_template)
+    summary_tag.insert_after(time_div)
+    with open("time.html", "a", encoding="utf-8") as f:
+        f.write(str(soup))

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4445,20 +4445,24 @@ def add_time_report_to_email(session, soup):
     """
     table_body_html = ""
 
-    for test in GV.TIMEREPORT_DICT:
+    data = GV.TIMEREPORT_DICT
+    sorted_data = dict(
+        sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
+    )
+    for test, values in sorted_data.items():
         table_body_html += f"""
         <tr>
             <th scope="row"
             style="border: 1px solid #ddd;padding: 8px;text-align: left">
             {test}</th>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
-            {GV.TIMEREPORT_DICT[test]["setup"]:0.2f}</td>
+            {values.get("setup", 'NA')}</td>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
-            {GV.TIMEREPORT_DICT[test]["call"]:0.2f}</td>
+            {values.get("call", 'NA')}</td>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
-            {GV.TIMEREPORT_DICT[test]["teardown"]:0.2f}</td>
+            {values.get("teardown", 'NA')}</td>
             <td style="border: 1px solid #ddd;padding: 8px;text-align: left">
-            {GV.TIMEREPORT_DICT[test]["total"]:0.2f}</td>
+            {values.get("total", 'NA')}</td>
         </tr>
         """
     table_html_template = f"""
@@ -4493,12 +4497,3 @@ def add_time_report_to_email(session, soup):
     """
     with open("time.html", "a") as f:
         f.write(table_html_template)
-    try:
-        time_report_file = os.path.join(
-            ocsci_log_path, "session__test_time_report_file"
-        )
-        with open("test_time_report.html", "a") as f:
-            f.write(table_html_template)
-        log.info(f"Test Time report saved to '{time_report_file}'")
-    except Exception:
-        log.exception("Failed save report to logs directory")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4472,7 +4472,7 @@ def add_time_report_to_email(session, soup):
 
     table_html_template = f"""
     <table style="border-collapse: collapse; width: 100%; border: 1px solid #ddd;font-size:small">
-        <caption style="font-size:medium text-align: left font-weight: bold">
+        <caption style="font-size:medium; text-align:left; font-weight:bold">
             Test cases that took most amount of time to run in seconds
         </caption>
         <thead>


### PR DESCRIPTION
This functionality will give us a file named session_test_time_report_file.csv that will have time test arranged in ascending order of the total time taken by them to complete the test group by test name.  It will also show time taken for setup of the test,  call of test, and teardown of the test.  

example:
```
(venv-ocsci)[sdurgbun ocs-ci] (feat/testTimingReport)$ cat session_test_time_report_file.csv 
testName        setup   call    teardown        total
tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py::TestClone::test_pvc_to_pvc_clone[CephFileSystem]   24.09   205.12  44.05   273.26
tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py::TestClone::test_pvc_to_pvc_clone[CephBlockPool]    52.33   213.14  31.28   296.75
(venv-ocsci)[sdurgbun ocs-ci] (feat/testTimingReport)$ 
```

It will also send the top 5 most time taking test details on the email too
