### PR TITLE
ODF4.17 UI deployment, remove 'data protection' page

### DIFF
--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -387,7 +387,10 @@ class DeploymentUI(PageNavigator):
         Configure Data Protection
 
         """
-        if self.ocs_version_semantic >= version.VERSION_4_14:
+        if (
+            self.ocs_version_semantic >= version.VERSION_4_14
+            and self.ocs_version_semantic <= version.VERSION_4_16
+        ):
             self.do_click(self.dep_loc["next"], enable_screenshot=True)
 
     def enable_taint_nodes(self):


### PR DESCRIPTION
The dev team removed the 'data protection' page from the storage system creation procedure. 

https://url.corp.redhat.com/77c7e95

4.17.0-45 [without  "data protection" page]
![image](https://github.com/user-attachments/assets/e630838f-05bb-4a16-8bf6-b5918f7872f5)
https://url.corp.redhat.com/6406492

4.17.0-37 [with  "data protection" page]
![image](https://github.com/user-attachments/assets/2f1eb28a-5cd8-4989-9e6e-bab0acf4f72a)
https://url.corp.redhat.com/6dd5f76