### PR TITLE
Test Squad Ownership Decorators

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -486,6 +486,9 @@ red_squad = pytest.mark.red_squad
 turquoise_squad = pytest.mark.turquoise_squad
 yellow_squad = pytest.mark.yellow_squad
 
+# Ignore test during squad decorator check in pytest collection
+ignore_owner = pytest.mark.ignore_owner
+
 # Marks to identify the cluster type in which the test case should run
 runs_on_provider = pytest.mark.runs_on_provider
 

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -484,6 +484,7 @@ orange_squad = pytest.mark.orange_squad
 purple_squad = pytest.mark.purple_squad
 red_squad = pytest.mark.red_squad
 turquoise_squad = pytest.mark.turquoise_squad
+yellow_squad = pytest.mark.yellow_squad
 
 # Marks to identify the cluster type in which the test case should run
 runs_on_provider = pytest.mark.runs_on_provider

--- a/ocs_ci/helpers/pvc_ops.py
+++ b/ocs_ci/helpers/pvc_ops.py
@@ -2,6 +2,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import ignore_leftovers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import delete_pvcs
@@ -48,6 +49,7 @@ def delete_pods(pod_objs):
         pod_obj.delete()
 
 
+@brown_squad
 @ignore_leftovers
 def test_create_delete_pvcs(multi_pvc_factory, pod_factory, project=None):
     # create the pods for deleting

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1830,6 +1830,7 @@ SQUADS = {
     "Yellow": ["/managed-service/"],
     "Turquoise": ["/disaster-recovery/"],
 }
+SQUAD_CHECK_IGNORED_MARKERS = ["libtest"]
 
 PRODUCTION_JOBS_PREFIX = ["jnk"]
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1830,7 +1830,7 @@ SQUADS = {
     "Yellow": ["/managed-service/"],
     "Turquoise": ["/disaster-recovery/"],
 }
-SQUAD_CHECK_IGNORED_MARKERS = ["libtest"]
+SQUAD_CHECK_IGNORED_MARKERS = ["ignore_owner", "libtest"]
 
 PRODUCTION_JOBS_PREFIX = ["jnk"]
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -631,6 +631,10 @@ class ArchitectureNotSupported(Exception):
     pass
 
 
+class MissingSquadDecoratorError(Exception):
+    pass
+
+
 class PDBNotCreatedException(Exception):
     pass
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -57,6 +57,7 @@ markers =
     black_squad: marker for black squad
     yellow_squad: marker for yellow squad
     turquoise_squad: marker for turquoise squad
+    ignore_owner: marker to ignore test during squad decorator check in pytest collection
 
 # Clusterctx used without hyphen, to keep the original format if it's None
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s %(clusterctx)s - %(message)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import base64
 import copy
 import logging
 import os
+import pandas as pd
 import random
 import time
 import tempfile
@@ -44,6 +45,7 @@ from ocs_ci.ocs.exceptions import (
     PoolNotDeletedFromUI,
     StorageClassNotDeletedFromUI,
     ResourceNotDeleted,
+    MissingSquadDecoratorError,
 )
 from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implementation
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
@@ -181,6 +183,97 @@ def pytest_logger_config(logger_config):
     logger_config.set_formatter_class(OCSLogFormatter)
 
 
+def verify_squad_owners(items):
+    """
+    Verify that all tests collected are decorated with a squad marker
+
+    Args:
+        items: list of collected tests
+
+    """
+    items_without_squad_marker = {}
+    for item in items:
+        base_dir = os.path.join(constants.TOP_DIR, "tests")
+        ignored_markers = constants.SQUAD_CHECK_IGNORED_MARKERS
+        if item.fspath.strpath.startswith(base_dir):
+            item_markers = [marker.name for marker in item.iter_markers()]
+            if any(marker in item_markers for marker in ignored_markers):
+                log.debug(
+                    "Ignoring test case %s as it has a marker in the ignore list",
+                    item.name,
+                )
+            elif not any(["_squad" in marker for marker in item_markers]):
+                log.debug("%s is missing a squad owner marker", item.name)
+                items_without_squad_marker.update({item.name: item.fspath.strpath})
+
+    if items_without_squad_marker:
+        msg = f"""
+Missing squad decorator for the following test items: {json.dumps(items_without_squad_marker, indent=4)}
+
+Tests are required to be decorated with their squad owner. Please add the tests respective owner.
+
+For example:
+
+    @magenta_squad
+    def test_name():
+
+Test owner marks can be imported from `ocs_ci.framework.pytest_customization.marks`
+            """
+        raise MissingSquadDecoratorError(msg)
+
+
+def export_squad_marker_to_csv(items, filename=None):
+    """
+    Export data regarding tests that are missing squad markers to a CSV
+
+    Args:
+        items: list of collected tests
+        filename: name of the file to export the data to
+
+    """
+    _filename = filename or "squad_decorator_data.csv"
+    test_data = {"File": [], "Name": [], "Suggestions": []}
+    ignored_markers = constants.SQUAD_CHECK_IGNORED_MARKERS
+    for item in items:
+        item_markers = [marker.name for marker in item.iter_markers()]
+        if any(marker in item_markers for marker in ignored_markers):
+            log.debug(
+                "Ignoring test case %s as it has a marker in the ignore list", item.name
+            )
+        else:
+            item_squad = None
+            for marker in item_markers:
+                if "_squad" in marker:
+                    item_squad = marker.split("_")[0]
+                    item_squad = item_squad.capitalize()
+                    log.info("Test item %s has squad marker: %s", item.name, marker)
+            if not item_squad:
+                suggested_squads = []
+                for squad, paths in constants.SQUADS.items():
+                    for _path in paths:
+                        test_path = os.path.relpath(
+                            item.fspath.strpath, constants.TOP_DIR
+                        )
+                        if _path in test_path:
+                            suggested_squads.append(squad)
+                test_data["File"].append(item.fspath.strpath)
+                test_data["Name"].append(item.name)
+                test_data["Suggestions"].append(",".join(suggested_squads))
+
+    df = pd.DataFrame(data=test_data)
+    df.to_csv(
+        _filename,
+        header=["File ", "Test Name", "Squad Suggestions"],
+        index=False,
+        sep=",",
+        mode="a",
+    )
+    num_tests = len(test_data["Name"])
+    num_files = len(set(test_data["File"]))
+    log.info("Exported squad marker info to %s", _filename)
+    log.info("%s tests require action across %s files", num_tests, num_files)
+
+
 def pytest_collection_modifyitems(session, items):
     """
     A pytest hook to filter out skipped tests satisfying
@@ -196,24 +289,16 @@ def pytest_collection_modifyitems(session, items):
     deploy = config.RUN["cli_params"].get("deploy")
     skip_ocs_deployment = config.ENV_DATA["skip_ocs_deployment"]
 
+    # Verify tests are decorated with the correct squad owner
+    verify_squad_owners(items)
+
     # Add squad markers to each test item based on filepath
     for item in items:
         # check, if test already have squad marker manually assigned
-        skip_path_squad_marker = False
         for marker in item.iter_markers():
             if "_squad" in marker.name:
                 squad = marker.name.split("_")[0]
                 item.user_properties.append(("squad", squad.capitalize()))
-                skip_path_squad_marker = True
-        if not skip_path_squad_marker:
-            for squad, paths in constants.SQUADS.items():
-                for _path in paths:
-                    # Limit the test_path to the tests directory
-                    test_path = os.path.relpath(item.fspath.strpath, constants.TOP_DIR)
-                    if _path in test_path:
-                        item.add_marker(f"{squad.lower()}_squad")
-                        item.user_properties.append(("squad", squad))
-                        break
 
     if not (teardown or deploy or (deploy and skip_ocs_deployment)):
         for item in items[:]:

--- a/tests/disaster-recovery/sc_arbiter/test_netsplit.py
+++ b/tests/disaster-recovery/sc_arbiter/test_netsplit.py
@@ -3,6 +3,7 @@ import logging
 import time
 import ocpnetsplit
 
+from ocs_ci.framework.pytest_customization.marks import turquoise_squad
 from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.exceptions import CommandFailed, CephHealthException
 from ocs_ci.ocs import constants
@@ -76,6 +77,7 @@ def get_logfile_map_from_logwriter_pods(logwriter_pods, is_rbd=False):
     return log_file_map
 
 
+@turquoise_squad
 class TestNetSplit:
     @pytest.fixture()
     def init_sanity(self, request):

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -32,6 +33,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -38,6 +39,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone.py
+++ b/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -14,6 +15,7 @@ from ocs_ci.ocs.benchmark_operator import BMO_NAME
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @flowtests
 class TestPvcSnapshotAndCloneWithBaseOperation(E2ETest):
     """

--- a/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
+++ b/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from concurrent.futures import ThreadPoolExecutor
-
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -19,6 +19,7 @@ from ocs_ci.ocs import flowtest
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @flowtests
 @ignore_leftovers
 class TestPvcSnapshotAndCloneWithBaseOperation(E2ETest):

