### PR TITLE
Update `test_s3_route_reconcile` to 4.16 expectations

### DIFF
--- a/tests/functional/object/mcg/test_s3_routes.py
+++ b/tests/functional/object/mcg/test_s3_routes.py
@@ -100,7 +100,7 @@ class TestS3Routes:
     def test_s3_routes_reconcile(self, revert_routes):
         """
         Tests:
-            1. Validates S3 route is not reconciled after changing insecureEdgeTerminationPolicy.
+            1. Validates S3 route is reconciled after setting denyHTTP to true in the storage cluster.
             2. Validates rgw route is not recreated after enabling disableRoute in the storage cluster.
         """
 

--- a/tests/functional/object/mcg/test_s3_routes.py
+++ b/tests/functional/object/mcg/test_s3_routes.py
@@ -48,10 +48,19 @@ class TestS3Routes:
             )
             if (
                 nb_s3_route_obj.data["spec"]["tls"]["insecureEdgeTerminationPolicy"]
-                == "Redirect"
+                == "None"
             ):
-                s3_route_param = '{"spec":{"tls":{"insecureEdgeTerminationPolicy":"Allow","termination":"reencrypt"}}}'
-                nb_s3_route_obj.patch(params=s3_route_param, format_type="merge")
+                # Set spec.multiCloudGateway.denyHTTP to true on ocs-storagecluster
+                storagecluster_obj = ocp.OCP(
+                    kind=constants.STORAGECLUSTER,
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    resource_name=constants.DEFAULT_CLUSTERNAME,
+                )
+                lb_param = '[{"op": "replace", "path": "/spec/multiCloudGateway/denyHTTP", "value": false}]'
+                logger.info(
+                    "Patching noobaa resource to disable disableLoadBalancerService"
+                )
+                storagecluster_obj.patch(params=lb_param, format_type="json")
 
             # Revert disableRoute param
             if config.ENV_DATA.get("platform") in constants.ON_PREM_PLATFORMS:


### PR DESCRIPTION
Update the test case to the latest expecations, and cover https://bugzilla.redhat.com/show_bug.cgi?id=2283797 by:
- Changing `spec.multiCloudGateway.denyHTTP` to true on the ocs-storagecluster resource
- Validating that as a result, `spec.tls.insecureEdgeTerminationPolicy` is reconciled to None on the S3 route