### PR TITLE
add Deployment init to constructor

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -314,6 +314,7 @@ class HypershiftHostedOCP(HyperShiftBase, MetalLBInstaller, CNVInstaller, Deploy
         HyperShiftBase.__init__(self)
         MetalLBInstaller.__init__(self)
         CNVInstaller.__init__(self)
+        Deployment.__init__(self)
         self.name = name
         if config.ENV_DATA["clusters"].get(self.name):
             cluster_path = (

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -311,10 +311,10 @@ class HostedClients(HyperShiftBase):
 
 class HypershiftHostedOCP(HyperShiftBase, MetalLBInstaller, CNVInstaller, Deployment):
     def __init__(self, name):
+        Deployment.__init__(self)
         HyperShiftBase.__init__(self)
         MetalLBInstaller.__init__(self)
         CNVInstaller.__init__(self)
-        Deployment.__init__(self)
         self.name = name
         if config.ENV_DATA["clusters"].get(self.name):
             cluster_path = (


### PR DESCRIPTION
we fail to reach fields that are instantiated in the Deployment constructor. Addressing this.

The issue is seen below:
https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/39107/