### PR TITLE
Handle SIGTERM as SIGINT for first attempt

### DIFF
--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -19,6 +19,8 @@ kill_counter = 0
 
 def signal_term_handler(sig, frame):
     print(f"Got SIGTERM: {sig}")
+    if hasattr(framework.config, "RUN"):
+        framework.config.RUN["aborted"] = True
     global kill_counter
     if kill_counter:
         print("Second attempt to SIGTERM, exiting process with RC: 143")

--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import signal
 import sys
 import time
 
@@ -11,6 +12,25 @@ from ocs_ci import framework
 from ocs_ci.ocs.constants import OCP_VERSION_CONF_DIR, OCS_VERSION_CONF_DIR
 from ocs_ci.ocs.exceptions import MissingRequiredConfigKeyError
 from ocs_ci.utility import utils
+
+
+kill_counter = 0
+
+
+def signal_term_handler(sig, frame):
+    print(f"Got SIGTERM: {sig}")
+    global kill_counter
+    if kill_counter:
+        print("Second attempt to SIGTERM, exiting process with RC: 143")
+        sys.exit(143)
+    else:
+        pid = os.getpid()
+        print(f"Killing run-ci process {pid} with SIGINT to allow fixtures finalize!")
+        kill_counter += 1
+        os.kill(pid, signal.SIGINT)
+
+
+signal.signal(signal.SIGTERM, signal_term_handler)
 
 
 def check_config_requirements():

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1753,7 +1753,11 @@ def email_reports(session):
     [recipients.append(mailid) for mailid in mailids.split(",")]
     sender = "ocs-ci@redhat.com"
     msg = MIMEMultipart("alternative")
+    aborted_message = ""
+    if config.RUN.get("aborted"):
+        aborted_message = "[JOB ABORTED] "
     msg["Subject"] = (
+        f"{aborted_message}"
         f"ocs-ci results for {get_testrun_name()} "
         f"({build_str}"
         f"RUN ID: {config.RUN['run_id']}) "


### PR DESCRIPTION
In the Jenkins job, when it's aborted it's trying to SIGTERM with signal 15 which doesn't allow the pytest to finish gracefully.

With changing it to SIGINT, the pytest should attempt to finalize the fixtures and clean up the resources gracefully.