### PR TITLE
[release-4.14 backport] Add support for running OCS-CI with the `mcg` and `rgw` marks (#9070)

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -57,7 +57,7 @@ libtest = pytest.mark.libtest
 
 team_marks = [manage, ecosystem, e2e]
 
-# components  and other markerr
+# components and other markers
 ocp = pytest.mark.ocp
 rook = pytest.mark.rook
 ui = pytest.mark.ui

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -57,10 +57,12 @@ libtest = pytest.mark.libtest
 
 team_marks = [manage, ecosystem, e2e]
 
-# components  and other markers
+# components  and other markerr
 ocp = pytest.mark.ocp
 rook = pytest.mark.rook
 ui = pytest.mark.ui
+mcg = pytest.mark.mcg
+rgw = pytest.mark.rgw
 csi = pytest.mark.csi
 monitoring = pytest.mark.monitoring
 workloads = pytest.mark.workloads

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -635,7 +635,7 @@ class ArchitectureNotSupported(Exception):
     pass
 
 
-class MissingSquadDecoratorError(Exception):
+class MissingDecoratorError(Exception):
     pass
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -58,6 +58,8 @@ markers =
     yellow_squad: marker for yellow squad
     turquoise_squad: marker for turquoise squad
     ignore_owner: marker to ignore test during squad decorator check in pytest collection
+    mcg: marker for MCG related tests
+    rgw: marker for RGW related tests
 
 # Clusterctx used without hyphen, to keep the original format if it's None
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s %(clusterctx)s - %(message)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ from ocs_ci.ocs.exceptions import (
     PoolNotDeletedFromUI,
     StorageClassNotDeletedFromUI,
     ResourceNotDeleted,
-    MissingSquadDecoratorError,
+    MissingDecoratorError,
 )
 from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implementation
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
@@ -189,7 +189,7 @@ def pytest_logger_config(logger_config):
     logger_config.set_formatter_class(OCSLogFormatter)
 
 
-def verify_squad_owners(items):
+def verify_test_decorators_requirements(items):
     """
     Verify that all tests collected are decorated with a squad marker
 
@@ -198,6 +198,7 @@ def verify_squad_owners(items):
 
     """
     items_without_squad_marker = {}
+    red_no_mcg_or_rgw_items = {}
     for item in items:
         base_dir = os.path.join(constants.TOP_DIR, "tests")
         ignored_markers = constants.SQUAD_CHECK_IGNORED_MARKERS
@@ -208,12 +209,24 @@ def verify_squad_owners(items):
                     "Ignoring test case %s as it has a marker in the ignore list",
                     item.name,
                 )
+
+            # Verify tests are decorated with the correct squad owner
             elif not any(["_squad" in marker for marker in item_markers]):
                 log.debug("%s is missing a squad owner marker", item.name)
                 items_without_squad_marker.update({item.name: item.fspath.strpath})
 
+            # Verify red squad tests are decorated with either @mcg or @rgw
+            elif (
+                "red_squad" in item_markers
+                and "mcg" not in item_markers
+                and "rgw" not in item_markers
+            ):
+                log.debug("%s is a red_squad test without @mcg or @rgw", item.name)
+                red_no_mcg_or_rgw_items.update({item.name: item.fspath.strpath})
+
+    err_msg = ""
     if items_without_squad_marker:
-        msg = f"""
+        err_msg += f"""
 Missing squad decorator for the following test items: {json.dumps(items_without_squad_marker, indent=4)}
 
 Tests are required to be decorated with their squad owner. Please add the tests respective owner.
@@ -224,8 +237,17 @@ For example:
     def test_name():
 
 Test owner marks can be imported from `ocs_ci.framework.pytest_customization.marks`
