### PR TITLE
Update RDR tier1 sequential failover and relocate tests

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -8,6 +8,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
 from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility.utils import ceph_health_check
@@ -25,19 +26,34 @@ class TestSequentialFailover:
     """
 
     @pytest.mark.parametrize(
-        argnames=["primary_cluster_down"],
+        argnames=["primary_cluster_down", "pvc_interface"],
         argvalues=[
             pytest.param(
-                False, marks=pytest.mark.polarion_id("OCS-4771"), id="primary_up"
+                *[False, constants.CEPHBLOCKPOOL],
+                marks=pytest.mark.polarion_id("OCS-4771"),
+                id="primary_up-rbd",
             ),
             pytest.param(
-                True, marks=pytest.mark.polarion_id("OCS-4770"), id="primary_down"
+                *[True, constants.CEPHBLOCKPOOL],
+                marks=pytest.mark.polarion_id("OCS-4770"),
+                id="primary_down-rbd",
+            ),
+            pytest.param(
+                *[False, constants.CEPHFILESYSTEM],
+                marks=pytest.mark.polarion_id("OCS-4734"),
+                id="primary_up-cephfs",
+            ),
+            pytest.param(
+                *[True, constants.CEPHFILESYSTEM],
+                marks=pytest.mark.polarion_id("OCS-4733"),
+                id="primary_down-cephfs",
             ),
         ],
     )
     def test_sequential_failover_to_secondary(
         self,
         primary_cluster_down,
+        pvc_interface,
         dr_workload,
         nodes_multicluster,
         node_restart_teardown,
@@ -47,7 +63,9 @@ class TestSequentialFailover:
         when primary cluster is Up/Down
 
         """
-        workloads = dr_workload(num_of_subscription=5)
+        workloads = dr_workload(
+            num_of_subscription=2, num_of_appset=3, pvc_interface=pvc_interface
+        )
 
         primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
             workloads[0].workload_namespace
@@ -59,15 +77,24 @@ class TestSequentialFailover:
             workloads[0].workload_namespace
         )
 
+        # Verify the creation of ReplicationDestination resources on secondary cluster
+        if pvc_interface == constants.CEPHFILESYSTEM:
+            config.switch_to_cluster_by_name(secondary_cluster_name)
+            for wl in workloads:
+                dr_helpers.wait_for_replication_destinations_creation(
+                    wl.workload_pvc_count, wl.workload_namespace
+                )
+
         scheduling_interval = dr_helpers.get_scheduling_interval(
             workloads[0].workload_namespace
         )
-        wait_time = 2 * scheduling_interval  # Time in minutes
+        wait_time = 1.5 * scheduling_interval  # Time in minutes
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         time.sleep(wait_time * 60)
 
         # Stop primary cluster nodes
         if primary_cluster_down:
+            config.switch_to_cluster_by_name(primary_cluster_name)
             logger.info(f"Stopping nodes of primary cluster: {primary_cluster_name}")
             nodes_multicluster[primary_cluster_index].stop_nodes(primary_cluster_nodes)
 
@@ -81,6 +108,10 @@ class TestSequentialFailover:
                         dr_helpers.failover,
                         failover_cluster=secondary_cluster_name,
                         namespace=wl.workload_namespace,
+                        workload_type=wl.workload_type,
+                        workload_placement_name=wl.appset_placement_name
+                        if wl.workload_type == constants.APPLICATION_SET
+                        else None,
                     )
                 )
                 time.sleep(5)
@@ -120,6 +151,20 @@ class TestSequentialFailover:
         for wl in workloads:
             dr_helpers.wait_for_all_resources_deletion(wl.workload_namespace)
 
-        dr_helpers.wait_for_mirroring_status_ok(
-            replaying_images=sum([wl.workload_pvc_count for wl in workloads])
-        )
+        if pvc_interface == constants.CEPHFILESYSTEM:
+            for wl in workloads:
+                # Verify the deletion of ReplicationDestination resources on secondary cluster
+                config.switch_to_cluster_by_name(secondary_cluster_name)
+                dr_helpers.wait_for_replication_destinations_deletion(
+                    wl.workload_namespace
+                )
+                # Verify the creation of ReplicationDestination resources on primary cluster
+                config.switch_to_cluster_by_name(primary_cluster_name)
+                dr_helpers.wait_for_replication_destinations_creation(
+                    wl.workload_pvc_count, wl.workload_namespace
+                )
+
+        if pvc_interface == constants.CEPHBLOCKPOOL:
+            dr_helpers.wait_for_mirroring_status_ok(
+                replaying_images=sum([wl.workload_pvc_count for wl in workloads])
+            )

