### PR TITLE
fix registry node reboot test case.

### DIFF
--- a/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
+++ b/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
@@ -87,7 +87,7 @@ class TestRegistryRebootNode(E2ETest):
         )(wait_for_nodes_status)(timeout=900)
 
         # Validate cluster health ok and all pods are running
-        self.sanity_helpers.health_check(tries=40)
+        self.sanity_helpers.health_check(tries=70)
 
         # Validate storage pods are running
         wait_for_storage_pods()
@@ -154,7 +154,7 @@ class TestRegistryRebootNode(E2ETest):
             )(wait_for_nodes_status)(timeout=900)
 
         # Validate cluster health ok and all pods are running
-        self.sanity_helpers.health_check(tries=40)
+        self.sanity_helpers.health_check(tries=120)
 
         # Validate storage pods are running
         wait_for_storage_pods()


### PR DESCRIPTION
fixing a test case in registry where the cephtoolbox is taking more time to come up after reboot. So increasing the retries in health check, so that script will try again and detect all the nodes and pods in expected state.

fixes #9255 