### PR TITLE
Add deployment config of AWS control plane hosting cluster

### DIFF
--- a/conf/deployment/aws/ipi_3az_rhcos_3m_3w_ctrplane_hosting.yaml
+++ b/conf/deployment/aws/ipi_3az_rhcos_3m_3w_ctrplane_hosting.yaml
@@ -1,0 +1,18 @@
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+ENV_DATA:
+  platform: 'aws'
+  deployment_type: 'ipi'
+  region: 'us-east-2'
+  worker_availability_zones:
+    - 'us-east-2a'
+    - 'us-east-2b'
+    - 'us-east-2c'
+  master_availability_zones:
+    - 'us-east-2a'
+    - 'us-east-2b'
+    - 'us-east-2c'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_instance_type: 'm6i.xlarge'
+  master_instance_type: 'm6i.xlarge'


### PR DESCRIPTION
AWS controle plan hosting cluster is required for onboarding ODF on AWS HCP cluster