### PR TITLE
Bumps ACM and Submariner versions for OCP 4.15 and later

### DIFF
--- a/conf/ocsci/acm_2.10.yaml
+++ b/conf/ocsci/acm_2.10.yaml
@@ -1,0 +1,4 @@
+---
+ENV_DATA:
+  acm_version: "2.10"
+  acm_hub_channel: release-2.10

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.15-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.15-config.yaml
@@ -10,5 +10,6 @@ DEPLOYMENT:
   ignition_version: "3.2.0"
 ENV_DATA:
   vm_template: "rhcos-415.92.202309142014-0-vmware.x86_64"
-  acm_hub_channel: release-2.9
-  acm_version: "2.9"
+  acm_hub_channel: release-2.10
+  acm_version: "2.10"
+  submariner_version: "0.17.0"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.16-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.16-config.yaml
@@ -11,5 +11,6 @@ DEPLOYMENT:
 ENV_DATA:
   # TODO: replace with 4.16 once template is available
   vm_template: "rhcos-415.92.202311241643-0-vmware.x86_64"
-  acm_hub_channel: release-2.9
-  acm_version: "2.9"
+  acm_hub_channel: release-2.10
+  acm_version: "2.10"
+  submariner_version: "0.17.0"


### PR DESCRIPTION
Update ACM version to 2.10 and Submariner version to 0.17.0 for OCP 4.15 and 4.16 config files