### PR TITLE
test_ceph_csidriver_runs_on_non_ocs_nodes: remove from tier1

### DIFF
--- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -7,7 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_multus_enabled,
 )
-from ocs_ci.framework.testlib import tier1, ManageTest, ignore_leftovers
+from ocs_ci.framework.testlib import tier2, ManageTest, ignore_leftovers
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
 from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @skipif_flexy_deployment
 @skipif_managed_service
 @skipif_multus_enabled
-@tier1
+@tier2
 @pytest.mark.polarion_id("OCS-2490")
 @pytest.mark.bugzilla("1794389")
 @ignore_leftovers


### PR DESCRIPTION
Change tier: 1-->2
fix #8396 
