### PR TITLE
Add required configuration file for regressions execution on aws hcp cluster

### DIFF
--- a/conf/deployment/aws/hcp_ipi_3az_3w_m5.4x.yaml
+++ b/conf/deployment/aws/hcp_ipi_3az_3w_m5.4x.yaml
@@ -1,0 +1,13 @@
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+ENV_DATA:
+  platform: 'aws'
+  deployment_type: 'ipi'
+  region: 'us-east-2'
+  worker_availability_zones:
+    - 'us-east-2a'
+    - 'us-east-2b'
+    - 'us-east-2c'
+  worker_replicas: 3
+  worker_instance_type: 'm5.4xlarge'
+  cluster_namespace: "odf-storage"


### PR DESCRIPTION

Signed-off-by: suchita-g <sgatfane@redhat.com>
The hcp aws deployment is not yet automated hence may be new parameter can be updated as per need of deployment automation. For now deployment is done with default parameter in custom namespace