### PR TITLE
Use `mcg_obj instead` of `mcg_obj_session` at `test_deletion_sync_after_instant_deletion` and skip TestLogBasedBucketReplication at d/c clusters

### DIFF
--- a/tests/manage/mcg/test_log_based_bucket_replication.py
+++ b/tests/manage/mcg/test_log_based_bucket_replication.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import red_squad
 from ocs_ci.framework.testlib import (
     skipif_aws_creds_are_missing,
     skipif_vsphere_ipi,
+    skipif_disconnected_cluster,
     ignore_leftover_label,
     polarion_id,
     tier1,
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @ignore_leftover_label(constants.MON_APP_LABEL)  # tier4b test requirement
 @skipif_aws_creds_are_missing
+@skipif_disconnected_cluster
 class TestLogBasedBucketReplication(MCGTest):
     """
     Test log-based replication with deletion sync.

--- a/tests/manage/mcg/test_log_based_bucket_replication.py
+++ b/tests/manage/mcg/test_log_based_bucket_replication.py
@@ -245,7 +245,7 @@ class TestLogBasedBucketReplication(MCGTest):
     @tier3
     @polarion_id("OCS-4940")
     def test_deletion_sync_after_instant_deletion(
-        self, mcg_obj_session, log_based_replication_setup
+        self, mcg_obj, log_based_replication_setup
     ):
         """
         Test deletion sync behavior when an object is immediately deleted after being uploaded to the source bucket.
@@ -267,7 +267,7 @@ class TestLogBasedBucketReplication(MCGTest):
         mockup_logger.delete_all_objects_and_log(source_bucket.name)
 
         upload_test_objects_to_source_and_wait_for_replication(
-            mcg_obj_session,
+            mcg_obj,
             source_bucket,
             target_bucket,
             mockup_logger,
@@ -275,7 +275,7 @@ class TestLogBasedBucketReplication(MCGTest):
         )
 
         delete_objects_from_source_and_wait_for_deletion_sync(
-            mcg_obj_session,
+            mcg_obj,
             source_bucket,
             target_bucket,
             mockup_logger,


### PR DESCRIPTION
Fixes: #8811, #8978