### PR TITLE
Test Automation for space reclaim with storageclass annotations.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -842,6 +842,7 @@ def storageclass_factory_fixture(
         volume_binding_mode="Immediate",
         allow_volume_expansion=True,
         kernelMountOptions=None,
+        annotations=None,
     ):
         """
         Args:
@@ -867,6 +868,7 @@ def storageclass_factory_fixture(
                 till pod attachment.
             allow_volume_expansion (bool): True to Allows volume expansion
             kernelMountOptions (str): Mount option for security context
+            annotations (dict): dict of annotation to be added to the storageclass.
 
         Returns:
             object: helpers.create_storage_class instance with links to
@@ -905,6 +907,7 @@ def storageclass_factory_fixture(
                 volume_binding_mode=volume_binding_mode,
                 allow_volume_expansion=allow_volume_expansion,
                 kernelMountOptions=kernelMountOptions,
+                annotations=annotations,
             )
             assert sc_obj, f"Failed to create {interface} storage class"
             sc_obj.secret = secret

--- a/tests/functional/storageclass/test_storageclass_reclaim_space.py
+++ b/tests/functional/storageclass/test_storageclass_reclaim_space.py
@@ -1,0 +1,96 @@
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.helpers.helpers import get_rbd_image_info
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.utility.retry import retry
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    polarion_id,
+    tier1,
+)
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@polarion_id("OCS-6197")
+class TestStorageClassReclamespace:
+    @retry(UnexpectedBehaviour, tries=5, delay=10)
+    def wait_till_expected_image_size(self, expected_size):
+        """
+        Waiting till rbd image size is became expected size.
+        """
+        image_size = get_rbd_image_info(self.pool_name, self.rbd_image_name).get(
+            "used_size_gib"
+        )
+
+        if image_size != expected_size:
+            raise UnexpectedBehaviour(
+                f"RBD image {self.rbd_image_name} size is not expected as {expected_size}GiB"
+            )
+        log.info(f" RBD Image { self.rbd_image_name} is size of {image_size}GiB")
+        return True
+
+    @tier1
+    def test_storageclass_reclaimspace(
+        self, storageclass_factory, pvc_factory, pod_factory
+    ):
+        """
+        Test Space Reclaim Operation with Storageclass annotation.
+
+        Steps:
+
+        1. Create a RBD storageclass with  reclaimspace annotations.
+        "reclaimspace.csiaddons.openshift.io/schedule: */3 * * * *".
+        2. Create a pvc
+        4. Create a pods
+        5. Write a 2.0GiB data on rnd block
+        6. destroy pod
+        7. wait for reclaimspace operation to be complete
+        6. verify reclaimspace Job ran successfully for the storageclass.
+        """
+
+        # Storegeclass ReclaimSpace annotations.
+        reclaimspace_annotations = {
+            "reclaimspace.csiaddons.openshift.io/schedule": "*/3 * * * *"
+        }
+
+        # Creating StorageClass with reclaimspace annotations.
+        self.sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL, annotations=reclaimspace_annotations
+        )
+
+        # Create a PVC with volume block mode
+        pvc_obj = pvc_factory(
+            size=5, storageclass=self.sc_obj, volume_mode=constants.VOLUME_MODE_BLOCK
+        )
+
+        pod_obj = pod_factory(
+            pvc=pvc_obj,
+            status=constants.STATUS_RUNNING,
+            raw_block_pv=True,
+        )
+
+        storage_path = pod_obj.get_storage_path("block")
+
+        log.info("Writing 2.0GiB of data to the block device")
+        pod_obj.exec_cmd_on_pod(
+            f"dd if=/dev/zero of={storage_path} bs=1M count=2048 oflag=direct"
+        )
+
+        self.pool_name = self.sc_obj.data["parameters"]["pool"]
+        self.rbd_image_name = pvc_obj.get_rbd_image_name
+
+        assert self.wait_till_expected_image_size(
+            2.0
+        ), f"RBD Image '{self.rbd_image_name}' expected size of '2.0 GiB' does not match the actual size."
+
+        pod_obj.delete()
+        pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+
+        assert self.wait_till_expected_image_size(
+            0.0
+        ), f"RBD Image '{self.rbd_image_name}' expected size of '0.0 GiB' does not match the actual size."
+
+        log.info("ReclaimSpace JOB has ran successfully. ")

--- a/tests/functional/storageclass/test_storageclass_reclaim_space.py
+++ b/tests/functional/storageclass/test_storageclass_reclaim_space.py
@@ -17,24 +17,25 @@ log = logging.getLogger(__name__)
 @polarion_id("OCS-6197")
 class TestStorageClassReclamespace:
     @retry(UnexpectedBehaviour, tries=5, delay=10)
-    def wait_till_expected_image_size(self, expected_size):
+    def wait_till_expected_image_size(self, pvc_obj, expected_size):
         """
         Waiting till rbd image size is became expected size.
         """
-        image_size = get_rbd_image_info(self.pool_name, self.rbd_image_name).get(
+        rbd_image_name = pvc_obj.get_rbd_image_name
+        image_size = get_rbd_image_info(self.pool_name, rbd_image_name).get(
             "used_size_gib"
         )
 
         if image_size != expected_size:
             raise UnexpectedBehaviour(
-                f"RBD image {self.rbd_image_name} size is not expected as {expected_size}GiB"
+                f"RBD image {rbd_image_name} size is not expected as {expected_size}GiB"
             )
-        log.info(f" RBD Image { self.rbd_image_name} is size of {image_size}GiB")
+        log.info(f" RBD Image { rbd_image_name} is size of {image_size}GiB")
         return True
 
     @tier1
     def test_storageclass_reclaimspace(
-        self, storageclass_factory, pvc_factory, pod_factory
+        self, storageclass_factory, multi_pvc_factory, pod_factory
     ):
         """
         Test Space Reclaim Operation with Storageclass annotation.
