### PR TITLE
Add the kubevirt VM node functionalities for the hosted cluster

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -17,9 +17,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_in_statuses_concurrently
 from ocs_ci.ocs.version import get_ocp_version
 from ocs_ci.utility.retry import retry
-
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler, get_latest_release_version
-from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.ocs.utils import get_namespce_name_by_pattern
 

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -135,6 +135,24 @@ def get_cluster_vm_namespace(cluster_name=None):
 
 
 @switch_to_orig_index_at_last
+def is_hosted_cluster(cluster_name=None):
+    """
+    Check if the cluster is a hosted cluster
+
+    Args:
+        cluster_name (str): The cluster name
+
+    Returns:
+        bool: True, if the cluster is a hosted cluster. False, otherwise.
+
+    """
+    cluster_name = cluster_name or config.ENV_DATA["cluster_name"]
+    config.switch_to_provider()
+    ocp_obj = OCP(kind=constants.HOSTED_CLUSTERS, namespace="clusters")
+    return ocp_obj.is_exist(resource_name=cluster_name)
+
+
+@switch_to_orig_index_at_last
 def get_hosted_cluster_type(cluster_name=None):
     """
     Get the hosted cluster type

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3219,7 +3219,7 @@ def client_cluster_health_check():
     """
     wait_for_cluster_connectivity(tries=120, delay=5)
     logger.info("Checking the cluster health")
-    wait_for_nodes_status(timeout=300, sleep=10)
+    wait_for_nodes_status(timeout=420, sleep=10)
 
     logger.info("Checking that there are no extra Ceph pods on the cluster")
     mon_pods = pod.get_mon_pods()

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -223,7 +223,7 @@ PROVISIONING = "Provisioning"
 AGENT_SERVICE_CONFIG = "AgentServiceConfig"
 INFRA_ENV = "InfraEnv"
 DEFALUT_DEVICE_CLASS = "ssd"
-VM = "VM"
+VM = "vm"
 HOSTED_CLUSTERS = "hostedclusters"
 
 # Provisioners
@@ -271,6 +271,7 @@ OPENSHIFT_IMAGE_REGISTRY_DEPLOYMENT = "image-registry"
 OPENSHIFT_IMAGE_SELECTOR = "docker-registry=default"
 OPENSHIFT_INGRESS_NAMESPACE = "openshift-ingress"
 OPENSHIFT_MONITORING_NAMESPACE = "openshift-monitoring"
+CLUSTERS_NAMESPACE = "clusters"
 MASTER_MACHINE = "master"
 WORKER_MACHINE = "worker"
 BOOTSTRAP_MACHINE = "bootstrap"
@@ -293,6 +294,10 @@ NON_MS_CLUSTER_TYPE = "non_ms"
 # HCI cluster types
 HCI_CLIENT = "hci_client"
 HCI_PROVIDER = "provider"