--- a/tests/e2e/flowtest/test_base_operation_node_drain.py
+++ b/tests/e2e/flowtest/test_base_operation_node_drain.py
@@ -5,6 +5,7 @@ from time import sleep
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework.pytest_customization.marks import (
+    magenta_squad,
     skipif_bm,
     skipif_aws_i3,
     skipif_vsphere_ipi,
@@ -28,6 +29,7 @@ class TestBaseOperationNodeDrain(E2ETest):
 
     """
 
+    @magenta_squad
     @skipif_aws_i3
     @skipif_bm
     @skipif_vsphere_ipi

--- a/tests/e2e/kcs/test_disable_mcg_external_service.py
+++ b/tests/e2e/kcs/test_disable_mcg_external_service.py
@@ -9,11 +9,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     bugzilla,
     skipif_external_mode,
+    magenta_squad,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 class TestDisableMCGExternalService:
     @pytest.fixture()
     def patch_noobaa_object(self, request):

--- a/tests/e2e/kcs/test_maintenance_pod.py
+++ b/tests/e2e/kcs/test_maintenance_pod.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier2,
     skipif_external_mode,
+    magenta_squad,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs.resources.deployment import (
@@ -25,6 +26,7 @@ from ocs_ci.utility.utils import ceph_health_check
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier2
 @skipif_external_mode
 @bugzilla("2103256")

--- a/tests/e2e/kcs/test_mon_crash_recovery_scenario.py
+++ b/tests/e2e/kcs/test_mon_crash_recovery_scenario.py
@@ -12,7 +12,11 @@ from ocs_ci.ocs.resources.deployment import get_mon_deployments
 from ocs_ci.ocs.resources.pvc import get_pvc_objs
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, run_io_in_bg
 from ocs_ci.ocs.resources.storage_cluster import ceph_mon_dump
-from ocs_ci.framework.pytest_customization.marks import tier3, skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    tier3,
+    skipif_external_mode,
+    magenta_squad,
+)
 from ocs_ci.ocs.defaults import OCS_OPERATOR_NAME
 from ocs_ci.helpers.helpers import wait_for_resource_state
 
@@ -20,6 +24,7 @@ from ocs_ci.helpers.helpers import wait_for_resource_state
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier3
 @pytest.mark.polarion_id("OCS-4942")
 @pytest.mark.bugzilla("2151591")

--- a/tests/e2e/kcs/test_monitor_recovery.py
+++ b/tests/e2e/kcs/test_monitor_recovery.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     system_test,
     skipif_ocp_version,
+    magenta_squad,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.ocp import OCP, switch_to_project
@@ -49,6 +50,7 @@ from ocs_ci.utility.utils import exec_cmd
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @ignore_leftovers
 @pytest.mark.last

--- a/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import warp
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -20,6 +21,7 @@ from ocs_ci.ocs.resources.pod import (
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier3
 @ignore_leftovers
 @skipif_managed_service

--- a/tests/e2e/kcs/test_noobaa_rebuild.py
+++ b/tests/e2e/kcs/test_noobaa_rebuild.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -21,6 +22,7 @@ from ocs_ci.ocs.resources.pvc import get_pvc_objs
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier3
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2653")

--- a/tests/e2e/kcs/test_noobaadb_pw_reset.py
+++ b/tests/e2e/kcs/test_noobaadb_pw_reset.py
@@ -4,6 +4,7 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier3,
@@ -23,6 +24,7 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier3
 @pytest.mark.polarion_id("OCS-4662")
 @skipif_ocs_version("<4.9")

--- a/tests/e2e/kcs/test_selinux_relabel_solution.py
+++ b/tests/e2e/kcs/test_selinux_relabel_solution.py
@@ -19,11 +19,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     bugzilla,
     polarion_id,
+    magenta_squad,
 )
 
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 class TestSelinuxrelabel(E2ETest):
     def create_deploymentconfig_pod(self, **kwargs):
         """

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
@@ -9,6 +9,7 @@ import botocore.exceptions as boto3exception
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -56,6 +57,7 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
@@ -8,6 +8,7 @@ import botocore.exceptions as boto3exception
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -48,6 +49,7 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -107,6 +108,7 @@ def multipart_setup(pod_obj, origin_dir, result_dir):
     return mpu_key, origin_dir, result_dir, parts
 
 
+@red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
     skipif_managed_service,
+    red_squad,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs import bucket_utils
@@ -25,6 +26,7 @@ ROOT_OBJ = "RootKey-" + str(uuid.uuid4().hex)
 COPY_OBJ = "CopyKey-" + str(uuid.uuid4().hex)
 
 
+@red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/lifecycle/pvc_clone/test_pgsql_pvc_clone.py
+++ b/tests/e2e/lifecycle/pvc_clone/test_pgsql_pvc_clone.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -18,6 +19,7 @@ from ocs_ci.utility import kms
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier2
 class TestPvcCloneOfWorkloads(E2ETest):
     """

--- a/tests/e2e/lifecycle/pvc_snapshot/test_pgsql_pvc_snapshot.py
+++ b/tests/e2e/lifecycle/pvc_snapshot/test_pgsql_pvc_snapshot.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -16,6 +17,7 @@ from ocs_ci.utility import kms
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier2
 class TestPvcSnapshotOfWorkloads(E2ETest):
     """

--- a/tests/e2e/longevity/test_all_stages.py
+++ b/tests/e2e/longevity/test_all_stages.py
@@ -1,4 +1,5 @@
 import logging
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, skipif_external_mode
 from ocs_ci.ocs.longevity import Longevity
 
@@ -6,6 +7,7 @@ from ocs_ci.ocs.longevity import Longevity
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_external_mode
 class TestLongevity(E2ETest):
     """

--- a/tests/e2e/longevity/test_stage0.py
+++ b/tests/e2e/longevity/test_stage0.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, ignore_leftovers, skipif_external_mode
 from ocs_ci.ocs.longevity import Longevity
 
@@ -7,6 +8,7 @@ from ocs_ci.ocs.longevity import Longevity
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_external_mode
 @ignore_leftovers
 class TestLongevity(E2ETest):

--- a/tests/e2e/longevity/test_stage1.py
+++ b/tests/e2e/longevity/test_stage1.py
@@ -1,9 +1,11 @@
 import logging
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, skipif_external_mode
 
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_external_mode
 class TestLongevity(E2ETest):
     """

--- a/tests/e2e/longevity/test_stage2.py
+++ b/tests/e2e/longevity/test_stage2.py
@@ -1,11 +1,13 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs.longevity import Longevity
 
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 class TestLongevityStage2(E2ETest):
     """
     Tests Longevity Testing - Stage 2

--- a/tests/e2e/longevity/test_stage3.py
+++ b/tests/e2e/longevity/test_stage3.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, ignore_leftovers, skipif_external_mode
 from ocs_ci.ocs.longevity import Longevity
 
@@ -7,6 +8,7 @@ from ocs_ci.ocs.longevity import Longevity
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_external_mode
 @ignore_leftovers
 class TestLongevity(E2ETest):

--- a/tests/e2e/longevity/test_stage4.py
+++ b/tests/e2e/longevity/test_stage4.py
@@ -1,11 +1,13 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs.longevity import Longevity
 
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 class TestLongevityStage4(E2ETest):
     """
     Tests Longevity Testing - Stage 4

--- a/tests/e2e/performance/csi_tests/test_auto_reclaim_space_multi_clones.py
+++ b/tests/e2e/performance/csi_tests/test_auto_reclaim_space_multi_clones.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from uuid import uuid4
 
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     performance,
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+@grey_squad
 @performance
 @skipif_ocs_version("<4.14")
 class TestReclaimSpaceCronJobMultiClones(PASTest):

--- a/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
+++ b/tests/e2e/performance/csi_tests/test_bulk_pod_attachtime_performance.py
@@ -8,7 +8,7 @@ import pytest
 import pathlib
 import time
 from datetime import datetime
-
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a, polarion_id
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants, scale_lib
@@ -25,6 +25,7 @@ Interfaces_info = {
 }
 
 
+@grey_squad
 @performance
 @performance_a
 class TestBulkPodAttachPerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pod_attachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_attachtime.py
@@ -8,6 +8,7 @@ import os
 import pytest
 import statistics
 
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
@@ -44,6 +45,7 @@ class ResultsAnalyse(PerfResult):
         self.es_connect()
 
 
+@grey_squad
 @performance
 @performance_a
 class TestPodStartTime(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/e2e/performance/csi_tests/test_pod_reattachtime.py
@@ -6,6 +6,7 @@ import time
 import statistics
 import os
 
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.helpers.helpers import get_full_test_logs_path
@@ -18,6 +19,7 @@ from ocs_ci.ocs.exceptions import PodNotCreated
 logger = logging.getLogger(__name__)
 
 
+@grey_squad
 @performance
 @performance_a
 class TestPodReattachTimePerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
@@ -10,6 +10,7 @@ import pytest
 
 from ocs_ci.utility import utils, templating
 from ocs_ci.ocs.perftests import PASTest
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import performance_lib
 from ocs_ci.helpers.helpers import (
@@ -40,6 +41,7 @@ Interfaces_info = {
 }
 
 
+@grey_squad
 @performance
 @performance_b
 class TestBulkCloneCreation(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
@@ -10,6 +10,7 @@ import datetime
 import ocs_ci.ocs.exceptions as ex
 import ocs_ci.ocs.resources.pvc as pvc
 from concurrent.futures import ThreadPoolExecutor
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a, polarion_id
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.ocs import constants
@@ -21,6 +22,7 @@ log = logging.getLogger(__name__)
 Interface_Types = {constants.CEPHFILESYSTEM: "CephFS", constants.CEPHBLOCKPOOL: "RBD"}
 
 
+@grey_squad
 @performance
 @performance_a
 class TestPVCCreationPerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_clone_performance.py
@@ -7,6 +7,7 @@ import pytest
 import statistics
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_b
 from ocs_ci.helpers import helpers, performance_lib
 from ocs_ci.utility.utils import convert_device_size
@@ -92,6 +93,7 @@ class ClonesResultsAnalyse(ResultsAnalyse):
         logger.info("test_clones_creation_performance finished successfully.")
 
 
+@grey_squad
 @performance
 @performance_b
 class TestPVCClonePerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_creation_deletion_performance.py
@@ -10,6 +10,7 @@ import statistics
 import tempfile
 import yaml
 
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.helpers import helpers, performance_lib
@@ -35,6 +36,7 @@ Interface_Info = {
 Operations_Mesurment = ["create", "delete", "csi_create", "csi_delete"]
 
 
+@grey_squad
 @performance
 @performance_a
 class TestPVCCreationDeletionPerformance(PASTest):

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_clone_performance.py
@@ -10,6 +10,7 @@ import pytest
 
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.perfresult import ResultsAnalyse
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -41,6 +42,7 @@ Interfaces_info = {
 ERR_MSG = "Error in command"
 
 
+@grey_squad
 @performance
 @performance_b
 @skipif_ocp_version("<4.6")

--- a/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -15,6 +15,7 @@ import yaml
 
 # Local modules
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -38,6 +39,7 @@ log = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+@grey_squad
 @performance
 @performance_b
 @skipif_ocp_version("<4.6")

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -8,6 +8,7 @@ import statistics
 
 # Local modules
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.ocs.ocp import OCP, switch_to_project
 from ocs_ci.utility import templating
 from ocs_ci.ocs import constants
@@ -30,6 +31,7 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@grey_squad
 @performance
 @performance_b
 @skipif_ocp_version("<4.6")

--- a/tests/e2e/performance/io_workload/test_fio_benchmark.py
+++ b/tests/e2e/performance/io_workload/test_fio_benchmark.py
@@ -12,6 +12,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_c, skipif_ocs_version
 from ocs_ci.ocs.perfresult import PerfResult
 from ocs_ci.helpers.helpers import get_full_test_logs_path
@@ -128,6 +129,7 @@ class FIOResultsAnalyse(PerfResult):
         # Todo: Fail test if 5% deviation from benchmark value
 
 
+@grey_squad
 @performance
 @performance_c
 class TestFIOBenchmark(PASTest):

--- a/tests/e2e/performance/io_workload/test_io_performance.py
+++ b/tests/e2e/performance/io_workload/test_io_performance.py
@@ -4,12 +4,14 @@ Module to perform IOs with several weights
 import pytest
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import ManageTest
 
 
 logger = logging.getLogger(__name__)
 
 
+@grey_squad
 class TestIOPerformance(ManageTest):
     """
     Test IO performance

--- a/tests/e2e/performance/io_workload/test_perf_pgsql.py
+++ b/tests/e2e/performance/io_workload/test_perf_pgsql.py
@@ -6,6 +6,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.perf_pgsql import PerfPGSQL
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.node import get_node_resource_utilization_from_adm_top
@@ -26,6 +27,7 @@ def pgsql(request):
     return pgsql
 
 
+@grey_squad
 @performance
 @performance_c
 @pytest.mark.polarion_id("OCS-2725")

--- a/tests/e2e/performance/io_workload/test_small_file_workload.py
+++ b/tests/e2e/performance/io_workload/test_small_file_workload.py
@@ -25,6 +25,7 @@ import pytest
 
 # Local modules
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import grey_squad
 from ocs_ci.framework.testlib import performance, performance_a
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import benchmark_operator, constants
@@ -360,6 +361,7 @@ class SmallFileResultsAnalyse(PerfResult):
         log.debug(f"The Initial DB is : {self.results['full-res']}")
 
 
+@grey_squad
 @performance
 @performance_a
 class TestSmallFileWorkload(PASTest):

--- a/tests/e2e/performance/mcg/test_mcg_cosbench.py
+++ b/tests/e2e/performance/mcg/test_mcg_cosbench.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.perfresult import ResultsAnalyse
@@ -22,6 +23,7 @@ def cosbench(request):
     return cosbench
 
 
+@red_squad
 @performance
 @performance_c
 @pytest.mark.polarion_id("OCS-3694")

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -4,6 +4,7 @@ from ocs_ci.ocs import hsbench
 from ocs_ci.utility import utils
 from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
     vsphere_platform_required,
     bugzilla,
     skipif_ocs_version,
@@ -42,6 +43,7 @@ def s3bench(request):
     return s3bench
 
 
+@orange_squad
 @scale
 class TestHsBench(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_list_objects.py
+++ b/tests/e2e/scale/noobaa/test_list_objects.py
@@ -7,6 +7,7 @@ from ocs_ci.ocs.bucket_utils import (
     sync_object_directory,
     list_objects_from_bucket,
 )
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.framework.testlib import scale, bugzilla, skipif_ocs_version
 from ocs_ci.ocs.resources.mcg import MCG
@@ -15,6 +16,7 @@ from ocs_ci.ocs.resources.mcg import MCG
 log = logging.getLogger(__name__)
 
 
+@orange_squad
 @scale
 class TestListOfObjects(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
+++ b/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs import hsbench
@@ -27,6 +28,7 @@ def s3bench(request):
     return s3bench
 
 
+@orange_squad
 @scale
 @skipif_ocs_version("<4.9")
 class TestScaleBucketReplication(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -3,6 +3,7 @@ import logging
 import time
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import MCGTest, scale, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp, scale_pgsql
 from ocs_ci.utility import utils
@@ -51,6 +52,7 @@ def worker_node(request):
     return worker_node
 
 
+@orange_squad
 @scale
 @skipif_ocs_version("<4.5")
 @pytest.mark.parametrize(

--- a/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     skipif_ocs_version,
@@ -27,6 +28,7 @@ def s3bench(request):
     return s3bench
 
 
+@orange_squad
 @scale
 class TestScaleNamespace(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     skipif_ocs_version,
@@ -12,6 +13,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@orange_squad
 @skipif_ocs_version("!=4.6")
 @scale
 class TestScaleNamespace(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
@@ -4,6 +4,7 @@ import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.utility.utils import ocsci_log_path
@@ -20,6 +21,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@orange_squad
 @scale
 class TestScaleOCBCreateDelete(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation.py
@@ -6,7 +6,10 @@ from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
-from ocs_ci.framework.pytest_customization.marks import vsphere_platform_required
+from ocs_ci.framework.pytest_customization.marks import (
+    vsphere_platform_required,
+    orange_squad,
+)
 
 log = logging.getLogger(__name__)
 
@@ -19,6 +22,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
@@ -5,7 +5,10 @@ from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
-from ocs_ci.framework.pytest_customization.marks import on_prem_platform_required
+from ocs_ci.framework.pytest_customization.marks import (
+    on_prem_platform_required,
+    orange_squad,
+)
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +21,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_start_time_respin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_start_time_respin_noobaa_pods.py
@@ -5,6 +5,7 @@ import pytest
 import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.helpers import helpers
 from ocs_ci.utility.utils import ocsci_log_path
@@ -21,6 +22,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@orange_squad
 @scale
 class TestScaleOBCStartTime(E2ETest):
 

--- a/tests/e2e/scale/noobaa/test_warp.py
+++ b/tests/e2e/scale/noobaa/test_warp.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     bugzilla,
+    orange_squad,
 )
 
 log = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ def warps3(request):
     return warps3
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 class TestWarp(E2ETest):

--- a/tests/e2e/scale/test_cephfs_many_files.py
+++ b/tests/e2e/scale/test_cephfs_many_files.py
@@ -7,7 +7,7 @@ from tempfile import mkdtemp, NamedTemporaryFile
 import uuid
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import scale
+from ocs_ci.framework.pytest_customization.marks import scale, orange_squad
 from ocs_ci.framework.testlib import E2ETest, ignore_leftovers
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.utility.utils import run_cmd, ceph_health_check
@@ -124,6 +124,7 @@ def million_file_cephfs(request):
     return million_file_cephfs
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @pytest.mark.parametrize(

--- a/tests/e2e/scale/test_osd_node_balancing.py
+++ b/tests/e2e/scale/test_osd_node_balancing.py
@@ -6,6 +6,7 @@ import pytest
 from uuid import uuid4
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
     skipif_aws_i3,
     skipif_bm,
     skipif_external_mode,
@@ -135,6 +136,7 @@ class ElasticData(PerfResult):
         logger.info(f"skew_value: {new_data['skew_value']}")
 
 
+@orange_squad
 @scale_changed_layout
 @skipif_aws_i3
 @skipif_bm

--- a/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
+++ b/tests/e2e/scale/test_pods_are_not_oomkilled_while_running_ios.py
@@ -5,6 +5,7 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources import pod as Pod
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources.pod import get_all_pods
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.helpers.helpers import (
     default_storage_class,
@@ -16,6 +17,7 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@orange_squad
 @scale
 @pytest.mark.parametrize(
     argnames=["interface"],

--- a/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
+++ b/tests/e2e/scale/test_pv_scale_and_respin_ceph_pods.py
@@ -12,6 +12,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants, scale_lib
 from ocs_ci.helpers import helpers, disruption_helpers
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
 
@@ -206,6 +207,7 @@ class BasePvcCreateRespinCephPods(E2ETest):
         self.kube_job_pvc_list.clear()
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @skipif_external_mode

--- a/tests/e2e/scale/test_pv_scale_ocs_create_delete_pvcs.py
+++ b/tests/e2e/scale/test_pv_scale_ocs_create_delete_pvcs.py
@@ -9,6 +9,7 @@ import threading
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 
 log = logging.getLogger(__name__)
@@ -145,6 +146,7 @@ class BasePvcPodCreateDelete(E2ETest):
         self.cephfs_sc_obj.delete()
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @pytest.mark.parametrize(

--- a/tests/e2e/scale/test_pvc_creation_deletion_scale.py
+++ b/tests/e2e/scale/test_pvc_creation_deletion_scale.py
@@ -12,12 +12,14 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.ocs import constants, scale_lib
 from ocs_ci.utility.utils import ocsci_log_path
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import scale, E2ETest, polarion_id
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 
 log = logging.getLogger(__name__)
 
 
+@orange_squad
 @scale
 class TestPVCCreationDeletionScale(E2ETest):
     """

--- a/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
+++ b/tests/e2e/scale/test_scale_12_OCS_worker_nodes_and_6000_PVCs.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
 )
 from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
     skipif_aws_i3,
     skipif_bm,
     skipif_external_mode,
@@ -38,6 +39,7 @@ log_path = ocsci_log_path()
 SCALE_DATA_FILE = f"{log_path}/scale_data_file.yaml"
 
 
+@orange_squad
 @scale_changed_layout
 @skipif_aws_i3
 @skipif_bm

--- a/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
+++ b/tests/e2e/scale/test_scale_3_OCS_worker_nodes_and_1500_PVCs.py
@@ -11,6 +11,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 from ocs_ci.ocs import constants, scale_lib, platform_nodes, machine
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
     skipif_external_mode,
     ipi_deployment_required,
     skipif_vsphere_ipi,
@@ -57,6 +58,7 @@ def fioscale(request):
     return fioscale
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @skipif_external_mode
@@ -112,6 +114,7 @@ class TestScaleRespinCephPods(E2ETest):
         )
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @bugzilla("2092737")
@@ -177,6 +180,7 @@ class TestScaleRespinOperatorPods(E2ETest):
             )
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @skipif_external_mode

--- a/tests/e2e/scale/test_scale_amq.py
+++ b/tests/e2e/scale/test_scale_amq.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.amq import AMQ
@@ -22,6 +23,7 @@ def test_fixture_amq(request):
     return amq
 
 
+@orange_squad
 @scale
 @pytest.mark.skip(
     reason="Skipped due to github issue #3372, TC is failing "

--- a/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
+++ b/tests/e2e/scale/test_scale_osds_fill_75%_reboot_workers.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.testlib import scale, E2ETest, ignore_leftovers
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
     skipif_external_mode,
     skipif_aws_i3,
 )
@@ -26,6 +27,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 logger = logging.getLogger(__name__)
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @skipif_external_mode

--- a/tests/e2e/scale/test_scale_pgsql.py
+++ b/tests/e2e/scale/test_scale_pgsql.py
@@ -3,6 +3,7 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import scale_pgsql
 from ocs_ci.utility import utils
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import E2ETest, scale, ignore_leftovers
 from ocs_ci.ocs.node import get_node_resource_utilization_from_adm_top
 
@@ -21,6 +22,7 @@ def pgsql(request):
     return pgsql
 
 
+@orange_squad
 @scale
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2239")

--- a/tests/e2e/scale/test_scale_pvc_expand.py
+++ b/tests/e2e/scale/test_scale_pvc_expand.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     scale,
@@ -30,6 +31,7 @@ def resize_pvc(request):
     return resize_pvc
 
 
+@orange_squad
 @scale
 @skipif_ocs_version("<4.5")
 @ignore_leftovers

--- a/tests/e2e/scale/test_scale_small_file_workload.py
+++ b/tests/e2e/scale/test_scale_small_file_workload.py
@@ -13,6 +13,7 @@ import time
 import pytest
 
 # Local modules
+from ocs_ci.framework.pytest_customization.marks import orange_squad
 from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster
@@ -22,6 +23,7 @@ from ocs_ci.ocs.small_file_workload import SmallFiles
 log = logging.getLogger(__name__)
 
 
+@orange_squad
 @scale
 class TestSmallFileWorkloadScale(E2ETest):
     """

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -30,6 +30,7 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
 
 
+@orange_squad
 @pre_upgrade
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_pvcs_pods.py
@@ -30,6 +30,7 @@ log_path = ocsci_log_path()
 SCALE_DATA_FILE = f"{log_path}/scale_data_file.yaml"
 
 
+@orange_squad
 @skipif_external_mode
 @skipif_bm
 @pre_upgrade

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_bm,
     skipif_external_mode,
     vsphere_platform_required,
+    orange_squad,
 )
 from ocs_ci.utility.utils import ocsci_log_path
 from ocs_ci.utility import utils, templating
@@ -32,6 +33,7 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
+@orange_squad
 @pre_upgrade
 @vsphere_platform_required
 @skipif_external_mode
@@ -108,6 +110,7 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@orange_squad
 @post_upgrade
 @vsphere_platform_required
 @skipif_external_mode

--- a/tests/e2e/system_test/mon/test_restore_ceph_mon_quorum.py
+++ b/tests/e2e/system_test/mon/test_restore_ceph_mon_quorum.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ignore_leftovers,
     skipif_external_mode,
+    magenta_squad,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs import constants
@@ -30,6 +31,7 @@ from ocs_ci.helpers.sanity_helpers import Sanity
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @ignore_leftovers
 @system_test
 @skipif_ocs_version("<4.9")

--- a/tests/e2e/system_test/test_cluster_full_and_recovery.py
+++ b/tests/e2e/system_test/test_cluster_full_and_recovery.py
@@ -4,7 +4,11 @@ import time
 from ocs_ci.helpers import helpers
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs.benchmark_operator_fio import get_file_size
-from ocs_ci.framework.pytest_customization.marks import system_test, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    system_test,
+    polarion_id,
+    magenta_squad,
+)
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 from ocs_ci.ocs import constants
@@ -22,6 +26,7 @@ from ocs_ci.ocs.cluster import (
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @polarion_id("OCS-4621")
 class TestClusterFullAndRecovery(E2ETest):

--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from tempfile import NamedTemporaryFile
-from ocs_ci.framework.pytest_customization.marks import bugzilla
+from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     skipif_ocs_version,
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+@magenta_squad
 @tier3
 @skipif_ocp_version("<4.13")
 @skipif_ocs_version("<4.13")

--- a/tests/e2e/system_test/test_full_cluster_health.py
+++ b/tests/e2e/system_test/test_full_cluster_health.py
@@ -14,12 +14,17 @@ from ocs_ci.utility import templating
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.disruptive_operations import osd_node_reboot
 from ocs_ci.ocs.node import wait_for_nodes_status
-from ocs_ci.framework.pytest_customization.marks import system_test, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    system_test,
+    polarion_id,
+    magenta_squad,
+)
 from ocs_ci.helpers import sanity_helpers
 
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 class TestFullClusterHealth(PASTest):
     """
     Test Cluster health when storage is ~85%

--- a/tests/e2e/system_test/test_mcg_recovery.py
+++ b/tests/e2e/system_test/test_mcg_recovery.py
@@ -6,12 +6,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     polarion_id,
     skipif_ocs_version,
+    magenta_squad,
 )
 from ocs_ci.framework.testlib import E2ETest
 
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @ignore_leftovers
 @polarion_id("OCS-2716")

--- a/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     system_test,
     skipif_vsphere_ipi,
+    magenta_squad,
 )
 from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
 from ocs_ci.ocs.bucket_utils import (
@@ -33,6 +34,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @skipif_ocs_version("<4.9")
 @skipif_vsphere_ipi

--- a/tests/e2e/system_test/test_nsfs_system.py
+++ b/tests/e2e/system_test/test_nsfs_system.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     ignore_leftovers,
     skipif_ocs_version,
+    magenta_squad,
 )
 from ocs_ci.helpers.helpers import wait_for_resource_state
 from ocs_ci.ocs import constants
@@ -33,6 +34,7 @@ from ocs_ci.ocs.resources.pod import get_mds_pods, wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @skipif_mcg_only
 @ignore_leftovers

--- a/tests/e2e/system_test/test_object_expiration.py
+++ b/tests/e2e/system_test/test_object_expiration.py
@@ -4,7 +4,11 @@ from time import sleep
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import bugzilla, system_test
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    system_test,
+    magenta_squad,
+)
 from ocs_ci.framework.testlib import version
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
@@ -12,6 +16,7 @@ from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @system_test
 @bugzilla("2039309")
 @skipif_ocs_version("<4.11")

