### PR TITLE
Appset deployment using pull model

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -40,7 +40,6 @@ from ocs_ci.ocs.cluster import (
     get_lvm_full_version,
     check_cephcluster_status,
 )
-from ocs_ci.ocs.constants import CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
     ChannelNotFound,
@@ -345,7 +344,9 @@ class Deployment(object):
             )
             for cluster in managed_clusters:
                 config.switch_to_cluster_by_name(cluster["metadata"]["name"])
-                run_cmd(f"oc create -f {CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}")
+                run_cmd(
+                    f"oc create -f {constants.CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}"
+                )
 
     def do_deploy_ocs(self):
         """

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -343,10 +343,11 @@ class Deployment(object):
                 "for appset pull model gitops deployment"
             )
             for cluster in managed_clusters:
-                config.switch_to_cluster_by_name(cluster["metadata"]["name"])
-                run_cmd(
-                    f"oc create -f {constants.CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}"
-                )
+                if cluster["metadata"]["name"] != constants.ACM_LOCAL_CLUSTER:
+                    config.switch_to_cluster_by_name(cluster["metadata"]["name"])
+                    run_cmd(
+                        f"oc create -f {constants.CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}"
+                    )
 
     def do_deploy_ocs(self):
         """

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -283,7 +283,7 @@ class Deployment(object):
         # Multicluster operations
         if config.multicluster:
             # Gitops operator is needed on all clusters for appset type workload deployment using pull model
-            for cluster_index in range(config.multicluster):
+            for cluster_index in range(config.nclusters):
                 config.switch_ctx(cluster_index)
                 self.deploy_gitops_operator()
 
@@ -343,7 +343,8 @@ class Deployment(object):
                 "Create clusterrolebinding on both the managed clusters needed "
                 "for appset pull model gitops deployment"
             )
-            for _ in managed_clusters:
+            for cluster in managed_clusters:
+                config.switch_to_cluster_by_name(cluster["metadata"]["name"])
                 run_cmd(f"oc create -f {CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}")
 
     def do_deploy_ocs(self):

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -339,7 +339,7 @@ class Deployment(object):
             gitops_obj.wait_for_phase("successful", timeout=720)
 
             logger.info(
-                "Create clusterrolebinding on both the managed clusters needed "
+                "Create clusterrolebinding on both the managed clusters, needed "
                 "for appset pull model gitops deployment"
             )
             for cluster in managed_clusters:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -282,8 +282,9 @@ class Deployment(object):
 
         # Multicluster operations
         if config.multicluster:
-            for _ in config.clusters:
-                # Gitops operator is needed on all clusters for appset type workload deployment using pull model
+            # Gitops operator is needed on all clusters for appset type workload deployment using pull model
+            for cluster_index in range(config.multicluster):
+                config.switch_ctx(cluster_index)
                 self.deploy_gitops_operator()
 
             # Switching back context to ACM as below configs are specific to hub cluster

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2455,6 +2455,9 @@ UI_INPUT_RULES_STORAGE_SYSTEM = {
 
 # DR
 DRPC_PATH = os.path.join(TEMPLATE_DIR, "DR", "drpc.yaml")
+CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH = os.path.join(
+    TEMPLATE_DIR, "DR", "clusterrolebinding_appset_pullmodel.yaml"
+)
 APPLICATION_SET = "ApplicationSet"
 PLACEMENT = "Placement"
 GITOPS_CLUSTER_NAMESPACE = "openshift-gitops"

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -361,6 +361,7 @@ class BusyBox_AppSet(DRWorkload):
                 app_set_yaml_data["spec"]["predicates"][0]["requiredClusterSelector"][
                     "labelSelector"
                 ]["matchExpressions"][0]["values"][0] = self.preferred_primary_cluster
+            elif app_set_yaml_data["kind"] == constants.APPLICATION_SET:
                 if self.appset_model == "pull":
                     # load appset_yaml_file
                     app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
@@ -375,6 +376,7 @@ class BusyBox_AppSet(DRWorkload):
                     app_set_yaml_data["spec"]["template"]["metadata"]["labels"][
                         1
                     ] = "apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'"
+
         log.info(app_set_yaml_data_list)
         templating.dump_data_to_temp_yaml(app_set_yaml_data_list, self.appset_yaml_file)
         config.switch_acm_ctx()

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -363,15 +363,16 @@ class BusyBox_AppSet(DRWorkload):
                 ]["matchExpressions"][0]["values"][0] = self.preferred_primary_cluster
                 if self.appset_model == "pull":
                     # load appset_yaml_file
