### PR TITLE
Add changes for toleration of toolbox pod

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2543,8 +2543,8 @@ def check_toleration_on_pods(toleration_key=constants.TOLERATION_KEY):
         selector=[constants.TOOL_APP_LABEL],
         exclude_selector=True,
     )
-    flag = False
     for pod_obj in pod_objs:
+        flag = False
         resource_name = pod_obj.name
         tolerations = pod_obj.get().get("spec").get("tolerations")
         for key in tolerations:

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -32,7 +32,6 @@ from ocs_ci.utility import version
 from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     brown_squad,
-    skipif_ocs_version,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 
@@ -75,7 +74,6 @@ class TestNonOCSTaintAndTolerations(E2ETest):
 
         request.addfinalizer(finalizer)
 
-    @skipif_ocs_version(">4.15")
     def test_non_ocs_taint_and_tolerations(self):
         """
         Test runs the following steps

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -144,22 +144,6 @@ class TestNonOCSTaintAndTolerations(E2ETest):
             logger.info(f"Successfully added toleration to {sub}")
 
         if not config.ENV_DATA["mcg_only_deployment"]:
-            if version.get_semantic_ocs_version_from_config() < version.VERSION_4_15:
-                logger.info(
-                    "Add tolerations to the ocsinitializations.ocs.openshift.io"
-                )
-                param = (
-                    '{"spec":  {"tolerations": '
-                    '[{"effect": "NoSchedule", "key": "xyz", "operator": "Equal", '
-                    '"value": "true"}]}}'
-                )
-                ocsini_obj = ocp.OCP(
-                    resource_name=constants.OCSINIT,
-                    namespace=config.ENV_DATA["cluster_namespace"],
-                    kind=constants.OCSINITIALIZATION,
-                )
-                ocsini_obj.patch(params=param, format_type="merge")
-                logger.info(f"Successfully added toleration to {ocsini_obj.kind}")
             logger.info("Add tolerations to the configmap rook-ceph-operator-config")
             configmap_obj = ocp.OCP(
                 kind=constants.CONFIGMAP,

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -28,7 +28,12 @@ from ocs_ci.ocs.node import (
     get_worker_nodes,
 )
 from ocs_ci.ocs.resources import storage_cluster
-from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
+from ocs_ci.utility import version
+from ocs_ci.framework.pytest_customization.marks import (
+    bugzilla,
+    brown_squad,
+    skipif_ocs_version,
+)
 from ocs_ci.helpers.sanity_helpers import Sanity
 
 logger = logging.getLogger(__name__)
@@ -70,6 +75,7 @@ class TestNonOCSTaintAndTolerations(E2ETest):
 
         request.addfinalizer(finalizer)
 
+    @skipif_ocs_version(">4.15")
     def test_non_ocs_taint_and_tolerations(self):
         """
         Test runs the following steps
@@ -114,10 +120,12 @@ class TestNonOCSTaintAndTolerations(E2ETest):
             )
         else:
             param = (
-                f'{{"spec": {{"placement": {{"all": {tolerations}, "mds": {tolerations}, '
-                f'"noobaa-core": {tolerations}, "rgw": {tolerations}}}}}}}'
+                f'"all": {tolerations}, "mds": {tolerations}, '
+                f'"noobaa-core": {tolerations}, "rgw": {tolerations}, '
             )
-
+            if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_15:
+                param += f'"toolbox": {tolerations}'
+            param = f'{{"spec": {{"placement": {{{param}}}}}}}'
         storagecluster_obj.patch(params=param, format_type="merge")
         logger.info(f"Successfully added toleration to {storagecluster_obj.kind}")
 
@@ -138,20 +146,22 @@ class TestNonOCSTaintAndTolerations(E2ETest):
             logger.info(f"Successfully added toleration to {sub}")
 
         if not config.ENV_DATA["mcg_only_deployment"]:
-            logger.info("Add tolerations to the ocsinitializations.ocs.openshift.io")
-            param = (
-                '{"spec":  {"tolerations": '
-                '[{"effect": "NoSchedule", "key": "xyz", "operator": "Equal", '
-                '"value": "true"}]}}'
-            )
-            ocsini_obj = ocp.OCP(
-                resource_name=constants.OCSINIT,
-                namespace=config.ENV_DATA["cluster_namespace"],
-                kind=constants.OCSINITIALIZATION,
-            )
-            ocsini_obj.patch(params=param, format_type="merge")
-            logger.info(f"Successfully added toleration to {ocsini_obj.kind}")
-
+            if version.get_semantic_ocs_version_from_config() < version.VERSION_4_15:
+                logger.info(
+                    "Add tolerations to the ocsinitializations.ocs.openshift.io"
+                )
+                param = (
+                    '{"spec":  {"tolerations": '
+                    '[{"effect": "NoSchedule", "key": "xyz", "operator": "Equal", '
+                    '"value": "true"}]}}'
+                )
+                ocsini_obj = ocp.OCP(
+                    resource_name=constants.OCSINIT,
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    kind=constants.OCSINITIALIZATION,
+                )
+                ocsini_obj.patch(params=param, format_type="merge")
+                logger.info(f"Successfully added toleration to {ocsini_obj.kind}")
             logger.info("Add tolerations to the configmap rook-ceph-operator-config")
             configmap_obj = ocp.OCP(
                 kind=constants.CONFIGMAP,


### PR DESCRIPTION
The process for enabling the toolbox & adding tolerations to them had changed in ODF 4.15.
https://issues.redhat.com/browse/RHSTOR-5012
ODF 4.15 onwards we need to add an entry for "toolbox" in storagecluster CR
spec:
placement:
toolbox:
tolerations:
- effect: NoSchedule
key: xyz
operator: Equal
value: "true"