### PR TITLE
Provider-Client: Add runs_on_provider marker in test case

### DIFF
--- a/tests/manage/z_cluster/test_delete_rook_ceph_mon_pod.py
+++ b/tests/manage/z_cluster/test_delete_rook_ceph_mon_pod.py
@@ -5,6 +5,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
+    runs_on_provider,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants
@@ -15,6 +16,7 @@ from ocs_ci.framework.testlib import ManageTest, tier2
 log = logging.getLogger(__name__)
 
 
+@runs_on_provider
 @brown_squad
 @tier2
 @skipif_external_mode

--- a/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
+++ b/tests/manage/z_cluster/test_rook_ceph_log_rotate.py
@@ -19,11 +19,13 @@ from ocs_ci.framework.testlib import (
     skipif_external_mode,
     ignore_leftovers,
     config,
+    runs_on_provider,
 )
 
 log = logging.getLogger(__name__)
 
 
+@runs_on_provider
 @brown_squad
 @tier2
 @ignore_leftovers

--- a/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/manage/z_cluster/test_rook_ceph_operator_log_type.py
@@ -17,11 +17,13 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
     bugzilla,
+    runs_on_provider,
 )
 
 log = logging.getLogger(__name__)
 
 
+@runs_on_provider
 @brown_squad
 @tier2
 @bugzilla("1962821")


### PR DESCRIPTION
Add runs_on_provider marker in the test cases:
 1. tests/manage/z_cluster/test_delete_rook_ceph_mon_pod.py::TestDeleteRookCephMonPod::test_delete_rook_ceph_mon_pod
2. tests/manage/z_cluster/test_rook_ceph_log_rotate.py::TestRookCephLogRotate::test_rook_ceph_log_rotate
3. tests/manage/z_cluster/test_rook_ceph_operator_log_type.py::TestRookCephOperatorLogType::test_rook_ceph_operator_log_type