-                    app_set_yaml_data["template"]["metadata"] = "annotations:"
-                    app_set_yaml_data["template"]["metadata"]["annotations:"][0] = (
+                    app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
+                        0
+                    ] = (
                         "apps.open-cluster-management.io/ocm"
                         "-managed-cluster: '{{name}}'"
                     )
-                    app_set_yaml_data["template"]["metadata"]["annotations:"][1] = (
-                        "argocd.argoproj.io/skip-reconcile: " "'true'"
-                    )
-                    app_set_yaml_data["template"]["metadata"]["labels"][
+                    app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
+                        1
+                    ] = "argocd.argoproj.io/skip-reconcile: 'true'"
+                    app_set_yaml_data["spec"]["template"]["metadata"]["labels"][
                         1
                     ] = "apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'"
         log.info(app_set_yaml_data_list)
@@ -445,6 +446,18 @@ class BusyBox_AppSet(DRWorkload):
         """
 
         self.check_pod_pvc_status(skip_replication_resources=False)
+
+        appset_resource_name = (
+            self._get_applicaionset_name() + self.preferred_primary_cluster
+        )
+
+        if self.appset_model == "pull":
+            appset_pull_obj = ocp.OCP(
+                kind=constants.APPLICATION_ARGOCD,
+                resource_name=appset_resource_name,
+                namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+            )
+            appset_pull_obj.wait_for_phase(phase="Succeeded", timeout=60)
 
     def check_pod_pvc_status(self, skip_replication_resources=False):
         """

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -6,6 +6,8 @@ This module will have all DR related workload classes
 import logging
 import os
 import tempfile
+import yaml
+
 from subprocess import TimeoutExpired
 from time import sleep
 
@@ -369,17 +371,17 @@ class BusyBox_AppSet(DRWorkload):
                     )
                     app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
                         "apps.open-cluster-management.io/ocm-managed-cluster"
-                    ] = "'{{name}}'"
+                    ] = "{{name}}"
                     app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
                         "argocd.argoproj.io/skip-reconcile"
-                    ] = "'true'"
+                    ] = "true"
 
                     # Assign values to the "labels" key
                     app_set_yaml_data["spec"]["template"]["metadata"]["labels"][
                         "apps.open-cluster-management.io/pull-to-ocm-managed-cluster"
-                    ] = "'true'"
+                    ] = "true"
 
-        log.info(app_set_yaml_data_list)
+        log.info(yaml.dump(app_set_yaml_data_list))
         templating.dump_data_to_temp_yaml(app_set_yaml_data_list, self.appset_yaml_file)
         config.switch_acm_ctx()
         run_cmd(f"oc create -f {self.appset_yaml_file}")

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -463,6 +463,7 @@ class BusyBox_AppSet(DRWorkload):
                 resource_name=appset_resource_name,
                 namespace=constants.GITOPS_CLUSTER_NAMESPACE,
             )
+            appset_pull_obj._has_phase = True
             appset_pull_obj.wait_for_phase(phase="Succeeded", timeout=120)
 
     def check_pod_pvc_status(self, skip_replication_resources=False):

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -454,7 +454,7 @@ class BusyBox_AppSet(DRWorkload):
         self.check_pod_pvc_status(skip_replication_resources=False)
 
         appset_resource_name = (
-            self._get_applicaionset_name() + self.preferred_primary_cluster
+            self._get_applicaionset_name() + "-" + self.preferred_primary_cluster
         )
 
         if self.appset_model == "pull":
@@ -463,7 +463,7 @@ class BusyBox_AppSet(DRWorkload):
                 resource_name=appset_resource_name,
                 namespace=constants.GITOPS_CLUSTER_NAMESPACE,
             )
