### PR TITLE
[WIP] Updated the platform check condition

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -224,7 +224,10 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                     "replica"
                 ] = no_of_worker_nodes
 
-                if self.platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
+                if self.platform in [
+                    constants.BAREMETAL_PLATFORM,
+                    constants.VSPHERE_PLATFORM,
+                ]:
                     storage_cluster_data["spec"]["storageDeviceSets"][0][
                         "count"
                     ] = number_of_disks_available
@@ -246,7 +249,10 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                     "replica"
                 ] = no_of_worker_nodes
 
-                if self.platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
+                if self.platform in [
+                    constants.BAREMETAL_PLATFORM,
+                    constants.VSPHERE_PLATFORM,
+                ]:
                     storage_cluster_data["spec"]["storageDeviceSets"][0][
                         "count"
                     ] = number_of_disks_available


### PR DESCRIPTION
Updated the platform check value from 'constants.HCI_PROVIDER_CLIENT_PLATFORMS' with 'constants.BAREMETAL_PLATFORM', and 'constants.VSPHERE_PLATFORM' as its mentioned in deployment config.

The Error it was causing during ocs installation is, due to unavailable of enough pvs the number of osds its trying to create was unsuccessful and the storage-cluster was not moving to 'Ready' status