### PR TITLE
Collect OCP logs for whole z_cluster directory

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -680,7 +680,7 @@ def pytest_runtest_makereport(item, call):
                 for x in [
                     "ecosystem",
                     "e2e/performance",
-                    "tests/manage/z_cluster",
+                    "tests/functional/z_cluster",
                 ]
             )
             else False


### PR DESCRIPTION
with PR: https://github.com/red-hat-storage/ocs-ci/pull/9182 Since we reorganized the directory, we must update the path correctly in order to gather the ocp logs for the failed z_cluster test.