### PR TITLE
Replacing crypt device check from pod to node.

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2850,3 +2850,22 @@ def is_node_rack_or_zone_exist(failure_domain, node_name):
     """
     node_obj = get_node_objs([node_name])[0]
     return get_node_rack_or_zone(failure_domain, node_obj) is not None
+
+
+def list_encrypted_rbd_devices_onnode(node):
+    """
+    Get rbd crypt devices from the node
+
+    Args:
+        node: node name
+
+    Returns:
+        List of encrypted osd device names
+    """
+    node_obj = OCP(kind="node")
+    crypt_devices_out = node_obj.exec_oc_debug_cmd(
+        node=node,
+        cmd_list=["lsblk | grep crypt | awk '{print $1}'"],
+    ).split("\n")
+    crypt_devices = [device.strip() for device in crypt_devices_out if device != ""]
+    return crypt_devices

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2869,3 +2869,23 @@ def list_encrypted_rbd_devices_onnode(node):
     ).split("\n")
     crypt_devices = [device.strip() for device in crypt_devices_out if device != ""]
     return crypt_devices
+
+
+def verify_crypt_device_present_onnode(node, vol_handle):
+    """
+    Find the crypt device maching for given volume handle.
+
+    Args:
+        node : node name
+        vol_handle : volumen handle name.
+    """
+    device_list = list_encrypted_rbd_devices_onnode(node)
+    crypt_device = [device for device in device_list if vol_handle in device]
+    if not crypt_device:
+        log.error(
+            f"crypt device for volume handle {vol_handle} not present on node : {node}"
+        )
+        return False
+
+    log.info(f"Crypt device for volume handle {vol_handle} present on the node: {node}")
+    return True

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -2878,6 +2878,10 @@ def verify_crypt_device_present_onnode(node, vol_handle):
     Args:
         node : node name
         vol_handle : volumen handle name.
+
+    Returns:
+        True: if volume handle device found on the node.
+        False: if volume handle device not found on the node.
     """
     device_list = list_encrypted_rbd_devices_onnode(node)
     crypt_device = [device for device in device_list if vol_handle in device]

--- a/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -25,7 +25,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.utility import kms
 from semantic_version import Version
-from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
+from ocs_ci.ocs.node import verify_crypt_device_present_onnode
 
 
 log = logging.getLogger(__name__)
