### PR TITLE
RDR - Skip PVC and PV deletion check for CephFS

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -664,33 +664,28 @@ def wait_for_all_resources_deletion(
         namespace, timeout, check_replication_resources_state
     )
 
-    logger.info("Waiting for all PVCs to be deleted")
-    all_pvcs = get_all_pvc_objs(namespace=namespace)
+    if not (
+        config.MULTICLUSTER["multicluster_mode"] == "regional-dr"
+        and "cephs" in namespace
+    ):
+        logger.info("Waiting for all PVCs to be deleted")
+        all_pvcs = get_all_pvc_objs(namespace=namespace)
 
-    for pvc_obj in all_pvcs:
-        if "volsync-" not in pvc_obj.name:
+        for pvc_obj in all_pvcs:
             pvc_obj.ocp.wait_for_delete(
                 resource_name=pvc_obj.name, timeout=timeout, sleep=5
             )
 
     if config.MULTICLUSTER["multicluster_mode"] != "metro-dr":
-        logger.info("Waiting for all PVs to be deleted")
-        # Check whether volsync PVCs are still present. The value from the previous step is not obtained because the
-        # PVCs might be in deleting state and the count may change.
-        num_of_volsync_pvc = len(
-            [
-                pvc_obj.name
-                for pvc_obj in get_all_pvc_objs(namespace=namespace)
-                if "volsync-" in pvc_obj.name
-            ]
-        )
-        sample = TimeoutSampler(
-            timeout=timeout,
-            sleep=5,
-            func=get_pv_count,
-            namespace=namespace,
-        )
-        sample.wait_for_func_value(num_of_volsync_pvc)
+        if "cephs" not in namespace:
+            logger.info("Waiting for all PVs to be deleted")
+            sample = TimeoutSampler(
+                timeout=timeout,
+                sleep=5,
+                func=get_pv_count,
+                namespace=namespace,
+            )
+            sample.wait_for_func_value(0)
 
 
 def wait_for_replication_destinations_creation(rep_dest_count, namespace, timeout=900):


### PR DESCRIPTION
To fix the test case 
tests/disaster-recovery/regional-dr/test_failover.py::TestFailover::test_failover[primary_up_cephfs]
the checks for automatic deletion of CephFS PVC and PV from the primary cluster after failover, is removed. The PVCs and PVs will not be deleted automatically for CepHFS based workloads after failover.

Fixes #9040
