### PR TITLE
test_pvc_bulk_creation_deletion_performance - a fix for reading pvc deletion logs in 4.14

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -924,7 +924,7 @@ def delete_bulk_pvcs(pvc_yaml_dir, pv_names_list, namespace):
     cmd = f"delete -f {pvc_yaml_dir}/"
     oc.exec_oc_cmd(command=cmd, out_yaml_format=False)
 
-    time.sleep(len(pv_names_list) * 2)  # previously was len(pv_names_list) / 2
+    time.sleep(len(pv_names_list) * 5)  # previously was len(pv_names_list) / 2
 
     for pv_name in pv_names_list:
         validate_pv_delete(pv_name)

--- a/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
+++ b/tests/e2e/performance/csi_tests/test_pvc_bulk_creation_deletion_performance.py
@@ -147,7 +147,7 @@ class TestPVCCreationPerformance(PASTest):
         self.interface = interface_type
         self.sc_obj = storageclass_factory(self.interface)
 
-        bulk_creation_time_limit = bulk_size / 2
+        bulk_creation_time_limit = bulk_size  # old value was bulk_size / 2
 
         log.info(f"Start creating new {bulk_size} PVCs")
 


### PR DESCRIPTION
This PR contains a fix to support reading deletion times from logs in 4.14. 