### PR TITLE
Use the correct namespace while waiting for new pod in disruption_helpers

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -139,7 +139,9 @@ class Disruptions:
 
     def delete_resource(self, resource_id=0):
         pod_ocp = ocp.OCP(
-            kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
+            kind=constants.POD,
+            namespace=self.resource_obj[resource_id].namespace
+            or config.ENV_DATA["cluster_namespace"],
         )
         if self.cluster_kubeconfig:
             # Setting 'cluster_kubeconfig' attribute to use as the value of the


### PR DESCRIPTION
Use the correct namespace of the initial pod while waiting for new pod in disruption_helpers.
Fixes #9187 