+
             """
-        raise MissingSquadDecoratorError(msg)
+    if red_no_mcg_or_rgw_items:
+        err_msg += f"""
+The following tests are missing either the @mcg or @rgw decorators: {json.dumps(red_no_mcg_or_rgw_items, indent=4)}
+
+Red squad tests are required to be decorated with either @mcg or @rgw. Please add either depending on the tests's focus.
+
+                """
+    if err_msg:
+        raise MissingDecoratorError(err_msg)
 
 
 def export_squad_marker_to_csv(items, filename=None):
@@ -295,9 +317,8 @@ def pytest_collection_modifyitems(session, config, items):
     deploy = ocsci_config.RUN["cli_params"].get("deploy")
     skip_ocs_deployment = ocsci_config.ENV_DATA["skip_ocs_deployment"]
 
-    # Verify tests are decorated with the correct squad owner
     if config.option.collectonly:
-        verify_squad_owners(items)
+        verify_test_decorators_requirements(items)
 
     # Add squad markers to each test item based on filepath
     for item in items:

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     flowtests,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -33,6 +34,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     flowtests,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -39,6 +40,7 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import warp
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, mcg
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -21,6 +21,7 @@ from ocs_ci.ocs.resources.pod import (
 log = logging.getLogger(__name__)
 
 
+@mcg
 @magenta_squad
 @tier3
 @ignore_leftovers
@@ -86,7 +87,6 @@ class TestNoobaaBackupAndRecovery(E2ETest):
 
     @pytest.fixture()
     def warps3(self, request):
-
         warps3 = warp.Warp()
         warps3.create_resource_warp(replicas=4, multi_client=True)
 

--- a/tests/e2e/kcs/test_noobaa_rebuild.py
+++ b/tests/e2e/kcs/test_noobaa_rebuild.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_external_mode,
+    mcg,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs import constants
@@ -22,6 +23,7 @@ from ocs_ci.ocs.resources.pvc import get_pvc_objs
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @magenta_squad
 @tier3
 @ignore_leftovers

--- a/tests/e2e/kcs/test_noobaadb_pw_reset.py
+++ b/tests/e2e/kcs/test_noobaadb_pw_reset.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_ocs_version,
+    mcg,
 )
 from ocs_ci.helpers.helpers import (
     wait_for_resource_state,
@@ -24,6 +25,7 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @magenta_squad
 @tier3
 @pytest.mark.polarion_id("OCS-4662")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -57,6 +58,7 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -49,6 +50,7 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -108,6 +109,7 @@ def multipart_setup(pod_obj, origin_dir, result_dir):
     return mpu_key, origin_dir, result_dir, parts
 
 
+@mcg
 @red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs import bucket_utils
@@ -26,6 +27,7 @@ ROOT_OBJ = "RootKey-" + str(uuid.uuid4().hex)
 COPY_OBJ = "CopyKey-" + str(uuid.uuid4().hex)
 
 
+@mcg
 @red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service

--- a/tests/e2e/performance/mcg/test_mcg_cosbench.py
+++ b/tests/e2e/performance/mcg/test_mcg_cosbench.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.perfresult import ResultsAnalyse
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def cosbench(request):
-
     cosbench = Cosbench()
 
     def teardown():
@@ -23,6 +22,7 @@ def cosbench(request):
     return cosbench
 
 
+@mcg
 @red_squad
 @performance
 @performance_c

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     bugzilla,
     skipif_ocs_version,
+    mcg,
+    rgw,
 )
 
 log = logging.getLogger(__name__)
@@ -15,7 +17,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def hsbenchs3(request):
-
     hsbenchs3 = hsbench.HsBench()
     hsbenchs3.create_test_user()
     hsbenchs3.create_resource_hsbench()
@@ -31,7 +32,6 @@ def hsbenchs3(request):
 
 @pytest.fixture(scope="function")
 def s3bench(request):
-
     s3bench = hsbench.HsBench()
     s3bench.create_resource_hsbench()
     s3bench.install_hsbench()
@@ -50,6 +50,7 @@ class TestHsBench(E2ETest):
     Test writing one million S3 objects to a single bucket
     """
 
+    @rgw
     @vsphere_platform_required
     @pytest.mark.polarion_id("OCS-2321")
     def test_s3_benchmark_hsbench(self, hsbenchs3):
@@ -73,6 +74,7 @@ class TestHsBench(E2ETest):
         # Check ceph health status
         utils.ceph_health_check()
 
+    @mcg
     @bugzilla("1998680")
     @skipif_ocs_version("<4.9")
     @pytest.mark.polarion_id("OCS-2698")

--- a/tests/e2e/scale/noobaa/test_list_objects.py
+++ b/tests/e2e/scale/noobaa/test_list_objects.py
@@ -7,7 +7,7 @@ from ocs_ci.ocs.bucket_utils import (
     sync_object_directory,
     list_objects_from_bucket,
 )
-from ocs_ci.framework.pytest_customization.marks import orange_squad
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.framework.testlib import scale, bugzilla, skipif_ocs_version
 from ocs_ci.ocs.resources.mcg import MCG
