### PR TITLE
Tests to verify RDR failover with CephFS

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -33,7 +33,7 @@ ENV_DATA:
 
   dr_workload_subscription_cephfs: [
     { name: "busybox-1", workload_dir: "rdr/busybox/cephfs/app-busybox-1", pod_count: 20, pvc_count: 20 },
-    { name: "busybox-2", workload_dir: "rdr/busybox/cephfs/app-busybox-2", pod_count: 5, pvc_count: 5 },
+    { name: "busybox-2", workload_dir: "rdr/busybox/cephfs/app-busybox-2", pod_count: 20, pvc_count: 4 },
   ]
 
   # dr_policy_name: PLACEHOLDER

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -30,4 +30,10 @@ ENV_DATA:
       dr_workload_app_pvc_selector: {'appname': 'busybox_app5'}, pod_count: 20, pvc_count: 20
     },
   ]
+
+  dr_workload_subscription_cephfs: [
+    { name: "busybox-1", workload_dir: "rdr/busybox/cephfs/app-busybox-1", pod_count: 20, pvc_count: 20 },
+    { name: "busybox-2", workload_dir: "rdr/busybox/cephfs/app-busybox-2", pod_count: 5, pvc_count: 5 },
+  ]
+
   # dr_policy_name: PLACEHOLDER

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -667,9 +667,10 @@ def wait_for_all_resources_deletion(
     logger.info("Waiting for all PVCs to be deleted")
     all_pvcs = get_all_pvc_objs(namespace=namespace)
     for pvc_obj in all_pvcs:
-        pvc_obj.ocp.wait_for_delete(
-            resource_name=pvc_obj.name, timeout=timeout, sleep=5
-        )
+        if "volsync-" not in pvc_obj.name:
+            pvc_obj.ocp.wait_for_delete(
+                resource_name=pvc_obj.name, timeout=timeout, sleep=5
+            )
 
     if config.MULTICLUSTER["multicluster_mode"] != "metro-dr":
         logger.info("Waiting for all PVs to be deleted")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -180,6 +180,7 @@ CEPH_CLUSTER_NAME = "ocs-storagecluster-cephcluster"
 ENDPOINTS = "Endpoints"
 WEBHOOK = "ValidatingWebhookConfiguration"
 ROOK_CEPH_WEBHOOK = "rook-ceph-webhook"
+REPLICATION_SOURCE = "ReplicationSource"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -181,6 +181,7 @@ ENDPOINTS = "Endpoints"
 WEBHOOK = "ValidatingWebhookConfiguration"
 ROOK_CEPH_WEBHOOK = "rook-ceph-webhook"
 REPLICATION_SOURCE = "ReplicationSource"
+REPLICATIONDESTINATION = "ReplicationDestination"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -239,7 +239,7 @@ class BusyBox(DRWorkload):
                     check_replication_resources_state=False,
                 )
 
-            log.info("Verify backend RBD images are deleted")
+            log.info("Verify backend images or subvolumes are deleted")
             for cluster in get_non_acm_cluster_config():
                 config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
                 rbd_pool_name = (
@@ -248,14 +248,20 @@ class BusyBox(DRWorkload):
                     else constants.DEFAULT_CEPHBLOCKPOOL
                 )
                 for image_uuid in image_uuids:
