### PR TITLE
Test for feature of cleanup of stale subvolumes

### DIFF
--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -1,0 +1,33 @@
+import logging
+
+from ocs_ci.framework.testlib import (
+    skipif_ocs_version,
+    ManageTest,
+    tier1,
+    acceptance,
+)
+from ocs_ci.helpers.helpers import retrieve_cli_binary
+from ocs_ci.utility.utils import run_cmd
+
+logger = logging.getLogger(__name__)
+
+
+@tier1
+@acceptance
+class TestSubvolumesCommand(ManageTest):
+    @skipif_ocs_version("<4.15")
+    def test_pvc_stale_volume_cleanup_cli(self):
+        """
+        1. Create a new PVC with Retain strategy.
+        2. Delete the PVC
+        3. Check for stale volumes
+        4. Run the odf cli.
+        5. Check for stale volumes
+        6. No stale volumes should be present of the deleted PVC.
+        """
+        retrieve_cli_binary(cli_type="odf")
+        inital_subvolume_list = run_cmd(
+            cmd="odf subvolume ls",
+        )
+        logger.info(f"{inital_subvolume_list=}")
+        logger.info("I am here")

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     acceptance,
 )
+from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import retrieve_cli_binary
 from ocs_ci.utility.utils import run_cmd
 
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 @acceptance
 class TestSubvolumesCommand(ManageTest):
     @skipif_ocs_version("<4.15")
-    def test_pvc_stale_volume_cleanup_cli(self):
+    def test_pvc_stale_volume_cleanup_cli(self, storageclass_factory, pvc_factory):
         """
         1. Create a new PVC with Retain strategy.
         2. Delete the PVC
@@ -26,8 +27,43 @@ class TestSubvolumesCommand(ManageTest):
         6. No stale volumes should be present of the deleted PVC.
         """
         retrieve_cli_binary(cli_type="odf")
-        inital_subvolume_list = run_cmd(
-            cmd="odf subvolume ls",
-        )
+        output = run_cmd(cmd="odf subvolume ls")
+        inital_subvolume_list = self.parse_subvolume_ls_output(output)
         logger.info(f"{inital_subvolume_list=}")
-        logger.info("I am here")
+        cephfs_sc_obj = storageclass_factory(
+            interface=constants.CEPHFILESYSTEM,
+            reclaim_policy=constants.RECLAIM_POLICY_RETAIN,
+        )
+        pvc_obj = pvc_factory(
+            storageclass=cephfs_sc_obj,
+            interface=constants.CEPHFILESYSTEM,
+            size=3,
+            access_mode=constants.ACCESS_MODE_RWX,
+            status=constants.STATUS_BOUND,
+        )
+        output = run_cmd(cmd="odf subvolume ls")
+        later_subvolume_list = self.parse_subvolume_ls_output(output)
+        old = set(inital_subvolume_list)
+        new = set(later_subvolume_list)
+        new_pvc = list(new.difference(old))[0]
+        logger.info(f"{new_pvc=}")
+
+        # Deleteting PVC and SC
+        cephfs_sc_obj.delete()
+        pvc_obj.delete()
+
+        # Deleteing stale subvolume
+        run_cmd(cmd=f"odf subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}")
+
+        # Checking for stale volumes
+        output = run_cmd(cmd="odf subvolume ls --stale")
+        stale_volumes = self.parse_subvolume_ls_output(output)
+        assert len(stale_volumes) == 0  # No stale volumes available
+
+    def parse_subvolume_ls_output(self, output):
+        subvolumes = []
+        subvolumes_list = output.strip().split("\n")[1:]
+        for item in subvolumes_list:
+            fs, sv, svg, status = item.split(" ")
+            subvolumes.append((fs, sv, svg, status))
+        return subvolumes

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -34,7 +34,7 @@ class TestSubvolumesCommand(ManageTest):
 
         if not Path(constants.CLI_TOOL_LOCAL_PATH).exists():
             retrieve_cli_binary(cli_type="odf")
-        output = run_cmd(cmd="odf subvolume ls")
+        output = run_cmd(cmd="odf-cli subvolume ls")
         inital_subvolume_list = self.parse_subvolume_ls_output(output)
         logger.info(f"{inital_subvolume_list=}")
         cephfs_sc_obj = storageclass_factory(
@@ -48,7 +48,7 @@ class TestSubvolumesCommand(ManageTest):
             access_mode=constants.ACCESS_MODE_RWX,
             status=constants.STATUS_BOUND,
         )
-        output = run_cmd(cmd="odf subvolume ls")
+        output = run_cmd(cmd="odf-cli subvolume ls")
         later_subvolume_list = self.parse_subvolume_ls_output(output)
         old = set(inital_subvolume_list)
         new = set(later_subvolume_list)
@@ -60,10 +60,10 @@ class TestSubvolumesCommand(ManageTest):
         pvc_obj.delete()
 
         # Deleteing stale subvolume
-        run_cmd(cmd=f"odf subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}")
+        run_cmd(cmd=f"odf-cli subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}")
 
         # Checking for stale volumes
-        output = run_cmd(cmd="odf subvolume ls --stale")
+        output = run_cmd(cmd="odf-cli subvolume ls --stale")
         stale_volumes = self.parse_subvolume_ls_output(output)
         assert len(stale_volumes) == 0  # No stale volumes available
 

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import retrieve_cli_binary
 from ocs_ci.utility.utils import run_cmd
+from ocs_ci.framework.testlib import ignore_leftovers
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 @acceptance
 class TestSubvolumesCommand(ManageTest):
     @skipif_ocs_version("<4.15")
+    @ignore_leftovers
     def test_pvc_stale_volume_cleanup_cli(self, storageclass_factory, pvc_factory):
         """
         1. Create a new PVC with Retain strategy.

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -30,7 +30,10 @@ class TestSubvolumesCommand(ManageTest):
         5. Check for stale volumes
         6. No stale volumes should be present of the deleted PVC.
         """
-        retrieve_cli_binary(cli_type="odf")
+        from pathlib import Path
+
+        if not Path(constants.CLI_TOOL_LOCAL_PATH).exists():
+            retrieve_cli_binary(cli_type="odf")
         output = run_cmd(cmd="odf subvolume ls")
         inital_subvolume_list = self.parse_subvolume_ls_output(output)
         logger.info(f"{inital_subvolume_list=}")

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
     acceptance,
+    green_squad,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import retrieve_cli_binary
@@ -16,9 +17,10 @@ logger = logging.getLogger(__name__)
 
 @tier1
 @acceptance
+@ignore_leftovers
+@green_squad
 class TestSubvolumesCommand(ManageTest):
     @skipif_ocs_version("<4.15")
-    @ignore_leftovers
     def test_pvc_stale_volume_cleanup_cli(self, storageclass_factory, pvc_factory):
         """
         1. Create a new PVC with Retain strategy.


### PR DESCRIPTION
Feature link: https://issues.redhat.com/browse/RHSTOR-5150

Test will deploy a ODF cluster (this feature is only available for version > 4.16)

1. Create Storage class with retain policy
2. Create PVC with the same storage class
3. Check of subvolumes
4. Delete the PVC
5. Check for subvolume, you will see a  stale subvolume
6. Delete the subvolume using odf-cli