### PR TITLE
ITR - Allow ocs-ci to run parallely

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -157,6 +157,12 @@ to the pytest.
 * `--install-lvmo` - Deploy LVMCluster, will skip ODF deployment.
 * `--lvmo-disks` - Number of disks to add to SNO deployment.
 * `--lvmo-disks-size` - Size of disks to add to SNO deployment.
+* `--disable-environment-checker` - Disable the leftover checks in existing flow.
+* `--resource-checker` - This will identify the leftover which was created by test cases. This is
+    similar to environment-checker, only difference is resource-checker will track the resources
+    created during test case run whereas environment-checker will track all resources in
+    cluster irrespective of who created.
+* `--kubeconfig` - Location of kubeconfig.
 
 ## Examples
 

--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -154,6 +154,19 @@ def process_ocsci_conf(arguments):
 
     args, unknown = parser.parse_known_args(args=arguments)
     load_config(args.ocsci_conf)
+    if unknown:
+        for each_arg in unknown:
+            if each_arg.startswith("--cluster-path"):
+                if "=" in each_arg:
+                    framework.config.ENV_DATA["cluster_path"] = each_arg.split("=", 1)[
+                        1
+                    ]
+                else:
+                    cluster_path_position = unknown.index("--cluster-path")
+                    framework.config.ENV_DATA["cluster_path"] = unknown[
+                        cluster_path_position + 1
+                    ]
+                break
     ocs_version = args.ocs_version or framework.config.ENV_DATA.get("ocs_version")
     ocp_version = args.ocp_version or framework.config.ENV_DATA.get("ocp_version")
     ocs_registry_image = framework.config.DEPLOYMENT.get("ocs_registry_image")

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -350,6 +350,11 @@ def pytest_addoption(parser):
             "Resource checker checks for the left over resources which are added while running the test cases."
         ),
     )
+    parser.addoption(
+        "--kubeconfig",
+        dest="kubeconfig",
+        help=("Kubeconfig location which will be loaded as environmental variable"),
+    )
 
 
 def pytest_configure(config):
@@ -645,6 +650,8 @@ def process_cluster_cli_params(config):
     ocsci_config.RUN["disable_environment_checker"] = disable_environment_checker
     resource_checker = get_cli_param(config, "resource_checker")
     ocsci_config.RUN["resource_checker"] = resource_checker
+    custom_kubeconfig_location = get_cli_param(config, "kubeconfig")
+    ocsci_config.RUN["custom_kubeconfig_location"] = custom_kubeconfig_location
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -341,6 +341,15 @@ def pytest_addoption(parser):
         default=False,
         help="Disable environment checks for test cases.",
     )
+    parser.addoption(
+        "--resource-checker",
+        dest="resource_checker",
+        action="store_true",
+        default=False,
+        help=(
+            "Resource checker checks for the left over resources which are added while running the test cases."
+        ),
+    )
 
 
 def pytest_configure(config):
@@ -634,6 +643,8 @@ def process_cluster_cli_params(config):
         )
     disable_environment_checker = get_cli_param(config, "disable_environment_checker")
     ocsci_config.RUN["disable_environment_checker"] = disable_environment_checker
+    resource_checker = get_cli_param(config, "resource_checker")
+    ocsci_config.RUN["resource_checker"] = resource_checker
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -652,6 +652,9 @@ def process_cluster_cli_params(config):
     ocsci_config.RUN["resource_checker"] = resource_checker
     custom_kubeconfig_location = get_cli_param(config, "kubeconfig")
     ocsci_config.RUN["custom_kubeconfig_location"] = custom_kubeconfig_location
+    if custom_kubeconfig_location:
+        os.environ["KUBECONFIG"] = custom_kubeconfig_location
+        ocsci_config.RUN["kubeconfig"] = custom_kubeconfig_location
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -768,7 +768,7 @@ def pytest_runtest_makereport(item, call):
         test_name = item.nodeid
         # Write the failure information to a file
         with open(
-            f'{ocsci_config.ENV_DATA["cluster_path"]}/failed_testcases.txt', "a"
+            f'{ocsci_config.ENV_DATA.get("cluster_path")}/failed_testcases.txt', "a"
         ) as file:
             file.write(f"{test_name}\n")
 
