### PR TITLE
Update the squad paths under CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,10 @@
 #/build/logs/ @doctocat
 /tests/functional/disaster-recovery/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
+/tests/cross_functional/resilience/ @red-hat-storage/brown-squad
+/tests/functional/nfs_feature/ @red-hat-storage/brown-squad
+/tests/functional/odf-cli/ @red-hat-storage/brown-squad
+/tests/functional/pod_and_daemons/ @red-hat-storage/brown-squad
 /tests/functional/z_cluster/ @red-hat-storage/brown-squad
 /tests/functional/pv/pv_services/ @red-hat-storage/green-squad
 /tests/functional/storageclass/ @red-hat-storage/green-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,8 @@
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
 /tests/cross_functional/performance/ @red-hat-storage/grey-squad
 /tests/cross_functional/scale/ @red-hat-storage/orange-squad
-/tests/ui/ @red-hat-storage/black-squad
+/tests/functional/ui/ @red-hat-storage/black-squad
+/tests/cross_functional/ui/ @red-hat-storage/black-squad
 /ocs_ci/ocs/ui/ @red-hat-storage/black-squad
 
 # The `docs/*` pattern will match files like

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 /tests/functional/monitoring/ @red-hat-storage/blue-squad
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
-/tests/ecosystem/upgrade/ @red-hat-storage/purple-squad
+/tests/functional/upgrade/ @red-hat-storage/purple-squad
 /tests/e2e/flowtest/ @red-hat-storage/magenta-squad
 /tests/e2e/lifecycle/ @red-hat-storage/magenta-squad
 /tests/e2e/workloads/ @red-hat-storage/magenta-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@
 /tests/functional/upgrade/ @red-hat-storage/purple-squad
 /tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
-/tests/e2e/performance/ @red-hat-storage/grey-squad
+/tests/cross_functional/performance/ @red-hat-storage/grey-squad
 /tests/e2e/scale/ @red-hat-storage/orange-squad
 /tests/ui/ @red-hat-storage/black-squad
 /ocs_ci/ocs/ui/ @red-hat-storage/black-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,8 +35,8 @@
 /tests/manage/pv_services/ @red-hat-storage/green-squad
 /tests/manage/storageclass/ @red-hat-storage/green-squad
 /tests/manage/monitoring/ @red-hat-storage/blue-squad
-/tests/manage/mcg/ @red-hat-storage/red-squad
-/tests/manage/rgw/ @red-hat-storage/red-squad
+/tests/functional/object/mcg/  @red-hat-storage/red-squad
+/tests/functional/object/rgw/  @red-hat-storage/red-squad
 /tests/ecosystem/upgrade/ @red-hat-storage/purple-squad
 /tests/e2e/flowtest/ @red-hat-storage/magenta-squad
 /tests/e2e/lifecycle/ @red-hat-storage/magenta-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,8 @@
 /tests/functional/upgrade/ @red-hat-storage/purple-squad
 /tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
+/tests/cross_functional/system_test/ @red-hat-storage/magenta-squad
+/tests/cross_functional/kcs/ @red-hat-storage/magenta-squad
 /tests/cross_functional/performance/ @red-hat-storage/grey-squad
 /tests/cross_functional/scale/ @red-hat-storage/orange-squad
 /tests/functional/ui/ @red-hat-storage/black-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
+/tests/functional/disaster-recovery/metro-dr/ @red-hat-storage/turquoise-squad
 /tests/functional/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
 /tests/functional/z_cluster/ @red-hat-storage/brown-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,7 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
-/tests/functional/disaster-recovery/metro-dr/ @red-hat-storage/turquoise-squad
-/tests/functional/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
+/tests/functional/disaster-recovery/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
 /tests/functional/z_cluster/ @red-hat-storage/brown-squad
 /tests/functional/pv/pv_services/ @red-hat-storage/green-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,8 +32,9 @@
 /tests/functional/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
 /tests/functional/z_cluster/ @red-hat-storage/brown-squad
-/tests/manage/pv_services/ @red-hat-storage/green-squad
-/tests/manage/storageclass/ @red-hat-storage/green-squad
+/tests/functional/pv/pv_services/ @red-hat-storage/green-squad
+/tests/functional/storageclass/ @red-hat-storage/green-squad
+/tests/functional/encryption/ @red-hat-storage/green-squad
 /tests/manage/monitoring/ @red-hat-storage/blue-squad
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
@@ -43,7 +44,6 @@
 /tests/e2e/workloads/ @red-hat-storage/magenta-squad
 /tests/e2e/performance/ @red-hat-storage/grey-squad
 /tests/e2e/scale/ @red-hat-storage/orange-squad
-/tests/encryption @red-hat-storage/green-squad
 /tests/ui/ @red-hat-storage/black-squad
 /ocs_ci/ocs/ui/ @red-hat-storage/black-squad
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,10 +39,11 @@
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
 /tests/functional/upgrade/ @red-hat-storage/purple-squad
