### PR TITLE
In the consumer verification steps restart the ocs-operator pod even if the consumer addon is in a Ready state

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2589,14 +2589,15 @@ def consumer_verification_steps_after_provider_node_replacement():
             wait_for_addon_to_be_ready()
         except TimeoutExpiredError:
             log.warning("The consumer addon is not in a ready state")
-            log.info("Try to restart the ocs-operator pod")
-            pod.delete_pods([pod.get_ocs_operator_pod()])
-            log.info("Wait again for the consumer addon to be in ready state")
-            try:
-                wait_for_addon_to_be_ready()
-            except TimeoutExpiredError:
-                log.warning("The consumer addon is not in a ready state")
-                return False
+
+        log.info("Try to restart the ocs-operator pod")
+        pod.delete_pods([pod.get_ocs_operator_pod()])
+        log.info("Wait again for the consumer addon to be in ready state")
+        try:
+            wait_for_addon_to_be_ready()
+        except TimeoutExpiredError:
+            log.warning("The consumer addon is not in a ready state")
+            return False
 
         if not wait_for_consumer_storage_provider_endpoint_in_provider_wnodes():
             log.warning(


### PR DESCRIPTION
I saw in this failed test https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-odf-multicluster/2032/testReport/tests.manage.z_cluster.nodes.test_automated_recovery_from_failed_nodes_reactive_ms/TestAutomatedRecoveryFromFailedNodeReactiveMS/test_automated_recovery_from_failed_nodes_reactive_ms_stopped_node_/, that even if the consumer addon is in a Ready state, we still need to restart the ocs-operator pod to update the consumer mon endpoints. That's why we must restart the consumer ocs-operator pod even if the consumer addon is Ready.