### PR TITLE
Set cluster_kubeconfig based on the type of resource available in provider cluster only

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -357,6 +357,43 @@ NATIVE_STORAGE_CLIENT_YAML = os.path.join(
     PROVIDER_CLIENT_DEPLOYMENT_DIR, "native_storage_client.yaml"
 )
 
+PROVIDER_CLUSTER_RESOURCE_KINDS = [
+    "cephblockpoolradosnamespaces",
+    "cephblockpoolradosnamespace",
+    "cephblockpools",
+    "cephblockpool",
+    "cephclients",
+    "cephclient",
+    "cephclusters",
+    "cephcluster",
+    "cephfilesystems",
+    "cephfilesystem",
+    "cephfilesystemsubvolumegroups",
+    "cephfilesystemsubvolumegroup",
+    "cephobjectstores",
+    "cephobjectstore",
+    "cephobjectstoreusers",
+    "cephobjectstoreuser",
+    "localvolumediscoveries",
+    "localvolumediscovery",
+    "localvolumediscoveryresults",
+    "localvolumediscoveryresult",
+    "localvolumes",
+    "localvolume",
+    "localvolumesets",
+    "localvolumeset",
+    "storageclusters",
+    "storagecluster",
+    "storageconsumers",
+    "storageconsumer",
+    "storageprofiles",
+    "storageprofile",
+    "storagerequests",
+    "storagerequest",
+    "storagesystems",
+    "storagesystem",
+]
+
 OCS_CLIENT_OPERATOR_CONTROLLER_MANAGER_PREFIX = "ocs-client-operator-controller-manager"
 OCS_CLIENT_OPERATOR_CONSOLE = "ocs-client-operator-console"
 STORAGE_CLIENT_NAME = "storage-client"


### PR DESCRIPTION
In provider mode multicluster run, set 'cluster_kubeconfig' if the resource kind is available only in provider cluster.
* Created a primary list of 'Kind' which are available in provider cluster.
* Set the cluster_kubeconfig value to provider cluster kubeconfig path if the Kind is available in the list.

Advantages:
* When using the class OCP or OCS, need not switch cluster context to provider to get/create/delete/patch/decribe etc.. a resource that is in provider cluster.

Example: Need not bother about the current cluster context when using the function https://github.com/red-hat-storage/ocs-ci/blob/0b95c6fa7e9a190726079bfd3018daa190e0413b/ocs_ci/ocs/resources/storage_cluster.py#L1658 and also when using the returned object.


* Enables simultaneous usages of two instances of different kinds where one of them is in provider and the other one is in the client cluster.
 eg: When using threading (or a mechanism to run two oc commands at the same time) , get StorageCluster(from provider) and application pod(from client) at the same time. Switching context is not helpful in this situation.

Limitations:
* All config values are not set as the cluster where the resource is present. eg: ocs_version. This have less impact because these config values are not used in 'oc' commands. cluster_namespace will be used which is going to be same for provider and client going forward. Added a TODO to overcome this.
