### PR TITLE
Fix Submariner UI installation for OCP 4.15

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -628,7 +628,7 @@ acm_page_nav = {
     "Welcome_page": ("Welcome", By.LINK_TEXT),
     "Overview_page": ("Overview", By.LINK_TEXT),
     "Infrastructure": (
-        "//button[normalize-space()='Infrastructure' and @class='pf-c-nav__link']",
+        "//button[normalize-space()='Infrastructure' and @class='pf-v5-c-nav__link']",
         By.XPATH,
     ),
     "Clusters_page": ("Clusters", By.LINK_TEXT),
@@ -1718,6 +1718,7 @@ locators = {
             **acm_configuration_4_11,
             **acm_configuration_4_12,
             **acm_configuration_4_13,
+            **acm_configuration_4_14,
         },
         "validation": {
             **validation,


### PR DESCRIPTION
Fixes: #9342 

Updated locators for Submariner UI installation to work with OCP 4.15