### PR TITLE
[BZ-2249640] verify nodeAffinity for cephtoolbox pod

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3010,19 +3010,15 @@ def get_worker_node_where_ceph_toolbox_not_running():
 
     Returns:
         List of worker nodes other than the node where ceph tool box is already running.
+
     """
-    log.info(
-        "Testing cephtoolbox pod with nodeaffinity in the openshift-storage namespace."
-    )
-
-    ct_pod = pod.get_ceph_tools_pod()
-    # Identify on which node the ceph toolbox is running currently
-    ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
-
+    ct_pod_running_node_name = get_ceph_tools_running_node()
     worker_nodes = get_worker_nodes()
-    log.info(worker_nodes)
-
+    log.info(
+        f"List of all worker nodes available in the cluster currently {worker_nodes}"
+    )
     other_nodes = [node for node in worker_nodes if node != ct_pod_running_node_name]
+    log.info(f"List of worker nodes where ceph tools pod is not running: {other_nodes}")
     return other_nodes
 
 
@@ -3034,8 +3030,8 @@ def apply_node_affinity_for_ceph_toolbox(node_name, wait_time=60):
         node_name = node name which need to be added in the node affinity
 
     Returns:
-        bool: return True --> if node affinity applied successfully .
-        bool: return False --> if node affinity fails.
+        bool: True if node affinity applied successfully
+
     """
     resource_name = constants.DEFAULT_CLUSTERNAME
     if config.DEPLOYMENT["external_mode"]:
@@ -3053,24 +3049,32 @@ def apply_node_affinity_for_ceph_toolbox(node_name, wait_time=60):
         f'"values": ["{node_name}"]}}]}}]}}}}}}}}'
     )
     param = f'{{"spec": {{"placement": {nodeaffinity}}}}}'
+    ct_pod = pod.get_ceph_tools_pod(skip_creating_pod=True)
+    ct_pod_name = ct_pod.name
     storagecluster_obj.patch(params=param, format_type="merge")
     log.info(
         f"Successfully applied node affinity for ceph toolbox pod with {node_name}"
     )
-    log.info(
-        "Script will be in sleep for a minute to make sure cephtools pod failovered with node affinity"
-    )
-    time.sleep(wait_time)
-    ct_new_pod = pod.get_ceph_tools_pod(skip_creating_pod=True)
+    ct_pod.ocp.wait_for_delete(ct_pod_name), f"Pod {ct_pod_name} is not deleted"
     log.info(
         "Identify on which node the ceph toolbox is running after failover due to node affinity"
     )
-    ct_new_pod_running_node_name = ct_new_pod.data["spec"].get("nodeName")
+    ct_new_pod_running_node_name = get_ceph_tools_running_node()
     if node_name == ct_new_pod_running_node_name:
         log.info(
             f"ceph toolbox pod failovered to the new node {ct_new_pod_running_node_name}"
             f" given in node affinity successfully "
         )
         return True
-    else:
-        return False
+
+
+def get_ceph_tools_running_node():
+    """
+    Get node name where the ceph tools pod is currently running
+
+    :return: Node name (str)
+
+    """
+    ct_pod = pod.get_ceph_tools_pod(wait=True, skip_creating_pod=True)
+    ct_pod_running_node = ct_pod.data["spec"].get("nodeName")
+    return ct_pod_running_node

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3022,7 +3022,7 @@ def get_worker_node_where_ceph_toolbox_not_running():
     return other_nodes
 
 
-def apply_node_affinity_for_ceph_toolbox(node_name, wait_time=60):
+def apply_node_affinity_for_ceph_toolbox(node_name):
     """
     Apply node affinity for ceph toolbox pod.
 
@@ -3072,7 +3072,8 @@ def get_ceph_tools_running_node():
     """
     Get node name where the ceph tools pod is currently running
 
