### PR TITLE
Skip checking for Gitops config

### DIFF
--- a/conf/ocsci/deploy_gitops_operator.yaml
+++ b/conf/ocsci/deploy_gitops_operator.yaml
@@ -1,3 +1,0 @@
----
-ENV_DATA:
-  deploy_gitops_operator: True

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -279,15 +279,13 @@ class Deployment(object):
         Returns:
 
         """
-        if not config.ENV_DATA.get("deploy_gitops_operator"):
-            return
 
         # Multicluster operations
         if config.multicluster:
-            config.switch_acm_ctx()
-
-            self.deploy_gitops_operator()
-
+            acm_indexes = get_all_acm_indexes()
+            for acm_ctx in acm_indexes:
+                self.deploy_gitops_operator(switch_ctx=acm_ctx)
+            config.switch_ctx(get_active_acm_index())
             logger.info("Creating GitOps CLuster Resource")
             run_cmd(f"oc create -f {constants.GITOPS_CLUSTER_YAML}")
 


### PR DESCRIPTION
- Skip checking for gitops config as it's required every time 
- Install Gitops operator on both cluster
- Install gitopscluster only on active cluster