### PR TITLE
Update 4.16 locator for ACM page

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1863,6 +1863,7 @@ locators = {
             **acm_configuration_4_11,
             **acm_configuration_4_12,
             **acm_configuration_4_13,
+            **acm_configuration_4_14,
         },
         "validation": {
             **validation,


### PR DESCRIPTION
Fixes: #9833 

Updated locator dict for Submariner (downstream_unreleased) UI installation to work with OCP 4.16