### PR TITLE
Refactor `nsfs_bucket_factory_fixture` and fix various NSFS issues

### DIFF
--- a/ocs_ci/ocs/resources/mcg_params.py
+++ b/ocs_ci/ocs/resources/mcg_params.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-import boto3
 
 from ocs_ci.ocs.resources.namespacestore import NamespaceStore
 from ocs_ci.ocs.resources.objectbucket import ObjectBucket
@@ -41,12 +40,12 @@ class NSFS:
         interface_pod (Pod): The pod that will be used to interact with the NSFS
         bucket_name (str): The name of the NSFS bucket
         mounted_bucket_path (str): The path to where the bucket is "mounted" in the FS
-        s3_client (boto3.client): The boto3 client that will be used to interact with the NSFS
+        s3_creds (str): The NSFS S3 credentials
         nss (NamespaceStore): The namespacestore that the NSFS uses
     """
     interface_pod: Pod = None
     bucket_obj: ObjectBucket = None
     bucket_name: str = None
     mounted_bucket_path: str = None
-    s3_client: boto3.client = None
+    s3_creds: dict = None
     nss: NamespaceStore = None

--- a/ocs_ci/ocs/resources/mcg_params.py
+++ b/ocs_ci/ocs/resources/mcg_params.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import boto3
 
 from ocs_ci.ocs.resources.namespacestore import NamespaceStore
 from ocs_ci.ocs.resources.objectbucket import ObjectBucket
@@ -21,7 +22,6 @@ class NSFS:
         mount_path (str): The path to the mount point of the NSFS
         uid (int): The UID of the user that will be used to create the NSFS
         gid (int): The GID of the user that will be used to create the NSFS
-        verify_health (bool): Whether to verify the health of the NSFS bucket after its creation
     """
 
     method: str = "CLI"
@@ -34,7 +34,6 @@ class NSFS:
     mount_path: str = "/nsfs"
     uid: int = 5678
     gid: int = 1234
-    verify_health: bool = True
     """
     State parameters; These should not be modified unless needed, and will be (over/)written
     after the NSFS object will be passed to the bucket factory.
@@ -42,12 +41,12 @@ class NSFS:
         interface_pod (Pod): The pod that will be used to interact with the NSFS
         bucket_name (str): The name of the NSFS bucket
         mounted_bucket_path (str): The path to where the bucket is "mounted" in the FS
-        s3_creds (str): The NSFS S3 credentials
+        s3_client (boto3.client): The boto3 client that will be used to interact with the NSFS
         nss (NamespaceStore): The namespacestore that the NSFS uses
     """
     interface_pod: Pod = None
     bucket_obj: ObjectBucket = None
     bucket_name: str = None
     mounted_bucket_path: str = None
-    s3_creds: dict = None
+    s3_client: boto3.client = None
     nss: NamespaceStore = None

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -590,23 +590,18 @@ class MCGNamespaceBucket(ObjectBucket):
         actual_read_resources = ns_properties.get("read_resources")
         actual_write_resource = ns_properties.get("write_resource")
 
-        write_resource_ok, read_resources_ok = False, False
-        write_resource_ok = self.write_ns_resource == actual_write_resource
+        expected_read_resources = self.read_ns_resources
         if isinstance(self.read_ns_resources[0], dict):
-            actual_read_resources = set(
-                (read_source.resource, read_source.path)
-                for read_source in actual_read_resources
-            )
-            expected_read_resources = set(
-                (read_source.resource, read_source.path)
-                for read_source in self.read_ns_resources
-            )
-            read_resources_ok = actual_read_resources == expected_read_resources
-        else:
-            read_resources_ok = set(actual_read_resources) == set(
-                self.read_ns_resources
-            )
-        return write_resource_ok and read_resources_ok
+            actual_read_resources = [
+                (r["resource"], r["path"]) for r in actual_read_resources
+            ]
+            expected_read_resources = [
+                (r["resource"], r["path"]) for r in self.read_ns_resources
+            ]
+
+        return set(actual_read_resources) == set(expected_read_resources) and set(
+            actual_write_resource
+        ) == set(self.write_ns_resource)
 
     def internal_verify_deletion(self):
         # Retrieve the NooBaa system information

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -589,9 +589,24 @@ class MCGNamespaceBucket(ObjectBucket):
         ns_properties = match_buckets[0].get("namespace")
         actual_read_resources = ns_properties.get("read_resources")
         actual_write_resource = ns_properties.get("write_resource")
