### PR TITLE
Fix to a multi snapshots test 

### DIFF
--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -10,6 +10,7 @@ import re
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility import version
@@ -426,6 +427,8 @@ def extruct_timestamp_from_log(line):
     return results
 
 
+# Sometimes, the logs are not available due to the connection issues, retry added
+@retry(Exception, tries=6, delay=5, backoff=2)
 def measure_total_snapshot_creation_time(snap_name, start_time):
     """
     Measure Snapshot creation time based on logs
@@ -539,6 +542,8 @@ def get_snapshot_time(snap_name, status, start_time):
         return None
 
 
+# Sometimes, the logs are not available due to the connection issues, retry added
+@retry(Exception, tries=6, delay=5, backoff=2)
 def measure_csi_snapshot_creation_time(interface, snapshot_id, start_time):
     """
 
@@ -1036,5 +1041,5 @@ def wait_for_cronjobs(namespace, cronjobs_num, msg, timeout=60):
                 return sample
     except TimeoutExpiredError:
         raise Exception(
-            f"{msg} \n Only {len(sample) -1} cronjobs found.\n This is the full list: \n {sample}"
+            f"{msg} \n Only {len(sample) - 1} cronjobs found.\n This is the full list: \n {sample}"
         )

--- a/ocs_ci/helpers/performance_lib.py
+++ b/ocs_ci/helpers/performance_lib.py
@@ -576,12 +576,12 @@ def measure_csi_snapshot_creation_time(interface, snapshot_id, start_time):
                 et = line.split(" ")[1]
                 et = datetime.strptime(et, time_format)
     if st is None:
-        logger.error(f"Cannot find start time of snapshot {snapshot_id}")
-        raise Exception(f"Cannot find start time of snapshot {snapshot_id}")
+        logger.error(f"Cannot find csi start time of snapshot {snapshot_id}")
+        raise Exception(f"Cannot find csi start time of snapshot {snapshot_id}")
 
     if et is None:
-        logger.error(f"Cannot find end time of snapshot {snapshot_id}")
-        raise Exception(f"Cannot find end time of snapshot {snapshot_id}")
+        logger.error(f"Cannot find csi end time of snapshot {snapshot_id}")
+        raise Exception(f"Cannot find csi end time of snapshot {snapshot_id}")
 
     total_time = (et - st).total_seconds()
     if total_time < 0:

--- a/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -182,7 +182,7 @@ class TestPvcMultiSnapshotPerformance(PASTest):
             except CommandFailed as cmdFailedEx:
                 log.info(f"Exception caught {cmdFailedEx}")
                 log.info("Continue to teardown ")
-                if '"pas-testing-rbd" not found' in cmdFailedEx:
+                if "pas-testing-rbd" in cmdFailedEx and "not found" in cmdFailedEx:
                     pass
             # Verify deletion by checking the backend CEPH pools using the toolbox
             results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")

--- a/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -176,7 +176,10 @@ class TestPvcMultiSnapshotPerformance(PASTest):
 
             # Deleting the Data pool
             log.info(f"Deleting the test storage pool : {self.sc_name}")
-            self.delete_ceph_pool(self.sc_name)
+            try:
+                self.delete_ceph_pool(self.sc_name)
+            except Exception:
+                pass
             # Verify deletion by checking the backend CEPH pools using the toolbox
             results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
             log.debug(f"Existing pools are : {results}")

--- a/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -26,6 +26,7 @@ from ocs_ci.framework.testlib import (
 
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs import constants, exceptions
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.perfresult import ResultsAnalyse
 from ocs_ci.ocs.perftests import PASTest
@@ -178,8 +179,11 @@ class TestPvcMultiSnapshotPerformance(PASTest):
             log.info(f"Deleting the test storage pool : {self.sc_name}")
             try:
                 self.delete_ceph_pool(self.sc_name)
-            except Exception:
-                pass
+            except CommandFailed as cmdFailedEx:
+                log.info(f"Exception caught {cmdFailedEx}")
+                log.info("Continue to teardown ")
+                if '"pas-testing-rbd" not found' in cmdFailedEx:
+                    pass
             # Verify deletion by checking the backend CEPH pools using the toolbox
             results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")
             log.debug(f"Existing pools are : {results}")
@@ -328,7 +332,7 @@ class TestPvcMultiSnapshotPerformance(PASTest):
             raise Exception(err_msg)
 
         # wait until snapshot is ready
-        timeout = 720
+        timeout = 900  # old value 720
         sleep_time = 10
         snap_con_name = None
         snap_uid = None

--- a/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
+++ b/tests/cross_functional/performance/csi_tests/test_pvc_multi_snapshot_performance.py
@@ -181,8 +181,10 @@ class TestPvcMultiSnapshotPerformance(PASTest):
                 self.delete_ceph_pool(self.sc_name)
             except CommandFailed as cmdFailedEx:
                 log.info(f"Exception caught {cmdFailedEx}")
-                log.info("Continue to teardown ")
-                if "pas-testing-rbd" in cmdFailedEx and "not found" in cmdFailedEx:
+                if "pas-testing-rbd" in str(cmdFailedEx) and "not found" in str(
+                    cmdFailedEx
+                ):
+                    log.info("Continue to teardown ")
                     pass
             # Verify deletion by checking the backend CEPH pools using the toolbox
             results = self.ceph_cluster.toolbox.exec_cmd_on_pod("ceph osd pool ls")


### PR DESCRIPTION
This PR contains :

* adding retries while searching logs , to overcome occasional network disconnections. 
* ignoring exception on ceph pool deletion ( fix of occdasional teardown failures) - similarly to the way it is implemented in test_pvc_clone_performance.py test ( lines 143-145) . 