### PR TITLE
[release-4.13 backport] Backport the mcg and rgw decorators along with their enforcement mechanism

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -2,6 +2,7 @@
 In this pytest plugin we will keep all our pytest marks used in our tests and
 all related hooks/plugins to markers.
 """
+
 import os
 
 import pytest
@@ -58,6 +59,8 @@ team_marks = [manage, ecosystem, e2e]
 ocp = pytest.mark.ocp
 rook = pytest.mark.rook
 ui = pytest.mark.ui
+mcg = pytest.mark.mcg
+rgw = pytest.mark.rgw
 csi = pytest.mark.csi
 monitoring = pytest.mark.monitoring
 workloads = pytest.mark.workloads

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1800,6 +1800,7 @@ SQUADS = {
     "Yellow": ["/managed-service/"],
     "Turquoise": ["/disaster-recovery/"],
 }
+DECORATORS_CHECK_IGNORED_MARKERS = ["libtest"]
 
 PRODUCTION_JOBS_PREFIX = ["jnk"]
 

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -639,17 +639,5 @@ class MissingDecoratorError(Exception):
     pass
 
 
-class PDBNotCreatedException(Exception):
-    pass
-
-
-class UnableUpgradeConnectionException(Exception):
-    pass
-
-
-class NoThreadingLockUsedError(Exception):
-    pass
-
-
 class VSLMNotFoundException(Exception):
     pass

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -635,5 +635,21 @@ class ReturnedEmptyResponseException(Exception):
     pass
 
 
+class MissingDecoratorError(Exception):
+    pass
+
+
+class PDBNotCreatedException(Exception):
+    pass
+
+
+class UnableUpgradeConnectionException(Exception):
+    pass
+
+
+class NoThreadingLockUsedError(Exception):
+    pass
+
+
 class VSLMNotFoundException(Exception):
     pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -57,6 +57,8 @@ markers =
     black_squad: marker for black squad
     yellow_squad: marker for yellow squad
     turquoise_squad: marker for turquoise squad
+    mcg: marker for MCG related tests
+    rgw: marker for RGW related tests
 
 # Clusterctx used without hyphen, to keep the original format if it's None
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s %(clusterctx)s - %(message)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from ocs_ci.ocs.exceptions import (
     PoolNotDeletedFromUI,
     StorageClassNotDeletedFromUI,
     ResourceNotDeleted,
+    MissingDecoratorError,
 )
 from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implementation
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
@@ -181,7 +182,68 @@ def pytest_logger_config(logger_config):
     logger_config.set_formatter_class(OCSLogFormatter)
 
 
-def pytest_collection_modifyitems(session, items):
+def verify_test_decorators_requirements(items):
+    """
+    Verify that all tests collected are decorated with a squad marker
+
+    Args:
+        items: list of collected tests
+
+    """
+    items_without_squad_marker = {}
+    red_no_mcg_or_rgw_items = {}
+    for item in items:
+        base_dir = os.path.join(constants.TOP_DIR, "tests")
+        ignored_markers = constants.SQUAD_CHECK_IGNORED_MARKERS
+        if item.fspath.strpath.startswith(base_dir):
+            item_markers = [marker.name for marker in item.iter_markers()]
+            if any(marker in item_markers for marker in ignored_markers):
+                log.debug(
+                    "Ignoring test case %s as it has a marker in the ignore list",
+                    item.name,
+                )
+
+            # Verify tests are decorated with the correct squad owner
+            elif not any(["_squad" in marker for marker in item_markers]):
+                log.debug("%s is missing a squad owner marker", item.name)
+                items_without_squad_marker.update({item.name: item.fspath.strpath})
+
+            # Verify red squad tests are decorated with either @mcg or @rgw
+            elif (
+                "red_squad" in item_markers
+                and "mcg" not in item_markers
+                and "rgw" not in item_markers
+            ):
+                log.debug("%s is a red_squad test without @mcg or @rgw", item.name)
+                red_no_mcg_or_rgw_items.update({item.name: item.fspath.strpath})
+
+    err_msg = ""
+    if items_without_squad_marker:
+        err_msg += f"""
+Missing squad decorator for the following test items: {json.dumps(items_without_squad_marker, indent=4)}
+
+Tests are required to be decorated with their squad owner. Please add the tests respective owner.
+
+For example:
+
+    @magenta_squad
+    def test_name():
+
+Test owner marks can be imported from `ocs_ci.framework.pytest_customization.marks`
+
+            """
+    if red_no_mcg_or_rgw_items:
+        err_msg += f"""
+The following tests are missing either the @mcg or @rgw decorators: {json.dumps(red_no_mcg_or_rgw_items, indent=4)}
+
+Red squad tests are required to be decorated with either @mcg or @rgw. Please add either depending on the tests's focus.
+
+                """
+    if err_msg:
+        raise MissingDecoratorError(err_msg)
+
+
+def pytest_collection_modifyitems(session, pytest_config, items):
     """
     A pytest hook to filter out skipped tests satisfying
     skipif_ocs_version, skipif_upgraded_from or skipif_no_kms
@@ -195,6 +257,9 @@ def pytest_collection_modifyitems(session, items):
     teardown = config.RUN["cli_params"].get("teardown")
     deploy = config.RUN["cli_params"].get("deploy")
     skip_ocs_deployment = config.ENV_DATA["skip_ocs_deployment"]
+
+    if pytest_config.option.collectonly:
+        verify_test_decorators_requirements(items)
 
     # Add squad markers to each test item based on filepath
     for item in items:
@@ -1114,9 +1179,11 @@ def pod_factory_fixture(request, pvc_factory):
         if deployment_config or deployment:
             d_name = pod_obj.get_labels().get("name")
             d_ocp_dict = ocp.OCP(
-                kind=constants.DEPLOYMENTCONFIG
-                if deployment_config
-                else constants.DEPLOYMENT,
+                kind=(
+                    constants.DEPLOYMENTCONFIG
+                    if deployment_config
+                    else constants.DEPLOYMENT
+                ),
                 namespace=pod_obj.namespace,
             ).get(resource_name=d_name)
             d_obj = OCS(**d_ocp_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ def pytest_logger_config(logger_config):
 
 def verify_test_decorators_requirements(items):
     """
-    Verify that all tests collected are decorated with a squad marker
+    Verify that all collected tests have the required decorators
 
     Args:
         items: list of collected tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,7 +190,6 @@ def verify_test_decorators_requirements(items):
         items: list of collected tests
 
     """
-    items_without_squad_marker = {}
     red_no_mcg_or_rgw_items = {}
     for item in items:
         base_dir = os.path.join(constants.TOP_DIR, "tests")
@@ -203,11 +202,6 @@ def verify_test_decorators_requirements(items):
                     item.name,
                 )
 
