### PR TITLE
assisted installer api: removing deprecated keys

### DIFF
--- a/ocs_ci/deployment/assisted_installer.py
+++ b/ocs_ci/deployment/assisted_installer.py
@@ -176,13 +176,11 @@ class AssistedInstallerCluster(object):
             "cpu_architecture": self.cpu_architecture,
             "high_availability_mode": self.high_availability_mode,
             "base_dns_domain": self.base_dns_domain,
-            "api_vip": self.api_vip,
             "api_vips": [
                 {
                     "ip": self.api_vip,
                 }
             ],
-            "ingress_vip": self.ingress_vip,
             "ingress_vips": [
                 {
                     "ip": self.ingress_vip,


### PR DESCRIPTION
Newest version of Assisted Installer API deprecated `api_vip` and `ingress_vip` keys in favor of `api_vips` and `ingress_vips`.