### PR TITLE
Update MCG bucket policy usage to fix MalformedPolicy errors 

### DIFF
--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -99,9 +99,11 @@ class NoobaaAccount(object):
                 "s3_access": s3_access,
                 "default_pool": backingstore_name,
             }
-        params_dict if (
-            version.get_semantic_ocs_version_from_config() < version.VERSION_4_9
-        ) else params_dict.pop("default_pool")
+        (
+            params_dict
+            if (version.get_semantic_ocs_version_from_config() < version.VERSION_4_9)
+            else params_dict.pop("default_pool")
+        )
         response = mcg.send_rpc_query(
             api="account_api", method="create_account", params=params_dict
         ).json()
@@ -161,7 +163,7 @@ def gen_bucket_policy(
         "Statement": [
             {
                 "Action": actions,
-                "Principal": principals,
+                "Principal": {"AWS": principals},
                 "Resource": resources,
                 "Effect": effect,
                 "Sid": sid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5778,7 +5778,7 @@ def nsfs_bucket_factory_fixture(
 
             # Allow access to the export dir by adding a bucket policy
             bucket_policy = gen_bucket_policy(
-                user_list=["*"],
+                user_list="*",
                 actions_list=["*"],
                 resources_list=["*"],
             )

--- a/tests/functional/object/mcg/flowtest/test_mcg_namespace_disruptions_crd.py
+++ b/tests/functional/object/mcg/flowtest/test_mcg_namespace_disruptions_crd.py
@@ -174,7 +174,7 @@ class TestMcgNamespaceDisruptionsCrd(E2ETest):
 
         # Admin sets Public access policy(*)
         bucket_policy_generated = gen_bucket_policy(
-            user_list=["*"],
+            user_list="*",
             actions_list=["GetObject"],
             resources_list=[f'{ns_bucket}/{"*"}'],
         )

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -368,7 +368,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets policy all users '*' (Public access)
         bucket_policy_generated = gen_bucket_policy(
-            user_list=["*"],
+            user_list="*",
             actions_list=["GetObject"],
             resources_list=[f'{s3_bucket.name}/{"*"}'],
         )

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -133,9 +133,9 @@ class TestS3BucketPolicy(MCGTest):
         modified_policy = json.loads(get_modified_policy["Policy"])
         logger.info(f"Got modified bucket policy: {modified_policy}")
 
-        actions_from_modified_policy = modified_policy["statement"][0]["action"]
+        actions_from_modified_policy = modified_policy["Statement"][0]["Action"]
         modified_actions = list(map(str, actions_from_modified_policy))
-        initial_actions = list(map(str.lower, actions))
+        initial_actions = actions
         logger.info(f"Actions from modified_policy: {modified_actions}")
         logger.info(f"User provided actions actions: {initial_actions}")
         if modified_actions == initial_actions:
@@ -251,12 +251,16 @@ class TestS3BucketPolicy(MCGTest):
         # Admin sets policy on obc bucket with obc account principal
         bucket_policy_generated = gen_bucket_policy(
             user_list=[obc_obj.obc_account],
-            actions_list=["PutObject"]
-            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
-            else ["GetObject", "DeleteObject"],
-            effect="Allow"
-            if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
-            else "Deny",
+            actions_list=(
+                ["PutObject"]
+                if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
+                else ["GetObject", "DeleteObject"]
+            ),
+            effect=(
+                "Allow"
+                if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
+                else "Deny"
+            ),
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
         )
         bucket_policy = json.dumps(bucket_policy_generated)

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -694,7 +694,7 @@ class TestS3BucketPolicy(MCGTest):
         # Statement_1 public read access to a bucket
         single_statement_policy = gen_bucket_policy(
             sid="statement-1",
-            user_list=["*"],
+            user_list="*",
             actions_list=["GetObject"],
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
             effect="Allow",
@@ -706,14 +706,14 @@ class TestS3BucketPolicy(MCGTest):
             "statement_2": {
                 "Action": "s3:PutObject",
                 "Effect": "Allow",
-                "Principal": obc_obj.obc_account,
+                "Principal": {"AWS": obc_obj.obc_account},
                 "Resource": [f'arn:aws:s3:::{obc_obj.bucket_name}/{"*"}'],
                 "Sid": "Statement-2",
             },
             "statement_3": {
                 "Action": "s3:DeleteObject",
                 "Effect": "Deny",
-                "Principal": [obc_obj.obc_account],
+                "Principal": {"AWS": [obc_obj.obc_account]},
                 "Resource": [f'arn:aws:s3:::{"*"}'],
                 "Sid": "Statement-3",
             },


### PR DESCRIPTION
Fixes: #9130

The structure of the bucket policy jsons that are accepted by MCG has been changed in https://github.com/noobaa/noobaa-core/commit/f37589305dc77157ce318f08344a369755f53796 and https://github.com/noobaa/noobaa-core/commit/47d93c442439331ccb5d6ede40a8fc82eda91422.

This PR adjusts OCS-CI to these new constraints.