### PR TITLE
Download virtctl tool

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -203,6 +203,8 @@ ENV_DATA:
   opm_owner_repo: "operator-framework/operator-registry"
   # opm tool release tag (particular version or "latest") to be downloaded
   opm_release_tag: "latest"
+  # virtctl tool github owner and repository (used in api url for downloading opm tool)
+  virtctl_owner_repo: "kubevirt/kubevirt"
   # vault environment variables
   vault_deploy_mode: external
   KMS_PROVIDER: vault

--- a/ocs_ci/helpers/disconnected.py
+++ b/ocs_ci/helpers/disconnected.py
@@ -1,21 +1,16 @@
-import json
 import logging
 import os
-import platform
 
 from ocs_ci.framework import config
+from ocs_ci.helpers.github import get_asset_from_github
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
-    NotFoundError,
-    UnsupportedOSType,
 )
 from ocs_ci.utility.utils import (
     clone_repo,
-    download_file,
     exec_cmd,
     get_ocp_version,
-    get_url_content,
     prepare_bin_dir,
 )
 
@@ -32,52 +27,11 @@ def get_opm_tool():
     except (CommandFailed, FileNotFoundError):
         logger.info("opm tool is not available, installing it")
         opm_release_tag = config.ENV_DATA.get("opm_release_tag", "latest")
-        if opm_release_tag != "latest":
-            opm_release_tag = f"tags/{opm_release_tag}"
-        opm_releases_api_url = (
-            f"https://api.github.com/repos/{config.ENV_DATA.get('opm_owner_repo')}/"
-            f"releases/{opm_release_tag}"
+        get_asset_from_github(
+            name="opm",
+            owner_repo=config.ENV_DATA.get("opm_owner_repo"),
+            release_tag=opm_release_tag,
         )
-        if config.AUTH.get("github"):
-            github_auth = (
-                config.AUTH["github"].get("username"),
-                config.AUTH["github"].get("token"),
-            )
-            logger.debug(f"Using github authentication (user: {github_auth[0]})")
-        else:
-            github_auth = None
-            logger.warning(
-                "Github credentials are not provided in data/auth.yaml file. "
-                "You might encounter issues with accessing github api as it "
-                "have very strict rate limit for unauthenticated requests "
-                "(60 requests per hour). Please check docs/getting_started.md "
-                "file to find how to configure github authentication."
-            )
-        release_data = json.loads(
-            get_url_content(opm_releases_api_url, auth=github_auth)
-        )
-
-        if platform.system() == "Darwin":
-            opm_asset_name = "darwin-amd64-opm"
-        elif platform.system() == "Linux":
-            opm_asset_name = "linux-amd64-opm"
-        else:
-            raise UnsupportedOSType
-
-        for asset in release_data["assets"]:
-            if asset["name"] == opm_asset_name:
-                opm_download_url = asset["browser_download_url"]
-                break
-        else:
-            raise NotFoundError(
-                f"opm binary for selected type {opm_asset_name} was not found"
-            )
-        prepare_bin_dir()
-        bin_dir = os.path.expanduser(config.RUN["bin_dir"])
-        logger.info(f"Downloading opm tool from '{opm_download_url}' to '{bin_dir}'")
-        download_file(opm_download_url, os.path.join(bin_dir, "opm"))
-        cmd = f"chmod +x {os.path.join(bin_dir, 'opm')}"
-        exec_cmd(cmd)
         opm_version = exec_cmd("opm version")
     logger.info(f"opm tool is available: {opm_version.stdout.decode('utf-8')}")
 

--- a/ocs_ci/helpers/github.py
+++ b/ocs_ci/helpers/github.py
@@ -51,9 +51,11 @@ def get_asset_from_github(name, owner_repo, release_tag="latest"):
         )
     release_data = json.loads(get_url_content(releases_api_url, auth=github_auth))
 
-    if platform.system() == "Darwin":
+    if platform.system() == "Darwin" and platform.machine() == "x86_64":
         asset_name = "darwin-amd64"
