### PR TITLE
Get the pagerduty service id of the default cluster if we use multicluster run

### DIFF
--- a/tests/manage/monitoring/pagerduty/test_deployment_status.py
+++ b/tests/manage/monitoring/pagerduty/test_deployment_status.py
@@ -18,6 +18,20 @@ from ocs_ci.utility import pagerduty
 log = logging.getLogger(__name__)
 
 
+def get_pagerduty_service_id():
+    """
+    Get the pagerduty service id in the current run
+
+    Returns:
+        str: The pagerduty service id in the current run
+
+    """
+    if config.multicluster:
+        return config.default_cluster_ctx.RUN["pagerduty_service_id"]
+    else:
+        return config.RUN["pagerduty_service_id"]
+
+
 @tier4
 @tier4c
 @managed_service_required
@@ -48,7 +62,7 @@ def test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_ceph_mgr.get("stop"),
-            pagerduty_service_ids=[config.RUN["pagerduty_service_id"]],
+            pagerduty_service_ids=[get_pagerduty_service_id()],
         )
 
 
@@ -80,7 +94,7 @@ def test_ceph_osd_stopped_pd(measure_stop_ceph_osd):
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_ceph_osd.get("stop"),
-            pagerduty_service_ids=[config.RUN["pagerduty_service_id"]],
+            pagerduty_service_ids=[get_pagerduty_service_id()],
         )
 
 
@@ -114,7 +128,7 @@ def test_stop_worker_nodes_pd(measure_stop_worker_nodes):
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_worker_nodes.get("stop"),
-            pagerduty_service_ids=[config.RUN["pagerduty_service_id"]],
+            pagerduty_service_ids=[get_pagerduty_service_id()],
         )
 
 
@@ -152,7 +166,7 @@ def test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
             summary=target_label,
             measure_end_time=measure_stop_ceph_mon.get("stop"),
             time_min=time_min,
-            pagerduty_service_ids=[config.RUN["pagerduty_service_id"]],
+            pagerduty_service_ids=[get_pagerduty_service_id()],
         )
 
 
@@ -184,5 +198,5 @@ def test_ceph_mons_quorum_lost_pd(measure_stop_ceph_mon):
     api.check_incident_cleared(
         summary=target_label,
         measure_end_time=measure_stop_ceph_mon.get("stop"),
-        pagerduty_service_ids=[config.RUN["pagerduty_service_id"]],
+        pagerduty_service_ids=[get_pagerduty_service_id()],
     )


### PR DESCRIPTION
fix #8454 