### PR TITLE
Add addtion timeout for pod creations on provider-cleint platform

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1425,6 +1425,7 @@ def dc_pod_factory(request, pvc_factory, service_account_factory):
         raw_block_pv=False,
         sa_obj=None,
         wait=True,
+        timeout=180,
     ):
         """
         Args:
@@ -1446,6 +1447,7 @@ def dc_pod_factory(request, pvc_factory, service_account_factory):
             replica_count (int): Replica count for deployment config
             raw_block_pv (str): True if pod with raw block pvc
             sa_obj (object) : If specific service account is needed
+            timeout (int): Time in seconds to wait
 
         """
         if custom_data:
@@ -1474,7 +1476,7 @@ def dc_pod_factory(request, pvc_factory, service_account_factory):
         log.info(dc_pod_obj.name)
         if wait:
             helpers.wait_for_resource_state(
-                dc_pod_obj, constants.STATUS_RUNNING, timeout=180
+                dc_pod_obj, constants.STATUS_RUNNING, timeout=timeout
             )
         dc_pod_obj.pvc = pvc
         return dc_pod_obj

--- a/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
@@ -3,6 +3,7 @@ from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import ManageTest, tier2
+from ocs_ci.framework import config
 
 
 @green_squad
@@ -59,7 +60,13 @@ class TestRunIOMultipleDcPods(ManageTest):
 
         dc_pod_objs = list()
         for pvc_obj in pvc_objs:
-            dc_pod_objs.append(dc_pod_factory(pvc=pvc_obj))
+            if (
+                config.ENV_DATA["platform"].lower()
+                in constants.HCI_PROVIDER_CLIENT_PLATFORMS
+            ):
+                dc_pod_objs.append(dc_pod_factory(pvc=pvc_obj, timeout=360))
+            else:
+                dc_pod_objs.append(dc_pod_factory(pvc=pvc_obj))
         return dc_pod_objs
 
     def test_run_io_multiple_dc_pods(self, dc_pods):


### PR DESCRIPTION
Signed-off-by: suchita-g <sgatfane@redhat.com>
Fixing Tier2 TC :
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-odf-multicluster/2147/testReport/tests.manage.pv_services.test_run_io_multiple_dc_pods/TestRunIOMultipleDcPods/test_run_io_multiple_dc_pods_CephFileSystem_/ 
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-odf-multicluster/2147/testReport/tests.manage.pv_services.test_run_io_multiple_dc_pods/TestRunIOMultipleDcPods/test_run_io_multiple_dc_pods_CephBlockPool_/
This test Failed with a timeout Error while waiting for pod in dc_pod_factory function. 
During phase-1, slowness was observed when multiple PVCs or PODs were created on
 Provider-client platform