### PR TITLE
Add runs_on_provider marker in the tests test_monitoring_defaults

### DIFF
--- a/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_monitoring_defaults.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     blue_squad,
     skipif_mcg_only,
     bugzilla,
+    runs_on_provider,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.first
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_managed_service
+@runs_on_provider
 def test_monitoring_enabled(threading_lock):
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
@@ -82,6 +84,7 @@ def test_monitoring_enabled(threading_lock):
 @tier1
 @pytest.mark.polarion_id("OCS-1265")
 @skipif_managed_service
+@runs_on_provider
 def test_ceph_mgr_dashboard_not_deployed():
     """
     Check that `ceph mgr dashboard`_ is not deployed after installation of OCS
@@ -120,6 +123,7 @@ def test_ceph_mgr_dashboard_not_deployed():
 @tier1
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
+@runs_on_provider
 def test_ceph_rbd_metrics_available(threading_lock):
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
@@ -143,6 +147,7 @@ def test_ceph_rbd_metrics_available(threading_lock):
 @metrics_for_external_mode_required
 @pytest.mark.polarion_id("OCS-1268")
 @skipif_managed_service
+@runs_on_provider
 def test_ceph_metrics_available(threading_lock):
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
@@ -176,6 +181,7 @@ def test_ceph_metrics_available(threading_lock):
 @pytest.mark.post_ocp_upgrade
 @pytest.mark.polarion_id("OCS-1302")
 @skipif_managed_service
+@runs_on_provider
 def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.


### PR DESCRIPTION
Add runs_on_provider marker in the tests test_monitoring_defaults. This will make the test to run on the provider cluster while using a multicluster configuration.