### PR TITLE
Skip the test case test_mon_failures_with_intransit_encryption due to the ocs-ci issue 8464

### DIFF
--- a/tests/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/encryption/test_mon_failure_in_intransit_encryption.py
@@ -26,6 +26,9 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.13")
 @pytest.mark.polarion_id("OCS-4919")
 @green_squad
+@pytest.mark.skip(
+    reason="Skipping due to the issue https://github.com/red-hat-storage/ocs-ci/issues/8464"
+)
 class TestMonFailuresWithIntransitEncryption:
     @pytest.fixture(autouse=True)
     def teardown_fixture(self, request):


### PR DESCRIPTION
Skip the test case test_mon_failures_with_intransit_encryption due to the issue #8464. This is to avoid errors in the test cases that foww this test case.