### PR TITLE
Update pools locator

### DIFF
--- a/ocs_ci/ocs/ui/block_pool.py
+++ b/ocs_ci/ocs/ui/block_pool.py
@@ -21,7 +21,7 @@ class BlockPoolUI(PageNavigator):
     def __init__(self):
         super().__init__()
 
-    def create_pool(self, pool_type_block=True, replica, compression):
+    def create_pool(self, replica, compression, pool_type_block=True):
         """
         Create block pool via UI
 

--- a/ocs_ci/ocs/ui/block_pool.py
+++ b/ocs_ci/ocs/ui/block_pool.py
@@ -21,11 +21,12 @@ class BlockPoolUI(PageNavigator):
     def __init__(self):
         super().__init__()
 
-    def create_pool(self, replica, compression):
+    def create_pool(self, pool_type_block=True, replica, compression):
         """
         Create block pool via UI
 
         Args:
+            pool_type_block: True if type of storage pool is block, False otherwise
             replica (int): replica size usually 2,3
             compression (bool): True to enable compression otherwise False
 
@@ -36,6 +37,8 @@ class BlockPoolUI(PageNavigator):
         pool_name = create_unique_resource_name("test", "rbd-pool")
         self.navigate_block_pool_page()
         self.do_click(self.bp_loc["create_block_pool"])
+        if pool_type_block:
+            self.do_click(self.bp_loc["pool_type_block"])
         self.do_send_keys(self.bp_loc["new_pool_name"], pool_name)
         self.do_click(self.bp_loc["first_select_replica"])
         if replica == 2:
@@ -48,6 +51,8 @@ class BlockPoolUI(PageNavigator):
         wait_for_text_result = self.wait_until_expected_text_is_found(
             self.bp_loc["pool_state_inside_pool"], "Ready", timeout=30
         )
+        if not pool_type_block:
+            pool_name = f"ocs-storagecluster-cephfilesystem-{pool_name}"
         if wait_for_text_result is True:
             logger.info(f"Pool {pool_name} was created and it is in Ready state")
             return [pool_name, True]

--- a/ocs_ci/ocs/ui/page_objects/edit_label_form.py
+++ b/ocs_ci/ocs/ui/page_objects/edit_label_form.py
@@ -122,7 +122,7 @@ class EditLabelForm(BaseUI):
         )
         logger.info(f"Clicking on Actions for {block_pool_name}")
         self.do_click(self.bp_loc["actions_outside_pool"], enable_screenshot=True)
-        logger.info(f"Clicking on Edit labels")
+        logger.info("Clicking on Edit labels")
         self.do_click(self.bp_loc["edit_labels_of_pool"])
 
     def enter_label_and_save(self, label):

