### PR TITLE
Adding skipif_hci_provider_and_client similar to skipif_managed_service

### DIFF
--- a/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/e2e/workloads/ocp/logging/test_openshift-logging.py
@@ -22,7 +22,10 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
 )
 from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    skipif_ms_provider_and_consumer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,6 +162,7 @@ class Testopenshiftloggingonocs(E2ETest):
     @pytest.mark.polarion_id("OCS-657")
     @tier1
     @skipif_managed_service
+    @skipif_ms_provider_and_consumer
     def test_create_new_project_to_verify_logging(
         self, create_pvc_and_deploymentconfig_pod
     ):

--- a/tests/manage/monitoring/prometheus/test_capacity.py
+++ b/tests/manage/monitoring/prometheus/test_capacity.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     gather_metrics_on_fail,
     skipif_managed_service,
+    skipif_ms_provider_and_consumer,
     blue_squad,
 )
 from ocs_ci.ocs import constants
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"
 )
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_rbd_capacity_workload_alerts(
     workload_storageutilization_97p_rbd, threading_lock
 ):
@@ -90,6 +92,7 @@ def test_rbd_capacity_workload_alerts(
     "ceph_cluster_total_used_bytes", "cluster:memory_usage_bytes:sum"
 )
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_cephfs_capacity_workload_alerts(
     workload_storageutilization_97p_cephfs, threading_lock
 ):

--- a/tests/manage/monitoring/prometheus/test_ceph.py
+++ b/tests/manage/monitoring/prometheus/test_ceph.py
@@ -1,7 +1,13 @@
 import logging
 import pytest
 
-from ocs_ci.framework.testlib import tier4, tier4a, skipif_managed_service, blue_squad
+from ocs_ci.framework.testlib import (
+    tier4,
+    tier4a,
+    skipif_managed_service,
+    skipif_ms_provider_and_consumer,
+    blue_squad,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
@@ -14,6 +20,7 @@ log = logging.getLogger(__name__)
 @tier4a
 @pytest.mark.polarion_id("OCS-903")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts when Placement group
@@ -60,6 +67,7 @@ def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
 @tier4a
 @pytest.mark.polarion_id("OCS-898")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts for Ceph health triggered.

--- a/tests/manage/monitoring/prometheus/test_deployment_status.py
+++ b/tests/manage/monitoring/prometheus/test_deployment_status.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     bugzilla,
     skipif_managed_service,
+    skipif_ms_provider_and_consumer,
     skipif_ocs_version,
 )
 from ocs_ci.ocs import constants
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
 @tier4c
 @pytest.mark.polarion_id("OCS-1052")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
     """
     Test that there is appropriate alert when ceph manager
@@ -50,6 +52,7 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
 @tier4c
 @pytest.mark.polarion_id("OCS-904")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
     """
     Test that there is appropriate alert related to ceph monitor quorum
@@ -92,6 +95,7 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
 @pytest.mark.polarion_id("OCS-2724")
 @pytest.mark.parametrize("create_mon_quorum_loss", [True])
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 @skipif_ocs_version("<4.9")
 def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
     """
@@ -122,6 +126,7 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
 @tier4c
 @pytest.mark.polarion_id("OCS-900")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
     """
     Test that there is appropriate alert related to situation when ceph osd

