### PR TITLE
fix test_failure_propagator

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -64,8 +64,8 @@ run it belongs here.
 * `skipped_on_ceph_health_ratio` - The ratio of tests skipped due to Ceph unhealthy against the
   number of tests being collected for the test execution
 * `skipped_on_ceph_health_threshold` - The allowed threshold for the ratio of tests skipped due to Ceph unhealthy against the
-  number of tests being collected for the test execution. The default value is set to 0.1 (10%).
-  For acceptance suite, the value would be set to 0
+  number of tests being collected for the test execution. The default value is set to 0.
+  For acceptance suite, the value would be always overwritten to 0.
 
 #### DEPLOYMENT
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -37,7 +37,7 @@ RUN:
   skipped_tests_ceph_health: 0
   number_of_tests: None
   skipped_on_ceph_health_ratio: 0
-  skipped_on_ceph_health_threshold: 0.1
+  skipped_on_ceph_health_threshold: 0
 
 
 # In this section we are storing all deployment related configuration but not

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -78,7 +78,7 @@ class TestFailurePropagator:
                     config.RUN.get("skipped_tests_ceph_health")
                     / number_of_eligible_tests
                 ),
-                1,
+                3,
             )
             log.info(
                 f"skipped_on_ceph_health_ratio: {config.RUN.get('skipped_on_ceph_health_ratio')}"


### PR DESCRIPTION
- set default skipped_on_ceph_health_threshold to 0
- update rounding of skipped_on_ceph_health_ratio to 3 digits