### PR TITLE
Remove the try and except from the function "get_mds_cache_memory_limit" and move it to the test "test_check_mds_cache_memory_limit"

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2027,14 +2027,10 @@ def get_mds_cache_memory_limit():
 
     """
     pod_obj = pod.get_ceph_tools_pod()
-    try:
-        ceph_cmd = "ceph config show mds.ocs-storagecluster-cephfilesystem-a mds_cache_memory_limit"
-        mds_a_cache_memory_limit = pod_obj.exec_ceph_cmd(ceph_cmd=ceph_cmd)
-        ceph_cmd = "ceph config show mds.ocs-storagecluster-cephfilesystem-b mds_cache_memory_limit"
-        mds_b_cache_memory_limit = pod_obj.exec_ceph_cmd(ceph_cmd=ceph_cmd)
-    except IOError as ioe:
-        if "ENOENT" not in ioe:
-            raise ioe
+    ceph_cmd = "ceph config show mds.ocs-storagecluster-cephfilesystem-a mds_cache_memory_limit"
+    mds_a_cache_memory_limit = pod_obj.exec_ceph_cmd(ceph_cmd=ceph_cmd)
+    ceph_cmd = "ceph config show mds.ocs-storagecluster-cephfilesystem-b mds_cache_memory_limit"
+    mds_b_cache_memory_limit = pod_obj.exec_ceph_cmd(ceph_cmd=ceph_cmd)
 
     if mds_a_cache_memory_limit != mds_b_cache_memory_limit:
         raise UnexpectedBehaviour(

--- a/tests/manage/z_cluster/test_ceph_default_values_check.py
+++ b/tests/manage/z_cluster/test_ceph_default_values_check.py
@@ -24,6 +24,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import get_mds_cache_memory_limit
 from ocs_ci.utility import version
 from ocs_ci.utility.retry import retry
+from ocs_ci.ocs.exceptions import CommandFailed
 
 
 log = logging.getLogger(__name__)
@@ -155,12 +156,12 @@ class TestCephDefaultValuesCheck(ManageTest):
         Testcase to check mds cache memory limit post ocs upgrade
 
         """
-        mds_cache_memory_limit = get_mds_cache_memory_limit()
         mds_cache_memory_limit = retry(
-            (IOError),
+            (IOError, CommandFailed),
             tries=6,
             delay=20,
             backoff=1,
+            text_in_exception="ENOENT",
         )(get_mds_cache_memory_limit)()
         expected_mds_value = 4294967296
         expected_mds_value_in_GB = int(expected_mds_value / 1073741274)


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/7101
In the PR, I implement the following:

- Remove the try and except in the function `get_mds_cache_memory_limit`.
- Remove the redundant line in the test `test_check_mds_cache_memory_limit`.
- In the test `test_check_mds_cache_memory_limit`, update the `retry` clause with the correct parameters.
