### PR TITLE
restructure baremetal configuration - backport 4.14

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -52,8 +52,8 @@ class BAREMETALUPI(Deployment):
     class OCPDeployment(BaseOCPDeployment):
         def __init__(self):
             super().__init__()
-            self.helper_node_details = config.AUTH["baremetal"]
-            self.mgmt_details = config.AUTH["ipmi"]
+            self.bm_config = config.ENV_DATA["baremetal"]
+            self.srv_details = config.ENV_DATA["baremetal"]["servers"]
             self.aws = aws.AWS()
 
         def deploy_prereq(self):
@@ -94,16 +94,16 @@ class BAREMETALUPI(Deployment):
                 config.ENV_DATA.get("cluster_path"), constants.WORKER_IGN
             )
 
-            self.host = self.helper_node_details["bm_httpd_server"]
-            self.user = self.helper_node_details["bm_httpd_server_user"]
+            self.host = self.bm_config["bm_httpd_server"]
+            self.user = self.bm_config["bm_httpd_server_user"]
             self.private_key = os.path.expanduser(config.DEPLOYMENT["ssh_key_private"])
 
             self.helper_node_handler = Connection(
                 self.host, self.user, self.private_key
             )
-            cmd = f"rm -rf {self.helper_node_details['bm_path_to_upload']}"
+            cmd = f"rm -rf {self.bm_config['bm_path_to_upload']}"
             logger.info(self.helper_node_handler.exec_cmd(cmd=cmd))
-            cmd = f"mkdir -m 755 {self.helper_node_details['bm_path_to_upload']}"
+            cmd = f"mkdir -m 755 {self.bm_config['bm_path_to_upload']}"
             assert self.helper_node_handler.exec_cmd(
                 cmd=cmd
             ), "Failed to create required folder"
@@ -118,15 +118,13 @@ class BAREMETALUPI(Deployment):
                 upload_file(
                     self.host,
                     key,
-                    os.path.join(
-                        self.helper_node_details["bm_path_to_upload"], f"{val}"
-                    ),
+                    os.path.join(self.bm_config["bm_path_to_upload"], f"{val}"),
                     self.user,
                     key_file=self.private_key,
                 )
 
             # Perform Cleanup for stale entry's
-            cmd = f"rm -rf {self.helper_node_details['bm_tftp_base_dir']}"
+            cmd = f"rm -rf {self.bm_config['bm_tftp_base_dir']}"
             assert self.helper_node_handler.exec_cmd(cmd=cmd), "Failed to Delete folder"
 
             # Installing Required packages
@@ -147,19 +145,19 @@ class BAREMETALUPI(Deployment):
                 cmd=cmd
             ), "Failed to Start dnsmasq service"
 
-            cmd = f"mkdir -m 755 -p {self.helper_node_details['bm_tftp_base_dir']}"
+            cmd = f"mkdir -m 755 -p {self.bm_config['bm_tftp_base_dir']}"
+            assert self.helper_node_handler.exec_cmd(
+                cmd=cmd
+            ), "Failed to create required folder"
+
+            cmd = f"mkdir -m 755 -p {self.bm_config['bm_tftp_base_dir']}ocs4qe"
             assert self.helper_node_handler.exec_cmd(
                 cmd=cmd
             ), "Failed to create required folder"
 
             cmd = (
-                f"mkdir -m 755 -p {self.helper_node_details['bm_tftp_base_dir']}ocs4qe"
+                f"mkdir -m 755 -p {self.bm_config['bm_tftp_base_dir']}ocs4qe/baremetal"
             )
-            assert self.helper_node_handler.exec_cmd(
-                cmd=cmd
-            ), "Failed to create required folder"
-
-            cmd = f"mkdir -m 755 -p {self.helper_node_details['bm_tftp_base_dir']}ocs4qe/baremetal"
             assert self.helper_node_handler.exec_cmd(
                 cmd=cmd
             ), "Failed to create required folder"
