### PR TITLE
Run setup_acm_ui fixture only for UI tests

### DIFF
--- a/conf/ocsci/dr_ui.yaml
+++ b/conf/ocsci/dr_ui.yaml
@@ -2,6 +2,7 @@
 #Perform Failover/Relocate via ACM UI (Combination of ODF>=4.13 and ACM>=2.7 is supported, please look at the code)
 
 RUN:
+  dr_action_via_ui: true
   rdr_failover_via_ui: true
   rdr_relocate_via_ui: true
   mdr_failover_via_ui: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4875,6 +4875,8 @@ def setup_acm_ui(request):
 
 
 def setup_acm_ui_fixture(request):
+    if not ocsci_config.RUN.get("dr_action_via_ui"):
+        return
     restore_ctx_index = ocsci_config.cur_index
     ocsci_config.switch_acm_ctx()
     driver = login_to_acm()

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -21,7 +21,6 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
-from ocs_ci.utility import version
 from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
@@ -87,12 +86,8 @@ class TestFailover:
 
         """
         if config.RUN.get("rdr_failover_via_ui"):
-            ocs_version = version.get_semantic_ocs_version_from_config()
-            if ocs_version <= version.VERSION_4_12:
-                logger.error("ODF/ACM version isn't supported for Failover operation")
-                raise NotImplementedError
+            acm_obj = AcmAddClusters()
 
-        acm_obj = AcmAddClusters()
         rdr_workload = dr_workload(num_of_subscription=1, pvc_interface=pvc_interface)[
             0
         ]

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -21,7 +21,6 @@ from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.ocs.utils import get_active_acm_index
-from ocs_ci.utility import version
 from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 
 logger = logging.getLogger(__name__)
@@ -98,14 +97,8 @@ class TestFailoverAndRelocate:
 
         """
         if config.RUN.get("rdr_failover_via_ui"):
-            ocs_version = version.get_semantic_ocs_version_from_config()
-            if ocs_version <= version.VERSION_4_12:
-                logger.error(
-                    "ODF/ACM version isn't supported for Failover/Relocate operation"
-                )
-                raise NotImplementedError
+            acm_obj = AcmAddClusters()
 
-        acm_obj = AcmAddClusters()
         if workload_type == constants.SUBSCRIPTION:
             rdr_workload = dr_workload(num_of_subscription=1)[0]
             drpc_obj = DRPC(namespace=rdr_workload.workload_namespace)

--- a/tests/functional/disaster-recovery/regional-dr/test_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_relocate.py
@@ -15,7 +15,6 @@ from ocs_ci.helpers.dr_helpers_ui import (
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
-from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +54,8 @@ class TestRelocate:
 
         """
         if config.RUN.get("rdr_relocate_via_ui"):
-            ocs_version = version.get_semantic_ocs_version_from_config()
-            if ocs_version <= version.VERSION_4_12:
-                logger.error("ODF/ACM version isn't supported for Relocate operation")
-                raise NotImplementedError
+            acm_obj = AcmAddClusters()
 
-        acm_obj = AcmAddClusters()
         if workload_type == constants.SUBSCRIPTION:
             rdr_workload = dr_workload(num_of_subscription=1)[0]
         else:


### PR DESCRIPTION
This pull request addresses an issue where the setup_acm_ui fixture was running for all tests, including those focused on the CLI functionality. This caused unnecessary setup steps and test failures when running CLI tests.
Now, the fixture will only be executed when running tests with `conf/ocsci/dr_ui.yaml` conf.