-    :return: Node name (str)
+    Returns:
+         str: name of the node where ceph tools is running
 
     """
     ct_pod = pod.get_ceph_tools_pod(wait=True, skip_creating_pod=True)

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3001,3 +3001,63 @@ def get_node_by_internal_ip(internal_ip):
             return n
 
     return None
+
+def get_worker_node_where_ceph_toolbox_not_running():
+    log.info(
+        "Testing cephtoolbox pod with nodeaffinity in the openshift-storage namespace."
+    )
+
+    ct_pod = pod.get_ceph_tools_pod()
+    # Identify on which node the ceph toolbox is running currently
+    ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
+
+    worker_nodes = get_worker_nodes()
+    log.info(worker_nodes)
+
+    other_nodes = [node for node in worker_nodes if node != ct_pod_running_node_name]
+    return other_nodes
+
+
+def apply_node_affinity_for_ceph_toolbox(node_name):
+    """
+    Apply node affinity for ceph toolbox pod.
+
+    Args:
+        node_name = node name which need to be added in the node affinity
+
+    Returns:
+        True: if node affinity applied successfully .
+        False: if node affinity fails
+    """
+    resource_name = constants.DEFAULT_CLUSTERNAME
+    if config.DEPLOYMENT["external_mode"]:
+        resource_name = constants.DEFAULT_CLUSTERNAME_EXTERNAL_MODE
+
+    storagecluster_obj = ocp.OCP(
+        resource_name=resource_name,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        kind=constants.STORAGECLUSTER,
+    )
+    nodeaffinity = (
+        f'{{"toolbox": {{"nodeAffinity": {{"requiredDuringSchedulingIgnoredDuringExecution": '
+        f'{{"nodeSelectorTerms": [{{"matchExpressions": [{{"key": "kubernetes.io/hostname",'
+        f'"operator": "In",'
+        f'"values": ["{node_name}"]}}]}}]}}}}}}}}'
+    )
+    param = f'{{"spec": {{"placement": {nodeaffinity}}}}}'
+    storagecluster_obj.patch(params=param, format_type="merge")
+    log.info(
+        f"Successfully applied node affinity for ceph toolbox pod with {node_name}"
+    )
+
+    ct_new_pod = pod.get_ceph_tools_pod()
+    # Identify on which node the ceph toolbox is running after failover due to nodeaffinity
+    ct_new_pod_running_node_name = ct_new_pod.data["spec"].get("nodeName")
+    if node_name == ct_new_pod_running_node_name:
+        log.info(
+            f"ceph toolbox pod failovered to the new node {ct_new_pod_running_node_name}"
+            f" given in node affinity successfully "
+        )
+        return True
+    else:
+        return False

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3002,6 +3002,7 @@ def get_node_by_internal_ip(internal_ip):
 
     return None
 
+
 def get_worker_node_where_ceph_toolbox_not_running():
     log.info(
         "Testing cephtoolbox pod with nodeaffinity in the openshift-storage namespace."
@@ -3026,8 +3027,8 @@ def apply_node_affinity_for_ceph_toolbox(node_name):
         node_name = node name which need to be added in the node affinity
 
     Returns:
-        True: if node affinity applied successfully .
-        False: if node affinity fails
+        bool: return True --> if node affinity applied successfully .
+        bool: return False --> if node affinity fails.
     """
     resource_name = constants.DEFAULT_CLUSTERNAME
     if config.DEPLOYMENT["external_mode"]:

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3055,7 +3055,7 @@ def apply_node_affinity_for_ceph_toolbox(node_name):
     log.info(
         f"Successfully applied node affinity for ceph toolbox pod with {node_name}"
     )
-    ct_pod.ocp.wait_for_delete(ct_pod_name), f"Pod {ct_pod_name} is not deleted"
+    ct_pod.ocp.wait_for_delete(ct_pod_name)
     log.info(
         "Identify on which node the ceph toolbox is running after failover due to node affinity"
     )

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3026,7 +3026,7 @@ def get_worker_node_where_ceph_toolbox_not_running():
     return other_nodes
 
 
