### PR TITLE
RDR - Sequential failover from UI

### DIFF
--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -31,7 +31,6 @@ if config.RUN.get("rdr_failover_via_ui"):
     tier_name = tier4a
 
 
-@tier1
 class TestSequentialFailover:
     """
     Test Sequential Failover actions

--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -6,7 +6,7 @@ import pytest
 
 from ocs_ci.framework import config
 
-# from ocs_ci.framework.testlib import tier1, tier4a
+from ocs_ci.framework.testlib import tier1, polarion_id
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 polarion_id_primary_up = "OCS-4771"
 polarion_id_primary_down = "OCS-4770"
-# tier_name = tier1
+tier_name = tier1
 if config.RUN.get("rdr_failover_via_ui"):
     polarion_id_primary_up = "OCS-5032"
     polarion_id_primary_down = "OCS-5033"
-    # tier_name = tier4a
+    tier_name = pytest.mark.tier4a
 
 
 class TestSequentialFailover:
@@ -43,12 +43,12 @@ class TestSequentialFailover:
         argvalues=[
             pytest.param(
                 False,
-                # marks=[polarion_id(polarion_id_primary_up), tier_name],
+                marks=[polarion_id(polarion_id_primary_up), tier_name],
                 id="primary_up",
             ),
             pytest.param(
                 True,
-                # marks=[polarion_id(polarion_id_primary_down), tier_name],
+                marks=[polarion_id(polarion_id_primary_down), tier_name],
                 id="primary_down",
             ),
         ],

--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -56,6 +56,7 @@ class TestSequentialFailover:
     def test_sequential_failover_to_secondary(
         self,
         primary_cluster_down,
+        setup_acm_ui,
         dr_workload,
         nodes_multicluster,
         node_restart_teardown,

--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -5,13 +5,30 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.testlib import tier1, tier4a, polarion_id
 from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.utility import version
+from ocs_ci.ocs.acm.acm import AcmAddClusters
+from ocs_ci.helpers.dr_helpers_ui import (
+    dr_submariner_validation_from_ui,
+    check_cluster_status_on_acm_console,
+    failover_relocate_ui,
+    verify_failover_relocate_status_ui,
+)
 
 logger = logging.getLogger(__name__)
+
+polarion_id_primary_up = "OCS-4771"
+polarion_id_primary_down = "OCS-4770"
+tier_name = tier1
+if config.RUN.get("rdr_failover_via_ui"):
+    polarion_id_primary_up = "OCS-5032"
+    polarion_id_primary_down = "OCS-5033"
+    tier_name = tier4a
 
 
 @tier1
@@ -25,10 +42,14 @@ class TestSequentialFailover:
         argnames=["primary_cluster_down"],
         argvalues=[
             pytest.param(
-                False, marks=pytest.mark.polarion_id("OCS-4771"), id="primary_up"
+                False,
+                marks=[polarion_id(polarion_id_primary_up), tier_name],
+                id="primary_up",
             ),
             pytest.param(
-                True, marks=pytest.mark.polarion_id("OCS-4770"), id="primary_down"
+                True,
+                marks=[polarion_id(polarion_id_primary_down), tier_name],
+                id="primary_down",
             ),
         ],
     )
@@ -43,7 +64,15 @@ class TestSequentialFailover:
         Tests to verify failover action for multiple workloads one after another from primary to secondary cluster
         when primary cluster is Up/Down
 
+        This test is also compatible to be run from ACM UI. Pass the yaml conf/ocsci/dr_ui.yaml to test from UI.
+
         """
+        if config.RUN.get("rdr_failover_via_ui"):
+            ocs_version = version.get_semantic_ocs_version_from_config()
+            if ocs_version <= version.VERSION_4_12:
+                logger.error("ODF/ACM version isn't supported for Failover operation")
+                raise NotImplementedError
+        acm_obj = AcmAddClusters()
         workloads = dr_workload(num_of_subscription=5)
 
         primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
@@ -63,23 +92,54 @@ class TestSequentialFailover:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         time.sleep(wait_time * 60)
 
