### PR TITLE
In the test "test_rook_operator_restart_during_mon_failover" increase timeout waiting for the pods

### DIFF
--- a/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -91,7 +91,7 @@ class TestDrainNodeMon(ManageTest):
         schedule_nodes([node_name])
 
         log.info("Wait for all the pods in openshift-storage to be running.")
-        assert wait_for_pods_to_be_running(timeout=300)
+        assert wait_for_pods_to_be_running(timeout=480, sleep=20)
 
         sample = TimeoutSampler(
             timeout=100,


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/9430