### PR TITLE
Use the nsfs-deployment pod for file access commands in `nsfs_bucket_factory` instead of the noobaa-endpoint pods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5705,16 +5705,8 @@ def nsfs_bucket_factory_fixture(
             exptected_count=original_endpoint_pods_count,
         )
 
-        # Get one of the endpoint pods for filesystem access in this fixture
-        endpoint_pod = Pod(
-            **get_pods_having_label(
-                constants.NOOBAA_ENDPOINT_POD_LABEL,
-                ocsci_config.ENV_DATA["cluster_namespace"],
-            )[0]
-        )
-
         # Apply the necessary permissions on the filesystem
-        endpoint_pod.exec_cmd_on_pod("chmod -R 777 /nsfs")
+        nsfs_obj.interface_pod.exec_cmd_on_pod("chmod -R 777 /nsfs")
 
         # Create a new MCG account and get its credentials
         nsfs_obj.s3_creds = mcg_account_factory(
@@ -5742,9 +5734,8 @@ def nsfs_bucket_factory_fixture(
             new_dir_name = helpers.create_unique_resource_name(
                 resource_description="nsfs-bucket", resource_type="dir"
             )
-            endpoint_pod.exec_cmd_on_pod(
-                "mkdir -m"
-                f" {nsfs_obj.existing_dir_mode} /nsfs/{nsfs_obj.nss.name}/{new_dir_name}"
+            nsfs_obj.interface_pod.exec_cmd_on_pod(
+                "mkdir -m" f" {nsfs_obj.existing_dir_mode} /nsfs/{new_dir_name}"
             )
             new_dir_path = f"/{new_dir_name}"
 


### PR DESCRIPTION
In https://github.com/red-hat-storage/ocs-ci/pull/8452 we switched to make file access commands (chmod and mkdir) in the factory using the noobaa-endpoint pods instead of the pod which we deployed in order to mount the ceph-fs volume. 

This worked because the noobaa-endpoint pods mount the same volume when we create the Namespacestore of the NSFS, but it has the disadvantage of relying on noobaa for setup, while we're supposed to be testing it. This usage of the noobaa-endpoint pods was a workaround to bypass permission issues, and since in 4.15 it seems we're no longer encountering these, this PR makes the change to use the original interface pod. 