### PR TITLE
A fixing to performance lib for correct calculation of pvc/clone deletion time in 4.14

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -12,7 +12,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
-
+from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 DATE_TIME_FORMAT = "%Y I%m%d %H:%M:%S.%f"
@@ -680,7 +680,16 @@ def get_pvc_provision_times(interface, pvc_name, start_time, time_type="all", op
                                 results[name]["delete"][
                                     "start"
                                 ] = extruct_timestamp_from_log(line)
-                        if re.search(f'delete "{pv_name}": succeeded', line):
+                        if (
+                            re.search(f'delete "{pv_name}": succeeded', line)
+                            and (
+                                version.get_semantic_ocs_version_from_config()
+                                <= version.VERSION_4_13
+                            )
+                        ) or re.search(
+                            f'delete "{pv_name}": persistentvolume deleted succeeded',
+                            line,
+                        ):
                             if results[name]["delete"]["end"] is None:
                                 results[name]["delete"][
                                     "end"

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
@@ -191,7 +191,7 @@ class TestBulkCloneCreation(PASTest):
                 resource_count=self.pvc_count,
                 namespace=self.namespace,
                 status=constants.STATUS_COMPLETED,
-                timeout=5400, #old value 1200
+                timeout=1200,
                 sleep_time=30,
             )
             log.info("All the PODs completed writing data to the PVC's")
@@ -224,7 +224,7 @@ class TestBulkCloneCreation(PASTest):
                     resource_count=self.pvc_count * 2,
                     namespace=self.namespace,
                     status=constants.STATUS_BOUND,
-                    timeout=5400,#old value 1200
+                    timeout=1200,
                     sleep_time=30,
                 )
             except Exception as ex:
@@ -252,7 +252,7 @@ class TestBulkCloneCreation(PASTest):
             )
 
             log.info(
-                f"Total creation time = {total_time} secs, csi creation time = {csi_creation_time} secs,"
+                f"Total creation time = {total_time} secs, csi creation time = {csi_creation_time},"
                 f" data size = {self.total_files_size} MB, speed = {speed} MB/sec "
                 f"for {self.interface} clone in bulk of {self.pvc_count} clones."
             )

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_clone_performance.py
@@ -5,6 +5,7 @@ The results are uploaded to the ES server
 """
 import logging
 import re
+import json
 
 import pytest
 
@@ -179,6 +180,9 @@ class TestBulkCloneCreation(PASTest):
                 project=self.namespace,
                 tmp_path=tmp_path,
             )
+
+            log.debug(f"PODs data list is : {json.dumps(pod_dict_list, indent=3)}")
+
             job_pod_file.create(namespace=self.namespace)
 
             # Check all PODs are in Completed state
@@ -187,7 +191,7 @@ class TestBulkCloneCreation(PASTest):
                 resource_count=self.pvc_count,
                 namespace=self.namespace,
                 status=constants.STATUS_COMPLETED,
-                timeout=1200,
+                timeout=5400, #old value 1200
                 sleep_time=30,
             )
             log.info("All the PODs completed writing data to the PVC's")
@@ -220,7 +224,7 @@ class TestBulkCloneCreation(PASTest):
                     resource_count=self.pvc_count * 2,
                     namespace=self.namespace,
                     status=constants.STATUS_BOUND,
-                    timeout=1200,
+                    timeout=5400,#old value 1200
                     sleep_time=30,
                 )
             except Exception as ex:
@@ -248,7 +252,7 @@ class TestBulkCloneCreation(PASTest):
             )
 
             log.info(
-                f"Total creation time = {total_time} secs, csi creation time = {csi_creation_time},"
+                f"Total creation time = {total_time} secs, csi creation time = {csi_creation_time} secs,"
                 f" data size = {self.total_files_size} MB, speed = {speed} MB/sec "
                 f"for {self.interface} clone in bulk of {self.pvc_count} clones."
             )


### PR DESCRIPTION
This PR is a very much needed fix, since the deletion time notification has changed in the csi logs in ODF 4.14. 

Therefore we need to keep the old code for ODF <=4.13 and implement a new calculation starting 4.14. 
