### PR TITLE
[release-4.15] Skip test_automated_recovery_from_stopped_node_and_start on compact mode deployment

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -582,6 +582,11 @@ skipif_gcp_platform = pytest.mark.skipif(
     reason="Test will not run on GCP deployed cluster",
 )
 
+skipif_compact_mode = pytest.mark.skipif(
+    config.ENV_DATA.get("worker_replicas") == 0,
+    reason="This test is not supported for compact mode deployment types.",
+)
+
 # Squad marks
 aqua_squad = pytest.mark.aqua_squad
 black_squad = pytest.mark.black_squad

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -221,6 +221,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @tier4a
 @ipi_deployment_required
 @skipif_ibm_cloud
+@skipif_compact_mode
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None
@@ -277,7 +278,8 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
         argnames=["additional_node"],
         argvalues=[
             pytest.param(
-                True, marks=[(pytest.mark.polarion_id("OCS-2191")), skipif_compact_mode]
+                True,
+                marks=pytest.mark.polarion_id("OCS-2191"),
             ),
             pytest.param(False, marks=pytest.mark.polarion_id("OCS-2190")),
         ],

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -277,8 +277,7 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
         argnames=["additional_node"],
         argvalues=[
             pytest.param(
-                True,
-                marks=pytest.mark.polarion_id("OCS-2191"),
+                True, marks=[(pytest.mark.polarion_id("OCS-2191")), skipif_compact_mode]
             ),
             pytest.param(False, marks=pytest.mark.polarion_id("OCS-2190")),
         ],


### PR DESCRIPTION
fixes https://github.com/red-hat-storage/ocs-ci/issues/10088