### PR TITLE
bz mark is stale.

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -111,7 +111,6 @@ def test_ceph_mgr_dashboard_not_deployed():
 @skipif_ocs_version("<4.6")
 @metrics_for_external_mode_required
 @tier1
-@pytest.mark.bugzilla("1779336")
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
 def test_ceph_rbd_metrics_available():


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1779336 closed as WONTFIX but the issue is not observed anymore.
running steps manually leads to Expected results
----
1. Install OCP/OCS cluster 
2. Login as kubeadmin to OCP Console
3. Go to Monitoring -> Metrics page
4. Type eg. ceph_rbd_write_ops into the query and run it
----