-/tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
-/tests/cross_functional/system_test/ @red-hat-storage/magenta-squad
+/tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/cross_functional/kcs/ @red-hat-storage/magenta-squad
+/tests/cross_functional/longevity/ @red-hat-storage/magenta-squad
+/tests/cross_functional/system_test/ @red-hat-storage/magenta-squad
 /tests/cross_functional/performance/ @red-hat-storage/grey-squad
 /tests/cross_functional/scale/ @red-hat-storage/orange-squad
 /tests/functional/ui/ @red-hat-storage/black-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
-/tests/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
+/tests/functional/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
 /tests/manage/z_cluster/ @red-hat-storage/brown-squad
 /tests/manage/pv_services/ @red-hat-storage/green-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,9 +39,8 @@
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
 /tests/functional/upgrade/ @red-hat-storage/purple-squad
-/tests/e2e/flowtest/ @red-hat-storage/magenta-squad
-/tests/e2e/lifecycle/ @red-hat-storage/magenta-squad
-/tests/e2e/workloads/ @red-hat-storage/magenta-squad
+/tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
+/tests/functional/workloads/ @red-hat-storage/magenta-squad
 /tests/e2e/performance/ @red-hat-storage/grey-squad
 /tests/e2e/scale/ @red-hat-storage/orange-squad
 /tests/ui/ @red-hat-storage/black-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,27 +29,49 @@
 # directory at the root of the repository and any of its
 # subdirectories.
 #/build/logs/ @doctocat
+
+# Turquoise-squad
 /tests/functional/disaster-recovery/ @red-hat-storage/turquoise-squad
+
+# Aqua-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
+
+# Brown-squad
 /tests/cross_functional/resilience/ @red-hat-storage/brown-squad
 /tests/functional/nfs_feature/ @red-hat-storage/brown-squad
 /tests/functional/odf-cli/ @red-hat-storage/brown-squad
 /tests/functional/pod_and_daemons/ @red-hat-storage/brown-squad
 /tests/functional/z_cluster/ @red-hat-storage/brown-squad
+
+# Green-squad
 /tests/functional/pv/pv_services/ @red-hat-storage/green-squad
 /tests/functional/storageclass/ @red-hat-storage/green-squad
 /tests/functional/encryption/ @red-hat-storage/green-squad
+
+# Blue-squad
 /tests/functional/monitoring/ @red-hat-storage/blue-squad
+
+# Red-squad
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
+
+# Purple-squad
 /tests/functional/upgrade/ @red-hat-storage/purple-squad
+
+# Magenta-squad
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
 /tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/cross_functional/kcs/ @red-hat-storage/magenta-squad
 /tests/cross_functional/longevity/ @red-hat-storage/magenta-squad
 /tests/cross_functional/system_test/ @red-hat-storage/magenta-squad
+
+# Grey-squad
 /tests/cross_functional/performance/ @red-hat-storage/grey-squad
+
+# Orange-squad
 /tests/cross_functional/scale/ @red-hat-storage/orange-squad
+
+# Black-squad
 /tests/functional/ui/ @red-hat-storage/black-squad
 /tests/cross_functional/ui/ @red-hat-storage/black-squad
 /ocs_ci/ocs/ui/ @red-hat-storage/black-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@
 /tests/functional/pv/pv_services/ @red-hat-storage/green-squad
 /tests/functional/storageclass/ @red-hat-storage/green-squad
 /tests/functional/encryption/ @red-hat-storage/green-squad
-/tests/manage/monitoring/ @red-hat-storage/blue-squad
+/tests/functional/monitoring/ @red-hat-storage/blue-squad
 /tests/functional/object/mcg/  @red-hat-storage/red-squad
 /tests/functional/object/rgw/  @red-hat-storage/red-squad
 /tests/ecosystem/upgrade/ @red-hat-storage/purple-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /tests/cross_functional/flowtest/ @red-hat-storage/magenta-squad
 /tests/functional/workloads/ @red-hat-storage/magenta-squad
 /tests/cross_functional/performance/ @red-hat-storage/grey-squad
-/tests/e2e/scale/ @red-hat-storage/orange-squad
+/tests/cross_functional/scale/ @red-hat-storage/orange-squad
 /tests/ui/ @red-hat-storage/black-squad
 /ocs_ci/ocs/ui/ @red-hat-storage/black-squad
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@
 #/build/logs/ @doctocat
 /tests/functional/disaster-recovery/regional-dr/ @red-hat-storage/turquoise-squad
 /tests/lvmo/ @red-hat-storage/aqua-squad
-/tests/manage/z_cluster/ @red-hat-storage/brown-squad
+/tests/functional/z_cluster/ @red-hat-storage/brown-squad
 /tests/manage/pv_services/ @red-hat-storage/green-squad
 /tests/manage/storageclass/ @red-hat-storage/green-squad
 /tests/manage/monitoring/ @red-hat-storage/blue-squad


### PR DESCRIPTION
The latest directory restructure of OCS-CI has left obsolete paths in the CODEOWNERS file, which means that squads are no longer being requested to review or get notified of changes to tests under their main directories. 

This PR updates these paths as closely as possible to the original structure. 



