### PR TITLE
Update PV reclaim policy from Retain to Delete in pvc_factory_fixture finalizer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1112,7 +1112,7 @@ def pvc_factory_fixture(request, project_factory):
                 instance.ocp.wait_for_delete(instance.name)
 
         # Wait for PVs to delete
-        # If they have ReclaimPolicy set to Retain then delete them manually
+        # If they have ReclaimPolicy set to Retain then change to Delete
         for pv_obj in pv_objs:
             if (
                 pv_obj.data.get("spec", {}).get("persistentVolumeReclaimPolicy")
@@ -1120,10 +1120,10 @@ def pvc_factory_fixture(request, project_factory):
                 and pv_obj is not None
             ):
                 helpers.wait_for_resource_state(pv_obj, constants.STATUS_RELEASED)
-                pv_obj.delete()
-                pv_obj.ocp.wait_for_delete(pv_obj.name)
-            else:
-                pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
+                patch_param = '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+                pv_obj.ocp.patch(resource_name=pv_obj.name, params=patch_param)
+
+            pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
After this pull request, the PV reclaim policy will be updated from Retain to Delete in the pvc_factory_fixture finalizer. This ensures that PVs are deleted along with backend images and subvolumes, preventing orphaned images/subvolumes from accumulating in the cluster.
