### PR TITLE
Create two new test cases for resize osd and add verification for OSDs encryption

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2806,6 +2806,9 @@ OPERATION_TERMINATE = "terminate"
 # Resize osd
 MAX_RESIZE_OSD = "8Ti"
 AWS_MAX_RESIZE_OSD_COUNT = 1
+# The max total cluster capacity, including all OSDs
+MAX_TOTAL_CLUSTER_CAPACITY = "12Ti"
+MAX_IBMCLOUD_TOTAL_CLUSTER_CAPACITY = "24Ti"
 
 # CCOCTL
 CCOCTL_LOG_FILE = "ccoctl-service-id.log"

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4908,3 +4908,43 @@ def get_latest_release_version():
         return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
     except CommandFailed:
         return
+
+
+def sum_of_two_storage_sizes(storage_size1, storage_size2, convert_size=1024):
+    """
+    Calculate the sum of two storage sizes given as strings.
+    Valid units: "Mi", "Gi", "Ti", "MB", "GB", "TB".
+
+    Args:
+        storage_size1 (str): The first storage size, e.g., "800Mi", "100Gi", "2Ti".
+        storage_size2 (str): The second storage size, e.g., "700Mi", "500Gi", "300Gi".
+        convert_size (int): Set convert by 1000 or 1024. The default value is 1024.
+
+    Returns:
+        str: The sum of the two storage sizes as a string, e.g., "1500Mi", "600Gi", "2300Gi".
+
+    Raises:
+        ValueError: If the units of the storage sizes are not match the Valid units
+
+    """
+    valid_units = {"Mi", "Gi", "Ti", "MB", "GB", "TB"}
+    unit1 = storage_size1[-2:]
+    unit2 = storage_size2[-2:]
+    if unit1 not in valid_units or unit2 not in valid_units:
+        raise ValueError(f"Storage sizes must have valid units: {valid_units}")
+
+    storage_size1 = storage_size1.replace("B", "i")
+    storage_size2 = storage_size2.replace("B", "i")
+
+    if "Mi" in f"{storage_size1}{storage_size2}":
+        unit, units_to_convert = "Mi", "MB"
+    elif "Gi" in f"{storage_size1}{storage_size2}":
+        unit, units_to_convert = "Gi", "GB"
+    else:
+        unit, units_to_convert = "Ti", "TB"
+
+    size1 = convert_device_size(storage_size1, units_to_convert, convert_size)
+    size2 = convert_device_size(storage_size2, units_to_convert, convert_size)
+    size = size1 + size2
+    new_storage_size = f"{size}{unit}"
+    return new_storage_size

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -46,7 +46,12 @@ from ocs_ci.ocs.node import get_nodes, wait_for_nodes_status
 from ocs_ci.ocs.cluster import is_vsphere_ipi_cluster
 from ocs_ci.helpers.disruption_helpers import delete_resource_multiple_times
 from ocs_ci.framework import config
-from ocs_ci.utility.utils import convert_device_size
+from ocs_ci.utility.utils import (
+    convert_device_size,
+    get_pytest_fixture_value,
+    sum_of_two_storage_sizes,
+)
+from ocs_ci.ocs import defaults
 
 logger = logging.getLogger(__name__)
 
@@ -68,19 +73,31 @@ class TestResizeOSD(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, create_pvcs_and_pods):
+    def setup(self, request, create_pvcs_and_pods):
         """
         Init all the data for the resize osd test
 
         """
-        check_resize_osd_pre_conditions()
+        self.old_storage_size = get_storage_size()
+        size_to_increase = (
+            get_pytest_fixture_value(request, "size_to_increase")
+            or self.old_storage_size
+        )
+        logger.info(
+            f"old storage size = {self.old_storage_size}, size to increase = {size_to_increase}"
+        )
+        self.new_storage_size = sum_of_two_storage_sizes(
+            self.old_storage_size, size_to_increase
+        )
+        logger.info(
+            f"The new expected storage size for the storage cluster is {self.new_storage_size}"
+        )
+        check_resize_osd_pre_conditions(self.new_storage_size)
         self.create_pvcs_and_pods = create_pvcs_and_pods
 
         self.old_osd_pods = get_osd_pods()
-        self.old_storage_size = get_storage_size()
         self.old_osd_pvcs = get_deviceset_pvcs()
         self.old_osd_pvs = get_deviceset_pvs()
-        self.new_storage_size = None
 
         self.pod_file_name = "fio_test"
         self.sanity_helpers = Sanity()
@@ -193,7 +210,7 @@ class TestResizeOSD(ManageTest):
         logger.info(f"Restart the worker node: {wnode.name}")
         if is_vsphere_ipi_cluster():
             nodes.restart_nodes(nodes=[wnode], wait=False)
