### PR TITLE
Add marker in tests to ignore the pod rook-ceph-detect-version during environment check

### DIFF
--- a/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -23,7 +23,9 @@ log = logging.getLogger(__name__)
 @tier4c
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
-@ignore_leftover_label(constants.drain_canary_pod_label)
+@ignore_leftover_label(
+    constants.drain_canary_pod_label, constants.ROOK_CEPH_DETECT_VERSION_LABEL
+)
 @pytest.mark.polarion_id("OCS-2413")
 class TestResourceDeletionDuringPvcClone(ManageTest):
     """

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     polarion_id,
     skipif_managed_service,
     skipif_external_mode,
+    ignore_leftover_label,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
@@ -43,6 +44,7 @@ log = logging.getLogger(__name__)
 @tier4c
 @skipif_managed_service
 @skipif_external_mode
+@ignore_leftover_label(constants.ROOK_CEPH_DETECT_VERSION_LABEL)
 class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
     """
     Kill ceph daemon while creation/deletion of PVCs, and pods are progressing


### PR DESCRIPTION
Add marker in the test cases given below to ignore the pod rook-ceph-detect-version during environment check.

1. tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
2. tests/manage/pv_services/pvc_clone/test_resource_deletion_during_pvc_clone.py

Fixes #8800 