@@ -171,7 +169,7 @@ class BAREMETALUPI(Deployment):
             ), "Failed to install required package"
 
             # Copy syslinux files to the tftp path
-            cmd = f"cp -ar /usr/share/syslinux/* {self.helper_node_details['bm_tftp_dir']}"
+            cmd = f"cp -ar /usr/share/syslinux/* {self.bm_config['bm_tftp_dir']}"
             assert self.helper_node_handler.exec_cmd(
                 cmd=cmd
             ), "Failed to Copy required files"
@@ -205,7 +203,7 @@ class BAREMETALUPI(Deployment):
             if check_for_rhcos_images(initramfs_image_path):
                 cmd = (
                     "wget -O "
-                    f"{self.helper_node_details['bm_tftp_dir']}"
+                    f"{self.bm_config['bm_tftp_dir']}"
                     "/rhcos-installer-initramfs.x86_64.img "
                     f"{initramfs_image_path}"
                 )
@@ -226,7 +224,7 @@ class BAREMETALUPI(Deployment):
             if check_for_rhcos_images(kernel_image_path):
                 cmd = (
                     "wget -O "
-                    f"{self.helper_node_details['bm_tftp_dir']}"
+                    f"{self.bm_config['bm_tftp_dir']}"
                     "/rhcos-installer-kernel-x86_64 "
                     f"{kernel_image_path}"
                 )
@@ -243,7 +241,7 @@ class BAREMETALUPI(Deployment):
                 if check_for_rhcos_images(metal_image_path):
                     cmd = (
                         "wget -O "
-                        f"{self.helper_node_details['bm_path_to_upload']}"
+                        f"{self.bm_config['bm_path_to_upload']}"
                         f"/{constants.BM_METAL_IMAGE} "
                         f"{metal_image_path}"
                     )
@@ -269,7 +267,7 @@ class BAREMETALUPI(Deployment):
                 if check_for_rhcos_images(rootfs_image_path):
                     cmd = (
                         "wget -O "
-                        f"{self.helper_node_details['bm_path_to_upload']}"
+                        f"{self.bm_config['bm_path_to_upload']}"
                         "/rhcos-live-rootfs.x86_64.img "
                         f"{rootfs_image_path}"
                     )
@@ -280,7 +278,7 @@ class BAREMETALUPI(Deployment):
                     raise RhcosImageNotFound
 
             # Create pxelinux.cfg directory
-            cmd = f"mkdir -m 755 {self.helper_node_details['bm_tftp_dir']}/pxelinux.cfg"
+            cmd = f"mkdir -m 755 {self.bm_config['bm_tftp_dir']}/pxelinux.cfg"
             assert self.helper_node_handler.exec_cmd(
                 cmd=cmd
             ), "Failed to create required folder"
@@ -295,29 +293,29 @@ class BAREMETALUPI(Deployment):
             logger.info("Deploying OCP cluster for Bare Metal platform")
             logger.info(f"Openshift-installer will be using log level:{log_cli_level}")
             ocp_version = get_ocp_version()
