### PR TITLE
Skip tier2 workload tests in disconnected proxy clusters

### DIFF
--- a/tests/functional/pv/pvc_clone/test_pgsql_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pgsql_pvc_clone.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
     skipif_hci_provider_and_client,
+    skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import STATUS_COMPLETED, VOLUME_MODE_FILESYSTEM, CEPHBLOCKPOOL
@@ -22,6 +24,8 @@ log = logging.getLogger(__name__)
 
 @magenta_squad
 @tier2
+@skipif_proxy_cluster
+@skipif_disconnected_cluster
 class TestPvcCloneOfWorkloads(E2ETest):
     """
     Tests to create multiple clones of same pgsql PVC at different utilization

--- a/tests/functional/pv/pvc_snapshot/test_pgsql_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_pgsql_pvc_snapshot.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
     skipif_hci_provider_and_client,
+    skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import CEPHBLOCKPOOL
@@ -20,6 +22,8 @@ log = logging.getLogger(__name__)
 
 @magenta_squad
 @tier2
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestPvcSnapshotOfWorkloads(E2ETest):
     """
     Tests to verify PVC snapshot feature for pgsql workloads

--- a/tests/functional/workloads/pvc_snapshot_and_clone/test_cloned_and_restored_pvc_resize.py
+++ b/tests/functional/workloads/pvc_snapshot_and_clone/test_cloned_and_restored_pvc_resize.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.testlib import (
     skipif_ocp_version,
     E2ETest,
     tier2,
+    skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.ocs.constants import VOLUME_MODE_FILESYSTEM
 
@@ -18,6 +20,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
 @pytest.mark.polarion_id("OCS-2309")
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestPvcResizeOfClonedAndRestoredPVC(E2ETest):
     """
     Tests to verify PVC resize feature for

--- a/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.testlib import (
     tier2,
     skipif_external_mode,
     skipif_hci_provider_and_client,
+    skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import (
@@ -24,6 +26,8 @@ log = logging.getLogger(__name__)
 @magenta_squad
 @skipif_hci_provider_and_client
 @tier2
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestCompressedSCAndSupportSnapClone(E2ETest):
     """
     Tests to create new compressed sc and their support for

--- a/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_external_mode,
     skipif_hci_provider_and_client,
+    skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
@@ -25,6 +27,8 @@ log = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @ignore_leftovers
 @tier2
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
     @pytest.mark.parametrize(
         argnames=["replica", "compression"],


### PR DESCRIPTION
Added skip tags for tier2 workload tests in disconnected cluster and proxy cluster.

Added skip tags for disconnected and proxy cluster in three test files in workloads.