-def apply_node_affinity_for_ceph_toolbox(node_name):
+def apply_node_affinity_for_ceph_toolbox(node_name, wait_time=60):
     """
     Apply node affinity for ceph toolbox pod.
 
@@ -3057,9 +3057,14 @@ def apply_node_affinity_for_ceph_toolbox(node_name):
     log.info(
         f"Successfully applied node affinity for ceph toolbox pod with {node_name}"
     )
-
+    log.info(
+        "Script will be in sleep for a minute to make sure cephtools pod failovered with node affinity"
+    )
+    time.sleep(wait_time)
     ct_new_pod = pod.get_ceph_tools_pod(skip_creating_pod=True)
-    # Identify on which node the ceph toolbox is running after failover due to nodeaffinity
+    log.info(
+        "Identify on which node the ceph toolbox is running after failover due to node affinity"
+    )
     ct_new_pod_running_node_name = ct_new_pod.data["spec"].get("nodeName")
     if node_name == ct_new_pod_running_node_name:
         log.info(

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3004,6 +3004,13 @@ def get_node_by_internal_ip(internal_ip):
 
 
 def get_worker_node_where_ceph_toolbox_not_running():
+    """
+    This function get a list of all worker nodes
+    and compare each worker node name with the node name of ceph tool box running.
+
+    Returns:
+        List of worker nodes other than the node where ceph tool box is already running.
+    """
     log.info(
         "Testing cephtoolbox pod with nodeaffinity in the openshift-storage namespace."
     )
@@ -3051,7 +3058,7 @@ def apply_node_affinity_for_ceph_toolbox(node_name):
         f"Successfully applied node affinity for ceph toolbox pod with {node_name}"
     )
 
-    ct_new_pod = pod.get_ceph_tools_pod()
+    ct_new_pod = pod.get_ceph_tools_pod(skip_creating_pod=True)
     # Identify on which node the ceph toolbox is running after failover due to nodeaffinity
     ct_new_pod_running_node_name = ct_new_pod.data["spec"].get("nodeName")
     if node_name == ct_new_pod_running_node_name:

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -2,14 +2,10 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.ocs import ocp, constants
-from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
 from ocs_ci.framework.testlib import tier1, tier4b, polarion_id
 from ocs_ci.helpers.sanity_helpers import Sanity
-from ocs_ci.ocs.resources.pod import (
-    wait_for_pods_to_be_running,
-)
+from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.node import (
     unschedule_nodes,
     drain_nodes,
@@ -19,6 +15,10 @@ from ocs_ci.ocs.node import (
     get_worker_nodes,
     get_worker_node_where_ceph_toolbox_not_running,
     apply_node_affinity_for_ceph_toolbox,
+)
+from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources.pod import (
+    wait_for_pods_to_be_running,
 )
 
 log = logging.getLogger(__name__)
@@ -121,8 +121,8 @@ class TestCephtoolboxPod:
         """
         worker_nodes = get_worker_nodes()
         log.info(f"Current available worker nodes are {worker_nodes}")
