### PR TITLE
Refined in-transit encryption test cases.

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1258,8 +1258,8 @@ def in_transit_encryption_verification():
 
     keys_found = retry(
         (ValueError),
-        tries=5,
-        delay=60,
+        tries=10,
+        delay=5,
     )(search_secure_keys)()
 
     if len(keys_to_match) != len(keys_found):
@@ -1275,22 +1275,6 @@ def in_transit_encryption_verification():
         f" {','.join(keys_found)} keys configured."
     )
 
-    # Verify ceph monitor protocol version
-    log.info("Verifying ceph monitor protocol version.")
-    ceph_mon_data = ceph_mon_dump()
-    v2_protocol_mon = sum(
-        1
-        for mon in ceph_mon_data["mons"]
-        if mon["public_addrs"]["addrvec"][0]["type"] == "v2"
-    )
-
-    if not v2_protocol_mon:
-        log.error("ceph mons are not configured with v2 protocol version. ")
-        raise ValueError(
-            "ceph mon protocol is not configured with 'v2' version which is recomended for in-transit encryption."
-        )
-
-    log.info("Ceph mons are configured with 'v2' protocol version.")
     return True
 
 

--- a/tests/functional/encryption/test_intransit_encryption_sanity.py
+++ b/tests/functional/encryption/test_intransit_encryption_sanity.py
@@ -17,9 +17,6 @@ from ocs_ci.framework import config
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(
-    reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/8759"
-)
 @green_squad
 @skipif_hci_provider_and_client
 class TestInTransitEncryptionSanity:

--- a/tests/functional/encryption/test_intransit_encryption_sanity.py
+++ b/tests/functional/encryption/test_intransit_encryption_sanity.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     green_squad,
     skipif_hci_provider_and_client,
+    cloud_platform_required,
 )
 from ocs_ci.framework import config
 
@@ -19,6 +20,7 @@ log = logging.getLogger(__name__)
 
 @green_squad
 @skipif_hci_provider_and_client
+@cloud_platform_required
 class TestInTransitEncryptionSanity:
     @pytest.fixture(autouse=True)
     def set_encryption_at_teardown(self, request):

--- a/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
@@ -90,6 +90,7 @@ class TestMonFailuresWithIntransitEncryption:
         time.sleep(10)
 
         def restart_mgr_pod():
+            ceph_obj.scan_cluster()
             mgr_pod = ceph_obj.mgrs[0]
             mgr_pod.delete(wait=True)
 

--- a/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     skipif_ocs_version,
     green_squad,
+    cloud_platform_required,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -28,6 +29,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.13")
 @pytest.mark.polarion_id("OCS-4919")
 @green_squad
+@cloud_platform_required
 class TestMonFailuresWithIntransitEncryption:
     @pytest.fixture(autouse=True)
     def teardown_fixture(self, request):

--- a/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
@@ -26,9 +26,6 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.13")
 @pytest.mark.polarion_id("OCS-4919")
 @green_squad
-@pytest.mark.skip(
-    reason="Skipping due to the issue https://github.com/red-hat-storage/ocs-ci/issues/8464"
-)
 class TestMonFailuresWithIntransitEncryption:
     @pytest.fixture(autouse=True)
     def teardown_fixture(self, request):
@@ -61,7 +58,7 @@ class TestMonFailuresWithIntransitEncryption:
             8. Verify the in-transit encryption configuration after
             scaling up mons and restarting mgr pod.
         """
-
+        self.mons = []
         if not get_in_transit_encryption_config_state():
             if config.ENV_DATA.get("in_transit_encryption"):
                 pytest.fail(


### PR DESCRIPTION
Following changes done.

1.  reduce waiting time to confirm Ceph configs.
2. Removed check for Ceph protocol version v2 check since it's being by default.
3. Fixed tests cases error by initialising the empty list `self.mons = []` at the begning   of test case. 