### PR TITLE
test_new_sc_new_rbd_pool and test_create_delete_pool fixed, moved to black squad

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -5,7 +5,6 @@ import os
 import gc
 import time
 import zipfile
-import traceback
 from functools import reduce
 from selenium import webdriver
 from selenium.common.exceptions import (
@@ -890,7 +889,7 @@ def login_ui(console_url=None, username=None, password=None, **kwargs):
     proceed_to_login_console()
 
     try:
-        wait = WebDriverWait(driver, 40)
+        wait = WebDriverWait(driver, 15)
         if username is not None:
             element = wait.until(
                 ec.element_to_be_clickable(
@@ -915,7 +914,9 @@ def login_ui(console_url=None, username=None, password=None, **kwargs):
     except TimeoutException:
         take_screenshot("login")
         copy_dom("login")
-        logger.error(traceback.format_stack())
+        logger.warning(
+            "Login with my_htpasswd_provider or kube:admin text not found, trying to login"
+        )
 
     username_el = wait_for_element_to_be_clickable(login_loc["username"], 60)
     if username is None:

--- a/ocs_ci/ocs/ui/storageclass.py
+++ b/ocs_ci/ocs/ui/storageclass.py
@@ -42,6 +42,7 @@ class StorageClassUI(PageNavigator):
         self.do_click(self.sc_loc["pool_dropdown"])
         self.do_click([f"button[data-test={pool_name}", By.CSS_SELECTOR])
         self.do_click(self.sc_loc["save_storageclass"])
+        self.page_has_loaded()
         if self.verify_storageclass_existence(sc_name):
             return sc_name
         else:

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1451,8 +1451,8 @@ validation_4_9 = {
 validation_4_10 = {
     "system-capacity": ("//div[contains(text(),'System Capacity')]", By.XPATH),
     "ocs-storagecluster-storagesystem": (
-        "a[href='/odf/system/ocs.openshift.io~v1~storagecluster/ocs-storagecluster-storagesystem/overview']",
-        By.CSS_SELECTOR,
+        "//a[.='ocs-storagecluster-storagesystem']",
+        By.XPATH,
     ),
     "ocs-external-storagecluster-storagesystem": (
         "a[href='/odf/system/ocs.openshift.io~v1~storagecluster/ocs-external-storagecluster-storagesystem/overview']",

--- a/tests/cross_functional/ui/test_create_pool_block_pool.py
+++ b/tests/cross_functional/ui/test_create_pool_block_pool.py
@@ -3,8 +3,8 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     skipif_ui_not_support,
-    green_squad,
     skipif_hci_provider_or_client,
+    black_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, ui
 from ocs_ci.ocs.exceptions import (
@@ -75,7 +75,7 @@ class TestPoolUserInterface(ManageTest):
     @ui
     @tier1
     @skipif_ocs_version("<4.8")
-    @green_squad
+    @black_squad
     def test_create_delete_pool(
         self,
         replica,
@@ -86,7 +86,7 @@ class TestPoolUserInterface(ManageTest):
         pod,
     ):
         """
-        test create delete pool have the following workflow
+        test create delete pool has the following workflow
         .* Create new RBD pool
         .* Associate the pool with storageclass
         .* Create PVC based on the storageclass

--- a/tests/cross_functional/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
+++ b/tests/cross_functional/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
@@ -10,8 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ui,
     skipif_ibm_cloud_managed,
-    green_squad,
     skipif_hci_provider_or_client,
+    black_squad,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -23,7 +23,7 @@ from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 log = logging.getLogger(__name__)
 
 
-@green_squad
+@black_squad
 @ui
 @tier1
 @skipif_external_mode


### PR DESCRIPTION
Tests were fixed with locator fix and page_has_loaded injections.

The management console ui elements and transition flow changes frequently, which is a reason of the failures. 

Considering the tests are mostly UI and similar tests implemented with CLI approach are existing, I moved tests to **black squad** to not loose them from view and tune in timely manner.

Fixes: #6980
Fixes: #6302
Fixes: #9026
Fixes: #9462