### PR TITLE
[Close loop BZ: 2239208] Test case to create PVC in megabytes

### DIFF
--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -3,14 +3,14 @@ import logging
 from ocs_ci.framework.testlib import bugzilla, tier1
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad
 
 log = logging.getLogger(__name__)
 
 
 @tier1
 @bugzilla("2239208")
-@blue_squad
+@green_squad
 @pytest.mark.polarion_id("OCS-5476")
 class TestPvcCreationInMegabytes:
     """

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,0 +1,64 @@
+import pytest
+import logging
+from ocs_ci.framework.testlib import bugzilla, tier1
+from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    argnames="interface",
+    argvalues=[
+        pytest.param(
+            *[constants.CEPHFILESYSTEM], marks=pytest.mark.polarion_id("OCS-323")
+        ),
+    ],
+)
+@tier1
+@bugzilla("2239208")
+@magenta_squad
+class TestPvcCreationInMegabytes:
+    """
+    1. This class takes care of creating Cephfs PVC with small size 499M, 500M, 501M.
+    2.Passing size_unit as 'M' [mega-bytes] and the created PVC size will be displayed in 'Mi' format in pvc yaml.
+    3.Verifying the created PVC size by converting it from 'Mi' [mebi-bytes] to 'bytes'
+    and comparing it with the given size.
+    4. The expectation here is the created PVC sized should be greater than or equal to the given size.
+    It should not be lesser than the given size.
+    """
+
+    def test_pvc_creation_in_megabytes(self, interface, pvc_factory):
+        """
+        This function facilitates
+        1. Create PVC in Cephfs with size_unit as "M" . Used access mode is RWX.
+        2. Convert the PVC's size from 'Mi' to bytes.
+        3. Validate created PVC size with the given_pvc_size in "M" format after converting it into bytes.
+        """
+
+        access_mode = constants.ACCESS_MODE_RWX
+        log.info(f"Creating {interface} based PVC")
+        given_pvc_size = ["499", "500", "501"]
+        for size in given_pvc_size:
+            log.info(f"Creating {interface} based PVC with the given size {size}M")
+            # Creating PVC using pvc_factory
+            pvc_obj = pvc_factory(
+                interface=interface, access_mode=access_mode, size=size, size_unit="M"
+            )
+            # getting pvc yaml using pvc_obj.get() and getting the pvc capacity from the yaml
+            actual_pvc_size = pvc_obj.get().get("status").get("capacity").get("storage")
+            logging.info(f"PVC created with {actual_pvc_size} capacity")
+            # conversion formulae for 'M' to bytes
+            mega_bytes_to_bytes = 1000 * 1000
+            # conversion formulae for 'Mi' to bytes
+            mebi_bytes_to_bytes = 1024 * 1024
+
+            if (int(actual_pvc_size[:-2]) * mebi_bytes_to_bytes) >= (
+                int(size) * mega_bytes_to_bytes
+            ):
+                log.info("PVC created correctly")
+            else:
+                log.error("Created PVC size didn't met the given size")
+                assert (
+                    False
+                ), f"Actual PVC size {actual_pvc_size} is different than the given PVC size {size}M"

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,23 +1,17 @@
 import pytest
 import logging
 from ocs_ci.framework.testlib import bugzilla, tier1
+
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    argnames="interface",
-    argvalues=[
-        pytest.param(
-            *[constants.CEPHFILESYSTEM], marks=pytest.mark.polarion_id("OCS-323")
-        ),
-    ],
-)
 @tier1
 @bugzilla("2239208")
-@magenta_squad
+@blue_squad
+@pytest.mark.polarion_id("OCS-5476")
 class TestPvcCreationInMegabytes:
     """
     1. This class takes care of creating Cephfs PVC with small size 499M, 500M, 501M.
