### PR TITLE
Adding client namespace pods to disruptive test

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -134,6 +134,22 @@ class Disruptions:
         if self.resource == "ocs_provider_server":
             self.resource_obj = [pod.get_ocs_provider_server_pod()]
             self.selector = constants.PROVIDER_SERVER_LABEL
+        if self.resource == "client_operator_console":
+            self.resource_obj = [pod.get_client_operator_console_pods]
+            self.selector = constants.CLIENT_OPERATOR_CONSOLE_LABEL
+            # Setting resource_count because console pod also have the same label.
+            resource_count = len(
+                pod.get_pods_having_label(
+                    constants.CLIENT_OPERATOR_CONSOLE_LABEL,
+                    config.ENV_DATA["cluster_namespace"],
+                )
+            )
+        if self.resource == "client_operator_controller_manager":
+            self.resource_obj = [pod.get_client_operator_controller_manager_pods]
+            self.selector = constants.CLIENT_OPERATOR_CONTROLLER_MANAGER_LABEL
+        if self.resource == "csi_addons_controller_manager":
+            self.resource_obj = [pod.get_csi_addons_controller_manager_pods]
+            self.selector = constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL
 
         self.resource_count = resource_count or len(self.resource_obj)
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -415,6 +415,8 @@ CEPH_OBJECT_CONTROLLER_DETECT_VERSION_LABEL = (
     "app=ceph-object-controller-detect-version"
 )
 CSI_ADDONS_CONTROLLER_MANAGER_LABEL = "app.kubernetes.io/name=csi-addons"
+CLIENT_OPERATOR_CONTROLLER_MANAGER_LABEL = "control-plane=controller-manager"
+CLIENT_OPERATOR_CONSOLE_LABEL = "app.kubernetes.io/name=ocs-client-operator-console"
 
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"
 DEFAULT_DEVICESET_LSO_PVC_NAME = "ocs-deviceset-localblock"

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -3583,3 +3583,62 @@ def wait_for_pods_deletion(
         namespace=namespace,
     )
     sampler.wait_for_func_status(True)
+
+
+def get_csi_addons_controller_manager_pods(namespace=None):
+    """
+    Fetches info about csi-addons-controller-manager pods in the cluster
+
+    Args:
+        namespace (str): Namespace in which pod csi-addons-controller-manager is present
+
+    Returns:
+        list : List of csi-addons-controller-manager pod objects
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    csi_addons = get_pods_having_label(
+        constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL, namespace
+    )
+    csi_addons_pods = [Pod(**addons_controller) for addons_controller in csi_addons]
+    return csi_addons_pods
+
+
+def get_client_operator_controller_manager_pods(namespace=None):
+    """
+    Fetches info about ocs-client-operator-controller-manager pods in the cluster
+
+    Args:
+        namespace (str): Namespace in which pod ocs-client-operator-controller-manager is present
+
+    Returns:
+        list : List of ocs-client-operator-controller-manager pod objects
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    client_operator = get_pods_having_label(
+        constants.CLIENT_OPERATOR_CONTROLLER_MANAGER_LABEL, namespace
+    )
+    client_operator_pods = [Pod(**operator) for operator in client_operator]
+    return client_operator_pods
+
+
+def get_client_operator_console_pods(namespace=None):
+    """
+    Fetches info about ocs-client-operator-console pods in the cluster
+
+    Args:
+        namespace (str): Namespace in which pod ocs-client-operator-console is present
+
+    Returns:
+        list : List of ocs-client-operator-console pod objects
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    client_operator_console = get_pods_having_label(
+        constants.CLIENT_OPERATOR_CONSOLE_LABEL, namespace
+    )
+    client_operator_console_pods = [
+        Pod(**operator) for operator in client_operator_console
+    ]
+    return client_operator_console_pods

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -25,6 +25,9 @@ from ocs_ci.ocs.resources.pod import (
     get_cephfsplugin_provisioner_pods,
     get_rbdfsplugin_provisioner_pods,
     get_operator_pods,
+    get_client_operator_console_pods,
+    get_client_operator_controller_manager_pods,
+    get_csi_addons_controller_manager_pods,
 )
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.helpers import (
@@ -259,6 +262,16 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 "mds",
             ]
 
+            # TODO: Update this check when new platform name is added in the config
+            if "hci" in config.ENV_DATA.get("platform"):
+                ceph_csi_pods_to_delete.extend(
+                    [
+                        "client_operator_console",
+                        "client_operator_controller_manager",
+                        "csi_addons_controller_manager",
+                    ]
+                )
+
         (
             pvc_objs,
             pod_objs,
@@ -358,6 +371,13 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 "cephfsplugin_provisioner": partial(get_cephfsplugin_provisioner_pods),
                 "rbdplugin_provisioner": partial(get_rbdfsplugin_provisioner_pods),
                 "operator": partial(get_operator_pods),
+                "client_operator_console": partial(get_client_operator_console_pods),
+                "client_operator_controller_manager": partial(
+                    get_client_operator_controller_manager_pods
+                ),
+                "csi_addons_controller_manager": partial(
+                    get_csi_addons_controller_manager_pods
+                ),
             }
 
         # Disruption object for each pod type


### PR DESCRIPTION
Upgade the test tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py to consider the pods client_operator_controller_manager, csi_addons_controller_manager and client_operator_controller_manager for disruption. These pods are targetted to client cluster.