### PR TITLE
Adding CommandFailed exception for retry

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -366,7 +366,10 @@ class CephCluster(object):
         Wait for Noobaa health to be OK
         """
         return retry(
-            exceptions.NoobaaHealthException, tries=tries, delay=delay, backoff=1
+            (exceptions.NoobaaHealthException, exceptions.CommandFailed),
+            tries=tries,
+            delay=delay,
+            backoff=1,
         )(self.noobaa_health_check)()
 
     def mon_change_count(self, new_count):


### PR DESCRIPTION
There are scenerios in external cluster where "noobaa-default-backing-store" is not created immediatly and given retry mechanism is not honored because its failed with CommandFailed.

So adding CommandFailed excepton for retry

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)