### PR TITLE
enable ceph metrics for internal and external clusters

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -277,6 +277,7 @@ OCP_QE_DEVICEPATH_REPO = "https://github.com/anubhav-here/device-by-id-ocp.git"
 
 # Default pools
 DEFAULT_CEPHBLOCKPOOL = "ocs-storagecluster-cephblockpool"
+DEFAULT_CEPHBLOCKPOOL_EXTERNAL = "ocs-external-storagecluster-ceph-rgw"
 # Default StorageClass
 DEFAULT_STORAGECLASS_CEPHFS = f"{DEFAULT_CLUSTERNAME}-cephfs"
 DEFAULT_STORAGECLASS_RBD = f"{DEFAULT_CLUSTERNAME}-ceph-rbd"

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -199,38 +199,6 @@ def test_monitoring_reporting_ok_when_idle(workload_idle):
 @skipif_managed_service
 @skipif_ocs_version("<4.6")
 class TestCephMonitoringAvailable:
-    @pytest.fixture(scope="class")
-    def enable_rbd_metrics(self, request):
-        self.ct_pod = pod.get_ceph_tools_pod()
-        self.pools_enabled = self.ct_pod.exec_ceph_cmd(
-            "ceph config get mgr mgr/prometheus/rbd_stats_pools", out_yaml_format=False
-        )
-
-        def restore_ceph_rbd_metrics_settings():
-            self.ct_pod.exec_ceph_cmd(
-                'ceph config set mgr mgr/prometheus/rbd_stats_pools ""',
-                out_yaml_format=False,
-            )
-            pools_enabled = ",".join(self.pools_enabled)
-            self.ct_pod.exec_ceph_cmd(
-                f'ceph config set mgr mgr/prometheus/rbd_stats_pools "{pools_enabled}"',
-                out_yaml_format=False,
-            )
-
-        default_pool = (
-            constants.DEFAULT_CEPHBLOCKPOOL_EXTERNAL
-            if config.DEPLOYMENT["external_mode"]
-            else constants.DEFAULT_CEPHBLOCKPOOL
-        )
-
-        # set all pools to be monitored by prometheus
-        if not (default_pool in self.pools_enabled or "*" in self.pools_enabled):
-            self.ct_pod.exec_ceph_cmd(
-                'ceph config set mgr mgr/prometheus/rbd_stats_pools "*"',
-                out_yaml_format=False,
-            )
-            request.addfinalizer(restore_ceph_rbd_metrics_settings)
-
     @blue_squad
     @metrics_for_external_mode_required
     @tier1

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -195,6 +195,7 @@ def test_monitoring_reporting_ok_when_idle(workload_idle):
     osds_msg = "ceph_osd_{up,in} metrics should indicate no OSD issues"
     assert all(osd_validations), osds_msg
 
+
 @skipif_mcg_only
 @skipif_managed_service
 @skipif_ocs_version("<4.6")

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -112,6 +112,7 @@ def test_ceph_mgr_dashboard_not_deployed():
         msg = "ceph mgr dashboard route should not be deployed as part of OCS"
         assert "ceph-mgr-dashboard" not in route_name, msg
 
+
 @bugzilla("2238400")
 @blue_squad
 @tier1


### PR DESCRIPTION
We need to solve the problem frequently happening on External mode deployments when the **test_ceph_rbd_metrics_available** fails because ceph is not configured to enable rbd metrics. 
My intention was to enable it and disable after the test.
More info about problem is here -> https://bugzilla.redhat.com/show_bug.cgi?id=2237412

Test passes on internal deployment -> http://pastebin.test.redhat.com/1109172

Test fails on my currently available External mode deployment
I am getting an error when trying to run any 'ceph' command on external mode cluster (for instance 'ceph -s ')

via 'oc rsh' to external toolbox

{CommandFailed}Error during execution of command: oc -n openshift-storage rsh rook-ceph-tools-6ccd65499-cwplh ceph config get mgr mgr/prometheus/rbd_stats_pools --format json-pretty.
Error is 2023-09-11T13:13:12.312+0000 7f815a6f3640 -1 auth: error parsing file /etc/ceph/keyring: error setting modifier for [client.admin] type=key val=admin-secret: Malformed input2023-09-11T13:13:12.312+0000 7f815a6f3640 -1 auth: failed to load /etc/ceph/keyring: (5) Input/output error2023-09-11T13:13:12.317+0000 7f815a6f3640 -1 auth: error parsing file /etc/ceph/keyring: error setting modifier for [client.admin] type=key val=admin-secret: Malformed input2023-09-11T13:13:12.317+0000 7f815a6f3640 -1 auth: failed to load /etc/ceph/keyring: (5) Input/output error2023-09-11T13:13:12.317+0000 7f815a6f3640 -1 auth: error parsing file /etc/ceph/keyring: error setting modifier for [client.admin] type=key val=admin-secret: Malformed input2023-09-11T13:13:12.317+0000 7f815a6f3640 -1 auth: failed to load /etc/ceph/keyring: ...

via 'oc debug' to external toolbox 

ceph -s      
Error initializing cluster client: ObjectNotFound('RADOS object not found (error calling conf_read_file)')
 