### PR TITLE
thread_lock added to all PrometheusAPI calls

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -712,8 +712,13 @@ def pytest_runtest_makereport(item, call):
     ):
         metrics = item.get_closest_marker("gather_metrics_on_fail").args
         try:
+            threading_lock = call.getfixturevalue("threading_lock")
             collect_prometheus_metrics(
-                metrics, f"{item.name}-{call.when}", call.start, call.stop
+                metrics,
+                f"{item.name}-{call.when}",
+                call.start,
+                call.stop,
+                threading_lock=threading_lock,
             )
         except Exception:
             log.exception("Failed to collect prometheus metrics")

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2387,7 +2387,9 @@ class LVM(object):
 
     """
 
-    def __init__(self, fstrim=False, fail_on_thin_pool_not_empty=False):
+    def __init__(
+        self, fstrim=False, fail_on_thin_pool_not_empty=False, threading_lock=None
+    ):
         """
         Initiate the class, gets 2 parameters.
         Args:
@@ -2405,6 +2407,7 @@ class LVM(object):
         self.vg_data = None
         self.node_ssh = None
         self.new_prom = None
+        self.threading_lock = threading_lock
         func_list = [
             self.cluster_ip(),
             self.get_lvmcluster(),
@@ -2461,7 +2464,7 @@ class LVM(object):
         thread_init_class(func_list, shutdown=0)
 
     def init_prom(self):
-        self.new_prom = PrometheusAPI()
+        self.new_prom = PrometheusAPI(threading_lock=self.threading_lock)
 
     def get_lvmcluster(self):
         """

--- a/ocs_ci/ocs/cluster_load.py
+++ b/ocs_ci/ocs/cluster_load.py
@@ -52,6 +52,7 @@ class ClusterLoad:
         sa_factory=None,
         pod_factory=None,
         target_percentage=None,
+        threading_lock=None,
     ):
         """
         Initializer for ClusterLoad
@@ -63,9 +64,9 @@ class ClusterLoad:
             pod_factory (function): A call to pod_factory function
             target_percentage (float): The percentage of cluster load that is
                 required. The value should be greater than 0.1 and smaller than 0.95
-
+            threading_lock (threading.RLock): A threading.RLock object to be used for threading lock
         """
-        self.prometheus_api = PrometheusAPI()
+        self.prometheus_api = PrometheusAPI(threading_lock=threading_lock)
         self.pvc_factory = pvc_factory
         self.sa_factory = sa_factory
         self.pod_factory = pod_factory

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -643,5 +643,9 @@ class UnableUpgradeConnectionException(Exception):
     pass
 
 
+class NoThreadingLockUsedError(Exception):
+    pass
+
+
 class VSLMNotFoundException(Exception):
     pass

--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -346,6 +346,7 @@ def workload_fio_storageutilization(
     keep_fio_data=False,
     minimal_time=480,
     throw_skip=True,
+    threading_lock=None,
 ):
     """
     This function implements core functionality of fio storage utilization
@@ -392,6 +393,7 @@ def workload_fio_storageutilization(
             (See more details in the function 'measure_operation')
         throw_skip (bool): if True function will raise pytest.skip.Exception and test will be skipped,
             otherwise return None
+        threading_lock (threading.RLock): lock to be used for thread synchronization when calling 'oc' cmd
 
     Returns:
         dict: measurement results with timestamps and other medatada from
@@ -537,6 +539,7 @@ def workload_fio_storageutilization(
         test_file,
         measure_after=True,
         minimal_time=minimal_time,
+        threading_lock=threading_lock,
     )
 
     # we don't need to delete anything if this fixture has been already

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -67,7 +67,7 @@ class OCP(object):
             field_selector (str): Selector (field query) to filter on, supports
                 '=', '==', and '!='. (e.g. status.phase=Running)
             cluster_kubeconfig (str): Path to the cluster kubeconfig file. Useful in a multicluster configuration
-            threading_lock (threading.Lock): threading.Lock object that is used
+            threading_lock (threading.RLock): threading.RLock object that is used
                 for handling concurrent oc commands
             silent (bool): If True will silent errors from the server, default false
             skip_tls_verify (bool): Adding '--insecure-skip-tls-verify' to oc command for

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1319,6 +1319,7 @@ def collect_prometheus_metrics(
     start,
     stop,
     step=1.0,
+    threading_lock=None,
 ):
     """
     Collects metrics from Prometheus and saves them in file in json format.
@@ -1333,8 +1334,9 @@ def collect_prometheus_metrics(
         start (str): start timestamp of required datapoints
         stop (str): stop timestamp of required datapoints
         step (float): step of required datapoints
+        threading_lock: (threading.RLock): Lock to use for thread safety (default: None)
     """
-    api = PrometheusAPI()
+    api = PrometheusAPI(threading_lock=threading_lock)
     log_dir_path = os.path.join(
         os.path.expanduser(ocsci_config.RUN["log_dir"]),
         f"failed_testcase_ocs_logs_{ocsci_config.RUN['run_id']}",

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults
-from ocs_ci.ocs.exceptions import AlertingError, AuthError
+from ocs_ci.ocs.exceptions import AlertingError, AuthError, NoThreadingLockUsedError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.ssl_certs import get_root_ca_cert
 from ocs_ci.utility.utils import TimeoutIterator
@@ -330,6 +330,11 @@ class PrometheusAPI(object):
         Args:
             user (str): OpenShift username used to connect to API
         """
+        if not threading_lock:
+            raise NoThreadingLockUsedError(
+                "using threading.Lock object is mandatory for PrometheusAPI class"
+            )
+
         if (
             config.ENV_DATA["platform"].lower() == "ibm_cloud"
             and config.ENV_DATA["deployment_type"] == "managed"

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -330,7 +330,7 @@ class PrometheusAPI(object):
         Args:
             user (str): OpenShift username used to connect to API
         """
-        if not threading_lock:
+        if threading_lock is None:
             raise NoThreadingLockUsedError(
                 "using threading.Lock object is mandatory for PrometheusAPI class"
             )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -469,7 +469,7 @@ def run_cmd(
         timeout (int): Timeout for the command, defaults to 600 seconds.
         ignore_error (bool): True if ignore non zero return code and do not
             raise the exception.
-        threading_lock (threading.Lock): threading.Lock object that is used
+        threading_lock (threading.RLock): threading.RLock object that is used
             for handling concurrent oc commands
         silent (bool): If True will silent errors from the server, default false
 
@@ -599,7 +599,7 @@ def exec_cmd(
         timeout (int): Timeout for the command, defaults to 600 seconds.
         ignore_error (bool): True if ignore non zero return code and do not
             raise the exception.
-        threading_lock (threading.Lock): threading.Lock object that is used
+        threading_lock (threading.RLock): threading.RLock object that is used
             for handling concurrent oc commands
         silent (bool): If True will silent errors from the server, default false
         use_shell (bool): If True will pass the cmd without splitting

--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -65,7 +65,7 @@ def measure_operation(
             and utilized data are measured after the utilization is completed
         pagerduty_service_ids (list): Service IDs from PagerDuty system used
             incidents query
-        threading_lock (threading.Lock): Lock used for synchronization of the threads in Prometheus calls
+        threading_lock (threading.RLock): Lock used for synchronization of the threads in Prometheus calls
 
     Returns:
         dict: contains information about `start` and `stop` time of given

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,9 +424,10 @@ def threading_lock():
     threading.Lock object that can be used in threads across multiple tests.
 
     Returns:
-        threading.Lock: lock object
+        threading.Rlock: Reentrant Lock object. A reentrant lock (or RLock) is a type of lock that allows the same
+        thread to acquire the lock multiple times without causing a deadlock
     """
-    return threading.Lock()
+    return threading.RLock()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -1766,6 +1767,7 @@ def cluster_load(
     pvc_factory_session,
     service_account_factory_session,
     pod_factory_session,
+    threading_lock,
 ):
     """
     Run IO during the test execution
@@ -1799,6 +1801,7 @@ def cluster_load(
                 pvc_factory=pvc_factory_session,
                 pod_factory=pod_factory_session,
                 target_percentage=io_load,
+                threading_lock=threading_lock,
             )
             cl_load_obj.reach_cluster_load_percentage()
         except Exception as ex:
@@ -1808,7 +1811,7 @@ def cluster_load(
     if (log_utilization or io_in_bg) and not deployment_test:
         if not cl_load_obj:
             try:
-                cl_load_obj = ClusterLoad()
+                cl_load_obj = ClusterLoad(threading_lock=threading_lock)
             except Exception as ex:
                 log.error(cluster_load_error_msg, ex)
                 cluster_load_error = ex

--- a/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
+++ b/tests/e2e/workloads/ocp/registry/test_registry_by_increasing_num_of_image_registry_pods.py
@@ -61,13 +61,13 @@ class TestRegistryByIncreasingNumPods(E2ETest):
         request.addfinalizer(finalizer)
 
     @pytest.mark.polarion_id("OCS-1900")
-    def test_registry_by_increasing_num_of_registry_pods(self, count=3):
+    def test_registry_by_increasing_num_of_registry_pods(self, threading_lock, count=3):
         """
         Test registry by increasing number of registry pods and
         validate all the image-registry pod should have the same PVC backend.
 
         """
-        api = prometheus.PrometheusAPI()
+        api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
         # Increase the replica count to 3
         assert modify_registry_pod_count(

--- a/tests/lvmo/test_lvm_alerts.py
+++ b/tests/lvmo/test_lvm_alerts.py
@@ -61,8 +61,10 @@ class TestLvmCapacityAlerts(ManageTest):
     block = False
 
     @pytest.fixture()
-    def init_lvm(self):
-        self.lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+    def init_lvm(self, threading_lock):
+        self.lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         disk1 = self.lvm.pv_data["pv_list"][0]
         log.info(f"PV List: {self.lvm.pv_data['pv_list']}")
         self.disk_size = self.lvm.pv_data[disk1]["pv_size"]
@@ -91,6 +93,7 @@ class TestLvmCapacityAlerts(ManageTest):
         pvc_factory,
         pod_factory,
         volume_binding_mode,
+        threading_lock,
     ):
         """
 

--- a/tests/lvmo/test_lvm_clone_base.py
+++ b/tests/lvmo/test_lvm_clone_base.py
@@ -61,6 +61,7 @@ class TestLvmSnapshot(ManageTest):
         pvc_clone_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete snapshot
@@ -74,7 +75,9 @@ class TestLvmSnapshot(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"

--- a/tests/lvmo/test_lvm_clone_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_clone_bigger_than_disk.py
@@ -58,6 +58,7 @@ class TestLvmCloneBiggerThanDisk(ManageTest):
         pvc_clone_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete snapshot
@@ -74,7 +75,9 @@ class TestLvmCloneBiggerThanDisk(ManageTest):
 
         access_mode = constants.ACCESS_MODE_RWO
 
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         disk1 = lvm.pv_data["pv_list"][0]
         disk_size = lvm.pv_data[disk1]["pv_size"]
         pvc_size = int(float(disk_size)) * 2

--- a/tests/lvmo/test_lvm_multi_clone.py
+++ b/tests/lvmo/test_lvm_multi_clone.py
@@ -65,6 +65,7 @@ class TestLvmMultiClone(ManageTest):
         pvc_clone_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete multi snapshot
@@ -77,7 +78,9 @@ class TestLvmMultiClone(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"

--- a/tests/lvmo/test_lvm_multi_snapshot.py
+++ b/tests/lvmo/test_lvm_multi_snapshot.py
@@ -66,6 +66,7 @@ class TestLvmMultiSnapshot(ManageTest):
         snapshot_restore_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete multi snapshot
@@ -78,7 +79,9 @@ class TestLvmMultiSnapshot(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"

--- a/tests/lvmo/test_lvm_snapshot_base.py
+++ b/tests/lvmo/test_lvm_snapshot_base.py
@@ -62,6 +62,7 @@ class TestLvmSnapshot(ManageTest):
         snapshot_restore_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete snapshot
@@ -74,7 +75,9 @@ class TestLvmSnapshot(ManageTest):
         .* Run IO
 
         """
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         logger.info(f"LVMCluster version is {lvm.get_lvm_version()}")
         logger.info(
             f"Lvm thin-pool overprovisionRation is {lvm.get_lvm_thin_pool_config_overprovision_ratio()}"

--- a/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
+++ b/tests/lvmo/test_lvm_snapshot_bigger_than_disk.py
@@ -60,6 +60,7 @@ class TestLvmSnapshotBiggerThanDisk(ManageTest):
         snapshot_restore_factory,
         pvc_factory,
         pod_factory,
+        threading_lock,
     ):
         """
         test create delete snapshot
@@ -77,7 +78,9 @@ class TestLvmSnapshotBiggerThanDisk(ManageTest):
 
         access_mode = constants.ACCESS_MODE_RWO
 
-        lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+        lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         disk1 = lvm.pv_data["pv_list"][0]
         disk_size = lvm.pv_data[disk1]["pv_size"]
         pvc_size = int(float(disk_size)) * 2

--- a/tests/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/lvmo/test_lvmo_pvc_resize.py
@@ -58,8 +58,10 @@ class TestLVMPVCResize(ManageTest):
     block = False
 
     @pytest.fixture()
-    def init_lvm(self):
-        self.lvm = LVM(fstrim=True, fail_on_thin_pool_not_empty=True)
+    def init_lvm(self, threading_lock):
+        self.lvm = LVM(
+            fstrim=True, fail_on_thin_pool_not_empty=True, threading_lock=threading_lock
+        )
         disk1 = self.lvm.pv_data["pv_list"][0]
         log.info(f"PV List: {self.lvm.pv_data['pv_list']}")
         self.disk_size = self.lvm.pv_data[disk1]["pv_size"]

--- a/tests/manage/mcg/test_noobaa_prometheus.py
+++ b/tests/manage/mcg/test_noobaa_prometheus.py
@@ -19,9 +19,9 @@ logger = logging.getLogger(__name__)
 
 
 @retry(ReturnedEmptyResponseException, tries=30, delay=10, backoff=1)
-def get_bucket_used_bytes_metric(bucket_name):
+def get_bucket_used_bytes_metric(bucket_name, threading_lock):
     response = json.loads(
-        PrometheusAPI()
+        PrometheusAPI(threading_lock=threading_lock)
         .get(f'query?query=NooBaa_bucket_used_bytes{{bucket_name="{bucket_name}"}}')
         .content.decode("utf-8")
     )

--- a/tests/manage/monitoring/conftest.py
+++ b/tests/manage/monitoring/conftest.py
@@ -399,7 +399,13 @@ def measure_corrupt_pg(request, measurement_dir):
 
 @pytest.fixture
 def workload_storageutilization_05p_rbd(
-    project, fio_pvc_dict, fio_job_dict, fio_configmap_dict, measurement_dir, tmp_path
+    project,
+    fio_pvc_dict,
+    fio_job_dict,
+    fio_configmap_dict,
+    measurement_dir,
+    tmp_path,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_05p_rbd"
     measured_op = workload_fio_storageutilization(
@@ -411,6 +417,7 @@ def workload_storageutilization_05p_rbd(
         measurement_dir,
         tmp_path,
         target_percentage=0.05,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -424,6 +431,7 @@ def workload_storageutilization_50p_rbd(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_50p_rbd"
     measured_op = workload_fio_storageutilization(
@@ -435,13 +443,20 @@ def workload_storageutilization_50p_rbd(
         measurement_dir,
         tmp_path,
         target_percentage=0.5,
+        threading_lock=threading_lock,
     )
     return measured_op
 
 
 @pytest.fixture
 def workload_storageutilization_checksum_rbd(
-    project, fio_pvc_dict, fio_job_dict, fio_configmap_dict, measurement_dir, tmp_path
+    project,
+    fio_pvc_dict,
+    fio_job_dict,
+    fio_configmap_dict,
+    measurement_dir,
+    tmp_path,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_checksum_rbd"
     measured_op = workload_fio_storageutilization(
@@ -454,6 +469,7 @@ def workload_storageutilization_checksum_rbd(
         tmp_path,
         target_size=10,
         with_checksum=True,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -467,6 +483,7 @@ def workload_storageutilization_85p_rbd(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_85p_rbd"
     measured_op = workload_fio_storageutilization(
@@ -478,6 +495,7 @@ def workload_storageutilization_85p_rbd(
         measurement_dir,
         tmp_path,
         target_percentage=0.85,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -491,6 +509,7 @@ def workload_storageutilization_97p_rbd(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_97p_rbd"
     measured_op = workload_fio_storageutilization(
@@ -502,13 +521,20 @@ def workload_storageutilization_97p_rbd(
         measurement_dir,
         tmp_path,
         target_percentage=0.97,
+        threading_lock=threading_lock,
     )
     return measured_op
 
 
 @pytest.fixture
 def workload_storageutilization_05p_cephfs(
-    project, fio_pvc_dict, fio_job_dict, fio_configmap_dict, measurement_dir, tmp_path
+    project,
+    fio_pvc_dict,
+    fio_job_dict,
+    fio_configmap_dict,
+    measurement_dir,
+    tmp_path,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_05p_cephfs"
     measured_op = workload_fio_storageutilization(
@@ -520,6 +546,7 @@ def workload_storageutilization_05p_cephfs(
         measurement_dir,
         tmp_path,
         target_percentage=0.05,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -533,6 +560,7 @@ def workload_storageutilization_50p_cephfs(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_50p_cephfs"
     measured_op = workload_fio_storageutilization(
@@ -544,6 +572,7 @@ def workload_storageutilization_50p_cephfs(
         measurement_dir,
         tmp_path,
         target_percentage=0.5,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -557,6 +586,7 @@ def workload_storageutilization_85p_cephfs(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_85p_cephfs"
     measured_op = workload_fio_storageutilization(
@@ -568,6 +598,7 @@ def workload_storageutilization_85p_cephfs(
         measurement_dir,
         tmp_path,
         target_percentage=0.85,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -581,6 +612,7 @@ def workload_storageutilization_97p_cephfs(
     measurement_dir,
     tmp_path,
     supported_configuration,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_97p_cephfs"
     measured_op = workload_fio_storageutilization(
@@ -592,6 +624,7 @@ def workload_storageutilization_97p_cephfs(
         measurement_dir,
         tmp_path,
         target_percentage=0.97,
+        threading_lock=threading_lock,
     )
     return measured_op
 
@@ -601,7 +634,13 @@ def workload_storageutilization_97p_cephfs(
 
 @pytest.fixture
 def workload_storageutilization_10g_rbd(
-    project, fio_pvc_dict, fio_job_dict, fio_configmap_dict, measurement_dir, tmp_path
+    project,
+    fio_pvc_dict,
+    fio_job_dict,
+    fio_configmap_dict,
+    measurement_dir,
+    tmp_path,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_10G_rbd"
     measured_op = workload_fio_storageutilization(
@@ -613,13 +652,20 @@ def workload_storageutilization_10g_rbd(
         measurement_dir,
         tmp_path,
         target_size=10,
+        threading_lock=threading_lock,
     )
     return measured_op
 
 
 @pytest.fixture
 def workload_storageutilization_10g_cephfs(
-    project, fio_pvc_dict, fio_job_dict, fio_configmap_dict, measurement_dir, tmp_path
+    project,
+    fio_pvc_dict,
+    fio_job_dict,
+    fio_configmap_dict,
+    measurement_dir,
+    tmp_path,
+    threading_lock,
 ):
     fixture_name = "workload_storageutilization_10G_cephfs"
     measured_op = workload_fio_storageutilization(
@@ -631,6 +677,7 @@ def workload_storageutilization_10g_cephfs(
         measurement_dir,
         tmp_path,
         target_size=10,
+        threading_lock=threading_lock,
     )
     return measured_op
 

--- a/tests/manage/monitoring/prometheus/test_alerting_works.py
+++ b/tests/manage/monitoring/prometheus/test_alerting_works.py
@@ -12,11 +12,11 @@ log = logging.getLogger(__name__)
 
 
 @blue_squad
-def test_alerting_works():
+def test_alerting_works(threading_lock):
     """
     If alerting works then there is at least one alert.
     """
-    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+    prometheus = ocs_ci.utility.prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts_response = prometheus.get(
         "alerts", payload={"silenced": False, "inhibited": False}
     )
@@ -30,11 +30,11 @@ def test_alerting_works():
 @pytest.mark.polarion_id("OCS-2503")
 @bugzilla("1897674")
 @tier1
-def test_prometheus_rule_failures():
+def test_prometheus_rule_failures(threading_lock):
     """
     There should be no PrometheusRuleFailures alert when OCS is configured.
     """
-    prometheus = ocs_ci.utility.prometheus.PrometheusAPI()
+    prometheus = ocs_ci.utility.prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts_response = prometheus.get(
         "alerts", payload={"silenced": False, "inhibited": False}
     )

--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -23,12 +23,14 @@ log = logging.getLogger(__name__)
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"
 )
 @skipif_managed_service
-def test_rbd_capacity_workload_alerts(workload_storageutilization_97p_rbd):
+def test_rbd_capacity_workload_alerts(
+    workload_storageutilization_97p_rbd, threading_lock
+):
     """
     Test that there are appropriate alerts when ceph cluster is utilized
     via RBD interface.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     measure_end_time = workload_storageutilization_97p_rbd.get("stop")
 
     # Check utilization on 97%
@@ -88,11 +90,13 @@ def test_rbd_capacity_workload_alerts(workload_storageutilization_97p_rbd):
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"
 )
 @skipif_managed_service
-def test_cephfs_capacity_workload_alerts(workload_storageutilization_97p_cephfs):
+def test_cephfs_capacity_workload_alerts(
+    workload_storageutilization_97p_cephfs, threading_lock
+):
     """
     Test that there are appropriate alerts when ceph cluster is utilized.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     measure_end_time = workload_storageutilization_97p_cephfs.get("stop")
 
     # Check utilization on 97%

--- a/tests/manage/monitoring/prometheus/test_ceph.py
+++ b/tests/manage/monitoring/prometheus/test_ceph.py
@@ -14,14 +14,14 @@ log = logging.getLogger(__name__)
 @tier4a
 @pytest.mark.polarion_id("OCS-903")
 @skipif_managed_service
-def test_corrupt_pg_alerts(measure_corrupt_pg):
+def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts when Placement group
     on one OSD is corrupted.ceph manager
     is unavailable and that this alert is cleared when the manager
     is back online.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_corrupt_pg.get("prometheus_alerts")
     for target_label, target_msg, target_states, target_severity in [
@@ -60,14 +60,14 @@ def test_corrupt_pg_alerts(measure_corrupt_pg):
 @tier4a
 @pytest.mark.polarion_id("OCS-898")
 @skipif_managed_service
-def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg):
+def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts for Ceph health triggered.
     For this check of Ceph Warning state is used measure_stop_ceph_osd
     utilization monitor and for Ceph Error state is used measure_corrupt_pg
     utilization.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")
     target_label = constants.ALERT_CLUSTERWARNINGSTATE

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -20,13 +20,13 @@ log = logging.getLogger(__name__)
 @tier4c
 @pytest.mark.polarion_id("OCS-1052")
 @skipif_managed_service
-def test_ceph_manager_stopped(measure_stop_ceph_mgr):
+def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
     """
     Test that there is appropriate alert when ceph manager
     is unavailable and that this alert is cleared when the manager
     is back online.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_ceph_mgr.get("prometheus_alerts")
@@ -50,13 +50,13 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr):
 @tier4c
 @pytest.mark.polarion_id("OCS-904")
 @skipif_managed_service
-def test_ceph_monitor_stopped(measure_stop_ceph_mon):
+def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
     """
     Test that there is appropriate alert related to ceph monitor quorum
     when there is even number of ceph monitors and that this alert
     is cleared when monitors are back online.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_ceph_mon.get("prometheus_alerts")
@@ -93,12 +93,12 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon):
 @pytest.mark.parametrize("create_mon_quorum_loss", [True])
 @skipif_managed_service
 @skipif_ocs_version("<4.9")
-def test_ceph_mons_quorum_lost(measure_stop_ceph_mon):
+def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
     """
     Test to verify that CephMonQuorumLost alert is seen and
     that this alert is cleared when monitors are back online.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_ceph_mon.get("prometheus_alerts")
@@ -122,12 +122,12 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon):
 @tier4c
 @pytest.mark.polarion_id("OCS-900")
 @skipif_managed_service
-def test_ceph_osd_stopped(measure_stop_ceph_osd):
+def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
     """
     Test that there is appropriate alert related to situation when ceph osd
     is down. Alert is cleared when osd disk is back online.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")

--- a/tests/manage/monitoring/prometheus/test_hpa.py
+++ b/tests/manage/monitoring/prometheus/test_hpa.py
@@ -17,11 +17,11 @@ logger = logging.getLogger(__name__)
 @marks.polarion_id("OCS-2375")
 @marks.bugzilla("1836299")
 @skipif_managed_service
-def test_hpa_maxreplica_alert():
+def test_hpa_maxreplica_alert(threading_lock):
     """
     Test to verify that no HPA max replica alert is triggered
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     logger.info(
         f"Verifying whether {constants.ALERT_KUBEHPAREPLICASMISMATCH} "

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -22,11 +22,11 @@ log = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
-def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
+def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock):
     """
     Test that there are appropriate alerts when NooBaa Bucket Quota is reached.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_noobaa_exceed_bucket_quota.get("prometheus_alerts")
 
@@ -119,12 +119,12 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
 @skipif_managed_service
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
-def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted):
+def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted, threading_lock):
     """
     Test that there are appropriate alerts when target bucket used of
     namespace store used in namespace bucket is deleted.
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_noobaa_ns_target_bucket_deleted.get("prometheus_alerts")
 

--- a/tests/manage/monitoring/prometheus/test_rgw.py
+++ b/tests/manage/monitoring/prometheus/test_rgw.py
@@ -19,13 +19,13 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2323")
 @pytest.mark.bugzilla("1953615")
 @skipif_managed_service
-def test_rgw_unavailable(measure_stop_rgw):
+def test_rgw_unavailable(measure_stop_rgw, threading_lock):
     """
     Test that there is appropriate alert when RGW is unavailable and that
     this alert is cleared when the RGW interface is back online.
 
     """
-    api = prometheus.PrometheusAPI()
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_rgw.get("prometheus_alerts")

--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -33,13 +33,13 @@ logger = logging.getLogger(__name__)
 @pytest.mark.first
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_managed_service
-def test_monitoring_enabled():
+def test_monitoring_enabled(threading_lock):
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
     has a post deployment marker) by asking for values of one ceph and one
     noobaa related metrics.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
 
     if (
         storagecluster_independent_check()
@@ -120,12 +120,12 @@ def test_ceph_mgr_dashboard_not_deployed():
 @tier1
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
-def test_ceph_rbd_metrics_available():
+def test_ceph_rbd_metrics_available(threading_lock):
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
     See also: https://ceph.com/rbd/new-in-nautilus-rbd-performance-monitoring/
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus, metrics.ceph_rbd_metrics
     )
@@ -143,7 +143,7 @@ def test_ceph_rbd_metrics_available():
 @metrics_for_external_mode_required
 @pytest.mark.polarion_id("OCS-1268")
 @skipif_managed_service
-def test_ceph_metrics_available():
+def test_ceph_metrics_available(threading_lock):
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
 
@@ -155,7 +155,7 @@ def test_ceph_metrics_available():
     Since ODF 4.9 only subset of all ceph metrics ``ceph_metrics_healthy`` will
     be always available, as noted in BZ 2028649.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus,
         metrics.ceph_metrics_healthy,
@@ -176,14 +176,14 @@ def test_ceph_metrics_available():
 @pytest.mark.post_ocp_upgrade
 @pytest.mark.polarion_id("OCS-1302")
 @skipif_managed_service
-def test_monitoring_reporting_ok_when_idle(workload_idle):
+def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.
 
     If this test case fails, the status is either reported wrong or the
     cluster is in a broken state. Either way, a failure here is not good.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
 
     health_result = prometheus.query_range(
         query="ceph_health_status",

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -32,12 +32,12 @@ CPU_USAGE_POD = (
 @marks.polarion_id("OCS-2364")
 @marks.bugzilla("1849309")
 @skipif_managed_service
-def test_mcg_cpu_usage(workload_idle):
+def test_mcg_cpu_usage(workload_idle, threading_lock):
     """
     Without any IO  workload, cpu utilization of MCG pods should be minimal.
     No pod should utilize more than 0.1 cpu units.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     cpu_result = prometheus.query_range(
         query=CPU_USAGE_POD + '{namespace="openshift-storage",pod=~"^noobaa.*"}',
         start=workload_idle["start"],

--- a/tests/manage/monitoring/prometheusmetrics/test_rgw.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_rgw.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 @tier4c
 @pytest.mark.polarion_id("OCS-2385")
 @skipif_managed_service
-def test_ceph_rgw_metrics_after_metrics_exporter_respin(rgw_deployments):
+def test_ceph_rgw_metrics_after_metrics_exporter_respin(
+    rgw_deployments, threading_lock
+):
     """
     RGW metrics should be provided via OCP Prometheus even after
     ocs-metrics-exporter pod is respinned.
@@ -52,7 +54,7 @@ def test_ceph_rgw_metrics_after_metrics_exporter_respin(rgw_deployments):
     )
 
     logger.info("Collect RGW metrics")
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus, metrics.ceph_rgw_metrics
     )

--- a/tests/manage/monitoring/test_workload_fixture.py
+++ b/tests/manage/monitoring/test_workload_fixture.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 @blue_squad
 @pytest.mark.libtest
 @skipif_managed_service
-def test_workload_rbd(workload_storageutilization_50p_rbd):
+def test_workload_rbd(workload_storageutilization_50p_rbd, threading_lock):
     """
     Purpose of this test is to make the workload fixture executed, and
     show how to query prometheus.
@@ -62,7 +62,7 @@ def test_workload_rbd(workload_storageutilization_50p_rbd):
     Note that this test is valid only on 3 osd cluster with all pools using
     3 way replication.
     """
-    prometheus = PrometheusAPI()
+    prometheus = PrometheusAPI(threading_lock=threading_lock)
     # Asking for values of `ceph_osd_stat_bytes_used` for every 15s in
     # when the workload fixture was utilizing 50% of the OCS storage.
     result_used = prometheus.query_range(

--- a/tests/manage/monitoring/test_workload_with_distruptions.py
+++ b/tests/manage/monitoring/test_workload_with_distruptions.py
@@ -263,7 +263,7 @@ class TestCephOSDSlowOps(object):
     @tier3
     @pytest.mark.polarion_id("OCS-5158")
     @blue_squad
-    def test_ceph_osd_slow_ops_alert(self, setup):
+    def test_ceph_osd_slow_ops_alert(self, setup, threading_lock):
         """
         Test to verify bz #1966139, more info about Prometheus alert - #1885441
 
@@ -279,7 +279,7 @@ class TestCephOSDSlowOps(object):
         storage ends - fail the test
         """
 
-        api = PrometheusAPI()
+        api = PrometheusAPI(threading_lock=threading_lock)
 
         while get_percent_used_capacity() < self.full_osd_threshold:
             time_passed_sec = time.perf_counter() - self.start_workload_time

--- a/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
+++ b/tests/manage/pv_services/pvc_clone/test_clone_when_pvc_full.py
@@ -47,7 +47,7 @@ class TestCloneWhenFull(ManageTest):
             access_modes_cephfs=[constants.ACCESS_MODE_RWO],
         )
 
-    def test_clone_when_full(self, pvc_clone_factory, pod_factory):
+    def test_clone_when_full(self, pvc_clone_factory, pod_factory, threading_lock):
         """
         Create a clone from an existing PVC when the PVC is 100% utilized.
         Verify data integrity.
@@ -57,7 +57,7 @@ class TestCloneWhenFull(ManageTest):
         """
         pvc_size_expanded = 6
         file_name = "fio_full"
-        prometheus_api = PrometheusAPI()
+        prometheus_api = PrometheusAPI(threading_lock=threading_lock)
 
         # Run IO to utilize 100% of volume
         log.info("Run IO on all pods to utilise 100% of PVCs")

--- a/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
+++ b/tests/manage/pv_services/pvc_resize/test_pvc_expansion_when_full.py
@@ -43,7 +43,7 @@ class TestPvcExpansionWhenFull(ManageTest):
             access_modes_cephfs=[constants.ACCESS_MODE_RWO],
         )
 
-    def test_pvc_expansion_when_full(self):
+    def test_pvc_expansion_when_full(self, threading_lock):
         """
         Verify PVC expansion when the PVC is 100% utilized.
         Verify utilization alert will stop firing after volume expansion.
@@ -79,7 +79,7 @@ class TestPvcExpansionWhenFull(ManageTest):
             )
             log.info(f"Verified: Used space on pod {pod_obj.name} is 100%")
 
-        prometheus_api = PrometheusAPI()
+        prometheus_api = PrometheusAPI(threading_lock=threading_lock)
 
         # Wait till utilization alerts starts
         for response in TimeoutSampler(140, 5, prometheus_api.get, "alerts"):


### PR DESCRIPTION
To avoid concurrency issues when `oc` cmd called same time when PrometheusAPI constructor logs in via `oc` we need to pass threading_lock every PrometheusAPI call, otherwise unauthorized user issues and other not expected issues may happen.

Fixes #4621