### PR TITLE
make sure flexy working directory is writable by group

### DIFF
--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -463,6 +463,9 @@ class FlexyBase(object):
             f"sudo chown -R {constants.FLEXY_USER_LOCAL_UID} {self.flexy_host_dir}"
         )
         exec_cmd(chown_cmd)
+        # make sure that flexy_host_dir is writable by group
+        chmod_cmd = f"sudo chmod g+w {self.flexy_host_dir}"
+        exec_cmd(chmod_cmd)
 
     def flexy_backup_work_dir(self):
         """


### PR DESCRIPTION
This should fix following issue:
```
01:53:21 - MainThread - ocs_ci.utility.utils - INFO  - Cloning repository into /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/flexy-dir/flexy-ocs-private
01:53:21 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: git clone --depth=1 https://git-repository-url/flexy-ocs-private.git /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/flexy-dir/flexy-ocs-private
01:53:21 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: fatal: could not create work tree dir '/home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/flexy-dir/flexy-ocs-private': Permission denied

01:53:21 - MainThread - ocs_ci.deployment.deployment - ERROR  - Error during execution of command: git clone --depth=1 https://git-repository-url/flexy-ocs-private.git /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/flexy-dir/flexy-ocs-private.
Error is fatal: could not create work tree dir '/home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/flexy-dir/flexy-ocs-private': Permission denied
```

https://url.corp.redhat.com/3a34122
