### PR TITLE
Fix test_change_client_ocs_version_and_stop_heartbeat test

### DIFF
--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -77,6 +77,8 @@ class StorageConsumer:
             + "'",
             "--subresource",
             "status",
+            "--namespace",
+            config.cluster_ctx.ENV_DATA["cluster_namespace"],
         ]
         exec_cmd(" ".join(cmd))
 

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -47,8 +47,8 @@ def check_alert_list(
         target_alerts = [
             alert
             for alert in target_alerts
-            if alert["message"] == msg
-            and alert["severity_level"] == severity
+            if alert["annotations"]["message"] == msg
+            and alert["annotations"]["severity_level"] == severity
             and alert["state"] == state
         ]
         assert_msg = (

--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -1177,7 +1177,7 @@ def measure_change_client_ocs_version_and_stop_heartbeat(
         nonlocal client
         nonlocal original_cluster
         # run_time of operation
-        run_time = 60 * 3
+        run_time = 60 * 7
         client.stop_heartbeat()
         client.set_ocs_version("4.13.0")
         logger.info(f"Waiting for {run_time} seconds")

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -45,11 +45,17 @@ def test_change_client_ocs_version_and_stop_heartbeat(
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
             "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s)",
+            "severity": "warning",
+        },
+        {
+            "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
+            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 300 (s)",
+            "severity": "error",
         },
         {
             "label": constants.ALERT_STORAGECLIENTINCOMPATIBLEOPERATORVERSION,
-            "msg": f"Storage Client Operator ({client_name}) differs by more "
-            "than 1 minor version. Client configuration may be incompatible and unsupported",
+            "msg": f"Storage Client Operator ({client_name}) differs by more than 1 minor version",
+            "severity": "error",
         },
     ]
     states = ["firing"]
@@ -60,14 +66,7 @@ def test_change_client_ocs_version_and_stop_heartbeat(
             msg=target_alert["msg"],
             alerts=alerts,
             states=states,
-            severity="error",
-        )
-        prometheus.check_alert_list(
-            label=target_alert["label"],
-            msg=target_alert["msg"],
-            alerts=alerts,
-            states=states,
-            severity="warning",
+            severity=target_alert["severity"],
         )
         api.check_alert_cleared(
             label=target_alert["label"],

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -44,8 +44,7 @@ def test_change_client_ocs_version_and_stop_heartbeat(
     target_alerts = [
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
-            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s). "
-            "Lossy network connectivity might exist",
+            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s).",
         },
         {
             "label": constants.ALERT_STORAGECLIENTINCOMPATIBLEOPERATORVERSION,

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -44,7 +44,7 @@ def test_change_client_ocs_version_and_stop_heartbeat(
     target_alerts = [
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
-            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s).",
+            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s)",
         },
         {
             "label": constants.ALERT_STORAGECLIENTINCOMPATIBLEOPERATORVERSION,

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import (
     tier4c,
@@ -41,20 +42,31 @@ def test_change_client_ocs_version_and_stop_heartbeat(
     client_name = measure_change_client_ocs_version_and_stop_heartbeat.get(
         "metadata"
     ).get("client_name")
+    cluster_namespace = config.ENV_DATA["cluster_namespace"]
+    cluster_name = config.ENV_DATA["storage_cluster_name"]
     target_alerts = [
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
-            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 120 (s)",
+            "msg": (
+                f"Storage Client ({client_name}) heartbeat missed for more than 120 (s) "
+                f"in namespace:cluster {cluster_namespace}:{cluster_name}."
+            ),
             "severity": "warning",
         },
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
-            "msg": f"Storage Client ({client_name}) heartbeat missed for more than 300 (s)",
+            "msg": (
+                f"Storage Client ({client_name}) heartbeat missed for more than 300 (s) "
+                f"in namespace:cluster {cluster_namespace}:{cluster_name}."
+            ),
             "severity": "error",
         },
         {
             "label": constants.ALERT_STORAGECLIENTINCOMPATIBLEOPERATORVERSION,
-            "msg": f"Storage Client Operator ({client_name}) differs by more than 1 minor version",
+            "msg": (
+                f"Storage Client Operator ({client_name}) differs by more than 1 minor "
+                f"version in namespace:cluster {cluster_namespace}:{cluster_name}."
+            ),
             "severity": "error",
         },
     ]

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -59,7 +59,7 @@ def test_change_client_ocs_version_and_stop_heartbeat(
                 f"Storage Client ({client_name}) heartbeat missed for more than 300 (s) "
                 f"in namespace:cluster {cluster_namespace}:{cluster_name}."
             ),
-            "severity": "error",
+            "severity": "critical",
         },
         {
             "label": constants.ALERT_STORAGECLIENTINCOMPATIBLEOPERATORVERSION,
@@ -67,7 +67,7 @@ def test_change_client_ocs_version_and_stop_heartbeat(
                 f"Storage Client Operator ({client_name}) differs by more than 1 minor "
                 f"version in namespace:cluster {cluster_namespace}:{cluster_name}."
             ),
-            "severity": "error",
+            "severity": "critical",
         },
     ]
     states = ["firing"]


### PR DESCRIPTION
* Fixes https://github.com/red-hat-storage/ocs-ci/issues/9394
* Fixes test_change_client_ocs_version_and_stop_heartbeat test case
* Updates check_alert_list function to correctly check alerts with same label but different message