### PR TITLE
add bz mark for failing test

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     metrics_for_external_mode_required,
     blue_squad,
     skipif_mcg_only,
+    bugzilla,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp
@@ -167,6 +168,7 @@ def test_ceph_metrics_available():
     assert list_of_metrics_without_results == [], msg
 
 
+@bugzilla("2238400")
 @skipif_mcg_only
 @blue_squad
 @tier1


### PR DESCRIPTION
2023-09-09 04:55:29,516 - Thread-2 - DEBUG - urllib3.connectionpool._new_conn.939 - Starting new HTTPS connection (1): prometheus-k8s-openshift-monitoring.apps.j-039aikt1c33-t1.qe.rh-ocs.com:443
2023-09-09 04:55:29,579 - Thread-2 - DEBUG - urllib3.connectionpool._make_request.433 - https://prometheus-k8s-openshift-monitoring.apps.j-039aikt1c33-t1.qe.rh-ocs.com:443 "GET /api/v1/query?query=cluster%3Aceph_disk_latency%3Ajoin_ceph_node_disk_irate1m&time=1694235329.513803 HTTP/1.1" 200 87
2023-09-09 04:55:29,581 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.validate_status.303 - content value: {'status': 'success', 'data': {'resultType': 'vector', 'result': []}}
2023-09-09 04:55:29,582 - Thread-2 - WARNING - ocs_ci.utility.retry.f_retry.43 - list index out of range, Retrying in 5 seconds...
2023-09-09 04:55:34,587 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.get.422 - GET https://prometheus-k8s-openshift-monitoring.apps.j-039aikt1c33-t1.qe.rh-ocs.com/api/v1/query
2023-09-09 04:55:34,587 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.get.423 - headers={'Authorization': 'Bearer sha256~3bVSj60T2LuFCsg2PJ5jHK5MarLwvaEAqFe_dsOlBBY'}
2023-09-09 04:55:34,587 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.get.424 - verify=False
2023-09-09 04:55:34,587 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.get.425 - params={'query': '**cluster:ceph_disk_latency:join_ceph_node_disk_irate1m**', 'time': '1694235334.587269'}
2023-09-09 04:55:34,589 - Thread-2 - DEBUG - urllib3.connectionpool._new_conn.939 - Starting new HTTPS connection (1): prometheus-k8s-openshift-monitoring.apps.j-039aikt1c33-t1.qe.rh-ocs.com:443
2023-09-09 04:55:34,653 - Thread-2 - DEBUG - urllib3.connectionpool._make_request.433 - https://prometheus-k8s-openshift-monitoring.apps.j-039aikt1c33-t1.qe.rh-ocs.com:443 "GET /api/v1/query?query=cluster%3Aceph_disk_latency%3Ajoin_ceph_node_disk_irate1m&time=1694235334.587269 HTTP/1.1" 200 87
2023-09-09 04:55:34,655 - Thread-2 - DEBUG - /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/ocs_ci/utility/prometheus.py.validate_status.303 - content value: {'status': 'success', 'data': {'resultType': 'vector', 'result': []}}
2023-09-09 04:55:46,536 - MainThread - ERROR - tests.manage.monitoring.conftest.workload_idle.785 - Timed out after 600s running get("load_status")
2023-09-09 04:55:46,537 - MainThread - ERROR - tests.manage.monitoring.conftest.workload_idle.786 - io_in_bf failed to stop after 600 timeout, bug in io_in_bf (of ocs-ci) prevents execution of test cases which uses this fixture, rerun the affected test cases in a dedicated run and consider ocs-ci fix

BZ #2238400


