### PR TITLE
[release-4.12] Disconnected deployment fixes/enhancements

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -109,7 +109,7 @@ def mirror_images_from_mapping_file(mapping_file, icsp=None, ignore_image=None):
         f"oc image mirror --filter-by-os='.*' -f {mapping_file} "
         f"--insecure --registry-config={pull_secret_path} "
         "--max-per-registry=2 --continue-on-error=true --skip-missing=true",
-        timeout=3600,
+        timeout=18000,
         ignore_error=True,
     )
 
@@ -277,7 +277,7 @@ def mirror_index_image_via_oc_mirror(index_image, packages, icsp=None):
     if icsp:
         cmd += " --continue-on-error --skip-missing"
     try:
-        exec_cmd(cmd, timeout=7200)
+        exec_cmd(cmd, timeout=18000)
     except CommandFailed:
         # if icsp is configured, the oc mirror command might fail (return non 0 rc),
         # even though we use --continue-on-error and --skip-missing arguments

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -42,6 +42,7 @@ from ocs_ci.ocs.exceptions import (
     CephHealthException,
     ClientDownloadError,
     CommandFailed,
+    ConfigurationError,
     TagNotFoundException,
     TimeoutException,
     TimeoutExpiredError,
@@ -3385,6 +3386,15 @@ def mirror_image(image):
         str: the mirrored image link
 
     """
+    mirror_registry = config.DEPLOYMENT.get("mirror_registry")
+    if not mirror_registry:
+        raise ConfigurationError(
+            'DEPLOYMENT["mirror_registry"] parameter not configured!\n'
+            "This might be caused by previous failure in OCP deployment or wrong configuration."
+        )
+    if image.startswith(mirror_registry):
+        log.debug(f"Skipping mirror of image {image}, it is already mirrored.")
+        return image
     with prepare_customized_pull_secret(image) as authfile_fo:
         # login to mirror registry
         login_to_mirror_registry(authfile_fo.name)


### PR DESCRIPTION
* extend timeout for oc mirror command execution
* mirror_image: handle missing configuration
* extend timeout for oc image mirror command
* if DEPLOYMENT["mirror_registry"] is not configured, raise error with explanation what could be the root cause

fixes: https://github.com/red-hat-storage/ocs-ci/issues/9379
fixes: https://github.com/red-hat-storage/ocs-ci/issues/9377

cherrypick of: https://github.com/red-hat-storage/ocs-ci/pull/9391