### PR TITLE
Add a way of fetching the marks of the current test from anywhere in ocs-ci and increase the verification timeout of obc deletion on tier4 tests

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -2,6 +2,7 @@
 In this pytest plugin we will keep all our pytest marks used in our tests and
 all related hooks/plugins to markers.
 """
+
 import os
 
 import pytest
@@ -596,3 +597,16 @@ ignore_owner = pytest.mark.ignore_owner
 
 # Marks to identify the cluster type in which the test case should run
 runs_on_provider = pytest.mark.runs_on_provider
+
+current_test_marks = []
+
+
+def get_current_test_marks():
+    """
+    Get the list of the current active marks
+
+    The current_active_marks global is updated by
+    ocs_ci/tests/conftest.py::update_current_test_marks_global at the start of each test
+
+    """
+    return current_test_marks

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -226,7 +226,7 @@ class ObjectBucket(ABC):
             logger.warning(f"{self.name} deletion timed out. Verifying deletion.")
             verify = True
         if verify:
-            # Increae the timeout to 15 minutes if the test is tier4
+            # Increase the timeout to 15 minutes if the test is tier4
             timeout = 60
             if any("tier4" in mark for mark in get_current_test_marks()):
                 timeout *= 15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5408,19 +5408,19 @@ def vault_tenant_sa_setup_factory(request):
             ] = f"https://{vault.vault_server}:{vault.port}"
             vdict[vault.kmsid]["vaultBackendPath"] = vault_resource_name
             if not ocsci_config.ENV_DATA.get("VAULT_CA_ONLY", None):
-                vdict[vault.kmsid]["vaultClientCertFromSecret"] = (
-                    get_default_if_keyval_empty(
-                        ocsci_config.ENV_DATA,
-                        "VAULT_CLIENT_CERT",
-                        defaults.VAULT_DEFAULT_CLIENT_CERT,
-                    )
+                vdict[vault.kmsid][
+                    "vaultClientCertFromSecret"
+                ] = get_default_if_keyval_empty(
+                    ocsci_config.ENV_DATA,
+                    "VAULT_CLIENT_CERT",
+                    defaults.VAULT_DEFAULT_CLIENT_CERT,
                 )
-                vdict[vault.kmsid]["vaultClientCertKeyFromSecret"] = (
-                    get_default_if_keyval_empty(
-                        ocsci_config.ENV_DATA,
-                        "VAULT_CLIENT_KEY",
-                        defaults.VAULT_DEFAULT_CLIENT_KEY,
-                    )
+                vdict[vault.kmsid][
+                    "vaultClientCertKeyFromSecret"
+                ] = get_default_if_keyval_empty(
+                    ocsci_config.ENV_DATA,
+                    "VAULT_CLIENT_KEY",
+                    defaults.VAULT_DEFAULT_CLIENT_KEY,
                 )
             else:
                 vdict[vault.kmsid].pop("vaultClientCertFromSecret")
@@ -6254,12 +6254,12 @@ def set_live_must_gather_images(pytestconfig):
         and not live_deployment
         and (version.get_semantic_ocs_version_from_config() >= version.VERSION_4_13)
     ):
-        ocsci_config.REPORTING["default_ocs_must_gather_image"] = (
-            defaults.MUST_GATHER_UPSTREAM_IMAGE
-        )
-        ocsci_config.REPORTING["default_ocs_must_gather_latest_tag"] = (
-            defaults.MUST_GATHER_UPSTREAM_TAG
-        )
+        ocsci_config.REPORTING[
+            "default_ocs_must_gather_image"
+        ] = defaults.MUST_GATHER_UPSTREAM_IMAGE
+        ocsci_config.REPORTING[
+            "default_ocs_must_gather_latest_tag"
+        ] = defaults.MUST_GATHER_UPSTREAM_TAG
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Fixes: #6552