### PR TITLE
Bumping webdriver-manager version to 4.0.2 due to selenium issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "range-key-dict==1.1.0",
         "GitPython==3.1.41",
         "selenium==3.141.0",
-        "webdriver-manager==4.0.0",
+        "webdriver-manager==4.0.2",
         # greenlet 1.0.0 is broken on ppc64le
         # https://github.com/python-greenlet/greenlet/issues/230
         # by default program attempting to load an x86_64-only library from a native arm64 process


### PR DESCRIPTION
Looks like this PR https://github.com/SergeyPirogov/webdriver_manager/pull/666 from webdriver-manager is a specific fix for issue isuue https://github.com/red-hat-storage/ocs-ci/issues/10173.
The webdriver-manager fix is in 4.0.2 new version