### PR TITLE
Skip unsupported Feature Encryption, new SC  and NFS TC for HCI PC Platform

### DIFF
--- a/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone.py
+++ b/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     E2ETest,
     flowtests,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
@@ -51,6 +52,7 @@ class TestPvcSnapshotAndCloneWithBaseOperation(E2ETest):
 
     @skipif_ocs_version("<4.9")
     @skipif_ocp_version("<4.9")
+    @skipif_hci_provider_and_client
     @pytest.mark.parametrize(
         argnames=["kv_version"],
         argvalues=[

--- a/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
+++ b/tests/e2e/flowtest/pvc_snapshot_and_clone/test_pgsql_pvc_snapshot_and_clone_with_base_operation.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     flowtests,
     ignore_leftovers,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
@@ -119,6 +120,7 @@ class TestPvcSnapshotAndCloneWithBaseOperation(E2ETest):
 
     @skipif_ocs_version("<4.9")
     @skipif_ocp_version("<4.9")
+    @skipif_hci_provider_and_client
     @pytest.mark.parametrize(
         argnames=["kv_version"],
         argvalues=[

--- a/tests/e2e/lifecycle/pvc_clone/test_pgsql_pvc_clone.py
+++ b/tests/e2e/lifecycle/pvc_clone/test_pgsql_pvc_clone.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     E2ETest,
     tier2,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import STATUS_COMPLETED, VOLUME_MODE_FILESYSTEM, CEPHBLOCKPOOL
@@ -152,6 +153,7 @@ class TestPvcCloneOfWorkloads(E2ETest):
 
     @skipif_ocs_version("<4.8")
     @skipif_ocp_version("<4.8")
+    @skipif_hci_provider_and_client
     @pytest.mark.parametrize(
         argnames=["kv_version"],
         argvalues=[

--- a/tests/e2e/lifecycle/pvc_snapshot/test_pgsql_pvc_snapshot.py
+++ b/tests/e2e/lifecycle/pvc_snapshot/test_pgsql_pvc_snapshot.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     E2ETest,
     tier2,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import CEPHBLOCKPOOL
@@ -123,6 +124,7 @@ class TestPvcSnapshotOfWorkloads(E2ETest):
     )
     @skipif_ocs_version("<4.8")
     @skipif_ocp_version("<4.8")
+    @skipif_hci_provider_and_client
     def test_encrypted_pvc_snapshot(
         self,
         kv_version,

--- a/tests/encryption/test_intransit_encryption_sanity.py
+++ b/tests/encryption/test_intransit_encryption_sanity.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_ocs_version,
     green_squad,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.framework import config
 
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
     reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/8759"
 )
 @green_squad
+@skipif_hci_provider_and_client
 class TestInTransitEncryptionSanity:
     @pytest.fixture(autouse=True)
     def set_encryption_at_teardown(self, request):

--- a/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/manage/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     skipif_ocp_version,
     skipif_managed_service,
+    skipif_hci_provider_and_client,
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
     polarion_id,
@@ -40,6 +41,7 @@ ERRMSG = "Error in command"
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
 @polarion_id("OCS-4270")
@@ -73,6 +75,7 @@ class TestDefaultNfsDisabled(ManageTest):
 @skipif_ocs_version("<4.11")
 @skipif_ocp_version("<4.11")
 @skipif_managed_service
+@skipif_hci_provider_and_client
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
 class TestNfsEnable(ManageTest):

--- a/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
     polarion_id,
     skipif_external_mode,
     bugzilla,
+    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import (
@@ -55,6 +56,7 @@ class TestRbdSpaceReclaim(ManageTest):
         )
 
     @polarion_id("OCS-2759")
+    @skipif_hci_provider_and_client
     @tier1
     def test_rbd_space_reclaim_cronjob(self, pause_and_resume_cluster_load):
         """
@@ -148,6 +150,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
     @tier1
     @bugzilla("2046677")
+    @skipif_hci_provider_and_client
     @skipif_external_mode
     @pytest.mark.parametrize(
         argnames=["replica", "compression", "volume_binding_mode", "pvc_status"],

--- a/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/manage/pv_services/space_reclaim/test_rbd_space_reclaim.py
@@ -201,6 +201,7 @@ class TestRbdSpaceReclaim(ManageTest):
     @polarion_id("OCS-3733")
     @tier2
     @skipif_external_mode
+    @skipif_hci_provider_and_client
     def test_no_volume_mounted(self):
         """
         Test reclaimspace job with no volume mounted

--- a/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/manage/pv_services/test_change_reclaim_policy_of_pv.py
@@ -5,7 +5,12 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import ManageTest, tier1, skipif_managed_service
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    skipif_managed_service,
+    skipif_hci_provider_and_client,
+)
 from ocs_ci.ocs.constants import RECLAIM_POLICY_DELETE, RECLAIM_POLICY_RETAIN
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.helpers import (
@@ -29,7 +34,11 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_RETAIN],
-            marks=[pytest.mark.polarion_id("OCS-962"), skipif_managed_service],
+            marks=[
+                pytest.mark.polarion_id("OCS-962"),
+                skipif_managed_service,
+                skipif_hci_provider_and_client,
+            ],
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_DELETE],
@@ -37,7 +46,11 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_RETAIN],
-            marks=[pytest.mark.polarion_id("OCS-964"), skipif_managed_service],
+            marks=[
+                pytest.mark.polarion_id("OCS-964"),
+                skipif_managed_service,
+                skipif_hci_provider_and_client,
+            ],
         ),
     ],
 )

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -110,8 +110,10 @@ class TestPvcAssignPodNode(ManageTest):
         pod.get_fio_rw_iops(pod_obj)
 
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if (ocs_version >= version.VERSION_4_12) and (
+        if ocs_version >= version.VERSION_4_12 and (
             config.ENV_DATA.get("platform") != constants.FUSIONAAS_PLATFORM
+            or config.ENV_DATA.get("platform")
+            not in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         ):
             self.verify_access_token_notin_odf_pod_logs()
 

--- a/tests/manage/pv_services/test_raw_block_pv.py
+++ b/tests/manage/pv_services/test_raw_block_pv.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     acceptance,
     skipif_managed_service,
+    hci_provider_and_client_required,
 )
 from ocs_ci.ocs import constants, node
 from ocs_ci.helpers import helpers
