### PR TITLE
In case of high skip rate due to Ceph health not OK - Report test case and squad causing that

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -33,7 +33,7 @@ RUN:
   # This config file disables scale app pods to use OCS workers
   use_ocs_worker_for_scale: False
   load_status: None
-  skip_reason_test_found: None
+  skip_reason_test_found: {}
   skipped_tests_ceph_health: 0
   number_of_tests: None
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -33,6 +33,10 @@ RUN:
   # This config file disables scale app pods to use OCS workers
   use_ocs_worker_for_scale: False
   load_status: None
+  skip_reason_test_found: None
+  skipped_tests_ceph_health: 0
+  number_of_tests: None
+
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -662,6 +662,7 @@ def pytest_collection_modifyitems(session, config, items):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    ocsci_config.RUN["number_of_tests"] = len(item.session.items)
     outcome = yield
     rep = outcome.get_result()
     # we only look at actual failing test calls, not setup/teardown

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -662,7 +662,6 @@ def pytest_collection_modifyitems(session, config, items):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    ocsci_config.RUN["number_of_tests"] = len(item.session.items)
     outcome = yield
     rep = outcome.get_result()
     # we only look at actual failing test calls, not setup/teardown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1514,6 +1514,15 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                         ceph_health_check_base()
                         log.info("Ceph health check passed at teardown")
             except CephHealthException:
+                if config.RUN["skip_reason_test_found"] is None:
+                    squad_name = None
+                    for marker in node.iter_markers():
+                        if "_squad" in marker.name:
+                            squad_name = marker.name
+                    config.RUN["skip_reason_test_found"] = {
+                        "test_name": node.name,
+                        "squad": squad_name,
+                    }
                 log.info("Ceph health check failed at teardown")
                 # Retrying to increase the chance the cluster health will be OK
                 # for next test
@@ -1532,6 +1541,7 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                     log.info("Ceph health check passed at setup")
                     return
             except CephHealthException:
+                config.RUN["skipped_tests_ceph_health"] += 1
                 skipped = True
                 # skip because ceph is not in good health
                 pytest.skip("Ceph health check failed at setup")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1499,7 +1499,7 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
     node = request.node
 
     # ignore ceph health check for the TestFailurePropagator test cases
-    if "FailurePropagator" in node.cls:
+    if "FailurePropagator" in str(node.cls):
         return
 
     def finalizer():
@@ -1530,7 +1530,7 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                         ceph_health_check_base()
                         log.info("Ceph health check passed at teardown")
             except CephHealthException:
-                if config.RUN["skip_reason_test_found"] is None:
+                if not config.RUN["skip_reason_test_found"]:
                     squad_name = None
                     for marker in node.iter_markers():
                         if "_squad" in marker.name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1518,7 +1518,6 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                     for mark in node.iter_markers():
                         if "ceph_health_retry" == mark.name:
                             ceph_health_retry = True
