### PR TITLE
Fix check_obc_option

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -10,7 +10,6 @@ from ocs_ci.ocs.ui.page_objects.data_foundation_tabs_common import CreateResourc
 from ocs_ci.ocs.ui.page_objects.object_service import ObjectService
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.page_objects.resource_list import ResourceList
-from tests.conftest import delete_projects
 
 
 class BucketsUI(PageNavigator, ResourceList):
@@ -78,7 +77,9 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         BucketsUI.select_project(namespace)
 
         obc_found = self.wait_until_expected_text_is_found(
-            locator=self.sc_loc["obc_menu_name"], expected_text=text, timeout=10
+            locator=self.sc_loc["obc_menu_name"],
+            expected_text="Object Bucket Claims",
+            timeout=10,
         )
 
         if not obc_found:

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -63,7 +63,10 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         self.sc_loc = self.obc_loc
 
     def check_obc_option(self, text="Object Bucket Claims"):
-        """check OBC is visible to user after giving admin access"""
+        """check OBC is visible to user after giving admin access
+
+        Returns:
+            bool: True if list of OBCs is visible to the user, False if not"""
 
         sc_name = create_unique_resource_name("namespace-", "interface")
         self.do_click(self.sc_loc["Developer_dropdown"])

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -32,7 +32,8 @@ class BucketsUI(PageNavigator, ResourceList):
         """
         logger.info(f"Select project {namespace}")
         self.do_click(self.generic_locators["project_selector"])
-        self.wait_for_namespace_selection(project_name=namespace, obc=True)
+        self.do_send_keys(self.pvc_loc["search-project"], text=namespace)
+        self.wait_for_namespace_selection(project_name=namespace)
 
 
 class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
@@ -73,8 +74,9 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
 
         self.do_click(self.sc_loc["Developer_dropdown"])
         self.do_click(self.sc_loc["select_administrator"], timeout=5)
-        BucketsUI.navigate_object_bucket_claims_page(self)
+        BucketsUI.navigate_persistentvolumeclaims_page()
         BucketsUI.select_project(self, namespace)
+        BucketsUI.navigate_object_bucket_claims_page(self)
 
         obc_found = self.wait_until_expected_text_is_found(
             locator=self.sc_loc["obc_menu_name"],

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -89,9 +89,7 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         namespaces.append(namespace_obj)
         delete_projects(namespaces)
 
-        if not obc_found:
-            return False
-        return True
+        return obc_found
 
     def _check_obc_cannot_be_used_before(self, rule_exp):
         """

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -31,8 +31,8 @@ class BucketsUI(PageNavigator, ResourceList):
         Notice: the func works from PersistantVolumeClaims, VolumeSnapshots and OBC pages
         """
         logger.info(f"Select project {namespace}")
-        self.do_click(self.generic_locators["project_selector"], obc=True)
-        self.wait_for_namespace_selection(project_name=namespace)
+        self.do_click(self.generic_locators["project_selector"])
+        self.wait_for_namespace_selection(project_name=namespace, obc=True)
 
 
 class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -71,7 +71,7 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         self.do_click(self.sc_loc["create_project"])
         self.do_send_keys(self.sc_loc["project_name"], sc_name)
         self.do_click(self.sc_loc["save_project"])
-        self.choose_expanded_mode(mode=True, locator=self.page_nav["Storage"])
+        BucketsUI.navigate_object_bucket_claims_page()
         obc_found = self.wait_until_expected_text_is_found(
             locator=self.sc_loc["obc_menu_name"], expected_text=text, timeout=10
         )
@@ -87,7 +87,8 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         delete_projects(namespaces)
 
         if not obc_found:
-            return None
+            return False
+        return True
 
     def _check_obc_cannot_be_used_before(self, rule_exp):
         """

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -71,7 +71,7 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         self.do_click(self.sc_loc["create_project"])
         self.do_send_keys(self.sc_loc["project_name"], sc_name)
         self.do_click(self.sc_loc["save_project"])
