### PR TITLE
Fix alert list checking #9978

### DIFF
--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -38,7 +38,7 @@ def check_alert_list(
             it is not checked if there is more of occurences than one.
     """
 
-    target_alerts = [
+    all_alerts = [
         alert for alert in alerts if alert.get("labels").get("alertname") == label
     ]
     logger.info(f"Checking properties of found {label} alerts")
@@ -46,7 +46,7 @@ def check_alert_list(
     for key, state in enumerate(states):
         target_alerts = [
             alert
-            for alert in target_alerts
+            for alert in all_alerts
             if alert["annotations"]["message"] == msg
             and alert["annotations"]["severity_level"] == severity
             and alert["state"] == state


### PR DESCRIPTION
Checking alert list fails if filtering for more than two states. Reason was the loop on provided states filtered the examined alert list by the fist element in the states list. Therefore respective tests always fail when filtering for the second and further states.
Fixed by repeatedly filtering the original and not the filtered one.