@@ -28,17 +22,20 @@ class TestPvcCreationInMegabytes:
     It should not be lesser than the given size.
     """
 
-    def test_pvc_creation_in_megabytes(self, interface, pvc_factory):
+    def test_pvc_creation_in_megabytes(self, pvc_factory):
         """
         This function facilitates
         1. Create PVC in Cephfs with size_unit as "M" . Used access mode is RWX.
         2. Convert the PVC's size from 'Mi' to bytes.
         3. Validate created PVC size with the given_pvc_size in "M" format after converting it into bytes.
         """
-
         access_mode = constants.ACCESS_MODE_RWX
-        log.info(f"Creating {interface} based PVC")
+        interface = constants.CEPHFILESYSTEM
         given_pvc_size = ["499", "500", "501"]
+        # conversion formulae for 'M' to bytes
+        mega_bytes_to_bytes = 1000 * 1000
+        # conversion formulae for 'Mi' to bytes
+        mebi_bytes_to_bytes = 1024 * 1024
         for size in given_pvc_size:
             log.info(f"Creating {interface} based PVC with the given size {size}M")
             # Creating PVC using pvc_factory
@@ -47,18 +44,14 @@ class TestPvcCreationInMegabytes:
             )
             # getting pvc yaml using pvc_obj.get() and getting the pvc capacity from the yaml
             actual_pvc_size = pvc_obj.get().get("status").get("capacity").get("storage")
-            logging.info(f"PVC created with {actual_pvc_size} capacity")
-            # conversion formulae for 'M' to bytes
-            mega_bytes_to_bytes = 1000 * 1000
-            # conversion formulae for 'Mi' to bytes
-            mebi_bytes_to_bytes = 1024 * 1024
-
-            if (int(actual_pvc_size[:-2]) * mebi_bytes_to_bytes) >= (
-                int(size) * mega_bytes_to_bytes
-            ):
-                log.info("PVC created correctly")
+            log.info(f"PVC created with the capacity of {actual_pvc_size} ")
+            created_pvc_in_bytes = int(actual_pvc_size[:-2]) * mebi_bytes_to_bytes
+            requested_pvc_in_bytes = int(size) * mega_bytes_to_bytes
+            if created_pvc_in_bytes >= requested_pvc_in_bytes:
+                log.info(
+                    f"Created PVC {created_pvc_in_bytes} bytes where the requested was {requested_pvc_in_bytes} bytes"
+                )
             else:
-                log.error("Created PVC size didn't met the given size")
                 assert (
                     False
                 ), f"Actual PVC size {actual_pvc_size} is different than the given PVC size {size}M"

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -31,29 +31,29 @@ class TestPvcCreationInMegabytes:
         """
         access_mode = constants.ACCESS_MODE_RWX
         interface = constants.CEPHFILESYSTEM
-        given_pvc_size_mb = ["499", "500", "501"]
+        given_pvc_sizes_mb = ["499", "500", "501"]
         # conversion formulae for 'M' to bytes
         mega_bytes_to_bytes = 1000 * 1000
         # conversion formulae for 'Mi' to bytes
         mebi_bytes_to_bytes = 1024 * 1024
-        for size in given_pvc_size_mb:
-            log.info(f"Creating {interface} based PVC with the given size {size}M")
+        for size_mb in given_pvc_sizes_mb:
+            log.info(f"Creating {interface} based PVC with the given size {size_mb}M")
             # Creating PVC using pvc_factory
             pvc_obj = pvc_factory(
-                interface=interface, access_mode=access_mode, size=size, size_unit="M"
+                interface=interface,
+                access_mode=access_mode,
+                size=size_mb,
+                size_unit="M",
             )
             # getting pvc yaml using pvc_obj.get() and getting the pvc capacity from the yaml
