### PR TITLE
fix wrong PRs merging

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1428,13 +1428,10 @@ validation_4_13 = {
 
 validation_4_14 = {
     "system-capacity": ("//div[contains(text(),'System raw capacity')]", By.XPATH),
-}
-
-validation_4_14 = {
     "storagesystems_overview": (
         "//button[@data-test='horizontal-link-Overview']",
         By.XPATH,
-    )
+    ),
 }
 
 topology = {


### PR DESCRIPTION
after merging different PRs in a short period the dictionary of locators (validation_4_14) where duplicated but not merged