-            for machine in self.mgmt_details:
-                if self.mgmt_details[machine].get("cluster_name") or self.mgmt_details[
+            for machine in self.srv_details:
+                if self.srv_details[machine].get("cluster_name") or self.srv_details[
                     machine
                 ].get("extra_node"):
                     pxe_file_path = self.create_pxe_files(
                         ocp_version=ocp_version,
-                        role=self.mgmt_details[machine].get("role"),
-                        disk_path=self.mgmt_details[machine].get("root_disk_id"),
+                        role=self.srv_details[machine].get("role"),
+                        disk_path=self.srv_details[machine].get("root_disk_id"),
                     )
                     upload_file(
                         server=self.host,
                         localpath=pxe_file_path,
-                        remotepath=f"{self.helper_node_details['bm_tftp_dir']}"
-                        f"/pxelinux.cfg/01-{self.mgmt_details[machine]['private_mac'].replace(':', '-')}",
+                        remotepath=f"{self.bm_config['bm_tftp_dir']}"
+                        f"/pxelinux.cfg/01-{self.srv_details[machine]['private_mac'].replace(':', '-')}",
                         user=self.user,
                         key_file=self.private_key,
                     )
             # Applying Permission
-            cmd = f"chmod 755 -R {self.helper_node_details['bm_tftp_dir']}"
+            cmd = f"chmod 755 -R {self.bm_config['bm_tftp_dir']}"
             self.helper_node_handler.exec_cmd(cmd=cmd)
 
             # Applying Permission
-            cmd = f"chmod 755 -R {self.helper_node_details['bm_path_to_upload']}"
+            cmd = f"chmod 755 -R {self.bm_config['bm_path_to_upload']}"
             self.helper_node_handler.exec_cmd(cmd=cmd)
 
             # Restarting dnsmasq service
@@ -334,33 +332,30 @@ class BAREMETALUPI(Deployment):
                 cluster_name=cluster_name,
                 delete_from_base_domain=True,
             )
-            for machine in self.mgmt_details:
+            for machine in self.srv_details:
                 if (
-                    self.mgmt_details[machine].get("cluster_name")
+                    self.srv_details[machine].get("cluster_name")
                     == constants.BM_DEFAULT_CLUSTER_NAME
                 ):
-                    if (
-                        self.mgmt_details[machine]["role"]
-                        == constants.BOOTSTRAP_MACHINE
-                    ):
+                    if self.srv_details[machine]["role"] == constants.BOOTSTRAP_MACHINE:
                         self.set_pxe_boot_and_reboot(machine)
-                        bootstrap_ip = self.mgmt_details[machine]["ip"]
-                        api_record_ip_list.append(self.mgmt_details[machine]["ip"])
+                        bootstrap_ip = self.srv_details[machine]["ip"]
+                        api_record_ip_list.append(self.srv_details[machine]["ip"])
 
                     elif (
-                        self.mgmt_details[machine]["role"] == constants.MASTER_MACHINE
+                        self.srv_details[machine]["role"] == constants.MASTER_MACHINE
                         and master_count < config.ENV_DATA["master_replicas"]
                     ):
                         self.set_pxe_boot_and_reboot(machine)
-                        api_record_ip_list.append(self.mgmt_details[machine]["ip"])
+                        api_record_ip_list.append(self.srv_details[machine]["ip"])
                         master_count += 1
 
                     elif (
-                        self.mgmt_details[machine]["role"] == constants.WORKER_MACHINE
+                        self.srv_details[machine]["role"] == constants.WORKER_MACHINE
                         and worker_count < config.ENV_DATA["worker_replicas"]
                     ):
                         self.set_pxe_boot_and_reboot(machine)
-                        apps_record_ip_list.append(self.mgmt_details[machine]["ip"])
+                        apps_record_ip_list.append(self.srv_details[machine]["ip"])
                         worker_count += 1
 
             logger.info("Configuring DNS records")
@@ -569,7 +564,7 @@ class BAREMETALUPI(Deployment):
             """
             headers = {"content-type": "application/json"}
             response = requests.get(
-                url=self.helper_node_details["bm_status_check"], headers=headers
+                url=self.bm_config["bm_status_check"], headers=headers
             )
             return response.json()[0]["status"]
 
@@ -582,7 +577,7 @@ class BAREMETALUPI(Deployment):
             """
             headers = {"content-type": "application/json"}
             response = requests.get(
-                url=self.helper_node_details["bm_status_check"], headers=headers
+                url=self.bm_config["bm_status_check"], headers=headers
             )
             return response.json()[0]["user"]
 
@@ -611,7 +606,7 @@ class BAREMETALUPI(Deployment):
                 }
             headers = {"content-type": "application/json"}
             response = requests.put(
-                url=self.helper_node_details["bm_status_check"],
+                url=self.bm_config["bm_status_check"],
                 json=payload,
                 headers=headers,
             )
