### PR TITLE
Adding volumeMode param to snapshot_restore_factory

### DIFF
--- a/tests/functional/pv/pv_services/test_rbd_image_metadata.py
+++ b/tests/functional/pv/pv_services/test_rbd_image_metadata.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -55,7 +56,9 @@ class TestRbdImageMetadata:
         rbd_images.append(snap_image_name)
 
         # restore the snapshot
-        restored_pvc = snapshot_restore_factory(snapshot_obj=snap_obj, timeout=600)
+        restored_pvc = snapshot_restore_factory(
+            snapshot_obj=snap_obj, volume_mode=pvc_obj.get_pvc_vol_mode, timeout=600
+        )
         log.info(f"restored the snapshot {restored_pvc.name} created!")
 
         # create a clone of the PVC

--- a/tests/functional/pv/pv_services/test_rbd_image_metadata.py
+++ b/tests/functional/pv/pv_services/test_rbd_image_metadata.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants


### PR DESCRIPTION
This PR fixes https://github.com/red-hat-storage/ocs-ci/issues/9966

Currently, we create source pvc with block volumemode but during restore snapshot , by default it take filesystem, which causes test case to fail.
This fix add additional param called volume_mode to snapshot_restore_factory
