### PR TITLE
ci: fix mgr pdb resource count

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1240,9 +1240,26 @@ def validate_pdb_creation():
     item_list = pdb_obj.get().get("items")
     pdb_count = constants.PDB_COUNT
     pdb_required = [constants.MDS_PDB, constants.MON_PDB, constants.OSD_PDB]
+
+    if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_15:
+        pdb_count = constants.PDB_COUNT_2_MGR
+        pdb_required = [
+            constants.MDS_PDB,
+            constants.MON_PDB,
+            constants.OSD_PDB,
+            constants.MGR_PDB,
+        ]
+
     if config.DEPLOYMENT.get("arbiter_deployment"):
         pdb_count = constants.PDB_COUNT_ARBITER
-        pdb_required.extend((constants.MGR_PDB, constants.RGW_PDB))
+        pdb_required = [
+            constants.MDS_PDB,
+            constants.MON_PDB,
+            constants.OSD_PDB,
+            constants.MGR_PDB,
+            constants.RGW_PDB,
+        ]
+
     if len(item_list) != pdb_count:
         raise PDBNotCreatedException(
             f"Not All PDB's created. Expected {pdb_count} PDB's but found {len(item_list)}"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1216,6 +1216,7 @@ MON_PDB = "rook-ceph-mon-pdb"
 MGR_PDB = "rook-ceph-mgr-pdb"
 RGW_PDB = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
 PDB_COUNT = 3
+PDB_COUNT_2_MGR = 4
 PDB_COUNT_ARBITER = 5
 
 # Root Disk size

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -47,6 +47,7 @@ VERSION_4_11 = get_semantic_version("4.11", True)
 VERSION_4_12 = get_semantic_version("4.12", True)
 VERSION_4_13 = get_semantic_version("4.13", True)
 VERSION_4_14 = get_semantic_version("4.14", True)
+VERSION_4_15 = get_semantic_version("4.15", True)
 
 
 def get_semantic_ocs_version_from_config(cluster_config=None):


### PR DESCRIPTION
from recent ocs operator changes we are trying to
have more than 1 mgr by deafult,
So to imply it we need to check for the mgr pdb
which would get created if mgr count >1