### PR TITLE
BM deployment: use config.AUTH instead of load_auth_config - backport for 4.12

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -28,7 +28,6 @@ from ocs_ci.utility.utils import (
     run_cmd,
     upload_file,
     get_ocp_version,
-    load_auth_config,
     wait_for_co,
     check_for_rhcos_images,
     get_infra_id,
@@ -51,8 +50,8 @@ class BAREMETALUPI(Deployment):
     class OCPDeployment(BaseOCPDeployment):
         def __init__(self):
             super().__init__()
-            self.helper_node_details = load_auth_config()["baremetal"]
-            self.mgmt_details = load_auth_config()["ipmi"]
+            self.helper_node_details = config.AUTH["baremetal"]
+            self.mgmt_details = config.AUTH["ipmi"]
             self.aws = aws.AWS()
 
         def deploy_prereq(self):
@@ -846,7 +845,7 @@ class BaremetalPSIUPI(Deployment):
             self.flexy_deployment = True
             super().__init__()
             self.flexy_instance = FlexyBaremetalPSI()
-            self.psi_conf = load_auth_config()["psi"]
+            self.psi_conf = config.AUTH["psi"]
             self.utils = psiutils.PSIUtils(self.psi_conf)
 
         def deploy_prereq(self):

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -3,12 +3,13 @@ import logging
 import pyipmi
 import pyipmi.interfaces
 
+from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.constants import VM_POWERED_OFF, VM_POWERED_ON
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.node import wait_for_nodes_status, get_worker_nodes, get_master_nodes
 from ocs_ci.ocs.ocp import OCP, wait_for_cluster_connectivity
-from ocs_ci.utility.utils import TimeoutSampler, load_auth_config, exec_cmd
+from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class BAREMETAL(object):
         Initialize the variables required
 
         """
-        self.mgmt_details = load_auth_config()["ipmi"]
+        self.mgmt_details = config.AUTH["ipmi"]
 
     def get_ipmi_ctx(self, host, user, password):
         """


### PR DESCRIPTION
Use standard `config.AUTH` object for bare metal deployment related configuration instead of directly loading the auth.yaml file.

This change will allow us to move the BM config from the global auth.yaml file to separated secret file and also automatically locking the resource in resource locker. 

**This PR has to be merged in sync with https://url.corp.redhat.com/d1e37a7 and with changes in Resource Locker!**

This is backport of https://github.com/red-hat-storage/ocs-ci/pull/8459