@@ -31,7 +32,11 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             constants.RECLAIM_POLICY_RETAIN,
-            marks=[pytest.mark.polarion_id("OCS-750"), skipif_managed_service],
+            marks=[
+                pytest.mark.polarion_id("OCS-750"),
+                skipif_managed_service,
+                hci_provider_and_client_required,
+            ],
         ),
     ],
 )

--- a/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -4,7 +4,12 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    skipif_external_mode,
+    skipif_hci_provider_and_client,
+)
 from tests.fixtures import create_rbd_secret, create_project
 
 log = logging.getLogger(__name__)
@@ -13,6 +18,7 @@ log = logging.getLogger(__name__)
 @green_squad
 @skipif_external_mode
 @tier2
+@skipif_hci_provider_and_client
 @pytest.mark.usefixtures(
     create_project.__name__,
     create_rbd_secret.__name__,

--- a/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
+++ b/tests/manage/storageclass/test_create_multiple_sc_with_same_pool_name.py
@@ -6,7 +6,12 @@ from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs.exceptions import ResourceLeftoversException
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    skipif_external_mode,
+    skipif_hci_provider_and_client,
+)
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret,
@@ -55,6 +60,7 @@ def resources(request):
 @green_squad
 @skipif_external_mode
 @tier2
+@skipif_hci_provider_and_client
 @pytest.mark.usefixtures(
     create_project.__name__,
     create_rbd_secret.__name__,


### PR DESCRIPTION
Skip the Test after Tier1 and Tier2 analysis for unsupported Feature:
1. NFS
2. Encryption
3. TC which involves the creation of new storageclass
4. Adjust test step to skip verification with  for above unsupported feature 