### PR TITLE
W/A for ccoctl and glibc_2.34 not found

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1075,6 +1075,11 @@ OCS_OPERATOR_BUNDLE_IMAGE = "quay.io/rhceph-dev/ocs-operator-bundle"
 OPENSHIFT_UPGRADE_INFO_API = (
     "https://api.openshift.com/api/upgrades_info/v1/graph?channel={channel}"
 )
+# OCP 4.16.0-0.nightly-2024-04-08-024331 image where it didn't require glibc 2.34
+OCP_4_16_CCOCTL_WA_IMAGE = (
+    "registry.ci.openshift.org/ocp/release@"
+    "sha256:d6329f1a221f0422294d41ce2a7bfe3f0d38a41ee3da99fea10e4288fab1efb6"
+)
 
 # Podsecurity admission policies
 PSA_PRIVILEGED = "privileged"

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -8,6 +8,7 @@ import yaml
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
+from ocs_ci.utility import version
 from ocs_ci.utility.deployment import get_ocp_release_image_from_installer
 from ocs_ci.utility.utils import (
     exec_cmd,
@@ -27,7 +28,11 @@ def configure_cloud_credential_operator():
     ccoctl_path = os.path.join(bin_dir, "ccoctl")
     if not os.path.isfile(ccoctl_path):
         pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-        release_image = get_ocp_release_image_from_installer()
+        # W/A of the issue https://github.com/red-hat-storage/ocs-ci/issues/9674
+        if version.get_semantic_ocp_version_from_config() == version.VERSION_4_16:
+            release_image = constants.OCP_4_16_CCOCTL_WA_IMAGE
+        else:
+            release_image = get_ocp_release_image_from_installer()
         cco_image = get_cco_container_image(release_image, pull_secret_path)
         extract_ccoctl_binary(cco_image, pull_secret_path)
 


### PR DESCRIPTION
Related W/A issue:
https://github.com/red-hat-storage/ocs-ci/issues/9674