### PR TITLE
Adding a new test case for test_auto_reclaim_space_cronjob.py test

### DIFF
--- a/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -255,9 +255,6 @@ class TestReclaimSpaceCronJob(ManageTest):
                 cmd="get reclaimspacecronjob",
                 namespace=self.namespace,
             ):
-                # if (len(sample) > 1 and cronjobs_exist) or (
-                #     len(sample) == 1 and not cronjobs_exist
-                # ):
                 if (
                     len(sample) == cronjobs_num + 1
                 ):  # in the result one line is always a title

--- a/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -49,33 +49,31 @@ class TestReclaimSpaceCronJob(ManageTest):
                 if os.path.exists(temp_file):
                     run_cmd(f"rm {temp_file}")
 
-            run_oc_command(cmd=f"delete namespace {self.namespace}")
+            if self.delete_namespace:
+                run_oc_command(cmd=f"delete namespace {self.namespace}")
 
         request.addfinalizer(finalizer)
 
-    def test_reclaim_space_cronjob(self):
+    def __reclaim_space_cronjob(self):
         """
-        Test case to check reclaim space cronjobs are created correctly for rbd pvcs in openshift-* namespace
+        Method which tests that cronjobs are created for RBD PVCs and not created for CEPHFS PVCs
         """
         num_of_pvcs = 10
-        namespace = f"openshift-{uuid4().hex}"
-        self.namespace = namespace
-        result = run_oc_command(cmd=f"create namespace {self.namespace}")
-        assert ERRMSG not in result[0], (
-            f"Failed to create namespace with name {namespace}" f"got result: {result}"
+
+        existing_pvcs_num = 0
+        for line in run_oc_command(f"get pvc", namespace=self.namespace):
+            if constants.STATUS_BOUND in line:
+                existing_pvcs_num += 1
+
+        logger.info(f"There are {existing_pvcs_num} existing PVCs")
+
+        cron_jobs_result = run_oc_command(
+            f"get reclaimspacecronjob", namespace=self.namespace
         )
-        logger.info(f"Namespace {namespace} created")
-
-        result = run_oc_command(cmd=f"get namespace {namespace} -o yaml")
-        namespace_dict = yaml.safe_load("\n".join(result))
-
-        schedule = namespace_dict["metadata"]["annotations"][
-            "reclaimspace.csiaddons.openshift.io/schedule"
-        ]
-        assert (
-            schedule == "@weekly"
-        ), f"Namespace {namespace} created with schedule {schedule}, expected @weekly"
-        logger.info(f"Existence of schedule {schedule} validated.")
+        existing_cronjobs_num = (
+            len(cron_jobs_result) - 1
+        )  # first line of the result is title
+        logger.info(f"There are {existing_cronjobs_num} existing cronjobs")
 
         self.pvc_objs_created, _ = helpers.create_multiple_pvcs(
             sc_name=constants.DEFAULT_STORAGECLASS_RBD,
@@ -87,7 +85,7 @@ class TestReclaimSpaceCronJob(ManageTest):
         logger.info("Wait for all of the PVCs to be in Bound state")
         performance_lib.wait_for_resource_bulk_status(
             "pvc",
-            num_of_pvcs,
+            num_of_pvcs + existing_pvcs_num,
             self.namespace,
             constants.STATUS_BOUND,
             num_of_pvcs * 2,
@@ -97,7 +95,8 @@ class TestReclaimSpaceCronJob(ManageTest):
         # will raise an exception. so in this point the creation succeed
 
         result = self.wait_for_cronjobs(
-            True, f"No reclaim space cron jobs exist in namespace {namespace}"
+            num_of_pvcs + existing_cronjobs_num,
+            f"No reclaim space cron jobs exist in namespace {self.namespace}",
         )
         logger.info(f"Reclaim space jobs after PVC creation {result}")
 
@@ -120,7 +119,8 @@ class TestReclaimSpaceCronJob(ManageTest):
             "Validating that all the cron jobs were deleted following deletion of the PVCs"
         )
         self.wait_for_cronjobs(
-            False, "After PVCs deletion some reclaimspacecronjobs were left"
+            existing_cronjobs_num,
+            "After PVCs deletion some reclaimspacecronjobs were left",
         )
 
         # create CephFS PVC and test that no reclaim space job created for it
@@ -128,7 +128,7 @@ class TestReclaimSpaceCronJob(ManageTest):
             pvc_obj = helpers.create_pvc(
                 sc_name=constants.DEFAULT_STORAGECLASS_CEPHFS,
                 size="1Gi",
-                namespace=namespace,
+                namespace=self.namespace,
             )
             helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND)
         except Exception as e:
@@ -139,11 +139,47 @@ class TestReclaimSpaceCronJob(ManageTest):
         self.pvc_objs_created.append(pvc_obj)
 
         self.wait_for_cronjobs(
-            False, "After CephtFS PVC creation reclaim space cron job exists"
+            existing_cronjobs_num,
+            "After CephtFS PVC creation reclaim space cron job exists",
         )
 
         logger.info("No reclaim space cron job was created for CephFS PVCs")
         pvc_obj.delete()
+
+    def test_reclaim_space_cronjob(self):
+        """
+        Test case to check reclaim space cronjobs are created correctly for rbd pvcs in openshift-* namespace
+        """
+        namespace = f"openshift-{uuid4().hex}"
+        self.namespace = namespace
+        result = run_oc_command(cmd=f"create namespace {self.namespace}")
+        assert ERRMSG not in result[0], (
+            f"Failed to create namespace with name {namespace}" f"got result: {result}"
+        )
+        logger.info(f"Namespace {namespace} created")
+
+        result = run_oc_command(cmd=f"get namespace {namespace} -o yaml")
+        namespace_dict = yaml.safe_load("\n".join(result))
+
+        schedule = namespace_dict["metadata"]["annotations"][
+            "reclaimspace.csiaddons.openshift.io/schedule"
+        ]
+        assert (
+            schedule == "@weekly"
+        ), f"Namespace {namespace} created with schedule {schedule}, expected @weekly"
+        logger.info(f"Existence of schedule {schedule} validated.")
+
+        self.delete_namespace = True
+        self.__reclaim_space_cronjob()
+
+    def test_reclaim_space_cronjob_on_existing_namespace(self):
+        """
+        Test case to check reclaim space cronjobs are created correctly for rbd pvcs in existing openshift-* namespaces
+        ("openshift-monitoring" is taken as example)
+        """
+        self.namespace = "openshift-monitoring"
+        self.delete_namespace = False
+        self.__reclaim_space_cronjob()
 
     def test_skip_reclaim_space(self):
         """
@@ -175,6 +211,7 @@ class TestReclaimSpaceCronJob(ManageTest):
             f"Failed to create namespace with name {namespace} " f"got result: {res}"
         )
         logger.info(f"Namespace {namespace} created")
+        self.delete_namespace = True
 
         try:
             pvc_obj = helpers.create_pvc(
@@ -190,21 +227,19 @@ class TestReclaimSpaceCronJob(ManageTest):
         logger.info(f"PVC by name {pvc_obj.name} created")
         self.pvc_objs_created.append(pvc_obj)
 
-        self.wait_for_cronjobs(
-            False, "For RBD PVC creation reclaim space cron job exists"
-        )
+        self.wait_for_cronjobs(0, "For RBD PVC creation reclaim space cron job exists")
 
         logger.info(
             "No reclaim space cron job was created for RBD PVC if skipReclaimspaceSchedule is True."
         )
         pvc_obj.delete()
 
-    def wait_for_cronjobs(self, cronjobs_exist, msg, timeout=60):
+    def wait_for_cronjobs(self, cronjobs_num, msg, timeout=60):
         """
         Runs 'oc get reclaimspacecronjob' with the TimeoutSampler
 
         Args:
-            cronjobs_exist (bool): Condition to be tested, True if cronjobs should exist, False otherwise
+            cronjobs_num (int): the exact number of cronjobs that should exist
             msg (str): Error message to be printed if the desired condition is not reached
             timeout (int): Timeout
         Returns:
@@ -220,9 +255,12 @@ class TestReclaimSpaceCronJob(ManageTest):
                 cmd="get reclaimspacecronjob",
                 namespace=self.namespace,
             ):
