### PR TITLE
Update PVC expansion check on pods in test

### DIFF
--- a/tests/functional/pv/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -165,11 +165,12 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
                     continue
                 df_out = df_out.split()
                 new_size_mount = df_out[df_out.index(pod_obj.get_storage_path()) - 4]
-                if new_size_mount in [
-                    f"{pvc_size_expanded - 0.1}G",
-                    f"{float(pvc_size_expanded)}G",
-                    f"{pvc_size_expanded}G",
-                ]:
+                if (
+                    pvc_size_expanded - 0.7
+                    <= float(new_size_mount[:-1])
+                    <= pvc_size_expanded
+                    and new_size_mount[-1] == "G"
+                ):
                     log.info(
                         f"Verified: Expanded size of PVC {pod_obj.pvc.name} "
                         f"is reflected on pod {pod_obj.name}"


### PR DESCRIPTION
Update the test test_resource_deletion_during_pvc_expansion to check a range of filesystem size.
Fixes #9161
Test case: 
tests/manage/pv_services/pvc_resize/test_resource_deletion_during_pvc_expansion.py::TestResourceDeletionDuringPvcExpansion::test_resource_deletion_during_pvc_expansion[mgr]

It is expected to have a slight difference in the size of filesystem from the PVC size.