### PR TITLE
Add cephcsi-operator in the list of required csv

### DIFF
--- a/ocs_ci/deployment/helpers/odf_deployment_helpers.py
+++ b/ocs_ci/deployment/helpers/odf_deployment_helpers.py
@@ -32,6 +32,7 @@ def get_required_csvs():
             defaults.ODF_PROMETHEUS_OPERATOR,
             defaults.ODF_CLIENT_OPERATOR,
             defaults.RECIPE_OPERATOR,
+            defaults.CEPHCSI_OPERATOR,
         ]
         ocs_operator_names.extend(operators_4_16_additions)
     return ocs_operator_names

--- a/ocs_ci/deployment/helpers/odf_deployment_helpers.py
+++ b/ocs_ci/deployment/helpers/odf_deployment_helpers.py
@@ -32,7 +32,9 @@ def get_required_csvs():
             defaults.ODF_PROMETHEUS_OPERATOR,
             defaults.ODF_CLIENT_OPERATOR,
             defaults.RECIPE_OPERATOR,
-            defaults.CEPHCSI_OPERATOR,
         ]
         ocs_operator_names.extend(operators_4_16_additions)
+    if ocs_version >= version.VERSION_4_17:
+        operators_4_17_additions = [defaults.CEPHCSI_OPERATOR]
+        ocs_operator_names.extend(operators_4_17_additions)
     return ocs_operator_names

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -54,6 +54,7 @@ FUSION_OPERATOR_NAME = "isf-operator"
 FUSION_CATALOG_NAME = "isf-data-foundation-catalog"
 LIVE_CONTENT_SOURCE = "redhat-operators"
 OCS_CLIENT_OPERATOR_NAME = "ocs-client-operator"
+CEPHCSI_OPERATOR = "cephcsi-operator"
 
 # Noobaa S3 bucket website configurations
 website_config = {


### PR DESCRIPTION
Add ceph-csi operator to the list of csvs. This ensures proper verification of cephcsi-operator csv status.
Applicable for versions from 4.17.