--- a/tests/manage/monitoring/prometheus/test_hpa.py
+++ b/tests/manage/monitoring/prometheus/test_hpa.py
@@ -5,7 +5,10 @@ from ocs_ci.framework.pytest_customization.marks import tier1, blue_squad
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    skipif_ms_provider_and_consumer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +20,7 @@ logger = logging.getLogger(__name__)
 @marks.polarion_id("OCS-2375")
 @marks.bugzilla("1836299")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_hpa_maxreplica_alert(threading_lock):
     """
     Test to verify that no HPA max replica alert is triggered

--- a/tests/manage/monitoring/prometheusmetrics/test_rgw.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_rgw.py
@@ -10,7 +10,12 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import blue_squad
-from ocs_ci.framework.testlib import skipif_managed_service, skipif_ocs_version, tier4c
+from ocs_ci.framework.testlib import (
+    skipif_managed_service,
+    skipif_ms_provider_and_consumer,
+    skipif_ocs_version,
+    tier4c,
+)
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs import metrics
 from ocs_ci.ocs.resources.ocs import OCS
@@ -25,6 +30,7 @@ logger = logging.getLogger(__name__)
 @tier4c
 @pytest.mark.polarion_id("OCS-2385")
 @skipif_managed_service
+@skipif_ms_provider_and_consumer
 def test_ceph_rgw_metrics_after_metrics_exporter_respin(
     rgw_deployments, threading_lock
 ):

--- a/tests/manage/pv_services/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
+++ b/tests/manage/pv_services/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
     ManageTest,
@@ -55,6 +56,7 @@ else:
 @skipif_managed_service
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
+@skipif_hci_provider_and_client
 class TestEncryptedRbdTenantConfigmapOverride(ManageTest):
     """
     Tests to check Tenant configmap override vault namespace or not

--- a/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftover_label,
     skipif_ocp_version,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers import disruption_helpers
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @ignore_leftover_label(constants.drain_canary_pod_label)
 @pytest.mark.polarion_id("OCS-2369")
 class TestResourceDeletionDuringSnapshotRestore(ManageTest):

--- a/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     skipif_ocp_version,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.resources.pod import cal_md5sum, verify_data_integrity
 from ocs_ci.helpers.helpers import (
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 @green_squad
 @tier1
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @pytest.mark.polarion_id("OCS-2424")

--- a/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/manage/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     polarion_id,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.framework import config
@@ -42,6 +43,7 @@ log = logging.getLogger(__name__)
 @tier4
 @tier4c
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_external_mode
 class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
     """

--- a/tests/manage/pv_services/test_overprovision_level_policy_control.py
+++ b/tests/manage/pv_services/test_overprovision_level_policy_control.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_ocs_version,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 
@@ -42,6 +43,7 @@ def setup_sc(storageclass_factory_class):
 @bugzilla("2024545")
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_ocs_version("<4.10")
 @pytest.mark.polarion_id("OCS-4472")
 class TestOverProvisionLevelPolicyControl(ManageTest):

--- a/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
+++ b/tests/manage/pv_services/test_overprovision_level_policy_control_with_capacity.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.utility import version
@@ -34,6 +35,7 @@ def setup_sc(storageclass_factory_class):
 @pytest.mark.polarion_id("OCS-3778")
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 class TestOverProvisionLevelPolicyControlWithCapacity(ManageTest):
     """
     Test OverProvision Level Policy Control With Capacity.

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_no_lso,
     skipif_lso,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     brown_squad,
 )
 from ocs_ci.framework.testlib import (
@@ -122,7 +123,7 @@ def add_capacity_test(ui_flag=False):
 @skipif_lso
 @skipif_external_mode
 @skipif_ibm_power
-@skipif_managed_service
+@skipif_hci_provider_and_client
 @ceph_health_retry
 class TestAddCapacity(ManageTest):
     """
@@ -148,13 +149,14 @@ class TestAddCapacity(ManageTest):
 @ignore_leftovers
 @polarion_id("OCS-4647")
 @pytest.mark.second_to_last
-@skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_aws_i3
 @skipif_bm
 @skipif_bmpsi
 @skipif_external_mode
 @skipif_ibm_power
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_no_lso
 @ceph_health_retry
 class TestAddCapacityLSO(ManageTest):
@@ -187,6 +189,7 @@ class TestAddCapacityLSO(ManageTest):
 @skipif_external_mode
 @cloud_platform_required
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @ceph_health_retry
 class TestAddCapacityPreUpgrade(ManageTest):
     """

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_bm,
     skipif_external_mode,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.helpers import cluster_exp_helpers
 from ocs_ci.ocs import constants
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 @skipif_bm
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 class TestAddCapacity(ManageTest):
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @tier4b
 @skipif_managed_service
+@skipif_hci_provider_and_client
 class TestAddCapacityNodeRestart(ManageTest):
     """
     Test add capacity when one of the worker nodes got restart

--- a/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_bm,
     brown_squad,
 )
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 @skipif_bm
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @pytest.mark.polarion_id("OCS-2594")
 class TestAddNodeCrashCollector(ManageTest):
     """

--- a/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_delete_pod.py
@@ -3,7 +3,12 @@ import pytest
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
-from ocs_ci.framework.testlib import ignore_leftovers, tier4c, skipif_managed_service
+from ocs_ci.framework.testlib import (
+    ignore_leftovers,
+    tier4c,
+    skipif_managed_service,
+    skipif_hci_provider_and_client,
+)
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
@@ -26,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 @brown_squad
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_external_mode
 @ignore_leftovers
 @tier4c

--- a/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_node_expansion.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_flexy_deployment,
     skipif_ibm_flash,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     brown_squad,
 )
 
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 @brown_squad
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_flexy_deployment
 @skipif_ibm_flash
 @ignore_leftovers