-            # Verify tests are decorated with the correct squad owner
-            elif not any(["_squad" in marker for marker in item_markers]):
-                log.debug("%s is missing a squad owner marker", item.name)
-                items_without_squad_marker.update({item.name: item.fspath.strpath})
-
             # Verify red squad tests are decorated with either @mcg or @rgw
             elif (
                 "red_squad" in item_markers
@@ -218,20 +212,7 @@ def verify_test_decorators_requirements(items):
                 red_no_mcg_or_rgw_items.update({item.name: item.fspath.strpath})
 
     err_msg = ""
-    if items_without_squad_marker:
-        err_msg += f"""
-Missing squad decorator for the following test items: {json.dumps(items_without_squad_marker, indent=4)}
 
-Tests are required to be decorated with their squad owner. Please add the tests respective owner.
-
-For example:
-
-    @magenta_squad
-    def test_name():
-
-Test owner marks can be imported from `ocs_ci.framework.pytest_customization.marks`
-
-            """
     if red_no_mcg_or_rgw_items:
         err_msg += f"""
 The following tests are missing either the @mcg or @rgw decorators: {json.dumps(red_no_mcg_or_rgw_items, indent=4)}

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_crd.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -32,6 +34,8 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")

--- a/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
+++ b/tests/e2e/flowtest/mcg/test_mcg_namespace_disruptions_rpc.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     flowtests,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -38,6 +40,8 @@ from ocs_ci.ocs.resources.pod import wait_for_storage_pods
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import warp
-from ocs_ci.framework.pytest_customization.marks import magenta_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import mcg
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 
 @mcg
-@magenta_squad
 @tier3
 @ignore_leftovers
 @skipif_managed_service

--- a/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/e2e/kcs/test_noobaa_db_backup_and_recovery.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import warp
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, mcg
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -20,6 +21,8 @@ from ocs_ci.ocs.resources.pod import (
 log = logging.getLogger(__name__)
 
 
+@mcg
+@magenta_squad
 @tier3
 @ignore_leftovers
 @skipif_managed_service
@@ -84,7 +87,6 @@ class TestNoobaaBackupAndRecovery(E2ETest):
 
     @pytest.fixture()
     def warps3(self, request):
-
         warps3 = warp.Warp()
         warps3.create_resource_warp(replicas=4, multi_client=True)
 

--- a/tests/e2e/kcs/test_noobaa_rebuild.py
+++ b/tests/e2e/kcs/test_noobaa_rebuild.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_external_mode,
+    magenta_squad,
+    mcg,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs import constants
@@ -21,6 +23,8 @@ from ocs_ci.ocs.resources.pvc import get_pvc_objs
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@magenta_squad
 @tier3
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2653")

--- a/tests/e2e/kcs/test_noobaa_rebuild.py
+++ b/tests/e2e/kcs/test_noobaa_rebuild.py
@@ -9,7 +9,6 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_external_mode,
-    magenta_squad,
     mcg,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -24,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@magenta_squad
 @tier3
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2653")

--- a/tests/e2e/kcs/test_noobaadb_pw_reset.py
+++ b/tests/e2e/kcs/test_noobaadb_pw_reset.py
@@ -9,7 +9,6 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_ocs_version,
-    magenta_squad,
     mcg,
 )
 from ocs_ci.helpers.helpers import (
@@ -26,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@magenta_squad
 @tier3
 @pytest.mark.polarion_id("OCS-4662")
 @skipif_ocs_version("<4.9")

--- a/tests/e2e/kcs/test_noobaadb_pw_reset.py
+++ b/tests/e2e/kcs/test_noobaadb_pw_reset.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
     skipif_ocs_version,
+    magenta_squad,
+    mcg,
 )
 from ocs_ci.helpers.helpers import (
     wait_for_resource_state,
@@ -23,6 +25,8 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@magenta_squad
 @tier3
 @pytest.mark.polarion_id("OCS-4662")
 @skipif_ocs_version("<4.9")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_crd.py
@@ -9,6 +9,8 @@ import botocore.exceptions as boto3exception
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -56,6 +58,8 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_lifecyle_rpc.py
@@ -8,6 +8,8 @@ import botocore.exceptions as boto3exception
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import (
@@ -48,6 +50,8 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
         )
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_crd.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -107,6 +109,8 @@ def multipart_setup(pod_obj, origin_dir, result_dir):
     return mpu_key, origin_dir, result_dir, parts
 
 
+@mcg
+@red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
+++ b/tests/e2e/lifecycle/mcg/test_mcg_namespace_s3_ops_rpc.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     tier2,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import E2ETest, skipif_ocs_version
 from ocs_ci.ocs import bucket_utils
@@ -25,6 +27,8 @@ ROOT_OBJ = "RootKey-" + str(uuid.uuid4().hex)
 COPY_OBJ = "CopyKey-" + str(uuid.uuid4().hex)
 
 
+@mcg
+@red_squad
 @pytest.mark.polarion_id("OCS-2296")
 @skipif_managed_service
 @skipif_aws_creds_are_missing

--- a/tests/e2e/performance/mcg/test_mcg_cosbench.py
+++ b/tests/e2e/performance/mcg/test_mcg_cosbench.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import performance, performance_c
 from ocs_ci.ocs.perftests import PASTest
 from ocs_ci.ocs.perfresult import ResultsAnalyse
@@ -12,7 +13,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def cosbench(request):
-
     cosbench = Cosbench()
 
     def teardown():
@@ -22,6 +22,8 @@ def cosbench(request):
     return cosbench
 
 
+@mcg
+@red_squad
 @performance
 @performance_c
 @pytest.mark.polarion_id("OCS-3694")

--- a/tests/e2e/scale/noobaa/test_hsbench.py
+++ b/tests/e2e/scale/noobaa/test_hsbench.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     bugzilla,
     skipif_ocs_version,
+    mcg,
+    rgw,
 )
 
 log = logging.getLogger(__name__)
@@ -14,7 +16,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def hsbenchs3(request):
-
     hsbenchs3 = hsbench.HsBench()
     hsbenchs3.create_test_user()
     hsbenchs3.create_resource_hsbench()
@@ -30,7 +31,6 @@ def hsbenchs3(request):
 
 @pytest.fixture(scope="function")
 def s3bench(request):
-
     s3bench = hsbench.HsBench()
     s3bench.create_resource_hsbench()
     s3bench.install_hsbench()
@@ -48,6 +48,7 @@ class TestHsBench(E2ETest):
     Test writing one million S3 objects to a single bucket
     """
 
+    @rgw
     @vsphere_platform_required
     @pytest.mark.polarion_id("OCS-2321")
     def test_s3_benchmark_hsbench(self, hsbenchs3):
@@ -71,6 +72,7 @@ class TestHsBench(E2ETest):
         # Check ceph health status
         utils.ceph_health_check()
 
+    @mcg
     @bugzilla("1998680")
     @skipif_ocs_version("<4.9")
     @pytest.mark.polarion_id("OCS-2698")

--- a/tests/e2e/scale/noobaa/test_list_objects.py
+++ b/tests/e2e/scale/noobaa/test_list_objects.py
@@ -7,7 +7,7 @@ from ocs_ci.ocs.bucket_utils import (
     sync_object_directory,
     list_objects_from_bucket,
 )
-from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import mcg
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.framework.testlib import scale, bugzilla, skipif_ocs_version
 from ocs_ci.ocs.resources.mcg import MCG
@@ -17,7 +17,6 @@ log = logging.getLogger(__name__)
 
 
 @mcg
-@orange_squad
 @scale
 class TestListOfObjects(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_list_objects.py
+++ b/tests/e2e/scale/noobaa/test_list_objects.py
@@ -7,6 +7,7 @@ from ocs_ci.ocs.bucket_utils import (
     sync_object_directory,
     list_objects_from_bucket,
 )
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.framework.testlib import scale, bugzilla, skipif_ocs_version
 from ocs_ci.ocs.resources.mcg import MCG
@@ -15,6 +16,8 @@ from ocs_ci.ocs.resources.mcg import MCG
 log = logging.getLogger(__name__)
 
 
+@mcg
+@orange_squad
 @scale
 class TestListOfObjects(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
+++ b/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs import hsbench
@@ -29,7 +29,6 @@ def s3bench(request):
 
 
 @mcg
-@orange_squad
 @scale
 @skipif_ocs_version("<4.9")
 class TestScaleBucketReplication(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
+++ b/tests/e2e/scale/noobaa/test_scale_bucket_replication.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import time
 
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs import hsbench
@@ -27,6 +28,8 @@ def s3bench(request):
     return s3bench
 
 
+@mcg
+@orange_squad
 @scale
 @skipif_ocs_version("<4.9")
 class TestScaleBucketReplication(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import mcg
 from ocs_ci.framework.testlib import MCGTest, scale, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp, scale_pgsql
 from ocs_ci.utility import utils
@@ -53,7 +53,6 @@ def worker_node(request):
 
 
 @mcg
-@orange_squad
 @scale
 @skipif_ocs_version("<4.5")
 @pytest.mark.parametrize(

--- a/tests/e2e/scale/noobaa/test_scale_endpoint.py
+++ b/tests/e2e/scale/noobaa/test_scale_endpoint.py
@@ -3,6 +3,7 @@ import logging
 import time
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import MCGTest, scale, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp, scale_pgsql
 from ocs_ci.utility import utils
@@ -51,6 +52,8 @@ def worker_node(request):
     return worker_node
 
 
+@mcg
+@orange_squad
 @scale
 @skipif_ocs_version("<4.5")
 @pytest.mark.parametrize(

--- a/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
+    orange_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import hsbench
@@ -27,6 +29,8 @@ def s3bench(request):
     return s3bench
 
 
+@mcg
+@orange_squad
 @scale
 class TestScaleNamespace(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_crd.py
@@ -6,7 +6,6 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
-    orange_squad,
     mcg,
 )
 from ocs_ci.ocs import constants
@@ -30,7 +29,6 @@ def s3bench(request):
 
 
 @mcg
-@orange_squad
 @scale
 class TestScaleNamespace(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
@@ -6,12 +6,16 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
+    orange_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@orange_squad
 @skipif_ocs_version("!=4.6")
 @scale
 class TestScaleNamespace(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
+++ b/tests/e2e/scale/noobaa/test_scale_namespace_rpc.py
@@ -6,7 +6,6 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     on_prem_platform_required,
     scale,
-    orange_squad,
     mcg,
 )
 from ocs_ci.ocs import constants
@@ -15,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@orange_squad
 @skipif_ocs_version("!=4.6")
 @scale
 class TestScaleNamespace(E2ETest):

--- a/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
@@ -4,7 +4,7 @@ import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.utility.utils import ocsci_log_path
@@ -22,7 +22,6 @@ def teardown(request):
 
 
 @mcg
-@orange_squad
 @scale
 class TestScaleOCBCreateDelete(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_create_delete.py
@@ -4,6 +4,7 @@ import csv
 
 from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import orange_squad, mcg
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.utility.utils import ocsci_log_path
@@ -20,6 +21,8 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@mcg
+@orange_squad
 @scale
 class TestScaleOCBCreateDelete(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation.py
@@ -8,7 +8,6 @@ from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
-    orange_squad,
     mcg,
 )
 
@@ -24,7 +23,6 @@ def teardown(request):
 
 
 @mcg
-@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation.py
@@ -6,7 +6,11 @@ from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
-from ocs_ci.framework.pytest_customization.marks import vsphere_platform_required
+from ocs_ci.framework.pytest_customization.marks import (
+    vsphere_platform_required,
+    orange_squad,
+    mcg,
+)
 
 log = logging.getLogger(__name__)
 
@@ -19,6 +23,8 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@mcg
+@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
@@ -7,7 +7,6 @@ from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 from ocs_ci.framework.pytest_customization.marks import (
     on_prem_platform_required,
-    orange_squad,
     mcg,
     rgw,
 )
@@ -23,7 +22,6 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
-@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """

--- a/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
+++ b/tests/e2e/scale/noobaa/test_scale_obc_creation_repsin_noobaa_pods.py
@@ -5,7 +5,12 @@ from ocs_ci.ocs import constants, scale_noobaa_lib
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import scale, E2ETest
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
-from ocs_ci.framework.pytest_customization.marks import on_prem_platform_required
+from ocs_ci.framework.pytest_customization.marks import (
+    on_prem_platform_required,
+    orange_squad,
+    mcg,
+    rgw,
+)
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +23,7 @@ def teardown(request):
     request.addfinalizer(finalizer)
 
 
+@orange_squad
 @scale
 class TestScaleOCBCreation(E2ETest):
     """
@@ -41,12 +47,14 @@ class TestScaleOCBCreation(E2ETest):
                 *["noobaa-core", constants.NOOBAA_SC],
                 marks=[
                     pytest.mark.polarion_id("OCS-2645"),
+                    mcg,
                 ],
             ),
             pytest.param(
                 *["noobaa-db", constants.NOOBAA_SC],
                 marks=[
                     pytest.mark.polarion_id("OCS-2646"),
+                    mcg,
                 ],
             ),
             pytest.param(
@@ -54,6 +62,7 @@ class TestScaleOCBCreation(E2ETest):
                 marks=[
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-2647"),
+                    rgw,
                 ],
             ),
             pytest.param(
@@ -61,6 +70,7 @@ class TestScaleOCBCreation(E2ETest):
                 marks=[
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-2648"),
+                    rgw,
                 ],
             ),
         ],

--- a/tests/e2e/scale/noobaa/test_warp.py
+++ b/tests/e2e/scale/noobaa/test_warp.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     bugzilla,
+    orange_squad,
+    mcg,
 )
 
 log = logging.getLogger(__name__)
@@ -17,7 +19,6 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="function")
 def warps3(request):
-
     warps3 = warp.Warp()
     warps3.create_resource_warp()
 
@@ -28,6 +29,8 @@ def warps3(request):
     return warps3
 
 
+@mcg
+@orange_squad
 @scale
 @ignore_leftovers
 class TestWarp(E2ETest):

--- a/tests/e2e/scale/noobaa/test_warp.py
+++ b/tests/e2e/scale/noobaa/test_warp.py
@@ -10,7 +10,6 @@ from ocs_ci.framework.testlib import E2ETest, scale
 from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     bugzilla,
-    orange_squad,
     mcg,
 )
 
@@ -30,7 +29,6 @@ def warps3(request):
 
 
 @mcg
-@orange_squad
 @scale
 @ignore_leftovers
 class TestWarp(E2ETest):

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_external_mode,
     orange_squad,
+    mcg,
 )
 from ocs_ci.utility.utils import ocsci_log_path
 from ocs_ci.utility import utils, templating
@@ -30,6 +31,8 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
 
 
+@mcg
+@orange_squad
 @pre_upgrade
 @skipif_external_mode
 @skipif_bm
@@ -80,6 +83,7 @@ def test_scale_obc_pre_upgrade(tmp_path, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@mcg
 @post_upgrade
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_obc.py
@@ -32,7 +32,6 @@ obc_scaled_data_file = f"{log_path}/obc_scale_data_file.yaml"
 
 
 @mcg
-@orange_squad
 @pre_upgrade
 @skipif_external_mode
 @skipif_bm

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -12,6 +12,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_bm,
     skipif_external_mode,
     vsphere_platform_required,
+    orange_squad,
+    rgw,
 )
 from ocs_ci.utility.utils import ocsci_log_path
 from ocs_ci.utility import utils, templating
@@ -32,6 +34,8 @@ log_path = ocsci_log_path()
 obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
+@rgw
+@orange_squad
 @pre_upgrade
 @vsphere_platform_required
 @skipif_external_mode
@@ -108,6 +112,8 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
         w_obj.write(str(f"OBC_SCALE_LIST: {obc_scaled_list}\n"))
 
 
+@rgw
+@orange_squad
 @post_upgrade
 @vsphere_platform_required
 @skipif_external_mode

--- a/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/e2e/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -12,7 +12,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_bm,
     skipif_external_mode,
     vsphere_platform_required,
-    orange_squad,
     rgw,
 )
 from ocs_ci.utility.utils import ocsci_log_path
@@ -35,7 +34,6 @@ obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 
 
 @rgw
-@orange_squad
 @pre_upgrade
 @vsphere_platform_required
 @skipif_external_mode
@@ -113,7 +111,6 @@ def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
 
 
 @rgw
-@orange_squad
 @post_upgrade
 @vsphere_platform_required
 @skipif_external_mode

--- a/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
@@ -13,6 +13,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     system_test,
     skipif_vsphere_ipi,
+    magenta_squad,
+    mcg,
 )
 from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
 from ocs_ci.ocs.bucket_utils import (
@@ -33,13 +35,14 @@ from ocs_ci.ocs.exceptions import CommandFailed, ResourceWrongStatusException
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@magenta_squad
 @system_test
 @skipif_ocs_version("<4.9")
 @skipif_vsphere_ipi
 @skipif_external_mode
 @skipif_mcg_only
 class TestMCGReplicationWithDisruptions(E2ETest):
-
     """
     The objectives of this test case are:
     1) To verify that namespace buckets can be replicated across MCG clusters
@@ -87,7 +90,6 @@ class TestMCGReplicationWithDisruptions(E2ETest):
         test_directory_setup,
         nodes,
     ):
-
         # check uni bucket replication from multi (aws+azure) namespace bucket to s3-compatible namespace bucket
         target_bucket_name = bucket_factory(bucketclass=target_bucketclass)[0].name
         replication_policy = ("basic-replication-rule", target_bucket_name, None)

--- a/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/e2e/system_test/test_mcg_replication_with_disruptions.py
@@ -13,7 +13,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     system_test,
     skipif_vsphere_ipi,
-    magenta_squad,
     mcg,
 )
 from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
@@ -36,7 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@magenta_squad
 @system_test
 @skipif_ocs_version("<4.9")
 @skipif_vsphere_ipi

--- a/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
+++ b/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from semantic_version import Version
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier1,
@@ -31,7 +30,6 @@ log = logging.getLogger(__name__)
 
 
 @rgw
-@magenta_squad
 @tier1
 @bugzilla("2209616")
 @bugzilla("1937187")

--- a/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
+++ b/tests/e2e/workloads/app/amq/test_rgw_kafka_notifications.py
@@ -7,12 +7,14 @@ from datetime import datetime
 from semantic_version import Version
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier1,
     on_prem_platform_required,
     bugzilla,
     skipif_external_mode,
+    rgw,
 )
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs.amq import AMQ
@@ -28,6 +30,8 @@ from ocs_ci.utility.utils import exec_cmd, run_cmd, clone_notify
 log = logging.getLogger(__name__)
 
 
+@rgw
+@magenta_squad
 @tier1
 @bugzilla("2209616")
 @bugzilla("1937187")
@@ -50,7 +54,6 @@ class TestRGWAndKafkaNotifications(E2ETest):
         ) = self.kafkadrop_svc = self.kafkadrop_route = None
 
         def teardown():
-
             if self.kafka_topic:
                 self.kafka_topic.delete()
             if self.kafkadrop_pod:

--- a/tests/ecosystem/upgrade/test_noobaa.py
+++ b/tests/ecosystem/upgrade/test_noobaa.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     skipif_aws_creds_are_missing,
     skipif_managed_service,
+    mcg,
 )
 from ocs_ci.ocs.constants import BS_OPTIMAL
 from ocs_ci.ocs.bucket_utils import (
@@ -30,6 +31,7 @@ DOWNLOADED_OBJS = []
 @skipif_managed_service
 @aws_platform_required
 @pre_upgrade
+@mcg
 @red_squad
 def test_fill_bucket(
     mcg_obj_session, awscli_pod_session, multiregion_mirror_setup_session
@@ -86,6 +88,7 @@ def test_fill_bucket(
 @aws_platform_required
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2038")
+@mcg
 @red_squad
 def test_noobaa_postupgrade(
     mcg_obj_session, awscli_pod_session, multiregion_mirror_setup_session
@@ -133,6 +136,7 @@ def test_noobaa_postupgrade(
 @skipif_managed_service
 @bugzilla("1820974")
 @pre_upgrade
+@mcg
 @red_squad
 def test_buckets_before_upgrade(upgrade_buckets, mcg_obj_session):
     """
@@ -147,6 +151,7 @@ def test_buckets_before_upgrade(upgrade_buckets, mcg_obj_session):
 @bugzilla("1820974")
 @post_upgrade
 @pytest.mark.polarion_id("OCS-2181")
+@mcg
 @red_squad
 def test_buckets_after_upgrade(upgrade_buckets, mcg_obj_session):
     """
@@ -158,6 +163,7 @@ def test_buckets_after_upgrade(upgrade_buckets, mcg_obj_session):
 
 @pre_upgrade
 @skipif_managed_service
+@mcg
 @red_squad
 def test_start_upgrade_mcg_io(mcg_workload_job):
     """
@@ -175,6 +181,7 @@ def test_start_upgrade_mcg_io(mcg_workload_job):
 @skipif_managed_service
 @pytest.mark.polarion_id("OCS-2207")
 @bugzilla("1874243")
+@mcg
 @red_squad
 def test_upgrade_mcg_io(mcg_workload_job):
     """

--- a/tests/ecosystem/upgrade/test_resources.py
+++ b/tests/ecosystem/upgrade/test_resources.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     red_squad,
     brown_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import ocp
@@ -28,6 +29,7 @@ log = logging.getLogger(__name__)
 
 @skipif_aws_creds_are_missing
 @post_upgrade
+@mcg
 @brown_squad
 @pytest.mark.polarion_id("OCS-2220")
 def test_storage_pods_running(multiregion_mirror_setup_session):
@@ -132,6 +134,7 @@ def test_pod_log_after_upgrade():
 @post_upgrade
 @bugzilla("1973179")
 @pytest.mark.polarion_id("OCS-2666")
+@mcg
 @red_squad
 def test_noobaa_service_mon_after_ocs_upgrade():
     """

--- a/tests/manage/mcg/test_admission_control.py
+++ b/tests/manage/mcg/test_admission_control.py
@@ -6,6 +6,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
@@ -20,6 +21,8 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_ocs_version("<4.10")
 # We have to ignore leftovers since environment_checker runs before the
 # bucket_factory_session teardown, due to it being session-scoped.

--- a/tests/manage/mcg/test_azure_noobaa_sa.py
+++ b/tests/manage/mcg/test_azure_noobaa_sa.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_ocs_version,
     azure_platform_required,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -17,13 +19,14 @@ from ocs_ci.ocs.ocp import OCP
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @tier1
 @azure_platform_required
 @bugzilla("1970123")
 @pytest.mark.polarion_id("OCS-3963")
 @skipif_ocs_version("<4.10")
 class TestNoobaaStorageAccount:
-
     """
     Test azure Noobaa SA
     """

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     acceptance,
     performance,
     skipif_mcg_only,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -20,6 +22,8 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 class TestBucketCreation(MCGTest):
     """

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     performance,
     skipif_mcg_only,
     red_squad,
+    mcg,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -21,6 +22,7 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+@mcg
 @red_squad
 @skipif_managed_service
 class TestBucketCreation(MCGTest):

--- a/tests/manage/mcg/test_bucket_creation.py
+++ b/tests/manage/mcg/test_bucket_creation.py
@@ -11,7 +11,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     performance,
     skipif_mcg_only,
     red_squad,
-    mcg,
 )
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -22,7 +21,6 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
-@mcg
 @red_squad
 @skipif_managed_service
 class TestBucketCreation(MCGTest):

--- a/tests/manage/mcg/test_bucket_deletion.py
+++ b/tests/manage/mcg/test_bucket_deletion.py
@@ -14,6 +14,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_mcg_only,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -30,6 +32,8 @@ logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 class TestBucketDeletion(MCGTest):
     """

--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -45,13 +45,20 @@ from ocs_ci.ocs.constants import (
     bucket_website_action_list,
     bucket_version_action_list,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service, bugzilla
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    bugzilla,
+    red_squad,
+    mcg,
+)
 from ocs_ci.utility import version
 from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.3")
 class TestS3BucketPolicy(MCGTest):
@@ -242,12 +249,16 @@ class TestS3BucketPolicy(MCGTest):
         # Admin sets policy on obc bucket with obc account principal
         bucket_policy_generated = gen_bucket_policy(
             user_list=[obc_obj.obc_account],
-            actions_list=["PutObject"]
-            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
-            else ["GetObject", "DeleteObject"],
-            effect="Allow"
-            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
-            else "Deny",
+            actions_list=(
+                ["PutObject"]
+                if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
+                else ["GetObject", "DeleteObject"]
+            ),
+            effect=(
+                "Allow"
+                if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
+                else "Deny"
+            ),
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
         )
         bucket_policy = json.dumps(bucket_policy_generated)

--- a/tests/manage/mcg/test_bucket_replication.py
+++ b/tests/manage/mcg/test_bucket_replication.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, tier2
+from ocs_ci.framework.pytest_customization.marks import tier1, tier2, red_squad, mcg
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
@@ -19,6 +19,8 @@ from ocs_ci.framework.testlib import skipif_ocs_version
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_ocs_version("<4.9")
 class TestReplication(MCGTest):
     """

--- a/tests/manage/mcg/test_cached_buckets.py
+++ b/tests/manage/mcg/test_cached_buckets.py
@@ -16,12 +16,16 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     skipif_aws_creds_are_missing,
     tier2,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 class TestCachedBuckets(MCGTest):

--- a/tests/manage/mcg/test_db_nfs_mount.py
+++ b/tests/manage/mcg/test_db_nfs_mount.py
@@ -13,12 +13,16 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     polarion_id,
     vsphere_platform_required,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 class TestNoobaaDbNFSMount:
     @pytest.fixture()
     def mount_ngix_pod(self, request):
@@ -54,7 +58,6 @@ class TestNoobaaDbNFSMount:
 
     @pytest.fixture()
     def mount_noobaa_db_pod(self, request):
-
         # scale down noobaa db stateful set
         helpers.modify_statefulset_replica_count(
             constants.NOOBAA_DB_STATEFULSET, replica_count=0

--- a/tests/manage/mcg/test_endpoint_autoscale.py
+++ b/tests/manage/mcg/test_endpoint_autoscale.py
@@ -1,12 +1,19 @@
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import MCGTest, tier1, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
-
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    red_squad,
+    mcg,
+)
 
 # @pytest.mark.polarion_id("OCS-XXXX")
 # Skipped above 4.6 because of https://github.com/red-hat-storage/ocs-ci/issues/4129
-@skipif_ocs_version(["<4.5", ">4.6"])
+
+
+@mcg
+@red_squad
+@skipif_ocs_version(["<4.5", "<4.14"])
 @skipif_managed_service
 @tier1
 class TestEndpointAutoScale(MCGTest):

--- a/tests/manage/mcg/test_host_node_failure.py
+++ b/tests/manage/mcg/test_host_node_failure.py
@@ -3,6 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import (
     bugzilla,
     ignore_leftovers,
@@ -29,6 +30,8 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @tier4b
 @bugzilla("1853638")
 @ignore_leftovers

--- a/tests/manage/mcg/test_kms.py
+++ b/tests/manage/mcg/test_kms.py
@@ -2,7 +2,12 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_no_kms
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_no_kms,
+    red_squad,
+    mcg,
+)
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
@@ -11,6 +16,8 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_no_kms
 class TestNoobaaKMS(MCGTest):
     """

--- a/tests/manage/mcg/test_mcg_resources_disruptions.py
+++ b/tests/manage/mcg/test_mcg_resources_disruptions.py
@@ -13,6 +13,8 @@ from ocs_ci.framework.testlib import (
     tier4c,
     tier3,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -30,6 +32,8 @@ def setup(request):
     request.cls.cl_obj = cluster.CephCluster()
 
 
+@mcg
+@red_squad
 @ignore_leftovers()
 @pytest.mark.usefixtures(setup.__name__)
 class TestMCGResourcesDisruptions(MCGTest):

--- a/tests/manage/mcg/test_multi_region.py
+++ b/tests/manage/mcg/test_multi_region.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     skipif_managed_service,
     skipif_disconnected_cluster,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.bucket_utils import (
@@ -24,6 +26,8 @@ from ocs_ci.utility.retry import retry
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing

--- a/tests/manage/mcg/test_multicloud.py
+++ b/tests/manage/mcg/test_multicloud.py
@@ -4,11 +4,17 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import MCGTest
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    red_squad,
+    mcg,
+)
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 class TestMultiCloud(MCGTest):
     """

--- a/tests/manage/mcg/test_multipart_upload.py
+++ b/tests/manage/mcg/test_multipart_upload.py
@@ -19,6 +19,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     bugzilla,
     skipif_ocs_version,
+    red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +55,8 @@ def setup(pod_obj, bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 class TestS3MultipartUpload(MCGTest):
     """

--- a/tests/manage/mcg/test_namespace_crd.py
+++ b/tests/manage/mcg/test_namespace_crd.py
@@ -3,6 +3,7 @@ Tests for Namespace resources and buckets by using OpenShift CRDs only.
 These tests are valid only for OCS version 4.7 and above because in later
 versions are for Namespace bucket creation used CRDs instead of NooBaa RPC calls.
 """
+
 import logging
 from time import sleep
 import uuid
@@ -31,7 +32,11 @@ from ocs_ci.ocs.bucket_utils import (
     retrieve_verification_mode,
     wait_for_cache,
 )
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_creds_are_missing
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_aws_creds_are_missing,
+    red_squad,
+    mcg,
+)
 from ocs_ci.ocs import constants, bucket_utils
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
@@ -42,6 +47,8 @@ from ocs_ci.ocs.resources.bucket_policy import HttpResponseParser
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_disconnected_cluster
@@ -61,7 +68,10 @@ class TestNamespace(MCGTest):
         argvalues=[
             pytest.param(("oc", {"aws": [(1, DEFAULT_REGION)]})),
             pytest.param(("oc", {"azure": [(1, None)]})),
-            pytest.param(("oc", {"rgw": [(1, None)]}), marks=on_prem_platform_required),
+            pytest.param(
+                ("oc", {"rgw": [(1, None)]}),
+                marks=on_prem_platform_required,
+            ),
         ],
         # A test ID list for describing the parametrized tests
         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>

--- a/tests/manage/mcg/test_namespace_rpc.py
+++ b/tests/manage/mcg/test_namespace_rpc.py
@@ -3,6 +3,7 @@ Tests for Namespace resources and buckets by using RPC calls only.
 Most of these tests are valid only for OCS version lesser than 4.7
 because in later versions are for Namespace bucket creation used CRDs.
 """
+
 import logging
 
 import pytest
@@ -18,7 +19,11 @@ from ocs_ci.framework.testlib import (
     tier4a,
 )
 from ocs_ci.ocs.bucket_utils import sync_object_directory, verify_s3_object_integrity
-from ocs_ci.framework.pytest_customization.marks import skipif_aws_creds_are_missing
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_aws_creds_are_missing,
+    red_squad,
+    mcg,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -27,6 +32,8 @@ from ocs_ci.ocs.resources import pod
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("!=4.6")

--- a/tests/manage/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/manage/mcg/test_nb_mgmt_endpoint.py
@@ -2,6 +2,7 @@ import json
 import requests
 import logging
 
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework.testlib import tier1
 
 from ocs_ci.framework.testlib import MCGTest
@@ -12,6 +13,8 @@ from ocs_ci.ocs.bucket_utils import retrieve_verification_mode
 logger = logging.getLogger(name=__file__)
 
 
+@mcg
+@red_squad
 @tier1
 @skipif_ocs_version(">4.13")
 class TestNoobaaMgmtEndpoint(MCGTest):

--- a/tests/manage/mcg/test_noobaa_prometheus.py
+++ b/tests/manage/mcg/test_noobaa_prometheus.py
@@ -5,7 +5,13 @@ from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
     ReturnedEmptyResponseException,
 )
-from ocs_ci.framework.pytest_customization.marks import tier2, bugzilla, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    bugzilla,
+    polarion_id,
+    red_squad,
+    mcg,
+)
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.ocs.bucket_utils import write_random_test_objects_to_bucket
 from ocs_ci.utility.retry import retry
@@ -29,6 +35,8 @@ def get_bucket_used_bytes_metric(bucket_name):
     return value[1]
 
 
+@mcg
+@red_squad
 class TestNoobaaaPrometheus:
     @tier2
     @bugzilla("2168010")

--- a/tests/manage/mcg/test_noobaa_secret.py
+++ b/tests/manage/mcg/test_noobaa_secret.py
@@ -15,6 +15,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_disconnected_cluster,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.aws import update_config_from_s3
@@ -35,7 +37,6 @@ def cleanup(request):
     instances = []
 
     def factory(resource_obj):
-
         if isinstance(resource_obj, list):
             instances.extend(resource_obj)
         else:
@@ -58,6 +59,8 @@ def cleanup(request):
     return factory
 
 
+@mcg
+@red_squad
 @tier2
 @skipif_ocs_version("<4.11")
 @skipif_disconnected_cluster

--- a/tests/manage/mcg/test_nsfs.py
+++ b/tests/manage/mcg/test_nsfs.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     skipif_ocs_version,
     ignore_leftover_label,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
@@ -19,6 +21,8 @@ from tests.conftest import revert_noobaa_endpoint_scc_class
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_mcg_only
 @skipif_ocs_version("<4.10")
 @ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)

