### PR TITLE
create s3cli in separate NS

### DIFF
--- a/ocs_ci/ocs/awscli_pod.py
+++ b/ocs_ci/ocs/awscli_pod.py
@@ -88,7 +88,7 @@ def awscli_pod_cleanup(namespace=None):
     try:
         ocp_sts.delete(resource_name=constants.S3CLI_STS_NAME)
     except CommandFailed as e:
-        if "NotFound" not in str(e):
+        if "NotFound" in str(e):
             log.info("The AWS CLI STS was not found, assuming it was already deleted")
     except TimeoutError:
         log.warning("Standard deletion of the AWS CLI STS timed-out, forcing deletion")

--- a/ocs_ci/templates/mcg/s3cli-sts.yaml
+++ b/ocs_ci/templates/mcg/s3cli-sts.yaml
@@ -17,15 +17,13 @@ spec:
       labels:
         app: s3cli
     spec:
-      securityContext:
-        runAsUser: 0
       volumes:
         - name: service-ca
           configMap:
             name: awscli-service-ca
       containers:
         - name: s3cli
-          image: quay.io/ocsci/s3-cli-with-test-objects-multiarch:3.0
+          image: quay.io/ocsci/s3-cli-with-test-objects-multiarch:4.0
           command: ['/bin/sh']
           stdin: true
           tty: true


### PR DESCRIPTION
Currently awscli_pod_fixture is creating s3cli and statefulset in openshift-storage and cleaning the same resources irrespective which testcase is created. since resource are deleted during setup, when running testcases throuh ITR, test cases are failing.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)