@@ -776,7 +776,7 @@ def pytest_runtest_makereport(item, call):
         test_name = item.nodeid
         # Write the passed information to a file
         with open(
-            f'{ocsci_config.ENV_DATA["cluster_path"]}/passed_testcases.txt', "a"
+            f'{ocsci_config.ENV_DATA.get("cluster_path")}/passed_testcases.txt', "a"
         ) as file:
             file.write(f"{test_name}\n")
 
@@ -784,7 +784,7 @@ def pytest_runtest_makereport(item, call):
         test_name = item.nodeid
         # Write the skipped information to a file
         with open(
-            f'{ocsci_config.ENV_DATA["cluster_path"]}/skipped_testcases.txt', "a"
+            f'{ocsci_config.ENV_DATA.get("cluster_path")}/skipped_testcases.txt', "a"
         ) as file:
             file.write(f"{test_name}\n")
 

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -772,6 +772,22 @@ def pytest_runtest_makereport(item, call):
         ) as file:
             file.write(f"{test_name}\n")
 
+    if rep.passed and rep.when == "call":
+        test_name = item.nodeid
+        # Write the passed information to a file
+        with open(
+            f'{ocsci_config.ENV_DATA["cluster_path"]}/passed_testcases.txt', "a"
+        ) as file:
+            file.write(f"{test_name}\n")
+
+    if rep.skipped:
+        test_name = item.nodeid
+        # Write the skipped information to a file
+        with open(
+            f'{ocsci_config.ENV_DATA["cluster_path"]}/skipped_testcases.txt', "a"
+        ) as file:
+            file.write(f"{test_name}\n")
+
 
 def set_log_level(config):
     """

--- a/ocs_ci/framework/testlib.py
+++ b/ocs_ci/framework/testlib.py
@@ -5,6 +5,7 @@ from ocs_ci.ocs.constants import MCG_TESTS_MIN_NB_ENDPOINT_COUNT, MAX_NB_ENDPOIN
 
 
 @pytest.mark.usefixtures("environment_checker")  # noqa: F405
+@pytest.mark.usefixtures("resource_checker")
 class BaseTest:
     """
     Base test class for our testing.

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -566,9 +566,11 @@ class OCP(object):
             bool: True in case project creation succeeded, False otherwise
         """
         ocp = OCP(kind="namespace")
-        exec_output = run_cmd(
-            f"oc new-project {project_name}", threading_lock=self.threading_lock
-        )
+        if config.RUN["custom_kubeconfig_location"]:
+            cmd = f'oc --kubeconfig {config.RUN["custom_kubeconfig_location"]} new-project {project_name}'
+        else:
+            cmd = f"oc new-project {project_name}"
+        exec_output = run_cmd(cmd, threading_lock=self.threading_lock)
         if any(
             pattern in exec_output
             for pattern in [

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -373,9 +373,47 @@ class OCP(object):
         command = "create "
         if yaml_file:
             command += f"-f {yaml_file}"
+            if config.RUN["resource_checker"]:
+                yaml_dct = load_yaml(yaml_file)
+                kind = yaml_dct["kind"]
+                if kind == "PersistentVolume":
+                    config.RUN["RESOURCE_DICT_TEST"]["pv"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "Pod":
+                    config.RUN["RESOURCE_DICT_TEST"]["pod"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "StorageClass":
+                    config.RUN["RESOURCE_DICT_TEST"]["sc"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "PersistentVolumeClaim":
+                    config.RUN["RESOURCE_DICT_TEST"]["pvc"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "Namespace":
+                    config.RUN["RESOURCE_DICT_TEST"]["namespace"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "volumesnapshot":
+                    config.RUN["RESOURCE_DICT_TEST"]["vs"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "CephFileSystem":
+                    config.RUN["RESOURCE_DICT_TEST"]["cephfs"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+                if kind == "CephBlockPool":
+                    config.RUN["RESOURCE_DICT_TEST"]["cephbp"].append(
+                        yaml_dct["metadata"]["name"]
+                    )
+
         elif resource_name:
             # e.g "oc namespace my-project"
             command += f"{self.kind} {resource_name}"
+            if config.RUN["resource_checker"]:
+                config.RUN["RESOURCE_DICT_TEST"][self.kind] = resource_name
         if out_yaml_format:
             command += " -o yaml"
         output = self.exec_oc_cmd(command)

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -73,14 +73,21 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
     for item in items:
         ns = item.get("metadata", {}).get("namespace")
         if item.get("kind") == constants.PV:
-            ns = item.get("spec").get("claimRef").get("namespace")
+            ns = item.get("spec").get("claimRef", {}).get("namespace")
 
         item_labels = item.get("metadata", {}).get("labels", {})
-        excluded_item_labels = [
-            f"{key}={value}"
-            for key, value in item_labels.items()
-            if f"{key}={value}" in exclude_labels
-        ]
+        if exclude_labels:
+            excluded_item_labels = [
+                f"{key}={value}"
+                for key, value in item_labels.items()
+                if f"{key}={value}" in exclude_labels
+            ]
+
+            if excluded_item_labels:
+                log.debug(
+                    "ignoring item with app label %s: %s", excluded_item_labels[0], item
+                )
+                continue
 
         if (
             ns is not None
@@ -88,11 +95,6 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             and ns != config.ENV_DATA["cluster_namespace"]
         ):
             log.debug("ignoring item in %s namespace: %s", ns, item)
-            continue
-        if excluded_item_labels:
-            log.debug(
-                "ignoring item with app label %s: %s", excluded_item_labels[0], item
-            )
             continue
         if item.get("kind") == constants.POD:
             name = item.get("metadata", {}).get("name", "")

--- a/ocs_ci/utility/resource_check.py
+++ b/ocs_ci/utility/resource_check.py
@@ -1,0 +1,85 @@
+"""
+Module for resource check which was created during test cases
+"""
+import copy
+import logging
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import ocp, constants
+from ocs_ci.ocs.exceptions import ResourceLeftoversException
+from ocs_ci.utility.environment_check import get_environment_status
+
+log = logging.getLogger(__name__)
+
+
+def create_resource_dct():
+    """
+    Set the environment status and assign it into RESOURCE_DICT_TEST dictionary
+    """
+
+    POD = ocp.OCP(kind=constants.POD)
+    SC = ocp.OCP(kind=constants.STORAGECLASS)
+    PV = ocp.OCP(kind=constants.PV)
+    PVC = ocp.OCP(kind=constants.PVC)
+    NS = ocp.OCP(kind=constants.NAMESPACE)
+    VS = ocp.OCP(kind=constants.VOLUMESNAPSHOT)
+    CEPHFILESYSTEM = ocp.OCP(kind=constants.CEPHFILESYSTEM)
+    CEPHBLOCKPOOL = ocp.OCP(kind=constants.CEPHBLOCKPOOL)
+
+    config.RUN["KINDS"] = [POD, SC, CEPHFILESYSTEM, CEPHBLOCKPOOL, PV, PVC, NS, VS]
+    config.RUN["RESOURCE_DICT"] = {
+        "pod": [],
+        "sc": [],
+        "cephfs": [],
+        "cephbp": [],
+        "pv": [],
+        "pvc": [],
+        "namespace": [],
+        "vs": [],
+    }
+
+    config.RUN["RESOURCE_DICT_TEST"] = copy.deepcopy(config.RUN["RESOURCE_DICT"])
+    config.RUN["ENV_STATUS_POST"] = copy.deepcopy(config.RUN["RESOURCE_DICT"])
+    config.RUN["ENV_STATUS_POST_TEST"] = copy.deepcopy(config.RUN["RESOURCE_DICT"])
+
+
+def get_environment_status_after_execution(exclude_labels=None):
+    """
+    Set the environment status and assign it into ENV_STATUS_POST dictionary.
+    In addition, check for any leftovers from test execution
+
+    Args:
+        exclude_labels (list): App labels to ignore leftovers
+
+    Raises:
+         ResourceLeftoversException: In case there are leftovers in the
+            environment after the test execution
+
+    """
+    get_environment_status(config.RUN["ENV_STATUS_POST"], exclude_labels=exclude_labels)
+    for kind in config.RUN["ENV_STATUS_POST"]:
+        for item in config.RUN["ENV_STATUS_POST"][kind]:
+            config.RUN["ENV_STATUS_POST_TEST"][kind].append(item["metadata"]["name"])
+
+    # check leftovers
+    leftover_resources = {}
+    for kind in config.RUN["RESOURCE_DICT_TEST"]:
+        log.info(f"checking leftovers for {kind}")
+        if not config.RUN["RESOURCE_DICT_TEST"][kind]:
+            continue
+        else:
+            for item in config.RUN["RESOURCE_DICT_TEST"][kind]:
+                log.debug(f"checking if {item} exists in environment")
+                log.debug(f"checking in {config.RUN['ENV_STATUS_POST_TEST'][kind]}")
+                if item in config.RUN["ENV_STATUS_POST_TEST"][kind]:
+                    log.error(f"leftover detected: {item} for kind {kind}")
+                    if kind in leftover_resources.keys():
+                        leftover_resources[kind].append(item)
+                    else:
+                        leftover_resources[kind] = [item]
+    if len(leftover_resources) != 0:
+        log.error(f"leftovers identified: {leftover_resources}")
+        raise ResourceLeftoversException(
+            f"\nThere are leftovers in the environment after test case:"
+            f"\nleftovers identified: {leftover_resources}"
+        )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -637,6 +637,14 @@ def exec_cmd(
     log.info(f"Executing command: {masked_cmd}")
     if isinstance(cmd, str) and not kwargs.get("shell"):
         cmd = shlex.split(cmd)
+    if config.RUN.get("custom_kubeconfig_location") and cmd[0] == "oc":
+        if "--kubeconfig" in cmd:
+            cmd.pop(2)
+            cmd.pop(1)
+        cmd = list_insert_at_position(cmd, 1, ["--kubeconfig"])
+        cmd = list_insert_at_position(
+            cmd, 2, [config.RUN["custom_kubeconfig_location"]]
+        )
     if cluster_config and cmd[0] == "oc" and "--kubeconfig" not in cmd:
         kubepath = cluster_config.RUN["kubeconfig"]
         kube_index = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1801,6 +1801,9 @@ def cluster(
 
 @pytest.fixture(scope="class")
 def environment_checker(request):
+    if config.RUN["disable_environment_checker"]:
+        log.debug("Skipping environment checks")
+        return
     node = request.node
     # List of marks for which we will ignore the leftover checker
     marks_to_ignore = [m.mark for m in [deployment, ignore_leftovers]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1809,56 +1809,6 @@ def environment_checker(request):
         log.debug("Skipping environment checker")
         return
 
-    if ocsci_config.ENV_DATA["platform"] in {
-        constants.FUSIONAAS_PLATFORM,
-        constants.HCI_BAREMETAL,
-        constants.HCI_VSPHERE,
-    }:
-        log.error(
-            "Environment checker is NOT IMPLEMENTED for Fusion service and provider/client hci setup."
-            "This needs to be updated"
-        )
-    else:
-        exclude_labels = get_exclude_labels(request)
-        request.addfinalizer(
-            partial(get_status_after_execution, exclude_labels=exclude_labels)
-        )
-        get_status_before_execution(exclude_labels=exclude_labels)
-
-
-@pytest.fixture(scope="class")
-def resource_checker(request):
-    if not ocsci_config.RUN["resource_checker"]:
-        log.debug("Skipping resource checker")
-        return
-
-    create_resource_dct()
-    if ocsci_config.ENV_DATA["platform"] in {
-        constants.FUSIONAAS_PLATFORM,
-        constants.HCI_BAREMETAL,
-        constants.HCI_VSPHERE,
-    }:
-        log.error(
-            "Environment checker is NOT IMPLEMENTED for Fusion service and provider/client hci setup."
-            "This needs to be updated"
-        )
-    else:
-        exclude_labels = get_exclude_labels(request)
-        request.addfinalizer(
-            lambda: get_environment_status_after_execution(
-                exclude_labels=exclude_labels
-            )
-        )
-
-
-def get_exclude_labels(request):
-    """
-    Gets the labels which should be excluded for left over checks
-
-    Returns:
-        list: List of exclude labels
-
-    """
     node = request.node
     # List of marks for which we will ignore the leftover checker
     marks_to_ignore = [m.mark for m in [deployment, ignore_leftovers]]
@@ -1873,8 +1823,58 @@ def get_exclude_labels(request):
             return
         if mark.name == ignore_leftover_label.name:
             exclude_labels.extend(list(mark.args))
+    if ocsci_config.ENV_DATA["platform"] in {
+        constants.FUSIONAAS_PLATFORM,
+        constants.HCI_BAREMETAL,
+        constants.HCI_VSPHERE,
+    }:
+        log.error(
+            "Environment checker is NOT IMPLEMENTED for Fusion service and provider/client hci setup."
+            "This needs to be updated"
+        )
+    else:
+        request.addfinalizer(
+            partial(get_status_after_execution, exclude_labels=exclude_labels)
+        )
+        get_status_before_execution(exclude_labels=exclude_labels)
 
-    return exclude_labels
+
+@pytest.fixture(scope="class")
+def resource_checker(request):
+    if not ocsci_config.RUN["resource_checker"]:
+        log.debug("Skipping resource checker")
+        return
+
+    create_resource_dct()
+    node = request.node
+    # List of marks for which we will ignore the leftover checker
+    marks_to_ignore = [m.mark for m in [deployment, ignore_leftovers]]
+    # app labels of resources to be excluded for leftover check
+    exclude_labels = [
+        constants.must_gather_pod_label,
+        constants.S3CLI_APP_LABEL,
+        constants.MUST_GATHER_HELPER_LABEL,
+    ]
+    for mark in node.iter_markers():
+        if mark in marks_to_ignore:
+            return
+        if mark.name == ignore_leftover_label.name:
+            exclude_labels.extend(list(mark.args))
+    if ocsci_config.ENV_DATA["platform"] in {
+        constants.FUSIONAAS_PLATFORM,
+        constants.HCI_BAREMETAL,
+        constants.HCI_VSPHERE,
+    }:
+        log.error(
+            "Resource checker is NOT IMPLEMENTED for Fusion service and provider/client hci setup."
+            "This needs to be updated"
+        )
+    else:
+        request.addfinalizer(
+            lambda: get_environment_status_after_execution(
+                exclude_labels=exclude_labels
+            )
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -219,6 +219,7 @@ class TestClone(ManageTest):
             volume_mode=snapshot_obj.parent_volume_mode,
             access_mode=constants.ACCESS_MODE_ROX,
             status=constants.STATUS_BOUND,
+            timeout=300,
         )
         teardown_factory(restore_snapshot_obj)
 
@@ -333,6 +334,7 @@ class TestClone(ManageTest):
             volume_mode=snapshot_obj.parent_volume_mode,
             access_mode=constants.ACCESS_MODE_ROX,
             status=constants.STATUS_BOUND,
+            timeout=300,
         )
         teardown_factory(restore_snapshot_obj)
 
@@ -470,6 +472,7 @@ class TestClone(ManageTest):
             access_mode=constants.ACCESS_MODE_ROX,
             status=constants.STATUS_BOUND,
             restore_pvc_name="first-rwx-snapshot-restore-to-rox-mode-00",
+            timeout=300,
         )
         teardown_factory(restore_snapshot_obj)
 


### PR DESCRIPTION
This PR will allow us to run ocs-ci to run parrallely with ITR framework and it shouldn'tcause any functionality break of existing flow.
Introduces below 3 cli parameters

--disable-environment-checker: this will disable the left over checks in existing flow
--resource-checker: this will identify the leftover which was created by test cases. This is similiar to environment-checker, only difference is resource-checker will track the resources created during test case run where as environment-checker will track all resources in cluster irrespective of who created.
--kubeconfig: location of kubeconfig. 

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)