--- a/tests/manage/mcg/test_object_expiration.py
+++ b/tests/manage/mcg/test_object_expiration.py
@@ -4,7 +4,7 @@ from time import sleep
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla
+from ocs_ci.framework.pytest_customization.marks import tier1, bugzilla, red_squad, mcg
 from ocs_ci.framework.testlib import MCGTest, version
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
@@ -12,6 +12,8 @@ from ocs_ci.ocs.bucket_utils import s3_put_object, s3_get_object
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 class TestObjectExpiration(MCGTest):
     """
     Tests suite for object expiration

--- a/tests/manage/mcg/test_object_integrity.py
+++ b/tests/manage/mcg/test_object_integrity.py
@@ -14,6 +14,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_ocs_version,
     skipif_disconnected_cluster,
+    red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,8 @@ FILESIZE_SKIP = pytest.mark.skip("Current test filesize is too large.")
 RUNTIME_SKIP = pytest.mark.skip("Runtime is too long; Code needs to be parallelized")
 
 
+@mcg
+@red_squad
 @flaky
 @skipif_managed_service
 class TestObjectIntegrity(MCGTest):

--- a/tests/manage/mcg/test_object_versioning.py
+++ b/tests/manage/mcg/test_object_versioning.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier2,
     skipif_ocs_version,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs.bucket_utils import (
     s3_put_bucket_versioning,
@@ -23,6 +25,8 @@ from ocs_ci.ocs import constants
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 class TestObjectVersioning:
     @pytest.fixture(scope="function")
     def setup_file_object(self, request):

--- a/tests/manage/mcg/test_pv_pool.py
+++ b/tests/manage/mcg/test_pv_pool.py
@@ -4,7 +4,14 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier2, tier3
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_mcg_only,
+    tier2,
+    tier3,
+    red_squad,
+    mcg,
+)
+
 from ocs_ci.ocs.bucket_utils import (
     wait_for_pv_backingstore,
     check_pv_backingstore_status,
@@ -27,6 +34,9 @@ logger = logging.getLogger(__name__)
 LOCAL_DIR_PATH = "/awsfiles"
 
 
+@mcg
+@red_squad
+@skipif_mcg_only
 class TestPvPool:
     """
     Test pv pool related operations

