### PR TITLE
allow standalone LSO deployment (without ODF)

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -98,6 +98,7 @@ anywhere else.
 * `openshift_install_timeout` - Time (in seconds) to wait before timing out during OCP installation
 * `local_storage` - Deploy OCS with the local storage operator (aka LSO) (Default: false)
 * `local_storage_storagedeviceset_count` - This option allows one to control `spec.storageDeviceSets[0].count` of LSO backed StorageCluster.
+* `lso_standalone_deployment` - This option allows to deploy LSO separately (without actually deploying ODF)
 * `optional_operators_image` - If provided, it is used for LSO installation on unreleased OCP version
 * `disconnected` - Set if the cluster is deployed in a disconnected environment
 * `proxy` - Set if the cluster is deployed in a proxy environment

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -664,6 +664,10 @@ class Deployment(object):
             and ocp_version >= version.VERSION_4_9
         ):
             self.deploy_acm_hub()
+        if config.DEPLOYMENT.get("local_storage") and config.DEPLOYMENT.get(
+            "lso_standalone_deployment", False
+        ):
+            setup_local_storage(storageclass=self.DEFAULT_STORAGECLASS_LSO)
         self.do_deploy_lvmo()
         self.do_deploy_submariner()
         self.do_gitops_deploy()

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -664,9 +664,13 @@ class Deployment(object):
             and ocp_version >= version.VERSION_4_9
         ):
             self.deploy_acm_hub()
-        if config.DEPLOYMENT.get("local_storage") and config.DEPLOYMENT.get(
+
+        perform_lso_standalone_deployment = config.DEPLOYMENT.get(
             "lso_standalone_deployment", False
-        ):
+        ) and not ocp.OCP(kind=constants.STORAGECLASS).is_exist(
+            resource_name=self.DEFAULT_STORAGECLASS_LSO
+        )
+        if perform_lso_standalone_deployment:
             setup_local_storage(storageclass=self.DEFAULT_STORAGECLASS_LSO)
         self.do_deploy_lvmo()
         self.do_deploy_submariner()


### PR DESCRIPTION
- add `DEPLOYMENT.lso_standalone_deployment` parameter to allow LSO deployment separately (without ODF)
- this change will be helpful for HCP scenarios