### PR TITLE
Fix for the ocs-ci issue 7290

### DIFF
--- a/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -98,10 +98,11 @@ class TestRbdSpaceReclaim(ManageTest):
             )
             pod_obj.get_fio_results()
 
-        # Verify used size after IO
-        exp_used_size_after_io = used_size_before_io + (16 * self.pool_replica)
-        used_size_after_io = fetch_used_size(cbp_name, exp_used_size_after_io)
-        log.info(f"Used size after IO is {used_size_after_io}")
+            # Verify used size after IO
+            exp_used_size_after_io = used_size_before_io + (4 * self.pool_replica)
+            used_size_after_io = fetch_used_size(cbp_name, exp_used_size_after_io)
+            log.info(f"Used size after IO is in {filename} {used_size_after_io}")
+            used_size_before_io = used_size_after_io
 
         # Delete the file and validate the reclaimspace cronjob
         for filename in [fio_filename1, fio_filename2, fio_filename3]:


### PR DESCRIPTION
When we calculate the used size of the pool, the negligible difference between the expected size and actual size is 1.5Gb, but in my case sometimes, very rarely, it exceeds 1.5Gb to 2Gb, because of that script will fail. In this test we calculate the pool size after creating 4 files cumulatively. So assumed, calculating the pool size after each file creation would resolve the issue.