+# hosted cluster types
+HOSTED_CLUSTER_KUBEVIRT = "kubevirt"
+HOSTED_CLUSTER_AGENT = "agent"
+NON_HOSTED_CLUSTER = "non_hosted"
 
 # provider mode constants
 PROVIDER_MODE_OCS_DEPLOYMENT_PATH = os.path.join(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -223,7 +223,8 @@ PROVISIONING = "Provisioning"
 AGENT_SERVICE_CONFIG = "AgentServiceConfig"
 INFRA_ENV = "InfraEnv"
 DEFALUT_DEVICE_CLASS = "ssd"
-
+VM = "VM"
+HOSTED_CLUSTERS = "hostedclusters"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -110,7 +110,11 @@ class PlatformNodesFactory:
                 platform += "_lso"
             elif deployment_type in ("ipi", "upi"):
                 platform += f"_{deployment_type}"
-        elif get_client_type_by_name(cluster_name) == constants.HOSTED_CLUSTER_KUBEVIRT:
+        elif (
+            config.hci_client_exist()
+            and get_client_type_by_name(cluster_name)
+            == constants.HOSTED_CLUSTER_KUBEVIRT
+        ):
             platform = "kubevirt_vm"
 
         return self.cls_map[platform]()

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -80,3 +80,26 @@ def switch_to_client_for_function(func, client_index=0):
                 config.switch_ctx(orig_index)
 
     return inner
+
+
+def switch_to_provider_for_function(func):
+    """
+    A decorator for switching to the provider cluster for the function execution.
+    After the function execution, it switches back to the original index.
+
+    Args:
+        func (function): The function we want to decorate
+
+    """
+
+    def inner(*args, **kwargs):
+        orig_index = config.cur_index
+        try:
+            config.switch_to_provider()
+            return func(*args, **kwargs)
+        finally:
+            if config.cur_index != orig_index:
+                logger.info("Switching back to the original cluster")
+                config.switch_ctx(orig_index)
+
+    return inner

--- a/ocs_ci/utility/kubevirt_vm.py
+++ b/ocs_ci/utility/kubevirt_vm.py
@@ -105,7 +105,7 @@ class KubevirtVM(object):
         vm_list = self.get_all_kubevirt_vms()
         return [vm for vm in vm_list if get_vm_name(vm) in vm_names]
 
-    def wait_for_vms_status(self, vms, expected_status, timeout=180):
+    def wait_for_vms_status(self, vms, expected_status, timeout=300):
         """
         Wait for the VMs to be in the expected status
 

--- a/ocs_ci/utility/kubevirt_vm.py
+++ b/ocs_ci/utility/kubevirt_vm.py
@@ -1,0 +1,248 @@
+# -*- coding: utf8 -*-
+"""
+Module for interactions with IBM Cloud Cluster.
+
+"""
+
+import logging
+import time
+
+from ocs_ci.deployment.helpers.hypershift_base import get_cluster_vm_namespace
+from ocs_ci.framework import config
+from ocs_ci.utility.utils import run_cmd
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.utility.decorators import switch_to_provider_for_function
+from ocs_ci.ocs import constants
+
+
+logger = logging.getLogger(name=__file__)
+
+
+def get_vm_name(vm):
+    """
+    Get the virtual machine name
+
+    Args:
+        vm (dict): The dictionary that represents the virtual machine
+
+    Returns:
+        str: The virtual machine name
+
+    """
+    return vm["metadata"]["name"]
+
+
+class KubevirtVM(object):
+    """
+    Wrapper for VM objects with kubevirt. The class should be used in Provider mode
+    when we have provider and client clusters in the run, and the client is the primary cluster.
+    """
+
+    def __init__(self):
+        """
+        Constructor for access and modify the virtual machine (VM) in the cluster.
+        The class should be used in Provider mode when we have provider and client clusters in the run,
+        and the client is the primary cluster.
+
+        """
+        self.vm_namespace = get_cluster_vm_namespace()
+        provider_index = config.get_provider_index()
+        self.vm_kubeconfig = config.clusters[provider_index].RUN["kubeconfig"]
+
+        self.ocp_vm = OCP(
+            kind="vm",
+            cluster_kubeconfig=self.vm_kubeconfig,
+            namespace=self.vm_namespace,
+        )
+
+    @switch_to_provider_for_function
+    def run_kubevirt_vm_cmd(
+        self,
+        cmd,
+        secrets=None,
+        timeout=600,
+        ignore_error=False,
+        **kwargs,
+    ):
+        """
+        The wrapper function for 'run_cmd' that runs the VM commands.
+
+        Args:
+            cmd (str): command to run
+            secrets (list): A list of secrets to be masked with asterisks
+                This kwarg is popped in order to not interfere with
+                subprocess.run(``**kwargs``)
+            timeout (int): Timeout for the command, defaults to 600 seconds.
+            ignore_error (bool): True if ignore non zero return code and do not
+                raise the exception.
+
+        """
+        cmd = f"virtctl {cmd} -n {self.vm_namespace}"
+        return run_cmd(cmd, secrets, timeout, ignore_error, **kwargs)
+
+    def get_all_kubevirt_vms(self):
+        """
+        Get all the kubevirt VMs in teh cluster
+
+        Returns:
+            list: List of dictionaries. List of all the VM objects in the cluster.
+
+        """
+        vm_list = self.ocp_vm.get()["items"]
+        return vm_list
+
+    def get_kubevirt_vms_by_names(self, vm_names):
+        """
+        Get the VMs that have the given VM names
+
+        Args:
+            vm_names (list): The list of the VM names to search for.
+
+        Returns:
+            list: Get the VMs that have the given VM names
+
+        """
+        vm_list = self.get_all_kubevirt_vms()
+        return [vm for vm in vm_list if get_vm_name(vm) in vm_names]
+
+    def wait_for_vms_status(self, vms, expected_status, timeout=180):
+        for vm in vms:
+            self.ocp_vm.wait_for_resource(
+                condition=expected_status,
+                resource_name=get_vm_name(vm),
+                timeout=timeout,
+                sleep=10,
+            )
+
+    def stop_kubevirt_vms(self, vms, wait=True, force=False):
+        """
+        Stop the kubevirt VMs
+
+        Args:
+            vms (list): List of the kubevirt VM objects to stop
+            wait (bool): If true, wait for VM to stop. False, otherwise.
+            force (bool): Force stop a VM. This option might cause data inconsistency or data loss.
+
+        """
+        force_cmd_params = "--grace-period 0 --force" if force else ""
+        for vm in vms:
+            vm_name = get_vm_name(vm)
+            logger.info(f"Stopping the VM {vm_name}")
+            cmd = f"stop {vm_name} {force_cmd_params}"
+            self.run_kubevirt_vm_cmd(cmd)
+
+        if wait:
+            self.wait_for_vms_status(vms, constants.CNV_VM_STOPPED)
+
+    def start_kubevirt_vms(self, vms, wait=True, start_vm_in_pause_state=False):
+        """
+        Start the kubevirt VMs
+
+        Args:
+            vms (list): List of the kubevirt VM objects to start
+            wait (bool): If true, wait for VM to start. False, otherwise.
+            start_vm_in_pause_state (bool): If True, it will start the VMs in a pause state.
+
+        """
+        pause_cmd_param = "--pause " if start_vm_in_pause_state else ""
+        for vm in vms:
+            vm_name = get_vm_name(vm)
+            logger.info(f"Starting the VM {vm_name}")
+            cmd = f"start {pause_cmd_param}{vm_name}"
+            self.run_kubevirt_vm_cmd(cmd)
+
+        if wait:
+            self.wait_for_vms_status(vms, constants.VM_RUNNING)
+
+    def restart_kubevirt_vms(self, vms, wait=True):
+        """
+        Restart the kubevirt VMs
+
+        Args:
+            vms (list): List of the kubevirt VM objects to restart
+            wait (bool): If true, wait for VM to start. False, otherwise.
+
+        """
+        for vm in vms:
+            vm_name = get_vm_name(vm)
+            logger.info(f"Restart the VM {vm_name}")
+            cmd = f"restart {vm_name}"
+            self.run_kubevirt_vm_cmd(cmd)
+
+        if wait:
+            time_to_wait_for_status_change = 20
+            logger.info(
+                f"Wait {time_to_wait_for_status_change} for the VM status to change"
+            )
+            time.sleep(time_to_wait_for_status_change)
+            logger.info("Wait for the VMs to be running")
+            self.wait_for_vms_status(vms, constants.VM_RUNNING)
+
+    def restart_kubevirt_vms_by_stop_and_start(self, vms, wait=True, force=False):
+        """
+        Restart the VMs by stop and start
+
+        Args:
+            vms (list): List of the IBMCLoud Bare metal machines objects to restart
+            wait (bool): If true, wait for VM to restart. False, otherwise.
+            force (bool): Force stop a VM. This option might cause data inconsistency or data loss.
+
+        """
+        self.stop_kubevirt_vms(vms, wait=True, force=force)
+        self.start_kubevirt_vms(vms, wait)
+
+    def pause_kubevirt_vms(self, vms, wait=True):
+        """
+        Pause the kubevirt VMs
+
+        Args:
+            vms (list): List of the kubevirt VM objects to pause
+            wait (bool): If true, wait for VM to pause. False, otherwise.
+
+        """
+        for vm in vms:
+            vm_name = get_vm_name(vm)
+            logger.info(f"Pausing the VM {vm_name}")
+            cmd = f"pause {vm_name}"
+            self.run_kubevirt_vm_cmd(cmd)
+
+        if wait:
+            self.wait_for_vms_status(vms, constants.VM_PAUSED)
+
+    def unpause_kubevirt_vms(self, vms, wait=True):
+        """
+        Unpause the kubevirt VMs
+
+        Args:
+            vms (list): List of the kubevirt VM objects to unpause
+            wait (bool): If true, wait for VM to start. False, otherwise.
+
+        """
+        for vm in vms:
+            vm_name = get_vm_name(vm)
+            logger.info(f"Pausing the VM {vm_name}")
+            cmd = f"pause {vm_name}"
+            self.run_kubevirt_vm_cmd(cmd)
+
+        if wait:
+            self.wait_for_vms_status(vms, constants.VM_RUNNING)
+
+    def restart_kubevirt_vms_by_stop_and_start_teardown(self):
+        """
+        Start the vms in paused and stopped state.
+
+        """
+        vms = self.get_all_kubevirt_vms()
+        vms_paused = [
+            vm
+            for vm in vms
+            if self.ocp_vm.get_resource_status(get_vm_name(vm)) == constants.VM_PAUSED
+        ]
+        vms_stopped = [
+            vm
+            for vm in vms
+            if self.ocp_vm.get_resource_status(get_vm_name(vm))
+            == constants.CNV_VM_STOPPED
+        ]
+        self.unpause_kubevirt_vms(vms_paused, wait=True)
+        self.start_kubevirt_vms(vms_stopped, wait=True)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4717,11 +4717,7 @@ def switch_to_correct_cluster_at_setup(request):
         pytest.skip(f"The cluster type '{cluster_type}' does not exist in the run")
 
     client_type = get_pytest_fixture_value(request, "client_type")
-    if (
-        cluster_type == constants.HCI_CLIENT
-        and client_type
-        and client_type != constants.NON_HOSTED_CLUSTER
-    ):
+    if cluster_type == constants.HCI_CLIENT and client_type:
         switch_to_correct_client_type(client_type)
         return
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4640,6 +4640,48 @@ def get_pytest_fixture_value(request, fixture_name):
     return request.getfixturevalue(fixture_name)
 
 
+def get_client_type_by_name(cluster_name):
+    """
+    Get the client type by the cluster name
+
+    Args:
+        cluster_name (str): The cluster name
+
+    Returns:
+        str: The client type in lowercase(e.g. kubevirt, agent, non_hosted, etc.,)
+
+    """
+    from ocs_ci.deployment.helpers.hypershift_base import (
+        is_hosted_cluster,
+        get_hosted_cluster_type,
+    )
+
+    if not is_hosted_cluster(cluster_name):
+        return constants.NON_HOSTED_CLUSTER
+
+    return get_hosted_cluster_type(cluster_name)
+
+
+def switch_to_correct_client_type(client_type):
+    """
+    Switch to the correct client type
+
+    Args:
+        client_type (str): The client type(e.g. Kubevirt, Agent, non_hosted, etc.,)
+
+    """
+    client_indices = config.get_consumer_indexes_list()
+    for client_i in client_indices:
+        cluster_name = config.clusters[client_i].ENV_DATA["cluster_name"]
+        if get_client_type_by_name(cluster_name) == client_type:
+            # Switch to the correct client type
+            log.info(f"Switching to the client with the type '{client_type}'")
+            config.switch_ctx(client_i)
+            return
+
+    pytest.skip(f"The client type '{client_type}' does not exist in the run")
+
+
 def switch_to_correct_cluster_at_setup(request):
     """
     Switch to the correct cluster index at setup, according to the 'cluster_type' fixture parameter
@@ -4673,6 +4715,15 @@ def switch_to_correct_cluster_at_setup(request):
     # If the cluster is an MS cluster
     if not config.is_cluster_type_exist(cluster_type):
         pytest.skip(f"The cluster type '{cluster_type}' does not exist in the run")
+
+    client_type = get_pytest_fixture_value(request, "client_type")
+    if (
+        cluster_type == constants.HCI_CLIENT
+        and client_type
+        and client_type != constants.NON_HOSTED_CLUSTER
+    ):
+        switch_to_correct_client_type(client_type)
+        return
 
     # Switch to the correct cluster type
     log.info(f"Switching to the cluster with the cluster type '{cluster_type}'")

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -382,10 +382,14 @@ class TestNodesRestartHCI(ManageTest):
 
     @tier4a
     @pytest.mark.parametrize(
-        "cluster_type",
-        [HCI_CLIENT],
+        argnames=["cluster_type", "client_type"],
+        argvalues=[
+            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT]),
+            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT]),
+            pytest.param(*[HCI_CLIENT, constants.NON_HOSTED_CLUSTER]),
+        ],
     )