--- a/tests/manage/mcg/test_s3_prefix_list.py
+++ b/tests/manage/mcg/test_s3_prefix_list.py
@@ -11,17 +11,20 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier2,
     skipif_ocs_version,
+    red_squad,
+    mcg,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @bugzilla("2068110")
 @pytest.mark.polarion_id("OCS-3925")
 @tier2
 @skipif_ocs_version("<4.10")
 class TestS3PrefixList:
-
     """
     Test S3 prefix list operations
     """

--- a/tests/manage/mcg/test_s3_routes.py
+++ b/tests/manage/mcg/test_s3_routes.py
@@ -11,6 +11,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ibm_cloud,
     skipif_managed_service,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
@@ -21,8 +23,9 @@ logger = logging.getLogger(__name__)
 RECONCILE_WAIT = 60
 
 
+@mcg
+@red_squad
 class TestS3Routes:
-
     """
     Tests related to ODF S3 routes
     """

--- a/tests/manage/mcg/test_s3_with_java_sdk.py
+++ b/tests/manage/mcg/test_s3_with_java_sdk.py
@@ -6,12 +6,16 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     skipif_disconnected_cluster,
     tier1,
+    red_squad,
+    mcg,
 )
 from ocs_ci.ocs.bucket_utils import upload_objects_with_javasdk
 
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @skipif_ocs_version("<4.9")
 @skipif_disconnected_cluster
 class TestS3WithJavaSDK:

