### PR TITLE
Fixed default sc tests case which was failing

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4760,7 +4760,7 @@ def flatten_multilevel_dict(d):
     return leaves_list
 
 
-def is_rbd_default_storage_class(custom_sc=None):
+def is_rbd_default_storage_class(sc_name=None):
     """
     Check if RDB is a default storageclass for the cluster
 
@@ -4770,9 +4770,7 @@ def is_rbd_default_storage_class(custom_sc=None):
     Returns:
         bool : True if RBD is set as the  Default storage class for the cluster, False otherwise.
     """
-    default_rbd_sc = (
-        constants.DEFAULT_STORAGECLASS_RBD if custom_sc is None else custom_sc
-    )
+    default_rbd_sc = constants.DEFAULT_STORAGECLASS_RBD if sc_name is None else sc_name
     cmd = (
         f"oc get storageclass {default_rbd_sc} -o=jsonpath='{{.metadata.annotations}}' "
     )

--- a/tests/functional/storageclass/test_rbd_default_storageclass.py
+++ b/tests/functional/storageclass/test_rbd_default_storageclass.py
@@ -51,7 +51,7 @@ class TestRBDStorageClassAsDefaultStorageClass:
 
         assert is_rbd_default_storage_class(
             sc_name=sc_attached_to_pvc
-        ), "RBD is not default storageclass for Cluster."
+        ), f"RBD storageclass {sc_attached_to_pvc} is not default storageclass for Cluster."
 
         log.info("Attaching PVC to pod to start IO workload.")
         pod_obj = pod_factory(pvc=pvc_obj, status=constants.STATUS_RUNNING)


### PR DESCRIPTION
test `test_pvc_creation_without_storageclass_name` was failing in case of custom sorageclass present in the cluster and there are multiple default RBD storage class in the cluster.