### PR TITLE
Increase pod wait timeout in test test_worker_node_restart_during_pvc_clone

### DIFF
--- a/tests/functional/pv/pvc_clone/test_node_restart_during_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_node_restart_during_pvc_clone.py
@@ -164,7 +164,7 @@ class TestNodeRestartDuringPvcClone(ManageTest):
         # Verify the new pods are running
         log.info("Verify the new pods are running")
         for pod_obj in clone_pod_objs:
-            wait_for_resource_state(pod_obj, constants.STATUS_RUNNING)
+            wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=120)
         log.info("Verified: New pods are running")
 
         # Verify md5sum


### PR DESCRIPTION

Increase pod wait timeout in test test_worker_node_restart_during_pvc_clone. This Fixes #9449 