### PR TITLE
Skipping verify_ceph_file_content method because know issues

### DIFF
--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -202,6 +202,7 @@ class MustGather(object):
             r"^vmware-*",
             "^must-gather",
             r"-debug$",
+            r"^csi-addons-controller-manager*",
         ]
         for regular_ex in regular_ex_list:
             if re.search(regular_ex, pod_name) is not None:

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -202,6 +202,7 @@ class MustGather(object):
             r"^vmware-*",
             "^must-gather",
             r"-debug$",
+            # https://bugzilla.redhat.com/show_bug.cgi?id=2245246
             r"^csi-addons-controller-manager*",
         ]
         for regular_ex in regular_ex_list:

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -106,7 +106,9 @@ class MustGather(object):
 
         """
         self.search_file_path()
-        self.verify_ceph_file_content()
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2125204
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2049204
+        # self.verify_ceph_file_content()
         for file, file_path in self.files_path.items():
             if not Path(file_path).is_file():
                 self.files_not_exist.append(file)


### PR DESCRIPTION
Many tests failed because of content issues [ceph commands return errors != return 0]

https://bugzilla.redhat.com/show_bug.cgi?id=2049204
https://bugzilla.redhat.com/show_bug.cgi?id=2125204

`csi-addons-controller-manager` pod is reset after running the must-gather command 
https://bugzilla.redhat.com/show_bug.cgi?id=2245246