-                            break
                     if ceph_health_retry:
                         ceph_health_check(
                             namespace=config.ENV_DATA["cluster_namespace"]
@@ -1536,6 +1535,7 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                     for marker in node.iter_markers():
                         if "_squad" in marker.name:
                             squad_name = marker.name
+                            break
                     config.RUN["skip_reason_test_found"] = {
                         "test_name": node.name,
                         "squad": squad_name,

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -59,7 +59,7 @@ class TestFailurePropagator:
             f"This run had {skipped_on_ceph_health_percent * 100}% of the "
             f"tests skipped due to Ceph health not OK."
         )
-        if 0 < skipped_on_ceph_health_percent > 0.2:
+        if 0 < skipped_on_ceph_health_percent < 0.5:
             if config.RUN.get("skip_reason_test_found"):
                 test_name = config.RUN.get("skip_reason_test_found").get("test_name")
                 message = (

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -59,7 +59,7 @@ class TestFailurePropagator:
             f"This run had {skipped_on_ceph_health_percent * 100}% of the "
             f"tests skipped due to Ceph health not OK."
         )
-        if 0.5 < skipped_on_ceph_health_percent < 1:
+        if skipped_on_ceph_health_percent > 0.25:
             if config.RUN.get("skip_reason_test_found"):
                 test_name = config.RUN.get("skip_reason_test_found").get("test_name")
                 message = (

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -39,12 +39,17 @@ from ocs_ci.framework.pytest_customization.marks import (
 @scale
 class TestFailurePropagator:
     """
-    Test class for failure propagator test case. The test intention is to run last and propagate
-    teardown failures caught during the test execution, so regular test cases won't false negatively fail
+    Test class for failure propagator test case
     """
 
     @pytest.mark.second_to_last
     def test_report_skip_triggering_test(self):
+        """
+        This test runs second to last and examines the skipped test cases of the execution.
+        In case of high rate of skipped tests due to Ceph health not OK, which indicates something went wrong
+        with the cluster during the execution, it will fail and report the potential test case that caused
+        this problematic state
+        """
         pass_rate_counting_ceph_health_skips = (
             config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
         )
@@ -73,4 +78,8 @@ class TestFailurePropagator:
 
     @pytest.mark.last
     def test_failure_propagator(self):
+        """
+        This test intention is to run last and propagate teardown failures caught during the test execution,
+        so regular test cases won't false negatively fail
+        """
         pass

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -9,6 +9,15 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     tier4b,
     tier4c,
+    pre_upgrade,
+    post_upgrade,
+    pre_ocs_upgrade,
+    pre_ocp_upgrade,
+    post_ocp_upgrade,
+    post_ocs_upgrade,
+    workloads,
+    performance,
+    scale,
 )
 
 
@@ -19,6 +28,15 @@ from ocs_ci.framework.pytest_customization.marks import (
 @tier4a
 @tier4b
 @tier4c
+@pre_upgrade
+@post_upgrade
+@pre_ocs_upgrade
+@pre_ocp_upgrade
+@post_ocp_upgrade
+@post_ocs_upgrade
+@workloads
+@performance
+@scale
 class TestFailurePropagator:
     """
     Test class for failure propagator test case. The test intention is to run last and propagate
@@ -32,7 +50,7 @@ class TestFailurePropagator:
         )
         message = (
             f"This run had {1 - (pass_rate_counting_ceph_health_skips * 100)}% of the "
-            f"tests skipped due to Ceph health not OK. "
+            f"tests skipped due to Ceph health not OK."
         )
         if (
             config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
@@ -41,18 +59,17 @@ class TestFailurePropagator:
             if config.RUN["skip_reason_test_found"]:
                 message = (
                     message
-                    + f"The test that is likely to cause this is {config.RUN['skip_reason_test_found']['test_name']} "
+                    + f" The test that is likely to cause this is {config.RUN['skip_reason_test_found']['test_name']}"
                 )
                 if config.RUN["skip_reason_test_found"]["squad"]:
                     message = (
                         message
-                        + f"which is under {config.RUN['skip_reason_test_found']['squad']}'s responsibility"
+                        + f" which is under {config.RUN['skip_reason_test_found']['squad']}'s responsibility"
                     )
 
             else:
-                message = message + "Couldn't identify the test case that caused this"
+                message = message + " Couldn't identify the test case that caused this"
             pytest.fail(message)
-        pass
 
     @pytest.mark.last
     def test_failure_propagator(self):

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -50,27 +50,24 @@ class TestFailurePropagator:
         with the cluster during the execution, it will fail and report the potential test case that caused
         this problematic state
         """
-        pass_rate_counting_ceph_health_skips = (
-            config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
+        number_of_eligible_tests = config.RUN.get("number_of_tests") - 2
+
+        skipped_on_ceph_health_percent = (
+            config.RUN.get("skipped_tests_ceph_health") / number_of_eligible_tests
         )
         message = (
-            f"This run had {1 - (pass_rate_counting_ceph_health_skips * 100)}% of the "
+            f"This run had {skipped_on_ceph_health_percent * 100}% of the "
             f"tests skipped due to Ceph health not OK."
         )
-        if (
-            config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
-            > 0.2
-        ):
-            if config.RUN["skip_reason_test_found"]:
+        if 0 < skipped_on_ceph_health_percent > 0.2:
+            if config.RUN.get("skip_reason_test_found"):
+                test_name = config.RUN.get("skip_reason_test_found").get("test_name")
                 message = (
-                    message
-                    + f" The test that is likely to cause this is {config.RUN['skip_reason_test_found']['test_name']}"
+                    message + f" The test that is likely to cause this is {test_name}"
                 )
-                if config.RUN["skip_reason_test_found"]["squad"]:
-                    message = (
-                        message
-                        + f" which is under {config.RUN['skip_reason_test_found']['squad']}'s responsibility"
-                    )
+                squad = config.RUN.get("skip_reason_test_found").get("squad")
+                if squad:
+                    message = message + f" which is under {squad}'s responsibility"
 
             else:
                 message = message + " Couldn't identify the test case that caused this"

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -59,7 +59,7 @@ class TestFailurePropagator:
             f"This run had {skipped_on_ceph_health_percent * 100}% of the "
             f"tests skipped due to Ceph health not OK."
         )
-        if 0 < skipped_on_ceph_health_percent < 0.5:
+        if 0.5 < skipped_on_ceph_health_percent < 1:
             if config.RUN.get("skip_reason_test_found"):
                 test_name = config.RUN.get("skip_reason_test_found").get("test_name")
                 message = (

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -1,15 +1,59 @@
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    acceptance,
+    tier1,
+    tier2,
+    tier3,
+    tier4a,
+    tier4b,
+    tier4c,
+)
 
 
 @tier1
-@pytest.mark.last
+@acceptance
+@tier2
+@tier3
+@tier4a
+@tier4b
+@tier4c
 class TestFailurePropagator:
     """
     Test class for failure propagator test case. The test intention is to run last and propagate
     teardown failures caught during the test execution, so regular test cases won't false negatively fail
     """
 
+    @pytest.mark.second_to_last
+    def test_report_skip_triggering_test(self):
+        pass_rate_counting_ceph_health_skips = (
+            config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
+        )
+        message = (
+            f"This run had {1 - (pass_rate_counting_ceph_health_skips * 100)}% of the "
+            f"tests skipped due to Ceph health not OK. "
+        )
+        if (
+            config.RUN["skipped_tests_ceph_health"] / config.RUN["number_of_tests"]
+            > 0.2
+        ):
+            if config.RUN["skip_reason_test_found"]:
+                message = (
+                    message
+                    + f"The test that is likely to cause this is {config.RUN['skip_reason_test_found']['test_name']} "
+                )
+                if config.RUN["skip_reason_test_found"]["squad"]:
+                    message = (
+                        message
+                        + f"which is under {config.RUN['skip_reason_test_found']['squad']}'s responsibility"
+                    )
+
+            else:
+                message = message + "Couldn't identify the test case that caused this"
+            pytest.fail(message)
+        pass
+
+    @pytest.mark.last
     def test_failure_propagator(self):
         pass

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -43,7 +43,7 @@ class TestFailurePropagator:
     """
 
     @pytest.mark.second_to_last
-    def test_report_skip_triggering_test(self):
+    def test_report_skip_triggering_test(self, request):
         """
         This test runs second to last and examines the skipped test cases of the execution.
         In case of high rate of skipped tests due to Ceph health not OK, which indicates something went wrong
@@ -68,6 +68,7 @@ class TestFailurePropagator:
                 squad = config.RUN.get("skip_reason_test_found").get("squad")
                 if squad:
                     message = message + f" which is under {squad}'s responsibility"
+                    request.node.add_marker(squad)
 
             else:
                 message = message + " Couldn't identify the test case that caused this"


### PR DESCRIPTION
This test runs second to last and examines the skipped test cases of the execution.
In case of a high rate of skipped tests due to Ceph health not OK, which indicates something went wrong with the cluster during the execution, it will fail and report the potential test case that caused this problematic state.

Below is an example for how it works:

```
2023-09-12 01:03:10 E Failed: This run had 71.875% of the tests skipped due to Ceph health not OK. The test that is likely 
to cause this is test_bucket_creation[3-CLI-DEFAULT-BACKINGSTORE] which is under red_squad's responsibility
```

In this example, since this logic identified the culprit to be a test case belonging to Red Squad, `test_report_skip_triggering_test` was automatically marked with the `red_squad` marker and it will be categorized under Red Squad so it will be examined by that squad 