-    def test_hosted_cluster_nodes_restart(self, cluster_type, nodes):
+    def test_hosted_cluster_nodes_restart(self, cluster_type, client_type, nodes):
         """
         Test hosted cluster nodes restart
 
@@ -397,10 +401,16 @@ class TestNodesRestartHCI(ManageTest):
 
     @tier4a
     @pytest.mark.parametrize(
-        "cluster_type",
-        [HCI_CLIENT],
+        argnames=["cluster_type", "client_type"],
+        argvalues=[
+            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT]),
+            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT]),
+            pytest.param(*[HCI_CLIENT, constants.NON_HOSTED_CLUSTER]),
+        ],
     )
-    def test_hosted_cluster_nodes_restart_by_stop_and_start(self, cluster_type, nodes):
+    def test_hosted_cluster_nodes_restart_by_stop_and_start(
+        self, cluster_type, client_type, nodes
+    ):
         """
         Test hosted cluster nodes restart by stop and start
 

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -14,7 +14,7 @@ from ocs_ci.framework.testlib import (
     polarion_id,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.constants import HCI_PROVIDER
+from ocs_ci.ocs.constants import HCI_PROVIDER, HCI_CLIENT
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.node import (
     get_node_objs,
@@ -32,6 +32,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import SanityProviderMode
 from ocs_ci.ocs.cluster import (
     ceph_health_check,
+    client_cluster_health_check,
 )
 from ocs_ci.framework import config
 from ocs_ci.utility.utils import switch_to_correct_cluster_at_setup
@@ -378,3 +379,33 @@ class TestNodesRestartHCI(ManageTest):
         logger.info(f"Starting the MGR node {mgr_node.name}")
         nodes.start_nodes(nodes=[mgr_node], wait=True)
         self.sanity_helpers.health_check_provider_mode(tries=40)
+
+    @tier4a
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [HCI_CLIENT],
+    )
+    def test_hosted_cluster_nodes_restart(self, cluster_type, nodes):
+        """
+        Test hosted cluster nodes restart
+
+        """
+        ocp_nodes = get_nodes(node_type=constants.WORKER_MACHINE)[0:2]
+        nodes.restart_nodes(nodes=ocp_nodes, wait=True)
+        client_cluster_health_check()
+        self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)
+
+    @tier4a
+    @pytest.mark.parametrize(
+        "cluster_type",
+        [HCI_CLIENT],
+    )
+    def test_hosted_cluster_nodes_restart_by_stop_and_start(self, cluster_type, nodes):
+        """
+        Test hosted cluster nodes restart by stop and start
+
+        """
+        ocp_nodes = get_nodes(node_type=constants.WORKER_MACHINE)[0:2]
+        nodes.restart_nodes_by_stop_and_start(nodes=ocp_nodes, wait=True)
+        client_cluster_health_check()
+        self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -398,7 +398,7 @@ class TestNodesRestartHCI(ManageTest):
             ),
         ],
     )
