### PR TITLE
test_pod_reattachtime.py  - Increasing pod creation timeout and reducing number of files for cephfs many files test case 

### DIFF
--- a/tests/cross_functional/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/cross_functional/performance/csi_tests/test_pod_reattachtime.py
@@ -102,7 +102,7 @@ class TestPodReattachTimePerformance(PASTest):
                 marks=pytest.mark.polarion_id("OCS-2044"),
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 12, 600, 720],
+                *[constants.CEPHFILESYSTEM, 11, 600, 720],
                 marks=pytest.mark.polarion_id("OCS-2674"),
             ),
         ],
@@ -148,7 +148,6 @@ class TestPodReattachTimePerformance(PASTest):
 
         self.sc_obj = storageclass_factory(self.interface)
         for sample_index in range(1, samples_num + 1):
-
             csi_start_time = self.get_time("csi")
 
             logger.info(f"Start creating PVC number {sample_index}.")

--- a/tests/cross_functional/performance/csi_tests/test_pod_reattachtime.py
+++ b/tests/cross_functional/performance/csi_tests/test_pod_reattachtime.py
@@ -90,19 +90,19 @@ class TestPodReattachTimePerformance(PASTest):
         argnames=["interface", "copies", "timeout", "total_time_limit"],
         argvalues=[
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 3, 120, 70],
+                *[constants.CEPHBLOCKPOOL, 3, 120, 150],
                 marks=pytest.mark.polarion_id("OCS-2043"),
             ),
             pytest.param(
-                *[constants.CEPHBLOCKPOOL, 13, 600, 420],
+                *[constants.CEPHBLOCKPOOL, 13, 600, 720],
                 marks=pytest.mark.polarion_id("OCS-2673"),
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 3, 120, 70],
+                *[constants.CEPHFILESYSTEM, 3, 120, 150],
                 marks=pytest.mark.polarion_id("OCS-2044"),
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM, 13, 600, 420],
+                *[constants.CEPHFILESYSTEM, 12, 600, 720],
                 marks=pytest.mark.polarion_id("OCS-2674"),
             ),
         ],
@@ -220,7 +220,7 @@ class TestPodReattachTimePerformance(PASTest):
             files_written_list.append(files_written)
             data_written_list.append(data_written)
 
-            logger.info("Deleting the pod")
+            logger.info(f"Deleting the pod {pod_name}")
             rsh_cmd = f"delete pod {pod_name}"
             _ocp.exec_oc_cmd(rsh_cmd)
 


### PR DESCRIPTION
This PR handles 2 issues: 

1) Increasing pod creation timeout in test_pod_reattachtime.py test following failures on this.

From https://github.com/red-hat-storage/ocs-ci/issues/9336 :

The following test cases failed :

[tests.cross_functional.performance.csi_tests.test_pod_reattachtime.TestPodReattachTimePerformance.test_pod_reattach_time_performance[CephFileSystem-3-120-70]](https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/35137/testReport/tests.cross_functional.performance.csi_tests.test_pod_reattachtime/TestPodReattachTimePerformance/test_pod_reattach_time_performance_CephFileSystem_3_120_70_/)

Error:

ocs_ci.ocs.exceptions.PerformanceException: Pod creation time is 87.04964661598206 and greater than 70 seconds

[tests.cross_functional.performance.csi_tests.test_pod_reattachtime.TestPodReattachTimePerformance.test_pod_reattach_time_performance[CephFileSystem-13-600-420]](https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/35137/testReport/tests.cross_functional.performance.csi_tests.test_pod_reattachtime/TestPodReattachTimePerformance/test_pod_reattach_time_performance_CephFileSystem_13_600_420_/)

Error:

ocs_ci.ocs.exceptions.PerformanceException: Pod creation time is 491.2622141838074 and greater than 420 seconds

Conclusion: Submit a PR and increase Pod Creation time.

2) Reducing number of files in CephFS pod reattach with many files test case. 
We are reducing from 13 to 12 linux kernel copies written to the PVC prior to Pod Reattach action. 
During investigation a BZ was opened https://bugzilla.redhat.com/show_bug.cgi?id=2270545 
When the BZ will be fixed - the number of Linux Kernel copies should be again increased to 13 . 

Currently, because of the BZ , the maxumal number of files for pod reattach to succeed is ~ 800K files, while in 4.14 the number was ~860 K files. 
