### PR TITLE
Add the `skip_tls_verify` run config param

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -57,6 +57,7 @@ run it belongs here.
 * `log_utilization` - Enable logging of cluster utilization metrics every 10 seconds. Set via --log-cluster-utilization
 * `use_ocs_worker_for_scale` - Use OCS workers for scale testing (Default: false)
 * `load_status` - Current status of IO load
+* `skip_tls_verify` - Add '--insecure-skip-tls-verify' to oc commands.
 
 #### DEPLOYMENT
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -83,7 +83,7 @@ class OCP(object):
         self.cluster_kubeconfig = cluster_kubeconfig
         self.threading_lock = threading_lock
         self.silent = silent
-        self.skip_tls_verify = skip_tls_verify
+        self.skip_tls_verify = skip_tls_verify or config.RUN.get("skip_tls_verify")
 
     @property
     def api_version(self):


### PR DESCRIPTION
Adds the option to set the `skip_tls_verify` class member of the OCP object to true at its `__init__` method by having the following config param under RUN in an `ocsci-config ` file:

```
RUN:
  skip_tls_verify: true
```
External teams have expressed interest in this sort of config to overcome certification issues in their environments.


Required backports:
- [ ] 4.13
- [ ] 4.12
- [ ] 4.11