### PR TITLE
Skip `test_respin_mcg_pod_and_check_data_integrity_crd` until bug 2165907 is resolved

### DIFF
--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -22,6 +22,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     tier2,
     tier4c,
+    bugzilla,
 )
 from ocs_ci.ocs.bucket_utils import (
     sync_object_directory,
@@ -938,7 +939,10 @@ class TestNamespace(MCGTest):
     @pytest.mark.parametrize(
         argnames=["mcg_pod"],
         argvalues=[
-            pytest.param(*["noobaa-db"], marks=pytest.mark.polarion_id("OCS-2291")),
+            pytest.param(
+                *["noobaa-db"],
+                marks=[pytest.mark.polarion_id("OCS-2291"), bugzilla("2165907")],
+            ),
             pytest.param(*["noobaa-core"], marks=pytest.mark.polarion_id("OCS-2319")),
             pytest.param(
                 *["noobaa-operator"], marks=pytest.mark.polarion_id("OCS-2320")


### PR DESCRIPTION
Fixes #7870

Note that due to the findings in comments 28 and 30 in https://bugzilla.redhat.com/show_bug.cgi?id=2165907, this TC should be skipped in all cluster types and not just AWS-IPI-KMS_THALES.