### PR TITLE
Add env vars to suppress debconf messages

### DIFF
--- a/ocs_ci/templates/workloads/fio/fedora_deployment.yaml
+++ b/ocs_ci/templates/workloads/fio/fedora_deployment.yaml
@@ -22,6 +22,11 @@ spec:
           volumeDevices:
             - devicePath: /dev/rbdblock
               name: my-volume
+          env:
+            - name: DEBIAN_FRONTEND
+              value: noninteractive
+            - name: DEBCONF_NOWARNINGS
+              value: yes
           command:
             - /usr/bin/fio
           args:


### PR DESCRIPTION
This should reduce the noise when installing `fio`

See PR #7715