--- a/tests/functional/disaster-recovery/regional-dr/test_sequential_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_sequential_relocate.py
@@ -8,6 +8,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
 from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
 
@@ -15,19 +16,33 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
-@pytest.mark.polarion_id("OCS-4772")
+@pytest.mark.parametrize(
+    argnames=["pvc_interface"],
+    argvalues=[
+        pytest.param(
+            *[constants.CEPHBLOCKPOOL],
+            marks=pytest.mark.polarion_id("OCS-4772"),
+        ),
+        pytest.param(
+            *[constants.CEPHFILESYSTEM],
+            marks=pytest.mark.polarion_id("OCS-4735"),
+        ),
+    ],
+)
 class TestSequentialRelocate:
     """
     Test Sequential Relocate actions
 
     """
 
-    def test_sequential_relocate_to_secondary(self, dr_workload):
+    def test_sequential_relocate_to_secondary(self, pvc_interface, dr_workload):
         """
         Test to verify relocate action for multiple workloads one after another from primary to secondary cluster
 
         """
-        workloads = dr_workload(num_of_subscription=5)
+        workloads = dr_workload(
+            num_of_subscription=2, num_of_appset=3, pvc_interface=pvc_interface
+        )
 
         primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
             workloads[0].workload_namespace
@@ -36,10 +51,18 @@ class TestSequentialRelocate:
             workloads[0].workload_namespace
         )
 
+        # Verify the creation of ReplicationDestination resources on secondary cluster
+        if pvc_interface == constants.CEPHFILESYSTEM:
+            config.switch_to_cluster_by_name(secondary_cluster_name)
+            for wl in workloads:
+                dr_helpers.wait_for_replication_destinations_creation(
+                    wl.workload_pvc_count, wl.workload_namespace
+                )
+
         scheduling_interval = dr_helpers.get_scheduling_interval(
             workloads[0].workload_namespace
         )
-        wait_time = 2 * scheduling_interval  # Time in minutes
+        wait_time = 1.5 * scheduling_interval  # Time in minutes
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         time.sleep(wait_time * 60)
 
@@ -53,6 +76,10 @@ class TestSequentialRelocate:
                         dr_helpers.relocate,
                         preferred_cluster=secondary_cluster_name,
                         namespace=wl.workload_namespace,
+                        workload_type=wl.workload_type,
+                        workload_placement_name=wl.appset_placement_name
+                        if wl.workload_type == constants.APPLICATION_SET
+                        else None,
                     )
                 )
                 time.sleep(5)
@@ -75,6 +102,20 @@ class TestSequentialRelocate:
                 wl.workload_namespace,
             )
 
-        dr_helpers.wait_for_mirroring_status_ok(
-            replaying_images=sum([wl.workload_pvc_count for wl in workloads])
-        )
+        if pvc_interface == constants.CEPHFILESYSTEM:
+            for wl in workloads:
+                # Verify the deletion of ReplicationDestination resources on secondary cluster
+                config.switch_to_cluster_by_name(secondary_cluster_name)
+                dr_helpers.wait_for_replication_destinations_deletion(
+                    wl.workload_namespace
+                )
+                # Verify the creation of ReplicationDestination resources on primary cluster
+                config.switch_to_cluster_by_name(primary_cluster_name)
+                dr_helpers.wait_for_replication_destinations_creation(
+                    wl.workload_pvc_count, wl.workload_namespace
+                )
+
+        if pvc_interface == constants.CEPHBLOCKPOOL:
+            dr_helpers.wait_for_mirroring_status_ok(
+                replaying_images=sum([wl.workload_pvc_count for wl in workloads])
+            )


### PR DESCRIPTION
 - Add RBD appset type workload in existing tests
 - Add tests to cover CephFS (subscription and appset) based workloads