### PR TITLE
Add IBMCOS Namespacestore creation support and a basic creation test case

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -337,6 +337,18 @@ def oc_create_namespacestore(
                 "subPath": nss_tup[2] if nss_tup[2] else "",
             },
         },
+        constants.IBM_COS_PLATFORM: lambda: {
+            "type": "ibm-cos",
+            "ibmCos": {
+                "targetBucket": uls_name,
+                "signatureVersion": "v2",
+                "endpoint": get_attr_chain(cld_mgr, "ibmcos_client.endpoint"),
+                "secret": {
+                    "name": get_attr_chain(cld_mgr, "ibmcos_client.secret.name"),
+                    "namespace": nss_data["metadata"]["namespace"],
+                },
+            },
+        },
     }
 
     if (

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -3,6 +3,7 @@ Tests for Namespace resources and buckets by using OpenShift CRDs only.
 These tests are valid only for OCS version 4.7 and above because in later
 versions are for Namespace bucket creation used CRDs instead of NooBaa RPC calls.
 """
+
 import logging
 from time import sleep
 import uuid
@@ -133,6 +134,19 @@ class TestNamespace(MCGTest):
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"ibmcos": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    pytest.mark.polarion_id("OCS-5442"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
                         "type": "Multi",
                         "namespacestore_dict": {
                             "aws": [(1, DEFAULT_REGION)],
@@ -187,6 +201,7 @@ class TestNamespace(MCGTest):
             "AWS-OC-Single",
             "Azure-OC-Single",
             "RGW-OC-Single",
+            "IBM-OC-Single",
             "AWS+Azure-OC-Multi",
             "AWS+AWS-OC-Multi",
             "AZURE+AZURE-OC-Multi",


### PR DESCRIPTION
So far we've only been testing IBMCOS as an underlying storage with backingstores. This PR adds the option to create IBMCOS based Namespacestore buckets using the bucket_factory fxiture, and adds a basic IBMCOS NSS creation test case as a param to `test_namespace_bucket_creation_crd`.