### PR TITLE
Enhance destroy of MS clusters to avoid failures

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -125,8 +125,8 @@ class ROSAOCP(BaseOCPDeployment):
                 ocm.destroy_cluster(self.cluster_name)
             logger.info("Waiting for ROSA cluster to be uninstalled")
             sample = TimeoutSampler(
-                timeout=7200,
-                sleep=30,
+                timeout=14400,
+                sleep=300,
                 func=self.cluster_present,
                 cluster_name=self.cluster_name,
             )

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -505,7 +505,7 @@ def delete_odf_addon(cluster):
     cmd = f"rosa uninstall addon --cluster={cluster} {addon_name} --yes"
     utils.run_cmd(cmd)
     for addon_info in utils.TimeoutSampler(
-        4000, 30, get_addon_info, cluster, addon_name
+        7200, 300, get_addon_info, cluster, addon_name
     ):
         logger.info(f"Current addon installation info: " f"{addon_info}")
         if "not installed" in addon_info:
@@ -575,7 +575,7 @@ def destroy_appliance_mode_cluster(cluster):
             )
             for sample in utils.TimeoutSampler(
                 timeout=3600,
-                sleep=600,
+                sleep=300,
                 func=storageconsumers.get,
             ):
                 if len(sample.get("items")) == 0:
@@ -595,7 +595,7 @@ def destroy_appliance_mode_cluster(cluster):
 
     logger.info("Waiting for ROSA cluster state changed to uninstalling")
     for cluster_info in utils.TimeoutSampler(
-        1000, 90, ocm.get_cluster_details, cluster
+        3600, 90, ocm.get_cluster_details, cluster
     ):
         status = cluster_info["status"]["state"]
         logger.info(f"Cluster uninstalling status: {status}")
@@ -603,7 +603,7 @@ def destroy_appliance_mode_cluster(cluster):
             logger.info(f"Cluster '{cluster}' is uninstalling")
             break
     for service_status in utils.TimeoutSampler(
-        1000, 30, get_rosa_service_details, cluster
+        3600, 30, get_rosa_service_details, cluster
     ):
         if "deleting service" in service_status:
             logger.info("Rosa service status is 'deleting service'")


### PR DESCRIPTION
* wait with provider cluster deletion till all consumers are disconnected
* ignore `...service is already deleting` error message (usually happens on second try to destroy the cluster)

fixes: https://github.com/red-hat-storage/ocs-ci/issues/7690