### PR TITLE
update various pods with proxy env vars - release-4.13

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftover_label,
     upgrade_marks,
 )
+from ocs_ci.helpers.proxy import update_container_with_proxy_env
 from ocs_ci.ocs import constants, defaults, fio_artefacts, node, ocp, platform_nodes
 from ocs_ci.ocs.acm.acm import login_to_acm
 from ocs_ci.ocs.bucket_utils import (
@@ -2365,6 +2366,7 @@ def awscli_pod_fixture(request, scope_name):
     ] = service_ca_configmap_name
 
     update_container_with_mirrored_image(awscli_sts_dict)
+    update_container_with_proxy_env(awscli_sts_dict)
 
     s3cli_sts_obj = helpers.create_resource(**awscli_sts_dict)
     assert s3cli_sts_obj, "Failed to create S3CLI STS"
@@ -2430,6 +2432,7 @@ def scale_cli_fixture(request, scope_name):
     scalecli_pod_dict["metadata"]["name"] = scalecli_pod_name
 
     update_container_with_mirrored_image(scalecli_pod_dict)
+    update_container_with_proxy_env(scalecli_pod_dict)
 
     scalecli_pod_obj = Pod(**scalecli_pod_dict)
     assert scalecli_pod_obj.create(
@@ -2464,6 +2467,7 @@ def javasdk_pod_fixture(request, scope_name):
     javas3_pod_name = create_unique_resource_name(constants.JAVAS3_POD_NAME, scope_name)
     javas3_pod_dict["metadata"]["name"] = javas3_pod_name
     update_container_with_mirrored_image(javas3_pod_dict)
+    update_container_with_proxy_env(javas3_pod_dict)
     javas3_pod_obj = Pod(**javas3_pod_dict)
 
     assert javas3_pod_obj.create(do_reload=True), f"Failed to create {javas3_pod_name}"
@@ -6388,6 +6392,7 @@ def fedora_pod_fixture(request, scope_name):
     fedora_pod_dict["metadata"]["name"] = fedora_pod_name
 
     update_container_with_mirrored_image(fedora_pod_dict)
+    update_container_with_proxy_env(fedora_pod_dict)
 
     fedora_pod_obj = Pod(**fedora_pod_dict)
     assert fedora_pod_obj.create(

--- a/tests/manage/mcg/test_s3_with_java_sdk.py
+++ b/tests/manage/mcg/test_s3_with_java_sdk.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     skipif_disconnected_cluster,
+    skipif_proxy_cluster,
     tier1,
     red_squad,
     mcg,
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @skipif_ocs_version("<4.9")
 @skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestS3WithJavaSDK:
     @bugzilla("2064304")
     @pytest.mark.parametrize(


### PR DESCRIPTION
This is backport of https://github.com/red-hat-storage/ocs-ci/pull/8301 to `release-4.13` branch.