### PR TITLE
Backport ibm cloud fixes and enhancements - release 4.15

### DIFF
--- a/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml
@@ -2,23 +2,18 @@
 DEPLOYMENT:
   openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
-  ocs_operator_nodes_to_label: 6
 ENV_DATA:
   platform: 'ibm_cloud'
   deployment_type: 'ipi'
-  region: 'us-south'
+  region: 'us-east'
   base_domain: 'ibmcloud2.qe.rh-ocs.com'
   worker_instance_type: 'bx2-16x64'
-  worker_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
   master_instance_type: 'bx2-4x16'
+  worker_availability_zones:
+    - 'us-east-1'
   master_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
-  worker_replicas: 6
+    - 'us-east-1'
+  worker_replicas: 3
   master_replicas: 3
 
 # The following values need to be set in a separate config and passed to ocs-ci in

--- a/conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml
@@ -2,23 +2,18 @@
 DEPLOYMENT:
   openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
-  ocs_operator_nodes_to_label: 6
 ENV_DATA:
   platform: 'ibm_cloud'
   deployment_type: 'ipi'
-  region: 'us-south'
+  region: 'us-east'
   base_domain: 'ibmcloud2.qe.rh-ocs.com'
   worker_instance_type: 'bx2-16x64'
   worker_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
+    - 'us-east-2'
   master_instance_type: 'bx2-4x16'
   master_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
-  worker_replicas: 6
+    - 'us-east-2'
+  worker_replicas: 3
   master_replicas: 3
 
 # The following values need to be set in a separate config and passed to ocs-ci in

--- a/conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml
@@ -2,23 +2,18 @@
 DEPLOYMENT:
   openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
-  ocs_operator_nodes_to_label: 6
 ENV_DATA:
   platform: 'ibm_cloud'
   deployment_type: 'ipi'
-  region: 'us-south'
+  region: 'us-east'
   base_domain: 'ibmcloud2.qe.rh-ocs.com'
   worker_instance_type: 'bx2-16x64'
   worker_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
+    - 'us-east-3'
   master_instance_type: 'bx2-4x16'
   master_availability_zones:
-    - 'us-south-1'
-    - 'us-south-2'
-    - 'us-south-3'
-  worker_replicas: 6
+    - 'us-east-3'
+  worker_replicas: 3
   master_replicas: 3
 
 # The following values need to be set in a separate config and passed to ocs-ci in

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml
@@ -8,6 +8,7 @@ ENV_DATA:
   region: 'us-east'
   base_domain: 'ibmcloud2.qe.rh-ocs.com'
   worker_instance_type: 'bx2-16x64'
+  master_instance_type: 'bx2-4x16'
   worker_availability_zones:
     - 'us-east-1'
     - 'us-east-2'

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml
@@ -7,6 +7,7 @@ ENV_DATA:
   deployment_type: 'ipi'
   region: 'us-south'
   base_domain: 'ibmcloud2.qe.rh-ocs.com'
+  master_instance_type: 'bx2-4x16'
   worker_instance_type: 'bx2-8x32'
   worker_availability_zones:
     - 'us-south-1'

--- a/conf/ocsci/ibmcloud_region_dynamic_switching.yaml
+++ b/conf/ocsci/ibmcloud_region_dynamic_switching.yaml
@@ -1,0 +1,5 @@
+---
+# Use this config for dynamic switching of region in IBM cloud
+# This is mainly due to current limitation 50 load balancers per region
+ENV_DATA:
+  enable_region_dynamic_switching: true

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2509,3 +2509,6 @@ OPERATION_STOP = "stop"
 OPERATION_START = "start"
 OPERATION_RESTART = "restart"
 OPERATION_TERMINATE = "terminate"
+
+# CCOCTL
+CCOCTL_LOG_FILE = "ccoctl-service-id.log"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -164,3 +164,4 @@ CRUSH_DEVICE_CLASS = "ssd"
 
 # IBM Cloud
 IBM_CLOUD_LOAD_BALANCER_QUOTA = 50
+IBM_CLOUD_REGIONS = {"us-south", "us-east"}

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -160,3 +160,7 @@ MUST_GATHER_UPSTREAM_TAG = "latest"
 
 # CrushDeviceClass
 CRUSH_DEVICE_CLASS = "ssd"