-            appset_pull_obj.wait_for_phase(phase="Succeeded", timeout=60)
+            appset_pull_obj.wait_for_phase(phase="Succeeded", timeout=120)
 
     def check_pod_pvc_status(self, skip_replication_resources=False):
         """

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -363,19 +363,21 @@ class BusyBox_AppSet(DRWorkload):
                 ]["matchExpressions"][0]["values"][0] = self.preferred_primary_cluster
             elif app_set_yaml_data["kind"] == constants.APPLICATION_SET:
                 if self.appset_model == "pull":
-                    # load appset_yaml_file
-                    app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
-                        0
-                    ] = (
-                        "apps.open-cluster-management.io/ocm"
-                        "-managed-cluster: '{{name}}'"
+                    # load appset_yaml_file, add "annotations" key and add values to it
+                    app_set_yaml_data["spec"]["template"]["metadata"].setdefault(
+                        "annotations", {}
                     )
                     app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
-                        1
-                    ] = "argocd.argoproj.io/skip-reconcile: 'true'"
+                        "apps.open-cluster-management.io/ocm-managed-cluster"
+                    ] = "'{{name}}'"
+                    app_set_yaml_data["spec"]["template"]["metadata"]["annotations"][
+                        "argocd.argoproj.io/skip-reconcile"
+                    ] = "'true'"
+
+                    # Assign values to the "labels" key
                     app_set_yaml_data["spec"]["template"]["metadata"]["labels"][
-                        1
-                    ] = "apps.open-cluster-management.io/pull-to-ocm-managed-cluster: 'true'"
+                        "apps.open-cluster-management.io/pull-to-ocm-managed-cluster"
+                    ] = "'true'"
 
         log.info(app_set_yaml_data_list)
         templating.dump_data_to_temp_yaml(app_set_yaml_data_list, self.appset_yaml_file)

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1,6 +1,7 @@
 """
 General OCP object
 """
+
 import logging
 import os
 import re
@@ -1015,7 +1016,10 @@ class OCP(object):
             log.info(f"Cannot find resource object {self.resource_name}")
             return False
         try:
-            current_phase = data["status"]["phase"]
+            if self.kind == constants.APPLICATION_ARGOCD:
+                current_phase = data["status"]["operationState"]["phase"]
+            else:
+                current_phase = data["status"]["phase"]
             log.info(f"Resource {self.resource_name} is in phase: {current_phase}!")
             return current_phase == phase
         except KeyError:

--- a/ocs_ci/templates/DR/clusterrolebinding_appset_pullmodel.yaml
+++ b/ocs_ci/templates/DR/clusterrolebinding_appset_pullmodel.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6473,7 +6473,7 @@ def dr_workload(request):
     def factory(
         num_of_subscription=1,
         num_of_appset=0,
-        appset_model=None,
+        appset_model="pull",
         pvc_interface=constants.CEPHBLOCKPOOL,
         switch_ctx=None,
     ):
@@ -6484,8 +6484,8 @@ def dr_workload(request):
             pvc_interface (str): 'CephBlockPool' or 'CephFileSystem'.
                 This decides whether a RBD based or CephFS based resource is created. RBD is default.
             switch_ctx (int): The cluster index by the cluster name
-            appset_model (str): Appset Gitops deployment now supports "pull" model starting ACM 2.10 in addition
-                to default "push" model. Default value is set to None.
+            appset_model (str): Appset Gitops deployment now supports "pull" model starting ACM 2.10 which is now the
+                default selection in addition to "push" model.
 
         Raises:
             ResourceNotDeleted: In case workload resources not deleted properly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6473,6 +6473,7 @@ def dr_workload(request):
     def factory(
         num_of_subscription=1,
         num_of_appset=0,
+        appset_model=None,
         pvc_interface=constants.CEPHBLOCKPOOL,
         switch_ctx=None,
     ):
@@ -6483,6 +6484,8 @@ def dr_workload(request):
             pvc_interface (str): 'CephBlockPool' or 'CephFileSystem'.
                 This decides whether a RBD based or CephFS based resource is created. RBD is default.
             switch_ctx (int): The cluster index by the cluster name
+            appset_model (str): Appset Gitops deployment now supports "pull" model starting ACM 2.10 in addition
+                to default "push" model. Default value is set to None.
 
         Raises:
             ResourceNotDeleted: In case workload resources not deleted properly
@@ -6518,6 +6521,7 @@ def dr_workload(request):
                     "dr_workload_app_placement_name"
                 ],
                 workload_pvc_selector=workload_details["dr_workload_app_pvc_selector"],
+                appset_model=appset_model,
             )
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -54,27 +54,27 @@ class TestFailoverAndRelocate:
     @pytest.mark.parametrize(
         argnames=["workload_type", "primary_cluster_down", "appset_model"],
         argvalues=[
-            pytest.param(
-                constants.SUBSCRIPTION,
-                False,
-                None,
-                marks=pytest.mark.polarion_id(polarion_id_primary_up),
-                id="primary_up_subscription",
-            ),
-            pytest.param(
-                constants.SUBSCRIPTION,
-                True,
-                None,
-                marks=pytest.mark.polarion_id(polarion_id_primary_down),
-                id="primary_down_subscription",
-            ),
-            pytest.param(
-                constants.APPLICATION_SET,
-                False,
-                "push",
-                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
-                id="primary_up_appset",
-            ),
+            # pytest.param(
+            #     constants.SUBSCRIPTION,
+            #     False,
+            #     None,
+            #     marks=pytest.mark.polarion_id(polarion_id_primary_up),
+            #     id="primary_up_subscription",
+            # ),
+            # pytest.param(
+            #     constants.SUBSCRIPTION,
+            #     True,
+            #     None,
+            #     marks=pytest.mark.polarion_id(polarion_id_primary_down),
+            #     id="primary_down_subscription",
+            # ),
+            # pytest.param(
+            #     constants.APPLICATION_SET,
+            #     False,
+            #     "push",
+            #     marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
+            #     id="primary_up_appset",
+            # ),
             pytest.param(
                 constants.APPLICATION_SET,
                 False,
@@ -85,13 +85,13 @@ class TestFailoverAndRelocate:
                 ],
                 id="primary_up_appset",
             ),
-            pytest.param(
-                constants.APPLICATION_SET,
-                True,
-                "push",
-                marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
-                id="primary_down_appset",
-            ),
+            # pytest.param(
+            #     constants.APPLICATION_SET,
+            #     True,
+            #     "push",
+            #     marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
+            #     id="primary_down_appset",
+            # ),
             pytest.param(
                 constants.APPLICATION_SET,
                 True,

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -73,7 +73,7 @@ class TestFailoverAndRelocate:
             #     False,
             #     "push",
             #     marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
-            #     id="primary_up_appset",
+            #     id="primary_up_appset_push",
             # ),
             pytest.param(
                 constants.APPLICATION_SET,
@@ -83,14 +83,14 @@ class TestFailoverAndRelocate:
                     pytest.mark.polarion_id(polarion_id_primary_up_appset_pull),
                     skipif_ocs_version("<4.16"),
                 ],
-                id="primary_up_appset",
+                id="primary_up_appset_pull",
             ),
             # pytest.param(
             #     constants.APPLICATION_SET,
             #     True,
             #     "push",
             #     marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
-            #     id="primary_down_appset",
+            #     id="primary_down_appset_push",
             # ),
             # pytest.param(
             #     constants.APPLICATION_SET,
@@ -100,7 +100,7 @@ class TestFailoverAndRelocate:
             #         pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
             #         skipif_ocs_version("<4.16"),
             #     ],
-            #     id="primary_down_appset",
+            #     id="primary_down_appset_pull",
             # ),
         ],
     )
@@ -157,9 +157,9 @@ class TestFailoverAndRelocate:
         scheduling_interval = dr_helpers.get_scheduling_interval(
             rdr_workload.workload_namespace, workload_type
         )
-        wait_time = 2 * scheduling_interval  # Time in minutes
+        wait_time = scheduling_interval  # Time in minutes
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
-        sleep(wait_time * 60)
+        sleep(wait_time)
 
         # Set cluster_kubeconfig value for 'drpc_obj' object to fetch the details without switching the cluster context
         acm_cluster_kubeconfig = os.path.join(
@@ -252,11 +252,11 @@ class TestFailoverAndRelocate:
             logger.info(
                 f"Waiting for {wait_time} minutes before starting nodes of primary cluster: {primary_cluster_name}"
             )
-            sleep(wait_time * 60)
+            sleep(wait_time)
             nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
             wait_for_nodes_status([node.name for node in primary_cluster_nodes])
             logger.info("Wait for 180 seconds for pods to stabilize")
-            sleep(180)
+            sleep(60)
             logger.info(
                 "Wait for all the pods in openshift-storage to be in running state"
             )

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -29,6 +29,9 @@ polarion_id_primary_up = "OCS-4430"
 polarion_id_primary_down = "OCS-4427"
 polarion_id_primary_down_appset = "OCS-5009"
 polarion_id_primary_up_appset = "OCS-5010"
+polarion_id_primary_up_appset_pull = None
+polarion_id_primary_down_appset_pull = None
+
 
 if config.RUN.get("rdr_failover_via_ui"):
     polarion_id_primary_down = "OCS-4744"
@@ -46,30 +49,48 @@ class TestFailoverAndRelocate:
     """
 
     @pytest.mark.parametrize(
-        argnames=["workload_type", "primary_cluster_down"],
+        argnames=["workload_type", "primary_cluster_down", "appset_model"],
         argvalues=[
             pytest.param(
                 constants.SUBSCRIPTION,
                 False,
+                "none",
                 marks=pytest.mark.polarion_id(polarion_id_primary_up),
                 id="primary_up_subscription",
             ),
             pytest.param(
                 constants.SUBSCRIPTION,
                 True,
+                "none",
                 marks=pytest.mark.polarion_id(polarion_id_primary_down),
                 id="primary_down_subscription",
             ),
             pytest.param(
                 constants.APPLICATION_SET,
                 False,
+                "push",
                 marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
                 id="primary_up_appset",
             ),
             pytest.param(
                 constants.APPLICATION_SET,
+                False,
+                "pull",
+                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset_pull),
+                id="primary_up_appset",
+            ),
+            pytest.param(
+                constants.APPLICATION_SET,
                 True,
+                "push",
                 marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
+                id="primary_down_appset",
+            ),
+            pytest.param(
+                constants.APPLICATION_SET,
+                True,
+                "pull",
+                marks=pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
                 id="primary_down_appset",
             ),
         ],
