### PR TITLE
Control the order in which `test_default_backingstore_override_pre/post_upgrade` are executed 

### DIFF
--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -11,8 +11,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     tier1,
     tier2,
-    pre_upgrade,
-    post_upgrade,
     skipif_aws_creds_are_missing,
     ignore_leftovers,
     mcg,
@@ -74,7 +72,9 @@ class TestDefaultBackingstoreOverride(MCGTest):
             == alt_default_bs_name
         ), "The default OC bucket does not use the new default backingstore!"
 
-    @pre_upgrade
+    # Run after other pre-upgrade tests
+    @pytest.mark.order(constants.ORDER_BEFORE_OCS_UPGRADE + 1)
+    @pytest.mark.pre_upgrade  # @pre_upgrade conflicts with the order marker
     def test_default_backingstore_override_pre_upgrade(
         self,
         request,
@@ -98,7 +98,9 @@ class TestDefaultBackingstoreOverride(MCGTest):
             default_admin_resource == default_bc_bs == alt_default_bs_name
         ), "The new default backingstore was not overriden before the upgrade!"
 
-    @post_upgrade
+    # Run before other post-upgrade tests
+    @pytest.mark.order(constants.ORDER_AFTER_OCS_UPGRADE - 1)
+    @pytest.mark.post_upgrade  # @post_upgrade conflicts with the order marker
     @polarion_id("OCS-5194")
     def test_default_backingstore_override_post_upgrade(
         self,


### PR DESCRIPTION
Fixes: #9568

This PR uses `pytest.mark.order()` to control the order in which these tests are running in upgrade runs:

-  Run `test_default_backingstore_override_pre_upgrade` last before the upgrade : this pre-upgrade test sets an alternative default backingstore for MCG, which in turn can mess the management (patching, deletion, etc) of buckets that were created on top of the original default backingstore. Running it last makes sure that any prior MCG related test that are using the default backingstore/bucketclass will use the original default backingstore. 

- Run `test_default_backingstore_override_post_upgrade` first after the upgrade: this post-upgrade test validates that the alternative backingstore is still set as the default after the upgrade, and then reverts the change by setting back the original backingstore as the default. Running this test first after the upgrade makes sure this reversion takes place before other post-upgrade MCG related tests that expect the original default backingstore/bucketclass.