--- a/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/manage/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -5,6 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_flexy_deployment,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_multus_enabled,
     brown_squad,
 )
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 # https://github.com/red-hat-storage/ocs-ci/issues/4802
 @skipif_flexy_deployment
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_multus_enabled
 @tier2
 @pytest.mark.polarion_id("OCS-2490")

--- a/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/manage/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_ibm_cloud,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -42,6 +43,7 @@ class TestOCSWorkerNodeShutdown(ManageTest):
     @pytest.mark.polarion_id("OCS-2315")
     @skipif_ibm_cloud
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @skipif_external_mode
     @pytest.mark.bugzilla("2232106")
     def test_check_pod_status_after_two_nodes_shutdown_recovery(

--- a/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/manage/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_ibm_cloud,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -81,6 +82,7 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 @ignore_leftovers
 @tier4a
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2552")
 class TestCheckPodsAfterNodeFailure(ManageTest):

--- a/tests/manage/z_cluster/nodes/test_disk_failures.py
+++ b/tests/manage/z_cluster/nodes/test_disk_failures.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     skipif_ibm_cloud,
     skipif_external_mode,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.helpers.helpers import (
@@ -123,6 +124,7 @@ class TestDiskFailures(ManageTest):
         self.sanity_helpers = Sanity()
 
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @cloud_platform_required
     @pytest.mark.polarion_id("OCS-1085")
     @bugzilla("1825675")
@@ -171,6 +173,7 @@ class TestDiskFailures(ManageTest):
         self.sanity_helpers.health_check(tries=100)
 
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @cloud_platform_required
     @pytest.mark.polarion_id("OCS-1086")
     @skipif_ibm_cloud

--- a/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/manage/z_cluster/nodes/test_node_replacement_proactive.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.cluster import CephCluster, is_lso_cluster, is_ms_provider_clust
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_bmpsi,
     bugzilla,
     skipif_external_mode,
@@ -178,6 +179,7 @@ def delete_and_create_osd_node(osd_node_name):
 @ignore_leftovers
 @ipi_deployment_required
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_bmpsi
 @skipif_external_mode
 class TestNodeReplacementWithIO(ManageTest):
@@ -305,6 +307,7 @@ class TestNodeReplacement(ManageTest):
 @pytest.mark.polarion_id("OCS-2535")
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 class TestNodeReplacementTwice(ManageTest):
     """
     Node replacement twice:

--- a/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_maintenance.py
@@ -40,6 +40,7 @@ from ocs_ci.framework.testlib import (
     skipif_bm,
     bugzilla,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_more_than_three_workers,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
@@ -122,6 +123,7 @@ class TestNodesMaintenance(ManageTest):
 
     @tier1
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[
@@ -189,6 +191,7 @@ class TestNodesMaintenance(ManageTest):
     @tier4a
     @skipif_bm
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @pytest.mark.parametrize(
         argnames=["node_type"],
         argvalues=[
@@ -461,6 +464,7 @@ class TestNodesMaintenance(ManageTest):
     @bugzilla("1861104")
     @bugzilla("1946573")
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @skipif_more_than_three_workers
     @pytest.mark.polarion_id("OCS-2524")
     @tier4a

--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_vsphere_ipi,
     skipif_ibm_cloud,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_node_objs, get_nodes, wait_for_nodes_status
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @skipif_managed_service
+@skipif_hci_provider_and_client
 class TestNodesRestart(ManageTest):
     """
     Test ungraceful cluster shutdown

--- a/tests/manage/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_tainted_nodes,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources.pod import (
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_tainted_nodes
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @bugzilla("1992472")
 @pytest.mark.polarion_id("OCS-2705")
 class TestNonOCSTaintAndTolerations(E2ETest):

--- a/tests/manage/z_cluster/nodes/test_toleration.py
+++ b/tests/manage/z_cluster/nodes/test_toleration.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     ignore_leftovers,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.resources.pod import (
     get_all_pods,
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @tier4c
 @ignore_leftovers
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @pytest.mark.polarion_id("OCS-2450")
 class TestTaintAndTolerations(E2ETest):
     """

--- a/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/manage/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_vsphere_ipi,
     skipif_ibm_power,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     bugzilla,
     brown_squad,
 )
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @skipif_vsphere_ipi
 @skipif_ibm_power
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @ignore_leftovers
 @bugzilla("2029690")
 class TestWorkerNodesFailure(ManageTest):

--- a/tests/manage/z_cluster/test_ceph_default_values_check.py
+++ b/tests/manage/z_cluster/test_ceph_default_values_check.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     skipif_mcg_only,
     post_ocs_upgrade,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     runs_on_provider,
 )
 from ocs_ci.ocs.resources import pod
@@ -177,6 +178,7 @@ class TestCephDefaultValuesCheck(ManageTest):
     @post_ocs_upgrade
     @pytest.mark.polarion_id("OCS-2739")
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @skipif_ocs_version("<4.9")
     def test_noobaa_postgres_cm_post_ocs_upgrade(self):
         """

--- a/tests/manage/z_cluster/test_ceph_pg_log_dups_trim.py
+++ b/tests/manage/z_cluster/test_ceph_pg_log_dups_trim.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.cluster import get_specific_pool_pgid, get_osd_pg_log_dups_tracked
 from ocs_ci.ocs.resources.pod import (
@@ -31,6 +32,7 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_external_mode
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_ocs_version("<4.11")
 @pytest.mark.polarion_id("OCS-4471")
 @pytest.mark.bugzilla("2101798")

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -3,6 +3,7 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_cloud_managed,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     black_squad,
     polarion_id,
     tier3,
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 @black_squad
 @skipif_ibm_cloud_managed
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_ocs_version("<4.13")
 class TestErrorMessageImprovements(ManageTest):
     @bugzilla("2193109")

--- a/tests/ui/test_odf_topology.py
+++ b/tests/ui/test_odf_topology.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_cloud_managed,
     skipif_ocs_version,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     tier4a,
     ignore_leftovers,
 )
@@ -68,6 +69,7 @@ def teardown_depl_busybox(request):
 @black_squad
 @skipif_ibm_cloud_managed
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_external_mode
 @skipif_ocs_version("<4.13")
 class TestODFTopology(object):


### PR DESCRIPTION
Signed-off-by: suchita-g <sgatfane@redhat.com>
skipif_hci_provider_and_client is not applicable to nooba,mcg and obeject service test cases as this is supported in provider client solution