### PR TITLE
pin versions for python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,13 +75,13 @@ setup(
         # compatible systems. Resolves problem for m1 Mac chips
         "greenlet==1.1.2",
         "ovirt-engine-sdk-python==4.4.11",
-        "junitparser",
+        "junitparser==3.1.0",
         "flaky==3.7.0",
-        "ocp-network-split",
-        "pyopenssl",
-        "pyparsing ==2.4.7",
+        "ocp-network-split==0.3.0",
+        "pyopenssl==23.3.0",
+        "pyparsing==2.4.7",
         "mysql-connector-python==8.0.27",
-        "pytest-repeat",
+        "pytest-repeat==0.9.3",
         "pexpect>=4.8.0",
         # googleapis-common-protos 1.56.2 needs to have protobuf<4.0.0>=3.15.0
         "protobuf==4.21.7",
@@ -89,7 +89,7 @@ setup(
         "psutil==5.9.0",
         "azure-identity==1.12.0",
         "azure-mgmt-storage==21.0.0",
-        "fauxfactory",
+        "fauxfactory==3.1.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
There are few packages which installs or updates the latest version which breaks the ocs-ci due to conflict versions.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)