### PR TITLE
Skip the default backingstore override tests in deployments with limited connectivity

### DIFF
--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     ignore_leftovers,
     mcg,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @mcg
 @red_squad
 @ignore_leftovers  # needed for the upgrade TCs
+@skipif_disconnected_cluster
 class TestDefaultBackingstoreOverride(MCGTest):
     """
     Test overriding the default noobaa backingstore

--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     mcg,
     skipif_disconnected_cluster,
+    skipif_proxy_cluster,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @ignore_leftovers  # needed for the upgrade TCs
 @skipif_disconnected_cluster
+@skipif_proxy_cluster
 class TestDefaultBackingstoreOverride(MCGTest):
     """
     Test overriding the default noobaa backingstore


### PR DESCRIPTION
These tests attempt to create a backingstore of the same type as the original default noobaaa backingstore, which can result in failure when the platform is not on vSphere. 

In the case of a disconnected cluster on the AWS platform, the default backingstore is using an AWS bucket so the tests attempts to create such a backingstore and fails. 