### PR TITLE
use threading.lock, use Timer in measure_operation

### DIFF
--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -5,6 +5,7 @@ import requests
 import tempfile
 import time
 import yaml
+from threading import Timer
 from datetime import datetime
 
 from ocs_ci.framework import config
@@ -687,3 +688,75 @@ class PrometheusAPI(object):
             error_msg = f"{label} alerts were not cleared"
             logger.error(error_msg)
             raise AlertingError(error_msg)
+
+    def prometheus_log(self, prometheus_alert_list):
+        """
+        Log all alerts from Prometheus API to list
+
+        Args:
+            prometheus_alert_list (list): List to be populated with alerts
+        """
+
+        alerts_response = self.get(
+            "alerts", payload={"silenced": False, "inhibited": False}
+        )
+        msg = f"Request {alerts_response.request.url} failed"
+        if alerts_response.ok:
+            for alert in alerts_response.json().get("data").get("alerts"):
+                if alert not in prometheus_alert_list:
+                    logger.info(f"Adding {alert} to alert list")
+                    prometheus_alert_list.append(alert)
+        else:
+            # no need raise Assertion error or Exception here:
+            # 1. It will not lead to a test failure, fixture is in parallel Thread, in SetUp
+            # 2. One bad response should not fail the test
+            # 3. If Prometheus stopped responding, or we missed alert the test will fail anyway on checking alert list
+            logger.error(msg)
+
+
+class PrometheusAlertSubscriber(Timer):
+
+    prometheus_alert_list = []
+
+    def __init__(self, threading_lock, interval: float):
+        self.prometheus_api = PrometheusAPI(threading_lock=threading_lock)
+        super().__init__(
+            interval,
+            lambda: self.prometheus_api.prometheus_log(self.prometheus_alert_list),
+        )
+
+    def run(self):
+        """
+        Run logging of all prometheus alerts.
+
+        ! This method is called by Timer class, do not call it directly !
+        """
+        while not self.finished.wait(self.interval):
+            self.function(*self.args, **self.kwargs)
+
+    def get_alerts(self):
+        """
+        Get list of all alerts
+        """
+        return self.prometheus_alert_list
+
+    def clear_alerts(self):
+        """
+        Clear alert list
+        """
+        self.prometheus_alert_list = []
+
+    def subscribe(self):
+        """
+        Start logging of all prometheus alerts
+        """
+        logger.info("Logging of all prometheus alerts started")
+        self.daemon = True
+        self.start()
+
+    def unsubscribe(self):
+        """
+        Stop logging of all prometheus alerts
+        """
+        self.cancel()
+        logger.info("Logging of all prometheus alerts stopped")

--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -11,14 +11,12 @@ fixtures in ocs-ci.
 import json
 import logging
 import os
-import threading
 import time
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.utility.pagerduty import PagerDutyAPI
-from ocs_ci.utility.prometheus import PrometheusAPI
-
+from ocs_ci.utility.prometheus import PrometheusAlertSubscriber
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +41,7 @@ def measure_operation(
     metadata=None,
     measure_after=False,
     pagerduty_service_ids=None,
+    threading_lock=None,
 ):
     """
     Get dictionary with keys 'start', 'stop', 'metadata' and 'result' that
@@ -66,6 +65,7 @@ def measure_operation(
             and utilized data are measured after the utilization is completed
         pagerduty_service_ids (list): Service IDs from PagerDuty system used
             incidents query
+        threading_lock (threading.Lock): Lock used for synchronization of the threads in Prometheus calls
 
     Returns:
         dict: contains information about `start` and `stop` time of given
@@ -81,31 +81,6 @@ def measure_operation(
                 }
 
     """
-
-    def prometheus_log(info, prometheus_alert_list):
-        """
-        Log all alerts from Prometheus API every 3 seconds.
-
-        Args:
-            info (dict): Contains run key attribute that controls thread.
-                If `info['run'] == False` then thread will stop
-            prometheus_alert_list (list): List to be populated with alerts
-
-        """
-        prometheus = PrometheusAPI()
-        logger.info("Logging of all prometheus alerts started")
-        while info.get("run"):
-            alerts_response = prometheus.get(
-                "alerts", payload={"silenced": False, "inhibited": False}
-            )
-            msg = f"Request {alerts_response.request.url} failed"
-            assert alerts_response.ok, msg
-            for alert in alerts_response.json().get("data").get("alerts"):
-                if alert not in prometheus_alert_list:
-                    logger.info(f"Adding {alert} to alert list")
-                    prometheus_alert_list.append(alert)
-            time.sleep(3)
-        logger.info("Logging of all prometheus alerts stopped")
 
     # check if file with results for this operation already exists
     # if it exists then use it
@@ -129,15 +104,10 @@ def measure_operation(
             start_time = time.time()
 
         # init logging thread that checks for Prometheus alerts
-        # while workload is running
-        # based on https://docs.python.org/3/howto/logging-cookbook.html#logging-from-multiple-threads
-        info = {"run": True}
-        prometheus_alert_list = []
-
-        logging_thread_prometheus = threading.Thread(
-            target=prometheus_log, args=(info, prometheus_alert_list)
+        alert_subscriber = PrometheusAlertSubscriber(
+            threading_lock=threading_lock, interval=3
         )
-        logging_thread_prometheus.start()
+        alert_subscriber.subscribe()
 
         try:
             result = operation()
@@ -166,8 +136,10 @@ def measure_operation(
                     time.sleep(additional_time)
             # Dumping measurement results into result file.
             stop_time = time.time()
-            info["run"] = False
-            logging_thread_prometheus.join()
+
+            alert_subscriber.unsubscribe()
+            prometheus_alert_list = alert_subscriber.get_alerts()
+
             results = {
                 "start": start_time,
                 "stop": stop_time,

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -714,7 +714,7 @@ def measure_noobaa_exceed_bucket_quota(measurement_dir, request, mcg_obj, awscli
 
 
 @pytest.fixture
-def workload_idle(measurement_dir):
+def workload_idle(measurement_dir, threading_lock):
     """
     This workload represents a relative long timeframe when nothing special is
     happening, for test cases checking default status of various components
@@ -792,6 +792,7 @@ def workload_idle(measurement_dir):
         do_nothing,
         test_file,
         pagerduty_service_ids=[config.RUN.get("pagerduty_service_id")],
+        threading_lock=threading_lock,
     )
     if restart_io_in_bg:
         logger.info("reverting load_status to resume io_in_bg")


### PR DESCRIPTION
Fixed few problems:
1.  Prometheus alerts logging (via method refresh_connection) is now thread safe
2. Used inbuilt threading.Timer instead of the unsafe `while flag do request` construction

What it gives?

We have many failures with uncertain result, such as user not logged for the operation, creation of pod unsuccessful, etc caused by simultaneous `oc` comands
It affects **test_mcg_cpu_usage** and **test_monitoring_reporting_ok_when_idle**

Fixes: #8447 

