### PR TITLE
use cco image directly

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1103,6 +1103,10 @@ OCP_4_16_CCOCTL_WA_IMAGE = (
     "registry.ci.openshift.org/ocp/release@"
     "sha256:d6329f1a221f0422294d41ce2a7bfe3f0d38a41ee3da99fea10e4288fab1efb6"
 )
+CCO_IMAGE = (
+    "quay.io/openshift-release-dev/ocp-v4.0-art-dev@"
+    "sha256:63f758322004b02afb4b12e3294db4d77ea370ca2b2d00ce8ca512b12c0df385"
+)
 
 # Podsecurity admission policies
 PSA_PRIVILEGED = "privileged"

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -30,10 +30,12 @@ def configure_cloud_credential_operator():
         pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         # W/A of the issue https://github.com/red-hat-storage/ocs-ci/issues/9674
         if version.get_semantic_ocp_version_from_config() == version.VERSION_4_16:
-            release_image = constants.OCP_4_16_CCOCTL_WA_IMAGE
+            # use direct cco image till issue https://github.com/red-hat-storage/ocs-ci/issues/9674 is fixed
+            cco_image = constants.CCO_IMAGE
         else:
             release_image = get_ocp_release_image_from_installer()
-        cco_image = get_cco_container_image(release_image, pull_secret_path)
+            cco_image = get_cco_container_image(release_image, pull_secret_path)
+
         extract_ccoctl_binary(cco_image, pull_secret_path)
 
 


### PR DESCRIPTION

Related W/A issue:
https://github.com/red-hat-storage/ocs-ci/issues/9674

Since OCP 4.16.0-0.nightly-2024-04-08-024331 is rotated out, use cco image directly

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)