### PR TITLE
BM UPI deployment - dnsmasq configuration - backport for release-4.12

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1561,8 +1561,10 @@ MIN_NODE_MEMORY = 64 * 10**9
 AWS_CLOUDFORMATION_TAG = "aws:cloudformation:stack-name"
 
 # Bare Metal constants
-PXE_CONF_FILE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "dnsmasq.pxe.conf")
-COMMON_CONF_FILE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "dnsmasq.common.conf")
+DNSMASQ_PXE_CONF_FILE_TEMPLATE = os.path.join("ocp-deployment", "dnsmasq.pxe.conf.j2")
+DNSMASQ_COMMON_CONF_FILE_TEMPLATE = os.path.join(
+    "ocp-deployment", "dnsmasq.common.conf.j2"
+)
 RHCOS_IMAGES_FILE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "rhcos_images.yaml")
 PXE_FILE = os.path.join(TEMPLATE_DIR, "baremetal-pxefile")
 coreos_url_prefix = "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos"

--- a/ocs_ci/templates/ocp-deployment/dnsmasq.common.conf
+++ b/ocs_ci/templates/ocp-deployment/dnsmasq.common.conf
@@ -1,5 +1,0 @@
-interface=*
-except-interface=lo
-bind-dynamic
-log-queries
-log-dhcp

--- a/ocs_ci/templates/ocp-deployment/dnsmasq.common.conf.j2
+++ b/ocs_ci/templates/ocp-deployment/dnsmasq.common.conf.j2
@@ -1,0 +1,13 @@
+interface={{ interface }}
+no-resolv
+log-queries
+log-dhcp
+dhcp-range={{ dhcp_range }}
+#dhcp-authoritative
+
+{% if dhcp_options is defined %}
+{% for item in dhcp_options %}
+dhcp-option={{ item }}
+
+{% endfor %}
+{% endif %}

--- a/ocs_ci/templates/ocp-deployment/dnsmasq.pxe.conf
+++ b/ocs_ci/templates/ocp-deployment/dnsmasq.pxe.conf
@@ -1,3 +1,0 @@
-dhcp-boot=pxelinux.0
-enable-tftp
-tftp-root=/var/lib/tftpboot/ocs4qe/baremetal/

--- a/ocs_ci/templates/ocp-deployment/dnsmasq.pxe.conf.j2
+++ b/ocs_ci/templates/ocp-deployment/dnsmasq.pxe.conf.j2
@@ -1,0 +1,3 @@
+dhcp-boot=pxelinux.0
+enable-tftp
+tftp-root={{ tftp_root }}

--- a/ocs_ci/utility/connection.py
+++ b/ocs_ci/utility/connection.py
@@ -89,3 +89,17 @@ class Connection(object):
         )
         logger.debug(f"stderr: {stderr}")
         return (retcode, stdout, stderr)
+
+    def upload_file(self, localpath, remotepath):
+        """
+        Upload a file to remote server
+
+        Args:
+            localpath (str): Local file to upload
+            remotepath (str): Target path on the remote server. Filename should be included
+
+        """
+        sftp = self.client.open_sftp()
+        logger.info(f"uploading {localpath} to {self.user}@{self.host}:{remotepath}")
+        sftp.put(localpath, remotepath)
+        sftp.close()


### PR DESCRIPTION
This PR should separate dnsmasq configuration from BM UPI deployment to separated methods to make it reusable in other types of deployment (e.g. via Assisted Installer).

There were only small functional changes:

* it uses `syslinux-tftpboot` instead of `syslinux-nonlinux` to get the fails required for PXE boot
 * it sets the tftp root to `/tftpboot/` (based on what uses the syslinux-nonlinux package)

This is backport of [PR#9344](https://github.com/red-hat-storage/ocs-ci/pull/9344/)

**This PR has to be merged together with related [MR!1700](https://url.corp.redhat.com/dc31e6c).**