-        # <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
-        # <<This task will be done in another PR>>
+        # TODO: <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
+        # <<This task will be implemented as part of https://github.com/red-hat-storage/ocs-ci/issues/10358 >>
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
         log.info(
             "Apply node affinity with a node name other than currently running node."

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -15,6 +15,7 @@ from ocs_ci.ocs.node import (
     drain_nodes,
     schedule_nodes,
     taint_nodes,
+    untaint_nodes,
     get_worker_nodes,
     get_worker_node_where_ceph_toolbox_not_running,
     apply_node_affinity_for_ceph_toolbox,
@@ -36,6 +37,7 @@ class TestCephtoolboxPod:
     @pytest.fixture(scope="session", autouse=True)
     def teardown(self, request):
         def finalizer():
+            untaint_nodes()
             resource_name = constants.DEFAULT_CLUSTERNAME
             if config.DEPLOYMENT["external_mode"]:
                 resource_name = constants.DEFAULT_CLUSTERNAME_EXTERNAL_MODE

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import tier1, tier4b, polarion_id
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.node import (
     apply_node_affinity_for_ceph_toolbox,
+    check_taint_on_nodes,
     drain_nodes,
     get_ceph_tools_running_node,
     get_worker_nodes,
@@ -34,7 +35,8 @@ class TestCephtoolboxPod:
             2. Removes nodeaffinity to bring storage cluster with default values.
 
             """
-            untaint_nodes()
+            if check_taint_on_nodes():
+                untaint_nodes()
             resource_name = constants.DEFAULT_CLUSTERNAME
             if config.DEPLOYMENT["external_mode"]:
                 resource_name = constants.DEFAULT_CLUSTERNAME_EXTERNAL_MODE

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -1,0 +1,70 @@
+import logging
+import pytest
+import time
+
+from ocs_ci.ocs import node
+from ocs_ci.ocs.resources import pod
+from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
+from ocs_ci.framework.testlib import tier1
+from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.ocs.node import (
+    unschedule_nodes,
+    drain_nodes,
+    schedule_nodes,
+)
+
+log = logging.getLogger(__name__)
+
+
+@tier1
+@magenta_squad
+@bugzilla("2249640")
+class TestCephtoolboxPod:
+    @pytest.fixture(autouse=True)
+    def init_sanity(self):
+        """
+        Initialize Sanity instance
+
+        """
+        self.sanity_helpers = Sanity()
+
+    def test_node_affinity_to_ceph_toolbox_pod(self):
+        # This test verifies whether ceph toolbox failovered or not after applying node affinity
+        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        # Apply node affinity with a node name other than currently running node.
+        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+
+    def test_reboot_node_affinity_node(self):
+        # This test verifies ceph toolbox runs only on the node given in node-affility.
+        # Reboot the node after applying node-affinity.
+        # Expectation is the pod should come up only on that node mentioned in affinity.
+
+        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+
+        node_name = other_nodes[0]
+
+        # Unschedule ceph tool box running node.
+        unschedule_nodes([node_name])
+        log.info(f"node {node_name} unscheduled successfully")
+
+        # Drain node operation
+        drain_nodes([node_name])
+        log.info(f"node {node_name} drained successfully")
+
+        # Make the node schedule-able
+        schedule_nodes([node_name])
+        log.info(f"Scheduled the node {node_name}")
+        log.info(
+            "Script will sleep for 3 minutes before validating the ceph toolbox running node"
+        )
+        time.sleep(180)
+
+        ct_pod = pod.get_ceph_tools_pod()
+        # Identify on which node the ceph toolbox is running after node drain
+        ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
+        if node_name == ct_pod_running_node_name:
+            log.info(
+                f"ceph toolbox pod is running only on a node {ct_pod_running_node_name} which is in node-affinity"
+            )
+            assert True

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -93,3 +93,22 @@ class TestCephtoolboxPod:
                 f"ceph toolbox pod is running only on a node {ct_pod_running_node_name} which is in node-affinity"
             )
             assert True
+    def test_nodeaffinity_to_ceph_toolbox_with_default_taints(self):
+        # This test verifies whether ceph toolbox failovered or not after applying node affinity on tainted noded
+        worker_nodes = node.get_worker_nodes()
+        log.info(f"Current available worker nodes are {worker_nodes}")
+        node.taint_nodes(worker_nodes)
+        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        # Apply node affinity with a node name other than currently running node.
+        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+
+    def test_nodeaffinity_to_ceph_toolbox_with_custom_taints(self):
+        #This test verifies whether ceph toolbox failovered or not after applying node affinity on custom tainted node.
+        worker_nodes = node.get_worker_nodes()
+        log.info(f"Current available worker nodes are {worker_nodes}")
+        # <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
+        #<<The above task can be done in another PR>>
+        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        # Apply node affinity with a node name other than currently running node.
+        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -1,25 +1,23 @@
 import logging
 import pytest
+import random
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
 from ocs_ci.framework.testlib import tier1, tier4b, polarion_id
-from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.node import (
-    unschedule_nodes,
+    apply_node_affinity_for_ceph_toolbox,
     drain_nodes,
-    schedule_nodes,
-    taint_nodes,
-    untaint_nodes,
+    get_ceph_tools_running_node,
     get_worker_nodes,
     get_worker_node_where_ceph_toolbox_not_running,
-    apply_node_affinity_for_ceph_toolbox,
+    schedule_nodes,
+    taint_nodes,
+    unschedule_nodes,
+    untaint_nodes,
 )
-from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.resources.pod import (
-    wait_for_pods_to_be_running,
-)
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 
 log = logging.getLogger(__name__)
 
@@ -27,16 +25,15 @@ log = logging.getLogger(__name__)
 @brown_squad
 @bugzilla("2249640")
 class TestCephtoolboxPod:
-    @pytest.fixture(autouse=True)
-    def init_sanity(self):
-        """
-        Initialize Sanity instance
-        """
-        self.sanity_helpers = Sanity()
-
     @pytest.fixture(scope="session", autouse=True)
     def teardown(self, request):
         def finalizer():
+            """
+            Finalizer will take care of below activities:
+            1. Untaint the nodes: remove taints from nodes
+            2. Removes nodeaffinity to bring storage cluster with default values.
+
+            """
             untaint_nodes()
             resource_name = constants.DEFAULT_CLUSTERNAME
             if config.DEPLOYMENT["external_mode"]:
@@ -60,12 +57,16 @@ class TestCephtoolboxPod:
     def test_node_affinity_to_ceph_toolbox_pod(self):
         """
         This test verifies whether ceph toolbox failovered or not after applying node affinity
+
         """
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
+        other_node_name = random.choice(other_nodes)
         log.info(
             "Apply node affinity with a node name other than currently running node."
         )
-        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+        assert apply_node_affinity_for_ceph_toolbox(
+            other_node_name
+        ), "Failed to apply node affinity for the Ceph toolbox on the specified node."
 
     @tier4b
     @polarion_id("OCS-6087")
@@ -74,9 +75,10 @@ class TestCephtoolboxPod:
         This test verifies ceph toolbox runs only on the node given in node-affinity.
         Reboot the node after applying node-affinity.
         Expectation is the pod should come up only on that node mentioned in affinity.
+
         """
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
-        node_name = other_nodes[0]
+        node_name = random.choice(other_nodes)
         apply_node_affinity_for_ceph_toolbox(node_name)
         log.info("Unschedule ceph tools pod running node.")
         unschedule_nodes([node_name])
@@ -85,15 +87,14 @@ class TestCephtoolboxPod:
         log.info(f"node {node_name} drained successfully")
         schedule_nodes([node_name])
         log.info(f"Scheduled the node {node_name}")
-        ct_pod = pod.get_ceph_tools_pod(skip_creating_pod=True, wait=True)
         log.info("Identify on which node the ceph toolbox is running after node drain")
-        ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
+        ct_pod_running_node_name = get_ceph_tools_running_node()
         if node_name == ct_pod_running_node_name:
             log.info(
                 f"ceph toolbox pod is running on a node {node_name} which is in node-affinity"
             )
         else:
-            log.info(
+            log.error(
                 f"Ceph toolbox pod is not running on the nodeAffinity given node {node_name}."
             )
             assert False, "Ceph toolbox pod is not on the expected node."
@@ -103,28 +104,17 @@ class TestCephtoolboxPod:
     def test_nodeaffinity_to_ceph_toolbox_with_default_taints(self):
         """
         This test verifies whether ceph toolbox failovered or not after applying node affinity on tainted node
+
         """
         worker_nodes = get_worker_nodes()
         log.info(f"Current available worker nodes are {worker_nodes}")
         taint_nodes(worker_nodes)
+        log.info("Applied default taints on all the worker nodes")
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
+        other_node_name = random.choice(other_nodes)
         log.info(
             "Apply node affinity with a node name other than currently running node."
         )
-        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
-
-    @tier4b
-    @polarion_id("OCS-6091")
-    def test_nodeaffinity_to_ceph_toolbox_with_custom_taints(self):
-        """
-        This test verifies whether ceph toolbox failovered or not after applying node affinity on custom tainted node.
-        """
-        worker_nodes = get_worker_nodes()
-        log.info(f"Current available worker nodes are {worker_nodes}")
-        # TODO: <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
-        # <<This task will be implemented as part of https://github.com/red-hat-storage/ocs-ci/issues/10358 >>
-        other_nodes = get_worker_node_where_ceph_toolbox_not_running()
-        log.info(
-            "Apply node affinity with a node name other than currently running node."
-        )
-        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+        assert apply_node_affinity_for_ceph_toolbox(
+            other_node_name
+        ), "Failed to apply nodeaffinity with default taints"

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -62,7 +62,9 @@ class TestCephtoolboxPod:
         This test verifies whether ceph toolbox failovered or not after applying node affinity
         """
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
-        # Apply node affinity with a node name other than currently running node.
+        log.info(
+            "Apply node affinity with a node name other than currently running node."
+        )
         assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
 
     @tier4b
@@ -76,17 +78,15 @@ class TestCephtoolboxPod:
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
         node_name = other_nodes[0]
         apply_node_affinity_for_ceph_toolbox(node_name)
-        # Unschedule ceph tool box running node.
+        log.info("Unschedule ceph tools pod running node.")
         unschedule_nodes([node_name])
         log.info(f"node {node_name} unscheduled successfully")
-        # Drain node operation
         drain_nodes([node_name])
         log.info(f"node {node_name} drained successfully")
-        # Make the node schedule-able
         schedule_nodes([node_name])
         log.info(f"Scheduled the node {node_name}")
         ct_pod = pod.get_ceph_tools_pod(skip_creating_pod=True, wait=True)
-        # Identify on which node the ceph toolbox is running after node drain
+        log.info("Identify on which node the ceph toolbox is running after node drain")
         ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
         if node_name == ct_pod_running_node_name:
             log.info(
@@ -108,7 +108,9 @@ class TestCephtoolboxPod:
         log.info(f"Current available worker nodes are {worker_nodes}")
         taint_nodes(worker_nodes)
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
-        # Apply node affinity with a node name other than currently running node.
+        log.info(
+            "Apply node affinity with a node name other than currently running node."
+        )
         assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
 
     @tier4b
@@ -120,7 +122,9 @@ class TestCephtoolboxPod:
         worker_nodes = get_worker_nodes()
         log.info(f"Current available worker nodes are {worker_nodes}")
         # <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
-        # <<The above task can be done in another PR>>
+        # <<This task will be done in another PR>>
         other_nodes = get_worker_node_where_ceph_toolbox_not_running()
-        # Apply node affinity with a node name other than currently running node.
+        log.info(
+            "Apply node affinity with a node name other than currently running node."
+        )
         assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])

--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -1,38 +1,39 @@
 import logging
 import pytest
-import time
 
 from ocs_ci.framework import config
-from ocs_ci.ocs import ocp, node, constants
+from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import bugzilla, magenta_squad
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.pytest_customization.marks import bugzilla, brown_squad
+from ocs_ci.framework.testlib import tier1, tier4b, polarion_id
 from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.ocs.resources.pod import (
+    wait_for_pods_to_be_running,
+)
 from ocs_ci.ocs.node import (
     unschedule_nodes,
     drain_nodes,
     schedule_nodes,
-)
-from ocs_ci.ocs.resources.pod import (
-    wait_for_pods_to_be_running,
+    taint_nodes,
+    get_worker_nodes,
+    get_worker_node_where_ceph_toolbox_not_running,
+    apply_node_affinity_for_ceph_toolbox,
 )
 
 log = logging.getLogger(__name__)
 
 
-@tier1
-@magenta_squad
+@brown_squad
 @bugzilla("2249640")
 class TestCephtoolboxPod:
     @pytest.fixture(autouse=True)
     def init_sanity(self):
         """
         Initialize Sanity instance
-
         """
         self.sanity_helpers = Sanity()
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(scope="session", autouse=True)
     def teardown(self, request):
         def finalizer():
             resource_name = constants.DEFAULT_CLUSTERNAME
@@ -46,69 +47,78 @@ class TestCephtoolboxPod:
             params = '[{"op": "remove", "path": "/spec/placement/toolbox"},]'
             storagecluster_obj.patch(params=params, format_type="json")
             log.info("Patched storage cluster  back to the default")
-            time.sleep(100)
             assert (
                 wait_for_pods_to_be_running()
             ), "some of the pods didn't came up running"
 
         request.addfinalizer(finalizer)
 
+    @tier1
+    @polarion_id("OCS-6086")
     def test_node_affinity_to_ceph_toolbox_pod(self):
-        # This test verifies whether ceph toolbox failovered or not after applying node affinity
-        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        """
+        This test verifies whether ceph toolbox failovered or not after applying node affinity
+        """
+        other_nodes = get_worker_node_where_ceph_toolbox_not_running()
         # Apply node affinity with a node name other than currently running node.
-        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
 
+    @tier4b
+    @polarion_id("OCS-6087")
     def test_reboot_node_affinity_node(self):
-        # This test verifies ceph toolbox runs only on the node given in node-affility.
-        # Reboot the node after applying node-affinity.
-        # Expectation is the pod should come up only on that node mentioned in affinity.
-
-        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
-        node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
-
+        """
+        This test verifies ceph toolbox runs only on the node given in node-affinity.
+        Reboot the node after applying node-affinity.
+        Expectation is the pod should come up only on that node mentioned in affinity.
+        """
+        other_nodes = get_worker_node_where_ceph_toolbox_not_running()
         node_name = other_nodes[0]
-
+        apply_node_affinity_for_ceph_toolbox(node_name)
         # Unschedule ceph tool box running node.
         unschedule_nodes([node_name])
         log.info(f"node {node_name} unscheduled successfully")
-
         # Drain node operation
         drain_nodes([node_name])
         log.info(f"node {node_name} drained successfully")
-
         # Make the node schedule-able
         schedule_nodes([node_name])
         log.info(f"Scheduled the node {node_name}")
-        log.info(
-            "Script will sleep for 3 minutes before validating the ceph toolbox running node"
-        )
-        time.sleep(180)
-
-        ct_pod = pod.get_ceph_tools_pod()
+        ct_pod = pod.get_ceph_tools_pod(skip_creating_pod=True, wait=True)
         # Identify on which node the ceph toolbox is running after node drain
         ct_pod_running_node_name = ct_pod.data["spec"].get("nodeName")
         if node_name == ct_pod_running_node_name:
             log.info(
-                f"ceph toolbox pod is running only on a node {ct_pod_running_node_name} which is in node-affinity"
+                f"ceph toolbox pod is running on a node {node_name} which is in node-affinity"
             )
-            assert True
-    def test_nodeaffinity_to_ceph_toolbox_with_default_taints(self):
-        # This test verifies whether ceph toolbox failovered or not after applying node affinity on tainted noded
-        worker_nodes = node.get_worker_nodes()
-        log.info(f"Current available worker nodes are {worker_nodes}")
-        node.taint_nodes(worker_nodes)
-        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
-        # Apply node affinity with a node name other than currently running node.
-        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+        else:
+            log.info(
+                f"Ceph toolbox pod is not running on the nodeAffinity given node {node_name}."
+            )
+            assert False, "Ceph toolbox pod is not on the expected node."
 
+    @tier4b
+    @polarion_id("OCS-6090")
+    def test_nodeaffinity_to_ceph_toolbox_with_default_taints(self):
+        """
+        This test verifies whether ceph toolbox failovered or not after applying node affinity on tainted node
+        """
+        worker_nodes = get_worker_nodes()
+        log.info(f"Current available worker nodes are {worker_nodes}")
+        taint_nodes(worker_nodes)
+        other_nodes = get_worker_node_where_ceph_toolbox_not_running()
+        # Apply node affinity with a node name other than currently running node.
+        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])
+
+    @tier4b
+    @polarion_id("OCS-6091")
     def test_nodeaffinity_to_ceph_toolbox_with_custom_taints(self):
-        #This test verifies whether ceph toolbox failovered or not after applying node affinity on custom tainted node.
-        worker_nodes = node.get_worker_nodes()
+        """
+        This test verifies whether ceph toolbox failovered or not after applying node affinity on custom tainted node.
+        """
+        worker_nodes = get_worker_nodes()
         log.info(f"Current available worker nodes are {worker_nodes}")
         # <<PR9808 yet to be merged. Once it is merged, the custom taints function need to be called here.>>
-        #<<The above task can be done in another PR>>
-        other_nodes = node.get_worker_node_where_ceph_toolbox_not_running()
+        # <<The above task can be done in another PR>>
+        other_nodes = get_worker_node_where_ceph_toolbox_not_running()
         # Apply node affinity with a node name other than currently running node.
-        assert node.apply_node_affinity_for_ceph_toolbox(other_nodes[0])
-
+        assert apply_node_affinity_for_ceph_toolbox(other_nodes[0])


### PR DESCRIPTION
Automated below two tests from  https://docs.google.com/spreadsheets/d/1wCSwMk_L4SikzZ2UarUH1-VCXyGkHs-ZNdDEtWPG7f4/edit#gid=1509950578

**1.  Add nodeAffinity to cephToolbox pod**
            Test steps:
                 "1) Identify the ceph toolbox running node. Let's say Compute-0
                  2) Add node affinity for the toolbox pod to run on a different node than it is running by updating the storagecluster CR.
                  Let's say set it to Compute-1
                  eg:
                  spec:
                    placement:
                      toolbox:
                        nodeAffinity:
                          requiredDuringSchedulingIgnoredDuringExecution:
                            nodeSelectorTerms:
                            - matchExpressions:
                              - key: kubernetes.io/hostname
                                operator: In
                                values: 
                                - compute-1
                  3) Check if the toolbox pod get's scheduled to the new node."

**2. "Fail the tool box pod node affinity node by rebooting the node**
           Test steps:
            "1) Add node affinity for the toolbox pod to run on a compute-0 by updating the storagecluster CR.
                eg:
                spec:
                  placement:
                    toolbox:
                      nodeAffinity:
                        requiredDuringSchedulingIgnoredDuringExecution:
                          nodeSelectorTerms:
                          - matchExpressions:
                            - key: kubernetes.io/hostname
                              operator: In
                              values: 
                              - compute-0
                2) Reboot compute-0"
