### PR TITLE
Exclude the pods with the prefix name of 'report-status-to-provider' in the leftovers check

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -328,6 +328,7 @@ ACCESS_MODE_RWOP = "ReadWriteOncePod"
 # Pod names
 NB_DB_NAME_46_AND_BELOW = "noobaa-db-0"
 NB_DB_NAME_47_AND_ABOVE = "noobaa-db-pg-0"
+REPORT_STATUS_TO_PROVIDER_POD = "report-status-to-provider-"
 
 # Pod label
 MON_APP_LABEL = "app=rook-ceph-mon"

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -102,6 +102,9 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             if name.startswith("session-awscli"):
                 log.debug(f"ignoring item: {name}")
                 continue
+            if name.startswith(constants.REPORT_STATUS_TO_PROVIDER_POD):
+                log.debug(f"ignoring item: {name}")
+                continue
         if item.get("kind") == constants.NAMESPACE:
             name = item.get("metadata").get("generateName")
             if name == "openshift-must-gather-":


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/8398