### PR TITLE
CSI-Addons CR resources should not be editable after creation - 4.15

### DIFF
--- a/tests/e2e/system_test/test_cr_resources_validation.py
+++ b/tests/e2e/system_test/test_cr_resources_validation.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     skipif_ocs_version,
     ManageTest,
-    tier3,
+    tier2,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.performance_lib import run_oc_command
@@ -23,9 +23,9 @@ ERRMSG = "Error in command"
 
 
 @magenta_squad
-@tier3
-@skipif_ocp_version("<4.13")
-@skipif_ocs_version("<4.13")
+@tier2
+@skipif_ocp_version("<4.15")
+@skipif_ocs_version("<4.15")
 class TestCRRsourcesValidation(ManageTest):
     """
     Test that check that csi addons resources are not editable after creation

--- a/tests/manage/pv_services/space_reclaim/test_cr_resources_validation.py
+++ b/tests/manage/pv_services/space_reclaim/test_cr_resources_validation.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from tempfile import NamedTemporaryFile
-from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
+from ocs_ci.framework.pytest_customization.marks import bugzilla, grey_squad
 from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     skipif_ocs_version,
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
-@magenta_squad
+@grey_squad
 @tier2
 @skipif_ocp_version("<4.15")
 @skipif_ocs_version("<4.15")


### PR DESCRIPTION
This PR implements an automation for verifying that CR resources are not editable after creation in 4.15 