### PR TITLE
fix ordering for test_failure_propagator

### DIFF
--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -47,7 +47,7 @@ class TestFailurePropagator:
     Test class for failure propagator test case
     """
 
-    @pytest.mark.second_to_last
+    @pytest.mark.order("second_to_last")
     def test_report_skip_triggering_test(self, request):
         """
         This test runs second to last and examines the skipped test cases of the execution.
@@ -111,7 +111,7 @@ class TestFailurePropagator:
                 config.RUN["display_skipped_msg_in_email"] = message
                 pytest.fail(message)
 
-    @pytest.mark.last
+    @pytest.mark.order("last")
     def test_failure_propagator(self):
         """
         This test intention is to run last and propagate teardown failures caught during the test execution,


### PR DESCRIPTION
After we moved to pytest-order from pytest-ordering, test_failure_propagator order is broken its order.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)