@@ -630,7 +625,7 @@ class BAREMETALUPI(Deployment):
 
             """
             extra_data = ""
-            bm_install_files_loc = self.helper_node_details["bm_install_files"]
+            bm_install_files_loc = self.bm_config["bm_install_files"]
             extra_data_pxe = "rhcos-live-rootfs.x86_64.img coreos.inst.insecure"
             if Version.coerce(ocp_version) <= Version.coerce("4.6"):
                 bm_metal_loc = f"coreos.inst.image_url={bm_install_files_loc}{constants.BM_METAL_IMAGE}"
@@ -670,14 +665,14 @@ LABEL disk0
 
             """
             secrets = [
-                self.mgmt_details[machine]["mgmt_username"],
-                self.mgmt_details[machine]["mgmt_password"],
+                self.srv_details[machine]["mgmt_username"],
+                self.srv_details[machine]["mgmt_password"],
             ]
             # Changes boot prioriy to pxe
             cmd = (
-                f"ipmitool -I lanplus -U {self.mgmt_details[machine]['mgmt_username']} "
-                f"-P {self.mgmt_details[machine]['mgmt_password']} "
-                f"-H {self.mgmt_details[machine]['mgmt_console']} chassis bootdev pxe"
+                f"ipmitool -I lanplus -U {self.srv_details[machine]['mgmt_username']} "
+                f"-P {self.srv_details[machine]['mgmt_password']} "
+                f"-H {self.srv_details[machine]['mgmt_console']} chassis bootdev pxe"
             )
             run_cmd(cmd=cmd, secrets=secrets)
             logger.info(
@@ -686,12 +681,12 @@ LABEL disk0
             sleep(2)
             # Power On Machine
             cmd = (
-                f"ipmitool -I lanplus -U {self.mgmt_details[machine]['mgmt_username']} "
-                f"-P {self.mgmt_details[machine]['mgmt_password']} "
-                f"-H {self.mgmt_details[machine]['mgmt_console']} chassis power cycle || "
-                f"ipmitool -I lanplus -U {self.mgmt_details[machine]['mgmt_username']} "
-                f"-P {self.mgmt_details[machine]['mgmt_password']} "
-                f"-H {self.mgmt_details[machine]['mgmt_console']} chassis power on"
+                f"ipmitool -I lanplus -U {self.srv_details[machine]['mgmt_username']} "
+                f"-P {self.srv_details[machine]['mgmt_password']} "
+                f"-H {self.srv_details[machine]['mgmt_console']} chassis power cycle || "
+                f"ipmitool -I lanplus -U {self.srv_details[machine]['mgmt_username']} "
+                f"-P {self.srv_details[machine]['mgmt_password']} "
+                f"-H {self.srv_details[machine]['mgmt_console']} chassis power on"
             )
             run_cmd(cmd=cmd, secrets=secrets)
 

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -24,7 +24,7 @@ class BAREMETAL(object):
         Initialize the variables required
 
         """
-        self.mgmt_details = config.AUTH["ipmi"]
+        self.srv_details = config.ENV_DATA["baremetal"]["servers"]
 
     def get_ipmi_ctx(self, host, user, password):
         """
@@ -92,11 +92,11 @@ class BAREMETAL(object):
         """
         for node in baremetal_machine:
             if force:
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     logger.info(f"Powering Off {node.name}")
                     ipmi_ctx.chassis_control_power_down()
@@ -105,11 +105,11 @@ class BAREMETAL(object):
                 ocp.exec_oc_debug_cmd(
                     node=node.name, cmd_list=["shutdown now"], timeout=60
                 )
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     for status in TimeoutSampler(
                         600, 5, self.get_power_status, ipmi_ctx
@@ -175,20 +175,20 @@ class BAREMETAL(object):
 
         """
         for node in baremetal_machine:
-            if self.mgmt_details[node.name]:
+            if self.srv_details[node.name]:
                 ipmi_ctx = self.get_ipmi_ctx(
-                    host=self.mgmt_details[node.name]["mgmt_console"],
-                    user=self.mgmt_details[node.name]["mgmt_username"],
-                    password=self.mgmt_details[node.name]["mgmt_password"],
+                    host=self.srv_details[node.name]["mgmt_console"],
+                    user=self.srv_details[node.name]["mgmt_username"],
+                    password=self.srv_details[node.name]["mgmt_password"],
                 )
                 logger.info(f"Powering On {node.name}")
                 ipmi_ctx.chassis_control_power_up()
             if wait:
-                if self.mgmt_details[node.name]:
+                if self.srv_details[node.name]:
                     ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.mgmt_details[node.name]["mgmt_console"],
-                        user=self.mgmt_details[node.name]["mgmt_username"],
-                        password=self.mgmt_details[node.name]["mgmt_password"],
+                        host=self.srv_details[node.name]["mgmt_console"],
+                        user=self.srv_details[node.name]["mgmt_username"],
+                        password=self.srv_details[node.name]["mgmt_password"],
                     )
                     for status in TimeoutSampler(
                         600, 5, self.get_power_status, ipmi_ctx
@@ -236,11 +236,11 @@ class BAREMETAL(object):
         """
         node_ipmi_ctx = list()
         for node in baremetal_machine:
-            if self.mgmt_details[node.name]:
+            if self.srv_details[node.name]:
                 ipmi_ctx = self.get_ipmi_ctx(
-                    host=self.mgmt_details[node.name]["mgmt_console"],
-                    user=self.mgmt_details[node.name]["mgmt_username"],
-                    password=self.mgmt_details[node.name]["mgmt_password"],
+                    host=self.srv_details[node.name]["mgmt_console"],
+                    user=self.srv_details[node.name]["mgmt_username"],
+                    password=self.srv_details[node.name]["mgmt_password"],
                 )
                 node_ipmi_ctx.append(ipmi_ctx)
         return node_ipmi_ctx


### PR DESCRIPTION
This is backport of https://github.com/red-hat-storage/ocs-ci/pull/9274

Move BM configuraiton from `AUTH"[baremetal"]` and `AUTH["ipmi"]` to `ENV_DATA["baremetal"]` and `ENV_DATA["baremetal"]["servers"]` respectively.

This is just cosmetic change, but I think it will make the code and config little bit more readable and clean. (Right now for example the `AUTH["ipmi"]` section contains also information about the network configuration of the server (IP, MAC,...) and disks, so I think it make more sense to name the section differently and also have all the configuration related to the particular baremetal environment in one section (`ENV_DATA["baremetal"]`).

The configuration now looks like this:
```
ENV_DATA:
  baremetal:
    bm_private_nic: "..."
    bm_httpd_server: "..."
    bm_httpd_server_vm: "..."
    bm_path_to_upload: "..."
    bm_install_files: "..."
    bm_httpd_server_user: "..."
    bm_tftp_base_dir: "..."
    bm_tftp_dir: "..."
    bm_dnsmasq_dir: "..."
    bm_status_check: "..."
    bm_provisioner: "..."
    bm_provisioner_user: "..."
    servers:
      host001.example.com:
        mgmt_console: '...'
        mgmt_username: '...'
        mgmt_password: '...'
        role: '...'
        cluster_name: '...'
        public_mac: '...'
        private_mac: '...'
        ip: '...'
        root_disk_id: '...'
      host002.example.com:
        mgmt_console: '...'
        mgmt_username: '...'
        mgmt_password: '...'
        role: '...'
        cluster_name: '...'
        public_mac: '...'
        private_mac: '...'
        ip: '...'
        root_disk_id: '...'
      ...
```

*This PR has to be merged together with respective MR in ocs4-jenkins repo.*