### PR TITLE
skip oadp install on managed clusters fix:bz2280657

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -662,7 +662,6 @@ class Deployment(object):
         self.do_deploy_submariner()
         self.do_gitops_deploy()
         self.do_deploy_ocs()
-        self.do_deploy_oadp()
         self.do_deploy_rdr()
         self.do_deploy_fusion()
         self.do_deploy_odf_provider_mode()


### PR DESCRIPTION
It is now expected that OADP is installed by ramen automatically, bz: https://bugzilla.redhat.com/show_bug.cgi?id=2280657
Need deployment testing to verify this pr/bz.