--- a/tests/e2e/workloads/app/amq/test_amq_node_reboot_and_shutdown.py
+++ b/tests/e2e/workloads/app/amq/test_amq_node_reboot_and_shutdown.py
@@ -5,6 +5,7 @@ import time
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_vsphere_ipi,
     skipif_ibm_cloud,
+    magenta_squad,
 )
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -21,6 +22,7 @@ POD = ocp.OCP(kind=constants.POD, namespace=constants.AMQ_NAMESPACE)
 TILLER_NAMESPACE = "tiller"
 
 
+@magenta_squad
 @ignore_leftovers
 @workloads
 @skipif_vsphere_ipi

--- a/tests/e2e/workloads/app/amq/test_amq_pod_respin.py
+++ b/tests/e2e/workloads/app/amq/test_amq_pod_respin.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, ocp
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.helpers.disruption_helpers import Disruptions
@@ -39,6 +40,7 @@ def respin_amq_app_pod(kafka_namespace, pod_pattern):
             raise ie
 
 
+@magenta_squad
 @ignore_leftovers
 @workloads
 class TestAMQPodRespin(E2ETest):

--- a/tests/e2e/workloads/app/amq/test_amq_streamer_creation.py
+++ b/tests/e2e/workloads/app/amq/test_amq_streamer_creation.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, google_api_required
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.amq import AMQ
@@ -22,6 +23,7 @@ def test_fixture_amq(request):
     return amq
 
 
+@magenta_squad
 @google_api_required
 @pytest.mark.skip(reason="Skip due to helm permission issue")
 class TestAMQBasics(E2ETest):

--- a/tests/e2e/workloads/app/amq/test_amq_streams.py
+++ b/tests/e2e/workloads/app/amq/test_amq_streams.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.amq import AMQ
@@ -22,6 +23,7 @@ def test_fixture_amq(request):
     return amq
 
 
+@magenta_squad
 @workloads
 class TestAMQBasics(E2ETest):
     @pytest.mark.parametrize(

--- a/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
+++ b/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from semantic_version import Version
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier1,
@@ -28,6 +29,7 @@ from ocs_ci.utility.utils import exec_cmd, run_cmd, clone_notify
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier1
 @bugzilla("2209616")
 @bugzilla("1937187")

--- a/tests/e2e/workloads/app/bdi/test_bdi_workload.py
+++ b/tests/e2e/workloads/app/bdi/test_bdi_workload.py
@@ -1,7 +1,9 @@
 from ocs_ci.ocs.bdi.bdi_base_class import TestBdiWorkloadBaseClass
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import ipi_deployment_required, skipif_bm, skipif_lso
 
 
+@magenta_squad
 @ipi_deployment_required
 @skipif_bm
 @skipif_lso

--- a/tests/e2e/workloads/app/cosbench/test_cosbench.py
+++ b/tests/e2e/workloads/app/cosbench/test_cosbench.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import bugzilla
+from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs.cosbench import Cosbench
 
@@ -20,6 +20,7 @@ def cosbench(request):
     return cosbench
 
 
+@magenta_squad
 @workloads
 @pytest.mark.polarion_id("OCS-2529")
 class TestCosbenchWorkload(E2ETest):

--- a/tests/e2e/workloads/app/couchbase/test_couchbase.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, skipif_ocp_version
 from ocs_ci.ocs.couchbase import CouchBase
 
@@ -19,6 +20,7 @@ def couchbase(request):
     return couchbase
 
 
+@magenta_squad
 @skipif_ocp_version(">=4.13")
 @workloads
 @pytest.mark.polarion_id("OCS-785")

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_node_drain.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_node_drain.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node
 from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -16,6 +17,7 @@ from ocs_ci.ocs import flowtest
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_ocp_version(">=4.13")
 @workloads
 @ignore_leftovers

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_node_reboot.py
@@ -5,6 +5,7 @@ import pytest
 
 from ocs_ci.ocs import ocp
 from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -25,6 +26,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_ocp_version(">=4.13")
 @workloads
 @ignore_leftovers

--- a/tests/e2e/workloads/app/couchbase/test_couchbase_pod_respin.py
+++ b/tests/e2e/workloads/app/couchbase/test_couchbase_pod_respin.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -14,6 +15,7 @@ from ocs_ci.helpers.sanity_helpers import Sanity
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_ocp_version(">=4.13")
 @workloads
 @ignore_leftovers

--- a/tests/e2e/workloads/app/jenkins/test_jenkins.py
+++ b/tests/e2e/workloads/app/jenkins/test_jenkins.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs.jenkins import Jenkins
 from ocs_ci.ocs.constants import STATUS_COMPLETED
@@ -20,6 +21,7 @@ def jenkins(request):
     return jenkins
 
 
+@magenta_squad
 @workloads
 @pytest.mark.polarion_id("OCS-2175")
 class TestJenkinsWorkload(E2ETest):

--- a/tests/e2e/workloads/app/jenkins/test_jenkins_node_drain.py
+++ b/tests/e2e/workloads/app/jenkins/test_jenkins_node_drain.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.jenkins import Jenkins
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.ocs.constants import STATUS_COMPLETED, MASTER_MACHINE, WORKER_MACHINE
 
@@ -22,6 +23,7 @@ def jenkins(request):
     return jenkins
 
 
+@magenta_squad
 @workloads
 @ignore_leftovers
 class TestJenkinsNodeDrain(E2ETest):

--- a/tests/e2e/workloads/app/jenkins/test_jenkins_node_reboot.py
+++ b/tests/e2e/workloads/app/jenkins/test_jenkins_node_reboot.py
@@ -1,7 +1,10 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import skipif_vsphere_ipi
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_vsphere_ipi,
+    magenta_squad,
+)
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.constants import STATUS_COMPLETED, MASTER_MACHINE, WORKER_MACHINE
@@ -25,6 +28,7 @@ def jenkins(request, nodes):
     return jenkins
 
 
+@magenta_squad
 @workloads
 @ignore_leftovers
 @skipif_vsphere_ipi

--- a/tests/e2e/workloads/app/jenkins/test_jenkins_pod_respin.py
+++ b/tests/e2e/workloads/app/jenkins/test_jenkins_pod_respin.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.jenkins import Jenkins
@@ -22,6 +23,7 @@ def jenkins(request):
     return jenkins
 
 
+@magenta_squad
 @workloads
 class TestJenkinsPodRespin(E2ETest):
     """

--- a/tests/e2e/workloads/app/pgsql/test_pgsql.py
+++ b/tests/e2e/workloads/app/pgsql/test_pgsql.py
@@ -3,6 +3,7 @@ import pytest
 from datetime import datetime
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.pgsql import Postgresql
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, google_api_required
 from ocs_ci.ocs.node import get_node_resource_utilization_from_adm_top
 
@@ -21,6 +22,7 @@ def pgsql(request):
     return pgsql
 
 
+@magenta_squad
 @google_api_required
 @workloads
 @pytest.mark.polarion_id("OCS-807")

--- a/tests/e2e/workloads/app/pgsql/test_pgsql_node_drain.py
+++ b/tests/e2e/workloads/app/pgsql/test_pgsql_node_drain.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import node
 from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.ocs.pgsql import Postgresql
 from ocs_ci.ocs.node import get_node_resource_utilization_from_adm_top
@@ -24,6 +25,7 @@ def pgsql(request):
     return pgsql
 
 
+@magenta_squad
 @ignore_leftovers
 @workloads
 @pytest.mark.polarion_id("OCS-820")

--- a/tests/e2e/workloads/app/pgsql/test_pgsql_node_reboot.py
+++ b/tests/e2e/workloads/app/pgsql/test_pgsql_node_reboot.py
@@ -4,6 +4,7 @@ import random
 from datetime import datetime
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.ocs.pgsql import Postgresql
 from ocs_ci.ocs.node import (
@@ -27,6 +28,7 @@ def pgsql(request):
     return pgsql
 
 
+@magenta_squad
 @ignore_leftovers
 @workloads
 class TestPgSQLNodeReboot(E2ETest):

--- a/tests/e2e/workloads/app/pgsql/test_pgsql_pod_respin.py
+++ b/tests/e2e/workloads/app/pgsql/test_pgsql_pod_respin.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from datetime import datetime
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.ocs.pgsql import Postgresql
 from ocs_ci.helpers import disruption_helpers
@@ -23,6 +24,7 @@ def pgsql(request):
     return pgsql
 
 
+@magenta_squad
 @ignore_leftovers
 @workloads
 class TestPgSQLPodRespin(E2ETest):

--- a/tests/e2e/workloads/app/quay/test_quay_operator.py
+++ b/tests/e2e/workloads/app/quay/test_quay_operator.py
@@ -4,7 +4,11 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import bugzilla, skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    skipif_ocs_version,
+    magenta_squad,
+)
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -44,6 +48,7 @@ def _exec_cmd(cmd):
     exec_cmd(cmd)
 
 
+@magenta_squad
 @workloads
 class TestQuayWorkload(E2ETest):
     """

--- a/tests/e2e/workloads/app/test_jenkins_simulation.py
+++ b/tests/e2e/workloads/app/test_jenkins_simulation.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import ManageTest, workloads, polarion_id, bugzilla
 from ocs_ci.ocs import constants, node
 from ocs_ci.utility import templating
@@ -34,6 +35,7 @@ def pod(request, pvc_factory, pod_factory, interface_iterate):
     return pod
 
 
+@magenta_squad
 class TestJenkinsSimulation(ManageTest):
     """
     Run simulation for "Jenkins" - git clone

--- a/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
@@ -14,7 +14,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_all_pods, delete_deploymentconfig_pods
 from ocs_ci.utility.retry import retry
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3
+from ocs_ci.framework.pytest_customization.marks import skipif_aws_i3, magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -36,6 +36,7 @@ def setup_fixture(install_logging):
     logger.info("Testcases execution post deployment of openshift-logging")
 
 
+@magenta_squad
 @pytest.mark.usefixtures(setup_fixture.__name__)
 @ignore_leftovers
 class Testopenshiftloggingonocs(E2ETest):

--- a/tests/e2e/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/e2e/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
@@ -36,6 +36,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_i3,
     skipif_vsphere_ipi,
     skipif_ibm_cloud,
+    blue_squad,
 )
 
 log = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ def wait_for_nodes_status_and_prometheus_health_check(pods):
     assert prometheus_health_check(), "Prometheus health is degraded"
 
 
+@blue_squad
 @ignore_leftovers
 @workloads
 @skipif_vsphere_ipi

--- a/tests/e2e/workloads/ocp/registry/test_pod_from_registry.py
+++ b/tests/e2e/workloads/ocp/registry/test_pod_from_registry.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, tier1
 from ocs_ci.helpers import helpers
 from ocs_ci.utility import templating
@@ -8,6 +9,7 @@ from ocs_ci.utility import templating
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier1
 @pytest.mark.polarion_id("OCS-2085")
 class TestRegistryImage(E2ETest):

--- a/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs.registry import (
     validate_pvc_mount_on_registry_pod,
     get_registry_pod_obj,
 )
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, bugzilla
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.resources.pod import get_pod_logs
@@ -17,6 +18,7 @@ from ocs_ci.ocs.resources.pod import get_pod_logs
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @workloads
 @bugzilla("1981639")
 @bugzilla("2128263")

--- a/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_pod_respin.py
@@ -7,6 +7,7 @@ from ocs_ci.ocs.registry import (
     image_pull_and_push,
     validate_image_exists,
 )
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 from ocs_ci.helpers import disruption_helpers
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -15,6 +16,7 @@ log = logging.getLogger(__name__)
 IMAGE_URL = "docker.io/library/busybox"
 
 
+@magenta_squad
 @workloads
 class TestRegistryPodRespin(E2ETest):
     """

--- a/tests/e2e/workloads/ocp/registry/test_registry_pull_and_push_images_to_registry.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_pull_and_push_images_to_registry.py
@@ -7,11 +7,13 @@ from ocs_ci.ocs.registry import (
     image_pull_and_push,
     validate_image_exists,
 )
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads
 
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @workloads
 class TestRegistryPullAndPushImagestoRegistry(E2ETest):
     """

--- a/tests/e2e/workloads/ocp/registry/test_registry_reboot_node.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_reboot_node.py
@@ -16,12 +16,14 @@ from ocs_ci.ocs.node import wait_for_nodes_status, get_nodes
 from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.helpers.sanity_helpers import Sanity
 
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @workloads
 @ignore_leftovers
 class TestRegistryRebootNode(E2ETest):

--- a/tests/e2e/workloads/ocp/registry/test_registry_shutdown_and_recovery_node.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_shutdown_and_recovery_node.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -22,6 +23,7 @@ from ocs_ci.utility.retry import retry
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @workloads
 @ignore_leftovers
 class TestRegistryShutdownAndRecoveryNode(E2ETest):

--- a/tests/e2e/workloads/ocp/registry/test_simple_registry_workload.py
+++ b/tests/e2e/workloads/ocp/registry/test_simple_registry_workload.py
@@ -3,6 +3,7 @@ import pytest
 import shlex
 from subprocess import Popen, PIPE
 import logging
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.utility.svt import (
     svt_project_clone,
     svt_create_venv_setup,
@@ -13,6 +14,7 @@ from ocs_ci.utility.svt import (
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @pytest.mark.skip(
     reason="Skipped due to issue https://github.com/openshift/svt/issues/697"
 )

--- a/tests/e2e/workloads/pvc_snapshot_and_clone/test_cloned_and_restored_pvc_resize.py
+++ b/tests/e2e/workloads/pvc_snapshot_and_clone/test_cloned_and_restored_pvc_resize.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -12,6 +13,7 @@ from ocs_ci.ocs.constants import VOLUME_MODE_FILESYSTEM
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier2
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -19,6 +20,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier2
 class TestCompressedSCAndSupportSnapClone(E2ETest):
     """

--- a/tests/e2e/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
+++ b/tests/e2e/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ms_provider_and_consumer,
     ms_consumer_required,
     skipif_bm,
+    magenta_squad,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
@@ -26,6 +27,7 @@ from ocs_ci.ocs.resources.pod import get_all_pods
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier1
 @ignore_leftovers
 class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
@@ -115,6 +117,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         )
 
 
+@magenta_squad
 @tier1
 @ignore_leftovers
 @ms_provider_and_consumer_required

--- a/tests/e2e/workloads/test_data_consistency.py
+++ b/tests/e2e/workloads/test_data_consistency.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization import marks
+from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import exceptions
@@ -25,8 +25,9 @@ from ocs_ci.helpers.helpers import storagecluster_independent_check
 logger = logging.getLogger(__name__)
 
 
+@magenta_squad
 @tier1