@@ -16,6 +16,7 @@ from ocs_ci.ocs.resources.mcg import MCG
 log = logging.getLogger(__name__)
 
 
+@mcg
 @orange_squad
 @scale
 class TestListOfObjects(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
+++ b/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import orange_squad
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs import hsbench
@@ -28,6 +28,7 @@ def s3bench(request):
     return s3bench
 
 
+@mcg
 @orange_squad
 @scale
 @skipif_ocs_version("<4.9")

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import orange_squad
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import MCGTest, scale, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp, scale_pgsql
 from ocs_ci.utility import utils
@@ -52,6 +52,7 @@ def worker_node(request):
     return worker_node
 
 
+@mcg
 @orange_squad
 @scale
 @skipif_ocs_version("<4.5")

--- a/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import hsbench
@@ -28,6 +29,7 @@ def s3bench(request):
     return s3bench
 
 
+@mcg
 @orange_squad
 @scale
 class TestScaleNamespace(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
@@ -7,12 +7,14 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
+    mcg,
 )
 from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @orange_squad
 @skipif_ocs_version("!=4.6")
 @scale

--- a/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
@@ -4,7 +4,7 @@ import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import orange_squad
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.utility.utils import ocsci_log_path
@@ -21,6 +21,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@mcg
 @orange_squad
 @scale
 class TestScaleOCBCreateDelete(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation.py
@@ -9,6 +9,7 @@ from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     orange_squad,
+    mcg,
 )
 
 log = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@mcg
 @orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
@@ -8,6 +8,8 @@ from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
     on_prem_platform_required,
     orange_squad,
+    mcg,
+    rgw,
 )
 
 log = logging.getLogger(__name__)
@@ -45,12 +47,14 @@ class TestScaleOCBCreation(E2ETest):
                 *["noobaa-core", constants.NOOBAA_SC],
                 marks=[
                     pytest.mark.polarion_id("OCS-2645"),
+                    mcg,
                 ],
             ),
             pytest.param(
                 *["noobaa-db", constants.NOOBAA_SC],
                 marks=[
                     pytest.mark.polarion_id("OCS-2646"),
+                    mcg,
                 ],
             ),
             pytest.param(
@@ -58,6 +62,7 @@ class TestScaleOCBCreation(E2ETest):
                 marks=[
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-2647"),
+                    rgw,
                 ],
             ),
             pytest.param(
@@ -65,6 +70,7 @@ class TestScaleOCBCreation(E2ETest):
                 marks=[
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-2648"),
+                    rgw,
                 ],
             ),
         ],

--- a/tests/e2e/scale/noobaa/test_scale_obc_start_time_respin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_start_time_respin_noobaa_pods.py
@@ -6,7 +6,7 @@ import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import orange_squad
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.helpers import helpers
 from ocs_ci.utility.utils import ocsci_log_path
@@ -23,10 +23,10 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@mcg
 @orange_squad
 @scale
 class TestScaleOBCStartTime(E2ETest):
-
     namespace = config.ENV_DATA["cluster_namespace"]
     scale_obc_count = 10
     scale_obc_count_io = 2

--- a/tests/e2e/scale/noobaa/test_warp.py
+++ b/tests/e2e/scale/noobaa/test_warp.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     bugzilla,
     orange_squad,
+    mcg,
 )
 
 log = logging.getLogger(__name__)
@@ -18,7 +19,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def warps3(request):
-
     warps3 = warp.Warp()
     warps3.create_resource_warp()
 
@@ -29,6 +29,7 @@ def warps3(request):
     return warps3
 
 
+@mcg
 @orange_squad
 @scale
 @ignore_leftovers

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_external_mode,
     orange_squad,
+    mcg,
 )
 from ocs_ci.utility.utils import ocsci_log_path
 from ocs_ci.utility import utils, templating
@@ -30,6 +31,7 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
 
 
+@mcg
 @orange_squad
 @pre_upgrade
 @skipif_external_mode
@@ -81,6 +83,7 @@ def test_scale_obc_pre_upgrade(tmp_path, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@mcg
 @post_upgrade
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     vsphere_platform_required,
     orange_squad,
+    rgw,
 )
 from ocs_ci.utility.utils import ocsci_log_path
 from ocs_ci.utility import utils, templating
@@ -33,6 +34,7 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
+@rgw
 @orange_squad
 @pre_upgrade
 @vsphere_platform_required
