### PR TITLE
Retry if rack or zone return value is None but assignment is correct for test_crashcollector_pod_existence_on_ceph_pods_running_nodes

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -24,6 +24,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants, exceptions, ocp, defaults
 from ocs_ci.utility import version
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler, convert_device_size, get_az_count
 from ocs_ci.ocs import machine
 from ocs_ci.ocs.resources import pod
@@ -43,7 +44,6 @@ from ocs_ci.utility.rosa import (
 )
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.utility.vsphere import VSPHERE
-
 
 log = logging.getLogger(__name__)
 
@@ -2017,6 +2017,7 @@ def get_node_zone_dict():
     return node_zone_dict
 
 
+@retry(ValueError, tries=5, delay=10)
 def get_node_rack_or_zone(failure_domain, node_obj):
     """
     Get the worker node rack or zone name based on the failure domain value
@@ -2029,9 +2030,13 @@ def get_node_rack_or_zone(failure_domain, node_obj):
         str: The worker node rack/zone name
 
     """
-    return (
+    node_rack_or_zone = (
         get_node_zone(node_obj) if failure_domain == "zone" else get_node_rack(node_obj)
     )
+    if node_rack_or_zone:
+        return node_rack_or_zone
+    else:
+        raise ValueError
 
 
 def get_node_rack_or_zone_dict(failure_domain):

--- a/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -78,7 +78,7 @@ class TestAddNodeCrashCollector(ManageTest):
 
         new_node_name = list(set(get_node_names()) - set(old_nodes))[0]
         new_node = get_node_objs([new_node_name])[0]
-        logger.info(f"New worker node is {new_node_name}")
+        logger.info(f"New worker node is {new_node.name}")
 
         logger.info(f"Checking if the rack/zone of the node {new_node_name} is exist")
         timeout = 120


### PR DESCRIPTION
We saw a few failure instances for `test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py` over VMware where rack assignment is correct but function `get_node_rack_or_zone` returned None. The intention is to add retry to get the correct rack so as to stabilise the test.