### PR TITLE
Set the namespace dynamically in OC BS creation of GCP and Azure

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -714,6 +714,7 @@ def oc_create_google_backingstore(cld_mgr, backingstore_name, uls_name, region):
     """
     bs_data = templating.load_yaml(constants.MCG_BACKINGSTORE_YAML)
     bs_data["metadata"]["name"] = backingstore_name
+    bs_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
     bs_data["spec"] = {
         "type": constants.BACKINGSTORE_TYPE_GOOGLE,
         "googleCloudStorage": {
@@ -762,6 +763,7 @@ def oc_create_azure_backingstore(cld_mgr, backingstore_name, uls_name, region):
     """
     bs_data = templating.load_yaml(constants.MCG_BACKINGSTORE_YAML)
     bs_data["metadata"]["name"] = backingstore_name
+    bs_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
     bs_data["spec"] = {
         "type": constants.BACKINGSTORE_TYPE_AZURE,
         "azureBlob": {
@@ -2025,9 +2027,11 @@ def update_replication_policy(bucket_name, replication_policy_dict):
     replication_policy_patch_dict = {
         "spec": {
             "additionalConfig": {
-                "replicationPolicy": json.dumps(replication_policy_dict)
-                if replication_policy_dict
-                else ""
+                "replicationPolicy": (
+                    json.dumps(replication_policy_dict)
+                    if replication_policy_dict
+                    else ""
+                )
             }
         }
     }


### PR DESCRIPTION
When creating GCP and Azure Backingstores via OC + YAMLs, we've been using `openshift-storage` namespace regardless of the actual namespace we're using in a run. This PR simply sets the namespace from `config.ENV_DATA["cluster_namespace"]`.