### PR TITLE
Changing tests/functional/pv/pv_services/test_pvc_migrate_rwo_to_rwop.py  marker from tier1 to tier2

### DIFF
--- a/tests/functional/pv/pv_services/test_pvc_migrate_rwo_to_rwop.py
+++ b/tests/functional/pv/pv_services/test_pvc_migrate_rwo_to_rwop.py
@@ -5,7 +5,7 @@ import yaml
 from tempfile import NamedTemporaryFile
 
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.testlib import ManageTest, skipif_ocs_version, tier1
+from ocs_ci.framework.testlib import ManageTest, skipif_ocs_version, tier2
 from ocs_ci.helpers import helpers
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
     ],
 )
 @green_squad
+@tier2
 @skipif_ocs_version("<4.16")
 class TestMigrateRWO2RWOP(ManageTest):
     """
@@ -46,7 +47,6 @@ class TestMigrateRWO2RWOP(ManageTest):
         run_cmd(f"chmod 777 {temp_file.name}")
         run_cmd(f"sh {temp_file.name}")
 
-    @tier1
     def test_pvc_migrate_rwo_to_rwop(self, pvc_factory, pod_factory, interface):
         """
         Tests that changing access mode from ReadWriteOnce to ReadWriteOncePod is successful


### PR DESCRIPTION
This PR contains changing tests/functional/pv/pv_services/test_pvc_migrate_rwo_to_rwop.py  marker from tier1 to tier2