### PR TITLE
[RDR] Bumps ACM and Submariner versions for OCP 4.16

### DIFF
--- a/conf/examples/acm_hub_unreleased_image.yaml
+++ b/conf/examples/acm_hub_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  acm_unreleased_image: "2.10.0-DOWNSTREAM-2024-02-28-06-06-55"
+  acm_unreleased_image: "2.11.0-DOWNSTREAM-2024-05-16-05-38-44"

--- a/conf/examples/acm_hub_unreleased_image.yaml
+++ b/conf/examples/acm_hub_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  acm_unreleased_image: "2.11.0-DOWNSTREAM-2024-05-16-05-38-44"
+  acm_unreleased_image: "2.11.0-DOWNSTREAM-2024-05-09-04-23-50"

--- a/conf/examples/submariner_unreleased_image.yaml
+++ b/conf/examples/submariner_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  submariner_unreleased_image: "680159"
+  submariner_unreleased_image: "722673"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.16-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.16-config.yaml
@@ -11,6 +11,6 @@ DEPLOYMENT:
 ENV_DATA:
   # TODO: replace with 4.16 once template is available
   vm_template: "rhcos-416.94.202403071059-0-vmware.x86_64"
-  acm_hub_channel: release-2.10
-  acm_version: "2.10"
-  submariner_version: "0.17.0"
+  acm_hub_channel: release-2.11
+  acm_version: "2.11"
+  submariner_version: "0.18.0"


### PR DESCRIPTION
Update ACM version to 2.11 and Submariner version to 0.18.0 for OCP 4.16