### PR TITLE
Exclude checking the pod statuses with the name prefix "report-status-to-provider-"

### DIFF
--- a/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -143,8 +143,8 @@ class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
                     condition=constants.STATUS_FAILED,
                     resource_name=machine_name,
                     column="PHASE",
-                    timeout=240,
-                    sleep=10,
+                    timeout=720,
+                    sleep=30,
                 )
                 delete_machine(machine_name)
                 timeout = 1500 if is_vsphere_ipi_cluster() else 900


### PR DESCRIPTION
In the PR, I implemented the following:
- In the functions `check_pods_after_node_replacement` and `check_pods_in_running_state`, exclude checking the pod statuses with the name prefix `report-status-to-provider-`.
- Add the param `exclude_pod_name_prefixes` to the functions `check_pods_in_statuses` and `get_pods_in_statuses` for excluding the pod names with specific prefixes.