-@marks.bugzilla("1989301")
+@bugzilla("1989301")
 @pytest.mark.polarion_id("OCS-2735")
 def test_log_reader_writer_parallel(project, tmp_path):
     """

--- a/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -18,6 +19,7 @@ from ocs_ci.ocs import flowtest
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @skipif_external_mode
 @ignore_leftovers
 @tier2

--- a/tests/ecosystem/deployment/test_acm.py
+++ b/tests/ecosystem/deployment/test_acm.py
@@ -1,4 +1,5 @@
 from ocs_ci.ocs.acm.acm import import_clusters_with_acm
+from ocs_ci.framework.pytest_customization.marks import purple_squad
 from ocs_ci.framework.testlib import acm_import
 
 ####################################################################################################
@@ -6,6 +7,7 @@ from ocs_ci.framework.testlib import acm_import
 ####################################################################################################
 
 
+@purple_squad
 @acm_import
 def test_acm_import():
     import_clusters_with_acm()

--- a/tests/ecosystem/deployment/test_deployment.py
+++ b/tests/ecosystem/deployment/test_deployment.py
@@ -1,6 +1,7 @@
 import logging
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import purple_squad
 from ocs_ci.framework.testlib import deployment, polarion_id
 from ocs_ci.ocs.resources.storage_cluster import (
     ocs_install_verification,
@@ -18,6 +19,7 @@ from ocs_ci.utility.azure_utils import azure_storageaccount_check
 log = logging.getLogger(__name__)
 
 
+@purple_squad
 @deployment
 @polarion_id(get_polarion_id())
 def test_deployment(pvc_factory, pod_factory):

--- a/tests/ecosystem/upgrade/test_upgrade.py
+++ b/tests/ecosystem/upgrade/test_upgrade.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import purple_squad
 from ocs_ci.framework.testlib import (
     ocs_upgrade,
     polarion_id,
@@ -25,6 +26,7 @@ def teardown(request, nodes):
     request.addfinalizer(finalizer)
 
 
+@purple_squad
 @pytest.mark.polarion_id("OCS-1579")
 def test_worker_node_abrupt_shutdown(teardown):
     """
@@ -36,6 +38,7 @@ def test_worker_node_abrupt_shutdown(teardown):
     run_ocs_upgrade(operation=worker_node_shutdown, abrupt=True)
 
 
+@purple_squad
 @pytest.mark.polarion_id("OCS-1575")
 def test_worker_node_permanent_shutdown(teardown):
     """
@@ -46,6 +49,7 @@ def test_worker_node_permanent_shutdown(teardown):
     run_ocs_upgrade(operation=worker_node_shutdown, abrupt=False)
 
 
+@purple_squad
 @pytest.mark.polarion_id("OCS-1558")
 def test_osd_reboot(teardown):
     """
@@ -57,6 +61,7 @@ def test_osd_reboot(teardown):
     run_ocs_upgrade(operation=osd_node_reboot)
 
 
+@purple_squad
 @ocs_upgrade
 @polarion_id(get_polarion_id(upgrade=True))
 def test_upgrade():

--- a/tests/encryption/test_intransit_encryption_data_integrity.py
+++ b/tests/encryption/test_intransit_encryption_data_integrity.py
@@ -21,6 +21,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_intransit_encryption_notset
 @green_squad
 class TestDataIntegrityWithInTransitEncryption:

--- a/tests/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/encryption/test_mon_failure_in_intransit_encryption.py
@@ -21,6 +21,7 @@ from ocs_ci.helpers.helpers import modify_deployment_replica_count
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4a
 @skipif_ocs_version("<4.13")
 @pytest.mark.polarion_id("OCS-4919")

--- a/tests/internal/test_create_pvc_random_storage_class.py
+++ b/tests/internal/test_create_pvc_random_storage_class.py
@@ -6,9 +6,11 @@ import random
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest
 
 
+@green_squad
 @pytest.mark.polarion_id("OCS-288")
 class TestCreatePVCRandomStorageClass(ManageTest):
     """

--- a/tests/internal/test_create_storage_class_pvc.py
+++ b/tests/internal/test_create_storage_class_pvc.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.helpers import helpers
 
@@ -86,6 +87,7 @@ def teardown_fs():
     CEPHFS_SC_OBJ.delete()
 
 
+@green_squad
 class TestOSCBasics(ManageTest):
     @pytest.mark.polarion_id("OCS-336")
     def test_basics_rbd(self, test_fixture_rbd):

--- a/tests/internal/test_fio_fillup.py
+++ b/tests/internal/test_fio_fillup.py
@@ -4,6 +4,7 @@ Module to perform IOs with several weights
 import pytest
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import libtest
 from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs import constants
 
@@ -11,6 +12,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@libtest
 class TestPVCFillup(BaseTest):
     """
     Test PVC Fillup

--- a/tests/internal/test_skipif_ocp.py
+++ b/tests/internal/test_skipif_ocp.py
@@ -1,10 +1,12 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import libtest
 from ocs_ci.framework.testlib import BaseTest, skipif_ocp_version
 
 log = logging.getLogger(__name__)
 
 
+@libtest
 class TestSkipifOCP(BaseTest):
     """
     Tests to check the skipif_ocp marker

--- a/tests/internal/test_update_catalogsource.py
+++ b/tests/internal/test_update_catalogsource.py
@@ -1,7 +1,9 @@
+from ocs_ci.framework.pytest_customization.marks import libtest
 from ocs_ci.framework.testlib import managed_service_required
 from ocs_ci.ocs.managedservice import update_pull_secret, update_non_ga_version
 
 
+@libtest
 @managed_service_required
 def test_update_catalog_source():
     """

--- a/tests/libtest/test_elasticsearch.py
+++ b/tests/libtest/test_elasticsearch.py
@@ -10,6 +10,7 @@ import time
 from elasticsearch import Elasticsearch, exceptions as esexp
 
 # Local modules
+from ocs_ci.framework.pytest_customization.marks import libtest
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.helpers.performance_lib import run_command
 from ocs_ci.ocs import benchmark_operator, constants, defaults
@@ -24,6 +25,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@libtest
 class TestElasticsearch:
     """
     Testing the ElasticjSearch module used by ocs-ci

--- a/tests/libtest/test_requirements.py
+++ b/tests/libtest/test_requirements.py
@@ -1,2 +1,6 @@
+from ocs_ci.framework.pytest_customization.marks import libtest
+
+
+@libtest
 def test_requirements(supported_configuration):
     pass

--- a/tests/libtest/test_user.py
+++ b/tests/libtest/test_user.py
@@ -2,11 +2,13 @@ import logging
 import os
 from time import sleep
 
+from ocs_ci.framework.pytest_customization.marks import libtest
 from ocs_ci.utility.utils import exec_cmd
 
 logger = logging.getLogger(__name__)
 
 
+@libtest
 def test_user_creation(user_factory):
     user = user_factory()
     kubeconfig = os.getenv("KUBECONFIG")

--- a/tests/lvmo/test_lvm_alerts.py
+++ b/tests/lvmo/test_lvm_alerts.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
@@ -16,6 +17,7 @@ from ocs_ci.utility.lvmo_utils import lvmo_health_check
 log = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode", "status"],
     argvalues=[

--- a/tests/lvmo/test_lvm_clone_base.py
+++ b/tests/lvmo/test_lvm_clone_base.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
@@ -15,6 +16,7 @@ from ocs_ci.ocs.exceptions import Md5CheckFailed
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode"],
     argvalues=[

--- a/tests/lvmo/test_lvm_clone_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_clone_bigger_than_disk.py
@@ -2,7 +2,11 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier2, skipif_lvm_not_installed
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    skipif_lvm_not_installed,
+    aqua_squad,
+)
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
@@ -11,6 +15,7 @@ from ocs_ci.ocs.exceptions import LvSizeWrong
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @tier2
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.11")

--- a/tests/lvmo/test_lvm_manual_diskpath.py
+++ b/tests/lvmo/test_lvm_manual_diskpath.py
@@ -11,7 +11,11 @@ from ocs_ci.utility.lvmo_utils import (
     get_sno_disks_by_path,
     lvmo_health_check,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_lvm_not_installed, tier1
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_lvm_not_installed,
+    tier1,
+    aqua_squad,
+)
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.lvmo_utils import get_lvm_cluster_name
@@ -50,6 +54,7 @@ def create_lvm_cluster_cr_with_device_selector(disks):
     return lvm_cluster_cr.name
 
 
+@aqua_squad
 @tier1
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.12")

--- a/tests/lvmo/test_lvm_multi_clone.py
+++ b/tests/lvmo/test_lvm_multi_clone.py
@@ -7,6 +7,7 @@ import concurrent.futures
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
@@ -18,6 +19,7 @@ from ocs_ci.ocs.exceptions import Md5CheckFailed
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode"],
     argvalues=[

--- a/tests/lvmo/test_lvm_multi_snapshot.py
+++ b/tests/lvmo/test_lvm_multi_snapshot.py
@@ -7,6 +7,7 @@ import concurrent.futures
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
@@ -18,6 +19,7 @@ from ocs_ci.ocs.exceptions import Md5CheckFailed
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode"],
     argvalues=[

--- a/tests/lvmo/test_lvm_snapshot_base.py
+++ b/tests/lvmo/test_lvm_snapshot_base.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
@@ -15,6 +16,7 @@ from ocs_ci.ocs.exceptions import Md5CheckFailed
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode"],
     argvalues=[

--- a/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
@@ -2,7 +2,11 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_lvm_not_installed
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_lvm_not_installed,
+    aqua_squad,
+)
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
@@ -11,6 +15,7 @@ from ocs_ci.ocs.exceptions import LvSizeWrong
 logger = logging.getLogger(__name__)
 
 
+@aqua_squad
 @tier1
 @acceptance
 @skipif_lvm_not_installed

--- a/tests/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/lvmo/test_lvmo_pvc_resize.py
@@ -4,6 +4,7 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_lvm_not_installed,
+    aqua_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
@@ -13,6 +14,7 @@ from ocs_ci.ocs.cluster import LVM
 log = logging.getLogger(__name__)
 
 
+@aqua_squad
 @pytest.mark.parametrize(
     argnames=["volume_mode", "volume_binding_mode", "status"],
     argvalues=[

--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -6,6 +6,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
@@ -21,6 +22,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_ocs_version("<4.10")
 # We have to ignore leftovers since environment_checker runs before the
 # bucket_factory_session teardown, due to it being session-scoped.

--- a/tests/manage/mcg/test_azure_noobaa_sa.py
+++ b/tests/manage/mcg/test_azure_noobaa_sa.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_ocs_version,
     azure_platform_required,
+    red_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -17,6 +18,7 @@ from ocs_ci.ocs.ocp import OCP
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @tier1
 @azure_platform_required
 @bugzilla("1970123")

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     performance,
     skipif_mcg_only,
     bugzilla,
+    red_squad,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -22,6 +23,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 class TestBucketCreation(MCGTest):
     """

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_mcg_only,
+    red_squad,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
 
 
+@red_squad
 @skipif_managed_service
 class TestBucketDeletion(MCGTest):
     """

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -46,12 +46,17 @@ from ocs_ci.ocs.constants import (
     bucket_website_action_list,
     bucket_version_action_list,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service, bugzilla
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    bugzilla,
+    red_squad,
+)
 from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.3")
 class TestS3BucketPolicy(MCGTest):

--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, tier2
+from ocs_ci.framework.pytest_customization.marks import tier1, tier2, red_squad
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.utility.retry import retry
@@ -29,6 +29,7 @@ from ocs_ci.framework.testlib import skipif_ocs_version
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_ocs_version("<4.9")
 class TestReplication(MCGTest):
     """

--- a/tests/manage/mcg/test_cached_buckets.py
+++ b/tests/manage/mcg/test_cached_buckets.py
@@ -16,12 +16,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     skipif_aws_creds_are_missing,
     tier2,
+    red_squad,
 )
 from ocs_ci.framework.testlib import MCGTest
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 class TestCachedBuckets(MCGTest):

--- a/tests/manage/mcg/test_db_nfs_mount.py
+++ b/tests/manage/mcg/test_db_nfs_mount.py
@@ -13,12 +13,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     polarion_id,
     vsphere_platform_required,
+    red_squad,
 )
 from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestNoobaaDbNFSMount:
     @pytest.fixture()
     def mount_ngix_pod(self, request):

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -1,11 +1,15 @@
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import MCGTest, tier1, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    red_squad,
+)
 
 
 # @pytest.mark.polarion_id("OCS-XXXX")
 # Skipped above 4.6 because of https://github.com/red-hat-storage/ocs-ci/issues/4129
+@red_squad
 @skipif_ocs_version(["<4.5", ">4.6"])
 @skipif_managed_service
 @tier1

