### PR TITLE
Remove environment specific `disk_pattern` configuration from baremetal config files

### DIFF
--- a/conf/deployment/baremetal/ai_1az_rhcos_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/ai_1az_rhcos_nvme_intel_3m_3w.yaml
@@ -7,6 +7,3 @@ ENV_DATA:
   deployment_type: 'ai'
   worker_replicas: 3
   master_replicas: 3
-  mon_type: 'hostpath'
-  osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'

--- a/conf/deployment/baremetal/upi_1az_rhcos_compact_mode.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_compact_mode.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2505'

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_cluster_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_cluster_nvme_intel_3m_3w.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
   multus_cluster_net_interface: 'enp1s0f1'
   multus_create_public_net: false

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
   multus_public_net_interface: 'enp1s0f1'
   multus_cluster_net_interface: 'enp1s0f1'

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_public_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_public_nvme_intel_3m_3w.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
   is_multus_enabled: true
   multus_public_net_interface: 'enp1s0f1'
   multus_create_public_net: true

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2381'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_4w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_4w.yaml
@@ -9,7 +9,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2381'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_5w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_5w.yaml
@@ -10,7 +10,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2381'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_mcg_only_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_mcg_only_3m_3w.yaml
@@ -10,7 +10,6 @@ ENV_DATA:
   master_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2702'

--- a/conf/deployment/baremetal/upi_1az_rhel_nvme_intel_3m_3w.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhel_nvme_intel_3m_3w.yaml
@@ -10,7 +10,6 @@ ENV_DATA:
   mon_type: 'hostpath'
   osd_type: 'nvme'
   rhel_workers: true
-  disk_pattern: 'nvme-INTEL'
 REPORTING:
   polarion:
     deployment_id: 'OCS-2382'


### PR DESCRIPTION
- remove `disk_pattern` option from baremetal configuration files as this is environment specific and will be configured in credentials file for the particular environment
- this PR has to be merged together (or after) related MR with credential config files update