### PR TITLE
change ibmcloud iam account-policies to access-policies

### DIFF
--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -630,7 +630,7 @@ def get_cluster_account_policies(cluster_name, cluster_service_ids):
         list: Account policies for cluster
 
     """
-    cmd = "ibmcloud iam account-policies --output json"
+    cmd = "ibmcloud iam access-policies --output json"
     out = run_ibmcloud_cmd(cmd)
     account_policies = json.loads(out)
     matched_account_policies = []


### PR DESCRIPTION
There seems to be some change and `ibmcloud iam account-policies` command is not available anymore:
```
$ ibmcloud iam account-policies --output json 
FAILED
'account-policies' is not a registered command. Check your list of installed plug-ins. See 'ibmcloud iam help'.
```
the command was probably replaced by `ibmcloud iam access-policies`