### PR TITLE
[release-4.12 backport] Fix ObjectBucket::verify_health to only check S3 existence of MCG buckets

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -254,7 +254,7 @@ class ObjectBucket(ABC):
             for health_check in TimeoutSampler(
                 timeout, interval, self.internal_verify_health
             ):
-                if health_check:
+                if health_check and self.mcg.s3_verify_bucket_exists(self.name):
                     logger.info(f"{self.name} is healthy")
                     break
                 else:

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -254,11 +254,15 @@ class ObjectBucket(ABC):
             for health_check in TimeoutSampler(
                 timeout, interval, self.internal_verify_health
             ):
-                if health_check and self.mcg.s3_verify_bucket_exists(self.name):
+                if not health_check:
+                    logger.info(f"{self.name} is unhealthy. Rechecking.")
+                elif self.mcg and not self.mcg.s3_verify_bucket_exists(self.name):
+                    logger.info(
+                        f"{self.name} is healthy, but not found in S3. Rechecking."
+                    )
+                else:
                     logger.info(f"{self.name} is healthy")
                     break
-                else:
-                    logger.info(f"{self.name} is unhealthy. Rechecking.")
         except TimeoutExpiredError:
             logger.error(
                 f"{self.name} did not reach a healthy state within {timeout} seconds."


### PR DESCRIPTION
release-4.12 backport of #8330