### PR TITLE
Extend timeout for ocp deployment via Assisted Installer

### DIFF
--- a/ocs_ci/deployment/assisted_installer.py
+++ b/ocs_ci/deployment/assisted_installer.py
@@ -318,7 +318,7 @@ class AssistedInstallerCluster(object):
         logger.info("Started cluster installation")
         # wait for cluster installation success
         for sample in TimeoutSampler(
-            timeout=3600, sleep=300, func=self.api.get_cluster, cluster_id=self.id
+            timeout=7200, sleep=300, func=self.api.get_cluster, cluster_id=self.id
         ):
             status_per_hosts = [
                 h.get("progress", {}).get("installation_percentage", 0)


### PR DESCRIPTION
The timeout for OCP deployment via Assisted installer were set to 1 hour, but we spotted few cases when it takes little bit longer (e.g. 70 minutes or so) and the deployment was still successful. For example:
https://url.corp.redhat.com/8ee7238
![image](https://github.com/red-hat-storage/ocs-ci/assets/4759779/8f9560fd-b073-4439-8ce8-dc9ae84e012f)

It might be related to the data center occupation and performance.
I'm proposing to extend the timeout to two hours in this PR.