@@ -43,10 +44,10 @@ class TestStorageClassReclamespace:
 
         1. Create a RBD storageclass with  reclaimspace annotations.
         "reclaimspace.csiaddons.openshift.io/schedule: */3 * * * *".
-        2. Create a pvc
-        4. Create a pods
-        5. Write a 2.0GiB data on rnd block
-        6. destroy pod
+        2. Create a 3 PVC
+        4. Create a pod w.r.t each PVC
+        5. Write a 2.0GiB on block device mounted in the pod.
+        6. destroy all pods
         7. wait for reclaimspace operation to be complete
         6. verify reclaimspace Job ran successfully for the storageclass.
         """
@@ -60,37 +61,53 @@ class TestStorageClassReclamespace:
         self.sc_obj = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL, annotations=reclaimspace_annotations
         )
-
-        # Create a PVC with volume block mode
-        pvc_obj = pvc_factory(
-            size=5, storageclass=self.sc_obj, volume_mode=constants.VOLUME_MODE_BLOCK
-        )
-
-        pod_obj = pod_factory(
-            pvc=pvc_obj,
-            status=constants.STATUS_RUNNING,
-            raw_block_pv=True,
-        )
-
-        storage_path = pod_obj.get_storage_path("block")
-
-        log.info("Writing 2.0GiB of data to the block device")
-        pod_obj.exec_cmd_on_pod(
-            f"dd if=/dev/zero of={storage_path} bs=1M count=2048 oflag=direct"
-        )
-
         self.pool_name = self.sc_obj.data["parameters"]["pool"]
-        self.rbd_image_name = pvc_obj.get_rbd_image_name
 
-        assert self.wait_till_expected_image_size(
-            2.0
-        ), f"RBD Image '{self.rbd_image_name}' expected size of '2.0 GiB' does not match the actual size."
+        # Create a PVC's with volume block mode
+        pvc_objs = multi_pvc_factory(
+            size=5,
+            storageclass=self.sc_obj,
+            num_of_pvc=3,
+            access_modes=[f"{constants.ACCESS_MODE_RWO}-Block"],
+            wait_each=True,
+        )
 
-        pod_obj.delete()
-        pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+        # Create POds
+        self.pod_objs = []
 
-        assert self.wait_till_expected_image_size(
-            0.0
-        ), f"RBD Image '{self.rbd_image_name}' expected size of '0.0 GiB' does not match the actual size."
+        # Create pods
+        for pvc in pvc_objs:
+            pod_obj = pod_factory(
+                pvc=pvc,
+                status=constants.STATUS_RUNNING,
+                raw_block_pv=True,
+            )
+            self.pod_objs.append(pod_obj)
+
+        # Writing data to the block device
+        for pod_obj, pvc_obj in zip(self.pod_objs, pvc_objs):
+            storage_path = pod_obj.get_storage_path("block")
+            log.info("Writing 2.0GiB of data to the block device")
+            pod_obj.exec_cmd_on_pod(
+                f"dd if=/dev/zero of={storage_path} bs=1M count=2048 oflag=direct > /dev/null 2>&1 &",
+                shell=True,
+            )
+
+        # Wait until all writes are complete and the RBD image shows the expected size.
+        for pvc_obj in pvc_objs:
+            assert self.wait_till_expected_image_size(
+                pvc_obj, 2.0
+            ), f"RBD Image '{pvc_obj.get_rbd_image_name}' expected size of '2.0 GiB' does not match the actual size."
+
+        # Delete all pods
+        for pod_obj in self.pod_objs:
+            pod_obj.delete()
+            pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+
+        # Wait till reclaim space operations is complete
+        for pvc_obj in pvc_objs:
+            assert self.wait_till_expected_image_size(
+                pvc_obj, 0.0
+            ), f"RBD Image '{pvc_obj.get_rbd_image_name}' expected size of '0.0 GiB' does not match the actual size."
 
         log.info("ReclaimSpace JOB has ran successfully. ")


### PR DESCRIPTION
        Test Space Reclaim Operation with Storageclass annotation.

        Steps:

        1. Create a RBD storageclass with  reclaimspace annotations.
        "reclaimspace.csiaddons.openshift.io/schedule: */3 * * * *".
        2. Create a pvc
        4. Create a pods
        5. Write a 2.0GiB data on rbd block
        6. destroy pod
        7. wait for reclaimspace operation to be complete
        6. verify reclaimspace Job ran successfully for the storageclass.