### PR TITLE
Fix test case test_selinux_relabel_for_existing_pvc[5] and remove the default arg value setting from dict in the function modify_deploymentconfig_replica_count

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2879,7 +2879,7 @@ def modify_deployment_replica_count(
 
 
 def modify_deploymentconfig_replica_count(
-    deploymentconfig_name, replica_count, namespace=config.ENV_DATA["cluster_namespace"]
+    deploymentconfig_name, replica_count, namespace=None
 ):
     """
     Function to modify deploymentconfig replica count,
@@ -2894,6 +2894,7 @@ def modify_deploymentconfig_replica_count(
         bool: True in case if changes are applied. False otherwise
 
     """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
     dc_ocp_obj = ocp.OCP(kind=constants.DEPLOYMENTCONFIG, namespace=namespace)
     params = f'{{"spec": {{"replicas": {replica_count}}}}}'
     return dc_ocp_obj.patch(resource_name=deploymentconfig_name, params=params)

--- a/tests/cross_functional/kcs/test_selinux_relabel_solution.py
+++ b/tests/cross_functional/kcs/test_selinux_relabel_solution.py
@@ -315,7 +315,7 @@ class TestSelinuxrelabel(E2ETest):
 
         self.pod_obj = self.get_app_pod_obj()
         ocp.OCP(
-            kind=constants.POD, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
         ).wait_for_resource(
             condition=constants.STATUS_RUNNING,
             resource_name=self.pod_obj.name,


### PR DESCRIPTION
Setting the default value of the argument 'namespace' from config in the function caused failure of the test case modify_deploymentconfig_replica_count caused in provider mode multicluster run.
The value ENV_DATA["cluster_namespace"] will be dynamically changed during the test run due to context switching. This will not take effect in the function leading to test case failure.

Use config.ENV_DATA["cluster_namespace"] instead of constant value because the namespace is different for different clusters.

Failed test case: tests/cross_functional/kcs/test_selinux_relabel_solution.py::TestSelinuxrelabel::test_selinux_relabel_for_existing_pvc[5]
 
Fixes #10309 