### PR TITLE
Adding a new test case for reclaim space job and cronjob on rwop pvc

### DIFF
--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -13,9 +13,13 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
 )
 from ocs_ci.helpers import helpers
-from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.exceptions import (
+    TimeoutExpiredError,
+    UnexpectedBehaviour,
+)
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs.resources import pvc
+from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
 
@@ -285,3 +289,16 @@ class TestRwopPvc(ManageTest):
                 f"Pod {self.pod_obj.name} using RWOP pvc {self.pvc_obj.name} is not in Pending state"
                 f"Pod {second_pod_obj.name} using RWOP pvc {self.pvc_obj.name} is not in Pending state"
             )
+
+    def test_rwop_pvc_reclaim_space(self):
+        """
+        Test to verify creation of reclaim space job and reclaim space cron job on RWOP pvc
+        """
+
+        schedule = "weekly"
+        reclaim_space_job = self.pvc_obj.create_reclaim_space_cronjob(schedule)
+        helpers.wait_for_reclaim_space_cronjob(reclaim_space_job, schedule)
+
+        reclaim_space_job = self.pvc_obj.create_reclaim_space_job()
+
+        helpers.wait_for_reclaim_space_job(reclaim_space_job)

--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.15")
 class TestRwopPvc(ManageTest):
     """
-    Tests ReadWriteOncePod RBD PVC
+    Tests ReadWriteOncePod PVC
     """
 
     @pytest.fixture(autouse=True)
@@ -285,16 +285,3 @@ class TestRwopPvc(ManageTest):
                 f"Pod {self.pod_obj.name} using RWOP pvc {self.pvc_obj.name} is not in Pending state"
                 f"Pod {second_pod_obj.name} using RWOP pvc {self.pvc_obj.name} is not in Pending state"
             )
-
-    def test_rwop_pvc_reclaim_space(self):
-        """
-        Test to verify creation of reclaim space job and reclaim space cron job on RWOP pvc
-        """
-
-        schedule = "weekly"
-        reclaim_space_job = self.pvc_obj.create_reclaim_space_cronjob(schedule)
-        helpers.wait_for_reclaim_space_cronjob(reclaim_space_job, schedule)
-
-        reclaim_space_job = self.pvc_obj.create_reclaim_space_job()
-
-        helpers.wait_for_reclaim_space_job(reclaim_space_job)

--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -13,13 +13,9 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
 )
 from ocs_ci.helpers import helpers
-from ocs_ci.ocs.exceptions import (
-    TimeoutExpiredError,
-    UnexpectedBehaviour,
-)
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs.resources import pvc
-from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
 

--- a/tests/functional/pv/pv_services/test_rwop_pvc_reclaim_space.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc_reclaim_space.py
@@ -1,5 +1,4 @@
 import logging
-import pytest
 
 from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import green_squad

--- a/tests/functional/pv/pv_services/test_rwop_pvc_reclaim_space.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc_reclaim_space.py
@@ -1,0 +1,41 @@
+import logging
+import pytest
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier2,
+    skipif_ocs_version,
+)
+from ocs_ci.helpers import helpers
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@tier2
+@skipif_ocs_version("<4.15")
+class TestRwopPvcReclaimSpace(ManageTest):
+    """
+    Tests Reclaim Space on ReadWriteOncePod RBD PVC
+    """
+
+    def test_rwop_pvc_reclaim_space(self, pvc_factory):
+        """
+        Test to verify creation of reclaim space job and reclaim space cron job on RWOP pvc
+        """
+
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            access_mode=constants.ACCESS_MODE_RWOP,
+            size=10,
+        )
+
+        schedule = "weekly"
+        reclaim_space_job = pvc_obj.create_reclaim_space_cronjob(schedule)
+        helpers.wait_for_reclaim_space_cronjob(reclaim_space_job, schedule)
+
+        reclaim_space_job = pvc_obj.create_reclaim_space_job()
+
+        helpers.wait_for_reclaim_space_job(reclaim_space_job)


### PR DESCRIPTION
This PR contains the following: 

1) Adding a new test case for creating reclaim space job and reclaim space cron job on RWOP PVC
2) Two new functions in helpers.py for testing the desired job/cronjob status.