### PR TITLE
fixed minor logic issue

### DIFF
--- a/ocs_ci/ocs/ui/odf_topology.py
+++ b/ocs_ci/ocs/ui/odf_topology.py
@@ -190,7 +190,8 @@ def get_deployment_details_cli(deployment_name) -> dict:
         or node_metadata.get("labels") is None
     ):
         deployment_details["labels"] = ""
-    deployment_details["labels"] = node_metadata.get("labels")
+    else:
+        deployment_details["labels"] = node_metadata.get("labels")
     deployment_details[
         "annotation"
     ] = f"{len(node_metadata.get('annotations'))} annotation"


### PR DESCRIPTION
When deployment has no labels it should have empty string but not `null`

Addressed issue hit in automation regression
https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/557/14689/676157/676270/676273/log