+
+
+# IBM Cloud
+IBM_CLOUD_LOAD_BALANCER_QUOTA = 50

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -694,3 +694,7 @@ class UsernameNotFoundException(Exception):
 
 class MultiStorageClusterExternalCephHealth(Exception):
     pass
+
+
+class APIRequestError(Exception):
+    pass

--- a/ocs_ci/templates/ocp-deployment/install-config-ibm_cloud-ipi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-ibm_cloud-ipi.yaml.j2
@@ -8,13 +8,26 @@ compute:
   platform:
     ibmcloud:
       type: {{ worker_instance_type | default('bx2-16x64') }}
+{% if worker_availability_zones %}
+      zones:
+{% for zone in worker_availability_zones %}
+      - {{ zone }}
+{% endfor %}
+{% endif %}
   replicas: {{ worker_replicas | default(3) }}
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
   platform:
-    ibmcloud: {}
+    ibmcloud:
+      type: {{ master_instance_type | default('bx2-4x16') }}
+{% if master_availability_zones %}
+      zones:
+{% for zone in master_availability_zones %}
+      - {{ zone }}
+{% endfor %}
+{% endif %}
   replicas: {{ master_replicas | default(3) }}
 metadata:
   creationTimestamp: null

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -8,9 +8,8 @@ import yaml
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
+from ocs_ci.utility.deployment import get_ocp_release_image_from_installer
 from ocs_ci.utility.utils import (
-    delete_file,
-    download_file,
     exec_cmd,
 )
 
@@ -27,17 +26,10 @@ def configure_cloud_credential_operator():
     bin_dir = config.RUN["bin_dir"]
     ccoctl_path = os.path.join(bin_dir, "ccoctl")
     if not os.path.isfile(ccoctl_path):
-        # retrieve ccoctl binary from https://mirror.openshift.com
-        version = config.DEPLOYMENT.get("ccoctl_version")
-        source = f"https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{version}/ccoctl-linux.tar.gz"
-        bin_dir = config.RUN["bin_dir"]
-        tarball = os.path.join(bin_dir, "ccoctl-linux.tar.gz")
-        logger.info("Downloading ccoctl tarball from %s", source)
-        download_file(source, tarball)
-        cmd = f"tar -xzC {bin_dir} -f {tarball} ccoctl"
-        logger.info("Extracting ccoctl binary from %s", tarball)
-        exec_cmd(cmd)
-        delete_file(tarball)
+        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+        release_image = get_ocp_release_image_from_installer()
+        cco_image = get_cco_container_image(release_image, pull_secret_path)
+        extract_ccoctl_binary(cco_image, pull_secret_path)
 
 
 def create_manifests(openshift_installer, output_dir):

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -7,6 +7,7 @@ import shutil
 import yaml
 
 from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import (
     delete_file,
     download_file,
@@ -107,7 +108,11 @@ def create_service_id(cluster_name, cluster_path, credentials_requests_dir):
         f"ccoctl ibmcloud create-service-id --credentials-requests-dir {credentials_requests_dir} "
         f"--name {cluster_name} --output-dir {cluster_path}"
     )
-    exec_cmd(cmd)
+    completed_process = exec_cmd(cmd)
+    stderr = completed_process.stderr
+    if stderr:
+        with open(os.path.join(cluster_path, constants.CCOCTL_LOG_FILE), "+w") as fd:
+            fd.write(stderr.decode())
 
 
 def delete_service_id(cluster_name, credentials_requests_dir):

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -49,6 +49,33 @@ def login():
     config.RUN["ibmcloud_last_login"] = time.time()
 
 
+def set_region():
+    """
+    Sets the cluster region to ENV_DATA
+    """
+    region = get_region(config.ENV_DATA["cluster_path"])
+    logger.info(f"cluster region is {region}")
+    logger.info(f"updating region {region} to ENV_DATA ")
+    config.ENV_DATA["region"] = region
+
+
+def get_region(cluster_path):
+    """
+    Get region from metadata.json in given cluster_path
+
+    Args:
+        cluster_path: path to cluster install directory
+
+    Returns:
+        str: region where cluster is deployed
+
+    """
+    metadata_file = os.path.join(cluster_path, "metadata.json")
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+    return metadata["ibmcloud"]["region"]
+
+
 def run_ibmcloud_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwargs):
     """
     Wrapper function for `run_cmd` which if needed will perform IBM Cloud login

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -630,7 +630,7 @@ def get_cluster_account_policies(cluster_name, cluster_service_ids):
         list: Account policies for cluster
 
     """
