### PR TITLE
[RDR] Wait for pod stabilization after nodes startup

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -174,6 +174,8 @@ class TestFailover:
             sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
             wait_for_nodes_status([node.name for node in primary_cluster_nodes])
+            logger.info("Wait for 180 seconds for pods to stabilize")
+            sleep(180)
             logger.info(
                 "Wait for all the pods in openshift-storage to be in running state"
             )

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -225,6 +225,8 @@ class TestFailoverAndRelocate:
             sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
             wait_for_nodes_status([node.name for node in primary_cluster_nodes])
+            logger.info("Wait for 180 seconds for pods to stabilize")
+            sleep(180)
             logger.info(
                 "Wait for all the pods in openshift-storage to be in running state"
             )

--- a/tests/functional/disaster-recovery/regional-dr/test_node_operations_during_failover_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_node_operations_during_failover_relocate.py
@@ -148,6 +148,8 @@ class TestNodeDrainDuringFailoverRelocate:
         sleep(wait_time * 60)
         nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
         wait_for_nodes_status([node.name for node in primary_cluster_nodes])
+        logger.info("Wait for 180 seconds for pods to stabilize")
+        sleep(180)
         logger.info("Wait for all the pods in storage namespace to be in running state")
         assert wait_for_pods_to_be_running(
             timeout=720

--- a/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -106,6 +106,8 @@ class TestSequentialFailover:
             time.sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
             wait_for_nodes_status([node.name for node in primary_cluster_nodes])
+            logger.info("Wait for 180 seconds for pods to stabilize")
+            time.sleep(180)
             logger.info(
                 "Wait for all the pods in openshift-storage to be in running state"
             )


### PR DESCRIPTION
Added a 180 second delay after node startup to allow pods to stabilize before proceeding.
This addresses potential issues related to premature operations on unstable pods.

Also Fixes: #9178