### PR TITLE
restructure baremetal configuration

### DIFF
--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -24,7 +24,7 @@ class BAREMETAL(object):
         Initialize the variables required
 
         """
-        self.mgmt_details = config.AUTH["ipmi"]
+        self.srv_details = config.ENV_DATA["baremetal"]["servers"]
 
     def get_ipmi_ctx(self, host, user, password):
         """
@@ -92,11 +92,11 @@ class BAREMETAL(object):
         """
         for node in baremetal_machine:
             if force:
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     logger.info(f"Powering Off {node.name}")
                     ipmi_ctx.chassis_control_power_down()
@@ -105,11 +105,11 @@ class BAREMETAL(object):
                 ocp.exec_oc_debug_cmd(
                     node=node.name, cmd_list=["shutdown now"], timeout=60
                 )
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     for status in TimeoutSampler(
                         600, 5, self.get_power_status, ipmi_ctx
@@ -175,20 +175,20 @@ class BAREMETAL(object):
 
         """
         for node in baremetal_machine:
-            if self.mgmt_details[node.name]:
+            if self.srv_details[node.name]:
                 ipmi_ctx = self.get_ipmi_ctx(
-                    host=self.mgmt_details[node.name]["mgmt_console"],
-                    user=self.mgmt_details[node.name]["mgmt_username"],
-                    password=self.mgmt_details[node.name]["mgmt_password"],
+                    host=self.srv_details[node.name]["mgmt_console"],
+                    user=self.srv_details[node.name]["mgmt_username"],
+                    password=self.srv_details[node.name]["mgmt_password"],
                 )
                 logger.info(f"Powering On {node.name}")
                 ipmi_ctx.chassis_control_power_up()
             if wait:
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     for status in TimeoutSampler(
                         600, 5, self.get_power_status, ipmi_ctx
@@ -236,11 +236,11 @@ class BAREMETAL(object):
         """
         node_ipmi_ctx = list()
         for node in baremetal_machine:
-            if self.mgmt_details[node.name]:
+            if self.srv_details[node.name]:
                 ipmi_ctx = self.get_ipmi_ctx(
-                    host=self.mgmt_details[node.name]["mgmt_console"],
-                    user=self.mgmt_details[node.name]["mgmt_username"],
-                    password=self.mgmt_details[node.name]["mgmt_password"],
+                    host=self.srv_details[node.name]["mgmt_console"],
+                    user=self.srv_details[node.name]["mgmt_username"],
+                    password=self.srv_details[node.name]["mgmt_password"],
                 )
                 node_ipmi_ctx.append(ipmi_ctx)
         return node_ipmi_ctx


### PR DESCRIPTION
Move BM configuraiton from `AUTH"[baremetal"]` and `AUTH["ipmi"]` to `ENV_DATA["baremetal"]` and `ENV_DATA["baremetal"]["servers"]` respectively.

This is just cosmetic change, but I think it will make the code and config little bit more readable and clean. (Right now for example the `AUTH["ipmi"]` section contains also information about the network configuration of the server (IP, MAC,...) and disks, so I think it make more sense to name the section differently and also have all the configuration related to the particular baremetal environment in one section (`ENV_DATA["baremetal"]`).

The configuration now looks like this:
```
ENV_DATA:
  baremetal:
    bm_private_nic: "..."
    bm_httpd_server: "..."
    bm_httpd_server_vm: "..."
    bm_path_to_upload: "..."
    bm_install_files: "..."
    bm_httpd_server_user: "..."
    bm_tftp_base_dir: "..."
    bm_tftp_dir: "..."
    bm_dnsmasq_dir: "..."
    bm_status_check: "..."
    bm_provisioner: "..."
    bm_provisioner_user: "..."
    servers:
      host001.example.com:
        mgmt_console: '...'
        mgmt_username: '...'
        mgmt_password: '...'
        role: '...'
        cluster_name: '...'
        public_mac: '...'
        private_mac: '...'
        ip: '...'
        root_disk_id: '...'
      host002.example.com:
        mgmt_console: '...'
        mgmt_username: '...'
        mgmt_password: '...'
        role: '...'
        cluster_name: '...'
        public_mac: '...'
        private_mac: '...'
        ip: '...'
        root_disk_id: '...'
      ...
```

*This PR has to be merged together with respective MR in ocs4-jenkins repo.*