-    elif platform.system() == "Linux":
+    elif platform.system() == "Darwin" and platform.machine() == "arm64":
+        asset_name = "darwin-arm64"
+    elif platform.system() == "Linux" and platform.machine() == "x86_64":
         asset_name = "linux-amd64"
     else:
         raise UnsupportedOSType

--- a/ocs_ci/helpers/github.py
+++ b/ocs_ci/helpers/github.py
@@ -5,7 +5,6 @@ import platform
 
 from ocs_ci.framework import config
 
-# from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import (
     NotFoundError,
     UnsupportedOSType,

--- a/ocs_ci/helpers/github.py
+++ b/ocs_ci/helpers/github.py
@@ -1,0 +1,75 @@
+import json
+import logging
+import os
+import platform
+
+from ocs_ci.framework import config
+
+# from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import (
+    NotFoundError,
+    UnsupportedOSType,
+)
+from ocs_ci.utility.utils import (
+    download_file,
+    exec_cmd,
+    get_url_content,
+    prepare_bin_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_asset_from_github(name, owner_repo, release_tag="latest"):
+    """
+    Download and install asset from github.
+
+    Args:
+        name (str): name of the tool which should be downloaded
+        owner_repo (str): github repository with the tool in form owner/repo
+        release_tag (str): release tag to download (default: latest)
+
+    """
+    if release_tag != "latest":
+        release_tag = f"tags/{release_tag}"
+    releases_api_url = (
+        f"https://api.github.com/repos/{owner_repo}/releases/{release_tag}"
+    )
+    if config.AUTH.get("github"):
+        github_auth = (
+            config.AUTH["github"].get("username"),
+            config.AUTH["github"].get("token"),
+        )
+        logger.debug(f"Using github authentication (user: {github_auth[0]})")
+    else:
+        github_auth = None
+        logger.warning(
+            "Github credentials are not provided in data/auth.yaml file. "
+            "You might encounter issues with accessing github api as it "
+            "have very strict rate limit for unauthenticated requests "
+            "(60 requests per hour). Please check docs/getting_started.md "
+            "file to find how to configure github authentication."
+        )
+    release_data = json.loads(get_url_content(releases_api_url, auth=github_auth))
+
+    if platform.system() == "Darwin":
+        asset_name = "darwin-amd64"
+    elif platform.system() == "Linux":
+        asset_name = "linux-amd64"
+    else:
+        raise UnsupportedOSType
+
+    for asset in release_data["assets"]:
+        if asset_name in asset["name"]:
+            download_url = asset["browser_download_url"]
+            break
+    else:
+        raise NotFoundError(
+            f"{name} binary for selected type {asset_name} was not found"
+        )
+    prepare_bin_dir()
+    bin_dir = os.path.expanduser(config.RUN["bin_dir"])
+    logger.info(f"Downloading tool from '{download_url}' to '{bin_dir}'")
+    download_file(download_url, os.path.join(bin_dir, name))
+    cmd = f"chmod +x {os.path.join(bin_dir, name)}"
+    exec_cmd(cmd)

--- a/ocs_ci/helpers/virtctl.py
+++ b/ocs_ci/helpers/virtctl.py
@@ -3,6 +3,7 @@ import logging
 from ocs_ci.framework import config
 
 # from ocs_ci.ocs import constants
+from ocs_ci.deployment.cnv import CNVInstaller
 from ocs_ci.helpers.github import get_asset_from_github
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import exec_cmd
@@ -16,14 +17,19 @@ def get_virtctl_tool():
 
     """
     try:
-        virtctl_version = exec_cmd("virtctl version -c")
+        virtctl_version = exec_cmd("virtctl version -c", silent=True)
     except (CommandFailed, FileNotFoundError):
         logger.info("virtctl tool is not available, installing it")
-        virtctl_release_tag = config.ENV_DATA.get("virtctl_release_tag", "latest")
-        get_asset_from_github(
-            name="virtctl",
-            owner_repo=config.ENV_DATA.get("virtctl_owner_repo"),
-            release_tag=virtctl_release_tag,
-        )
-        virtctl_version = exec_cmd("virtctl version -c")
+        try:
+            cnv_obj = CNVInstaller()
+            cnv_obj.download_and_extract_virtctl_binary()
+            virtctl_version = exec_cmd("virtctl version -c")
+        except Exception:
+            virtctl_release_tag = config.ENV_DATA.get("virtctl_release_tag", "latest")
+            get_asset_from_github(
+                name="virtctl",
+                owner_repo=config.ENV_DATA.get("virtctl_owner_repo"),
+                release_tag=virtctl_release_tag,
+            )
+            virtctl_version = exec_cmd("virtctl version -c")
     logger.info(f"virtctl tool is available: {virtctl_version.stdout.decode('utf-8')}")

--- a/ocs_ci/helpers/virtctl.py
+++ b/ocs_ci/helpers/virtctl.py
@@ -1,0 +1,29 @@
+import logging
+
+from ocs_ci.framework import config
+
+# from ocs_ci.ocs import constants
+from ocs_ci.helpers.github import get_asset_from_github
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.utility.utils import exec_cmd
+
+logger = logging.getLogger(__name__)
+
+
+def get_virtctl_tool():
+    """
+    Download and install virtctl tool.
+
+    """
+    try:
+        virtctl_version = exec_cmd("virtctl version -c")
+    except (CommandFailed, FileNotFoundError):
+        logger.info("virtctl tool is not available, installing it")
+        virtctl_release_tag = config.ENV_DATA.get("virtctl_release_tag", "latest")
+        get_asset_from_github(
+            name="virtctl",
+            owner_repo=config.ENV_DATA.get("virtctl_owner_repo"),
+            release_tag=virtctl_release_tag,
+        )
+        virtctl_version = exec_cmd("virtctl version -c")
+    logger.info(f"virtctl tool is available: {virtctl_version.stdout.decode('utf-8')}")

--- a/ocs_ci/helpers/virtctl.py
+++ b/ocs_ci/helpers/virtctl.py
@@ -23,13 +23,17 @@ def get_virtctl_tool():
         try:
             cnv_obj = CNVInstaller()
             cnv_obj.download_and_extract_virtctl_binary()
-            virtctl_version = exec_cmd("virtctl version -c")
-        except Exception:
+            virtctl_version = exec_cmd("virtctl version -c", silent=True)
+        except Exception as err:
+            logger.info(
+                f"Downloading or extracting virtctl binary from OCP Cluster failed: {err}. "
+                "Falling back to download it from upstream github repo."
+            )
             virtctl_release_tag = config.ENV_DATA.get("virtctl_release_tag", "latest")
             get_asset_from_github(
                 name="virtctl",
                 owner_repo=config.ENV_DATA.get("virtctl_owner_repo"),
                 release_tag=virtctl_release_tag,
             )
-            virtctl_version = exec_cmd("virtctl version -c")
+            virtctl_version = exec_cmd("virtctl version -c", silent=True)
     logger.info(f"virtctl tool is available: {virtctl_version.stdout.decode('utf-8')}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 
 from ocs_ci.helpers.proxy import update_container_with_proxy_env
+from ocs_ci.helpers.virtctl import get_virtctl_tool
 from ocs_ci.ocs import constants, defaults, fio_artefacts, node, ocp, platform_nodes
 from ocs_ci.ocs.acm.acm import login_to_acm, AcmAddClusters
 from ocs_ci.ocs.awscli_pod import create_awscli_pod, awscli_pod_cleanup
@@ -8504,3 +8505,8 @@ def enable_guaranteed_bucket_logging_fixture(request, pvc_factory):
 
     request.addfinalizer(cleanup)
     return factory
+
+
+@pytest.fixture(scope="session")
+def virtctl_binary():
+    get_virtctl_tool()


### PR DESCRIPTION
This PR is adding new fixture to get virtctl tool. It checks if this tool is available and if not, it firstly try to get it from the CNV if installed on the cluster and as a fall-back it downloads it from upstream github repository.

Also separating getting asset from github to separated function and use it in the new `get_virtctl_tool` function and also in `get_opm_tool`.

fixes: https://github.com/red-hat-storage/ocs-ci/issues/10366