### PR TITLE
Allow ssh jump host configuration for external rhcs cluster

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -426,6 +426,12 @@ Configuration specific to external Ceph cluster
 * `rgw_cert_ca` - url pointing to CA certificate used to sign certificate for RGW with SSL
 * `use_rbd_namespace` - boolean parameter to use RBD namespace in pool
 * `rbd_namespace` - Name of RBD namespace to use in pool
+* `ssh_jump_host` - configuration of jump host as a map, if required or None
+    * `host` - fqdn or IP of the jump host
+    * `user` - username used for connecting to the jump host
+    * `private_key` - Private key used for connecting to the jump host
+    * `password` - Password used for connecting to the jump host
+        (only one of `private_key` and `password` is required)
 
 ##### login
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1894,7 +1894,13 @@ class Deployment(object):
 
         # get external cluster details
         host, user, password, ssh_key = get_external_cluster_client()
-        external_cluster = ExternalCluster(host, user, password, ssh_key)
+        external_cluster = ExternalCluster(
+            host,
+            user,
+            password,
+            ssh_key,
+            jump_host=config.EXTERNAL_MODE.get("ssh_jump_host"),
+        )
         external_cluster.get_external_cluster_details()
 
         # get admin keyring

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -47,15 +47,17 @@ class ExternalCluster(object):
     Helper for External RHCS cluster
     """
 
-    def __init__(self, host, user, password=None, ssh_key=None):
+    def __init__(self, host, user, password=None, ssh_key=None, jump_host=None):
         """
         Initialize the variables required for external RHCS cluster
 
         Args:
-             host (str): Host name with FQDN or IP
-             user (str): User name
-             password (password): Password for the Host (optional if ssh_key provided)
-             ssh_key (str): Path to SSH private key for the host (optional if password provided).
+            host (str): Host name with FQDN or IP
+            user (str): User name
+            password (password): Password for the Host (optional if ssh_key provided)
+            ssh_key (str): Path to SSH private key for the host (optional if password provided).
+            jump_host (dict): configuration of jump host, if required or None
+                the dict could contain following keys: host, user, private_key, password
 
         Raises:
             ExternalClusterCephSSHAuthDetailsMissing: In case one of SSH key or password
@@ -76,6 +78,7 @@ class ExternalCluster(object):
             user=self.user,
             password=self.password,
             private_key=self.ssh_key,
+            jump_host=jump_host,
         )
 
     def get_external_cluster_details(self):

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1444,7 +1444,13 @@ class VSPHEREUPI(VSPHEREBASE):
                 rbd_name = config.ENV_DATA.get("rbd_name") or defaults.RBD_NAME
                 # get external cluster details
                 host, user, password, ssh_key = get_external_cluster_client()
-                external_cluster = ExternalCluster(host, user, password, ssh_key)
+                external_cluster = ExternalCluster(
+                    host,
+                    user,
+                    password,
+                    ssh_key,
+                    jump_host=config.EXTERNAL_MODE.get("ssh_jump_host"),
+                )
                 external_cluster.remove_rbd_images(pvs_to_delete, rbd_name)
             except Exception as ex:
                 logger.warning(

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -647,7 +647,13 @@ def run_ocs_upgrade(
     # create external cluster object
     if config.DEPLOYMENT["external_mode"]:
         host, user, password, ssh_key = get_external_cluster_client()
-        external_cluster = ExternalCluster(host, user, password, ssh_key)
+        external_cluster = ExternalCluster(
+            host,
+            user,
+            password,
+            ssh_key,
+            jump_host=config.EXTERNAL_MODE.get("ssh_jump_host"),
+        )
 
     # For external cluster , create the secrets if upgraded version is 4.8
     if (

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -637,7 +637,13 @@ def ocs_install_verification(
             object_store_user = defaults.EXTERNAL_CLUSTER_OBJECT_STORE_USER
             realm = config.ENV_DATA.get("rgw-realm")
             host, user, password, ssh_key = get_external_cluster_client()
-            external_cluster = ExternalCluster(host, user, password, ssh_key)
+            external_cluster = ExternalCluster(
+                host,
+                user,
+                password,
+                ssh_key,
+                jump_host=config.EXTERNAL_MODE.get("ssh_jump_host"),
+            )
             assert external_cluster.is_object_store_user_exists(
                 user=object_store_user, realm=realm
             ), f"{object_store_user} doesn't exist in realm {realm}"


### PR DESCRIPTION
This update should allow configuration of SSH Jump host for connecting to external RHCS cluster nodes (in cases, when the RHCS cluster is not directly accessible).

The configuration is done in the config `EXTERNAL_MODE` section, for example like this:
```yaml
EXTERNAL_MODE:
    ssh_jump_host:
        host: jump.host.example.com
        user: test
        private_key: /path/to/private/ssh/key.pem
``` 