### PR TITLE
Use cluster context with cluster resources and add test - write to bucket from client

### DIFF
--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -63,7 +63,7 @@ def create_awscli_pod(scope_name=None, namespace=None, service_account=None):
     assert s3cli_sts_obj, "Failed to create S3CLI STS"
     if service_account:
         s3cli_sts_obj.ocp.exec_oc_cmd(
-            f"set serviceaccount statefulset {s3cli_sts_obj.name} {serviceaccount}"
+            f"set serviceaccount statefulset {s3cli_sts_obj.name} {service_account}"
         )
     awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
         lambda: Pod(**get_pods_having_label(constants.S3CLI_LABEL, namespace)[0])

--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -11,9 +11,11 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.helpers.proxy import update_container_with_proxy_env
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_pods_having_label, Pod
 from ocs_ci.utility import templating
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import update_container_with_mirrored_image
 
 log = logging.getLogger(__name__)

--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -1,0 +1,100 @@
+"""
+Methods used in awscli_pod fixtures in tests/conftest.py
+"""
+import logging
+
+from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import (
+    create_resource,
+    create_unique_resource_name,
+    wait_for_resource_state,
+)
+from ocs_ci.helpers.proxy import update_container_with_proxy_env
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import get_pods_having_label, Pod
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import update_container_with_mirrored_image
+
+log = logging.getLogger(__name__)
+
+
+def create_awscli_pod(scope_name=None):
+    """
+    Create AWS cli pod and its resources.
+
+    Args:
+        scope_name (str): The name of the fixture's scope
+
+    Returns:
+        object: awscli_pod_obj
+    """
+    # Create the service-ca configmap to be mounted upon pod creation
+    service_ca_data = templating.load_yaml(constants.AWSCLI_SERVICE_CA_YAML)
+    resource_type = scope_name or "caconfigmap"
+    service_ca_configmap_name = create_unique_resource_name(
+        constants.AWSCLI_SERVICE_CA_CONFIGMAP_NAME, resource_type
+    )
+    service_ca_data["metadata"]["name"] = service_ca_configmap_name
+    service_ca_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    s3cli_label_k, s3cli_label_v = constants.S3CLI_APP_LABEL.split("=")
+    service_ca_data["metadata"]["labels"] = {s3cli_label_k: s3cli_label_v}
+    log.info("Trying to create the AWS CLI service CA")
+    service_ca_configmap = create_resource(**service_ca_data)
+    OCP(
+        namespace=config.ENV_DATA["cluster_namespace"], kind="ConfigMap"
+    ).wait_for_resource(
+        resource_name=service_ca_configmap.name, column="DATA", condition="1"
+    )
+
+    log.info("Creating the AWS CLI StatefulSet")
+    awscli_sts_dict = templating.load_yaml(constants.S3CLI_MULTIARCH_STS_YAML)
+    awscli_sts_dict["spec"]["template"]["spec"]["volumes"][0]["configMap"][
+        "name"
+    ] = service_ca_configmap_name
+    awscli_sts_dict["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    update_container_with_mirrored_image(awscli_sts_dict)
+    update_container_with_proxy_env(awscli_sts_dict)
+    s3cli_sts_obj = create_resource(**awscli_sts_dict)
+
+    log.info("Verifying the AWS CLI StatefulSet is running")
+    assert s3cli_sts_obj, "Failed to create S3CLI STS"
+    awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
+        lambda: Pod(
+            **get_pods_having_label(
+                constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
+            )[0]
+        )
+    )()
+    wait_for_resource_state(awscli_pod_obj, constants.STATUS_RUNNING, timeout=180)
+    return awscli_pod_obj
+
+
+def awscli_pod_cleanup():
+    """
+    Delete AWS cli pod resources.
+    """
+    log.info("Deleting the AWS CLI StatefulSet")
+    ocp_sts = OCP(
+        kind="StatefulSet",
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    try:
+        ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME)
+    except CommandFailed as e:
+        if "NotFound" not in str(e):
+            log.info("The AWS CLI STS was not found, assuming it was already deleted")
+    except TimeoutError:
+        log.warning("Standard deletion of the AWS CLI STS timed-out, forcing deletion")
+        ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME, force=True)
+
+    log.info("Deleting the AWS CLI service CA")
+    ocp_cm = OCP(
+        kind="ConfigMap",
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    awscli_service_ca_query = ocp_cm.get(selector=constants.S3CLI_APP_LABEL).get(
+        "items"
+    )
+    if awscli_service_ca_query:
+        ocp_cm.delete(resource_name=awscli_service_ca_query[0]["metadata"]["name"])

--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -21,7 +21,7 @@ from ocs_ci.utility.utils import update_container_with_mirrored_image
 log = logging.getLogger(__name__)
 
 
-def create_awscli_pod(scope_name=None, namespace=None):
+def create_awscli_pod(scope_name=None, namespace=None, service_account=None):
     """
     Create AWS cli pod and its resources.
 
@@ -55,6 +55,10 @@ def create_awscli_pod(scope_name=None, namespace=None):
         "name"
     ] = service_ca_configmap_name
     awscli_sts_dict["metadata"]["namespace"] = namespace
+    if service_account:
+        awscli_sts_dict["spec"]["template"]["spec"]["containers"][0][
+            "serviceAccount"
+        ] = service_account
     update_container_with_mirrored_image(awscli_sts_dict)
     update_container_with_proxy_env(awscli_sts_dict)
     s3cli_sts_obj = create_resource(**awscli_sts_dict)

--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -21,16 +21,18 @@ from ocs_ci.utility.utils import update_container_with_mirrored_image
 log = logging.getLogger(__name__)
 
 
-def create_awscli_pod(scope_name=None):
+def create_awscli_pod(scope_name=None, namespace=None):
     """
     Create AWS cli pod and its resources.
 
     Args:
         scope_name (str): The name of the fixture's scope
+        namespace (str): Namespace for aws cli pod
 
     Returns:
         object: awscli_pod_obj
     """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
     # Create the service-ca configmap to be mounted upon pod creation
     service_ca_data = templating.load_yaml(constants.AWSCLI_SERVICE_CA_YAML)
     resource_type = scope_name or "caconfigmap"
@@ -38,14 +40,12 @@ def create_awscli_pod(scope_name=None):
         constants.AWSCLI_SERVICE_CA_CONFIGMAP_NAME, resource_type
     )
     service_ca_data["metadata"]["name"] = service_ca_configmap_name
-    service_ca_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    service_ca_data["metadata"]["namespace"] = namespace
     s3cli_label_k, s3cli_label_v = constants.S3CLI_APP_LABEL.split("=")
     service_ca_data["metadata"]["labels"] = {s3cli_label_k: s3cli_label_v}
     log.info("Trying to create the AWS CLI service CA")
     service_ca_configmap = create_resource(**service_ca_data)
-    OCP(
-        namespace=config.ENV_DATA["cluster_namespace"], kind="ConfigMap"
-    ).wait_for_resource(
+    OCP(namespace=namespace, kind="ConfigMap").wait_for_resource(
         resource_name=service_ca_configmap.name, column="DATA", condition="1"
     )
 
@@ -54,7 +54,7 @@ def create_awscli_pod(scope_name=None):
     awscli_sts_dict["spec"]["template"]["spec"]["volumes"][0]["configMap"][
         "name"
     ] = service_ca_configmap_name
-    awscli_sts_dict["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    awscli_sts_dict["metadata"]["namespace"] = namespace
     update_container_with_mirrored_image(awscli_sts_dict)
     update_container_with_proxy_env(awscli_sts_dict)
     s3cli_sts_obj = create_resource(**awscli_sts_dict)
@@ -62,24 +62,24 @@ def create_awscli_pod(scope_name=None):
     log.info("Verifying the AWS CLI StatefulSet is running")
     assert s3cli_sts_obj, "Failed to create S3CLI STS"
     awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
-        lambda: Pod(
-            **get_pods_having_label(
-                constants.S3CLI_LABEL, config.ENV_DATA["cluster_namespace"]
-            )[0]
-        )
+        lambda: Pod(**get_pods_having_label(constants.S3CLI_LABEL, namespace)[0])
     )()
     wait_for_resource_state(awscli_pod_obj, constants.STATUS_RUNNING, timeout=180)
     return awscli_pod_obj
 
 
-def awscli_pod_cleanup():
+def awscli_pod_cleanup(namespace=None):
     """
     Delete AWS cli pod resources.
+
+    Args:
+        namespace (str): Namespace for aws cli pod
     """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
     log.info("Deleting the AWS CLI StatefulSet")
     ocp_sts = OCP(
         kind="StatefulSet",
-        namespace=config.ENV_DATA["cluster_namespace"],
+        namespace=namespace,
     )
     try:
         ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME)
@@ -93,7 +93,7 @@ def awscli_pod_cleanup():
     log.info("Deleting the AWS CLI service CA")
     ocp_cm = OCP(
         kind="ConfigMap",
-        namespace=config.ENV_DATA["cluster_namespace"],
+        namespace=namespace,
     )
     awscli_service_ca_query = ocp_cm.get(selector=constants.S3CLI_APP_LABEL).get(
         "items"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -205,6 +205,7 @@ OCSINIT = "ocsinit"
 SUBSCRIPTION_WITH_ACM = "Subscription.operators.coreos.com"
 
 # Other
+AWSCLI_NAMESPACE = "awscli"
 SECRET = "Secret"
 TEST = "test"
 NAMESPACE = "Namespace"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2477,9 +2477,12 @@ def awscli_pod_client_session(
     def _create_awscli_pod():
         ocsci_config.switch_ctx(client_cluster)
         log.info(f"Switched to client with index {client_cluster}")
-        create_awscli_pod(namespace=constants.AWSCLI_NAMESPACE, service_account=sa.name)
+        awscli_pod = create_awscli_pod(
+            namespace=constants.AWSCLI_NAMESPACE, service_account=sa.name
+        )
         ocsci_config.switch_ctx(original_cluster)
         log.info(f"Switched to provider with index {original_cluster}")
+        return awscli_pod
 
     def _awscli_pod_cleanup():
         ocsci_config.switch_ctx(client_cluster)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2461,7 +2461,7 @@ def awscli_pod_client_session(request, project_factory):
         int: Index of client cluster where the awscli pod is running
 
     """
-    project = project_factory(constants.AWSCLI_NAMESPACE)
+    project_factory(constants.AWSCLI_NAMESPACE)
     original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_to_consumer()
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2411,6 +2411,14 @@ def mcg_obj_session(request):
     return mcg_obj_fixture(request)
 
 
+@pytest.fixture(scope="session")
+def aws_cli_project(project_factory_session):
+    """
+    awscli project for awscli_pod on client.
+    """
+    return project_factory_session(constants.AWSCLI_NAMESPACE)
+
+
 def mcg_obj_fixture(request, *args, **kwargs):
     """
     Returns an MCG resource that's connected to the S3 endpoint
@@ -2448,7 +2456,7 @@ def awscli_pod(request, awscli_pod_session):
 
 
 @pytest.fixture(scope="session")
-def awscli_pod_client_session(request, project_factory):
+def awscli_pod_client_session(request, aws_cli_project):
     """
     Creates a new AWSCLI pod for relaying commands on a client cluster.
 
@@ -2461,7 +2469,6 @@ def awscli_pod_client_session(request, project_factory):
         int: Index of client cluster where the awscli pod is running
 
     """
-    project_factory(constants.AWSCLI_NAMESPACE)
     original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_to_consumer()
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1422,11 +1422,19 @@ def service_account_factory_fixture(request):
         Delete the service account
         """
         for instance in instances:
+            original_cluster = None
+            if instance.ocp.cluster_context:
+                original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER.get(
+                    "multicluster_index"
+                )
+                config.switch_ctx(instance.ocp.cluster_context)
             helpers.remove_scc_policy(
                 sa_name=instance.name, namespace=instance.namespace
             )
             instance.delete()
             instance.ocp.wait_for_delete(resource_name=instance.name)
+            if original_cluster:
+                config.switch_ctx(original_cluster)
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2411,14 +2411,6 @@ def mcg_obj_session(request):
     return mcg_obj_fixture(request)
 
 
-@pytest.fixture(scope="session")
-def aws_cli_project(project_factory_session):
-    """
-    awscli project for awscli_pod on client.
-    """
-    return project_factory_session(constants.AWSCLI_NAMESPACE)
-
-
 def mcg_obj_fixture(request, *args, **kwargs):
     """
     Returns an MCG resource that's connected to the S3 endpoint
@@ -2456,7 +2448,7 @@ def awscli_pod(request, awscli_pod_session):
 
 
 @pytest.fixture(scope="session")
-def awscli_pod_client_session(request, aws_cli_project):
+def awscli_pod_client_session(request, project_factory_session):
     """
     Creates a new AWSCLI pod for relaying commands on a client cluster.
 
@@ -2471,6 +2463,10 @@ def awscli_pod_client_session(request, aws_cli_project):
     """
     original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_to_consumer()
+    log.info(
+        f"Creating namespace {constants.AWSCLI_NAMESPACE} on client for aws cli pod"
+    )
+    project_factory_session(constants.AWSCLI_NAMESPACE)
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_ctx(original_cluster)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1427,14 +1427,14 @@ def service_account_factory_fixture(request):
                 original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER.get(
                     "multicluster_index"
                 )
-                config.switch_ctx(instance.ocp.cluster_context)
+                ocsci_config.switch_ctx(instance.ocp.cluster_context)
             helpers.remove_scc_policy(
                 sa_name=instance.name, namespace=instance.namespace
             )
             instance.delete()
             instance.ocp.wait_for_delete(resource_name=instance.name)
             if original_cluster:
-                config.switch_ctx(original_cluster)
+                ocsci_config.switch_ctx(original_cluster)
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2448,7 +2448,9 @@ def awscli_pod(request, awscli_pod_session):
 
 
 @pytest.fixture(scope="session")
-def awscli_pod_client_session(request, project_factory_session):
+def awscli_pod_client_session(
+    request, project_factory_session, service_account_factory_session
+):
     """
     Creates a new AWSCLI pod for relaying commands on a client cluster.
 
@@ -2466,14 +2468,20 @@ def awscli_pod_client_session(request, project_factory_session):
     log.info(
         f"Creating namespace {constants.AWSCLI_NAMESPACE} on client for aws cli pod"
     )
-    project_factory_session(constants.AWSCLI_NAMESPACE)
+    project = project_factory_session(constants.AWSCLI_NAMESPACE)
+    log.info(
+        f"Creating service account {constants.AWSCLI_NAMESPACE} on client for aws cli pod"
+    )
+    sa = service_account_factory_session(
+        project=project, service_account=constants.AWSCLI_NAMESPACE
+    )
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_ctx(original_cluster)
 
     def _create_awscli_pod():
         ocsci_config.switch_ctx(client_cluster)
         log.info(f"Switched to client with index {client_cluster}")
-        create_awscli_pod(namespace=constants.AWSCLI_NAMESPACE)
+        create_awscli_pod(namespace=constants.AWSCLI_NAMESPACE, service_account=sa.name)
         ocsci_config.switch_ctx(original_cluster)
         log.info(f"Switched to provider with index {original_cluster}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2448,7 +2448,7 @@ def awscli_pod(request, awscli_pod_session):
 
 
 @pytest.fixture(scope="session")
-def awscli_pod_client_session(request):
+def awscli_pod_client_session(request, project_factory):
     """
     Creates a new AWSCLI pod for relaying commands on a client cluster.
 
@@ -2461,6 +2461,7 @@ def awscli_pod_client_session(request):
         int: Index of client cluster where the awscli pod is running
 
     """
+    project = project_factory(constants.AWSCLI_NAMESPACE)
     original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_to_consumer()
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
@@ -2469,14 +2470,14 @@ def awscli_pod_client_session(request):
     def _create_awscli_pod():
         ocsci_config.switch_ctx(client_cluster)
         log.info(f"Switched to client with index {client_cluster}")
-        create_awscli_pod()
+        create_awscli_pod(namespace=constants.AWSCLI_NAMESPACE)
         ocsci_config.switch_ctx(original_cluster)
         log.info(f"Switched to provider with index {original_cluster}")
 
     def _awscli_pod_cleanup():
         ocsci_config.switch_ctx(client_cluster)
         log.info(f"Switched to client with index {client_cluster}")
-        awscli_pod_cleanup()
+        awscli_pod_cleanup(namespace=constants.AWSCLI_NAMESPACE)
         ocsci_config.switch_ctx(original_cluster)
         log.info(f"Switched to provider with index {original_cluster}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2469,12 +2469,8 @@ def awscli_pod_client_session(
         f"Creating namespace {constants.AWSCLI_NAMESPACE} on client for aws cli pod"
     )
     project = project_factory_session(constants.AWSCLI_NAMESPACE)
-    log.info(
-        f"Creating service account {constants.AWSCLI_NAMESPACE} on client for aws cli pod"
-    )
-    sa = service_account_factory_session(
-        project=project, service_account=constants.AWSCLI_NAMESPACE
-    )
+    log.info("Creating service account on client for aws cli pod")
+    sa = service_account_factory_session(project=project)
     client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     ocsci_config.switch_ctx(original_cluster)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.helpers.proxy import update_container_with_proxy_env
 from ocs_ci.ocs import constants, defaults, fio_artefacts, node, ocp, platform_nodes
 from ocs_ci.ocs.acm.acm import login_to_acm
+from ocs_ci.ocs.awscli_pod import create_awscli_pod, awscli_pod_cleanup
 from ocs_ci.ocs.bucket_utils import (
     craft_s3_command,
     put_bucket_policy,
@@ -2446,6 +2447,46 @@ def awscli_pod(request, awscli_pod_session):
     return awscli_pod_session
 
 
+@pytest.fixture(scope="session")
+def awscli_pod_client_session(request):
+    """
+    Creates a new AWSCLI pod for relaying commands on a client cluster.
+
+    Args:
+        scope_name (str): The name of the fixture's scope,
+        used for giving a descriptive name to the pod and configmap
+
+    Returns:
+        pod: A pod running the AWS CLI
+        int: Index of client cluster where the awscli pod is running
+
+    """
+    original_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
+    ocsci_config.switch_to_consumer()
+    client_cluster = ocsci_config.cluster_ctx.MULTICLUSTER["multicluster_index"]
+    ocsci_config.switch_ctx(original_cluster)
+
+    def _create_awscli_pod():
+        ocsci_config.switch_ctx(client_cluster)
+        log.info(f"Switched to client with index {client_cluster}")
+        create_awscli_pod()
+        ocsci_config.switch_ctx(original_cluster)
+        log.info(f"Switched to provider with index {original_cluster}")
+
+    def _awscli_pod_cleanup():
+        ocsci_config.switch_ctx(client_cluster)
+        log.info(f"Switched to client with index {client_cluster}")
+        awscli_pod_cleanup()
+        ocsci_config.switch_ctx(original_cluster)
+        log.info(f"Switched to provider with index {original_cluster}")
+
+    request.addfinalizer(_awscli_pod_cleanup)
+
+    log.info("Cleaning up any previous AWS CLI resources on client")
+    _awscli_pod_cleanup()
+    return _create_awscli_pod(), client_cluster
+
+
 def awscli_pod_fixture(request, scope_name):
     """
     Creates a new AWSCLI pod for relaying commands
@@ -2458,87 +2499,11 @@ def awscli_pod_fixture(request, scope_name):
 
     """
 
-    def _create_awscli_pod():
-        # Create the service-ca configmap to be mounted upon pod creation
-        service_ca_data = templating.load_yaml(constants.AWSCLI_SERVICE_CA_YAML)
-        service_ca_configmap_name = create_unique_resource_name(
-            constants.AWSCLI_SERVICE_CA_CONFIGMAP_NAME, scope_name
-        )
-        service_ca_data["metadata"]["name"] = service_ca_configmap_name
-        service_ca_data["metadata"]["namespace"] = ocsci_config.ENV_DATA[
-            "cluster_namespace"
-        ]
-        s3cli_label_k, s3cli_label_v = constants.S3CLI_APP_LABEL.split("=")
-        service_ca_data["metadata"]["labels"] = {s3cli_label_k: s3cli_label_v}
-        log.info("Trying to create the AWS CLI service CA")
-        service_ca_configmap = helpers.create_resource(**service_ca_data)
-        OCP(
-            namespace=ocsci_config.ENV_DATA["cluster_namespace"], kind="ConfigMap"
-        ).wait_for_resource(
-            resource_name=service_ca_configmap.name, column="DATA", condition="1"
-        )
-
-        log.info("Creating the AWS CLI StatefulSet")
-        awscli_sts_dict = templating.load_yaml(constants.S3CLI_MULTIARCH_STS_YAML)
-        awscli_sts_dict["spec"]["template"]["spec"]["volumes"][0]["configMap"][
-            "name"
-        ] = service_ca_configmap_name
-        awscli_sts_dict["metadata"]["namespace"] = ocsci_config.ENV_DATA[
-            "cluster_namespace"
-        ]
-        update_container_with_mirrored_image(awscli_sts_dict)
-        update_container_with_proxy_env(awscli_sts_dict)
-        s3cli_sts_obj = helpers.create_resource(**awscli_sts_dict)
-
-        log.info("Verifying the AWS CLI StatefulSet is running")
-        assert s3cli_sts_obj, "Failed to create S3CLI STS"
-        awscli_pod_obj = retry(IndexError, tries=3, delay=15)(
-            lambda: Pod(
-                **get_pods_having_label(
-                    constants.S3CLI_LABEL, ocsci_config.ENV_DATA["cluster_namespace"]
-                )[0]
-            )
-        )()
-        helpers.wait_for_resource_state(
-            awscli_pod_obj, constants.STATUS_RUNNING, timeout=180
-        )
-        return awscli_pod_obj
-
-    def _awscli_pod_cleanup():
-        log.info("Deleting the AWS CLI StatefulSet")
-        ocp_sts = OCP(
-            kind="StatefulSet",
-            namespace=ocsci_config.ENV_DATA["cluster_namespace"],
-        )
-        try:
-            ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME)
-        except CommandFailed as e:
-            if "NotFound" not in str(e):
-                log.info(
-                    "The AWS CLI STS was not found, assuming it was already deleted"
-                )
-        except TimeoutError:
-            log.warning(
-                "Standard deletion of the AWS CLI STS timed-out, forcing deletion"
-            )
-            ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME, force=True)
-
-        log.info("Deleting the AWS CLI service CA")
-        ocp_cm = OCP(
-            kind="ConfigMap",
-            namespace=ocsci_config.ENV_DATA["cluster_namespace"],
-        )
-        awscli_service_ca_query = ocp_cm.get(selector=constants.S3CLI_APP_LABEL).get(
-            "items"
-        )
-        if awscli_service_ca_query:
-            ocp_cm.delete(resource_name=awscli_service_ca_query[0]["metadata"]["name"])
-
-    request.addfinalizer(_awscli_pod_cleanup)
+    request.addfinalizer(awscli_pod_cleanup)
 
     log.info("Cleaning up any previous AWS CLI resources")
-    _awscli_pod_cleanup()
-    return _create_awscli_pod()
+    awscli_pod_cleanup()
+    return create_awscli_pod(scope_name)
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -79,10 +79,12 @@ def test_write_file_to_bucket_on_client(
         f"ls -A1 {constants.AWSCLI_TEST_OBJ_DIR}"
     ).split(" ")
     # create s3_creds structure with s3_endpoint so that s3_internal_endpoint is not used
+    # TODO(fbalak): remove ssl=False option and provide correct certificate
     s3_creds = {
         "access_key_id": mcg_obj.access_key_id,
         "access_key": mcg_obj.access_key,
         "endpoint": mcg_obj.s3_endpoint,
+        "ssl": False,
     }
     # Write all downloaded objects to the new bucket
     sync_object_directory(

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     red_squad,
@@ -8,10 +9,22 @@ from ocs_ci.framework.pytest_customization.marks import (
     provider_client_ms_platform_required,
 )
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import sync_object_directory
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.framework.testlib import polarion_id
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def return_to_original_context():
+    """
+    Make sure that original context is restored after the test.
+    """
+    original_cluster = config.cluster_ctx.MULTICLUSTER["multicluster_index"]
+    return
+    log.info(f"Switching back to original cluster with index {original_cluster}")
+    config.switch_ctx(original_cluster)
 
 
 @mcg
@@ -39,3 +52,37 @@ def test_verify_backingstore_uses_rgw(mcg_obj_session):
         "backingstore status noobaa-default-backing-store"
     ).stdout
     assert f"endpoint: {rgw_endpoint}" in backingstore_data
+
+
+@mcg
+@red_squad
+@tier1
+@runs_on_provider
+@provider_client_ms_platform_required
+@pytest.mark.polarion_id("OCS-5214")
+def test_write_file_to_bucket_on_client(
+    bucket_factory, mcg_obj, awscli_pod_client_session, return_to_original_context
+):
+    """
+    Test object IO using the S3 SDK on bucket created on provider and used on client.
+    """
+    awscli_pod, client_cluster = awscli_pod_client_session
+    # Retrieve a list of all objects on the test-objects bucket and
+    # downloads them to the pod
+    bucketname = bucket_factory(1, interface="S3")[0].name
+    full_object_path = f"s3://{bucketname}"
+
+    provider_cluster = config.cluster_ctx.MULTICLUSTER["multicluster_index"]
+    config.switch_ctx(client_cluster)
+    log.info(f"Switched to client cluster with index {client_cluster}")
+    downloaded_files = awscli_pod.exec_cmd_on_pod(
+        f"ls -A1 {constants.AWSCLI_TEST_OBJ_DIR}"
+    ).split(" ")
+    # Write all downloaded objects to the new bucket
+    sync_object_directory(
+        awscli_pod, constants.AWSCLI_TEST_OBJ_DIR, full_object_path, mcg_obj
+    )
+
+    assert set(downloaded_files).issubset(
+        obj.key for obj in mcg_obj.s3_list_all_objects_in_bucket(bucketname)
+    )

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
@@ -72,7 +73,6 @@ def test_write_file_to_bucket_on_client(
     bucketname = bucket_factory(1, interface="S3")[0].name
     full_object_path = f"s3://{bucketname}"
 
-    provider_cluster = config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     config.switch_ctx(client_cluster)
     log.info(f"Switched to client cluster with index {client_cluster}")
     downloaded_files = awscli_pod.exec_cmd_on_pod(

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -78,9 +78,18 @@ def test_write_file_to_bucket_on_client(
     downloaded_files = awscli_pod.exec_cmd_on_pod(
         f"ls -A1 {constants.AWSCLI_TEST_OBJ_DIR}"
     ).split(" ")
+    # create s3_creds structure with s3_endpoint so that s3_internal_endpoint is not used
+    s3_creds = {
+        "access_key_id": mcg_obj.access_key_id,
+        "access_key": mcg_obj.access_key,
+        "endpoint": mcg_obj.s3_endpoint,
+    }
     # Write all downloaded objects to the new bucket
     sync_object_directory(
-        awscli_pod, constants.AWSCLI_TEST_OBJ_DIR, full_object_path, mcg_obj
+        awscli_pod,
+        constants.AWSCLI_TEST_OBJ_DIR,
+        full_object_path,
+        signed_request_creds=s3_creds,
     )
 
     assert set(downloaded_files).issubset(

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -70,7 +70,7 @@ def test_write_file_to_bucket_on_client(
     awscli_pod, client_cluster = awscli_pod_client_session
     # Retrieve a list of all objects on the test-objects bucket and
     # downloads them to the pod
-    bucketname = bucket_factory(1, interface="S3")[0].name
+    bucketname = bucket_factory(1, interface="OC")[0].name
     full_object_path = f"s3://{bucketname}"
 
     config.switch_ctx(client_cluster)


### PR DESCRIPTION
- move awscli_pod resources to [ocs_ci/ocs/awscli_pod.py](https://github.com/red-hat-storage/ocs-ci/compare/master...fbalak:mcg-client?expand=1#diff-dbd3f05a9264c49748dd0fd2257e0d7254e0b43543e1e7a965b54850a9b6fae9)
- add test_write_file_to_bucket_on_client
- execute oc commands with correct context
- delete buckets with correct context