-                if (len(sample) > 1 and cronjobs_exist) or (
-                    len(sample) == 1 and not cronjobs_exist
-                ):
+                # if (len(sample) > 1 and cronjobs_exist) or (
+                #     len(sample) == 1 and not cronjobs_exist
+                # ):
+                if (
+                    len(sample) == cronjobs_num + 1
+                ):  # in the result one line is always a title
                     return sample
         except TimeoutExpiredError:
             raise Exception(f"{msg}: {sample}")

--- a/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -67,7 +67,9 @@ class TestReclaimSpaceCronJob(ManageTest):
 
         logger.info(f"There are {existing_pvcs_num} existing PVCs")
 
-        cron_jobs_result = run_oc_command("get reclaimspacecronjob", namespace=self.namespace)
+        cron_jobs_result = run_oc_command(
+            "get reclaimspacecronjob", namespace=self.namespace
+        )
         existing_cronjobs_num = (
             len(cron_jobs_result) - 1
         )  # first line of the result is title

--- a/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -61,15 +61,13 @@ class TestReclaimSpaceCronJob(ManageTest):
         num_of_pvcs = 10
 
         existing_pvcs_num = 0
-        for line in run_oc_command(f"get pvc", namespace=self.namespace):
+        for line in run_oc_command("get pvc", namespace=self.namespace):
             if constants.STATUS_BOUND in line:
                 existing_pvcs_num += 1
 
         logger.info(f"There are {existing_pvcs_num} existing PVCs")
 
-        cron_jobs_result = run_oc_command(
-            f"get reclaimspacecronjob", namespace=self.namespace
-        )
+        cron_jobs_result = run_oc_command("get reclaimspacecronjob", namespace=self.namespace)
         existing_cronjobs_num = (
             len(cron_jobs_result) - 1
         )  # first line of the result is title


### PR DESCRIPTION
In this PR I've added a test case 'test_reclaim_space_cronjob_on_existing_namespace' which verifies the creation and deletion of cronjobs upon pvc creation/deletion in the existing "openshift-monitoring" namespace. 

This test case has a lot of common code with already existing test case 'test_reclaim_space_cronjob' . 
Therefore the shared code was refactored into  __reclaim_space_cronjob method. 


