### PR TITLE
Separate the cloning logic from `override_default_backingstore_fixture`

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1948,15 +1948,6 @@ BACKINGSTORE_TYPE_GOOGLE = "google-cloud-storage"
 BACKINGSTORE_TYPE_PV_POOL = "pv-pool"
 BACKINGSTORE_TYPE_IBMCOS = "ibm-cos"
 
-BS_TYPE_TO_PLATFORM_NAME_MAPPING = {
-    BACKINGSTORE_TYPE_AWS: "aws",
-    BACKINGSTORE_TYPE_AZURE: "azure",
-    BACKINGSTORE_TYPE_GOOGLE: "gcp",
-    BACKINGSTORE_TYPE_PV_POOL: "pv",
-    BACKINGSTORE_TYPE_S3_COMP: "rgw",
-    BACKINGSTORE_TYPE_IBMCOS: "ibmcos",
-}
-
 
 # Squads assignment
 # Tests are assigned to Squads based on patterns matching test path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ from ocs_ci.ocs.resources.deployment import Deployment
 from ocs_ci.ocs.resources.job import get_job_obj
 from ocs_ci.ocs.resources.backingstore import (
     backingstore_factory as backingstore_factory_implementation,
-    clone_backingstore,
+    clone_bs_dict_from_backingstore,
 )
 from ocs_ci.ocs.cluster import check_clusters
 from ocs_ci.ocs.resources.namespacestore import (
@@ -7252,10 +7252,10 @@ def override_default_backingstore_fixture(
         # 1. if the name of an alternative backingstore is not provided,
         # Create a new backingstore of the same type as the current default
         if alt_bs_name is None:
-            alt_bs_name = clone_backingstore(
+            bs_dict = clone_bs_dict_from_backingstore(
                 protype_backingstore_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
-                backingstore_factory=backingstore_factory,
             )
+            alt_bs_name = backingstore_factory("oc", bs_dict)[0].name
 
         # 2. Update the new default resource of the admin account
         mcg_obj_session.exec_mcg_cmd(

--- a/tests/libtest/test_clone_backingstore.py
+++ b/tests/libtest/test_clone_backingstore.py
@@ -1,0 +1,31 @@
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.backingstore import clone_backingstore
+from ocs_ci.framework.testlib import libtest
+
+
+@libtest
+def test_clone_backingstore(mcg_obj, backingstore_factory):
+    platform_to_bucketclass_dicts = {
+        constants.BACKINGSTORE_TYPE_AWS: {"aws": [(1, "eu-central-1")]},
+        constants.BACKINGSTORE_TYPE_AZURE: {"azure": [(1, None)]},
+        constants.BACKINGSTORE_TYPE_IBMCOS: {"ibmcos": [(1, None)]},
+        constants.BACKINGSTORE_TYPE_PV_POOL: {
+            "pv": [(1, 20, constants.DEFAULT_STORAGECLASS_RBD)]
+        },
+    }
+    prototypes = []
+    for type, bucketclass_dict in platform_to_bucketclass_dicts.items():
+        backingstore_name = backingstore_factory("oc", bucketclass_dict)[0].name
+        prototypes.append((backingstore_name, type))
+
+    for prototype in prototypes:
+        prototype_name, prototype_type = prototype
+        clone_name = clone_backingstore(prototype_name, backingstore_factory, mcg_obj)
+
+        clone_backingstore_data = OCP(
+            kind="backingstore",
+            resource_name=clone_name,
+        ).data
+        assert clone_backingstore_data["spec"]["type"] == prototype_type
+        assert clone_backingstore_data["status"]["phase"] == "Ready"

--- a/tests/libtest/test_clone_backingstore.py
+++ b/tests/libtest/test_clone_backingstore.py
@@ -1,7 +1,8 @@
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import libtest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.backingstore import clone_bs_dict_from_backingstore
-from ocs_ci.framework.testlib import libtest
 
 
 @libtest
@@ -30,5 +31,6 @@ def test_clone_backingstore(mcg_obj, backingstore_factory):
         clone_backingstore_data = OCP(
             kind="backingstore",
             resource_name=clone_bs_name,
+            namespace=config.ENV_DATA["cluster_namespace"],
         ).data
         assert clone_backingstore_data["spec"]["type"] == type

--- a/tests/libtest/test_clone_backingstore.py
+++ b/tests/libtest/test_clone_backingstore.py
@@ -23,12 +23,12 @@ def test_clone_backingstore(mcg_obj, backingstore_factory):
         prototype_bs_dict = clone_bs_dict_from_backingstore(prototype_backingstore)
         clone_bs_name = backingstore_factory("oc", prototype_bs_dict)[0].name
 
-        # Check if the clone type is the same as the prototype type
+        # Check the health of the clone
+        mcg_obj.check_backingstore_state(clone_bs_name, constants.BS_OPTIMAL)
+
+        # Check if type is the same as the prototype's
         clone_backingstore_data = OCP(
             kind="backingstore",
             resource_name=clone_bs_name,
         ).data
         assert clone_backingstore_data["spec"]["type"] == type
-
-        # Health check
-        mcg_obj.check_backingstore_state(clone_bs_name, constants.BS_OPTIMAL)

--- a/tests/libtest/test_clone_backingstore.py
+++ b/tests/libtest/test_clone_backingstore.py
@@ -1,31 +1,34 @@
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources.backingstore import clone_backingstore
+from ocs_ci.ocs.resources.backingstore import clone_bs_dict_from_backingstore
 from ocs_ci.framework.testlib import libtest
 
 
 @libtest
 def test_clone_backingstore(mcg_obj, backingstore_factory):
+    """
+    Test the functionality of clone_bs_dict_from_backingstore
+
+    """
     platform_to_bucketclass_dicts = {
         constants.BACKINGSTORE_TYPE_AWS: {"aws": [(1, "eu-central-1")]},
         constants.BACKINGSTORE_TYPE_AZURE: {"azure": [(1, None)]},
         constants.BACKINGSTORE_TYPE_IBMCOS: {"ibmcos": [(1, None)]},
         constants.BACKINGSTORE_TYPE_PV_POOL: {
-            "pv": [(1, 20, constants.DEFAULT_STORAGECLASS_RBD)]
+            "pv": [(1, 35, constants.DEFAULT_STORAGECLASS_RBD)]
         },
     }
-    prototypes = []
     for type, bucketclass_dict in platform_to_bucketclass_dicts.items():
-        backingstore_name = backingstore_factory("oc", bucketclass_dict)[0].name
-        prototypes.append((backingstore_name, type))
+        prototype_backingstore = backingstore_factory("oc", bucketclass_dict)[0].name
+        prototype_bs_dict = clone_bs_dict_from_backingstore(prototype_backingstore)
+        clone_bs_name = backingstore_factory("oc", prototype_bs_dict)[0].name
 
-    for prototype in prototypes:
-        prototype_name, prototype_type = prototype
-        clone_name = clone_backingstore(prototype_name, backingstore_factory, mcg_obj)
-
+        # Check if the clone type is the same as the prototype type
         clone_backingstore_data = OCP(
             kind="backingstore",
-            resource_name=clone_name,
+            resource_name=clone_bs_name,
         ).data
-        assert clone_backingstore_data["spec"]["type"] == prototype_type
-        assert clone_backingstore_data["status"]["phase"] == "Ready"
+        assert clone_backingstore_data["spec"]["type"] == type
+
+        # Health check
+        mcg_obj.check_backingstore_state(clone_bs_name, constants.BS_OPTIMAL)


### PR DESCRIPTION
Fixes: #9485

This PR also introduce a small libtest that verifies the cloning logic on various backingstore types.