### PR TITLE
Downgrade the boto3 version from 1.34.14 to 1.24.96

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pyyaml>=4.2b1",
         "jinja2==3.1.3",
         "openshift==0.11.2",
-        "boto3==1.34.14",
+        "boto3==1.24.96",
         "munch==2.5.0",
         "pytest==6.2.5",
         "pytest-logger==0.5.1",


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/9250

This is a temporary workaround since we can expect that other OCS-CI dependencies or needs will require the latest boto3 sometime in the future.