### PR TITLE
Add runs_on_provider decorator in test_noobaa_postgres_cm_post_ocs_upgrade

### DIFF
--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -187,6 +187,7 @@ class TestCephDefaultValuesCheck(ManageTest):
             f"mds_cache_memory_limit is set with a value of {expected_mds_value_in_GB}GB"
         )
 
+    @runs_on_provider
     @bugzilla("2012930")
     @post_ocs_upgrade
     @pytest.mark.polarion_id("OCS-2739")


### PR DESCRIPTION
Decorate the test case to run on provider cluster when running in provider mode multicluster configuration.

Test case : tests/functional/z_cluster/test_ceph_default_values_check.py::TestCephDefaultValuesCheck::test_noobaa_postgres_cm_post_ocs_upgrade

Fixes #10307 