### PR TITLE
When getting the rook-ceph-tool pod use the provider kubeconfig parameter if exist in the run

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -739,7 +739,7 @@ def get_ceph_tools_pod(skip_creating_pod=False, namespace=None):
         )
         cluster_kubeconfig = provider_kubeconfig
     else:
-        cluster_kubeconfig = ""
+        cluster_kubeconfig = config.ENV_DATA.get("provider_kubeconfig", "")
 
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     ocp_pod_obj = OCP(


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/8412