### PR TITLE
`test_anonymous_read_only`: Use s3_get_object with retry 

### DIFF
--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -389,7 +389,10 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Getting object by user: {user.email_id} on bucket: {s3_bucket.name} "
         )
-        assert s3_get_object(
+        retry_s3_get_object = retry(boto3exception.ClientError, tries=4, delay=10)(
+            s3_get_object
+        )
+        assert retry_s3_get_object(
             user, s3_bucket.name, object_key
         ), f"Failed: Get Object by user {user.email_id}"
 


### PR DESCRIPTION
Fixes: #9013

Requires a backport to 4.14