-        return set(actual_read_resources) == set(self.read_ns_resources) and set(
-            actual_write_resource
-        ) == set(self.write_ns_resource)
+
+        write_resource_ok, read_resources_ok = False, False
+        write_resource_ok = self.write_ns_resource == actual_write_resource
+        if isinstance(self.read_ns_resources[0], dict):
+            actual_read_resources = set(
+                (read_source.resource, read_source.path)
+                for read_source in actual_read_resources
+            )
+            expected_read_resources = set(
+                (read_source.resource, read_source.path)
+                for read_source in self.read_ns_resources
+            )
+            read_resources_ok = actual_read_resources == expected_read_resources
+        else:
+            read_resources_ok = set(actual_read_resources) == set(
+                self.read_ns_resources
+            )
+        return write_resource_ok and read_resources_ok
 
     def internal_verify_deletion(self):
         # Retrieve the NooBaa system information

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2306,6 +2306,45 @@ def wait_for_pods_to_be_running(
         return False
 
 
+def wait_for_pods_by_label_count(
+    label,
+    exptected_count,
+    namespace=config.ENV_DATA["cluster_namespace"],
+    timeout=200,
+    sleep=10,
+):
+    """
+
+    Wait for the expected number of pods with the given selector.
+
+    Args:
+        selector (str): The resource selector to search with
+        exptected_count (int): The expected number of pods with the given selector
+        namespace (str): the namespace ot the pods
+        timeout (int): time to wait for pods to be running
+        sleep (int): Time in seconds to sleep between attempts
+
+    """
+
+    try:
+        for pods_count in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_pod_count,
+            label=label,
+            namespace=namespace,
+        ):
+            # Check if the expected number of pods with the given selector is met
+            if pods_count == exptected_count:
+                logger.info(f"Found {exptected_count} pods with selector {label}")
+                return True
+    except TimeoutExpiredError:
+        logger.warning(
+            f"The expected number of pods was not met" f"after {timeout} seconds"
+        )
+        return False
+
+
 def list_of_nodes_running_pods(
     selector, namespace=config.ENV_DATA["cluster_namespace"]
 ):
@@ -3115,7 +3154,6 @@ def get_mon_label(mon_pod_obj):
 
 
 def set_osd_maintenance_mode(osd_deployment):
-
     """
     Set osd in maintenance mode for running ceph-objectstore commands
 

--- a/tests/manage/mcg/test_nsfs.py
+++ b/tests/manage/mcg/test_nsfs.py
@@ -77,7 +77,7 @@ class TestNSFSObjectIntegrity(MCGTest):
             pattern="nsfs-test-obj-",
             s3_creds=nsfs_obj.s3_creds,
             result_pod=nsfs_obj.interface_pod,
-            result_pod_path=nsfs_obj.mount_path + "/" + nsfs_obj.bucket_name,
+            result_pod_path=nsfs_obj.mounted_bucket_path,
         )
 
     @pytest.mark.polarion_id("OCS-3737")
@@ -120,7 +120,7 @@ class TestNSFSObjectIntegrity(MCGTest):
                 pattern="nsfs-test-obj-",
                 s3_creds=nsfs_obj.s3_creds,
                 result_pod=nsfs_obj.interface_pod,
-                result_pod_path=nsfs_obj.mount_path + "/" + nsfs_obj.bucket_name,
+                result_pod_path=nsfs_obj.mounted_bucket_path,
             )
         except Exception as e:
             assert "AccessDenied" in str(


### PR DESCRIPTION
- Fix the way we wait for the pods to mount the volume after setting NSFS
- Semantic changes to `mcg_account_factory_fixture`
- Use one of the noobaa-endpoint pods to interface with the volume, instead of the ubi8 pod: Fixes #8451
- Use the bucket_factory fixture with the `mcg-namespace` interface to create the NSFS bucket in the export scenario - removes the need for dealing with creation/cleanup logic in the fixture.
- Following step 6 at https://github.com/noobaa/noobaa-core/wiki/NSFS-on-Kubernetes, add the following policy to the export-scenario bucket:
```
            # Allow access to the export dir by adding a bucket policy
            bucket_policy = gen_bucket_policy(
                user_list=["*"],
                actions_list=["*"],
                resources_list=["*"],
            )
            bucket_policy = json.dumps(bucket_policy)
            put_bucket_policy(mcg_obj_session, nsfs_obj.bucket_name, bucket_policy)
```
This fixes #8244
- Other minor semantic changes

Required backports:
- [ ] 4.13
- [ ] 4.12


