### PR TITLE
[GSS] Test secrets are not exposed in Noobaa

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4497,6 +4497,10 @@ def get_noobaa_db_credentials_from_secret():
     Get credentials details i.e., user and password
     from noobaa-db secret
 
+    Returns:
+        user_name: Username for the db
+        password: Password for the db
+
     """
     ocp_secret_obj = OCP(
         kind=constants.SECRET, namespace=config.ENV_DATA["cluster_namespace"]

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4492,6 +4492,26 @@ def get_s3_credentials_from_secret(secret_name):
     return access_key, secret_key
 
 
+def get_noobaa_db_credentials_from_secret():
+    """
+    Get credentials details i.e., user and password
+    from noobaa-db secret
+
+    """
+    ocp_secret_obj = OCP(
+        kind=constants.SECRET, namespace=config.ENV_DATA["cluster_namespace"]
+    )
+    nb_db_secret = ocp_secret_obj.get(resource_name=constants.NOOBAA_DB_SECRET)
+
+    base64_user_name = nb_db_secret["data"]["user"]
+    base64_password = nb_db_secret["data"]["password"]
+
+    user_name = base64.b64decode(base64_user_name).decode("utf-8")
+    password = base64.b64decode(base64_password).decode("utf-8")
+
+    return user_name, password
+
+
 def verify_pvc_size(pod_obj, expected_size):
     """
     Verify PVC size is as expected or not.

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -555,6 +555,9 @@ NOOBAA_ENDPOINT_DEPLOYMENT = "noobaa-endpoint"
 NOOBAA_DB_STATEFULSET = "noobaa-db-pg"
 NOOBAA_CORE_STATEFULSET = "noobaa-core"
 