@@ -80,6 +101,7 @@ class TestFailoverAndRelocate:
         setup_acm_ui,
         dr_workload,
         workload_type,
+        appset_model,
         nodes_multicluster,
         node_restart_teardown,
     ):
@@ -95,6 +117,8 @@ class TestFailoverAndRelocate:
         pass the yaml conf/ocsci/dr_ui.yaml to trigger it.
         The value of lastGroupSyncTime is verified in each stage.
 
+        appset_model pull type was introduced with ACM 2.10 and would be supported with ODF 4.16 and above
+
         """
         if config.RUN.get("rdr_failover_via_ui"):
             acm_obj = AcmAddClusters()
@@ -103,7 +127,9 @@ class TestFailoverAndRelocate:
             rdr_workload = dr_workload(num_of_subscription=1)[0]
             drpc_obj = DRPC(namespace=rdr_workload.workload_namespace)
         else:
-            rdr_workload = dr_workload(num_of_subscription=0, num_of_appset=1)[0]
+            rdr_workload = dr_workload(
+                num_of_subscription=0, num_of_appset=1, appset_model=appset_model
+            )[0]
             drpc_obj = DRPC(
                 namespace=constants.GITOPS_CLUSTER_NAMESPACE,
                 resource_name=f"{rdr_workload.appset_placement_name}-drpc",
@@ -195,9 +221,11 @@ class TestFailoverAndRelocate:
                 secondary_cluster_name,
                 rdr_workload.workload_namespace,
                 workload_type,
-                rdr_workload.appset_placement_name
-                if workload_type != constants.SUBSCRIPTION
-                else None,
+                (
+                    rdr_workload.appset_placement_name
+                    if workload_type != constants.SUBSCRIPTION
+                    else None
+                ),
             )
 
         # Verify resources creation on secondary cluster (failoverCluster)
@@ -301,9 +329,11 @@ class TestFailoverAndRelocate:
                 primary_cluster_name,
                 rdr_workload.workload_namespace,
                 workload_type,
-                rdr_workload.appset_placement_name
-                if workload_type != constants.SUBSCRIPTION
-                else None,
+                (
+                    rdr_workload.appset_placement_name
+                    if workload_type != constants.SUBSCRIPTION
+                    else None
+                ),
             )
 
         # Verify resources deletion from secondary cluster

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.ocs.utils import get_active_acm_index
-from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
+from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler, skipif_ocs_version
 
 logger = logging.getLogger(__name__)
 
@@ -54,14 +54,14 @@ class TestFailoverAndRelocate:
             pytest.param(
                 constants.SUBSCRIPTION,
                 False,
-                "none",
+                None,
                 marks=pytest.mark.polarion_id(polarion_id_primary_up),
                 id="primary_up_subscription",
             ),
             pytest.param(
                 constants.SUBSCRIPTION,
                 True,
-                "none",
+                None,
                 marks=pytest.mark.polarion_id(polarion_id_primary_down),
                 id="primary_down_subscription",
             ),
@@ -76,7 +76,10 @@ class TestFailoverAndRelocate:
                 constants.APPLICATION_SET,
                 False,
                 "pull",
-                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset_pull),
+                marks=[
+                    pytest.mark.polarion_id(polarion_id_primary_up_appset_pull),
+                    skipif_ocs_version("<4.16"),
+                ],
                 id="primary_up_appset",
             ),
             pytest.param(
@@ -90,7 +93,10 @@ class TestFailoverAndRelocate:
                 constants.APPLICATION_SET,
                 True,
                 "pull",
-                marks=pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
+                marks=[
+                    pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
+                    skipif_ocs_version("<4.16"),
+                ],
                 id="primary_down_appset",
             ),
         ],

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -68,13 +68,13 @@ class TestFailoverAndRelocate:
             #     marks=pytest.mark.polarion_id(polarion_id_primary_down),
             #     id="primary_down_subscription",
             # ),
-            pytest.param(
-                constants.APPLICATION_SET,
-                False,
-                "push",
-                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
-                id="primary_up_appset",
-            ),
+            # pytest.param(
+            #     constants.APPLICATION_SET,
+            #     False,
+            #     "push",
+            #     marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
+            #     id="primary_up_appset",
+            # ),
             pytest.param(
                 constants.APPLICATION_SET,
                 False,
@@ -92,16 +92,16 @@ class TestFailoverAndRelocate:
             #     marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
             #     id="primary_down_appset",
             # ),
-            pytest.param(
-                constants.APPLICATION_SET,
-                True,
-                "pull",
-                marks=[
-                    pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
-                    skipif_ocs_version("<4.16"),
-                ],
-                id="primary_down_appset",
-            ),
+            # pytest.param(
+            #     constants.APPLICATION_SET,
+            #     True,
+            #     "pull",
+            #     marks=[
+            #         pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
+            #         skipif_ocs_version("<4.16"),
+            #     ],
+            #     id="primary_down_appset",
+            # ),
         ],
     )
     def test_failover_and_relocate(

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -68,13 +68,13 @@ class TestFailoverAndRelocate:
             #     marks=pytest.mark.polarion_id(polarion_id_primary_down),
             #     id="primary_down_subscription",
             # ),
-            # pytest.param(
-            #     constants.APPLICATION_SET,
-            #     False,
-            #     "push",
-            #     marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
-            #     id="primary_up_appset",
-            # ),
+            pytest.param(
+                constants.APPLICATION_SET,
+                False,
+                "push",
+                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
+                id="primary_up_appset",
+            ),
             pytest.param(
                 constants.APPLICATION_SET,
                 False,

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -6,7 +6,10 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    turquoise_squad,
+    skipif_ocs_version,
+)
 from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.dr_helpers_ui import (
@@ -21,7 +24,7 @@ from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.ocs.utils import get_active_acm_index
-from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler, skipif_ocs_version
+from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 
 logger = logging.getLogger(__name__)
 

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -54,27 +54,27 @@ class TestFailoverAndRelocate:
     @pytest.mark.parametrize(
         argnames=["workload_type", "primary_cluster_down", "appset_model"],
         argvalues=[
-            # pytest.param(
-            #     constants.SUBSCRIPTION,
-            #     False,
-            #     None,
-            #     marks=pytest.mark.polarion_id(polarion_id_primary_up),
-            #     id="primary_up_subscription",
-            # ),
-            # pytest.param(
-            #     constants.SUBSCRIPTION,
-            #     True,
-            #     None,
-            #     marks=pytest.mark.polarion_id(polarion_id_primary_down),
-            #     id="primary_down_subscription",
-            # ),
-            # pytest.param(
-            #     constants.APPLICATION_SET,
-            #     False,
-            #     "push",
-            #     marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
-            #     id="primary_up_appset_push",
-            # ),
+            pytest.param(
+                constants.SUBSCRIPTION,
+                False,
+                None,
+                marks=pytest.mark.polarion_id(polarion_id_primary_up),
+                id="primary_up_subscription",
+            ),
+            pytest.param(
+                constants.SUBSCRIPTION,
+                True,
+                None,
+                marks=pytest.mark.polarion_id(polarion_id_primary_down),
+                id="primary_down_subscription",
+            ),
+            pytest.param(
+                constants.APPLICATION_SET,
+                False,
+                "push",
+                marks=pytest.mark.polarion_id(polarion_id_primary_up_appset),
+                id="primary_up_appset_push",
+            ),
             pytest.param(
                 constants.APPLICATION_SET,
                 False,
@@ -85,23 +85,23 @@ class TestFailoverAndRelocate:
                 ],
                 id="primary_up_appset_pull",
             ),
-            # pytest.param(
-            #     constants.APPLICATION_SET,
-            #     True,
-            #     "push",
-            #     marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
-            #     id="primary_down_appset_push",
-            # ),
-            # pytest.param(
-            #     constants.APPLICATION_SET,
-            #     True,
-            #     "pull",
-            #     marks=[
-            #         pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
-            #         skipif_ocs_version("<4.16"),
-            #     ],
-            #     id="primary_down_appset_pull",
-            # ),
+            pytest.param(
+                constants.APPLICATION_SET,
+                True,
+                "push",
+                marks=pytest.mark.polarion_id(polarion_id_primary_down_appset),
+                id="primary_down_appset_push",
+            ),
+            pytest.param(
+                constants.APPLICATION_SET,
+                True,
+                "pull",
+                marks=[
+                    pytest.mark.polarion_id(polarion_id_primary_down_appset_pull),
+                    skipif_ocs_version("<4.16"),
+                ],
+                id="primary_down_appset_pull",
+            ),
         ],
     )
     def test_failover_and_relocate(
@@ -157,9 +157,9 @@ class TestFailoverAndRelocate:
         scheduling_interval = dr_helpers.get_scheduling_interval(
             rdr_workload.workload_namespace, workload_type
         )
-        wait_time = scheduling_interval  # Time in minutes
+        wait_time = 2 * scheduling_interval  # Time in minutes
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
-        sleep(wait_time)
+        sleep(wait_time * 60)
 
         # Set cluster_kubeconfig value for 'drpc_obj' object to fetch the details without switching the cluster context
         acm_cluster_kubeconfig = os.path.join(
@@ -252,11 +252,11 @@ class TestFailoverAndRelocate:
             logger.info(
                 f"Waiting for {wait_time} minutes before starting nodes of primary cluster: {primary_cluster_name}"
             )
-            sleep(wait_time)
+            sleep(wait_time * 60)
             nodes_multicluster[primary_cluster_index].start_nodes(primary_cluster_nodes)
             wait_for_nodes_status([node.name for node in primary_cluster_nodes])
             logger.info("Wait for 180 seconds for pods to stabilize")
-            sleep(60)
+            sleep(180)
             logger.info(
                 "Wait for all the pods in openshift-storage to be in running state"
             )


### PR DESCRIPTION
Starting ACM 2.10, appset gitops provides an option to choose between pull and push model, where push model was default so far. Starting ODF 4.16, we would recommend and switch to using pull model with ACM 2.10 and above versions.