### PR TITLE
added skip decorator to some monitoring tests

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -12,6 +12,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     metrics_for_external_mode_required,
     blue_squad,
+    skipif_mcg_only,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp
@@ -133,6 +134,7 @@ def test_ceph_rbd_metrics_available():
     assert list_of_metrics_without_results == [], msg
 
 
+@skipif_mcg_only
 @blue_squad
 @tier1
 @pytest.mark.bugzilla("2203795")


### PR DESCRIPTION
0 metrics found on MCG only deployment. We need to skip these tests to avoid failures

https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/599/14644/673212/673213/673214/log?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED%26page.page%3D1