@@ -165,12 +165,10 @@ class TestEncryptedRbdClone(ManageTest):
 
         log.info("Checking for encrypted device and running IO on all pods")
         for vol_handle, pod_obj in zip(self.vol_handles, self.pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             log.info(f"File created during IO {pod_obj.name}")
             pod_obj.run_io(
@@ -246,12 +244,10 @@ class TestEncryptedRbdClone(ManageTest):
                     )
         # Verify encrypted device is present and md5sum on all pods
         for vol_handle, pod_obj in zip(cloned_vol_handles, cloned_pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             log.info(f"Verifying md5sum on pod {pod_obj.name}")
             pod.verify_data_integrity(

--- a/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -25,6 +25,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.utility import kms
 from semantic_version import Version
+from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
 
 
 log = logging.getLogger(__name__)
@@ -164,14 +165,13 @@ class TestEncryptedRbdClone(ManageTest):
 
         log.info("Checking for encrypted device and running IO on all pods")
         for vol_handle, pod_obj in zip(self.vol_handles, self.pod_objs):
-            if pod_obj.exec_sh_cmd_on_pod(
-                command=f"lsblk | grep {vol_handle} | grep crypt"
-            ):
-                log.info(f"Encrypted device found in {pod_obj.name}")
-            else:
+            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
+            crypt_device = [device for device in rbd_devices if vol_handle in device]
+            if not crypt_device:
                 raise ResourceNotFoundError(
                     f"Encrypted device not found in {pod_obj.name}"
                 )
+
             log.info(f"File created during IO {pod_obj.name}")
             pod_obj.run_io(
                 storage_type="block",
@@ -246,11 +246,9 @@ class TestEncryptedRbdClone(ManageTest):
                     )
         # Verify encrypted device is present and md5sum on all pods
         for vol_handle, pod_obj in zip(cloned_vol_handles, cloned_pod_objs):
-            if pod_obj.exec_sh_cmd_on_pod(
-                command=f"lsblk | grep {vol_handle} | grep crypt"
-            ):
-                log.info(f"Encrypted device found in {pod_obj.name}")
-            else:
+            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
+            crypt_device = [device for device in rbd_devices if vol_handle in device]
+            if not crypt_device:
                 raise ResourceNotFoundError(
                     f"Encrypted device not found in {pod_obj.name}"
                 )

--- a/tests/functional/pv/pv_encryption/test_kmip_rbd_pv_encryption.py
+++ b/tests/functional/pv/pv_encryption/test_kmip_rbd_pv_encryption.py
@@ -18,8 +18,7 @@ from ocs_ci.helpers.helpers import (
     create_pods,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
-from ocs_ci.ocs.exceptions import ResourceNotFoundError
+from ocs_ci.ocs.node import verify_crypt_device_present_onnode
 
 
 log = logging.getLogger(__name__)
@@ -107,12 +106,10 @@ class TestKmipRbdPvEncryptionKMIP(ManageTest):
 
         # Verify whether encrypted device is present inside the pod and run IO
         for vol_handle, pod_obj in zip(vol_handles, pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             pod_obj.run_io(
                 storage_type="block",

--- a/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
+++ b/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.utility import kms
 from semantic_version import Version
+from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
 
 
 log = logging.getLogger(__name__)
@@ -163,12 +164,12 @@ class TestRbdPvEncryption(ManageTest):
 
         # Verify whether encrypted device is present inside the pod and run IO
         for vol_handle, pod_obj in zip(vol_handles, pod_objs):
-            if pod_obj.exec_sh_cmd_on_pod(
-                command=f"lsblk | grep {vol_handle} | grep crypt"
-            ):
-                log.info(f"Encrypted device found in {pod_obj.name}")
-            else:
-                log.error(f"Encrypted device not found in {pod_obj.name}")
+            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
+            crypt_device = [device for device in rbd_devices if vol_handle in device]
+            if not crypt_device:
+                raise ResourceNotFoundError(
+                    f"Encrypted device not found in {pod_obj.name}"
+                )
 
             pod_obj.run_io(
                 storage_type="block",

--- a/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
+++ b/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.utility import kms
 from semantic_version import Version
-from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
+from ocs_ci.ocs.node import verify_crypt_device_present_onnode
 
 
 log = logging.getLogger(__name__)
@@ -164,12 +164,10 @@ class TestRbdPvEncryption(ManageTest):
 
         # Verify whether encrypted device is present inside the pod and run IO
         for vol_handle, pod_obj in zip(vol_handles, pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             pod_obj.run_io(
                 storage_type="block",

--- a/tests/functional/pv/pv_encryption/test_rbd_pv_encryption_vaulttenantsa.py
+++ b/tests/functional/pv/pv_encryption/test_rbd_pv_encryption_vaulttenantsa.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.exceptions import (
     ResourceNotFoundError,
 )
 from ocs_ci.utility import kms
-from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
+from ocs_ci.ocs.node import verify_crypt_device_present_onnode
 
 log = logging.getLogger(__name__)
 
@@ -151,12 +151,10 @@ class TestRbdPvEncryptionVaultTenantSA(ManageTest):
 
         # Verify whether encrypted device is present inside the pod and run IO
         for vol_handle, pod_obj in zip(vol_handles, pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             pod_obj.run_io(
                 storage_type="block",

--- a/tests/functional/ui/test_pv_encryption_ui.py
+++ b/tests/functional/ui/test_pv_encryption_ui.py
@@ -31,7 +31,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.utility.utils import get_vault_cli, get_ocp_version
 from ocs_ci.ocs import constants
 from ocs_ci.utility import version
-from ocs_ci.ocs.node import list_encrypted_rbd_devices_onnode
+from ocs_ci.ocs.node import verify_crypt_device_present_onnode
 
 logger = logging.getLogger(__name__)
 
@@ -229,12 +229,10 @@ class TestPVEncryption(ManageTest):
             "Verify whether encrypted device is present inside the pod and run IO"
         )
         for vol_handle, pod_obj in zip(vol_handles, pod_objs):
-            rbd_devices = list_encrypted_rbd_devices_onnode(pod_obj.get_node())
-            crypt_device = [device for device in rbd_devices if vol_handle in device]
-            if not crypt_device:
-                raise ResourceNotFoundError(
-                    f"Encrypted device not found in {pod_obj.name}"
-                )
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
 
             logger.info(f"Running FIO on Pod '{pod_obj.name}'")
             pod_obj.run_io(


### PR DESCRIPTION
Encryption tests are failing because the crypt device is not visible from the pod in the new image. After a discussion with the dev team, we have decided to move the device check from the pod to the node.