### PR TITLE
Pass secret key as one of the arguments to create credentials

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3445,7 +3445,7 @@ class MDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             self.meta_obj.bucket_name,
         )
         self.create_generic_credentials(
-            self.meta_obj.access_key, self.meta_obj.access_key, acm_indexes
+            self.meta_obj.access_key, self.meta_obj.secret_key, acm_indexes
         )
         self.validate_secret_creation_oadp()
         # Reconfigure OADP on all ACM clusters


### PR DESCRIPTION
MDR runs were failing because while creating credentials for s3 we were passing only access key.