+        if config.RUN.get("rdr_failover_via_ui"):
+            logger.info("Start the process of Failover from ACM UI")
+            config.switch_acm_ctx()
+            dr_submariner_validation_from_ui(acm_obj)
+
         # Stop primary cluster nodes
         if primary_cluster_down:
             logger.info(f"Stopping nodes of primary cluster: {primary_cluster_name}")
             nodes_multicluster[primary_cluster_index].stop_nodes(primary_cluster_nodes)
 
-        # Initiate failover for all the workloads one after another
         config.switch_acm_ctx()
+        if config.RUN.get("rdr_failover_via_ui"):
+            if primary_cluster_down:
+                # Verify that the cluster is marked unknown in the ACM console
+                if config.RUN.get("rdr_failover_via_ui"):
+                    config.switch_acm_ctx()
+                    check_cluster_status_on_acm_console(
+                        acm_obj,
+                        down_cluster_name=primary_cluster_name,
+                        expected_text="Unknown",
+                    )
+            else:
+                # Verify that the cluster is marked Ready in the ACM console
+                check_cluster_status_on_acm_console(acm_obj)
+
+        # Initiate failover for all the workloads one after another
         failover_results = []
         with ThreadPoolExecutor() as executor:
             for wl in workloads:
-                failover_results.append(
-                    executor.submit(
-                        dr_helpers.failover,
-                        failover_cluster=secondary_cluster_name,
-                        namespace=wl.workload_namespace,
+                if config.RUN.get("rdr_failover_via_ui"):
+                    # Sequential failover process via ACM UI
+                    failover_relocate_ui(
+                        acm_obj,
+                        scheduling_interval=scheduling_interval,
+                        workload_to_move=f"{wl.workload_name}-1",
+                        policy_name=wl.dr_policy_name,
+                        failover_or_preferred_cluster=secondary_cluster_name,
+                        action=constants.ACTION_FAILOVER,
                     )
-                )
+                else:
+                    # Failover process via CLI
+                    failover_results.append(
+                        executor.submit(
+                            dr_helpers.failover,
+                            failover_cluster=secondary_cluster_name,
+                            namespace=wl.workload_namespace,
+                        )
+                    )
                 time.sleep(5)
 
         # Wait for failover results
@@ -118,3 +178,9 @@ class TestSequentialFailover:
         dr_helpers.wait_for_mirroring_status_ok(
             replaying_images=sum([wl.workload_pvc_count for wl in workloads])
         )
+
+        if config.RUN.get("rdr_failover_via_ui"):
+            config.switch_acm_ctx()
+            verify_failover_relocate_status_ui(
+                acm_obj=acm_obj, action=constants.ACTION_FAILOVER
+            )

--- a/tests/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -5,7 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import tier1, tier4a, polarion_id
+
+# from ocs_ci.framework.testlib import tier1, tier4a
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
@@ -24,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 polarion_id_primary_up = "OCS-4771"
 polarion_id_primary_down = "OCS-4770"
-tier_name = tier1
+# tier_name = tier1
 if config.RUN.get("rdr_failover_via_ui"):
     polarion_id_primary_up = "OCS-5032"
     polarion_id_primary_down = "OCS-5033"
-    tier_name = tier4a
+    # tier_name = tier4a
 
 
 class TestSequentialFailover:
@@ -42,12 +43,12 @@ class TestSequentialFailover:
         argvalues=[
             pytest.param(
                 False,
-                marks=[polarion_id(polarion_id_primary_up), tier_name],
+                # marks=[polarion_id(polarion_id_primary_up), tier_name],
                 id="primary_up",
             ),
             pytest.param(
                 True,
-                marks=[polarion_id(polarion_id_primary_down), tier_name],
+                # marks=[polarion_id(polarion_id_primary_down), tier_name],
                 id="primary_down",
             ),
         ],


### PR DESCRIPTION
RDR test cases to perform sequential failover from UI.

```
OCS-5032 - "RHSTOR-3320
Qualify ""Provide UI for configuring and operating DR at Application granularity""" Perform Sequential Failover of different workloads from ACM UI to secondary cluster when primary site is UP


OCS-5033 - "RHSTOR-3320
Qualify ""Provide UI for configuring and operating DR at Application granularity""" Perform Sequential Failover of different workloads from ACM UI to secondary cluster when primary site is Down
```