-            actual_pvc_size_mib = (
-                pvc_obj.get().get("status").get("capacity").get("storage")
+            actual_pvc_size = pvc_obj.get().get("status").get("capacity").get("storage")
+            log.info(f"PVC created with the capacity of size {actual_pvc_size} ")
+            created_pvc_size_bytes = int(actual_pvc_size[:-2]) * mebi_bytes_to_bytes
+            requested_pvc_size_bytes = int(size_mb) * mega_bytes_to_bytes
+            assert created_pvc_size_bytes >= requested_pvc_size_bytes, (
+                f"Actual PVC size {created_pvc_size_bytes} bytes is less"
+                f" than the given PVC size {requested_pvc_size_bytes}"
             )
-            log.info(f"PVC created with the capacity of {actual_pvc_size_mib} ")
-            created_pvc_in_bytes = int(actual_pvc_size_mib[:-2]) * mebi_bytes_to_bytes
-            requested_pvc_in_bytes = int(size) * mega_bytes_to_bytes
-            if created_pvc_in_bytes >= requested_pvc_in_bytes:
-                log.info(
-                    f"Created PVC {created_pvc_in_bytes} bytes where the requested was {requested_pvc_in_bytes} bytes"
-                )
-            else:
-                assert (
-                    False
-                ), f"Actual PVC size {actual_pvc_size_mib} is different than the given PVC size {size}M"
+            log.info(
+                f"Created PVC {created_pvc_size_bytes} bytes where the requested was {requested_pvc_size_bytes} bytes"
+            )

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,9 +1,9 @@
-import pytest
 import logging
+import pytest
 
-from ocs_ci.framework.testlib import bugzilla, tier1, E2ETest
-from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.testlib import bugzilla, E2ETest, tier1
+from ocs_ci.ocs import constants
 
 log = logging.getLogger(__name__)
 

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 @bugzilla("2239208")
 @green_squad
 @pytest.mark.polarion_id("OCS-5476")
-class TestPvcCreationInMegabytes:
+class TestPvcCreationInMegabytes(E2ETest):
     """
     1. This class takes care of creating Cephfs PVC with small size 499M, 500M, 501M.
     2.Passing size_unit as 'M' [mega-bytes] and the created PVC size will be displayed in 'Mi' format in pvc yaml.

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -31,21 +31,23 @@ class TestPvcCreationInMegabytes:
         """
         access_mode = constants.ACCESS_MODE_RWX
         interface = constants.CEPHFILESYSTEM
-        given_pvc_size = ["499", "500", "501"]
+        given_pvc_size_mb = ["499", "500", "501"]
         # conversion formulae for 'M' to bytes
         mega_bytes_to_bytes = 1000 * 1000
         # conversion formulae for 'Mi' to bytes
         mebi_bytes_to_bytes = 1024 * 1024
-        for size in given_pvc_size:
+        for size in given_pvc_size_mb:
             log.info(f"Creating {interface} based PVC with the given size {size}M")
             # Creating PVC using pvc_factory
             pvc_obj = pvc_factory(
                 interface=interface, access_mode=access_mode, size=size, size_unit="M"
             )
             # getting pvc yaml using pvc_obj.get() and getting the pvc capacity from the yaml
-            actual_pvc_size = pvc_obj.get().get("status").get("capacity").get("storage")
-            log.info(f"PVC created with the capacity of {actual_pvc_size} ")
-            created_pvc_in_bytes = int(actual_pvc_size[:-2]) * mebi_bytes_to_bytes
+            actual_pvc_size_mib = (
+                pvc_obj.get().get("status").get("capacity").get("storage")
+            )
+            log.info(f"PVC created with the capacity of {actual_pvc_size_mib} ")
+            created_pvc_in_bytes = int(actual_pvc_size_mib[:-2]) * mebi_bytes_to_bytes
             requested_pvc_in_bytes = int(size) * mega_bytes_to_bytes
             if created_pvc_in_bytes >= requested_pvc_in_bytes:
                 log.info(
@@ -54,4 +56,4 @@ class TestPvcCreationInMegabytes:
             else:
                 assert (
                     False
-                ), f"Actual PVC size {actual_pvc_size} is different than the given PVC size {size}M"
+                ), f"Actual PVC size {actual_pvc_size_mib} is different than the given PVC size {size}M"

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.framework.testlib import bugzilla, tier1
 from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
-from ocs_ci.framework.testlib import bugzilla, tier1
 
+from ocs_ci.framework.testlib import bugzilla, tier1
 from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad
 

--- a/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
+++ b/tests/functional/pv/pv_services/test_pvc_creation_in_megabytes.py
@@ -1,8 +1,7 @@
 import pytest
 import logging
 
-from ocs_ci.framework.testlib import E2ETest
-from ocs_ci.framework.testlib import bugzilla, tier1
+from ocs_ci.framework.testlib import bugzilla, tier1, E2ETest
 from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad
 


### PR DESCRIPTION
Link to BZ : [2239208](https://bugzilla.redhat.com/show_bug.cgi?id=2239208)

This  new test case will take care of:
1. Creating Cephfs PVC with small size 499M, 500M, 501M.
2. Passing size_unit as 'M' [mega-bytes] and the created PVC size will be displayed in 'Mi' format in pvc yaml.
3. Verifying the created PVC size by converting it from 'Mi' [mebi-bytes] to 'bytes' and comparing it with the given size.
4. The expectation here is the created PVC sized should be greater than or equal to the given size. It should not be lesser than the given size.