@@ -110,6 +112,7 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@rgw
 @orange_squad
 @post_upgrade
 @vsphere_platform_required

--- a/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     system_test,
     skipif_vsphere_ipi,
     magenta_squad,
+    mcg,
 )
 from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
 from ocs_ci.ocs.bucket_utils import (
@@ -34,6 +35,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @magenta_squad
 @system_test
 @skipif_ocs_version("<4.9")
@@ -89,7 +91,6 @@ class TestMCGReplicationWithDisruptions(E2ETest):
         test_directory_setup,
         nodes,
     ):
-
         # check uni bucket replication from multi (aws+azure) namespace bucket to s3-compatible namespace bucket
         target_bucket_name = bucket_factory(bucketclass=target_bucketclass)[0].name
         replication_policy = ("basic-replication-rule", target_bucket_name, None)

--- a/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
+++ b/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
     on_prem_platform_required,
     bugzilla,
     skipif_external_mode,
+    rgw,
 )
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs.amq import AMQ
@@ -29,6 +30,7 @@ from ocs_ci.utility.utils import exec_cmd, run_cmd, clone_notify
 log = logging.getLogger(__name__)
 
 
+@rgw
 @magenta_squad
 @tier1
 @bugzilla("2209616")
@@ -52,7 +54,6 @@ class TestRGWAndKafkaNotifications(E2ETest):
         ) = self.kafkadrop_svc = self.kafkadrop_route = None
 
         def teardown():