--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import (
     bugzilla,
     ignore_leftovers,
@@ -29,6 +30,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@red_squad
 @tier4b
 @bugzilla("1853638")
 @ignore_leftovers

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms
+from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms, red_squad
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
@@ -11,6 +11,7 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_no_kms
 class TestNoobaaKMS(MCGTest):
     """

--- a/tests/manage/mcg/test_log_based_bucket_replication.py
+++ b/tests/manage/mcg/test_log_based_bucket_replication.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs.resources.mockup_bucket_logger import MockupBucketLogger
 
 from ocs_ci.ocs import constants
 
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import (
     skipif_aws_creds_are_missing,
     skipif_vsphere_ipi,
@@ -27,6 +28,7 @@ from ocs_ci.ocs.scale_noobaa_lib import noobaa_running_node_restart
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @ignore_leftover_label(constants.MON_APP_LABEL)  # tier4b test requirement
 @skipif_aws_creds_are_missing
 class TestLogBasedBucketReplication(MCGTest):

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_mcg_only,
+    red_squad,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -31,6 +32,7 @@ def setup(request):
     request.cls.cl_obj = cluster.CephCluster()
 
 
+@red_squad
 @ignore_leftovers()
 @skipif_mcg_only
 @pytest.mark.usefixtures(setup.__name__)

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
     skipif_disconnected_cluster,
+    red_squad,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.bucket_utils import (
@@ -24,6 +25,7 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing

--- a/tests/manage/mcg/test_multicloud.py
+++ b/tests/manage/mcg/test_multicloud.py
@@ -4,11 +4,15 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import MCGTest
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    red_squad,
+)
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 class TestMultiCloud(MCGTest):
     """

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -19,6 +19,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     bugzilla,
     skipif_ocs_version,
+    red_squad,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ def setup(pod_obj, bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@red_squad
 @skipif_managed_service
 class TestS3MultipartUpload(MCGTest):
     """

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -31,7 +31,10 @@ from ocs_ci.ocs.bucket_utils import (
     retrieve_verification_mode,
     wait_for_cache,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_creds_are_missing
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_aws_creds_are_missing,
+    red_squad,
+)
 from ocs_ci.ocs import constants, bucket_utils
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
@@ -42,6 +45,7 @@ from ocs_ci.ocs.resources.bucket_policy import HttpResponseParser
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_disconnected_cluster

--- a/tests/manage/mcg/test_namespace_rpc.py
+++ b/tests/manage/mcg/test_namespace_rpc.py
@@ -18,7 +18,10 @@ from ocs_ci.framework.testlib import (
     tier4a,
 )
 from ocs_ci.ocs.bucket_utils import sync_object_directory, verify_s3_object_integrity
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_creds_are_missing
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_aws_creds_are_missing,
+    red_squad,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -27,6 +30,7 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/manage/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/manage/mcg/test_nb_mgmt_endpoint.py
@@ -2,6 +2,7 @@ import json
 import requests
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import tier1
 
 from ocs_ci.framework.testlib import MCGTest
@@ -12,6 +13,7 @@ from ocs_ci.ocs.bucket_utils import retrieve_verification_mode
 logger = logging.getLogger(name=__file__)
 
 
+@red_squad
 @tier1
 @skipif_ocs_version(">4.13")
 class TestNoobaaMgmtEndpoint(MCGTest):

--- a/tests/manage/mcg/test_noobaa_prometheus.py
+++ b/tests/manage/mcg/test_noobaa_prometheus.py
@@ -5,7 +5,12 @@ from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
     ReturnedEmptyResponseException,
 )
-from ocs_ci.framework.pytest_customization.marks import tier2, bugzilla, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    bugzilla,
+    polarion_id,
+    red_squad,
+)
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.ocs.bucket_utils import write_random_test_objects_to_bucket
 from ocs_ci.utility.retry import retry
@@ -29,6 +34,7 @@ def get_bucket_used_bytes_metric(bucket_name):
     return value[1]
 
 
+@red_squad
 class TestNoobaaaPrometheus:
     @tier2
     @bugzilla("2168010")

--- a/tests/manage/mcg/test_noobaa_secret.py
+++ b/tests/manage/mcg/test_noobaa_secret.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_disconnected_cluster,
+    red_squad,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.aws import update_config_from_s3
@@ -58,6 +59,7 @@ def cleanup(request):
     return factory
 
 
+@red_squad
 @tier2
 @skipif_ocs_version("<4.11")
 @skipif_disconnected_cluster

--- a/tests/manage/mcg/test_nsfs.py
+++ b/tests/manage/mcg/test_nsfs.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     skipif_ocs_version,
     ignore_leftover_label,
+    red_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
@@ -19,6 +20,7 @@ from tests.conftest import revert_noobaa_endpoint_scc_class
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_mcg_only
 @skipif_ocs_version("<4.10")
 @ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)

--- a/tests/manage/mcg/test_object_expiration.py
+++ b/tests/manage/mcg/test_object_expiration.py
@@ -4,7 +4,7 @@ from time import sleep
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla
+from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla, red_squad
 from ocs_ci.framework.testlib import MCGTest, version
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
@@ -12,6 +12,7 @@ from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestObjectExpiration(MCGTest):
     """
     Tests suite for object expiration

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -13,6 +13,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_disconnected_cluster,
+    red_squad,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ FILESIZE_SKIP = pytest.mark.skip("Current test filesize is too large.")
 RUNTIME_SKIP = pytest.mark.skip("Runtime is too long; Code needs to be parallelized")
 
 
+@red_squad
 @flaky
 @skipif_managed_service
 class TestObjectIntegrity(MCGTest):

--- a/tests/manage/mcg/test_object_versioning.py
+++ b/tests/manage/mcg/test_object_versioning.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier2,
     skipif_ocs_version,
+    red_squad,
 )
 from ocs_ci.ocs.bucket_utils import (
     s3_put_bucket_versioning,
@@ -23,6 +24,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestObjectVersioning:
     @pytest.fixture(scope="function")
     def setup_file_object(self, request):

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     tier2,
     tier3,
+    red_squad,
 )
 
 from ocs_ci.ocs.bucket_utils import (
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 LOCAL_DIR_PATH = "/awsfiles"
 
 
+@red_squad
 @skipif_mcg_only
 class TestPvPool:
     """

--- a/tests/manage/mcg/test_s3_prefix_list.py
+++ b/tests/manage/mcg/test_s3_prefix_list.py
@@ -11,11 +11,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier2,
     skipif_ocs_version,
+    red_squad,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @bugzilla("2068110")
 @pytest.mark.polarion_id("OCS-3925")
 @tier2

--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_cloud,
     skipif_managed_service,
     skipif_mcg_only,
+    red_squad,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 RECONCILE_WAIT = 60
 
 
+@red_squad
 class TestS3Routes:
 
     """

--- a/tests/manage/mcg/test_s3_with_java_sdk.py
+++ b/tests/manage/mcg/test_s3_with_java_sdk.py
@@ -7,12 +7,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
     tier1,
+    red_squad,
 )
 from ocs_ci.ocs.bucket_utils import upload_objects_with_javasdk
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_ocs_version("<4.9")
 @skipif_disconnected_cluster
 @skipif_proxy_cluster

--- a/tests/manage/mcg/test_verify_noobaa_status.py
+++ b/tests/manage/mcg/test_verify_noobaa_status.py
@@ -1,8 +1,12 @@
 import logging
 import re
 
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_ocs_version
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_ocs_version,
+    skipif_openshift_dedicated,
+    red_squad,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_pod_logs
 from ocs_ci.framework.testlib import polarion_id, bugzilla
@@ -11,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 log = logging.getLogger(__name__)
 
 
+@red_squad
 @tier1
 @polarion_id("OCS-2084")
 @bugzilla("1799077")
@@ -28,6 +33,7 @@ def test_verify_noobaa_status_cli(mcg_obj_session):
     log.info("Verified: noobaa status does not contain any error.")
 
 
+@red_squad
 @tier1
 @skipif_ocs_version("<4.8")
 @polarion_id("OCS-2748")

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -9,6 +9,7 @@ from flaky import flaky
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     skip_inconsistent,
+    red_squad,
 )
 from ocs_ci.framework.testlib import (
     MCGTest,
@@ -79,6 +80,7 @@ def file_setup(request):
     return zip_filename
 
 
+@red_squad
 @skipif_managed_service
 class TestBucketIO(MCGTest):
     """

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -3,6 +3,7 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     on_prem_platform_required,
+    red_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -27,6 +28,7 @@ from ocs_ci.ocs.ui.page_objects.object_buckets_tab import ObjectBucketsTab
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @skipif_ui_not_support("mcg_stores")
 class TestStoreUserInterface(object):
     """
@@ -97,6 +99,7 @@ class TestStoreUserInterface(object):
         assert test_store.check_resource_existence(should_exist=False)
 
 
+@red_squad
 @ui
 @skipif_ui_not_support("bucketclass")
 @tier1
@@ -232,6 +235,7 @@ class TestBucketclassUserInterface(object):
         assert test_bc.check_resource_existence(should_exist=False)
 
 
+@red_squad
 @skipif_ui_not_support("obc")
 class TestObcUserInterface(object):
     """

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -3,7 +3,7 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     on_prem_platform_required,
-    red_squad,
+    black_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -28,7 +28,7 @@ from ocs_ci.ocs.ui.page_objects.object_buckets_tab import ObjectBucketsTab
 logger = logging.getLogger(__name__)
 
 
-@red_squad
+@black_squad
 @skipif_ui_not_support("mcg_stores")
 class TestStoreUserInterface(object):
     """
@@ -99,7 +99,7 @@ class TestStoreUserInterface(object):
         assert test_store.check_resource_existence(should_exist=False)
 
 
-@red_squad
+@black_squad
 @ui
 @skipif_ui_not_support("bucketclass")
 @tier1
@@ -235,7 +235,7 @@ class TestBucketclassUserInterface(object):
         assert test_bc.check_resource_existence(should_exist=False)
 
 
-@red_squad
+@black_squad
 @skipif_ui_not_support("obc")
 class TestObcUserInterface(object):
     """

--- a/tests/manage/mcg/ui/test_namespace_store.py
+++ b/tests/manage/mcg/ui/test_namespace_store.py
@@ -3,7 +3,7 @@ import pytest
 
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import black_squad
 from ocs_ci.framework.testlib import tier1, ui, polarion_id
 from ocs_ci.ocs.ui.mcg_ui import NamespaceStoreUI
 from ocs_ci.ocs.resources.namespacestore import NamespaceStore
@@ -12,7 +12,7 @@ from ocs_ci.ocs.resources.namespacestore import NamespaceStore
 logger = logging.getLogger(__name__)
 
 
-@red_squad
+@black_squad
 class TestNamespaceStoreUI(object):
     """
     Test namespace-store via User Interface.

--- a/tests/manage/mcg/ui/test_namespace_store.py
+++ b/tests/manage/mcg/ui/test_namespace_store.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import tier1, ui, polarion_id
 from ocs_ci.ocs.ui.mcg_ui import NamespaceStoreUI
 from ocs_ci.ocs.resources.namespacestore import NamespaceStore
@@ -11,6 +12,7 @@ from ocs_ci.ocs.resources.namespacestore import NamespaceStore
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestNamespaceStoreUI(object):
     """
     Test namespace-store via User Interface.

--- a/tests/manage/monitoring/pagerduty/test_ceph.py
+++ b/tests/manage/monitoring/pagerduty/test_ceph.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     managed_service_required,
     skipif_ms_consumer,
@@ -15,6 +16,7 @@ from ocs_ci.utility import pagerduty
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @pytest.mark.skip(
     reason="measure_corrupt_pg is unstable and may turn cluster into segfault state"
 )

--- a/tests/manage/monitoring/pagerduty/test_deployment_status.py
+++ b/tests/manage/monitoring/pagerduty/test_deployment_status.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     bugzilla,
     managed_service_required,
@@ -32,6 +33,7 @@ def get_pagerduty_service_id():
         return config.RUN["pagerduty_service_id"]
 
 
+@blue_squad
 @tier4
 @tier4c
 @managed_service_required
@@ -66,6 +68,7 @@ def test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
         )
 
 
+@blue_squad
 @tier4
 @tier4c
 @managed_service_required
@@ -98,6 +101,7 @@ def test_ceph_osd_stopped_pd(measure_stop_ceph_osd):
         )
 
 
+@blue_squad
 @tier4
 @tier4b
 @managed_service_required
@@ -132,6 +136,7 @@ def test_stop_worker_nodes_pd(measure_stop_worker_nodes):
         )
 
 
+@blue_squad
 @tier4
 @tier4c
 @managed_service_required
@@ -170,6 +175,7 @@ def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
         )
 
 
+@blue_squad
 @tier4
 @tier4c
 @managed_service_required

--- a/tests/manage/monitoring/prometheus/test_alerting_works.py
+++ b/tests/manage/monitoring/prometheus/test_alerting_works.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import bugzilla, tier1
+from ocs_ci.framework.pytest_customization.marks import bugzilla, tier1, blue_squad
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 import ocs_ci.utility.prometheus
@@ -11,6 +11,7 @@ import ocs_ci.utility.prometheus
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 def test_alerting_works():
     """
     If alerting works then there is at least one alert.
@@ -25,6 +26,7 @@ def test_alerting_works():
     assert len(alerts) > 0
 
 
+@blue_squad
 @pytest.mark.polarion_id("OCS-2503")
 @bugzilla("1897674")
 @tier1

--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     gather_metrics_on_fail,
     skipif_managed_service,
+    blue_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
@@ -14,6 +15,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @pytest.mark.polarion_id("OCS-899")
 @pytest.mark.bugzilla("1943137")
 @tier2
@@ -78,6 +80,7 @@ def test_rbd_capacity_workload_alerts(workload_storageutilization_97p_rbd):
         )
 
 
+@blue_squad
 @pytest.mark.polarion_id("OCS-1934")
 @pytest.mark.bugzilla("1943137")
 @tier2

--- a/tests/manage/monitoring/prometheus/test_ceph.py
+++ b/tests/manage/monitoring/prometheus/test_ceph.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import tier4, tier4a, skipif_managed_service
+from ocs_ci.framework.testlib import tier4, tier4a, skipif_managed_service, blue_squad
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
@@ -9,6 +9,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier4
 @tier4a
 @pytest.mark.polarion_id("OCS-903")
@@ -54,6 +55,7 @@ def test_corrupt_pg_alerts(measure_corrupt_pg):
         )
 
 
+@blue_squad
 @tier4
 @tier4a
 @pytest.mark.polarion_id("OCS-898")

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     tier4c,
     bugzilla,
@@ -15,6 +16,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier4c
 @pytest.mark.polarion_id("OCS-1052")
 @skipif_managed_service
@@ -44,6 +46,7 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr):
     )
 
 
+@blue_squad
 @tier4c
 @pytest.mark.polarion_id("OCS-904")
 @skipif_managed_service
@@ -83,6 +86,7 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon):
         )
 
 
+@blue_squad
 @tier4c
 @bugzilla("1944513")
 @pytest.mark.polarion_id("OCS-2724")
@@ -114,6 +118,7 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon):
     )
 
 
+@blue_squad
 @tier4c
 @pytest.mark.polarion_id("OCS-900")
 @skipif_managed_service

--- a/tests/manage/monitoring/prometheus/test_hpa.py
+++ b/tests/manage/monitoring/prometheus/test_hpa.py
@@ -1,7 +1,7 @@
 import logging
 
 from ocs_ci.framework.pytest_customization import marks
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework.pytest_customization.marks import tier1, blue_squad
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     polarion_id,
     skipif_aws_creds_are_missing,
@@ -15,6 +16,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier2
 @polarion_id("OCS-1254")
 @skipif_managed_service
@@ -111,6 +113,7 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
         )
 
 
+@blue_squad
 @tier4a
 @polarion_id("OCS-2498")
 @skipif_managed_service

--- a/tests/manage/monitoring/prometheus/test_prometheus_rules.py
+++ b/tests/manage/monitoring/prometheus/test_prometheus_rules.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import bugzilla, tier4c
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 
@@ -8,6 +9,7 @@ from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier4c
 @bugzilla("2142763")
 @pytest.mark.polarion_id("OCS-4836")

--- a/tests/manage/monitoring/prometheus/test_rgw.py
+++ b/tests/manage/monitoring/prometheus/test_rgw.py
@@ -4,6 +4,7 @@ import pytest
 from semantic_version import Version
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import tier4c, skipif_managed_service
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
@@ -13,6 +14,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier4c
 @pytest.mark.polarion_id("OCS-2323")
 @pytest.mark.bugzilla("1953615")

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -2,8 +2,11 @@ import logging
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization import marks
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    skipif_managed_service,
+    tier1,
+)
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.version import get_ocp_version
@@ -12,6 +15,7 @@ from ocs_ci.utility.version import get_semantic_version, VERSION_4_10
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -11,6 +11,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     metrics_for_external_mode_required,
+    blue_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp
@@ -24,6 +25,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier1
 @pytest.mark.post_ocp_upgrade
 @pytest.mark.first
@@ -74,6 +76,7 @@ def test_monitoring_enabled():
         assert int(value) >= 0, "bucket status isn't a positive integer or zero"
 
 
+@blue_squad
 @tier1
 @pytest.mark.polarion_id("OCS-1265")
 @skipif_managed_service
@@ -108,6 +111,7 @@ def test_ceph_mgr_dashboard_not_deployed():
         assert "ceph-mgr-dashboard" not in route_name, msg
 
 
+@blue_squad
 @skipif_ocs_version("<4.6")
 @metrics_for_external_mode_required
 @tier1
@@ -129,6 +133,7 @@ def test_ceph_rbd_metrics_available():
     assert list_of_metrics_without_results == [], msg
 
 
+@blue_squad
 @tier1
 @pytest.mark.bugzilla("2203795")
 @metrics_for_external_mode_required
@@ -159,6 +164,7 @@ def test_ceph_metrics_available():
     assert list_of_metrics_without_results == [], msg
 
 
+@blue_squad
 @tier1
 @metrics_for_external_mode_required
 @pytest.mark.post_ocp_upgrade

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     bugzilla,
     tier3,
@@ -21,6 +22,7 @@ from ocs_ci.utility.prometheus import PrometheusAPI, check_query_range_result_en
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @tier3
 @pytest.mark.polarion_id("OCS-1306")
 @skipif_managed_service
@@ -93,6 +95,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon, threading_lock):
     assert mon_sample_size >= min_mon_samples
 
 
+@blue_squad
 @tier3
 @pytest.mark.polarion_id("OCS-1307")
 @skipif_managed_service
@@ -164,6 +167,7 @@ def test_monitoring_shows_osd_down(measure_stop_ceph_osd, threading_lock):
     assert osd_in_validation, osd_in_msg
 
 
+@blue_squad
 @tier3
 @bugzilla("2203795")
 @pytest.mark.polarion_id("OCS-2734")

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -11,7 +11,10 @@ from ocs_ci.framework.pytest_customization import marks
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.prometheus import check_query_range_result_limits
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    blue_squad,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +27,7 @@ CPU_USAGE_POD = (
 )
 
 
+@blue_squad
 @tier1
 @marks.polarion_id("OCS-2364")
 @marks.bugzilla("1849309")

--- a/tests/manage/monitoring/prometheusmetrics/test_rgw.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_rgw.py
@@ -9,6 +9,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import skipif_managed_service, skipif_ocs_version, tier4c
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs import metrics
@@ -19,6 +20,7 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @skipif_ocs_version("<4.6")
 @tier4c
 @pytest.mark.polarion_id("OCS-2385")

--- a/tests/manage/monitoring/sendgrid/test_capacity.py
+++ b/tests/manage/monitoring/sendgrid/test_capacity.py
@@ -5,12 +5,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     managed_service_required,
     skipif_ms_provider,
+    blue_squad,
 )
 from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
 
+@blue_squad
 @pytest.mark.polarion_id("OCS-2718")
 @tier2
 @managed_service_required

