### PR TITLE
Fix kebab menu locator for add capacity UI test

### DIFF
--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -30,9 +30,12 @@ class AddReplaceDeviceUI(PageNavigator):
             self.do_click(self.add_capacity_ui_loc["ocs_operator"])
             self.do_click(self.add_capacity_ui_loc["storage_cluster_tab"])
         time.sleep(1)
+        logger.info("Click on kebab menu of Storage Systems")
         self.do_click(
             self.add_capacity_ui_loc["kebab_storage_cluster"], avoid_stale=True
         )
+        self.take_screenshot()
+        logger.info("Click on Add Capacity button under the kebab menu")
         self.wait_until_expected_text_is_found(
             locator=self.add_capacity_ui_loc["add_capacity_button"],
             timeout=10,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1063,7 +1063,7 @@ add_capacity = {
         'a[data-test-id="horizontal-link-Storage System"]',
         By.CSS_SELECTOR,
     ),
-    "kebab_storage_cluster": ('button[data-test="kebab-button"]', By.CSS_SELECTOR),
+    "kebab_storage_cluster": ('button[aria-label="Dropdown toggle"]', By.CSS_SELECTOR),
     "add_capacity_button": ('button[data-test-action="Add Capacity"]', By.CSS_SELECTOR),
     "select_sc_add_capacity": (
         'button[data-test="add-cap-sc-dropdown"]',

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1063,7 +1063,7 @@ add_capacity = {
         'a[data-test-id="horizontal-link-Storage System"]',
         By.CSS_SELECTOR,
     ),
-    "kebab_storage_cluster": ('button[aria-label="Dropdown toggle"]', By.CSS_SELECTOR),
+    "kebab_storage_cluster": ("//button[@aria-label='Dropdown toggle']", By.XPATH),
     "add_capacity_button": ('button[data-test-action="Add Capacity"]', By.CSS_SELECTOR),
     "select_sc_add_capacity": (
         'button[data-test="add-cap-sc-dropdown"]',

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1063,7 +1063,7 @@ add_capacity = {
         'a[data-test-id="horizontal-link-Storage System"]',
         By.CSS_SELECTOR,
     ),
-    "kebab_storage_cluster": ('button[data-test-id="kebab-button"', By.CSS_SELECTOR),
+    "kebab_storage_cluster": ('button[data-test="kebab-button"]', By.CSS_SELECTOR),
     "add_capacity_button": ('button[data-test-action="Add Capacity"]', By.CSS_SELECTOR),
     "select_sc_add_capacity": (
         'button[data-test="add-cap-sc-dropdown"]',

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1063,7 +1063,7 @@ add_capacity = {
         'a[data-test-id="horizontal-link-Storage System"]',
         By.CSS_SELECTOR,
     ),
-    "kebab_storage_cluster": ('button[data-test="kebab-button"]', By.CSS_SELECTOR),
+    "kebab_storage_cluster": ('button[data-test-id="kebab-button"', By.CSS_SELECTOR),
     "add_capacity_button": ('button[data-test-action="Add Capacity"]', By.CSS_SELECTOR),
     "select_sc_add_capacity": (
         'button[data-test="add-cap-sc-dropdown"]',

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1063,7 +1063,7 @@ add_capacity = {
         'a[data-test-id="horizontal-link-Storage System"]',
         By.CSS_SELECTOR,
     ),
-    "kebab_storage_cluster": ("//button[@aria-label='Dropdown toggle']", By.XPATH),
+    "kebab_storage_cluster": ("//button[@data-test-id='kebab-button']", By.XPATH),
     "add_capacity_button": ('button[data-test-action="Add Capacity"]', By.CSS_SELECTOR),
     "select_sc_add_capacity": (
         'button[data-test="add-cap-sc-dropdown"]',

--- a/ocs_ci/utility/localstorage.py
+++ b/ocs_ci/utility/localstorage.py
@@ -152,7 +152,7 @@ def check_local_volume_local_volume_set():
         return lv_or_lvs_dict
 
 
-@retry(AssertionError, 12, 10, 1)
+@retry(AssertionError, 15, 15, 5)
 def check_pvs_created(num_pvs_required):
     """
     Verify that exact number of PVs were created and are in the Available state

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -142,7 +142,6 @@ class TestAddCapacity(ManageTest):
         add_capacity_test(ui_flag=False)
 
     @tier1
-    @brown_squad
     @black_squad
     def test_add_capacity_ui(self, reduce_and_resume_cluster_load):
         """
@@ -177,7 +176,6 @@ class TestAddCapacityLSO(ManageTest):
         storage_cluster.add_capacity_lso(ui_flag=False)
 
     @tier1
-    @brown_squad
     @black_squad
     def test_add_capacity_lso_ui(self, reduce_and_resume_cluster_load):
         """

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_stretch_cluster,
     skipif_hci_provider_and_client,
     brown_squad,
+    black_squad,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -115,7 +116,6 @@ def add_capacity_test(ui_flag=False):
     check_ceph_health_after_add_capacity(ceph_rebalance_timeout=3600)
 
 
-@brown_squad
 @ignore_leftovers
 @polarion_id("OCS-1191")
 @pytest.mark.second_to_last
@@ -134,6 +134,7 @@ class TestAddCapacity(ManageTest):
     """
 
     @acceptance
+    @brown_squad
     def test_add_capacity_cli(self, reduce_and_resume_cluster_load):
         """
         Add capacity on non-lso cluster via cli on Acceptance suite
@@ -141,6 +142,8 @@ class TestAddCapacity(ManageTest):
         add_capacity_test(ui_flag=False)
 
     @tier1
+    @brown_squad
+    @black_squad
     def test_add_capacity_ui(self, reduce_and_resume_cluster_load):
         """
         Add capacity on non-lso cluster via UI on tier1 suite
@@ -148,7 +151,6 @@ class TestAddCapacity(ManageTest):
         add_capacity_test(ui_flag=True)
 
 
-@brown_squad
 @ignore_leftovers
 @polarion_id("OCS-4647")
 @pytest.mark.second_to_last
@@ -167,6 +169,7 @@ class TestAddCapacityLSO(ManageTest):
     """
 
     @acceptance
+    @brown_squad
     def test_add_capacity_lso_cli(self, reduce_and_resume_cluster_load):
         """
         Add capacity on lso cluster via CLI on Acceptance suite
@@ -174,6 +177,8 @@ class TestAddCapacityLSO(ManageTest):
         storage_cluster.add_capacity_lso(ui_flag=False)
 
     @tier1
+    @brown_squad
+    @black_squad
     def test_add_capacity_lso_ui(self, reduce_and_resume_cluster_load):
         """
         Add capacity on lso cluster via UI on tier1 suite


### PR DESCRIPTION
Failure seen in https://url.corp.redhat.com/9c00079
When existing locator was checked, the data test attribute has changes in and it also has a missing closing bracket.

Before-
`"kebab_storage_cluster": ('button[data-test-id="kebab-button"', By.CSS_SELECTOR),`
After-
`"kebab_storage_cluster": ('button[data-test="kebab-button"]', By.CSS_SELECTOR),`