### PR TITLE
Fix teardown failures in dr_workload

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6487,6 +6487,7 @@ def dr_workload(request):
             list: objects of workload class.
 
         """
+        ctx.append(switch_ctx)
         total_pvc_count = 0
         workload_key = "dr_workload_subscription"
         if pvc_interface == constants.CEPHFILESYSTEM:
@@ -6522,7 +6523,6 @@ def dr_workload(request):
                 dr_helpers.wait_for_mirroring_status_ok(
                     replaying_images=total_pvc_count
                 )
-        ctx.append(switch_ctx)
         return instances
 
     def teardown():


### PR DESCRIPTION
Fixes #9689 
Append ctx before workload deployment to ensure proper teardown even if the setup fails.