### PR TITLE
Create a new image for Fedora with FIO

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1364,7 +1364,7 @@ def create_build_from_docker_image(
     install_package,
     namespace,
     source_image="quay.io/ocsci/fedora",
-    source_image_label="latest",
+    source_image_label="fio",
 ):
     """
     Allows to create a build config using a Dockerfile specified as an

--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -20,7 +20,7 @@ spec:
           claimName: tet-2
       containers:
       - name: fedora
-        image: quay.io/ocsci/fedora
+        image: quay.io/ocsci/fedora:fio
         resources:
           limits:
             memory: "2048Mi"

--- a/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
@@ -42,7 +42,7 @@ class TestRunIOMultipleDcPods(ManageTest):
         Note:- Step 1,2,3,7 are not required if we deploy dc in openshift-storage namespace
     """
 
-    num_of_pvcs = 1
+    num_of_pvcs = 10
     pvc_size = 5
 
     @pytest.fixture()

--- a/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py
@@ -42,7 +42,7 @@ class TestRunIOMultipleDcPods(ManageTest):
         Note:- Step 1,2,3,7 are not required if we deploy dc in openshift-storage namespace
     """
 
-    num_of_pvcs = 10
+    num_of_pvcs = 1
     pvc_size = 5
 
     @pytest.fixture()

--- a/tests/functional/workloads/ocp/registry/test_pod_from_registry.py
+++ b/tests/functional/workloads/ocp/registry/test_pod_from_registry.py
@@ -26,7 +26,7 @@ class TestRegistryImage(E2ETest):
         pvc_obj = pvc_factory(size=self.pvc_size)
         image_obj = helpers.create_build_from_docker_image(
             namespace=pvc_obj.namespace,
-            source_image_label="latest",
+            source_image_label="fio",
             image_name="fio",
             install_package="fio",
         )


### PR DESCRIPTION
#9333

Created a new image with FIO. We don't need to install FIO with `rsh` command. We can build the image with FIO.

Dockerfile:
```
FROM quay.io/ocsci/fedora:latest
RUN dnf install -y fio bash util-linux

```
Build and Push the image to quay:
```
docker buildx build --platform linux/amd64,linux/ppc64le,linux/s390x,linux/arm64 -t quay.io/ocsci/fedora:fio . --push
```

Relevant tests:
```
tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py::TestRunIOMultipleDcPods::test_run_io_multiple_dc_pods[CephBlockPool]
tests/functional/pv/pv_services/test_run_io_multiple_dc_pods.py::TestRunIOMultipleDcPods::test_run_io_multiple_dc_pods[CephFileSystem]
tests/functional/workloads/ocp/registry/test_pod_from_registry.py
```