### PR TITLE
test_pvc_snapshot_performance.py fix  - increasing get_fio_results timeout

### DIFF
--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -250,7 +250,7 @@ class TestPvcSnapshotPerformance(PASTest):
             self.pod_object.fillup_fs(size=file_size, fio_filename=file_name)
 
             # Wait for fio to finish
-            fio_result = self.pod_object.get_fio_results()
+            fio_result = self.pod_object.get_fio_results(timeout=1800)
             err_count = fio_result.get("jobs")[0].get("error")
             assert (
                 err_count == 0
@@ -606,7 +606,6 @@ class TestPvcSnapshotPerformance(PASTest):
         self.full_results.add_key("threads", threads)
         self.full_results.add_key("interface", interface)
         for test_num in range(self.tests_numbers):
-
             test_results = {"creation_time": None, "csi_creation_time": None}
 
             # deploy the smallfile workload

--- a/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_snapshot_performance.py
@@ -250,7 +250,7 @@ class TestPvcSnapshotPerformance(PASTest):
             self.pod_object.fillup_fs(size=file_size, fio_filename=file_name)
 
             # Wait for fio to finish
-            fio_result = self.pod_object.get_fio_results(timeout=1800)
+            fio_result = self.pod_object.get_fio_results(timeout=3600)
             err_count = fio_result.get("jobs")[0].get("error")
             assert (
                 err_count == 0


### PR DESCRIPTION
For snapshot of 100GB size cephFS single snapshot test case was failing. 
I increased get_fio_results timeout from 600 ( default) to 1800. 