### PR TITLE
test_ceph_metrics_presence_when_osd_down avoid failures because of trying to reach OSD pods

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_negative.py
@@ -169,6 +169,7 @@ def test_monitoring_shows_osd_down(measure_stop_ceph_osd, threading_lock):
 
 @blue_squad
 @tier3
+@skipif_external_mode
 @bugzilla("2203795")
 @pytest.mark.polarion_id("OCS-2734")
 @skipif_managed_service


### PR DESCRIPTION
failure case: https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/557/14972/694869/694945/694948/log

osd_to_stop = osds[-1]
E       IndexError: list index out of range

In an OCS external mode cluster, the OSD pods are managed by external ceph and may not be directly visible or manageable
