### PR TITLE
update flake8 to new version (6.1.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: trailing-whitespace
 
 - repo: https://github.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 6.1.0
   hooks:
     - id: flake8
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,9 +4,9 @@
 
 ## Prerequisites
 
-1. Python version >= 3.8
+1. Python version >= 3.8.1
 2. Following dependency packages for fedora/centos for successfully installing modules in virtualenv
-   - gcc, git, openssl-devel, python3-devel or python specific version packages 
+   - gcc, git, openssl-devel, python3-devel or python specific version packages
    depends on Python version installed e.g. python38-devel (or similar packages for ubuntu).
 3. Configure AWS Account credentials when testing with AWS platforms,
    check default section in `~/.aws/credentials` for access/secret key

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author="OCS QE",
     author_email="ocs-ci@redhat.com",
     license="MIT",
+    python_requires=">3.8.1",
     install_requires=[
         "apache-libcloud==3.1.0",
         "cryptography==41.0.5",


### PR DESCRIPTION
- required for python 3.12
- set minimal python version to 3.8.1

Python 3.12 is the default python on Fedora 39 and older versions of `flake8` (more precisely older versions of `pycodestyle` which is dependency for `flake8`) doesn't work on Python 3.12.

Example issues on Python 3.12 and older `flake8`:
```
    bootstrap_ignition_url = (
        f"http://{config.ENV_DATA.get('httpd_server')}/"
        f"{path_to_bootstrap_on_remote}"
    )
```
will raise following error (line 2229 is the second line from the code snippet above):
```
ocs_ci/deployment/vmware.py:2229:15: E231 missing whitespace after ':'
```
or this code:
```
            logger.info(
                f"Resource pool {pool} does not exist in cluster {self.cluster}"
            )
```
will raise following error (line 393 is the second line from the code snippet):
```
ocs_ci/deployment/vmware.py:393:45: E713 test for membership should be 'not in'
```