### PR TITLE
Add Bugzilla marker in the test 'test_recovery_from_volume_deletion' for skip the test until the BZ is fixed

### DIFF
--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -210,6 +210,7 @@ class TestDiskFailures(ManageTest):
         )
 
     @bugzilla("1830702")
+    @bugzilla("2248833")
     @vsphere_platform_required
     @pytest.mark.polarion_id("OCS-2172")
     @skipif_external_mode


### PR DESCRIPTION
See more details in the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2248833.