### PR TITLE
Improve the condition to skip debug pod in environment check

### DIFF
--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -96,7 +96,7 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             continue
         if item.get("kind") == constants.POD:
             name = item.get("metadata", {}).get("name", "")
-            if name.endswith("-debug"):
+            if name.endswith("-debug") or "-debug-" in name:
                 log.debug(f"ignoring item: {name}")
                 continue
             if name.startswith("session-awscli"):


### PR DESCRIPTION
Improve the condition to skip debug pod in environment check. The condition is improved to identify the pod name in the format given below.

```
apiVersion: v1
kind: Pod
metadata:
  annotations:
debug.openshift.io/source-container: container-00
debug.openshift.io/source-resource: /v1, Resource=nodes/j-043vi1cs33-t4c-wd2cj-worker-0-jx5h5
openshift.io/scc: rook-ceph-csi
  creationTimestamp: '2023-09-22T18:11:27Z'
  name: j-043vi1cs33-t4c-wd2cj-worker-0-jx5h5-debug-xlz94
  namespace: openshift-storage
  resourceVersion: '188073'
  uid: 8aaef796-538c-41e4-a0ea-49330d0b8ebc
```

Fixes #8747 