### PR TITLE
Increase timeout for creating the resources after rolling nodes restart

### DIFF
--- a/tests/manage/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/manage/z_cluster/nodes/test_nodes_restart.py
@@ -112,7 +112,8 @@ class TestNodesRestart(ManageTest):
         for node in ocp_nodes:
             nodes.restart_nodes(nodes=[node], wait=False)
             self.sanity_helpers.health_check(cluster_check=False, tries=60)
-        retry(CommandFailed, tries=3, delay=20, backoff=1)(
+
+        retry(CommandFailed, tries=8, delay=40, backoff=1)(
             self.sanity_helpers.create_resources
         )(pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory)
 


### PR DESCRIPTION
After the rolling nodes restart, it can take a little more time to successfully create resources (approximately 5 minutes).
This is not a bug because the process finished successfully, and the scenario of rolling restart nodes rarely happens.
fix #8649 