### PR TITLE
Update get_plugin_provisioner_leader to pass namespace to the function get_pod_logs

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1964,7 +1964,7 @@ def get_plugin_provisioner_leader(interface, namespace=None, leader_type="provis
     pods_log = {}
     for pod in pods:
         pods_log[pod] = get_pod_logs(
-            pod_name=pod.name, container=leader_types[leader_type]
+            pod_name=pod.name, container=leader_types[leader_type], namespace=namespace
         ).split("\n")
 
     for pod, log_list in pods_log.items():


### PR DESCRIPTION
In provider-client setup there will be context switching during the test run with multicliuster job. In test cases which needs to find the provisioner/snapshotter leader pod, the correct value of the namespace is required to pass to the function get_pod_logs. Othwerwise, if there is a context switch and the namespace value is taken frum ENV_DATA , it will be of a different cluster.

Fixes #9209 