### PR TITLE
Allow user-specified versions for installing unreleased ACM and Submariner

### DIFF
--- a/conf/examples/acm_hub_unreleased_image.yaml
+++ b/conf/examples/acm_hub_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  acm_unreleased_image: "2.10.0-DOWNSTREAM-2024-02-15-05-34-13"
+  acm_unreleased_image: "2.10.0-DOWNSTREAM-2024-02-28-06-06-55"

--- a/conf/examples/acm_hub_unreleased_image.yaml
+++ b/conf/examples/acm_hub_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  acm_unreleased_image: "2.7.0-DOWNSTREAM-2023-01-26-20-15-10"
+  acm_unreleased_image: "2.10.0-DOWNSTREAM-2024-02-15-05-34-13"

--- a/conf/examples/submariner_unreleased_image.yaml
+++ b/conf/examples/submariner_unreleased_image.yaml
@@ -1,0 +1,3 @@
+---
+ENV_DATA:
+  submariner_unreleased_image: "666535"

--- a/conf/examples/submariner_unreleased_image.yaml
+++ b/conf/examples/submariner_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  submariner_unreleased_image: "666535"
+  submariner_unreleased_image: "680159"

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1967,7 +1967,9 @@ class Deployment(object):
         logger.info("Writing tag data to snapshot.ver")
         acm_version = config.ENV_DATA.get("acm_version")
 
-        image_tag = get_latest_acm_tag_unreleased(version=acm_version)
+        image_tag = config.ENV_DATA.get(
+            "acm_unreleased_image"
+        ) or get_latest_acm_tag_unreleased(version=acm_version)
 
         with open(os.path.join(acm_hub_deploy_dir, "snapshot.ver"), "w") as f:
             f.write(image_tag)

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -172,11 +172,13 @@ class AcmAddClusters(AcmPageNavigator):
                 ]
             )
 
-            resp = requests.get(submariner_full_url, verify=False)
-            raw_msg = resp.json()["raw_messages"]
-            version_tag = raw_msg[0]["msg"]["pipeline"]["index_image"][
-                f"v{get_ocp_version()}"
-            ].split(":")[1]
+            version_tag = config.ENV_DATA.get("submariner_unreleased_image", None)
+            if version_tag is None:
+                resp = requests.get(submariner_full_url, verify=False)
+                raw_msg = resp.json()["raw_messages"]
+                version_tag = raw_msg[0]["msg"]["pipeline"]["index_image"][
+                    f"v{get_ocp_version()}"
+                ].split(":")[1]
             submariner_downstream_unreleased["spec"]["image"] = ":".join(
                 [constants.SUBMARINER_BREW_REPO, version_tag]
             )


### PR DESCRIPTION
This PR allows users to specify the desired versions of ACM and Submariner during installation. 
Previously, the latest versions were always pulled.