+# Noobaa db secret
+NOOBAA_DB_SECRET = "noobaa-db"
+
 # Auth Yaml
 OCSCI_DATA_BUCKET = "ocs-ci-data"
 AUTHYAML = "auth.yaml"

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1795,6 +1795,38 @@ def get_pod_logs(
     return pod.exec_oc_cmd(cmd, out_yaml_format=False)
 
 
+def filter_pod_logs(pod_logs, filter=[], any_filter=False):
+    """
+    To filter the pod logs with particular substring/s line by
+    line
+
+    Args:
+        pod_logs (str): Pod logs
+        filter (list): List of substrings that needs to be
+        present in the pod logs
+        any_filter(bool): True if any one filter is enough, False
+        if all filters should be present
+
+    Returns:
+        Str: Filtered pod logs
+
+    """
+
+    pod_log_lines = pod_logs.splitlines()
+
+    if any_filter:
+        filtered_lines = [
+            line for line in pod_log_lines if any(sub in line for sub in filter)
+        ]
+    else:
+        filtered_lines = [
+            line for line in pod_log_lines if all(sub in line for sub in filter)
+        ]
+
+    filtered_log = "\n".join(filtered_lines)
+    return filtered_log
+
+
 def get_pod_node(pod_obj):
     """
     Get the node that the pod is running on

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1795,38 +1795,6 @@ def get_pod_logs(
     return pod.exec_oc_cmd(cmd, out_yaml_format=False)
 
 
-def filter_pod_logs(pod_logs, filter=[], any_filter=False):
-    """
-    To filter the pod logs with particular substring/s line by
-    line
-
-    Args:
-        pod_logs (str): Pod logs
-        filter (list): List of substrings that needs to be
-        present in the pod logs
-        any_filter(bool): True if any one filter is enough, False
-        if all filters should be present
-
-    Returns:
-        Str: Filtered pod logs
-
-    """
-
-    pod_log_lines = pod_logs.splitlines()
-
-    if any_filter:
-        filtered_lines = [
-            line for line in pod_log_lines if any(sub in line for sub in filter)
-        ]
-    else:
-        filtered_lines = [
-            line for line in pod_log_lines if all(sub in line for sub in filter)
-        ]
-
-    filtered_log = "\n".join(filtered_lines)
-    return filtered_log
-
-
 def get_pod_node(pod_obj):
     """
     Get the node that the pod is running on

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -78,7 +78,6 @@ from ocs_ci.utility.rgwutils import get_rgw_count
 from ocs_ci.utility.utils import run_cmd, TimeoutSampler, convert_device_size
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.helpers.helpers import storagecluster_independent_check
-from ocs_ci.deployment.helpers.mcg_helpers import check_if_mcg_root_secret_public
 
 log = logging.getLogger(__name__)
 
@@ -782,13 +781,6 @@ def ocs_install_verification(
         and config.MULTICLUSTER.get("multicluster_mode") == "regional-dr"
     ):
         validate_serviceexport()
-
-    # check that noobaa root secrets are not public
-    if not (client_cluster or managed_service):
-        assert (
-            check_if_mcg_root_secret_public() is False
-        ), "Seems like MCG root secrets are public, please check"
-        log.info("Noobaa root secrets are not public")
 
     # Verify the owner of CSI deployments and daemonsets
     csi_owner_kind = constants.CONFIGMAP if hci_cluster else constants.DEPLOYMENT

--- a/tests/functional/object/mcg/test_noobaa_db_cleartext_postgres_password.py
+++ b/tests/functional/object/mcg/test_noobaa_db_cleartext_postgres_password.py
@@ -4,7 +4,7 @@ from ocs_ci.framework.testlib import tier2, BaseTest, bugzilla, polarion_id
 from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
-
+from ocs_ci.ocs.resources.pod import filter_pod_logs
 
 log = logging.getLogger(__name__)
 
@@ -43,3 +43,64 @@ class TestNoobaaSecurity(BaseTest):
         assert (
             "set=password" not in nooobaa_db_pod_logs
         ), f"noobaa-db pod logs include password logs:{nooobaa_db_pod_logs}"
+
+    def test_nb_db_password_in_core_and_endpoint(self):
+        """
+        Verify that postgres password is not exposed in
+        noobaa core and endpoint logs
+
+        1. Get the noobaa core log
+        2. Get the noobaa endpoint log
+        3. Verify postgres password doesnt exist in the endpoint and core logs
+
+        """
+
+        # get noobaa core log and verify that the password is not
+        # present in the log
+        nooba_core_pod = pod.get_noobaa_core_pod()
+        noobaa_core_pod_logs = pod.get_pod_logs(nooba_core_pod.name)
+        filtered_log = filter_pod_logs(
+            pod_logs=noobaa_core_pod_logs,
+            filter=[
+                "host",
+                "noobaa-db-pg-0.noobaa-db-pg",
+                "user",
+                "noobaa",
+                "database",
+                "nbcore",
+                "port",
+                "5432",
+                "password",
+            ],
+        )
+        assert (
+            len(filtered_log) == 0
+        ), f"Noobaa db password seems to be present in the noobaa core logs:\n{filtered_log}"
+        log.info(
+            "Verified that noobaa db password is not present in the noobaa core log."
+        )
+
+        # get noobaa endpoint log and verify that the password is not
+        # present in the log
+        noobaa_endpoint_pod = pod.get_noobaa_endpoint_pods()[0]
+        noobaa_endpoint_logs = pod.get_pod_logs(noobaa_endpoint_pod.name)
+        filtered_log = filter_pod_logs(
+            pod_logs=noobaa_endpoint_logs,
+            filter=[
+                "host",
+                "noobaa-db-pg-0.noobaa-db-pg",
+                "user",
+                "noobaa",
+                "database",
+                "nbcore",
+                "port",
+                "5432",
+                "password",
+            ],
+        )
+        assert (
+            len(filtered_log) == 0
+        ), f"Noobaa db password seems to be present in the noobaa endpoint logs:\n{filtered_log}"
+        log.info(
+            "Verified that noobaa db password is not present in the noobaa endpoint log."
+        )

--- a/tests/functional/object/mcg/test_noobaa_db_cleartext_postgres_password.py
+++ b/tests/functional/object/mcg/test_noobaa_db_cleartext_postgres_password.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import get_noobaa_db_credentials_from_secret
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.resources.pod import filter_pod_logs
+from ocs_ci.ocs.resources.pod import search_pattern_in_pod_logs
 
 log = logging.getLogger(__name__)
 
@@ -62,11 +62,9 @@ class TestNoobaaSecurity(BaseTest):
 
         # get noobaa core log and verify that the password is not
         # present in the log
-        nooba_core_pod = pod.get_noobaa_core_pod()
-        noobaa_core_pod_logs = pod.get_pod_logs(nooba_core_pod.name)
-        filtered_log = filter_pod_logs(
-            pod_logs=noobaa_core_pod_logs,
-            filter=[noobaa_db_password],
+        filtered_log = search_pattern_in_pod_logs(
+            pod_name=pod.get_noobaa_core_pod().name,
+            pattern=noobaa_db_password,
         )
         assert (
             len(filtered_log) == 0
@@ -77,11 +75,9 @@ class TestNoobaaSecurity(BaseTest):
 
         # get noobaa endpoint log and verify that the password is not
         # present in the log
-        noobaa_endpoint_pod = pod.get_noobaa_endpoint_pods()[0]
-        noobaa_endpoint_logs = pod.get_pod_logs(noobaa_endpoint_pod.name)
-        filtered_log = filter_pod_logs(
-            pod_logs=noobaa_endpoint_logs,
-            filter=[noobaa_db_password],
+        filtered_log = search_pattern_in_pod_logs(
+            pod_name=pod.get_noobaa_endpoint_pods()[0].name,
+            pattern=noobaa_db_password,
         )
         assert (
             len(filtered_log) == 0

--- a/tests/functional/object/mcg/test_noobaa_secret.py
+++ b/tests/functional/object/mcg/test_noobaa_secret.py
@@ -351,7 +351,7 @@ class TestNoobaaSecrets:
 @bugzilla("2219522")
 @polarion_id("OCS-5205")
 @runs_on_provider
-@tier2
+@acceptance
 def test_noobaa_root_secret():
     """
     This test verifies if the noobaa root secret is publicly
@@ -368,6 +368,8 @@ def test_noobaa_root_secret():
 @mcg
 @red_squad
 @acceptance
+@bugzilla()
+@polarion_id()
 def test_operator_logs_for_secret():
     """
     This test verifies if secrets are exposed

--- a/tests/functional/object/mcg/test_noobaa_secret.py
+++ b/tests/functional/object/mcg/test_noobaa_secret.py
@@ -368,8 +368,8 @@ def test_noobaa_root_secret():
 @mcg
 @red_squad
 @acceptance
-@bugzilla()
-@polarion_id()
+@bugzilla("2277186")
+@polarion_id("OCS-6184")
 def test_operator_logs_for_secret():
     """
     This test verifies if secrets are exposed


### PR DESCRIPTION
This PR addresses:

1. Automate bug: https://bugzilla.redhat.com/show_bug.cgi?id=2277186
2. PR #8981  introduced the test_noobaa_root_secret which is run as tier2 and also it does check post the ocs installation if secret is exposed. the check at installation verification is removed as it could potentially fail the deployment despite everything went right. Also made the test as acceptance to give it more priority there.
3. Automate bug: https://bugzilla.redhat.com/show_bug.cgi?id=2240778
