### PR TITLE
Create a new sanity helper class "SanityProviderMode" for the Provider Mode platform

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -141,6 +141,7 @@ REPORTING:
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
   storage_cluster_name: 'ocs-storagecluster'
+  storage_client_name: "storage-client"
   storage_device_sets_name: "storageDeviceSets"
   sno: false
   cluster_namespace: 'openshift-storage'

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3240,7 +3240,7 @@ def client_cluster_health_check():
         kind=constants.STORAGECLIENT, namespace=config.ENV_DATA["cluster_namespace"]
     )
     sc_obj.wait_for_resource(
-        resource_name=constants.DEFAULT_STORAGE_CLIENT,
+        resource_name=config.cluster_ctx.ENV_DATA.get("storage_client_name"),
         column="PHASE",
         condition="Connected",
         timeout=180,

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -293,6 +293,7 @@ JENKINS_BUILD = "jax-rs-build"
 JENKINS_BUILD_COMPLETE = "Complete"
 RIPSAW_DROP_CACHE = os.path.join(TEMPLATE_FIO_DIR, "drop_cache_pod.yaml")
 OCP_QE_DEVICEPATH_REPO = "https://github.com/anubhav-here/device-by-id-ocp.git"
+DEFAULT_STORAGE_CLIENT = "storage-client"
 
 # Default pools
 DEFAULT_CEPHBLOCKPOOL = "ocs-storagecluster-cephblockpool"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -293,7 +293,6 @@ JENKINS_BUILD = "jax-rs-build"
 JENKINS_BUILD_COMPLETE = "Complete"
 RIPSAW_DROP_CACHE = os.path.join(TEMPLATE_FIO_DIR, "drop_cache_pod.yaml")
 OCP_QE_DEVICEPATH_REPO = "https://github.com/anubhav-here/device-by-id-ocp.git"
-DEFAULT_STORAGE_CLIENT = "storage-client"
 
 # Default pools
 DEFAULT_CEPHBLOCKPOOL = "ocs-storagecluster-cephblockpool"

--- a/tests/libtest/test_sanity_provider_mode.py
+++ b/tests/libtest/test_sanity_provider_mode.py
@@ -1,0 +1,138 @@
+import logging
+from time import sleep
+import pytest
+
+from ocs_ci.helpers.sanity_helpers import SanityProviderMode
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
+from ocs_ci.framework.testlib import (
+    libtest,
+    ManageTest,
+    hci_provider_and_client_required,
+)
+from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup
+from ocs_ci.ocs.constants import HCI_PROVIDER, HCI_CLIENT
+
+log = logging.getLogger(__name__)
+
+
+@yellow_squad
+@libtest
+@hci_provider_and_client_required
+class TestSanityProviderModeWithDefaultParams(ManageTest):
+    """
+    Test the usage of the 'SanityProviderMode' class when using the default params
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, request, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+        switch_to_correct_cluster_at_setup(request)
+        # Pass the 'create_scale_pods_and_pvcs_using_kube_job_on_hci_clients' factory to the
+        # init method and use the default params
+        self.sanity_helpers = SanityProviderMode(
+            create_scale_pods_and_pvcs_using_kube_job_on_hci_clients
+        )
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.parametrize(
+        argnames=["cluster_type"],
+        argvalues=[
+            pytest.param(*[HCI_PROVIDER]),
+            pytest.param(*[HCI_CLIENT]),
+        ],
+    )
+    def test_sanity_ms(self, cluster_type):
+        orig_test_index = config.cur_index
+        log.info("Start creating resources for the clients")
+        self.sanity_helpers.create_resources_on_clients()
+        timeout = 60
+        log.info(f"Waiting {timeout} seconds for the IO to be running")
+        sleep(timeout)
+
+        log.info("Deleting the resources from the clients")
+        self.sanity_helpers.delete_resources_on_clients()
+        log.info("Check the cluster health")
+        self.sanity_helpers.health_check_provider_mode()
+
+        assert (
+            config.cur_index == orig_test_index
+        ), "The current index is different from the original test index"
+        log.info("The current index is equal to the original test index")
+
+
+@yellow_squad
+@libtest
+@hci_provider_and_client_required
+class TestSanityProviderModeWithOptionalParams(ManageTest):
+    """
+    Test the usage of the 'SanityProviderMode' class when passing optional params
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+
+        first_client_i = config.get_consumer_indexes_list()[0]
+        # Pass the 'create_scale_pods_and_pvcs_using_kube_job_on_hci_clients' factory to the
+        # init method and use the optional params
+        self.sanity_helpers = SanityProviderMode(
+            create_scale_pods_and_pvcs_using_kube_job_on_hci_clients,
+            scale_count=40,
+            pvc_per_pod_count=10,
+            start_io=True,
+            io_runtime=600,
+            max_pvc_size=25,
+            client_indices=[first_client_i],
+        )
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_ms_with_optional_params(
+        self, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients
+    ):
+        orig_test_index = config.cur_index
+        log.info("Start creating resources for the clients")
+        self.sanity_helpers.create_resources_on_clients()
+        timeout = 60
+        log.info(f"Waiting {timeout} seconds for the IO to be running")
+        sleep(timeout)
+
+        log.info("Deleting the resources from the clients")
+        self.sanity_helpers.delete_resources_on_clients()
+        log.info("Check the cluster health")
+        self.sanity_helpers.health_check_provider_mode()
+
+        assert (
+            config.cur_index == orig_test_index
+        ), "The current index is different from the original test index"
+        log.info("The current index is equal to the original test index")


### PR DESCRIPTION
The PR implements a new sanity helper class `SanityProviderMode` for the Provider Mode platform, that will extend the existing class `Sanity` with the following functionalities:

- Create and delete resources and run IO on multiple clients(It will use the fixture `create_scale_pods_and_pvcs_using_kube_job_on_hci_clients` to create the pods and PVCs and run IO on multiple clients).
- If the test runs on the provider, it will also check the cluster health of all the clients(Unless specified otherwise in the relevant param).
