### PR TITLE
Add fio parameter direct in disruption tests

### DIFF
--- a/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -227,6 +227,7 @@ class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
                 size=f"{io_size}G",
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_io",
+                direct=int(storage_type == "block"),
             )
 
     @polarion_id("OCS-2755")

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -227,6 +227,7 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 size=f"{io_size}G",
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_io",
+                direct=int(storage_type == "block"),
             )
 
     @polarion_id("OCS-5176")


### PR DESCRIPTION
Add fio parameter "direct=1" if the volume mode is "Block" in the tests given below.
1. tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
2. tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py