-    cmd = "ibmcloud iam account-policies --output json"
+    cmd = "ibmcloud iam access-policies --output json"
     out = run_ibmcloud_cmd(cmd)
     account_policies = json.loads(out)
     matched_account_policies = []

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -4,15 +4,17 @@ Module for interactions with IBM Cloud Cluster.
 
 """
 
-
 import json
 import logging
 import os
+import re
+import requests
 import time
-
+from json import JSONDecodeError
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import (
+    APIRequestError,
     CommandFailed,
     UnsupportedPlatformVersionError,
     UnexpectedBehaviour,
@@ -20,7 +22,7 @@ from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
 )
 from ocs_ci.utility import version as util_version
-from ocs_ci.utility.utils import get_ocp_version, run_cmd, TimeoutSampler
+from ocs_ci.utility.utils import get_infra_id, get_ocp_version, run_cmd, TimeoutSampler
 from ocs_ci.ocs.node import get_nodes
 
 
@@ -51,8 +53,11 @@ def login():
 
 def set_region():
     """
-    Sets the cluster region to ENV_DATA
+    Sets the cluster region to ENV_DATA when enable_region_dynamic_switching is
+    enabled.
     """
+    if not config.ENV_DATA.get("enable_region_dynamic_switching"):
+        return
     region = get_region(config.ENV_DATA["cluster_path"])
     logger.info(f"cluster region is {region}")
     logger.info(f"updating region {region} to ENV_DATA ")
@@ -99,7 +104,7 @@ def run_ibmcloud_cmd(cmd, secrets=None, timeout=600, ignore_error=False, **kwarg
     try:
         return run_cmd(cmd, secrets, timeout, ignore_error, **kwargs)
     except CommandFailed as ex:
-        if "Please login" in ex.message:
+        if "Please login" in str(ex):
             login()
             return run_cmd(cmd, secrets, timeout, ignore_error, **kwargs)
 
@@ -558,3 +563,146 @@ def label_nodes_region():
     worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
     for node in worker_nodes:
         node.add_label(rf"ibm-cloud\.kubernetes\.io/region={region}")
+
+
+def get_cluster_service_ids(cluster_name, get_infra_id_from_metadata=True):
+    """
+    Get cluster service IDs
+
+    Args:
+        cluster_name (str): cluster name
+        get_infra_id_from_metadata (bool): if set to true it will try to get
+            infra ID from metadata.json file (Default: True)
+
+    Returns:
+        list: service IDs for cluster
+
+    """
+    cmd = "ibmcloud iam service-ids --output json"
+    out = run_ibmcloud_cmd(cmd)
+    infra_id = ""
+    pattern = rf"{cluster_name}-[a-z0-9]{{5}}-.*"
+    service_ids = []
+    if get_infra_id_from_metadata:
+        try:
+            cluster_path = config.ENV_DATA["cluster_path"]
+            infra_id = get_infra_id(cluster_path)
+            pattern = rf"{infra_id}-.*"
+
+        except (FileNotFoundError, JSONDecodeError, KeyError):
+            logger.warning("Could not get infra ID")
+    for service_id in json.loads(out):
+        if re.match(pattern, service_id["name"]):
+            service_ids.append(service_id)
+    return service_ids
+
+
+def get_cluster_account_policies(cluster_name, cluster_service_ids):
+    """
+    Get cluster account policies.
+
+    Args:
+        cluster_name (str): cluster name
+        cluster_service_ids (list): list of service IDs, e.g. output from get_cluster_service_ids.
+
+    Returns:
+        list: Account policies for cluster
+
+    """
+    cmd = "ibmcloud iam account-policies --output json"
+    out = run_ibmcloud_cmd(cmd)
+    account_policies = json.loads(out)
+    matched_account_policies = []
+    if not cluster_service_ids:
+        logger.warning(
+            "No service ID provided, we cannot match any account policy without it!"
+        )
+        return matched_account_policies
+        cluster_service_ids = get_cluster_service_ids(cluster_name)
+    for account_policy in account_policies:
+        for subject in account_policy.get("subjects", []):
+            for attr in subject.get("attributes", []):
+                for service_id in cluster_service_ids:
+                    if attr.get("name") == "iam_id" and (
+                        attr.get("value") == service_id.get("iam_id")
+                    ):
+                        matched_account_policies.append(account_policy)
+    return matched_account_policies
+
+
+def delete_service_id(service_id):
+    """
+    Delete service ID
+
+    Args:
+        service_id (str): ID of service ID to delete
+    """
+    logger.info(f"Deleting service ID: {service_id}")
+    cmd = f"ibmcloud iam service-id-delete -f {service_id}"
+    run_ibmcloud_cmd(cmd)
+
+
+def get_api_token():
+    """
+    Get IBM Cloud API Token for API Calls authentication
+
+    Returns:
+        str: IBM Cloud API Token
+
+    """
+    token_cmd = "ibmcloud iam oauth-tokens --output json"
+    out = run_ibmcloud_cmd(token_cmd)
+    token = json.loads(out)
+    return token["iam_token"].split()[1]
+
+
+def delete_account_policy(policy_id, token=None):
+    """
+    Delete account policy
+
+    Args:
+        policy_id (str): policy ID
+        token (str): IBM Cloud token to be used for API calls - if not provided it will
+            create new one.
+
+    Returns:
+        bool: True in case it successfully deleted
+
+    Raises:
+        APIRequestError: in case API call didn't went well
+
+    """
+    if not token:
+        token = get_api_token()
+    url = f"https://iam.cloud.ibm.com/v1/policies/{policy_id}"
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.delete(url.format("YOUR_POLICY_ID_HERE"), headers=headers)
+    if response.status_code == 204:  # 204 means success (No Content)
+        logger.info(f"Policy id: {policy_id} deleted successfully.")
+    else:
+        raise APIRequestError(
+            f"Failed to delete policy id: {policy_id}. Status code: {response.status_code}\n"
+            f"Response content: {response.text}"
+        )
+
+
+def cleanup_policies_and_service_ids(cluster_name, get_infra_id_from_metadata=True):
+    """
+    Cleanup Account Policies and Service IDs for cluster.
+
+    Args:
+        cluster_name (str): cluster name
+        get_infra_id_from_metadata (bool): if set to true it will try to get
+            infra ID from metadata.json file (Default: True)
+
+    """
+    service_ids = get_cluster_service_ids(cluster_name, get_infra_id_from_metadata)
+    if not service_ids:
+        logger.info(f"No service ID found for cluster {cluster_name}")
+        return
+    account_policies = get_cluster_account_policies(cluster_name, service_ids)
+    api_token = get_api_token()
+    for policy in account_policies:
+        delete_account_policy(policy["id"], api_token)
+    for service_id in service_ids:
+        delete_service_id(service_id["id"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1782,6 +1782,7 @@ def cluster(
         deployer.deploy_cluster(log_cli_level)
     else:
         if ocsci_config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM:
+            ibmcloud.set_region()
             ibmcloud.login()
     if "cephcluster" not in ocsci_config.RUN.keys():
         check_clusters()


### PR DESCRIPTION
This PR contains backports of following PRs:
* [PR#9640](https://github.com/red-hat-storage/ocs-ci/pull/9640) use region dynamically for IBM cloud based on load balancers
* [PR#9774](https://github.com/red-hat-storage/ocs-ci/pull/9774) Add functionality for IBM Cloud Account Policies and Service IDs cleanup
* [PR#9591](https://github.com/red-hat-storage/ocs-ci/pull/9591) download ccoctl from image for IBM cloud
* [PR#9780](https://github.com/red-hat-storage/ocs-ci/pull/9780) Add zones to ibm cloud ipi
* [PR#9915](https://github.com/red-hat-storage/ocs-ci/pull/9915) change ibmcloud iam account-policies to access-policies
