### PR TITLE
Skip all the tests in the resize osd feature until the related BZs are fixed

### DIFF
--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     brown_squad,
     black_squad,
+    bugzilla,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -58,6 +59,8 @@ from ocs_ci.ocs import defaults
 logger = logging.getLogger(__name__)
 
 
+@bugzilla("2279843")
+@bugzilla("2295778")
 @brown_squad
 @ignore_leftovers
 @skipif_managed_service

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 
 @bugzilla("2279843")
 @bugzilla("2295778")
+@bugzilla("2295750")
 @brown_squad
 @ignore_leftovers
 @skipif_managed_service


### PR DESCRIPTION
As per the discussion here: https://app.slack.com/client/E27SFGS2W/C06DWD30QTZ, we decided to remove this feature from 4.16.
We need to skip all the tests in the resize osd feature until the related BZs are fixed and the feature is ready.
In the PR, we skip the resize osd tests until the following BZs are fixed:

- https://bugzilla.redhat.com/show_bug.cgi?id=2279843
- https://bugzilla.redhat.com/show_bug.cgi?id=2295778