--- a/tests/manage/monitoring/test_workload_example.py
+++ b/tests/manage/monitoring/test_workload_example.py
@@ -11,6 +11,7 @@ import textwrap
 
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import skipif_managed_service
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 TEST_NS = "namespace-test-fio-continuous-workload"
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_start_fio_job(
@@ -84,6 +86,7 @@ def test_start_fio_job(
         raise
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_stop_fio_job():

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -43,6 +43,7 @@ from datetime import datetime
 
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import tier1, skipif_managed_service
 from ocs_ci.utility.prometheus import PrometheusAPI
 
@@ -50,6 +51,7 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_workload_rbd(workload_storageutilization_50p_rbd):
@@ -123,6 +125,7 @@ def test_workload_rbd(workload_storageutilization_50p_rbd):
     assert not at_least_one_value_out_of_range
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_workload_rbd_in_some_other_way(workload_storageutilization_50p_rbd):
@@ -135,6 +138,7 @@ def test_workload_rbd_in_some_other_way(workload_storageutilization_50p_rbd):
     logger.info(workload_storageutilization_50p_rbd)
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_workload_cephfs(workload_storageutilization_50p_cephfs):
@@ -144,6 +148,7 @@ def test_workload_cephfs(workload_storageutilization_50p_cephfs):
     logger.info(workload_storageutilization_50p_cephfs)
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_workload_rbd_cephfs(
@@ -158,6 +163,7 @@ def test_workload_rbd_cephfs(
     logger.info(workload_storageutilization_50p_cephfs)
 
 
+@blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
 def test_workload_rbd_cephfs_minimal(
@@ -175,6 +181,7 @@ def test_workload_rbd_cephfs_minimal(
     logger.info(workload_storageutilization_05p_cephfs)
 
 
+@blue_squad
 @tier1
 @pytest.mark.polarion_id("OCS-2125")
 @skipif_managed_service

--- a/tests/manage/monitoring/test_workload_with_distruptions.py
+++ b/tests/manage/monitoring/test_workload_with_distruptions.py
@@ -57,6 +57,7 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 logger = logging.getLogger(__name__)
 
 
+@blue_squad
 @pre_upgrade
 @tier2
 @skipif_managed_service
@@ -72,6 +73,7 @@ def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
     assert fio["jobs"][0]["error"] == 0, msg
 
 
+@blue_squad
 @post_upgrade
 @tier2
 @skipif_managed_service

--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -10,6 +10,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility.connection import Connection
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -34,6 +35,7 @@ log = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+@brown_squad
 @tier1
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")
@@ -66,6 +68,7 @@ class TestDefaultNfsDisabled(ManageTest):
             log.error("nfs feature is enabled by default")
 
 
+@brown_squad
 @skipif_external_mode
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")

--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -57,6 +58,7 @@ else:
         ]
 
 
+@green_squad
 @tier1
 @skipif_ocs_version("<4.8")
 @skipif_ocp_version("<4.8")

--- a/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/manage/pv_services/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -58,6 +59,7 @@ else:
         ]
 
 
+@green_squad
 @pytest.mark.parametrize(
     argnames=argnames,
     argvalues=argvalues,

--- a/tests/manage/pv_services/pv_encryption/test_kmip_rbd_pv_encryption.py
+++ b/tests/manage/pv_services/pv_encryption/test_kmip_rbd_pv_encryption.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -21,6 +22,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @aws_platform_required
 @skipif_ocs_version("<4.12")
 @kms_config_required

--- a/tests/manage/pv_services/pv_encryption/test_rbd_pv_encryption.py
+++ b/tests/manage/pv_services/pv_encryption/test_rbd_pv_encryption.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -55,6 +56,7 @@ else:
         ]
 
 
+@green_squad
 @pytest.mark.parametrize(
     argnames=argnames,
     argvalues=argvalues,

--- a/tests/manage/pv_services/pv_encryption/test_rbd_pv_encryption_vaulttenantsa.py
+++ b/tests/manage/pv_services/pv_encryption/test_rbd_pv_encryption_vaulttenantsa.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     aws_platform_required,
     ManageTest,
@@ -39,6 +40,7 @@ else:
     ]
 
 
+@green_squad
 @aws_platform_required
 @skipif_ocs_version("<4.9")
 @kms_config_required

--- a/tests/manage/pv_services/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
+++ b/tests/manage/pv_services/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
@@ -3,6 +3,7 @@ import pytest
 
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     kms_config_required,
@@ -42,6 +43,7 @@ else:
     ]
 
 
+@green_squad
 @pytest.mark.parametrize(
     argnames=argnames,
     argvalues=argvalues,

--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -21,6 +22,7 @@ from ocs_ci.ocs.resources import pod as res_pod
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_clone/test_clone_with_different_access_mode.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_with_different_access_mode.py
@@ -3,6 +3,7 @@ import pytest
 from itertools import cycle
 
 from ocs_ci.ocs import constants, node
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -16,6 +17,7 @@ from ocs_ci.helpers import helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_clone/test_node_restart_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_node_restart_during_pvc_clone.py
@@ -6,6 +6,7 @@ from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.helpers.helpers import wait_for_resource_state
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -21,6 +22,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4
 @tier4b
 @ignore_leftovers

--- a/tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_pvc_to_pvc_clone.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -16,6 +17,7 @@ from ocs_ci.helpers import helpers
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @acceptance
 @skipif_ocs_version("<4.9")

--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -18,6 +19,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4c
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -12,6 +12,7 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 from ocs_ci.helpers.helpers import wait_for_resource_state
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -28,6 +29,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4
 @tier4b
 @ignore_leftovers

--- a/tests/manage/pv_services/pvc_resize/test_pod_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_pod_deletion_during_pvc_expansion.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.resources.pod import (
     get_pod_logs,
 )
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -19,6 +20,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4c
 @bugzilla("2164617")
 @polarion_id("OCS-4877")

--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -17,6 +18,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_ocs_version("<4.5")
 @skipif_upgraded_from(["4.4"])

--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -17,6 +18,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.5")
 @skipif_upgraded_from(["4.4"])

--- a/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -18,6 +19,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4c
 @skipif_ocs_version("<4.5")
 @skipif_upgraded_from(["4.4"])

--- a/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -16,6 +17,7 @@ from ocs_ci.helpers import helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @acceptance
 @skipif_ocs_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot_when_snapshotclass_deleted.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_pvc_snapshot_when_snapshotclass_deleted.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     bugzilla,
     ManageTest,
@@ -20,6 +21,7 @@ from ocs_ci.utility import templating
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier3
 @skipif_managed_service
 @bugzilla("1902711")

--- a/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_rbd_block_pvc_snapshot.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -15,6 +16,7 @@ from ocs_ci.helpers.helpers import wait_for_resource_state, create_pods
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -19,6 +20,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4c
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -19,6 +20,7 @@ from ocs_ci.utility import version
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_managed_service
 @skipif_ocs_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_small_files_pvc_cloned_status.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_small_files_pvc_cloned_status.py
@@ -5,6 +5,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -15,6 +16,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @polarion_id("OCS-3946")
 class TestPvcClonedStatusOfSmallSizeFiles(E2ETest):

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_at_different_pvc_utlilization_level.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -17,6 +18,7 @@ from ocs_ci.helpers.helpers import wait_for_resource_state, get_snapshot_content
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
@@ -3,6 +3,7 @@ import pytest
 from itertools import cycle
 
 from ocs_ci.ocs import constants, node
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -16,6 +17,7 @@ from ocs_ci.helpers import helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -15,6 +16,7 @@ from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2595")

--- a/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import os
 from tempfile import NamedTemporaryFile
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.14")
 class TestReclaimSpaceCronJob(ManageTest):

--- a/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -26,6 +27,7 @@ from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_ocs_version("<4.10")
 class TestRbdSpaceReclaim(ManageTest):
     """

--- a/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -25,6 +26,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_ocs_version("<4.10")
 class TestRbdSpaceReclaim(ManageTest):
     """

--- a/tests/manage/pv_services/test_ceph_capacity_recovery.py
+++ b/tests/manage/pv_services/test_ceph_capacity_recovery.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from ocs_ci.ocs.perftests import PASTest
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     tier2,
     skipif_ocs_version,
@@ -50,6 +51,7 @@ def check_health_status():
         return False
 
 
+@green_squad
 @tier2
 @skipif_external_mode
 @skipif_disconnected_cluster

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
@@ -14,6 +15,7 @@ from ocs_ci.helpers import helpers, disruption_helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @pytest.mark.skip(
     reason="This test is disabled because this scenario is covered in the "
     "test test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py"

--- a/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/manage/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -30,6 +31,7 @@ from ocs_ci.helpers import disruption_helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @pytest.mark.skip(
     reason="This test is disabled because this scenario is covered in the "
     "test test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py"

--- a/tests/manage/pv_services/test_cephfs_pvc_with_necessary_scc_permissions.py
+++ b/tests/manage/pv_services/test_cephfs_pvc_with_necessary_scc_permissions.py
@@ -2,6 +2,7 @@ import logging
 
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_pod
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -25,6 +26,7 @@ def validate_permissions(pod_obj):
     log.info("FSGroup is correctly set on subPath volume for CephFS CSI ")
 
 
+@green_squad
 @tier1
 @polarion_id("OCS-4931")
 @bugzilla("2182943")

--- a/tests/manage/pv_services/test_cephfs_with_mds_network_failure.py
+++ b/tests/manage/pv_services/test_cephfs_with_mds_network_failure.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     tier4b,
     skipif_external_mode,
+    green_squad,
 )
 from ocs_ci.ocs.resources.pod import search_pattern_in_pod_logs
 from ocs_ci.helpers.helpers import change_vm_network_state
@@ -18,6 +19,7 @@ from ocs_ci.helpers.helpers import change_vm_network_state
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_external_mode
 @vsphere_platform_required
 class TestCephFSWithMDSNetworkFailure:

--- a/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier1, skipif_managed_service
 from ocs_ci.ocs.constants import RECLAIM_POLICY_DELETE, RECLAIM_POLICY_RETAIN
 from ocs_ci.utility.utils import TimeoutSampler
@@ -16,6 +17,7 @@ from ocs_ci.helpers.helpers import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @pytest.mark.parametrize(
     argnames=["interface", "reclaim_policy"],

--- a/tests/manage/pv_services/test_create_large_sized_pvc_while_io_in_progress.py
+++ b/tests/manage/pv_services/test_create_large_sized_pvc_while_io_in_progress.py
@@ -3,12 +3,14 @@ import logging
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 class TestCreateLargeSizedPVCWhileIOInProgress(ManageTest):
     """

--- a/tests/manage/pv_services/test_create_pvc_invalid_access_mode.py
+++ b/tests/manage/pv_services/test_create_pvc_invalid_access_mode.py
@@ -2,12 +2,14 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier3
 from ocs_ci.ocs.exceptions import CommandFailed
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier3
 @pytest.mark.parametrize(
     argnames="interface",

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
@@ -21,6 +22,7 @@ from ocs_ci.helpers import helpers, disruption_helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @pytest.mark.skip(
     reason="This test is disabled because this scenario is covered in the "
     "test test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py"

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -6,6 +6,7 @@ from time import sleep
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4,
@@ -37,6 +38,7 @@ from ocs_ci.helpers import disruption_helpers, helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4
 @tier4c
 @skipif_managed_service

--- a/tests/manage/pv_services/test_del_mon_service_and_create_pvc.py
+++ b/tests/manage/pv_services/test_del_mon_service_and_create_pvc.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
@@ -32,6 +33,7 @@ log = logging.getLogger(__name__)
 POD_OBJ = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
 
 
+@green_squad
 @tier4c
 @ignore_leftovers
 @skipif_external_mode

--- a/tests/manage/pv_services/test_delete_create_pvc_same_name.py
+++ b/tests/manage/pv_services/test_delete_create_pvc_same_name.py
@@ -5,12 +5,14 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.helpers import helpers
 
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 class TestDeleteCreatePVCSameName(ManageTest):
     """

--- a/tests/manage/pv_services/test_delete_plugin_pod.py
+++ b/tests/manage/pv_services/test_delete_plugin_pod.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier4c
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
@@ -12,6 +13,7 @@ log = logging.getLogger(__name__)
 DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 
+@green_squad
 @tier4c
 @pytest.mark.parametrize(
     argnames=["interface", "resource_to_delete"],

--- a/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -18,6 +19,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 class TestDynamicPvc(ManageTest):
     """
     Automates the following test cases:

--- a/tests/manage/pv_services/test_expansion_snapshot_clone.py
+++ b/tests/manage/pv_services/test_expansion_snapshot_clone.py
@@ -9,6 +9,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -20,6 +21,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocp_version("<4.6")
 @pytest.mark.parametrize(

--- a/tests/manage/pv_services/test_no_space_left.py
+++ b/tests/manage/pv_services/test_no_space_left.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 import ocs_ci.ocs.exceptions as ex
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier2, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
@@ -12,6 +13,7 @@ from ocs_ci.ocs.resources.pod import get_used_space_on_mount_point
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[
@@ -76,6 +78,7 @@ class TestPVCFullWithIORWO(ManageTest):
         ), f"The used space is not 100% but {used_space} from the new pod"
 
 
+@green_squad
 @pytest.mark.polarion_id("OCS-854")
 @pytest.mark.bugzilla("1745344")
 @tier2

--- a/tests/manage/pv_services/test_overprovision_level_policy_control.py
+++ b/tests/manage/pv_services/test_overprovision_level_policy_control.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import verify_quota_resource_exist
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -36,6 +37,7 @@ def setup_sc(storageclass_factory_class):
     }
 
 
+@green_squad
 @tier1
 @bugzilla("2024545")
 @skipif_external_mode

--- a/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
+++ b/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster
 from ocs_ci.ocs.ocp import OCP, set_overprovision_policy, clear_overprovision_spec
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -28,6 +29,7 @@ def setup_sc(storageclass_factory_class):
     sc_blk_obj.delete()
 
 
+@green_squad
 @tier1
 @pytest.mark.polarion_id("OCS-3778")
 @skipif_external_mode

--- a/tests/manage/pv_services/test_pv_creation.py
+++ b/tests/manage/pv_services/test_pv_creation.py
@@ -10,6 +10,7 @@ import yaml
 from ocs_ci.framework import config
 from ocs_ci.ocs import exceptions, ocp
 from ocs_ci.ocs.constants import TEMPLATE_PV_PVC_DIR
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.utility import templating, utils
 
@@ -84,6 +85,7 @@ def verify_pv_exist(pv_name):
     return True
 
 
+@green_squad
 @tier1
 @pytest.mark.usefixtures(
     test_fixture.__name__,

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -4,6 +4,7 @@ import random
 
 from ocs_ci.framework import config
 from concurrent.futures import ThreadPoolExecutor
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -20,6 +21,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 class TestPvcAssignPodNode(ManageTest):
     """
     Automates the following test cases:

--- a/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
+++ b/tests/manage/pv_services/test_pvc_concurrent_deletion_creation.py
@@ -8,6 +8,7 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs
 from ocs_ci.ocs.resources.pvc import delete_pvcs
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier2, ManageTest, bugzilla
 from ocs_ci.helpers.helpers import (
     wait_for_resource_state,
@@ -18,6 +19,7 @@ from ocs_ci.helpers.helpers import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @bugzilla("1734259")
 @tier2
 @pytest.mark.parametrize(

--- a/tests/manage/pv_services/test_pvc_delete_subvolumegroup.py
+++ b/tests/manage/pv_services/test_pvc_delete_subvolumegroup.py
@@ -4,6 +4,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pvc import delete_pvcs
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     skipif_ocs_version,
@@ -17,6 +18,7 @@ from ocs_ci.helpers.helpers import get_cephfs_name
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_ocs_version("<4.12")
 @polarion_id("OCS-4664")
 @bugzilla("2124469")

--- a/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/manage/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -8,6 +8,7 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.helpers import helpers
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier1, acceptance, ManageTest
 from ocs_ci.utility import templating
 from ocs_ci.utility.retry import retry
@@ -48,6 +49,7 @@ def verify_pv_not_exists(pvc_obj, cbp_name, rbd_image_id):
     logger.info("Expected: PV should not be found " "after deleting corresponding PVC")
 
 
+@green_squad
 @pytest.mark.polarion_id("OCS-372")
 class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
     """

--- a/tests/manage/pv_services/test_pvc_deletion_during_io.py
+++ b/tests/manage/pv_services/test_pvc_deletion_during_io.py
@@ -3,12 +3,14 @@ import logging
 
 from ocs_ci.ocs import exceptions, constants
 from ocs_ci.ocs.resources import pod
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @pytest.mark.parametrize(
     argnames=["interface"],

--- a/tests/manage/pv_services/test_pvc_disruptive.py
+++ b/tests/manage/pv_services/test_pvc_disruptive.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, ignore_leftover_label
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 DISRUPTION_OPS = disruption_helpers.Disruptions()
 
 
+@green_squad
 @pytest.mark.skip(
     reason="This test is disabled because this scenario is covered in the test "
     "test_resource_deletion_during_pvc_pod_creation_and_io.py"

--- a/tests/manage/pv_services/test_pvc_evict_ceph_clients.py
+++ b/tests/manage/pv_services/test_pvc_evict_ceph_clients.py
@@ -6,7 +6,7 @@ import json
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import tier2
-from ocs_ci.framework.pytest_customization.marks import skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import skipif_ocs_version, green_squad
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_worker_nodes
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
@@ -14,6 +14,7 @@ from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.11")
 class TestPvcEvictCephClients:

--- a/tests/manage/pv_services/test_pvc_invalid_inputs.py
+++ b/tests/manage/pv_services/test_pvc_invalid_inputs.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier3, ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.resources.pvc import PVC
@@ -56,6 +57,7 @@ def teardown():
     log.info(f"Storage class: {SC_OBJ.name} deleted successfully")
 
 
+@green_squad
 @tier3
 @pytest.mark.usefixtures(test_fixture.__name__)
 @pytest.mark.polarion_id("OCS-284")

--- a/tests/manage/pv_services/test_pvc_rwx_writeable_after_pod_deletions.py
+++ b/tests/manage/pv_services/test_pvc_rwx_writeable_after_pod_deletions.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from concurrent.futures import ThreadPoolExecutor
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources import pod
@@ -10,6 +11,7 @@ from ocs_ci.helpers import helpers
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 class TestRWXMountPoint(ManageTest):
     """
     Automates the following test cases:

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -5,6 +5,7 @@ import pytest
 
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     tier1,
     ManageTest,
@@ -19,6 +20,7 @@ from ocs_ci.utility.utils import convert_device_size
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @acceptance
 @pytest.mark.parametrize(

--- a/tests/manage/pv_services/test_rbd_image_metadata.py
+++ b/tests/manage/pv_services/test_rbd_image_metadata.py
@@ -5,11 +5,17 @@ from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name, get_snapshot_content_obj
 from ocs_ci.ocs.defaults import RBD_NAME
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
-from ocs_ci.framework.pytest_customization.marks import tier2, polarion_id, bugzilla
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    polarion_id,
+    bugzilla,
+    green_squad,
+)
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 class TestRbdImageMetadata:
     @tier2
     @polarion_id("OCS-4465")

--- a/tests/manage/pv_services/test_rbd_rwx_pvc.py
+++ b/tests/manage/pv_services/test_rbd_rwx_pvc.py
@@ -2,11 +2,13 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, node
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @pytest.mark.polarion_id("OCS-2599")
 class TestRbdBlockPvc(ManageTest):

--- a/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pod_pvc_deletion.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, ignore_leftover_label
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -214,6 +215,7 @@ class DisruptionBase(ManageTest):
         log.info("Ceph cluster health is OK")
 
 
+@green_squad
 @pytest.mark.skip(
     reason="This test is disabled because this scenario is covered in the "
     "test test_resource_deletion_during_pvc_pod_deletion_and_io.py"

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_creation_and_io.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4,
@@ -28,6 +29,7 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4
 @tier4c
 @ignore_leftover_label(constants.drain_canary_pod_label)

--- a/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
+++ b/tests/manage/pv_services/test_resource_deletion_during_pvc_pod_deletion_and_io.py
@@ -5,6 +5,7 @@ from itertools import cycle
 import pytest
 from functools import partial
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4,
@@ -42,6 +43,7 @@ from ocs_ci.helpers import disruption_helpers
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4
 @tier4c
 @ignore_leftover_label(constants.drain_canary_pod_label)

--- a/tests/manage/pv_services/test_run_io_multiple_dc_pods.py
+++ b/tests/manage/pv_services/test_run_io_multiple_dc_pods.py
@@ -1,9 +1,11 @@
 import pytest
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 
+@green_squad
 @tier2
 @pytest.mark.parametrize(
     argnames=["interface"],

--- a/tests/manage/pv_services/test_run_io_multiple_pods.py
+++ b/tests/manage/pv_services/test_run_io_multiple_pods.py
@@ -1,9 +1,11 @@
 import pytest
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 
+@green_squad
 @tier2
 @pytest.mark.parametrize(
     argnames=["interface"],

--- a/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/manage/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -31,6 +32,7 @@ from ocs_ci.helpers import disruption_helpers, helpers
 logger = logging.getLogger(__name__)
 
 
+@green_squad
 @tier4b
 @ignore_leftovers
 @skipif_vsphere_ipi

--- a/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/manage/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -1,6 +1,7 @@
 import logging
 
 from ocs_ci.helpers import helpers
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     polarion_id,
     skipif_ocs_version,
@@ -11,6 +12,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_ocs_version("<4.3")
 @polarion_id("OCS-2130")

--- a/tests/manage/pv_services/test_verify_rwo_using_dc_pod.py
+++ b/tests/manage/pv_services/test_verify_rwo_using_dc_pod.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from itertools import cycle
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException, TimeoutExpiredError
@@ -15,6 +16,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @pytest.mark.parametrize(
     argnames="interface",

--- a/tests/manage/pv_services/test_verify_rwo_using_multiple_pods.py
+++ b/tests/manage/pv_services/test_verify_rwo_using_multiple_pods.py
@@ -3,12 +3,14 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.helpers.helpers import wait_for_resource_state
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @pytest.mark.parametrize(
     argnames="interface",

--- a/tests/manage/pv_services/test_verify_subpath.py
+++ b/tests/manage/pv_services/test_verify_subpath.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     polarion_id,
     ManageTest,
@@ -13,6 +14,7 @@ from ocs_ci.ocs.resources.pod import check_file_existence
 log = logging.getLogger(__name__)
 
 
+@green_squad
 class TestVerifySubpath(ManageTest):
     """
     Tests to verify subpath

--- a/tests/manage/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
+++ b/tests/manage/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
@@ -4,6 +4,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
+    green_squad,
 )
 from ocs_ci.ocs.cluster import (
     validate_compression,
@@ -15,6 +16,7 @@ from ocs_ci.ocs.exceptions import PoolNotReplicatedAsNeeded, PoolNotCompressedAs
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/storageclass/test_create_2sc_at_once_with_io.py
+++ b/tests/manage/storageclass/test_create_2sc_at_once_with_io.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
+    green_squad,
 )
 from ocs_ci.ocs.cluster import (
     validate_compression,
@@ -19,6 +20,7 @@ from ocs_ci.ocs.exceptions import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -3,12 +3,14 @@ import logging
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
 from tests.fixtures import create_rbd_secret, create_project
 
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_external_mode
 @tier2
 @pytest.mark.usefixtures(

--- a/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
@@ -5,6 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs.exceptions import ResourceLeftoversException
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
 from tests.fixtures import (
     create_ceph_block_pool,
@@ -51,6 +52,7 @@ def resources(request):
     return pods, pvcs, storageclasses
 
 
+@green_squad
 @skipif_external_mode
 @tier2
 @pytest.mark.usefixtures(

--- a/tests/manage/storageclass/test_create_sc_and_make_it_as_a_default.py
+++ b/tests/manage/storageclass/test_create_sc_and_make_it_as_a_default.py
@@ -3,6 +3,7 @@ import logging
 from ocs_ci.ocs import ocp
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from tests.fixtures import create_project
@@ -10,6 +11,7 @@ from tests.fixtures import create_project
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @pytest.mark.usefixtures(
     create_project.__name__,

--- a/tests/manage/storageclass/test_create_sc_reclaim_policy_rep2_comp.py
+++ b/tests/manage/storageclass/test_create_sc_reclaim_policy_rep2_comp.py
@@ -1,9 +1,10 @@
 import logging
 from ocs_ci.framework.testlib import ManageTest, tier2
-from ocs_ci.framework.pytest_customization.marks import polarion_id
 from ocs_ci.framework.pytest_customization.marks import (
+    polarion_id,
     skipif_external_mode,
     skipif_ocs_version,
+    green_squad,
 )
 from ocs_ci.ocs.resources.pod import delete_pods
 from ocs_ci.ocs.cluster import (
@@ -27,6 +28,7 @@ from ocs_ci.helpers.helpers import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/storageclass/test_create_storageclass_with_same_name.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_same_name.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier1, ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -72,6 +73,7 @@ def create_storageclass(sc_name, expect_fail=False):
         )
 
 
+@green_squad
 @tier1
 @pytest.mark.usefixtures(
     test_fixture.__name__,

--- a/tests/manage/storageclass/test_create_storageclass_with_wrong_provisioner.py
+++ b/tests/manage/storageclass/test_create_storageclass_with_wrong_provisioner.py
@@ -2,6 +2,7 @@ import pytest
 import logging
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier3, skipif_external_mode
 from tests.fixtures import (
     create_ceph_block_pool,
@@ -12,6 +13,7 @@ from tests.fixtures import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @skipif_external_mode
 @tier3
 @pytest.mark.usefixtures(

--- a/tests/manage/storageclass/test_custom_storageclass_names.py
+++ b/tests/manage/storageclass/test_custom_storageclass_names.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
     tier1,
     skipif_external_mode,
 )
@@ -20,6 +21,7 @@ from fauxfactory import gen_alpha, gen_special
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.14")

--- a/tests/manage/storageclass/test_delete_rbd_pool_attached_to_sc.py
+++ b/tests/manage/storageclass/test_delete_rbd_pool_attached_to_sc.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     ignore_resource_not_found_error_label,
     tier1,
+    green_squad,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
@@ -85,6 +86,7 @@ def preconditions_rbd_pool_created_associated_to_sc(
     return cbp_name
 
 
+@green_squad
 @ignore_resource_not_found_error_label
 class TestDeleteRbdPool(ManageTest):
     @tier1

--- a/tests/manage/storageclass/test_multiple_sc_comp_rep_data_delete.py
+++ b/tests/manage/storageclass/test_multiple_sc_comp_rep_data_delete.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
+    green_squad,
 )
 from ocs_ci.ocs.exceptions import (
     PoolDataNotErased,
@@ -23,6 +24,7 @@ from ocs_ci.ocs.defaults import MAX_BYTES_IN_POOL_AFTER_DATA_DELETE
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier2
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/storageclass/test_new_sc_rbd_replica2_3.py
+++ b/tests/manage/storageclass/test_new_sc_rbd_replica2_3.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
+    green_squad,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -16,6 +17,7 @@ from ocs_ci.ocs.cluster import (
 log = logging.getLogger(__name__)
 
 
+@green_squad
 @tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/storageclass/test_rbd_csi_default_sc.py
+++ b/tests/manage/storageclass/test_rbd_csi_default_sc.py
@@ -5,6 +5,7 @@ Basic test for creating PVC with default StorageClass - RBD-CSI
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier1, ManageTest, skipif_external_mode
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
@@ -51,6 +52,7 @@ def resources(request):
     return pod, pvc, storageclass
 
 
+@green_squad
 @skipif_external_mode
 @tier1
 @pytest.mark.usefixtures(

--- a/tests/manage/storageclass/test_storageclass_invalid.py
+++ b/tests/manage/storageclass/test_storageclass_invalid.py
@@ -9,6 +9,7 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import tier3, ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
@@ -92,6 +93,7 @@ def invalid_storageclass(request):
     storageclass.delete()
 
 
+@green_squad
 @tier3
 class TestStorageClassInvalid(ManageTest):
     def test_storageclass_invalid(self, invalid_storageclass):

--- a/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/manage/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -5,6 +5,7 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
+from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
 from tests.fixtures import (
     create_ceph_block_pool,
@@ -17,6 +18,7 @@ log = logging.getLogger(__name__)
 SC_OBJ = None
 
 
+@green_squad
 @skipif_external_mode
 @tier1
 @pytest.mark.usefixtures(

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_power,
     skipif_no_lso,
     skipif_lso,
+    brown_squad,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -95,6 +96,7 @@ def add_capacity_test(ui_flag=False):
     check_ceph_health_after_add_capacity(ceph_rebalance_timeout=3600)
 
 
+@brown_squad
 @ignore_leftovers
 @polarion_id("OCS-1191")
 @pytest.mark.second_to_last
@@ -127,6 +129,7 @@ class TestAddCapacity(ManageTest):
         add_capacity_test(ui_flag=True)
 
 
+@brown_squad
 @ignore_leftovers
 @polarion_id("OCS-4647")
 @pytest.mark.second_to_last
@@ -159,6 +162,7 @@ class TestAddCapacityLSO(ManageTest):
         storage_cluster.add_capacity_lso(ui_flag=True)
 
 
+@brown_squad
 @skipif_ocs_version("<4.4")
 @pre_upgrade
 @ignore_leftovers

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.ocs.cluster import is_flexible_scaling_enabled
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier2,
     ignore_leftovers,
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 # pgsql later
 
 
+@brown_squad
 @pytest.mark.parametrize(
     argnames=["percent_to_fill"],
     argvalues=[

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -23,6 +24,7 @@ from ocs_ci.ocs.cluster import (
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @pytest.mark.parametrize(
     argnames=["num_of_nodes", "workload_storageutilization_rbd"],
     argvalues=[

--- a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_bm,
+    brown_squad,
 )
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes, is_node_rack_or_zone_exist
 from ocs_ci.helpers.helpers import get_failure_domin
@@ -31,6 +32,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @ignore_leftovers
 @bugzilla("1898808")

--- a/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
@@ -4,7 +4,10 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework.testlib import ignore_leftovers, tier4c, skipif_managed_service
-from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode,
+    brown_squad,
+)
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -21,6 +24,7 @@ from ocs_ci.ocs import node
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @skipif_managed_service
 @skipif_external_mode
 @ignore_leftovers

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -6,11 +6,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_flexy_deployment,
     skipif_ibm_flash,
     skipif_managed_service,
+    brown_squad,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_managed_service
 @skipif_flexy_deployment

--- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_flexy_deployment,
     skipif_managed_service,
     skipif_multus_enabled,
+    brown_squad,
 )
 from ocs_ci.framework.testlib import tier2, ManageTest, ignore_leftovers
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
@@ -14,6 +15,7 @@ from ocs_ci.ocs.resources.pod import get_pod_node, get_plugin_pods
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_flexy_deployment
 @skipif_managed_service

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
@@ -25,6 +26,7 @@ from ocs_ci.ocs.node import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4
 @tier4b
 @ignore_leftovers

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -40,6 +41,7 @@ from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @ignore_leftovers
 @tier4b
 @ipi_deployment_required
@@ -213,6 +215,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
         self.sanity_helpers.health_check(tries=tries)
 
 
+@brown_squad
 @ignore_leftovers
 @tier4a
 @ipi_deployment_required

--- a/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
+++ b/tests/manage/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_ms.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import random
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4b,
     ManageTest,
@@ -221,6 +222,7 @@ FAILURE_TYPE_FUNC_CALL_DICT = {
 }
 
 
+@brown_squad
 @ignore_leftovers
 @tier4b
 @managed_service_required

--- a/tests/manage/z_cluster/nodes/test_az_failure.py
+++ b/tests/manage/z_cluster/nodes/test_az_failure.py
@@ -3,7 +3,10 @@ import random
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import aws_platform_required
+from ocs_ci.framework.pytest_customization.marks import (
+    aws_platform_required,
+    brown_squad,
+)
 from ocs_ci.framework.testlib import ManageTest, tier4, tier4b
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.helpers import sanity_helpers
@@ -11,6 +14,7 @@ from ocs_ci.helpers import sanity_helpers
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4
 @tier4b
 @pytest.mark.polarion_id("OCS-1287")

--- a/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -19,6 +20,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods, list_of_nodes_runnin
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @ignore_leftovers
 @tier4b
 class TestOCSWorkerNodeShutdown(ManageTest):

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import random
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4a,
@@ -76,6 +77,7 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
     return is_rook_ceph_pods_status_changed
 
 
+@brown_squad
 @ignore_leftovers
 @tier4a
 @skipif_managed_service

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -30,6 +31,7 @@ from ocs_ci.ocs import osd_operations
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4a
 @ignore_leftovers
 class TestDiskFailures(ManageTest):

--- a/tests/manage/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
+++ b/tests/manage/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
@@ -4,6 +4,7 @@ import pytest
 
 from time import sleep
 from ocs_ci.ocs import constants, node
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import E2ETest, tier1, bugzilla
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.node import get_worker_nodes
@@ -13,6 +14,7 @@ from ocs_ci.helpers import helpers
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier1
 @bugzilla("2075068")
 class TestKernelCrash(E2ETest):

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -173,6 +173,7 @@ def delete_and_create_osd_node(osd_node_name):
     )
 
 
+@brown_squad
 @tier4a
 @ignore_leftovers
 @ipi_deployment_required
@@ -251,6 +252,7 @@ class TestNodeReplacementWithIO(ManageTest):
         ), "Storagecluster node topology is having an entry of non ocs node(s) - Not expected"
 
 
+@brown_squad
 @tier4a
 @ignore_leftovers
 @skipif_bmpsi

--- a/tests/manage/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4a,
     ManageTest,
@@ -28,6 +29,7 @@ from ocs_ci.ocs.node import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @ignore_leftovers
 @tier4a
 @aws_based_platform_required

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -27,6 +27,7 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier1,
     tier2,
@@ -85,6 +86,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@brown_squad
 @ignore_leftovers
 class TestNodesMaintenance(ManageTest):
     """

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -31,6 +32,7 @@ from ocs_ci.ocs.cluster import is_vsphere_ipi_cluster
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @ignore_leftovers
 @skipif_managed_service
 class TestNodesRestart(ManageTest):

--- a/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart_ms.py
@@ -3,6 +3,7 @@ import pytest
 import random
 
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -44,6 +45,7 @@ from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @ignore_leftovers
 @managed_service_required
 class TestNodesRestartMS(ManageTest):

--- a/tests/manage/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -27,12 +27,13 @@ from ocs_ci.ocs.node import (
     get_worker_nodes,
 )
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.framework.pytest_customization.marks import bugzilla
+from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
 from ocs_ci.helpers.sanity_helpers import Sanity
 
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @ignore_leftovers
 @skipif_tainted_nodes

--- a/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
@@ -3,6 +3,7 @@ import time
 import pytest
 
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -20,6 +21,7 @@ from ocs_ci.helpers.sanity_helpers import Sanity
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @pytest.mark.polarion_id("OCS-2633")
 @bugzilla("1895819")

--- a/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery_ms.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_shutdown_and_recovery_ms.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -29,6 +30,7 @@ from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup, ceph_health
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @skipif_ibm_cloud
 @skipif_external_mode

--- a/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -3,6 +3,7 @@ import pytest
 import random
 
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -46,6 +47,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @skipif_ibm_cloud
 @skipif_external_mode

--- a/tests/manage/z_cluster/nodes/test_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_toleration.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     tier4c,
     E2ETest,
@@ -22,6 +23,7 @@ from ocs_ci.ocs.node import (
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4c
 @ignore_leftovers
 @skipif_managed_service

--- a/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_power,
     skipif_managed_service,
     bugzilla,
+    brown_squad,
 )
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier4b
 from ocs_ci.ocs import constants, node
@@ -20,6 +21,7 @@ from ocs_ci.utility.utils import ceph_health_check
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @skipif_aws_i3
 @skipif_vsphere_ipi

--- a/tests/manage/z_cluster/test_add_mds_to_cluster.py
+++ b/tests/manage/z_cluster/test_add_mds_to_cluster.py
@@ -7,6 +7,7 @@ import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.defaults import ROOK_CLUSTER_NAMESPACE
 from ocs_ci.ocs.resources.ocs import OCS
@@ -71,6 +72,7 @@ def get_mds_active_count():
 
 # @tier1
 # Test case is disabled, as per requirement not to support this scenario
+@brown_squad
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem

--- a/tests/manage/z_cluster/test_ceph_default_values_check.py
+++ b/tests/manage/z_cluster/test_ceph_default_values_check.py
@@ -2,7 +2,11 @@ import collections
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import bugzilla, skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    skipif_ocs_version,
+    brown_squad,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -25,6 +29,7 @@ from ocs_ci.utility.retry import retry
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")

--- a/tests/manage/z_cluster/test_ceph_pg_log_dups_trim.py
+++ b/tests/manage/z_cluster/test_ceph_pg_log_dups_trim.py
@@ -2,6 +2,7 @@ import logging
 import random
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -26,6 +27,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @skipif_external_mode
 @skipif_managed_service

--- a/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -7,7 +7,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.disruption_helpers import Disruptions
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.framework.pytest_customization.marks import skipif_rhel_os
+from ocs_ci.framework.pytest_customization.marks import skipif_rhel_os, brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -26,6 +26,7 @@ from ocs_ci.ocs.resources.pod import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @skipif_external_mode
 @skipif_ocs_version("<4.7")

--- a/tests/manage/z_cluster/test_delete_local_volume_sym_link.py
+++ b/tests/manage/z_cluster/test_delete_local_volume_sym_link.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.defaults import ROOK_CLUSTER_NAMESPACE
 from ocs_ci.framework.testlib import E2ETest, tier4b
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework.pytest_customization.marks import skipif_no_lso
+from ocs_ci.framework.pytest_customization.marks import skipif_no_lso, brown_squad
 from ocs_ci.helpers.helpers import wait_for_resource_state
 from ocs_ci.ocs.resources.pvc import get_deviceset_pvcs
 from ocs_ci.ocs.resources.pod import wait_for_storage_pods, get_pod_obj, get_pod_node
@@ -15,6 +15,7 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @skipif_no_lso
 @pytest.mark.polarion_id("OCS-2316")

--- a/tests/manage/z_cluster/test_delete_osd_deployment.py
+++ b/tests/manage/z_cluster/test_delete_osd_deployment.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -18,6 +19,7 @@ from ocs_ci.utility.utils import ceph_health_check
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4c
 @skipif_ocs_version("<4.10")
 @ignore_leftover_label(constants.OSD_APP_LABEL)

--- a/tests/manage/z_cluster/test_delete_rook_ceph_mon_pod.py
+++ b/tests/manage/z_cluster/test_delete_rook_ceph_mon_pod.py
@@ -2,7 +2,10 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode,
+    brown_squad,
+)
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
@@ -12,6 +15,7 @@ from ocs_ci.framework.testlib import ManageTest, tier2
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2481")

--- a/tests/manage/z_cluster/test_hugepages.py
+++ b/tests/manage/z_cluster/test_hugepages.py
@@ -15,6 +15,7 @@ from ocs_ci.ocs.node import (
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_external_mode,
@@ -27,6 +28,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @skipif_ocs_version("<4.8")
 @bugzilla("1995271")

--- a/tests/manage/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/manage/z_cluster/test_mon_data_avail_warn.py
@@ -8,6 +8,7 @@ import random
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -30,6 +31,7 @@ DD_BLOCK_SIZE = 16
 DD_COUNT = 64
 
 
+@brown_squad
 @tier2
 @bugzilla("1964055")
 @pytest.mark.polarion_id("OCS-2733")

--- a/tests/manage/z_cluster/test_mon_log_trimming.py
+++ b/tests/manage/z_cluster/test_mon_log_trimming.py
@@ -3,6 +3,7 @@ import random
 import threading
 import pytest
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import E2ETest, bugzilla, tier2, skipif_external_mode
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_mon_pods
@@ -12,6 +13,7 @@ from ocs_ci.helpers.helpers import get_mon_db_size_in_kb
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @skipif_external_mode
 @bugzilla("1941939")

--- a/tests/manage/z_cluster/test_multiple_mon_pods_stays_on_same_node.py
+++ b/tests/manage/z_cluster/test_multiple_mon_pods_stays_on_same_node.py
@@ -4,6 +4,7 @@ import pytest
 import time
 from semantic_version import Version
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -38,6 +39,7 @@ log = logging.getLogger(__name__)
 POD_OBJ = OCP(kind=POD, namespace=OPENSHIFT_STORAGE_NAMESPACE)
 
 
+@brown_squad
 @tier4c
 @ignore_leftovers
 @skipif_ocs_version("<4.8")

--- a/tests/manage/z_cluster/test_must_gather.py
+++ b/tests/manage/z_cluster/test_must_gather.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -27,6 +28,7 @@ def mustgather(request):
     return mustgather
 
 
+@brown_squad
 class TestMustGather(ManageTest):
     @tier1
     @pytest.mark.parametrize(

--- a/tests/manage/z_cluster/test_no_liveness_probe.py
+++ b/tests/manage/z_cluster/test_no_liveness_probe.py
@@ -9,7 +9,12 @@ from ocs_ci.ocs.constants import (
     CSI_RBDPLUGIN_LABEL,
     CSI_RBDPLUGIN_PROVISIONER_LABEL,
 )
-from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    bugzilla,
+    polarion_id,
+    brown_squad,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_containers_names_by_pod
 
@@ -18,6 +23,7 @@ log = getLogger("__name__")
 LIVENESS_CONTAINER = "liveness-prometheus"
 
 
+@brown_squad
 @tier1
 @bugzilla("2142901")
 @polarion_id("OCS-4847")

--- a/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
+++ b/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
@@ -5,6 +5,7 @@ import urllib.request
 import pytest
 
 from ocs_ci.helpers.helpers import get_noobaa_url
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -16,6 +17,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @bugzilla("1943388")
 @skipif_ocs_version("<4.8")

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -3,6 +3,7 @@ import pytest
 import time
 import random
 
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -17,6 +18,7 @@ from ocs_ci.ocs.exceptions import CommandFailed
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @bugzilla("1938049")
 @skipif_ocs_version("<4.6")

--- a/tests/manage/z_cluster/test_remove_mon_from_cluster.py
+++ b/tests/manage/z_cluster/test_remove_mon_from_cluster.py
@@ -9,6 +9,7 @@ Polarion-ID- OCS-355
 import logging
 import pytest
 from ocs_ci.ocs import ocp, constants
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import ManageTest, ignore_leftovers
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
@@ -61,6 +62,7 @@ def run_io_on_pool(pool_obj):
 # tier4
 # tier4c
 @ignore_leftovers
+@brown_squad
 # @pytest.mark.polarion_id("OCS-355")
 class TestRemoveMonFromCluster(ManageTest):
     pool_obj = ""

--- a/tests/manage/z_cluster/test_restart_mgr_while_two_mons_down.py
+++ b/tests/manage/z_cluster/test_restart_mgr_while_two_mons_down.py
@@ -10,7 +10,10 @@ from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
 from ocs_ci.ocs.resources.pod import get_deployments_having_label
-from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_external_mode,
+    brown_squad,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -21,6 +24,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @bugzilla("1990031")
 @polarion_id("OCS-2696")

--- a/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
+++ b/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -23,6 +24,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @ignore_leftovers
 @bugzilla("2116416")

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -10,6 +10,7 @@ from ocs_ci.helpers.helpers import (
     get_last_log_time_date,
     check_osd_log_exist_on_rook_ceph_operator_pod,
 )
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -21,6 +22,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier2
 @bugzilla("1962821")
 @skipif_ocs_version("<4.8")

--- a/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/manage/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -9,6 +9,7 @@ from ocs_ci.ocs.resources.pod import (
     get_operator_pods,
     wait_for_pods_to_be_running,
 )
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -22,6 +23,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@brown_squad
 @tier4b
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/manage/z_cluster/test_scc.py
+++ b/tests/manage/z_cluster/test_scc.py
@@ -22,12 +22,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     tier2,
     skipif_ocs_version,
+    brown_squad,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 
 logger = logging.getLogger(__name__)
 
 
+@brown_squad
 class TestSCC:
     @tier2
     @bugzilla("1938647")

--- a/tests/managed-service/test_acceptance.py
+++ b/tests/managed-service/test_acceptance.py
@@ -1,6 +1,7 @@
 import logging
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import ManageTest, acceptance, managed_service_required
 from ocs_ci.ocs.resources import pvc
 from ocs_ci.utility.utils import TimeoutSampler
@@ -9,6 +10,7 @@ from ocs_ci.helpers import helpers
 logger = logging.getLogger(__name__)
 
 
+@yellow_squad
 class TestAcceptance(ManageTest):
     """
     Acceptance test Managed Service

--- a/tests/managed-service/test_ms_markers.py
+++ b/tests/managed-service/test_ms_markers.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     libtest,
     ManageTest,
@@ -19,6 +20,7 @@ from ocs_ci.ocs.managedservice import check_and_change_current_index_to_default_
 logger = logging.getLogger(__name__)
 
 
+@yellow_squad
 @libtest
 @managed_service_required
 @ignore_leftovers

--- a/tests/managed-service/test_ms_upgrade.py
+++ b/tests/managed-service/test_ms_upgrade.py
@@ -2,6 +2,7 @@ import logging
 
 from ocs_ci.ocs.resources.pod import cal_md5sum
 from ocs_ci.helpers.managed_services import verify_provider_topology
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     pre_upgrade,
     post_upgrade,
@@ -12,6 +13,7 @@ from ocs_ci.framework.testlib import (
 logger = logging.getLogger(name=__file__)
 
 
+@yellow_squad
 @pre_upgrade
 @ms_consumer_required
 def test_prepare_block_md5_before_upgrade(block_md5):
@@ -22,6 +24,7 @@ def test_prepare_block_md5_before_upgrade(block_md5):
     pass
 
 
+@yellow_squad
 @pre_upgrade
 @ms_consumer_required
 def test_prepare_fs_md5_before_upgrade(fs_md5):
@@ -32,6 +35,7 @@ def test_prepare_fs_md5_before_upgrade(fs_md5):
     pass
 
 
+@yellow_squad
 @post_upgrade
 @ms_consumer_required
 def test_verify_block_md5_after_upgrade(block_md5, block_pod):
@@ -48,6 +52,7 @@ def test_verify_block_md5_after_upgrade(block_md5, block_pod):
     assert md5_after_upgrade == block_md5
 
 
+@yellow_squad
 @post_upgrade
 @ms_consumer_required
 def test_verify_fs_md5_after_upgrade(fs_md5, fs_pod):
@@ -64,6 +69,7 @@ def test_verify_fs_md5_after_upgrade(fs_md5, fs_pod):
     assert md5_after_upgrade == fs_md5
 
 
+@yellow_squad
 @post_upgrade
 @ms_provider_required
 def test_verify_provider_topology_after_upgrade():

--- a/tests/managed-service/test_pod_disruptions.py
+++ b/tests/managed-service/test_pod_disruptions.py
@@ -4,6 +4,7 @@ from itertools import cycle
 import pytest
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -20,6 +21,7 @@ from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster
 log = logging.getLogger(__name__)
 
 
+@yellow_squad
 @tier4c
 @managed_service_required
 @ignore_leftover_label(constants.TOOL_APP_LABEL)

--- a/tests/managed-service/test_post_installation_state.py
+++ b/tests/managed-service/test_post_installation_state.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, managedservice, ocp
 from ocs_ci.ocs.resources import pod, storage_cluster
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     acceptance,
     managed_service_required,
@@ -18,6 +19,7 @@ from ocs_ci.ocs.exceptions import CommandFailed
 log = logging.getLogger(__name__)
 
 
+@yellow_squad
 @managed_service_required
 class TestPostInstallationState(ManageTest):
     """

--- a/tests/managed-service/test_sanity_ms.py
+++ b/tests/managed-service/test_sanity_ms.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.helpers.sanity_helpers import SanityManagedService
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     libtest,
     ManageTest,
@@ -13,6 +14,7 @@ from ocs_ci.framework.testlib import (
 log = logging.getLogger(__name__)
 
 
+@yellow_squad
 @libtest
 @managed_service_required
 class TestSanityManagedServiceWithDefaultParams(ManageTest):
@@ -62,6 +64,7 @@ class TestSanityManagedServiceWithDefaultParams(ManageTest):
         log.info("The current index is equal to the original index")
 
 
+@yellow_squad
 @libtest
 @managed_service_required
 class TestSanityManagedServiceWithOptionalParams(ManageTest):

--- a/tests/managed-service/test_storageclassclaim.py
+++ b/tests/managed-service/test_storageclassclaim.py
@@ -1,6 +1,7 @@
 import logging
 
 from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -16,6 +17,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@yellow_squad
 @tier1
 @polarion_id("OCS-4628")
 @skipif_ocs_version("<4.11")

--- a/tests/managed-service/test_switch_to_correct_index_at_setup.py
+++ b/tests/managed-service/test_switch_to_correct_index_at_setup.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
 from ocs_ci.framework.testlib import (
     libtest,
     ManageTest,
@@ -20,6 +21,7 @@ from ocs_ci.ocs.managedservice import (
 logger = logging.getLogger(__name__)
 
 
+@yellow_squad
 @libtest
 class TestSwitchToCorrectIndexAtSetup(ManageTest):
     """

--- a/tests/ocs-monkey/test_ocs_monkey.py
+++ b/tests/ocs-monkey/test_ocs_monkey.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import time
 
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import ignore_leftovers
 from ocs_ci.utility.utils import clone_repo, run_cmd, ceph_health_check
 from ocs_ci.ocs import constants
@@ -11,6 +12,7 @@ from ocs_ci.ocs import constants
 log = logging.getLogger(__name__)
 
 
+@magenta_squad
 @ignore_leftovers
 def test_ocs_monkey():
     ocs_monkety_dir = "/tmp/ocs-monkey"

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -15,12 +15,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     pre_ocp_upgrade,
     post_ocp_upgrade,
     post_ocs_upgrade,
+    purple_squad,
     workloads,
     performance,
     scale,
 )
 
 
+@purple_squad
 @tier1
 @acceptance
 @tier2

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -3,6 +3,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
+    ignore_owner,
     tier1,
     tier2,
     tier3,
@@ -15,14 +16,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     pre_ocp_upgrade,
     post_ocp_upgrade,
     post_ocs_upgrade,
-    purple_squad,
     workloads,
     performance,
     scale,
 )
 
 
-@purple_squad
+@ignore_owner
 @tier1
 @acceptance
 @tier2

--- a/tests/ui/test_capacity_breakdown_ui.py
+++ b/tests/ui/test_capacity_breakdown_ui.py
@@ -124,6 +124,7 @@ class TestCapacityBreakdownUI(ManageTest):
             project_name=project_name, pod_name=pod_name
         ), "The Project/Pod not created on Capacity Breakdown"
 
+    @green_squad
     @ui
     @tier3
     @bugzilla("2225223")

--- a/tests/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
+++ b/tests/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ui,
     skipif_ibm_cloud_managed,
+    black_squad,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -21,6 +22,7 @@ from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 log = logging.getLogger(__name__)
 
 
+@black_squad
 @ui
 @tier1
 @skipif_external_mode

--- a/tests/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
+++ b/tests/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
@@ -10,7 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ui,
     skipif_ibm_cloud_managed,
-    black_squad,
+    green_squad,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -22,7 +22,7 @@ from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 log = logging.getLogger(__name__)
 
 
-@black_squad
+@green_squad
 @ui
 @tier1
 @skipif_external_mode

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -1,7 +1,10 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import skipif_ibm_cloud_managed
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_ibm_cloud_managed,
+    black_squad,
+)
 from ocs_ci.ocs.exceptions import UnexpectedODFAccessException
 from ocs_ci.ocs.ui.page_objects.object_bucket_claims_tab import ObjectBucketClaimsTab
 
@@ -23,6 +26,7 @@ from ocs_ci.utility.utils import ceph_health_check
 logger = logging.getLogger(__name__)
 
 
+@black_squad
 class TestOBCUi(ManageTest):
     """
     Validate User able to see the OBC resource from the Console
@@ -66,6 +70,7 @@ class TestOBCUi(ManageTest):
         obc_ui_obj.check_obc_option()
 
 
+@black_squad
 class TestUnprivilegedUserODFAccess(E2ETest):
     """
     Test if unprivileged user can see ODF dashboard

--- a/tests/ui/test_pv_encryption_ui.py
+++ b/tests/ui/test_pv_encryption_ui.py
@@ -22,6 +22,7 @@ from ocs_ci.ocs.ui.storageclass import StorageClassUI
 from ocs_ci.ocs.ui.pvc_ui import PvcUI
 from ocs_ci.ocs.ui.views import locators
 from ocs_ci.utility import kms
+from ocs_ci.framework.pytest_customization.marks import black_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -34,6 +35,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
+@black_squad
 @pytest.mark.parametrize(
     argnames=["kv_version"],
     argvalues=[

--- a/tests/ui/test_validation_ui.py
+++ b/tests/ui/test_validation_ui.py
@@ -25,6 +25,7 @@ from ocs_ci.utility import version
 logger = logging.getLogger(__name__)
 
 
+@black_squad
 @skipif_ibm_cloud_managed
 class TestUserInterfaceValidation(object):
     """
@@ -34,7 +35,6 @@ class TestUserInterfaceValidation(object):
 
     @ui
     @tier1
-    @black_squad
     @polarion_id("OCS-4925")
     @skipif_ui_not_support("validation")
     def test_storage_cluster_validation_ui(self, setup_ui_class):
@@ -51,7 +51,6 @@ class TestUserInterfaceValidation(object):
     @ui
     @tier1
     @acceptance
-    @black_squad
     @bugzilla("2155743")
     @polarion_id("OCS-2575")
     @skipif_ui_not_support("validation")
@@ -88,7 +87,6 @@ class TestUserInterfaceValidation(object):
 
     @ui
     @tier1
-    @black_squad
     @polarion_id("OCS-4642")
     @skipif_ocs_version("<4.9")
     @skipif_ui_not_support("validation")
@@ -105,7 +103,6 @@ class TestUserInterfaceValidation(object):
 
     @ui
     @tier1
-    @black_squad
     @skipif_ocs_version("<4.9")
     @skipif_external_mode
     @skipif_mcg_only


### PR DESCRIPTION
This is a large but fairly straight forward change set.

The first goal was to add validation in the pytest  collection process to verify that all collected tests were decorated with a squad owner marker. This was necessary to prepare for the new test directory structure proposal so we can move test locations without losing squad ownership of tests. The second goal was to add markers to all tests that were missing them.

Jira: https://url.corp.redhat.com/3be0f4e