### PR TITLE
Test resize OSD when one of the worker nodes got restarted or one of the resources got deleted in the middle of the process

### DIFF
--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import random
 
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants, ocp
@@ -267,3 +268,24 @@ class Disruptions:
             raise TimeoutExpiredError(
                 f"Waiting for pid of ceph-{self.resource} in {node_name}"
             )
+
+
+def delete_resource_multiple_times(resource_name, num_of_iterations):
+    """
+    Delete a specific resource(osd, rook-operator, mon, etc,.) multiple times.
+
+    Args:
+        resource_name (str): The resource name to delete
+        num_of_iterations (int): The number of iterations we delete the resource
+
+    """
+    d = Disruptions()
+    d.set_resource(resource_name)
+    resource_id = random.randrange(d.resource_count)
+
+    for i in range(num_of_iterations):
+        log.info(
+            f"Iteration {i}: Delete resource {resource_name} with id {resource_id}"
+        )
+        d.set_resource(resource_name)
+        d.delete_resource(resource_id)

--- a/ocs_ci/helpers/osd_resize.py
+++ b/ocs_ci/helpers/osd_resize.py
@@ -20,6 +20,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
     verify_storage_device_class,
     verify_device_class_in_osd_tree,
     get_deviceset_count,
+    resize_osd,
 )
 from ocs_ci.ocs.cluster import check_ceph_osd_tree, CephCluster
 from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler, convert_device_size
@@ -374,3 +375,23 @@ def update_resize_osd_count(old_storage_size):
         config.RUN["resize_osd_count"] = config.RUN.get("resize_osd_count", 0) + 1
     else:
         logger.warning("The osd size has not increased")
+
+
+def basic_resize_osd(old_storage_size):
+    """
+    The function perform the basic resize osd scenario. It increases the osd size by multiply 2
+
+    Args:
+        old_storage_size (str): The old storagecluster storage size(which represent the old osd size)
+
+    Returns:
+        str: The new storage size after increasing the osd size
+
+    """
+    logger.info(f"The current osd size is {old_storage_size}")
+    size = int(old_storage_size[0:-2])
+    size_type = old_storage_size[-2:]
+    new_storage_size = f"{size * 2}{size_type}"
+    logger.info(f"Increase the osd size to {new_storage_size}")
+    resize_osd(new_storage_size)
+    return new_storage_size


### PR DESCRIPTION
The PR implements two small test cases as described in the [OSD resize test plan](https://docs.google.com/spreadsheets/d/1wCSwMk_L4SikzZ2UarUH1-VCXyGkHs-ZNdDEtWPG7f4/edit#gid=105186681):
1. Test resize OSD when one of the worker nodes got restarted in the middle of the process.
2. Test resize OSD when one of the resources got deleted in the middle of the process.