-    def test_hosted_cluster_nodes_restart(self, cluster_type, client_type, nodes):
+    def test_client_cluster_nodes_restart(self, cluster_type, client_type, nodes):
         """
         Test hosted cluster nodes restart
 
@@ -426,7 +426,7 @@ class TestNodesRestartHCI(ManageTest):
             ),
         ],
     )
-    def test_hosted_cluster_nodes_restart_by_stop_and_start(
+    def test_client_cluster_nodes_restart_by_stop_and_start(
         self, cluster_type, client_type, nodes
     ):
         """

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -384,9 +384,18 @@ class TestNodesRestartHCI(ManageTest):
     @pytest.mark.parametrize(
         argnames=["cluster_type", "client_type"],
         argvalues=[
-            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT]),
-            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT]),
-            pytest.param(*[HCI_CLIENT, constants.NON_HOSTED_CLUSTER]),
+            pytest.param(
+                *[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT],
+                marks=pytest.mark.polarion_id("OCS-6170"),
+            ),
+            pytest.param(
+                *[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT],
+                marks=pytest.mark.polarion_id("OCS-6171"),
+            ),
+            pytest.param(
+                *[HCI_CLIENT, constants.NON_HOSTED_CLUSTER],
+                marks=pytest.mark.polarion_id("OCS-6172"),
+            ),
         ],
     )
     def test_hosted_cluster_nodes_restart(self, cluster_type, client_type, nodes):
