### PR TITLE
Adding pvc resize functionality to RWOP test

### DIFF
--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -59,6 +59,13 @@ class TestRwopPvc(ManageTest):
 
         # Verify that PVCs are reusable by creating new pods
         log.info(f"PVC obj {self.pvc_obj}")
+        self.create_pod_and_validate_pending(pod_factory, interface)
+
+        self.pvc_obj.resize_pvc(20, True)
+
+        self.create_pod_and_validate_pending(pod_factory, interface)
+
+    def create_pod_and_validate_pending(self, pod_factory, interface):
         new_pod_obj = helpers.create_pods(
             [self.pvc_obj],
             pod_factory,


### PR DESCRIPTION
This PR adds the following flow to RWOP test : 

- after we make sure that only one pod with the same priority can be attached to RWOP PVC, we resize the PVC and try to create another pod with the same priority and attach it to the PVC, making sure the operation will still not success. 