### PR TITLE
Disable test case: test_pv_creation

### DIFF
--- a/tests/manage/pv_services/test_pv_creation.py
+++ b/tests/manage/pv_services/test_pv_creation.py
@@ -11,7 +11,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import exceptions, ocp
 from ocs_ci.ocs.constants import TEMPLATE_PV_PVC_DIR
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.utility import templating, utils
 
 log = logging.getLogger(__name__)
@@ -85,8 +85,11 @@ def verify_pv_exist(pv_name):
     return True
 
 
+# @tier1
+# Test case is disabled.
+# The Recycle reclaim policy is deprecated in OpenShift Container Platform 4.
+# Dynamic provisioning is recommended for equivalent and better functionality.
 @green_squad
-@tier1
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )


### PR DESCRIPTION
This PR is to disable an outdated test case `test_pv_creation`.
Reason for Disabling:
 - No corresponding requirement or test case exists in Polarion.
 - Latest [OCP documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#reclaiming_understanding-persistent-storage) now classifies the used reclaim policy `Recycle` as deprecated. 

Also, discussed [here](https://url.corp.redhat.com/1acdac0) 

Signed-off-by: Sidhant Agrawal <sagrawal@redhat.com>