### PR TITLE
Fix cluster switching in the function storagecluster_independent_check

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -3031,7 +3031,7 @@ def storagecluster_independent_check():
     )
     if consumer_cluster_index is not None:
         # Switch back to consumer cluster context
-        config.switch_to_consumer(consumer_cluster_index)
+        config.switch_ctx(consumer_cluster_index)
     return ret_val
 
 


### PR DESCRIPTION
Fixes #8997

Changing the method to switch because "switch_to_consumer" method is not applicable for HCI provider-client platform.  