### PR TITLE
Removed skip test marker form the test

### DIFF
--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -134,9 +134,6 @@ class TestMetadataUnavailable(ManageTest):
         ), f"PVC {pvc_obj.name} is not deleted"
 
 
-@pytest.mark.skip(
-    reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/8759"
-)
 @tier1
 @skipif_ocs_version("<4.12")
 @skipif_ocp_version("<4.12")
@@ -224,9 +221,6 @@ class TestDefaultMetadataDisabled(ManageTest):
         ), f"PVC {cloned_pvc_obj.name} is not deleted"
 
 
-@pytest.mark.skip(
-    reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/8759"
-)
 @skipif_ocs_version("<4.12")
 @skipif_ocp_version("<4.12")
 @skipif_managed_service


### PR DESCRIPTION
Removed skip test marker form the  following metadata tests  since related issue fixed and closed https://github.com/red-hat-storage/ocs-ci/issues/8759

test_metadata_not_enabled_by_default[ocs-storagecluster-cephfilesystem-ocs-storagecluster-cephfs]
test_verify_metadata_details[ocs-storagecluster-cephfilesystem-ocs-storagecluster-cephfs]
test_metadata_details_available_only_when_metadata_flag_enabled[ocs-storagecluster-cephfilesystem-ocs-storagecluster-cephfs]
test_metadata_details_available_only_when_metadata_flag_enabled[ocs-storagecluster-cephblockpool-ocs-storagecluster-ceph-rbd]
test_metadata_update_for_PV_Retain[ocs-storagecluster-cephblockpool-ocs-storagecluster-ceph-rbd]