-                    status = verify_volume_deleted_in_backend(
-                        interface=constants.CEPHBLOCKPOOL,
-                        image_uuid=image_uuid,
-                        pool_name=rbd_pool_name,
-                    )
+                    # TODO: Add a better condition to identify CephFS or RBD
+                    if "cephfs" in self.workload_namespace:
+                        status = verify_volume_deleted_in_backend(
+                            interface=constants.CEPHFILESYSTEM, image_uuid=image_uuid
+                        )
+                    else:
+                        status = verify_volume_deleted_in_backend(
+                            interface=constants.CEPHBLOCKPOOL,
+                            image_uuid=image_uuid,
+                            pool_name=rbd_pool_name,
+                        )
                     if not status:
                         raise UnexpectedBehaviour(
-                            "RBD image(s) still exists on backend"
+                            "Images/subvolumes still exists on backend"
                         )
 
         except (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6373,7 +6373,7 @@ def dr_workload(request):
             num_of_subscription (int): Number of Subscription type workload to be created
             num_of_appset (int): Number of ApplicationSet type workload to be created
             pvc_interface (str): 'CephBlockPool' or 'CephFileSystem'.
-                This decides whether a RBD based or CephFS resource is created. RBD is default.
+                This decides whether a RBD based or CephFS based resource is created. RBD is default.
 
         Raises:
             ResourceNotDeleted: In case workload resources not deleted properly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6365,11 +6365,15 @@ def dr_workload(request):
     """
     instances = []
 
-    def factory(num_of_subscription=1, num_of_appset=0):
+    def factory(
+        num_of_subscription=1, num_of_appset=0, pvc_interface=constants.CEPHBLOCKPOOL
+    ):
         """
         Args:
             num_of_subscription (int): Number of Subscription type workload to be created
             num_of_appset (int): Number of ApplicationSet type workload to be created
+            pvc_interface (str): 'CephBlockPool' or 'CephFileSystem'.
+                This decides whether a RBD based or CephFS resource is created. RBD is default.
 
         Raises:
             ResourceNotDeleted: In case workload resources not deleted properly
@@ -6379,8 +6383,12 @@ def dr_workload(request):
 
         """
         total_pvc_count = 0
+        workload_key = "dr_workload_subscription"
+        if pvc_interface == constants.CEPHFILESYSTEM:
+            workload_key = "dr_workload_subscription_cephfs"
+
         for index in range(num_of_subscription):
-            workload_details = ocsci_config.ENV_DATA["dr_workload_subscription"][index]
+            workload_details = ocsci_config.ENV_DATA[workload_key][index]
             workload = BusyBox(
                 workload_dir=workload_details["workload_dir"],
                 workload_pod_count=workload_details["pod_count"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6413,7 +6413,10 @@ def dr_workload(request):
             total_pvc_count += workload_details["pvc_count"]
             workload.deploy_workload()
         if ocsci_config.MULTICLUSTER["multicluster_mode"] != "metro-dr":
-            dr_helpers.wait_for_mirroring_status_ok(replaying_images=total_pvc_count)
+            if pvc_interface != constants.CEPHFILESYSTEM:
+                dr_helpers.wait_for_mirroring_status_ok(
+                    replaying_images=total_pvc_count
+                )
         return instances
 
     def teardown():

--- a/tests/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_failover.py
@@ -6,6 +6,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
+from ocs_ci.helpers.dr_helpers import check_vrg_state
 from ocs_ci.helpers.dr_helpers_ui import (
     dr_submariner_validation_from_ui,
     check_cluster_status_on_acm_console,
@@ -169,6 +170,9 @@ class TestFailover:
             logger.info("Checking for Ceph Health OK")
             ceph_health_check()
         dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
+
+        # Check VRG state on primary cluster
+        check_vrg_state("secondary", rdr_workload.workload_namespace)
 
         if pvc_interface == constants.CEPHBLOCKPOOL:
             dr_helpers.wait_for_mirroring_status_ok(

--- a/tests/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/disaster-recovery/regional-dr/test_failover.py
@@ -170,9 +170,10 @@ class TestFailover:
             ceph_health_check()
         dr_helpers.wait_for_all_resources_deletion(rdr_workload.workload_namespace)
 
-        dr_helpers.wait_for_mirroring_status_ok(
-            replaying_images=rdr_workload.workload_pvc_count
-        )
+        if pvc_interface == constants.CEPHBLOCKPOOL:
+            dr_helpers.wait_for_mirroring_status_ok(
+                replaying_images=rdr_workload.workload_pvc_count
+            )
 
         if config.RUN.get("rdr_failover_via_ui"):
             config.switch_acm_ctx()


### PR DESCRIPTION
Test cases to verify failover with CephFS based workloads.

OCS-4726 -  Failover to secondary cluster when primary site is DOWN
OCS-4729 -Failover to secondary cluster when primary site is UP