### PR TITLE
Adds "skipif_mcg_only" decorator to the tests which are using ceph resources for mcg_only deployment

### DIFF
--- a/tests/manage/rgw/test_bucket_creation.py
+++ b/tests/manage/rgw/test_bucket_creation.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
+    skipif_mcg_only,
     red_squad,
     tier1,
     tier3,
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @red_squad
+@skipif_mcg_only
 class TestRGWBucketCreation:
     """
     Test creation of a bucket

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -9,6 +9,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
     red_squad,
+    skipif_mcg_only,
     tier1,
     tier3,
 )
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @red_squad
+@skipif_mcg_only
 class TestBucketDeletion:
     """
     Test deletion of RGW buckets

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -4,7 +4,7 @@ import pytest
 import uuid
 
 from ocs_ci.framework.testlib import ManageTest, tier1
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     abort_all_multipart_upload,
@@ -50,6 +50,7 @@ def setup(pod_obj, rgw_bucket_factory, test_directory_setup):
 
 
 @red_squad
+@skipif_mcg_only
 class TestS3MultipartUpload(ManageTest):
     """
     Test Multipart upload on RGW buckets

--- a/tests/manage/rgw/test_obc_quota.py
+++ b/tests/manage/rgw/test_obc_quota.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     bugzilla,
     skipif_ocs_version,
+    skipif_mcg_only,
     red_squad,
 )
 
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @bugzilla("1940823")
 @skipif_ocs_version("<4.10")
+@skipif_mcg_only
 class TestOBCQuota:
     """
     Test OBC Quota feature

--- a/tests/manage/rgw/test_object_bucket_size.py
+++ b/tests/manage/rgw/test_object_bucket_size.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
+    skipif_mcg_only,
     skipif_managed_service,
 )
 from ocs_ci.ocs.bucket_utils import get_bucket_available_size
@@ -63,6 +64,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
 @pytest.mark.polarion_id("OCS-2476")
 @bugzilla("1880747")
 @bugzilla("1880748")
+@skipif_mcg_only
 @tier1
 def test_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
     """

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
 )
 
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.resources.objectbucket import OBC
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @red_squad
+@skipif_mcg_only
 class TestObjectIntegrity(ManageTest):
     """
     Test data integrity of RGW buckets


### PR DESCRIPTION
Fixes #8574 