### PR TITLE
increase alert cleared timeout for test_ceph_health and alert collection for measure_noobaa_ns_target_bucket_deleted

### DIFF
--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -981,7 +981,7 @@ def measure_noobaa_ns_target_bucket_deleted(
 
         """
         # run_time of operation
-        run_time = 60 * 12
+        run_time = 60 * 14
         nonlocal ns_stores
         nonlocal cld_mgr
 

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -90,6 +90,7 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     # the time to wait is increased because it takes more time for Ceph
     # cluster to resolve its issues
     health_wait = 420
+    stop_time = max(measure_stop_ceph_osd.get("stop"), measure_corrupt_pg.get("stop"))
 
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")
     target_label = constants.ALERT_CLUSTERWARNINGSTATE
@@ -105,7 +106,7 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     )
     api.check_alert_cleared(
         label=target_label,
-        measure_end_time=measure_stop_ceph_osd.get("stop"),
+        measure_end_time=stop_time,
         time_min=health_wait,
     )
 
@@ -123,7 +124,7 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     )
     api.check_alert_cleared(
         label=target_label,
-        measure_end_time=measure_corrupt_pg.get("stop"),
+        measure_end_time=stop_time,
         time_min=health_wait,
     )
 

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -87,6 +87,9 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     utilization.
     """
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    # the time to wait is increased because it takes more time for Ceph
+    # cluster to resolve its issues
+    health_wait = 420
 
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")
     target_label = constants.ALERT_CLUSTERWARNINGSTATE
@@ -103,6 +106,7 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
     api.check_alert_cleared(
         label=target_label,
         measure_end_time=measure_stop_ceph_osd.get("stop"),
+        time_min=health_wait,
     )
 
     alerts = measure_corrupt_pg.get("prometheus_alerts")
@@ -117,13 +121,10 @@ def test_ceph_health(measure_stop_ceph_osd, measure_corrupt_pg, threading_lock):
         states=target_states,
         severity=target_severity,
     )
-    # the time to wait is increased because it takes more time for Ceph
-    # cluster to resolve its issues
-    pg_wait = 360
     api.check_alert_cleared(
         label=target_label,
         measure_end_time=measure_corrupt_pg.get("stop"),
-        time_min=pg_wait,
+        time_min=health_wait,
     )
 
 


### PR DESCRIPTION
- Fixes https://github.com/red-hat-storage/ocs-ci/issues/8138
- Fixes https://github.com/red-hat-storage/ocs-ci/issues/9509