### PR TITLE
Update test_pvc_assign_pod_node to skip the check for api access token in HCI provider-client platform

### DIFF
--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -110,11 +110,11 @@ class TestPvcAssignPodNode(ManageTest):
         pod.get_fio_rw_iops(pod_obj)
 
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if ocs_version >= version.VERSION_4_12 and (
-            config.ENV_DATA.get("platform") != constants.FUSIONAAS_PLATFORM
-            or config.ENV_DATA.get("platform")
-            not in constants.HCI_PROVIDER_CLIENT_PLATFORMS
-        ):
+        if ocs_version >= version.VERSION_4_12 and config.ENV_DATA.get(
+            "platform"
+        ) not in constants.HCI_PROVIDER_CLIENT_PLATFORMS + [
+            constants.FUSIONAAS_PLATFORM
+        ]:
             self.verify_access_token_notin_odf_pod_logs()
 
     @acceptance
@@ -209,7 +209,9 @@ class TestPvcAssignPodNode(ManageTest):
             pod.get_fio_rw_iops(pod_obj)
 
         ocs_version = version.get_semantic_ocs_version_from_config()
-        if (ocs_version >= version.VERSION_4_12) and (
-            config.ENV_DATA.get("platform") != constants.FUSIONAAS_PLATFORM
-        ):
+        if ocs_version >= version.VERSION_4_12 and config.ENV_DATA.get(
+            "platform"
+        ) not in constants.HCI_PROVIDER_CLIENT_PLATFORMS + [
+            constants.FUSIONAAS_PLATFORM
+        ]:
             self.verify_access_token_notin_odf_pod_logs()

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -95,7 +95,7 @@ class TestPvcAssignPodNode(ManageTest):
             config.ENV_DATA["platform"].lower()
             in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         ):
-            timeout = 180
+            timeout = 300
         helpers.wait_for_resource_state(
             resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
         )

--- a/tests/manage/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/manage/pv_services/test_pvc_assign_pod_node.py
@@ -95,7 +95,7 @@ class TestPvcAssignPodNode(ManageTest):
             config.ENV_DATA["platform"].lower()
             in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         ):
-            timeout = 300
+            timeout = 180
         helpers.wait_for_resource_state(
             resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
         )


### PR DESCRIPTION
Update tests/manage/pv_services/test_pvc_assign_pod_node.py to skip the check for api access token in HCI provider-client platform.
Fixes #9034 