-
             if self.kafka_topic:
                 self.kafka_topic.delete()
             if self.kafkadrop_pod:

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    mcg,
 )
 from ocs_ci.ocs.constants import BS_OPTIMAL
 from ocs_ci.ocs.bucket_utils import (
@@ -30,6 +31,7 @@ DOWNLOADED_OBJS = []
 @skipif_managed_service
 @aws_platform_required
 @pre_upgrade
+@mcg
 @red_squad
 def test_fill_bucket(
     mcg_obj_session, awscli_pod_session, multiregion_mirror_setup_session
@@ -86,6 +88,7 @@ def test_fill_bucket(
 @aws_platform_required
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2038")
+@mcg
 @red_squad
 def test_noobaa_postupgrade(
     mcg_obj_session, awscli_pod_session, multiregion_mirror_setup_session
@@ -133,6 +136,7 @@ def test_noobaa_postupgrade(
 @skipif_managed_service
 @bugzilla("1820974")
 @pre_upgrade
+@mcg
 @red_squad
 def test_buckets_before_upgrade(upgrade_buckets, mcg_obj_session):
     """
@@ -147,6 +151,7 @@ def test_buckets_before_upgrade(upgrade_buckets, mcg_obj_session):
 @bugzilla("1820974")
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2181")
+@mcg
 @red_squad
 def test_buckets_after_upgrade(upgrade_buckets, mcg_obj_session):
     """
@@ -158,6 +163,7 @@ def test_buckets_after_upgrade(upgrade_buckets, mcg_obj_session):
 
 @pre_upgrade
 @skipif_managed_service
+@mcg
 @red_squad
 def test_start_upgrade_mcg_io(mcg_workload_job):
     """
@@ -173,6 +179,7 @@ def test_start_upgrade_mcg_io(mcg_workload_job):
 @skipif_managed_service
 @pytest.mark.polarion_id("OCS-2207")
 @bugzilla("1874243")
+@mcg
 @red_squad
 def test_upgrade_mcg_io(mcg_workload_job):
     """

--- a/tests/ecosystem/upgrade/test_resources.py
+++ b/tests/ecosystem/upgrade/test_resources.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     red_squad,
     brown_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import ocp
@@ -28,6 +29,7 @@ log = logging.getLogger(__name__)
 
 @skipif_aws_creds_are_missing
 @post_upgrade
+@mcg
 @brown_squad
 @pytest.mark.polarion_id("OCS-2220")
 def test_storage_pods_running(multiregion_mirror_setup_session):
@@ -132,6 +134,7 @@ def test_pod_log_after_upgrade():
 @post_upgrade
 @bugzilla("1973179")
 @pytest.mark.polarion_id("OCS-2666")
+@mcg
 @red_squad
 def test_noobaa_service_mon_after_ocs_upgrade():
     """

--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
@@ -22,6 +22,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_ocs_version("<4.10")
 # We have to ignore leftovers since environment_checker runs before the

--- a/tests/manage/mcg/test_azure_noobaa_sa.py
+++ b/tests/manage/mcg/test_azure_noobaa_sa.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     azure_platform_required,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -18,6 +19,7 @@ from ocs_ci.ocs.ocp import OCP
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @tier1
 @azure_platform_required

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     bugzilla,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -23,6 +24,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestBucketCreation(MCGTest):

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_mcg_only,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestBucketDeletion(MCGTest):

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -49,6 +49,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     bugzilla,
     red_squad,
+    mcg,
 )
 from ocs_ci.utility import version
 from ocs_ci.utility.retry import retry
@@ -56,6 +57,7 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.3")

--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, tier2, red_squad
+from ocs_ci.framework.pytest_customization.marks import tier1, tier2, red_squad, mcg
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.utility.retry import retry
@@ -30,6 +30,7 @@ from ocs_ci.framework.testlib import skipif_ocs_version
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_ocs_version("<4.9")
 class TestReplication(MCGTest):

--- a/tests/manage/mcg/test_cached_buckets.py
+++ b/tests/manage/mcg/test_cached_buckets.py
@@ -17,12 +17,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing

--- a/tests/manage/mcg/test_db_nfs_mount.py
+++ b/tests/manage/mcg/test_db_nfs_mount.py
@@ -14,12 +14,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     vsphere_platform_required,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 class TestNoobaaDbNFSMount:
     @pytest.fixture()
@@ -56,7 +58,6 @@ class TestNoobaaDbNFSMount:
 
     @pytest.fixture()
     def mount_noobaa_db_pod(self, request):
-
         # scale down noobaa db stateful set
         helpers.modify_statefulset_replica_count(
             constants.NOOBAA_DB_STATEFULSET, replica_count=0

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -4,11 +4,15 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 
 
 # @pytest.mark.polarion_id("OCS-XXXX")
 # Skipped above 4.6 because of https://github.com/red-hat-storage/ocs-ci/issues/4129
+
+
+@mcg
 @red_squad
 @skipif_ocs_version(["<4.5", "<4.14"])
 @skipif_managed_service

--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -3,7 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import (
     bugzilla,
     ignore_leftovers,
@@ -30,6 +30,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @tier4b
 @bugzilla("1853638")

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -2,7 +2,12 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms, red_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_no_kms,
+    red_squad,
+    mcg,
+)
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
@@ -11,6 +16,7 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_no_kms
 class TestNoobaaKMS(MCGTest):

--- a/tests/manage/mcg/test_log_based_bucket_replication.py
+++ b/tests/manage/mcg/test_log_based_bucket_replication.py
@@ -10,7 +10,7 @@ from ocs_ci.ocs.resources.mockup_bucket_logger import MockupBucketLogger
 
 from ocs_ci.ocs import constants
 
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import (
     skipif_aws_creds_are_missing,
     skipif_vsphere_ipi,
@@ -28,6 +28,7 @@ from ocs_ci.ocs.scale_noobaa_lib import noobaa_running_node_restart
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @ignore_leftover_label(constants.MON_APP_LABEL)  # tier4b test requirement
 @skipif_aws_creds_are_missing

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     skipif_mcg_only,
     red_squad,
+    mcg,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -32,6 +33,7 @@ def setup(request):
     request.cls.cl_obj = cluster.CephCluster()
 
 
+@mcg
 @red_squad
 @ignore_leftovers()
 @skipif_mcg_only

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_disconnected_cluster,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.bucket_utils import (
@@ -25,6 +26,7 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_disconnected_cluster

--- a/tests/manage/mcg/test_multicloud.py
+++ b/tests/manage/mcg/test_multicloud.py
@@ -7,11 +7,13 @@ from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestMultiCloud(MCGTest):

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -20,6 +20,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ def setup(pod_obj, bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestS3MultipartUpload(MCGTest):

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -35,6 +35,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants, bucket_utils
 from ocs_ci.ocs.cluster import CephCluster
@@ -46,6 +47,7 @@ from ocs_ci.ocs.resources.bucket_policy import HttpResponseParser
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
@@ -66,7 +68,10 @@ class TestNamespace(MCGTest):
         argvalues=[
             pytest.param(("oc", {"aws": [(1, DEFAULT_REGION)]})),
             pytest.param(("oc", {"azure": [(1, None)]})),
-            pytest.param(("oc", {"rgw": [(1, None)]}), marks=on_prem_platform_required),
+            pytest.param(
+                ("oc", {"rgw": [(1, None)]}),
+                marks=on_prem_platform_required,
+            ),
         ],
         # A test ID list for describing the parametrized tests
         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>

--- a/tests/manage/mcg/test_namespace_rpc.py
+++ b/tests/manage/mcg/test_namespace_rpc.py
@@ -21,6 +21,7 @@ from ocs_ci.ocs.bucket_utils import sync_object_directory, verify_s3_object_inte
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster
@@ -30,6 +31,7 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/manage/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/manage/mcg/test_nb_mgmt_endpoint.py
@@ -2,7 +2,7 @@ import json
 import requests
 import logging
 
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import tier1
 
 from ocs_ci.framework.testlib import MCGTest
@@ -13,6 +13,7 @@ from ocs_ci.ocs.bucket_utils import retrieve_verification_mode
 logger = logging.getLogger(name=__file__)
 
 
+@mcg
 @red_squad
 @tier1
 @skipif_ocs_version(">4.13")

--- a/tests/manage/mcg/test_noobaa_prometheus.py
+++ b/tests/manage/mcg/test_noobaa_prometheus.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     polarion_id,
     red_squad,
+    mcg,
 )
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.ocs.bucket_utils import write_random_test_objects_to_bucket
@@ -34,6 +35,7 @@ def get_bucket_used_bytes_metric(bucket_name, threading_lock):
     return value[1]
 
 
+@mcg
 @red_squad
 class TestNoobaaaPrometheus:
     @tier2

--- a/tests/manage/mcg/test_noobaa_secret.py
+++ b/tests/manage/mcg/test_noobaa_secret.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_disconnected_cluster,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.aws import update_config_from_s3
@@ -36,7 +37,6 @@ def cleanup(request):
     instances = []
 
     def factory(resource_obj):
-
         if isinstance(resource_obj, list):
             instances.extend(resource_obj)
         else:
@@ -59,6 +59,7 @@ def cleanup(request):
     return factory
 
 
+@mcg
 @red_squad
 @tier2
 @skipif_ocs_version("<4.11")

--- a/tests/manage/mcg/test_nsfs.py
+++ b/tests/manage/mcg/test_nsfs.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ignore_leftover_label,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
@@ -20,6 +21,7 @@ from tests.conftest import revert_noobaa_endpoint_scc_class
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_mcg_only
 @skipif_ocs_version("<4.10")

--- a/tests/manage/mcg/test_object_expiration.py
+++ b/tests/manage/mcg/test_object_expiration.py
@@ -4,7 +4,7 @@ from time import sleep
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla, red_squad
+from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla, red_squad, mcg
 from ocs_ci.framework.testlib import MCGTest, version
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
@@ -12,6 +12,7 @@ from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 class TestObjectExpiration(MCGTest):
     """

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_disconnected_cluster,
     red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,7 @@ FILESIZE_SKIP = pytest.mark.skip("Current test filesize is too large.")
 RUNTIME_SKIP = pytest.mark.skip("Runtime is too long; Code needs to be parallelized")
 
 
+@mcg
 @red_squad
 @flaky
 @skipif_managed_service

--- a/tests/manage/mcg/test_object_versioning.py
+++ b/tests/manage/mcg/test_object_versioning.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     skipif_ocs_version,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.bucket_utils import (
     s3_put_bucket_versioning,
@@ -24,6 +25,7 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 class TestObjectVersioning:
     @pytest.fixture(scope="function")

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     tier3,
     red_squad,
+    mcg,
 )
 
 from ocs_ci.ocs.bucket_utils import (
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 LOCAL_DIR_PATH = "/awsfiles"
 
 
+@mcg
 @red_squad
 @skipif_mcg_only
 class TestPvPool:

--- a/tests/manage/mcg/test_s3_prefix_list.py
+++ b/tests/manage/mcg/test_s3_prefix_list.py
@@ -12,11 +12,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     skipif_ocs_version,
     red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @bugzilla("2068110")
 @pytest.mark.polarion_id("OCS-3925")

--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_mcg_only,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 RECONCILE_WAIT = 60
 
 
+@mcg
 @red_squad
 class TestS3Routes:
 

--- a/tests/manage/mcg/test_s3_with_java_sdk.py
+++ b/tests/manage/mcg/test_s3_with_java_sdk.py
@@ -8,12 +8,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_proxy_cluster,
     tier1,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.bucket_utils import upload_objects_with_javasdk
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_ocs_version("<4.9")
 @skipif_disconnected_cluster

--- a/tests/manage/mcg/test_verify_noobaa_status.py
+++ b/tests/manage/mcg/test_verify_noobaa_status.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_openshift_dedicated,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_pod_logs
@@ -15,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 log = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @tier1
 @polarion_id("OCS-2084")
@@ -33,6 +35,7 @@ def test_verify_noobaa_status_cli(mcg_obj_session):
     log.info("Verified: noobaa status does not contain any error.")
 
 
+@mcg
 @red_squad
 @tier1
 @skipif_ocs_version("<4.8")

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     skip_inconsistent,
     red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     MCGTest,
@@ -80,6 +81,7 @@ def file_setup(request):
     return zip_filename
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestBucketIO(MCGTest):

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     on_prem_platform_required,
     black_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -31,6 +32,7 @@ from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @black_squad
 class TestStoreUserInterface(object):
     """
@@ -126,6 +128,7 @@ class TestStoreUserInterface(object):
         ), f"resource kind='{kind}' name='{store_name}' preserved on cluster after deletion"
 
 
+@mcg
 @black_squad
 @ui
 @skipif_ui_not_support("bucketclass")
@@ -294,7 +297,7 @@ class TestObcUserInterface(object):
                     "three_dots",
                     True,
                 ],
-                marks=pytest.mark.polarion_id("OCS-4698"),
+                marks=[pytest.mark.polarion_id("OCS-4698"), mcg],
             ),
             pytest.param(
                 *[
@@ -303,7 +306,7 @@ class TestObcUserInterface(object):
                     "Actions",
                     True,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2542"),
+                marks=[pytest.mark.polarion_id("OCS-2542"), mcg],
             ),
             pytest.param(
                 *[

--- a/tests/manage/mcg/ui/test_verify_region_list.py
+++ b/tests/manage/mcg/ui/test_verify_region_list.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     bugzilla,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.constants import NOOBAA_REGIONS_CODE_URL, AWS_REGIONS_DOC_URL
 from ocs_ci.ocs.ui.views import locate_aws_regions, locate_noobaa_regions
@@ -93,6 +94,7 @@ def setup_browser(request):
 
 
 @tier3
+@mcg
 @red_squad
 @bugzilla("2183480")
 @polarion_id("OCS-5153")
@@ -115,7 +117,6 @@ def test_verify_aws_regions_list(setup_browser):
     navigate_noobaa_code = NavigateAWSDocsWebURL()
     setup_browser(navigate_noobaa_code, NOOBAA_REGIONS_CODE_URL)
     for region in aws_regions.values():
-
         # fetch the noobaa regions parameters from the
         # source code
         noobaa_regions_str = navigate_noobaa_code.fetch_noobaa_regions()

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     tier2,
     tier4a,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus, version
@@ -16,6 +17,7 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@mcg
 @blue_squad
 @tier2
 @polarion_id("OCS-1254")
@@ -113,6 +115,7 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
         )
 
 
+@mcg
 @blue_squad
 @tier4a
 @polarion_id("OCS-2498")

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     blue_squad,
     skipif_managed_service,
     tier1,
+    mcg,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants, ocp
@@ -15,6 +16,7 @@ from ocs_ci.utility.version import get_semantic_version, VERSION_4_10
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @blue_squad
 @tier1
 @skipif_ocs_version("<4.6")

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -14,6 +14,7 @@ from ocs_ci.utility.prometheus import check_query_range_result_limits
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     blue_squad,
+    mcg,
 )
 
 
@@ -27,6 +28,7 @@ CPU_USAGE_POD = (
 )
 
 
+@mcg
 @blue_squad
 @tier1
 @marks.polarion_id("OCS-2364")

--- a/tests/manage/rgw/test_bucket_creation.py
+++ b/tests/manage/rgw/test_bucket_creation.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
     skipif_mcg_only,
     red_squad,
+    rgw,
     tier1,
     tier3,
 )
@@ -17,6 +18,7 @@ import re
 logger = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @skipif_mcg_only
 class TestRGWBucketCreation:

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -9,6 +9,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
     red_squad,
+    rgw,
     skipif_mcg_only,
     tier1,
     tier3,
@@ -21,6 +22,7 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @skipif_mcg_only
 class TestBucketDeletion:

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import red_squad
+from ocs_ci.framework.pytest_customization.marks import red_squad, rgw
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -33,6 +33,7 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @tier4b
 @ignore_leftovers
@@ -57,7 +58,6 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
         self.sanity_helpers = Sanity()
 
     def create_obc_creation(self, bucket_factory, mcg_obj, key):
-
         # Create a bucket then read & write
         bucket_name = bucket_factory(amount=1, interface="OC", timeout=120)[0].name
         obj_data = "A random string data"

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -4,7 +4,7 @@ import pytest
 import uuid
 
 from ocs_ci.framework.testlib import ManageTest, tier1
-from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only, rgw
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     abort_all_multipart_upload,
@@ -49,6 +49,7 @@ def setup(pod_obj, rgw_bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@rgw
 @red_squad
 @skipif_mcg_only
 class TestS3MultipartUpload(ManageTest):

--- a/tests/manage/rgw/test_obc_quota.py
+++ b/tests/manage/rgw/test_obc_quota.py
@@ -14,11 +14,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_mcg_only,
     red_squad,
+    rgw,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @bugzilla("1940823")
 @skipif_ocs_version("<4.10")

--- a/tests/manage/rgw/test_object_bucket_size.py
+++ b/tests/manage/rgw/test_object_bucket_size.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
+    mcg,
     skipif_mcg_only,
     skipif_managed_service,
 )
@@ -58,6 +59,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
         )
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.7")

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
 )
 
-from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only, rgw
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.resources.objectbucket import OBC
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
@@ -16,6 +16,7 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @skipif_mcg_only
 class TestObjectIntegrity(ManageTest):

--- a/tests/manage/rgw/test_rgw_pod_existence.py
+++ b/tests/manage/rgw/test_rgw_pod_existence.py
@@ -1,7 +1,7 @@
 import logging
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import acceptance, red_squad
+from ocs_ci.framework.pytest_customization.marks import acceptance, red_squad, rgw
 from ocs_ci.helpers.helpers import storagecluster_independent_check
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -13,6 +13,7 @@ from ocs_ci.utility.rgwutils import get_rgw_count
 logger = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @acceptance
 class TestRGWPodExistence:

--- a/tests/manage/rgw/test_rgw_routes.py
+++ b/tests/manage/rgw/test_rgw_routes.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     skipif_external_mode,
     tier1,
+    rgw,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.bucket_utils import (
@@ -23,6 +24,7 @@ from ocs_ci.ocs.resources.objectbucket import OBC
 log = logging.getLogger(__name__)
 
 
+@rgw
 @red_squad
 @on_prem_platform_required
 class TestRGWRoutes:
@@ -33,7 +35,7 @@ class TestRGWRoutes:
 
     @skipif_external_mode
     @bugzilla("2139037")
-    @tier1  # TODO: tier2 instead?
+    @tier1
     @pytest.mark.parametrize(
         argnames="route_data",
         argvalues=[

--- a/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
+++ b/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
@@ -12,11 +12,13 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     bugzilla,
     skipif_external_mode,
+    mcg,
 )
 
 log = logging.getLogger(__name__)
 
 
+@mcg
 @brown_squad
 @tier2
 @bugzilla("1943388")

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     bugzilla,
     skipif_ocs_version,
+    mcg,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.ocp import OCP
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_ocs_version("<4.13")
 class TestErrorMessageImprovements(ManageTest):
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4865")
     def test_backing_store_creation_rules(self, setup_ui_class):
@@ -36,6 +38,7 @@ class TestErrorMessageImprovements(ManageTest):
         backing_store_tab.proceed_resource_creation()
         backing_store_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4867")
     def test_obc_creation_rules(self, setup_ui_class):
@@ -52,6 +55,7 @@ class TestErrorMessageImprovements(ManageTest):
         object_bucket_claim_create_tab.proceed_resource_creation()
         object_bucket_claim_create_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4869")
     def test_bucket_class_creation_rules(self, setup_ui_class):
@@ -69,6 +73,7 @@ class TestErrorMessageImprovements(ManageTest):
         bucket_class_create_tab.proceed_resource_creation()
         bucket_class_create_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4871")
     def test_namespace_store_creation_rules(


### PR DESCRIPTION
release-4.14 backport of  #9070