### PR TITLE
[release-4.14 backport] `test_anonymous_read_only`: Use s3_get_object with retry 

### DIFF
--- a/tests/manage/mcg/test_bucket_policy.py
+++ b/tests/manage/mcg/test_bucket_policy.py
@@ -389,7 +389,10 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Getting object by user: {user.email_id} on bucket: {s3_bucket.name} "
         )
-        assert s3_get_object(
+        retry_s3_get_object = retry(boto3exception.ClientError, tries=4, delay=10)(
+            s3_get_object
+        )
+        assert retry_s3_get_object(
             user, s3_bucket.name, object_key
         ), f"Failed: Get Object by user {user.email_id}"
 


### PR DESCRIPTION
release-4.14 backport of #9057