@@ -403,9 +412,18 @@ class TestNodesRestartHCI(ManageTest):
     @pytest.mark.parametrize(
         argnames=["cluster_type", "client_type"],
         argvalues=[
-            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT]),
-            pytest.param(*[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT]),
-            pytest.param(*[HCI_CLIENT, constants.NON_HOSTED_CLUSTER]),
+            pytest.param(
+                *[HCI_CLIENT, constants.HOSTED_CLUSTER_KUBEVIRT],
+                marks=pytest.mark.polarion_id("OCS-6173"),
+            ),
+            pytest.param(
+                *[HCI_CLIENT, constants.HOSTED_CLUSTER_AGENT],
+                marks=pytest.mark.polarion_id("OCS-6174"),
+            ),
+            pytest.param(
+                *[HCI_CLIENT, constants.NON_HOSTED_CLUSTER],
+                marks=pytest.mark.polarion_id("OCS-6175"),
+            ),
         ],
     )
     def test_hosted_cluster_nodes_restart_by_stop_and_start(

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -406,7 +406,9 @@ class TestNodesRestartHCI(ManageTest):
         ocp_nodes = get_nodes(node_type=constants.WORKER_MACHINE)[0:2]
         nodes.restart_nodes(nodes=ocp_nodes, wait=True)
         client_cluster_health_check()
-        self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)
+        # We can't test create resources on the clients due to the BZ:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2304799. After the BZ resolves we will add the line:
+        # self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)
 
     @tier4a
     @pytest.mark.parametrize(
@@ -436,4 +438,6 @@ class TestNodesRestartHCI(ManageTest):
         ocp_nodes = get_nodes(node_type=constants.WORKER_MACHINE)[0:2]
         nodes.restart_nodes_by_stop_and_start(nodes=ocp_nodes, wait=True)
         client_cluster_health_check()
-        self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)
+        # We can't test create resources on the clients due to the BZ:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2304799. After the BZ resolves we will add the line:
+        # self.sanity_helpers.create_resources_on_clients(tries=2, delay=30)


### PR DESCRIPTION
As part of the Provider mode platform testing, we need to test the hosted cluster node functionalities. 
Currently, we have two types of hosted clusters: `Kubevirt` and `Agent`. 
This PR is implementing the `Kubevirt` hosted cluster node functionalities. The `Kubevirt` nodes are VMs that run on the provider worker nodes. For performing the VM operations, we use the `virtctl` command line tool: https://docs.openshift.com/container-platform/4.16/virt/getting_started/virt-using-the-cli-tools.html#vm-management-commands_virt-using-the-cli-tools