### PR TITLE
Modify test_respin_app_pod_exported_nfs_volume_incluster to address teardown of deployment pod and pvc

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -610,6 +610,8 @@ SERVICE_ACCOUNT_TOKEN_SECRET = os.path.join(
 
 SIMPLE_APP_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "simple-app.yaml")
 
+NFS_APP_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "nfs_test_app.yaml")
+
 FEDORA_DC_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "fedora_dc.yaml")
 
 PERF_DC_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "performance_dc.yaml")

--- a/ocs_ci/templates/app-pods/nfs_test_app.yaml
+++ b/ocs_ci/templates/app-pods/nfs_test_app.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: nfs-test-pod
+  namespace: openshift-storage
+  labels:
+    app: nfs-test-pod
+spec:
+  template:
+    metadata:
+      labels:
+        name: nfs-test-pod
+    spec:
+      restartPolicy: Always
+      volumes:
+      - name: vol
+        persistentVolumeClaim:
+          claimName: nfs-pvc
+      containers:
+      - name: fedora
+        image: fedora
+        command: ['/bin/bash', '-ce', 'tail -f /dev/null']
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities: {}
+          privileged: true
+        volumeMounts:
+        - mountPath: /mnt
+          name: vol
+        livenessProbe:
+          exec:
+            command:
+            - 'sh'
+            - '-ec'
+            - 'df /mnt'
+          initialDelaySeconds: 3
+          periodSeconds: 3
+  replicas: 1
+  triggers:
+    - type: ConfigChange
+  paused: false

--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1284,8 +1284,7 @@ class TestNfsEnable(ManageTest):
                 out_yaml_format=False,
             )
             assert result.rstrip() == "Before respin" + """\n""" + "After respin"
-        except Exception as ex:
-            log.info(f"{ex}")
+
         finally:
             # Delete deployment config
             cmd_delete_deployment_config = "delete dc nfs-test-pod"

--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1143,52 +1143,7 @@ class TestNfsEnable(ManageTest):
 
             # Create deployment config for app pod
             log.info("----create deployment config----")
-            '''
-            deployment_config = """
-                        apiVersion: apps.openshift.io/v1
-                        kind: DeploymentConfig
-                        metadata:
-                          name: nfs-test-pod
-                          namespace: openshift-storage
-                          labels:
-                            app: nfs-test-pod
-                        spec:
-                          template:
-                            metadata:
-                              labels:
-                                name: nfs-test-pod
-                            spec:
-                              restartPolicy: Always
-                              volumes:
-                              - name: vol
-                                persistentVolumeClaim:
-                                  claimName: nfs-pvc
-                              containers:
-                              - name: fedora
-                                image: fedora
-                                command: ['/bin/bash', '-ce', 'tail -f /dev/null']
-                                imagePullPolicy: IfNotPresent
-                                securityContext:
-                                  capabilities: {}
-                                  privileged: true
-                                volumeMounts:
-                                - mountPath: /mnt
-                                  name: vol
-                                livenessProbe:
-                                  exec:
-                                    command:
-                                    - 'sh'
-                                    - '-ec'
-                                    - 'df /mnt'
-                                  initialDelaySeconds: 3
-                                  periodSeconds: 3
-                          replicas: 1
-                          triggers:
-                            - type: ConfigChange
-                          paused: false
-                        """
-                        '''
-            deployment_config_data = templating.load_yaml(constants.FIO_DEPLOYMENT_YAML)
+            deployment_config_data = templating.load_yaml(constants.NFS_APP_POD_YAML)
             helpers.create_resource(**deployment_config_data)
             time.sleep(60)
 

--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 import time
-import yaml
 import os
 
 
@@ -10,6 +9,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility.connection import Connection
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
+from ocs_ci.utility import templating
 from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -1143,6 +1143,7 @@ class TestNfsEnable(ManageTest):
 
             # Create deployment config for app pod
             log.info("----create deployment config----")
+            '''
             deployment_config = """
                         apiVersion: apps.openshift.io/v1
                         kind: DeploymentConfig
@@ -1186,7 +1187,8 @@ class TestNfsEnable(ManageTest):
                             - type: ConfigChange
                           paused: false
                         """
-            deployment_config_data = yaml.safe_load(deployment_config)
+                        '''
+            deployment_config_data = templating.load_yaml(constants.FIO_DEPLOYMENT_YAML)
             helpers.create_resource(**deployment_config_data)
             time.sleep(60)
 


### PR DESCRIPTION
Updated test_respin_app_pod_exported_nfs_volume_incluster to handle deployment deletion and pvc deletion if test fails. Fixes https://github.com/red-hat-storage/ocs-ci/issues/8602