### PR TITLE
[release-4.12] Update flake8 and minimal python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: trailing-whitespace
 
 - repo: https://github.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 6.1.0
   hooks:
     - id: flake8
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-1. Python version >= 3.8
+1. Python version >= 3.8.1
 2. Following dependency packages for fedora/centos for successfully installing modules in virtualenv
    - gcc, git, openssl-devel, python3-devel (or similar packages for ubuntu).
 3. Configure AWS Account credentials when testing with AWS platforms,

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author="OCS QE",
     author_email="ocs-ci@redhat.com",
     license="MIT",
+    python_requires=">3.8.1",
     install_requires=[
         "apache-libcloud==3.1.0",
         "cryptography==41.0.5",


### PR DESCRIPTION
- required for python 3.12
- set minimal python version to 3.8.1

Backport of https://github.com/red-hat-storage/ocs-ci/pull/8917