### PR TITLE
Stabilize test_create_scale_pods_and_pvcs_using_kube_job

### DIFF
--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -848,11 +848,15 @@ def check_and_add_enough_worker(worker_count):
                             )
                         )
                 else:
+                    # Getting the machineset configured during deployment of the cluster
+                    existing_ms_in_cluster = machine.get_machinesets()
+                    # Getting default machineset's zone from the cluster
+                    available_zone_in_cluster = existing_ms_in_cluster[0][-1]
                     ms_name.append(
                         machine.create_custom_machineset(
                             instance_type=constants.AWS_PRODUCTION_INSTANCE_TYPE,
                             labels=labels,
-                            zone="a",
+                            zone=available_zone_in_cluster,
                         )
                     )
                 for ms in ms_name:


### PR DESCRIPTION
 Fixing 

As part of this fix, we are  getting default machineset zone from the cluster, instead of hard coded with single value as "a". Because when it is a single zone cluster we may get "a" or "b" or "c" as zone. So we are getting that value from the cluster deployed and parsing it in the test case.

#9477