--- a/tests/manage/mcg/test_verify_noobaa_status.py
+++ b/tests/manage/mcg/test_verify_noobaa_status.py
@@ -1,8 +1,13 @@
 import logging
 import re
 
-from ocs_ci.framework.pytest_customization.marks import tier1, skipif_ocs_version
-from ocs_ci.framework.pytest_customization.marks import skipif_openshift_dedicated
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    skipif_ocs_version,
+    skipif_openshift_dedicated,
+    red_squad,
+    mcg,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_pod_logs
 from ocs_ci.framework.testlib import polarion_id, bugzilla
@@ -11,6 +16,8 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 log = logging.getLogger(__name__)
 
 
+@mcg
+@red_squad
 @tier1
 @polarion_id("OCS-2084")
 @bugzilla("1799077")
@@ -28,6 +35,8 @@ def test_verify_noobaa_status_cli(mcg_obj_session):
     log.info("Verified: noobaa status does not contain any error.")
 
 
+@mcg
+@red_squad
 @tier1
 @skipif_ocs_version("<4.8")
 @polarion_id("OCS-2748")

--- a/tests/manage/mcg/test_write_to_bucket.py
+++ b/tests/manage/mcg/test_write_to_bucket.py
@@ -9,6 +9,8 @@ from flaky import flaky
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     skip_inconsistent,
+    red_squad,
+    mcg,
 )
 from ocs_ci.framework.testlib import (
     MCGTest,
@@ -79,6 +81,8 @@ def file_setup(request):
     return zip_filename
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 class TestBucketIO(MCGTest):
     """

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -3,7 +3,6 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     on_prem_platform_required,
-    black_squad,
     mcg,
 )
 from ocs_ci.ocs import constants
@@ -26,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@black_squad
 @skipif_ui_not_support("mcg_stores")
 class TestStoreUserInterface(object):
     """
@@ -98,7 +96,6 @@ class TestStoreUserInterface(object):
 
 
 @mcg
-@black_squad
 @ui
 @skipif_ui_not_support("bucketclass")
 @tier1

--- a/tests/manage/mcg/ui/test_mcg_ui.py
+++ b/tests/manage/mcg/ui/test_mcg_ui.py
@@ -3,6 +3,8 @@ import logging
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     on_prem_platform_required,
+    black_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -23,6 +25,8 @@ from ocs_ci.ocs.ui.mcg_ui import BucketClassUI, MCGStoreUI, ObcUI, ObUI
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@black_squad
 @skipif_ui_not_support("mcg_stores")
 class TestStoreUserInterface(object):
     """
@@ -93,6 +97,8 @@ class TestStoreUserInterface(object):
         assert test_store.check_resource_existence(should_exist=False)
 
 
+@mcg
+@black_squad
 @ui
 @skipif_ui_not_support("bucketclass")
 @tier1
@@ -256,7 +262,7 @@ class TestObcUserInterface(object):
                     "three_dots",
                     True,
                 ],
-                marks=pytest.mark.polarion_id("OCS-4698"),
+                marks=[pytest.mark.polarion_id("OCS-4698"), mcg],
             ),
             pytest.param(
                 *[
@@ -265,7 +271,7 @@ class TestObcUserInterface(object):
                     "Actions",
                     True,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2542"),
+                marks=[pytest.mark.polarion_id("OCS-2542"), mcg],
             ),
             pytest.param(
                 *[

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     tier2,
     tier4a,
+    blue_squad,
+    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus, version
@@ -15,6 +17,8 @@ from ocs_ci.ocs.ocp import OCP
 log = logging.getLogger(__name__)
 
 
+@mcg
+@blue_squad
 @tier2
 @polarion_id("OCS-1254")
 @skipif_managed_service
@@ -111,6 +115,8 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
         )
 
 
+@mcg
+@blue_squad
 @tier4a
 @polarion_id("OCS-2498")
 @skipif_managed_service

--- a/tests/manage/monitoring/prometheus/test_noobaa.py
+++ b/tests/manage/monitoring/prometheus/test_noobaa.py
@@ -7,7 +7,6 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     tier2,
     tier4a,
-    blue_squad,
     mcg,
 )
 from ocs_ci.ocs import constants
@@ -18,7 +17,6 @@ log = logging.getLogger(__name__)
 
 
 @mcg
-@blue_squad
 @tier2
 @polarion_id("OCS-1254")
 @skipif_managed_service
@@ -116,7 +114,6 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota):
 
 
 @mcg
-@blue_squad
 @tier4a
 @polarion_id("OCS-2498")
 @skipif_managed_service

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -2,8 +2,12 @@ import logging
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization import marks
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
-from ocs_ci.framework.pytest_customization.marks import tier1
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    skipif_managed_service,
+    tier1,
+    mcg,
+)
 from ocs_ci.framework.testlib import skipif_ocs_version, skipif_ocp_version
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.version import get_ocp_version
@@ -12,6 +16,8 @@ from ocs_ci.utility.version import get_semantic_version, VERSION_4_10
 logger = logging.getLogger(__name__)
 
 
+@mcg
+@blue_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_mcg_hpa.py
@@ -3,7 +3,6 @@ import logging
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization import marks
 from ocs_ci.framework.pytest_customization.marks import (
-    blue_squad,
     skipif_managed_service,
     tier1,
     mcg,
@@ -17,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 @mcg
-@blue_squad
 @tier1
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -11,7 +11,11 @@ from ocs_ci.framework.pytest_customization import marks
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.prometheus import check_query_range_result_limits
-from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_managed_service,
+    blue_squad,
+    mcg,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +28,8 @@ CPU_USAGE_POD = (
 )
 
 
+@mcg
+@blue_squad
 @tier1
 @marks.polarion_id("OCS-2364")
 @marks.bugzilla("1849309")

--- a/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
+++ b/tests/manage/monitoring/prometheusmetrics/test_ocs_utilization.py
@@ -13,7 +13,6 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.prometheus import check_query_range_result_limits
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
-    blue_squad,
     mcg,
 )
 
@@ -29,7 +28,6 @@ CPU_USAGE_POD = (
 
 
 @mcg
-@blue_squad
 @tier1
 @marks.polarion_id("OCS-2364")
 @marks.bugzilla("1849309")

--- a/tests/manage/rgw/test_bucket_creation.py
+++ b/tests/manage/rgw/test_bucket_creation.py
@@ -2,7 +2,14 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import acceptance, tier1, tier3
+from ocs_ci.framework.pytest_customization.marks import (
+    acceptance,
+    skipif_mcg_only,
+    red_squad,
+    rgw,
+    tier1,
+    tier3,
+)
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.ocs.exceptions import CommandFailed
 import botocore
@@ -11,6 +18,9 @@ import re
 logger = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
+@skipif_mcg_only
 class TestRGWBucketCreation:
     """
     Test creation of a bucket

--- a/tests/manage/rgw/test_bucket_deletion.py
+++ b/tests/manage/rgw/test_bucket_deletion.py
@@ -6,7 +6,14 @@ from flaky import flaky
 from ocs_ci.ocs.bucket_utils import sync_object_directory
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import acceptance, tier1, tier3
+from ocs_ci.framework.pytest_customization.marks import (
+    acceptance,
+    red_squad,
+    rgw,
+    skipif_mcg_only,
+    tier1,
+    tier3,
+)
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import OBC
@@ -15,6 +22,9 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
+@skipif_mcg_only
 class TestBucketDeletion:
     """
     Test deletion of RGW buckets

--- a/tests/manage/rgw/test_host_node_failure.py
+++ b/tests/manage/rgw/test_host_node_failure.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import red_squad, rgw
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -32,6 +33,8 @@ from ocs_ci.utility.utils import ceph_health_check
 log = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
 @tier4b
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2374")
@@ -55,7 +58,6 @@ class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
         self.sanity_helpers = Sanity()
 
     def create_obc_creation(self, bucket_factory, mcg_obj, key):
-
         # Create a bucket then read & write
         bucket_name = bucket_factory(amount=1, interface="OC", timeout=120)[0].name
         obj_data = "A random string data"

--- a/tests/manage/rgw/test_multipart_upload.py
+++ b/tests/manage/rgw/test_multipart_upload.py
@@ -4,6 +4,7 @@ import pytest
 import uuid
 
 from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only, rgw
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     abort_all_multipart_upload,
@@ -48,6 +49,9 @@ def setup(pod_obj, rgw_bucket_factory, test_directory_setup):
     return bucket, object_key, origin_dir, res_dir, full_object_path, parts
 
 
+@rgw
+@red_squad
+@skipif_mcg_only
 class TestS3MultipartUpload(ManageTest):
     """
     Test Multipart upload on RGW buckets

--- a/tests/manage/rgw/test_obc_quota.py
+++ b/tests/manage/rgw/test_obc_quota.py
@@ -12,11 +12,15 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     bugzilla,
     skipif_ocs_version,
+    red_squad,
+    rgw,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
 @bugzilla("1940823")
 @skipif_ocs_version("<4.10")
 class TestOBCQuota:

--- a/tests/manage/rgw/test_object_bucket_size.py
+++ b/tests/manage/rgw/test_object_bucket_size.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
+    red_squad,
+    mcg,
     skipif_managed_service,
 )
 from ocs_ci.ocs.bucket_utils import get_bucket_available_size
