### PR TITLE
[release-4.15 backport] Ignore noobaa-endpoint pods leftovers in MCG tests

### DIFF
--- a/ocs_ci/framework/testlib.py
+++ b/ocs_ci/framework/testlib.py
@@ -1,7 +1,11 @@
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import *  # noqa: F403
-from ocs_ci.ocs.constants import MCG_TESTS_MIN_NB_ENDPOINT_COUNT, MAX_NB_ENDPOINT_COUNT
+from ocs_ci.ocs.constants import (
+    MCG_TESTS_MIN_NB_ENDPOINT_COUNT,
+    MAX_NB_ENDPOINT_COUNT,
+    NOOBAA_ENDPOINT_POD_LABEL,
+)
 
 
 @pytest.mark.usefixtures("environment_checker")  # noqa: F405
@@ -42,6 +46,8 @@ class EcosystemTest(BaseTest):
     pass
 
 
+# nb endpoint pods might change during MCG tests due to scaling or mounts
+@ignore_leftover_label(NOOBAA_ENDPOINT_POD_LABEL)  # noqa: F405
 @pytest.mark.usefixtures("nb_ensure_endpoint_count")
 class MCGTest(ManageTest):
     MIN_ENDPOINT_COUNT = MCG_TESTS_MIN_NB_ENDPOINT_COUNT

--- a/tests/functional/object/mcg/test_nsfs.py
+++ b/tests/functional/object/mcg/test_nsfs.py
@@ -5,12 +5,10 @@ from ocs_ci.framework.testlib import MCGTest, tier1, tier3
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     skipif_ocs_version,
-    ignore_leftover_label,
     red_squad,
     runs_on_provider,
     mcg,
 )
-from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
 from ocs_ci.ocs.exceptions import CommandFailed
 
@@ -27,7 +25,6 @@ logger = logging.getLogger(__name__)
 @runs_on_provider
 @skipif_mcg_only
 @skipif_ocs_version("<4.10")
-@ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)
 @pytest.mark.usefixtures(revert_noobaa_endpoint_scc_class.__name__)
 class TestNSFSObjectIntegrity(MCGTest):
     """


### PR DESCRIPTION
release-4.15 backport of #10350