### PR TITLE
Fixes test_ocs_operator_is_not_present for utilizing custom namespace

### DIFF
--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -627,7 +627,7 @@ class ValidationUI(PageNavigator):
         logger.info("Navigating to Installed Operator Page")
         self.navigate_installed_operators_page()
 
-        self.select_namespace(project_name="openshift-storage")
+        self.select_namespace(project_name=config.ENV_DATA["cluster_namespace"])
 
         logger.info("Searching for Openshift Data Foundation Operator")
         odf_operator_presence = self.wait_until_expected_text_is_found(


### PR DESCRIPTION
In Test case test_ocs_operator_is_not_present the use of namespace "openshift-storage" is hardcoded, hence this test is failing on platform where custom name is used for ODF deployment, like ROSA/AWS HCP Fix for: https://github.com/red-hat-storage/ocs-ci/issues/9876

Signed-off-by: suchita-g <sgatfane@redhat.com>