-        BucketsUI.navigate_object_bucket_claims_page()
+        BucketsUI.navigate_object_bucket_claims_page(self)
         obc_found = self.wait_until_expected_text_is_found(
             locator=self.sc_loc["obc_menu_name"], expected_text=text, timeout=10
         )

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -78,7 +78,6 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         if not obc_found:
             logger.info("user is not able to access OBC")
             self.take_screenshot()
-            return None
         else:
             logger.info("user is able to access OBC")
 
@@ -86,6 +85,9 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         namespace_obj = OCP(kind=constants.NAMESPACE, namespace=sc_name)
         namespaces.append(namespace_obj)
         delete_projects(namespaces)
+
+        if not obc_found:
+            return None
 
     def _check_obc_cannot_be_used_before(self, rule_exp):
         """

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -74,7 +74,7 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
         self.do_click(self.sc_loc["Developer_dropdown"])
         self.do_click(self.sc_loc["select_administrator"], timeout=5)
         BucketsUI.navigate_object_bucket_claims_page(self)
-        BucketsUI.select_project(namespace)
+        BucketsUI.select_project(self, namespace)
 
         obc_found = self.wait_until_expected_text_is_found(
             locator=self.sc_loc["obc_menu_name"],

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -31,7 +31,7 @@ class BucketsUI(PageNavigator, ResourceList):
         Notice: the func works from PersistantVolumeClaims, VolumeSnapshots and OBC pages
         """
         logger.info(f"Select project {namespace}")
-        self.do_click(self.generic_locators["project_selector"])
+        self.do_click(self.generic_locators["project_selector"], obc=True)
         self.wait_for_namespace_selection(project_name=namespace)
 
 

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -74,7 +74,7 @@ class ObjectBucketClaimsTab(ObjectService, BucketsUI, CreateResourceForm):
 
         self.do_click(self.sc_loc["Developer_dropdown"])
         self.do_click(self.sc_loc["select_administrator"], timeout=5)
-        BucketsUI.navigate_persistentvolumeclaims_page()
+        BucketsUI.navigate_persistentvolumeclaims_page(self)
         BucketsUI.select_project(self, namespace)
         BucketsUI.navigate_object_bucket_claims_page(self)
 

--- a/ocs_ci/ocs/ui/page_objects/page_navigator.py
+++ b/ocs_ci/ocs/ui/page_objects/page_navigator.py
@@ -350,7 +350,7 @@ class PageNavigator(BaseUI):
         storage_system_details.nav_ceph_blockpool()
         logger.info("Now at Block pool page")
 
