### PR TITLE
fix add_time_report_to_email keyError issue

### DIFF
--- a/ocs_ci/framework/pytest_customization/reports.py
+++ b/ocs_ci/framework/pytest_customization/reports.py
@@ -95,7 +95,7 @@ def pytest_sessionfinish(session, exitstatus):
     # creating report of test cases with total time in ascending order
     data = GV.TIMEREPORT_DICT
     sorted_data = dict(
-        sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
+        sorted(data.items(), key=lambda item: item[1].get("total"), reverse=True)
     )
     try:
         time_report_file = os.path.join(
@@ -150,6 +150,9 @@ def pytest_report_teststatus(report, config):
         )
         GV.TIMEREPORT_DICT[report.nodeid]["setup"] = round(report.duration, 2)
         GV.TIMEREPORT_DICT[report.nodeid]["total"] = round(report.duration, 2)
+
+    if "total" not in GV.TIMEREPORT_DICT[report.nodeid]:
+        GV.TIMEREPORT_DICT[report.nodeid]["total"] = 0
 
     if report.when == "call":
         logger.info(

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4494,7 +4494,7 @@ def add_time_report_to_email(session, soup):
     """
     data = GV.TIMEREPORT_DICT
     sorted_data = dict(
-        sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
+        sorted(data.items(), key=lambda item: item[1].get("total", 0), reverse=True)
     )
 
     file_loader = FileSystemLoader(constants.HTML_REPORT_TEMPLATE_DIR)


### PR DESCRIPTION
This fix should avoid following issues:

```
INTERNALERROR>   File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/pytest_customization/reports.py", line 166, in pytest_report_teststatus
INTERNALERROR>     GV.TIMEREPORT_DICT[report.nodeid]["total"] += round(report.duration, 2)
INTERNALERROR> KeyError: 'total'
```
and
```
email_reports(session)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/utils.py", line 1744, in email_reports
    add_time_report_to_email(session, soup)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/utils.py", line 4497, in add_time_report_to_email
    sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/utils.py", line 4497, in <lambda>
    sorted(data.items(), key=lambda item: item[1]["total"], reverse=True)
KeyError: 'total'
```