### PR TITLE
[RDR] Fix Functional Test: Typo in check_subctl_cli Fixture

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -30,7 +30,7 @@ def pytest_collection_modifyitems(items):
 @pytest.fixture(autouse=True)
 def check_subctl_cli():
     # Check whether subctl cli is present
-    if config.MULTICLUSER.get("multicluster_mode") != constants.RDR_MODE:
+    if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         return
     try:
         run_cmd("./bin/subctl")


### PR DESCRIPTION
Fixes: #9809 

This pull request fixes a typo in the check_subctl_cli fixture located in tests/functional/disaster-recovery/regional-dr/conftest.py.
The typo caused an AttributeError in functional tests due to a misspelling of the attribute name MULTICLUSER (should be MULTICLUSTER).

