### PR TITLE
Skip test_non_ocs_taint_and_toleration.py starting ODF 4.16

### DIFF
--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -29,6 +29,7 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
+from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.helpers.sanity_helpers import Sanity
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ logger = logging.getLogger(__name__)
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@skipif_ocs_version(">=4.16")
 @bugzilla("1992472")
 @pytest.mark.polarion_id("OCS-2705")
 class TestNonOCSTaintAndTolerations(E2ETest):


### PR DESCRIPTION
As per the [discussion](https://github.com/red-hat-storage/ocs-ci/pull/9811/files#r1606364971), we intent to skip running this test starting ODF 4.16.
Most of the steps in this test have to be modified according to the new 4.16 custom taint features. Here is the [PR](https://github.com/red-hat-storage/ocs-ci/pull/9808) for new test case.