### PR TITLE
Cephblockpool and sc creation is ideally not supported to customer on HCI PC platform

### DIFF
--- a/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/e2e/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
     skipif_external_mode,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import (
@@ -21,6 +22,7 @@ log = logging.getLogger(__name__)
 
 
 @magenta_squad
+@skipif_hci_provider_and_client
 @tier2
 class TestCompressedSCAndSupportSnapClone(E2ETest):
     """

--- a/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/e2e/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     tier2,
     ignore_leftovers,
     skipif_external_mode,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -21,6 +22,7 @@ log = logging.getLogger(__name__)
 
 @magenta_squad
 @skipif_external_mode
+@skipif_hci_provider_and_client
 @ignore_leftovers
 @tier2
 class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):

--- a/tests/manage/monitoring/test_workload_with_distruptions.py
+++ b/tests/manage/monitoring/test_workload_with_distruptions.py
@@ -39,6 +39,7 @@ from ocs_ci.framework.testlib import (
     pre_upgrade,
     post_upgrade,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs import fiojob
@@ -61,6 +62,7 @@ logger = logging.getLogger(__name__)
 @pre_upgrade
 @tier2
 @skipif_managed_service
+@skipif_hci_provider_and_client
 def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
     """
     Purpose of this test is to have checksum workload fixture executed.
@@ -77,6 +79,7 @@ def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
 @post_upgrade
 @tier2
 @skipif_managed_service
+@skipif_hci_provider_and_client
 def test_workload_with_checksum_verify(
     tmp_path,
     project,

--- a/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
+++ b/tests/manage/pv_services/pvc_snapshot/test_verify_rbd_trash_purge.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
@@ -21,6 +22,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2595")
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_external_mode
 class TestVerifyRbdTrashPurge(ManageTest):
     """

--- a/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
     tier2,
     polarion_id,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_external_mode,
 )
 from ocs_ci.ocs.exceptions import (
@@ -59,6 +60,7 @@ class TestRbdSpaceReclaim(ManageTest):
     @tier1
     @skipif_external_mode
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     def test_rbd_space_reclaim(self):
         """
         Test to verify RBD space reclamation
@@ -142,6 +144,7 @@ class TestRbdSpaceReclaim(ManageTest):
     @polarion_id("OCS-2774")
     @tier1
     @skipif_managed_service
+    @skipif_hci_provider_and_client
     @skipif_external_mode
     def test_rbd_space_reclaim_no_space(self):
         """

--- a/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/manage/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     acceptance,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs import constants, node
@@ -92,6 +93,7 @@ class TestDynamicPvc(ManageTest):
                     pytest.mark.polarion_id("OCS-530"),
                     pytest.mark.bugzilla("1772990"),
                     skipif_managed_service,
+                    skipif_hci_provider_and_client,
                 ],
             ),
             pytest.param(
@@ -110,6 +112,7 @@ class TestDynamicPvc(ManageTest):
                     pytest.mark.bugzilla("1750916"),
                     pytest.mark.bugzilla("1772990"),
                     skipif_managed_service,
+                    skipif_hci_provider_and_client,
                 ],
             ),
             pytest.param(
@@ -245,7 +248,11 @@ class TestDynamicPvc(ManageTest):
         argvalues=[
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_RETAIN],
-                marks=[pytest.mark.polarion_id("OCS-542"), skipif_managed_service],
+                marks=[
+                    pytest.mark.polarion_id("OCS-542"),
+                    skipif_managed_service,
+                    skipif_hci_provider_and_client,
+                ],
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_DELETE],

--- a/tests/manage/storageclass/conftest.py
+++ b/tests/manage/storageclass/conftest.py
@@ -1,6 +1,6 @@
 import logging
 from ocs_ci.framework import config
-from ocs_ci.ocs.constants import MANAGED_SERVICE_PLATFORMS
+from ocs_ci.ocs.constants import HCI_PC_OR_MS_PLATFORM
 
 log = logging.getLogger(__name__)
 
@@ -8,13 +8,14 @@ log = logging.getLogger(__name__)
 def pytest_collection_modifyitems(items):
     """
     A pytest hook to filter out storageclass tests
-    when running on managed service platforms
+    when running on managed service platforms and
+    on HCI Provider Client Platform
 
     Args:
         items: list of collected tests
 
     """
-    if config.ENV_DATA["platform"].lower() in MANAGED_SERVICE_PLATFORMS:
+    if config.ENV_DATA["platform"].lower() in HCI_PC_OR_MS_PLATFORM:
         for item in items.copy():
             if "manage/storageclass" in str(item.fspath):
                 log.debug(

--- a/tests/manage/z_cluster/test_scc.py
+++ b/tests/manage/z_cluster/test_scc.py
@@ -22,6 +22,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     tier2,
     skipif_ocs_version,
+    skipif_hci_provider_and_client,
     brown_squad,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -34,6 +35,7 @@ class TestSCC:
     @tier2
     @bugzilla("1938647")
     @polarion_id("OCS-4483")
+    @skipif_hci_provider_and_client
     def test_custom_scc_with_pod_respin(self, scc_factory):
         """
         Test if OCS deployments/pods get affected if custom scc is created


### PR DESCRIPTION
As Per Tier2 analysis, Skipping the Test cases on HCI Provider Client setup where Cephblockpool or storageclass creation is involved