### PR TITLE
Disable auto reclaimspace cronjob test at namespace level

### DIFF
--- a/tests/functional/pv/space_reclaim/test_auto_reclaim_space_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_auto_reclaim_space_cronjob.py
@@ -9,7 +9,6 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
-    tier2,
 )
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.helpers.performance_lib import run_oc_command
@@ -21,8 +20,11 @@ logger = logging.getLogger(__name__)
 ERRMSG = "Error in command"
 
 
+# @tier2
+# Test case is disabled
+# Creating reclaim space cron job for namespace with prefix openshift-* has been deprecated since 4.16
+# This will be implemented at storageclass level rather than at the namespace level in 4.17
 @green_squad
-@tier2
 @skipif_ocs_version("<4.14")
 class TestReclaimSpaceCronJob(ManageTest):
     """


### PR DESCRIPTION
This PR Disables following tests.

test_reclaim_space_cronjob
test_reclaim_space_cronjob_on_existing_namespace
test_skip_reclaim_space

These tests would validate auto create of reclaim space cron job for namespaces with prefix `openshift-*` by adding reclaimspace cron job annotation to the namespace. As there was an issue with ARO cluster, this feature was removed and will be implemented at storageclass level rather than at the namespace level in 4.17

4.17 EPIC to implement the same at storageclass level - https://issues.redhat.com/browse/RHSTOR-5876
