### PR TITLE
Set fio parameter direct in test_rbd_block_rwx_pvc

### DIFF
--- a/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
+++ b/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
@@ -75,6 +75,7 @@ class TestRbdBlockPvc(ManageTest):
                 io_direction="write",
                 runtime=5,
                 end_fsync=1,
+                direct=1,
             )
             log.info(f"IO started on pod {io_pod.name}")
 


### PR DESCRIPTION
Set fio parameter direct=1 for block volume mode RBD PVC in the test case 
tests/manage/pv_services/test_rbd_rwx_pvc.py::TestRbdBlockPvc::test_rbd_block_rwx_pvc