### PR TITLE
Update the function to get pool name in HCI platform

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -335,7 +335,16 @@ def get_pool_name(fixture_name):
         else:
             ceph_pool_name = "ocs-storagecluster-cephblockpool"
     elif fixture_name.endswith("cephfs"):
-        ceph_pool_name = "ocs-storagecluster-cephfilesystem-data0"
+        if (
+            config.ENV_DATA["platform"].lower()
+            in constants.HCI_PROVIDER_CLIENT_PLATFORMS
+            and config.ENV_DATA.get("cluster_type", "").lower() == constants.HCI_CLIENT
+        ):
+            # Get pool name form storageclass
+            default_sc = default_storage_class(constants.CEPHFILESYSTEM)
+            ceph_pool_name = default_sc.get()["parameters"]["pool"]
+        else:
+            ceph_pool_name = "ocs-storagecluster-cephfilesystem-data0"
     else:
         raise UnexpectedVolumeType("unexpected volume type, ocs-ci code is wrong")
     return ceph_pool_name


### PR DESCRIPTION
Update the function to get pool name in HCI platform.

This will fix the type of issue given below in different test cases.
```
failed on setup with "AssertionError: Pool: cephblockpool-storageconsumer-6d144005-903d-482b-8ba7-25b0dbc6eca8 doesn't exist!"
```
Fixed the code to generate the correct pool name.