### PR TITLE
dump configuration to file at the end of the execution

### DIFF
--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -2,7 +2,12 @@ import os
 import pytest
 import logging
 from py.xml import html
-from ocs_ci.utility.utils import dump_config_to_file, email_reports, save_reports, ocsci_log_path
+from ocs_ci.utility.utils import (
+    dump_config_to_file,
+    email_reports,
+    save_reports,
+    ocsci_log_path,
+)
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework import GlobalVariables as GV
 

--- a/ocs_ci/utility/tests/test_utils.py
+++ b/ocs_ci/utility/tests/test_utils.py
@@ -7,7 +7,7 @@ from sys import platform
 import pytest
 
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.utility import utils
+from ocs_ci.utility import utils, version
 
 
 def test_mask_secret_null():
@@ -166,3 +166,27 @@ def test_get_none_obj_attr():
 
 def test_get_empty_attr():
     assert utils.get_attr_chain(A(1), "") is None
+
+
+class B:
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "B-object"
+
+
+@pytest.mark.parametrize(
+    "data_to_filter,expected_output",
+    [
+        ({"a": "A", "b": "B"}, {"a": "A", "b": "B"}),
+        ({"v": version.VERSION_4_12}, {"v": "4.12"}),
+        ({"o": B()}, {"o": "B-object"}),
+        ({"t": [1, 2, B()]}, {"t": [1, 2, "B-object"]}),
+        ({"t": tuple([1, 2, B()])}, {"t": [1, 2, "B-object"]}),
+        ([1, 2, B()], [1, 2, "B-object"]),
+        (tuple([1, 2, B()]), [1, 2, "B-object"]),
+    ],
+)
+def test_filter_unrepresentable_values(data_to_filter, expected_output):
+    assert utils.filter_unrepresentable_values(data_to_filter) == expected_output

--- a/ocs_ci/utility/tests/test_utils.py
+++ b/ocs_ci/utility/tests/test_utils.py
@@ -186,6 +186,12 @@ class B:
         ({"t": tuple([1, 2, B()])}, {"t": [1, 2, "B-object"]}),
         ([1, 2, B()], [1, 2, "B-object"]),
         (tuple([1, 2, B()]), [1, 2, "B-object"]),
+        ([{"a": "b"}, 1, 2, 3], [{"a": "b"}, 1, 2, 3]),
+        ([{"a": "b"}, [B(), B()], 2, 3], [{"a": "b"}, ["B-object", "B-object"], 2, 3]),
+        (
+            [{"a": "b"}, [{"o": B()}, {"p": B()}], 2, 3],
+            [{"a": "b"}, [{"o": "B-object"}, {"p": "B-object"}], 2, 3],
+        ),
     ],
 )
 def test_filter_unrepresentable_values(data_to_filter, expected_output):

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2799,7 +2799,7 @@ def filter_unrepresentable_values(data_to_filter):
             if isinstance(data_to_filter[i], tuple):
                 data_to_filter[i] = list(data_to_filter[i])
             if isinstance(data_to_filter[i], (dict, list)):
-                data_to_filter = filter_unrepresentable_values(data_to_filter[i])
+                data_to_filter[i] = filter_unrepresentable_values(data_to_filter[i])
             elif not isinstance(
                 data_to_filter[i], (dict, list, tuple, str, int, float)
             ):

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -63,13 +63,14 @@ class TestFailurePropagator:
         if "acceptance" in config.RUN.get("cli_params").get("-m", ""):
             config.RUN["skipped_on_ceph_health_threshold"] = 0
 
-        log.info(
-            f"number_of_eligible_tests: {config.RUN.get('number_of_eligible_tests')}"
-        )
+        log.info(f"number_of_eligible_tests: {number_of_eligible_tests}")
         log.info(
             f"skipped_on_ceph_health_threshold: {config.RUN.get('skipped_on_ceph_health_threshold')}"
         )
         log.info(f"skip_reason_test_found: {config.RUN.get('skip_reason_test_found')}")
+        log.info(
+            f"skipped_tests_ceph_health: {config.RUN.get('skipped_tests_ceph_health')}"
+        )
 
         if number_of_eligible_tests > 0:
             config.RUN["skipped_on_ceph_health_ratio"] = round(

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from ocs_ci.framework import config
@@ -20,6 +21,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     performance,
     scale,
 )
+
+log = logging.getLogger(__name__)
 
 
 @ignore_owner
@@ -60,6 +63,14 @@ class TestFailurePropagator:
         if "acceptance" in config.RUN.get("cli_params").get("-m", ""):
             config.RUN["skipped_on_ceph_health_threshold"] = 0
 
+        log.info(
+            f"number_of_eligible_tests: {config.RUN.get('number_of_eligible_tests')}"
+        )
+        log.info(
+            f"skipped_on_ceph_health_threshold: {config.RUN.get('skipped_on_ceph_health_threshold')}"
+        )
+        log.info(f"skip_reason_test_found: {config.RUN.get('skip_reason_test_found')}")
+
         if number_of_eligible_tests > 0:
             config.RUN["skipped_on_ceph_health_ratio"] = round(
                 (
@@ -67,6 +78,9 @@ class TestFailurePropagator:
                     / number_of_eligible_tests
                 ),
                 1,
+            )
+            log.info(
+                f"skipped_on_ceph_health_ratio: {config.RUN.get('skipped_on_ceph_health_ratio')}"
             )
             message = (
                 f"This run had {config.RUN['skipped_on_ceph_health_ratio'] * 100}% of the "


### PR DESCRIPTION
Dump configuration to file at the end of the execution similarly as it is done in the beginning.
This might be useful for debugging various issues (e.g. compare the config with the dump from the start).

I have to introduce new function `filter_unrepresentable_values`, which converts _object like_ values from config object to string to be able to dump them to yaml.

I'm also adding few useful log messages to `test_report_skip_triggering_test`.