### PR TITLE
Modify the "SanityProviderMode" class to override the "Sanity" class methods and make the "Sanity" class more straightforward to use

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4891,3 +4891,22 @@ def get_latest_release_version():
         return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
     except CommandFailed:
         return
+
+
+def get_fixture_indirectly(request, fixture_name):
+    """
+    Get the value of a fixture name from the request even if the fixture was not passed in the test
+
+    Args:
+        request (_pytest.fixtures.SubRequest'): The pytest request fixture
+        fixture_name: Fixture for which this request is being performed
+
+    Returns:
+        Any: The fixture value
+
+    """
+    try:
+        fixture_value = request.getfixturevalue(fixture_name)
+        return fixture_value
+    except pytest.FixtureLookupError:
+        pytest.fail(f"The fixture '{fixture_name}' was not found")

--- a/tests/libtest/test_sanity.py
+++ b/tests/libtest/test_sanity.py
@@ -1,0 +1,207 @@
+import logging
+import pytest
+
+from ocs_ci.helpers.sanity_helpers import (
+    SanityProviderMode,
+    Sanity,
+    SanityWithInitParams,
+)
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
+from ocs_ci.framework.testlib import (
+    libtest,
+    ManageTest,
+)
+from ocs_ci.ocs.cluster import is_hci_cluster
+
+
+log = logging.getLogger(__name__)
+
+
+@yellow_squad
+@libtest
+class TestSanityWithCreateResourcesParams(ManageTest):
+    """
+    Test the usage of the 'Sanity' and 'SanityProviderMode' classes when passing the parameters
+    in the Sanity 'create_resources' method. This approach we used in our tests so far.
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+
+        if is_hci_cluster():
+            self.sanity_helpers = SanityProviderMode(
+                create_scale_pods_and_pvcs_using_kube_job_on_hci_clients
+            )
+        else:
+            self.sanity_helpers = Sanity()
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            if config.cur_index != self.orig_index:
+                log.warning("The current index is not equal to the original index")
+
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_create_resources(
+        self, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+    ):
+        """
+        Test Sanity 'create_resources' method
+
+        """
+        self.sanity_helpers.create_resources(
+            pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+        )
+        self.sanity_helpers.health_check(cluster_check=True, tries=12)
+
+    def test_sanity_create_and_delete_resources(
+        self, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+    ):
+        """
+        Test Sanity 'create_resources' and 'delete_resources' methods
+
+        """
+        self.sanity_helpers.create_resources(
+            pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+        )
+        self.sanity_helpers.delete_resources()
+        self.sanity_helpers.health_check(cluster_check=True, tries=12)
+
+
+@yellow_squad
+@libtest
+class TestSanityWithInitParams(ManageTest):
+    """
+    Test the usage of the 'Sanity' and 'SanityProviderMode' classes when passing the parameters
+    in the Sanity 'Init' method
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        pvc_factory,
+        pod_factory,
+        bucket_factory,
+        rgw_bucket_factory,
+        create_scale_pods_and_pvcs_using_kube_job_on_hci_clients,
+    ):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+
+        if is_hci_cluster():
+            first_client_i = config.get_consumer_indexes_list()[0]
+            # Pass the 'create_scale_pods_and_pvcs_using_kube_job_on_hci_clients' factory to the
+            # init method and use the optional params
+            self.sanity_helpers = SanityProviderMode(
+                create_scale_pods_and_pvcs_using_kube_job_on_hci_clients,
+                scale_count=40,
+                pvc_per_pod_count=10,
+                start_io=True,
+                io_runtime=600,
+                max_pvc_size=25,
+                client_indices=[first_client_i],
+            )
+        else:
+            self.sanity_helpers = SanityWithInitParams(
+                pvc_factory,
+                pod_factory,
+                bucket_factory,
+                rgw_bucket_factory,
+                run_io=True,
+            )
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_create_resources(self):
+        """
+        Test Sanity 'create_resources' method
+
+        """
+        self.sanity_helpers.create_resources()
+        self.sanity_helpers.health_check(cluster_check=True, tries=12)
+
+    def test_sanity_create_and_delete_resources(self):
+        """
+        Test Sanity 'create_resources' and 'delete_resources' methods
+
+        """
+        self.sanity_helpers.create_resources()
+        self.sanity_helpers.delete_resources()
+        self.sanity_helpers.health_check()
+
+
+@yellow_squad
+@libtest
+class TestSanityWithDefaultParams(ManageTest):
+    """
+    Test the usage of the 'Sanity' and 'SanityProviderMode' classes when using the default parameters
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, request):
+        """
+        Save the original index, and init the sanity instance
+        """
+        self.orig_index = config.cur_index
+
+        if is_hci_cluster():
+            self.sanity_helpers = SanityProviderMode.init_default(request)
+        else:
+            self.sanity_helpers = SanityWithInitParams.init_default(request)
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Make sure the original index is equal to the current index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_sanity_create_resources(self):
+        """
+        Test Sanity 'create_resources' method
+
+        """
+        self.sanity_helpers.create_resources()
+        self.sanity_helpers.health_check()
+
+    def test_sanity_create_and_delete_resources(self):
+        """
+        Test Sanity 'create_resources' and 'delete_resources' methods
+
+        """
+        self.sanity_helpers.create_resources()
+        self.sanity_helpers.delete_resources()
+        self.sanity_helpers.health_check()


### PR DESCRIPTION
The purpose of the PR is to implement the following:

- Create a new sanity class `SanityProviderMode`, for the Provider mode inherited from the `Sanity` class.
- Make the `Sanity` class more straightforward to use.

**There are important points we need to consider:**

- The existing tests should work with the `Sanity` class without any modifications. 
- The tests should work with the `SanityProviderMode` class with minimal change in the tests and keep the tests as clean and generic as possible.
- The `Sanity` and `SanityProviderMode` classes should be easier to use when writing new tests or modifying tests.

To achieve the goals above, I implemented the following:

1. Modify the `SanityProviderMode` class to override the `Sanity` class methods precisely as defined in the `Sanity` class. This way, the existing tests will run with both classes. 
2. Create a new class `SanityWithInitParams` inherited from the `Sanity` class. This class is the same as the `Sanity` class, except we pass the parameters for creating resources in the `init` method.
3. In both `SanityProviderMode` and `SanityWithInitParams`, add a new method to initialize the class with default parameters. This way, using the classes in the tests will be easier. 

I created a new test file `tests/libtest/test_sanity.py` in the PR, that tests all the options with the new classes I described here.