@@ -56,6 +58,8 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
         )
 
 
+@mcg
+@red_squad
 @skipif_managed_service
 @skipif_ocs_version("<4.7")
 @pytest.mark.polarion_id("OCS-2476")
@@ -80,9 +84,11 @@ def test_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
     ceph_obj = OCP(
         namespace=config.ENV_DATA["cluster_namespace"],
         kind="CephCluster",
-        resource_name=f"{constants.DEFAULT_CLUSTERNAME_EXTERNAL_MODE}-cephcluster"
-        if config.DEPLOYMENT["external_mode"]
-        else f"{constants.DEFAULT_CLUSTERNAME}-cephcluster",
+        resource_name=(
+            f"{constants.DEFAULT_CLUSTERNAME_EXTERNAL_MODE}-cephcluster"
+            if config.DEPLOYMENT["external_mode"]
+            else f"{constants.DEFAULT_CLUSTERNAME}-cephcluster"
+        ),
     )
     bucket_name = bucket_factory(amount=1, interface="S3")[0].name
     assert not compare_sizes(

--- a/tests/manage/rgw/test_object_integrity.py
+++ b/tests/manage/rgw/test_object_integrity.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
 )
 
+from ocs_ci.framework.pytest_customization.marks import red_squad, skipif_mcg_only, rgw
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.resources.objectbucket import OBC
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
@@ -15,6 +16,9 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 logger = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
+@skipif_mcg_only
 class TestObjectIntegrity(ManageTest):
     """
     Test data integrity of RGW buckets

--- a/tests/manage/rgw/test_rgw_pod_existence.py
+++ b/tests/manage/rgw/test_rgw_pod_existence.py
@@ -1,7 +1,7 @@
 import logging
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import acceptance
+from ocs_ci.framework.pytest_customization.marks import acceptance, red_squad, rgw
 from ocs_ci.helpers.helpers import storagecluster_independent_check
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -13,6 +13,8 @@ from ocs_ci.utility.rgwutils import get_rgw_count
 logger = logging.getLogger(__name__)
 
 
+@rgw
+@red_squad
 @acceptance
 class TestRGWPodExistence:
     """