-            wait_for_nodes_status(node_names=[wnode], timeout=300)
+            wait_for_nodes_status(node_names=[wnode.name], timeout=300)
         else:
             nodes.restart_nodes(nodes=[wnode], wait=True)
 
@@ -201,56 +218,67 @@ class TestResizeOSD(ManageTest):
 
     @tier4c
     @pytest.mark.parametrize(
-        argnames=["resource_name", "num_of_iterations"],
-        argvalues=[
+        "resource_name, num_of_iterations, size_to_increase",
+        [
             pytest.param(
-                *[OSD, 3],
+                OSD,
+                3,
+                f"{config.ENV_DATA.get('device_size', defaults.DEVICE_SIZE)}Gi",
                 marks=pytest.mark.polarion_id("OCS-5781"),
             ),
             pytest.param(
-                *[ROOK_OPERATOR, 3],
+                ROOK_OPERATOR,
+                3,
+                f"{config.ENV_DATA.get('device_size', defaults.DEVICE_SIZE)}Gi",
                 marks=pytest.mark.polarion_id("OCS-5782"),
             ),
             pytest.param(
-                *[MON_DAEMON, 5],
+                MON_DAEMON,
+                5,
+                f"{config.ENV_DATA.get('device_size', defaults.DEVICE_SIZE)}Gi",
                 marks=pytest.mark.polarion_id("OCS-5783"),
             ),
         ],
     )
-    def test_resize_osd_with_resource_delete(self, resource_name, num_of_iterations):
+    def test_resize_osd_with_resource_delete(
+        self, resource_name, num_of_iterations, size_to_increase
+    ):
         """
         Test resize OSD when one of the resources got deleted in the middle of the process
 
         """
         self.prepare_data_before_resize_osd()
-        self.new_storage_size = basic_resize_osd(self.old_storage_size)
+        resize_osd(self.new_storage_size)
         delete_resource_multiple_times(resource_name, num_of_iterations)
         self.verification_steps_post_resize_osd()
 
-    @tier4a
-    @pytest.mark.parametrize(
-        argnames=["workload_storageutilization_rbd"],
-        argvalues=[
-            pytest.param(
-                *[(0.70, True, 120)], marks=pytest.mark.polarion_id("OCS-5785")
-            ),
-        ],
-        indirect=["workload_storageutilization_rbd"],
-    )
-    def test_resize_osd_when_capacity_near_full(self, workload_storageutilization_rbd):
+    @tier4b
+    @polarion_id("OCS-5785")
+    def test_resize_osd_when_capacity_near_full(
+        self, benchmark_workload_storageutilization
+    ):
         """
-        Test resize osd when the cluster capacity is near full. The test will fill up the cluster to 70%
-        of the cluster capacity, and then it will start the osd resize steps.
+        Test resize OSD when the cluster capacity is near full
 
         """
+        target_percentage = 75
+        logger.info(
+            f"Fill up the cluster to {target_percentage}% of it's storage capacity"
+        )
+        benchmark_workload_storageutilization(target_percentage)
         self.prepare_data_before_resize_osd()
-        self.new_storage_size = basic_resize_osd(self.old_storage_size)
+        resize_osd(self.new_storage_size)
         self.verification_steps_post_resize_osd()
 
     @tier4a
     @pytest.mark.last
-    @polarion_id("OCS-5786")
-    def test_resize_osd_for_large_diff(self):
+    @pytest.mark.parametrize(
+        argnames=["size_to_increase"],
+        argvalues=[
+            pytest.param(*["2Ti"], marks=pytest.mark.polarion_id("OCS-5786")),
+        ],
+    )
+    def test_resize_osd_for_large_diff(self, size_to_increase):
         """
         Test resize osd for large differences. The test will increase the osd size to 4Ti.
         If the current OSD size is less than 1024Gi, we will skip the test, as the purpose of the test
@@ -262,10 +290,9 @@ class TestResizeOSD(ManageTest):
         max_osd_size_in_gb = 1024
         if current_osd_size_in_gb > max_osd_size_in_gb:
             pytest.skip(
-                f"The test will not run when the osd size is less than {max_osd_size_in_gb}Gi"
+                f"The test will not run when the osd size is greater than {max_osd_size_in_gb}Gi"
             )
 
         self.prepare_data_before_resize_osd()
-        self.new_storage_size = "4Ti"
         resize_osd(self.new_storage_size)
         self.verification_steps_post_resize_osd()


### PR DESCRIPTION
Create two new test cases: 

- Test resize osd when the cluster capacity is near full
- Test resize osd for large differences
- Add the MAX cluster size, and check that the expected size is less than the Max cluster size.
- Add verification steps for OSD encryption.