### PR TITLE
Select default storageclass in provider-client cluster

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -665,6 +665,10 @@ def default_storage_class(
         else:
             if external:
                 resource_name = constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD
+            elif config.ENV_DATA["platform"].lower() in constants.HCI_PC_OR_MS_PLATFORM:
+                storage_class = OCP(kind="storageclass")
+                # TODO: Select besed on storageclient name or namespace in case of multiple storageclients in a cluster
+                resource_name = [sc_data["metadata"]["name"] for sc_data in storage_class.get()["items"] if sc_data["provisioner"] == constants.RBD_PROVISIONER][0]
             else:
                 resource_name = constants.DEFAULT_STORAGECLASS_RBD
     elif interface_type == constants.CEPHFILESYSTEM:
@@ -678,6 +682,10 @@ def default_storage_class(
         else:
             if external:
                 resource_name = constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_CEPHFS
+            elif config.ENV_DATA["platform"].lower() in constants.HCI_PC_OR_MS_PLATFORM:
+                storage_class = OCP(kind="storageclass")
+                # TODO: Select besed on storageclient name or namespace in case of multiple storageclients in a cluster
+                resource_name = [sc_data["metadata"]["name"] for sc_data in storage_class.get()["items"] if sc_data["provisioner"] == constants.CEPHFS_PROVISIONER][0]
             else:
                 resource_name = constants.DEFAULT_STORAGECLASS_CEPHFS
     base_sc = OCP(kind="storageclass", resource_name=resource_name)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1662,6 +1662,7 @@ OCS_PROVISIONERS = [
     "openshift-storage-client.cephfs.csi.ceph.com",
 ]
 RBD_PROVISIONER = "openshift-storage.rbd.csi.ceph.com"
+CEPHFS_PROVISIONER = "openshift-storage.cephfs.csi.ceph.com"
 
 # Bucket Policy action lists
 bucket_website_action_list = ["PutBucketWebsite", "GetBucketWebsite", "PutObject"]


### PR DESCRIPTION
In client cluster, the name of the storageclass is not the default one. This PR is to select the correct storageclass in provider-client configurations.