### PR TITLE
Fix rerun_filter for ignore_next_measurement_file

### DIFF
--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -193,15 +193,14 @@ def ignore_next_measurement_file(err, name, test, plugin):
     to be used in monitoring tests that are marked as @flaky to make sure that
     the measurement is done again.
 
-    Reference to the description of flaky rerun_filter function::
+    Reference to the description of flaky rerun_filter function:
         https://github.com/box/flaky/blob/d29ca76d5a72845428a0716c74f8fa0d40d98532/flaky/flaky_decorator.py#L16
 
     Args:
         err (tuple): Information about the test failure (from sys.exc_info())
         name (str): The test name
         test (function): The test that has raised an error
-        plugin (function): The flaky plugin. Has a :prop:`stream` that can be written to in
-            order to add to the Flaky Report.
-    """
+        plugin (function): The flaky plugin.
+        """
     config.RUN["ignore_next_measurement_file"] = True
     return True

--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -201,6 +201,6 @@ def ignore_next_measurement_file(err, name, test, plugin):
         name (str): The test name
         test (function): The test that has raised an error
         plugin (function): The flaky plugin.
-        """
+    """
     config.RUN["ignore_next_measurement_file"] = True
     return True

--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -187,11 +187,25 @@ def measure_operation(
     return results
 
 
-def ignore_next_measurement_file():
+def ignore_next_measurement_file(err, name, test, plugin):
     """
     Sets config.RUN["ignore_next_measurement_file"] to True. This is supposed
     to be used in monitoring tests that are marked as @flaky to make sure that
     the measurement is done again.
+
+    Reference to the description of flaky rerun_filter function::
+        https://github.com/box/flaky/blob/d29ca76d5a72845428a0716c74f8fa0d40d98532/flaky/flaky_decorator.py#L16
+
+    Args:
+        err (`tuple` of `class`, :class:`Exception`, `traceback`):
+            Information about the test failure (from sys.exc_info())
+        name (`unicode`):
+            The test name
+        test (:class:`Function`):
+            The test that has raised an error
+        plugin (:class:`FlakyPytestPlugin`):
+            The flaky plugin. Has a :prop:`stream` that can be written to in
+            order to add to the Flaky Report.
     """
     config.RUN["ignore_next_measurement_file"] = True
     return True

--- a/ocs_ci/utility/workloadfixture.py
+++ b/ocs_ci/utility/workloadfixture.py
@@ -197,14 +197,10 @@ def ignore_next_measurement_file(err, name, test, plugin):
         https://github.com/box/flaky/blob/d29ca76d5a72845428a0716c74f8fa0d40d98532/flaky/flaky_decorator.py#L16
 
     Args:
-        err (`tuple` of `class`, :class:`Exception`, `traceback`):
-            Information about the test failure (from sys.exc_info())
-        name (`unicode`):
-            The test name
-        test (:class:`Function`):
-            The test that has raised an error
-        plugin (:class:`FlakyPytestPlugin`):
-            The flaky plugin. Has a :prop:`stream` that can be written to in
+        err (tuple): Information about the test failure (from sys.exc_info())
+        name (str): The test name
+        test (function): The test that has raised an error
+        plugin (function): The flaky plugin. Has a :prop:`stream` that can be written to in
             order to add to the Flaky Report.
     """
     config.RUN["ignore_next_measurement_file"] = True


### PR DESCRIPTION
rerun_filter function needs to have defined parameters