### PR TITLE
Run certain test cases on provider in HCI Provider-Client setup

### DIFF
--- a/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     bugzilla,
     skipif_ocs_version,
     skipif_external_mode,
+    runs_on_provider,
 )
 from ocs_ci.ocs.resources.pod import (
     get_pod_node,
@@ -26,6 +27,7 @@ from ocs_ci.ocs.resources.pod import (
 log = logging.getLogger(__name__)
 
 
+@runs_on_provider
 @brown_squad
 @tier2
 @skipif_external_mode

--- a/tests/manage/z_cluster/test_osd_heap_profile.py
+++ b/tests/manage/z_cluster/test_osd_heap_profile.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     bugzilla,
     skipif_external_mode,
+    runs_on_provider,
 )
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 from ocs_ci.utility.utils import TimeoutSampler
@@ -18,6 +19,7 @@ from ocs_ci.ocs.exceptions import CommandFailed
 log = logging.getLogger(__name__)
 
 
+@runs_on_provider
 @brown_squad
 @tier2
 @bugzilla("1938049")


### PR DESCRIPTION
Add runs_on_provider marker for the testcases given below.
1. tests/manage/z_cluster/test_coredump_check_for_ceph_daemon_crash.py::TestKillCephDaemon::test_coredump_check_for_ceph_daemon_crash
2. tests/manage/z_cluster/test_osd_heap_profile.py::TestOSDHeapProfile::test_osd_heap_profile