-    def wait_for_namespace_selection(self, project_name):
+    def wait_for_namespace_selection(self, project_name, obc=False):
         """
         If you have already navigated to namespace drop-down, this function waits for namespace selection on UI.
         It would be useful to avoid test failures in case of delays/latency in populating the list of projects under the
@@ -359,6 +359,7 @@ class PageNavigator(BaseUI):
 
         Args:
             project_name (str): Name of the project to be selected
+            obc (bool): Whether project selection is on OBC page. Default value is False
 
         Returns:
             bool: True if the project is found, raises NoSuchElementException otherwise with a log message
@@ -366,7 +367,7 @@ class PageNavigator(BaseUI):
 
         from ocs_ci.ocs.ui.helpers_ui import format_locator
 
-        if self.ocp_version_full in (version.VERSION_4_10, version.VERSION_4_11):
+        if self.ocp_version_full in (version.VERSION_4_10, version.VERSION_4_11) or obc:
             default_projects_is_checked = self.driver.find_element_by_xpath(
                 "//span[@class='pf-c-switch__toggle']"
             )

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -63,7 +63,7 @@ class TestOBCUi(ManageTest):
         """Login using created user"""
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
-        obc_ui_obj.check_obc_option()
+        assert obc_ui_obj.check_obc_option()
 
 
 class TestUnprivilegedUserODFAccess(E2ETest):

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -61,13 +61,15 @@ class TestOBCUi(ManageTest):
         # Create project and give the user admin access to it
         project = project_factory()
         ocp_obj = ocp.OCP()
-        ocp_obj.exec_oc_cmd(f"adm policy add-role-to-user admin {user[0]} -n {project}")
+        ocp_obj.exec_oc_cmd(
+            f"adm policy add-role-to-user admin {user[0]} -n {project.name}"
+        )
 
         # Login using created user
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
         assert obc_ui_obj.check_obc_option(
-            project
+            project.name
         ), f"User {user[0]} wasn't able to see the list of OBCs"
 
 

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -48,22 +48,27 @@ class TestOBCUi(ManageTest):
     @skipif_ibm_cloud_managed
     @bugzilla("2031705")
     @polarion_id("OCS-4620")
-    def test_create_storageclass_rbd(self, user_factory, login_factory):
-        """Create user"""
+    def test_project_admin_obcs_access(
+        self, user_factory, login_factory, project_factory
+    ):
+        """
+        Test if project admin can view the list of OBCs
+
+        """
         user = user_factory()
-        sleep(30)
+        logger.info(f"user created: {user[0]} password: {user[1]}")
 
-        """ Create RoleBinding """
+        # Create project and give the user admin access to it
+        project = project_factory()
         ocp_obj = ocp.OCP()
-        ocp_obj.exec_oc_cmd(
-            f"-n openshift-storage create rolebinding {user[0]} --role=mcg-operator.v4.11.0-noobaa-odf-ui-548459769c "
-            f"--user={user[0]} "
-        )
+        ocp_obj.exec_oc_cmd(f"adm policy add-role-to-user admin {user[0]} -n {project}")
 
-        """Login using created user"""
+        # Login using created user
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
-        assert obc_ui_obj.check_obc_option(), "User wasn't able to see the list of OBCs"
+        assert obc_ui_obj.check_obc_option(
+            project
+        ), f"User {user[0]} wasn't able to see the list of OBCs"
 
 
 class TestUnprivilegedUserODFAccess(E2ETest):

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -62,14 +62,14 @@ class TestOBCUi(ManageTest):
         project = project_factory()
         ocp_obj = ocp.OCP()
         ocp_obj.exec_oc_cmd(
-            f"adm policy add-role-to-user admin {user[0]} -n {project.resource_name}"
+            f"adm policy add-role-to-user admin {user[0]} -n {project.namespace}"
         )
 
         # Login using created user
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
         assert obc_ui_obj.check_obc_option(
-            project.resource_name
+            project.namespace
         ), f"User {user[0]} wasn't able to see the list of OBCs"
 
 

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -62,14 +62,14 @@ class TestOBCUi(ManageTest):
         project = project_factory()
         ocp_obj = ocp.OCP()
         ocp_obj.exec_oc_cmd(
-            f"adm policy add-role-to-user admin {user[0]} -n {project.name}"
+            f"adm policy add-role-to-user admin {user[0]} -n {project.resource_name}"
         )
 
         # Login using created user
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
         assert obc_ui_obj.check_obc_option(
-            project.name
+            project.resource_name
         ), f"User {user[0]} wasn't able to see the list of OBCs"
 
 

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -63,7 +63,7 @@ class TestOBCUi(ManageTest):
         """Login using created user"""
         login_factory(user[0], user[1])
         obc_ui_obj = ObjectBucketClaimsTab()
-        assert obc_ui_obj.check_obc_option()
+        assert obc_ui_obj.check_obc_option(), "User wasn't able to see the list of OBCs"
 
 
 class TestUnprivilegedUserODFAccess(E2ETest):

--- a/tests/ui/test_non_admin_user.py
+++ b/tests/ui/test_non_admin_user.py
@@ -16,7 +16,6 @@ from ocs_ci.framework.testlib import (
     tier1,
     E2ETest,
 )
-from time import sleep
 from ocs_ci.utility.utils import ceph_health_check
 
 


### PR DESCRIPTION
check_obc_option leaves leftovers when the user isn't able to see OBC: https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/29495/consoleFull