### PR TITLE
fix squad assignment for manage/rgw tests

### DIFF
--- a/tests/manage/rgw/test_bucket_creation.py
+++ b/tests/manage/rgw/test_bucket_creation.py
@@ -2,7 +2,12 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import acceptance, tier1, tier3
+from ocs_ci.framework.pytest_customization.marks import (
+    acceptance,
+    red_squad,
+    tier1,
+    tier3,
+)
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.ocs.exceptions import CommandFailed
 import botocore
@@ -11,6 +16,7 @@ import re
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestRGWBucketCreation:
     """
     Test creation of a bucket

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -6,7 +6,12 @@ from flaky import flaky
 from ocs_ci.ocs.bucket_utils import sync_object_directory
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import acceptance, tier1, tier3
+from ocs_ci.framework.pytest_customization.marks import (
+    acceptance,
+    red_squad,
+    tier1,
+    tier3,
+)
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import OBC
@@ -15,6 +20,7 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestBucketDeletion:
     """
     Test deletion of RGW buckets

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -32,6 +33,7 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@red_squad
 @tier4b
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2374")

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -4,6 +4,7 @@ import pytest
 import uuid
 
 from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     abort_all_multipart_upload,
@@ -48,6 +49,7 @@ def setup(pod_obj, rgw_bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@red_squad
 class TestS3MultipartUpload(ManageTest):
     """
     Test Multipart upload on RGW buckets

--- a/tests/manage/rgw/test_obc_quota.py
+++ b/tests/manage/rgw/test_obc_quota.py
@@ -12,11 +12,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     bugzilla,
     skipif_ocs_version,
+    red_squad,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @bugzilla("1940823")
 @skipif_ocs_version("<4.10")
 class TestOBCQuota:

--- a/tests/manage/rgw/test_object_bucket_size.py
+++ b/tests/manage/rgw/test_object_bucket_size.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
+    red_squad,
     skipif_managed_service,
 )
 from ocs_ci.ocs.bucket_utils import get_bucket_available_size
@@ -56,6 +57,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
         )
 
 
+@red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.7")
 @pytest.mark.polarion_id("OCS-2476")

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
 )
 
+from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.resources.objectbucket import OBC
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
@@ -15,6 +16,7 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 class TestObjectIntegrity(ManageTest):
     """
     Test data integrity of RGW buckets

--- a/tests/manage/rgw/test_rgw_pod_existence.py
+++ b/tests/manage/rgw/test_rgw_pod_existence.py
@@ -1,7 +1,7 @@
 import logging
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import acceptance
+from ocs_ci.framework.pytest_customization.marks import acceptance, red_squad
 from ocs_ci.helpers.helpers import storagecluster_independent_check
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -13,6 +13,7 @@ from ocs_ci.utility.rgwutils import get_rgw_count
 logger = logging.getLogger(__name__)
 
 
+@red_squad
 @acceptance
 class TestRGWPodExistence:
     """


### PR DESCRIPTION
Fix squad assignment for following tests:
```
test_bucket_creation[3-RGW-OC]              tests/manage/rgw/test_bucket_creation.py
test_duplicate_bucket_creation[3-RGW-OC]    tests/manage/rgw/test_bucket_creation.py
test_bucket_delete[3-RGW-OC]                tests/manage/rgw/test_bucket_deletion.py
test_bucket_delete_with_objects[RGW-OC]     tests/manage/rgw/test_bucket_deletion.py
test_nonexist_bucket_delete[RGW-OC]         tests/manage/rgw/test_bucket_deletion.py
test_rgw_host_node_failure                  tests/manage/rgw/test_host_node_failure.py
test_multipart_upload_operations            tests/manage/rgw/test_multipart_upload.py
test_obc_quota[1-RGW-OC-quota0]             tests/manage/rgw/test_obc_quota.py
test_object_bucket_size                     tests/manage/rgw/test_object_bucket_size.py
test_check_object_integrity                 tests/manage/rgw/test_object_integrity.py
test_empty_file_integrity                   tests/manage/rgw/test_object_integrity.py
test_rgw_pod_existence                      tests/manage/rgw/test_rgw_pod_existence.py
```

Initially the assignment for `test_bucket_creation.py` will be missing, to check if it will be catch by the PR checks.