### PR TITLE
Use full api path for subscription for CNV workload

### DIFF
--- a/ocs_ci/deployment/cnv.py
+++ b/ocs_ci/deployment/cnv.py
@@ -128,7 +128,7 @@ class CNVInstaller(object):
         logger.info("Creating subscription for CNV operator")
         run_cmd(f"oc create -f {cnv_subscription_manifest.name}")
         self.wait_for_the_resource_to_discover(
-            kind=constants.SUBSCRIPTION,
+            kind=constants.SUBSCRIPTION_WITH_ACM,
             namespace=self.namespace,
             resource_name=constants.KUBEVIRT_HYPERCONVERGED,
         )


### PR DESCRIPTION
Need for creating this PR is that when we choose cluster for DR then there are 2 diff subscription api ie `subscriptions.apps.open-cluster-management.io` and `subscriptions.operators.coreos.com` so it's better to use full api path