--- a/ocs_ci/ocs/ui/page_objects/edit_label_form.py
+++ b/ocs_ci/ocs/ui/page_objects/edit_label_form.py
@@ -116,10 +116,13 @@ class EditLabelForm(BaseUI):
         Args:
             block_pool_name (str): The name of the block pool to open the edit label page for.
         """
+        logger.info(f"Filtering pool page for {block_pool_name}")
         self.do_send_keys(
             self.generic_locators["search_resource_field"], block_pool_name
         )
-        self.do_click(self.bp_loc["actions_outside_pool"])
+        logger.info(f"Clicking on Actions for {block_pool_name}")
+        self.do_click(self.bp_loc["actions_outside_pool"], enable_screenshot=True)
+        logger.info(f"Clicking on Edit labels")
         self.do_click(self.bp_loc["edit_labels_of_pool"])
 
     def enter_label_and_save(self, label):

--- a/ocs_ci/ocs/ui/page_objects/storage_system_details.py
+++ b/ocs_ci/ocs/ui/page_objects/storage_system_details.py
@@ -66,6 +66,9 @@ class StorageSystemDetails(StorageSystemTab):
         self.nav_ceph_blockpool().verify_cephblockpool_status()
 
     def nav_ceph_blockpool(self):
+        """
+        Navigate to Block pools (for version 4.16 or lower)/Storage pools tab
+        """
         logger.info("Click on 'BlockPools' tab")
         if (
             self.ocp_version_semantic == version.VERSION_4_11

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1152,6 +1152,7 @@ block_pool = {
         'input[data-test="new-pool-name-textbox"]',
         By.CSS_SELECTOR,
     ),
+    "pool_type_block": ("type-block", By.ID),
     "first_select_replica": ('button[data-test="replica-dropdown"]', By.CSS_SELECTOR),
     "second_select_replica_2": ("//button[text()='2-way Replication']", By.XPATH),
     "second_select_replica_3": ("//button[text()='3-way Replication']", By.XPATH),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1161,7 +1161,10 @@ block_pool = {
         By.CSS_SELECTOR,
     ),
     "pool_confirm_create": ('button[data-test-id="confirm-action"]', By.CSS_SELECTOR),
-    "actions_outside_pool": ('button[aria-label="Actions"]', By.CSS_SELECTOR),
+    "actions_outside_pool": (
+        'button[aria-label="Actions"], button[data-test="kebab-button"]',
+        By.CSS_SELECTOR,
+    ),
     "edit_labels_of_pool": ("//a[normalize-space()='Edit labels']", By.XPATH),
     "edit_labels_of_pool_input": ("#tags-input", By.TAG_NAME),
     "invalid_label_name_note_edit_label_pool": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -316,7 +316,7 @@ generic_locators = {
         "//*[@class='pf-c-helper-text__item-text'] | "
         "//div[@data-test='field-requirements-popover']"
         "//*[@class='pf-v5-c-helper-text__item-text'] | "
-        "//ul//span[@class='pf-v5-c-helper-text__item-text']]",
+        "//ul//span[@class='pf-v5-c-helper-text__item-text']",
         By.XPATH,
     ),
     "ocp-overview-status-storage-popup-btn": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1097,7 +1097,7 @@ add_capacity_4_12 = {
 
 block_pool_4_12 = {
     "actions_inside_pool": (
-        "//span[text()='Actions']/..",
+        "//span[text()='Actions']/.. | //button[@data-test='kebab-button']",
         By.XPATH,
     ),
     "delete_pool_inside_pool": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -315,7 +315,8 @@ generic_locators = {
     "text_input_popup_rules": (
         "//*[@class='pf-c-helper-text__item-text'] | "
         "//div[@data-test='field-requirements-popover']"
-        "//*[@class='pf-v5-c-helper-text__item-text'] | //div[@class='pf-v5-c-popover__body']",
+        "//*[@class='pf-v5-c-helper-text__item-text'] | "
+        "//ul//span[@class='pf-v5-c-helper-text__item-text']]",
         By.XPATH,
     ),
     "ocp-overview-status-storage-popup-btn": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1165,7 +1165,10 @@ block_pool = {
         'button[aria-label="Actions"], button[data-test="kebab-button"]',
         By.CSS_SELECTOR,
     ),
-    "edit_labels_of_pool": ("//a[normalize-space()='Edit labels']", By.XPATH),
+    "edit_labels_of_pool": (
+        "//a[normalize-space()='Edit labels'] | //button[@id='Edit Labels']",
+        By.XPATH,
+    ),
     "edit_labels_of_pool_input": ("#tags-input", By.TAG_NAME),
     "invalid_label_name_note_edit_label_pool": (
         "//h4[contains(@class, 'c-alert__title')]",

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1598,7 +1598,11 @@ validation_4_11 = {
     "object-odf-4-10": ("//a[normalize-space()='Object']", By.XPATH),
     "blockandfile": ("//span[normalize-space()='Block and File']", By.XPATH),
     "blockandfile-odf-4-10": ("//a[normalize-space()='Block and File']", By.XPATH),
-    "blockpools": ("//span[normalize-space()='BlockPools']", By.XPATH),
+    "blockpools": (
+        "//span[normalize-space()='BlockPools'] | "
+        "//button[@data-test='horizontal-link-Storage pools']",
+        By.XPATH,
+    ),
     "blockpools-odf-4-10": ("//a[normalize-space()='BlockPools']", By.XPATH),
     "system-capacity": ("//div[contains(text(),'System Capacity')]", By.XPATH),
     "backingstorage-breadcrumb": ("//a[normalize-space()='BackingStores']", By.XPATH),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1174,7 +1174,7 @@ block_pool = {
     "edit_labels_of_pool_save": ("//button[normalize-space()='Save']", By.XPATH),
     "cancel_edit_labels_of_pool": ("//button[normalize-space()='Cancel']", By.XPATH),
     "edit_pool_inside_pool": (
-        'button[data-test-action="Edit BlockPool"]',
+        'button[data-test-action="Edit BlockPool"], button[id="Edit Resource"]',
         By.CSS_SELECTOR,
     ),
     "confirm_delete_inside_pool": ("//button[text()='Delete']", By.XPATH),
@@ -1191,7 +1191,7 @@ block_pool = {
     ),
     "used_raw_capacity_in_UI": ("//div[@class='ceph-raw-card-legend__text']", By.XPATH),
     "delete_pool_inside_pool": (
-        "//a[text()='Delete BlockPool']",
+        "//a[text()='Delete BlockPool'] | //button[@id='Delete']",
         By.XPATH,
     ),
 }

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -315,7 +315,7 @@ generic_locators = {
     "text_input_popup_rules": (
         "//*[@class='pf-c-helper-text__item-text'] | "
         "//div[@data-test='field-requirements-popover']"
-        "//*[@class='pf-v5-c-helper-text__item-text']",
+        "//*[@class='pf-v5-c-helper-text__item-text'] | //div[@class='pf-v5-c-popover__body']",
         By.XPATH,
     ),
     "ocp-overview-status-storage-popup-btn": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1354,7 +1354,10 @@ validation = {
     "storage_cluster_readiness": ("//*[contains(text(),'Ready')]", By.XPATH),
     "backingstore_name": ("input[placeholder='my-backingstore']", By.CSS_SELECTOR),
     "namespacestore_name": ("input[placeholder='my-namespacestore']", By.CSS_SELECTOR),
-    "blockpool_name": ("input[placeholder='my-block-pool']", By.CSS_SELECTOR),
+    "blockpool_name": (
+        "input[placeholder='my-block-pool'], input[id=pool-name]",
+        By.CSS_SELECTOR,
+    ),
     "input_value_validator_icon": (
         "button[aria-label='Validation'], .pf-c-icon",
         By.CSS_SELECTOR,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1356,7 +1356,7 @@ validation = {
     "namespacestore_name": ("input[placeholder='my-namespacestore']", By.CSS_SELECTOR),
     "blockpool_name": ("input[placeholder='my-block-pool']", By.CSS_SELECTOR),
     "input_value_validator_icon": (
-        "button[aria-label='Validation'], .pf-c-icon, .pf-v5-c-icon",
+        "button[aria-label='Validation'], .pf-c-icon",
         By.CSS_SELECTOR,
     ),
     "text_input_field_error_improvements": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1147,7 +1147,7 @@ block_pool_4_13 = {
 }
 
 block_pool = {
-    "create_block_pool": ("Create BlockPool", By.LINK_TEXT),
+    "create_block_pool": ("yaml-create", By.ID),
     "new_pool_name": (
         'input[data-test="new-pool-name-textbox"]',
         By.CSS_SELECTOR,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1355,7 +1355,10 @@ validation = {
     "backingstore_name": ("input[placeholder='my-backingstore']", By.CSS_SELECTOR),
     "namespacestore_name": ("input[placeholder='my-namespacestore']", By.CSS_SELECTOR),
     "blockpool_name": ("input[placeholder='my-block-pool']", By.CSS_SELECTOR),
-    "input_value_validator_icon": (".pf-c-icon, .pf-v5-c-icon", By.CSS_SELECTOR),
+    "input_value_validator_icon": (
+        "button[aria-label='Validation'], .pf-c-icon, .pf-v5-c-icon",
+        By.CSS_SELECTOR,
+    ),
     "text_input_field_error_improvements": (
         "input[data-ouia-component-id='OUIA-Generated-TextInputBase-1']",
         By.CSS_SELECTOR,

--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -139,6 +139,7 @@ class TestErrorMessageImprovements(ManageTest):
         blocking_pool_tab.check_edit_labels(block_pool_obj.name)
 
         blocking_pool_tab.proceed_resource_creation()
+        blocking_pool_tab.do_click(self.bp_loc["pool_type_block"])
         blocking_pool_tab.check_error_messages()
 
     @bugzilla("2193109")

--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -139,7 +139,7 @@ class TestErrorMessageImprovements(ManageTest):
         blocking_pool_tab.check_edit_labels(block_pool_obj.name)
 
         blocking_pool_tab.proceed_resource_creation()
-        blocking_pool_tab.do_click(self.bp_loc["pool_type_block"])
+        blocking_pool_tab.do_click(blocking_pool_tab.bp_loc["pool_type_block"])
         blocking_pool_tab.check_error_messages()
 
     @bugzilla("2193109")


### PR DESCRIPTION
Fixes tests.functional.ui.test_error_improvements.TestErrorMessageImprovements.test_blocking_pool_creation_rules failing due to UI changes in 4.17 related to Replica2 with cephfs: https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-deploy-ocs-cluster/39732/testReport/tests.functional.ui.test_error_improvements/TestErrorMessageImprovements/test_blocking_pool_creation_rules/