--- a/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
+++ b/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
@@ -11,11 +11,15 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     bugzilla,
     skipif_external_mode,
+    brown_squad,
+    mcg,
 )
 
 log = logging.getLogger(__name__)
 
 
+@mcg
+@brown_squad
 @tier2
 @bugzilla("1943388")
 @skipif_ocs_version("<4.8")

--- a/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
+++ b/tests/manage/z_cluster/test_noobaa_xss_vulnerability.py
@@ -11,7 +11,6 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     bugzilla,
     skipif_external_mode,
-    brown_squad,
     mcg,
 )
 
@@ -19,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 @mcg
-@brown_squad
 @tier2
 @bugzilla("1943388")
 @skipif_ocs_version("<4.8")

--- a/tests/ui/test_error_improvements.py
+++ b/tests/ui/test_error_improvements.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     tier3,
     bugzilla,
+    skipif_ocs_version,
+    mcg,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.ocp import OCP
@@ -19,7 +21,9 @@ logger = logging.getLogger(__name__)
 @black_squad
 @skipif_ibm_cloud_managed
 @skipif_managed_service
+@skipif_ocs_version("<4.13")
 class TestErrorMessageImprovements(ManageTest):
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4865")
     def test_backing_store_creation_rules(self, setup_ui_class):
@@ -36,6 +40,7 @@ class TestErrorMessageImprovements(ManageTest):
         backing_store_tab.proceed_resource_creation()
         backing_store_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4867")
     def test_obc_creation_rules(self, setup_ui_class):
@@ -52,6 +57,7 @@ class TestErrorMessageImprovements(ManageTest):
         object_bucket_claim_create_tab.proceed_resource_creation()
         object_bucket_claim_create_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4869")
     def test_bucket_class_creation_rules(self, setup_ui_class):
@@ -69,6 +75,7 @@ class TestErrorMessageImprovements(ManageTest):
         bucket_class_create_tab.proceed_resource_creation()
         bucket_class_create_tab.check_error_messages()
 
+    @mcg
     @bugzilla("2193109")
     @polarion_id("OCS-4871")
     def test_namespace_store_creation_rules(


### PR DESCRIPTION
release-4.13 backport of https://github.com/red-hat-storage/ocs-ci/pull/9070

This PR also backports the enforcement mechanism that checks that any `red_squad` test is decorated with either `mcg` or `rgw`, and since this branch does not have the original squad ownership validations, some additional adjustments were required.