### PR TITLE
adjust workload-alerts test

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -337,6 +337,7 @@ def workload_fio_storageutilization(
     keep_fio_data=False,
     minimal_time=480,
     throw_skip=True,
+    extra_time=40,
 ):
     """
     This function implements core functionality of fio storage utilization
@@ -383,6 +384,12 @@ def workload_fio_storageutilization(
             (See more details in the function 'measure_operation')
         throw_skip (bool): if True function will raise pytest.skip.Exception and test will be skipped,
             otherwise return None
+        extra_time (int): Extra number of seconds to monitor a system, after
+            operation and minimal time ends. Useful for monitoring the system on
+            capacity tests, where estimated operation time is unknown.
+            e.g.
+            CephClusterNearFull is in firing if utilization is >75% for 40s.
+            CephClusterCriticallyFull is in firing if utilization is >80% for 40s
 
     Returns:
         dict: measurement results with timestamps and other medatada from
@@ -528,6 +535,7 @@ def workload_fio_storageutilization(
         test_file,
         measure_after=True,
         minimal_time=minimal_time,
+        extra_time=extra_time,
     )
 
     # we don't need to delete anything if this fixture has been already

--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.polarion_id("OCS-899")
 @pytest.mark.bugzilla("1943137")
+@pytest.mark.bugzilla("2237742")
 @tier2
 @gather_metrics_on_fail(
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"
@@ -80,6 +81,7 @@ def test_rbd_capacity_workload_alerts(workload_storageutilization_97p_rbd):
 
 @pytest.mark.polarion_id("OCS-1934")
 @pytest.mark.bugzilla("1943137")
+@pytest.mark.bugzilla("2237742")
 @tier2
 @gather_metrics_on_fail(
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"


### PR DESCRIPTION
Currently the tests test_cephfs_capacity_workload_alerts and test_rbd_capacity_workload_alerts are failing to capture CephClusterNearFull and CephClusterCriticallyFull most of the time

Log analysis and manual test run shows several problems:
1. Prometheus stops to respond during the utilization 4-5 minutes. If the malfunction happens in the end of utilization we miss the alerts
2. Silent Error. When Prometheus stops to respond the workload fixture receives assertion error `assert alerts_response.ok, msg` in parallel thread (which is called from measure_operation) before test starts and the test proceed without measurements
```
measured_op = measure_operation(
        lambda: write_data_via_fio(
            fio_job_file, write_timeout, pvc_size, target_percentage
        ),
        test_file,
        measure_after=True,
        minimal_time=minimal_time,
        extra_time=extra_time,
    )
```
3. Cluster should violate prometheus rules for a period of time before alerts are actually starting to fire. 
CephClusterNearFull is in firing if utilization is >75% for 40s.
CephClusterCriticallyFull is in firing if utilization is >80% for 40s.

All the issues addressed and bz mark added, to stop failing the tests until Prometheus malfunction fixed

FIXES #8323
