### PR TITLE
A few improvements for skips Ceph health reporting

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -57,6 +57,15 @@ run it belongs here.
 * `log_utilization` - Enable logging of cluster utilization metrics every 10 seconds. Set via --log-cluster-utilization
 * `use_ocs_worker_for_scale` - Use OCS workers for scale testing (Default: false)
 * `load_status` - Current status of IO load
+* `skip_reason_test_found` - In the case the cluster left unhealthy, this param is used to determine the
+  test case that is likely to cause that
+* `skipped_tests_ceph_health` - The number of tests that got skipped due to Ceph being unhealthy
+* `number_of_tests` - The number of tests being collected for the test execution
+* `skipped_on_ceph_health_ratio` - The ratio of tests skipped due to Ceph unhealthy against the
+  number of tests being collected for the test execution
+* `skipped_on_ceph_health_threshold` - The allowed threshold for the ratio of tests skipped due to Ceph unhealthy against the
+  number of tests being collected for the test execution. The default value is set to 0.1 (10%).
+  For acceptance suite, the value would be set to 0
 
 #### DEPLOYMENT
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -36,6 +36,8 @@ RUN:
   skip_reason_test_found: {}
   skipped_tests_ceph_health: 0
   number_of_tests: None
+  skipped_on_ceph_health_ratio: 0
+  skipped_on_ceph_health_threshold: 0.1
 
 
 # In this section we are storing all deployment related configuration but not

--- a/ocs_ci/utility/reporting.py
+++ b/ocs_ci/utility/reporting.py
@@ -73,6 +73,13 @@ def get_rp_launch_attributes():
         rp_attrs["fips"] = True
     if config.ENV_DATA.get("encryption_at_rest"):
         rp_attrs["encryption_at_rest"] = True
+    if config.RUN["skipped_on_ceph_health_ratio"] > 0:
+        rp_attrs["ceph_health_skips"] = True
+    if (
+        config.RUN["skipped_on_ceph_health_ratio"]
+        > config.RUN["skipped_on_ceph_health_threshold"]
+    ):
+        rp_attrs["ceph_health_skips_over_threshold"] = True
 
     return rp_attrs
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1486,6 +1486,14 @@ def parse_html_for_email(soup):
             data = td.text.replace("&apos", "")
             td.string = data
 
+    skips_ceph_health_ratio = config.RUN.get("skipped_on_ceph_health_ratio")
+    if skips_ceph_health_ratio > 0:
+        skipped = soup.body.find_all(attrs={"class": "skipped"})
+        skipped_number = skipped[0].string.split(" ")[0]
+        skipped[0].string.replace_with(
+            f"{skipped_number} skipped ({skips_ceph_health_ratio * 100}% caused by Ceph health issues)"
+        )
+
     main_header = soup.find("h1")
     main_header.string.replace_with("OCS-CI RESULTS")
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1491,7 +1491,7 @@ def parse_html_for_email(soup):
         skipped = soup.body.find_all(attrs={"class": "skipped"})
         skipped_number = skipped[0].string.split(" ")[0]
         skipped[0].string.replace_with(
-            f"{skipped_number} skipped ({skips_ceph_health_ratio * 100}% caused by Ceph health issues)"
+            f"{skipped_number} skipped ({skips_ceph_health_ratio * 100}% on Ceph health)"
         )
 
     main_header = soup.find("h1")

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -54,27 +54,46 @@ class TestFailurePropagator:
         """
         number_of_eligible_tests = config.RUN.get("number_of_tests") - 2
 
-        skipped_on_ceph_health_percent = (
-            config.RUN.get("skipped_tests_ceph_health") / number_of_eligible_tests
-        )
-        message = (
-            f"This run had {skipped_on_ceph_health_percent * 100}% of the "
-            f"tests skipped due to Ceph health not OK."
-        )
-        if skipped_on_ceph_health_percent > 0.25:
-            if config.RUN.get("skip_reason_test_found"):
-                test_name = config.RUN.get("skip_reason_test_found").get("test_name")
-                message = (
-                    message + f" The test that is likely to cause this is {test_name}"
-                )
-                squad = config.RUN.get("skip_reason_test_found").get("squad")
-                if squad:
-                    message = message + f" which is under {squad}'s responsibility"
-                    request.node.add_marker(squad)
+        # for acceptance suite, the value of config.RUN["skipped_on_ceph_health_threshold"] would be set to 0
+        # so any skip on Ceph health during an acceptance suite execution would cause
+        # test_report_skip_triggering_test to fail
+        if "acceptance" in config.RUN.get("cli_params").get("-m", ""):
+            config.RUN["skipped_on_ceph_health_threshold"] = 0
 
-            else:
-                message = message + " Couldn't identify the test case that caused this"
-            pytest.fail(message)
+        if number_of_eligible_tests > 0:
+            config.RUN["skipped_on_ceph_health_ratio"] = round(
+                (
+                    config.RUN.get("skipped_tests_ceph_health")
+                    / number_of_eligible_tests
+                ),
+                1,
+            )
+            message = (
+                f"This run had {config.RUN['skipped_on_ceph_health_ratio'] * 100}% of the "
+                f"tests skipped due to Ceph health not OK."
+            )
+            if (
+                config.RUN["skipped_on_ceph_health_ratio"]
+                > config.RUN["skipped_on_ceph_health_threshold"]
+            ):
+                if config.RUN.get("skip_reason_test_found"):
+                    test_name = config.RUN.get("skip_reason_test_found").get(
+                        "test_name"
+                    )
+                    message = (
+                        message
+                        + f" The test that is likely to cause this is {test_name}"
+                    )
+                    squad = config.RUN.get("skip_reason_test_found").get("squad")
+                    if squad:
+                        message = message + f" which is under {squad}'s responsibility"
+                        request.node.add_marker(squad)
+
+                else:
+                    message = (
+                        message + " Couldn't identify the test case that caused this"
+                    )
+                pytest.fail(message)
 
     @pytest.mark.last
     def test_failure_propagator(self):


### PR DESCRIPTION
* Added skips on Ceph health percentage to the results breakdown
* Added 2 ReportPortal attributes - `ceph_health_skips` and `ceph_health_skips_over_threshold`
* For acceptance suite, the value of config.RUN["skipped_on_ceph_health_threshold"] would be set to 0 so any skip on Ceph health during an acceptance suite execution would cause test_report_skip_triggering_test to fail
