### PR TITLE
Fix `test_noobaa_rebuild` and make sure it updates the mcg_obj_session s3 credentials after resetting the noobaa-admin secret

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -128,23 +128,7 @@ class MCG:
         ) + "/rpc"
         self.region = config.ENV_DATA["region"]
 
-        admin_credentials = self.get_noobaa_admin_credentials_from_secret()
-        self.access_key_id = admin_credentials["AWS_ACCESS_KEY_ID"]
-        self.access_key = admin_credentials["AWS_SECRET_ACCESS_KEY"]
-        self.noobaa_user = admin_credentials["email"]
-        self.noobaa_password = admin_credentials["password"]
-
-        self.noobaa_token = self.retrieve_nb_token()
-
-        self.s3_resource = boto3.resource(
-            "s3",
-            verify=retrieve_verification_mode(),
-            endpoint_url=self.s3_endpoint,
-            aws_access_key_id=self.access_key_id,
-            aws_secret_access_key=self.access_key,
-        )
-
-        self.s3_client = self.s3_resource.meta.client
+        self.update_s3_creds()
 
         if config.ENV_DATA["platform"].lower() == "aws" and kwargs.get(
             "create_aws_creds"
@@ -1083,6 +1067,30 @@ class MCG:
         ).decode("utf-8")
 
         return credentials_dict
+
+    def update_s3_creds(self):
+        """
+        Set the S3 credentials of the NooBaa admin user from the
+        noobaa-admin secret, and update the S3 resource and client
+
+        """
+        admin_credentials = self.get_noobaa_admin_credentials_from_secret()
+        self.access_key_id = admin_credentials["AWS_ACCESS_KEY_ID"]
+        self.access_key = admin_credentials["AWS_SECRET_ACCESS_KEY"]
+        self.noobaa_user = admin_credentials["email"]
+        self.noobaa_password = admin_credentials["password"]
+
+        self.noobaa_token = self.retrieve_nb_token()
+
+        self.s3_resource = boto3.resource(
+            "s3",
+            verify=retrieve_verification_mode(),
+            endpoint_url=self.s3_endpoint,
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.access_key,
+        )
+
+        self.s3_client = self.s3_resource.meta.client
 
     def reset_admin_pw(self, new_password):
         """

--- a/tests/cross_functional/kcs/test_noobaa_rebuild.py
+++ b/tests/cross_functional/kcs/test_noobaa_rebuild.py
@@ -70,7 +70,7 @@ class TestNoobaaRebuild(E2ETest):
 
         request.addfinalizer(finalizer)
 
-    def test_noobaa_rebuild(self, bucket_factory):
+    def test_noobaa_rebuild(self, bucket_factory_session, mcg_obj_session):
         """
         Test case to verify noobaa rebuild. Verifies KCS: https://access.redhat.com/solutions/5948631
 
@@ -150,7 +150,8 @@ class TestNoobaaRebuild(E2ETest):
             )
         else:
             dep_ocp.exec_oc_cmd(
-                "delete secrets noobaa-admin noobaa-endpoints noobaa-operator noobaa-server noobaa-root-master-key"
+                "delete secrets noobaa-admin noobaa-endpoints noobaa-operator "
+                "noobaa-server noobaa-root-master-key-backend noobaa-root-master-key-volume"
             )
 
         # Scale back noobaa-operator deployment
@@ -185,6 +186,10 @@ class TestNoobaaRebuild(E2ETest):
         logger.info("Verifying all resources are Running and matches expected result")
         self.sanity_helpers.health_check(tries=120)
 
+        # Since the rebuild changed the noobaa-admin secret, update
+        # the s3 credentials in mcg_object_session
+        mcg_obj_session.update_s3_creds()
+
         # Verify default backingstore/bucketclass
         default_bs = OCP(
             kind=constants.BACKINGSTORE, namespace=config.ENV_DATA["cluster_namespace"]
@@ -200,4 +205,4 @@ class TestNoobaaRebuild(E2ETest):
 
         # Create OBCs
         logger.info("Creating OBCs after noobaa rebuild")
-        bucket_factory(amount=3, interface="OC", verify_health=True)
+        bucket_factory_session(amount=3, interface="OC", verify_health=True)


### PR DESCRIPTION
Fixes: #8811

Note that even though this test is under Magenta Squad, this issue failed many Red Squad tests.