### PR TITLE
Ignore 'check if MCG root secret is public' if we use MS

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -765,7 +765,7 @@ def ocs_install_verification(
         validate_serviceexport()
 
     # check that noobaa root secrets are not public
-    if not client_cluster:
+    if not (client_cluster or managed_service):
         assert (
             check_if_mcg_root_secret_public() is False
         ), "Seems like MCG root secrets are public, please check"


### PR DESCRIPTION
Currently, the MS deployment failed with the error: 

> 2024-02-05 14:39:15  12:39:14 - MainThread - ocs_ci.ocs.ocp - WARNING  - Failed to get resource: noobaa-endpoint of kind: Deployment, selector: None, Error: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-storage get Deployment noobaa-endpoint -n openshift-storage -o yaml.
2024-02-05 14:39:15  Error is Error from server (NotFound): deployments.apps "noobaa-endpoint" not found

See, for example, the failed deployment here: https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/33416/console.
We need to remove the check in the function `check_if_mcg_root_secret_public`.