### PR TITLE
Deploy and configure Ingress Node Firewall to be able to restrict SSH access to nodes.

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -329,6 +329,8 @@ higher priority).
 * `ceph_threshold_backfill_full_ratio` - Configure backfillFullRatio the ceph osd full thresholds value in the StorageCluster CR.
 * `ceph_threshold_full_ratio` - Configure fullRatio the ceph osd full thresholds value in the StorageCluster CR.
 * `ceph_threshold_near_full_ratio` - Configure nearFullRatio the ceph osd full thresholds value in the StorageCluster CR.
+* `restrict_ssh_access_to_nodes` - Deploy and configure Ingress Node Firewall Operator to restrict SSH access to nodes.
+* `allow_ssh_access_from_subnets` - Defines a list of subnets wit allowed SSH access to nodes.
 
 #### UPGRADE
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -29,6 +29,7 @@ from ocs_ci.deployment.helpers.mcg_helpers import (
 )
 from ocs_ci.deployment.helpers.odf_deployment_helpers import get_required_csvs
 from ocs_ci.deployment.acm import Submariner
+from ocs_ci.deployment.ingress_node_firewall import restrict_ssh_access_to_nodes
 from ocs_ci.deployment.helpers.lso_helpers import (
     setup_local_storage,
     cleanup_nodes_for_lso_install,
@@ -749,6 +750,9 @@ class Deployment(object):
         )
         if ibmcloud_ipi:
             ibmcloud.label_nodes_region()
+        # configure Ingress Node Firewall and restrict SSH access to nodes
+        if config.ENV_DATA.get("restrict_ssh_access_to_nodes", False):
+            restrict_ssh_access_to_nodes()
 
     def label_and_taint_nodes(self):
         """

--- a/ocs_ci/deployment/ingress_node_firewall.py
+++ b/ocs_ci/deployment/ingress_node_firewall.py
@@ -1,0 +1,201 @@
+import logging
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, exceptions
+from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import TimeoutSampler
+
+
+logger = logging.getLogger(__name__)
+
+
+def restrict_ssh_access_to_nodes():
+    """
+    Deploy IngressNodeFirewall and configure rules to restrict SSH access to nodes
+    """
+    logger.info(
+        "Deploy and configure IngressNodeFirewall to restrict SSH access to nodes"
+    )
+    if config.ENV_DATA.get("allow_ssh_access_from_subnets"):
+        logger.debug(
+            "SSH access to nodes will be restricted except for clients from following subnets: "
+            f"{config.ENV_DATA['allow_ssh_access_from_subnets']}"
+        )
+        rules = [
+            {
+                "sourceCIDRs": config.ENV_DATA["allow_ssh_access_from_subnets"],
+                "rules": [
+                    {
+                        "order": 10,
+                        "protocolConfig": {
+                            "protocol": "TCP",
+                            "tcp": {
+                                "ports": "22",
+                            },
+                        },
+                        "action": "Allow",
+                    },
+                ],
+            },
+        ]
+    else:
+        logger.warning(
+            "SSH access to nodes will be restricted and no exceptions will be configured "
+            "(ENV_DATA['allow_ssh_access_from_subnets'] is not configured)."
+        )
+        rules = []
+
+    rules.append(
+        {
+            "sourceCIDRs": [
+                "0.0.0.0/0",
+                "::/0",
+            ],
+            "rules": [
+                {
+                    "order": 90,
+                    "protocolConfig": {
+                        "protocol": "TCP",
+                        "tcp": {
+                            "ports": "22",
+                        },
+                    },
+                    "action": "Deny",
+                },
+            ],
+        },
+    )
+    deploy_ingress_node_firewall(rules=rules)
+
+
+def deploy_ingress_node_firewall(rules):
+    """
+    Deploy Ingress Node Firewall Operator used for example for restricting SSH access to nodes
+
+    Args:
+        rules (dict): dictionary of IngressNodeFirewall Rules (content of `spec.ingress`)
+
+    """
+    inf = IngressNodeFirewallInstaller()
+    # create openshift-ingress-node-firewall namespace
+    inf.create_namespace()
+
+    # create operator group
+    inf.create_operatorgroup()
+
+    # subscribe to the Ingress Node Firewall Operator
+    inf.create_subscription()
+
+    # verify installation
+    inf.verify_csv_status()
+
+    # create config
+    inf.create_config()
+
+    # add firewall rules
+    inf.create_rules(rules=rules)
+
+
+class IngressNodeFirewallInstaller(object):
+    """
+    IngressNodeFirewall Installer class for Ingress Node Firewall deployment
+
+    """
+
+    def __init__(self):
+        self.namespace = constants.INGRESS_NODE_FIREWALL_NAMESPACE
+
+    def create_namespace(self):
+        """
+        Creates the namespace for IngressNodeFirewall resources
+
+        Raises:
+            CommandFailed: If the 'oc create' command fails.
+
+        """
+        try:
+            logger.info(
+                f"Creating namespace {self.namespace} for IngressNodeFirewall resources"
+            )
+            namespace_yaml_file = templating.load_yaml(constants.INF_NAMESPACE_YAML)
+            namespace_yaml = OCS(**namespace_yaml_file)
+            namespace_yaml.create()
+            logger.info(
+                f"IngressNodeFirewall namespace {self.namespace} was created successfully"
+            )
+        except exceptions.CommandFailed as err:
+            if (
+                f'project.project.openshift.io "{self.namespace}" already exists'
+                in str(err)
+            ):
+                logger.info(f"Namespace {self.namespace} already exists")
+            else:
+                raise err
+
+    def create_operatorgroup(self):
+        """
+        Creates an OperatorGroup for IngressNodeFirewall
+
+        """
+        logger.info("Creating OperatorGroup for IngressNodeFirewall")
+        operatorgroup_yaml_file = templating.load_yaml(constants.INF_OPERATORGROUP_YAML)
+        operatorgroup_yaml = OCS(**operatorgroup_yaml_file)
+        operatorgroup_yaml.create()
+        logger.info("IngressNodeFirewall OperatorGroup created successfully")
+
+    def create_subscription(self):
+        """
+        Creates subscription for IngressNodeFirewall operator
+
+        """
+        logger.info("Creating Subscription for IngressNodeFirewall")
+        subscription_yaml_file = templating.load_yaml(constants.INF_SUBSCRIPTION_YAML)
+        subscription_yaml = OCS(**subscription_yaml_file)
+        subscription_yaml.create()
+        logger.info("IngressNodeFirewall Subscription created successfully")
+
+    def verify_csv_status(self):
+        """
+        Verify the CSV status for the IngressNodeFirewall Operator deployment equals Succeeded
+
+        """
+        for csv in TimeoutSampler(
+            timeout=900,
+            sleep=15,
+            func=get_csvs_start_with_prefix,
+            csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,
+            namespace=self.namespace,
+        ):
+            if csv:
+                break
+        csv_name = csv[0]["metadata"]["name"]
+        csv_obj = CSV(resource_name=csv_name, namespace=self.namespace)
+        csv_obj.wait_for_phase(phase="Succeeded", timeout=720)
+
+    def create_config(self):
+        """
+        Creates configuration for IngressNodeFirewall
+
+        """
+        logger.info("Creating IngressNodeFirewallConfig")
+        config_yaml_file = templating.load_yaml(constants.INF_CONFIG_YAML)
+        config_yaml = OCS(**config_yaml_file)
+        config_yaml.create()
+        logger.info("IngressNodeFirewallConfig created successfully")
+
+    def create_rules(self, rules):
+        """
+        Create IngressNodeFirewall Rules
+
+        Args:
+            rules (dict): dictionary of IngressNodeFirewall Rules (content of `spec.ingress`)
+
+        """
+        logger.info("Creating IngressNodeFirewall Rules")
+        rules_yaml_file = templating.load_yaml(constants.INF_RULES_YAML)
+        rules_yaml_file["spec"]["ingress"] = rules
+        rules_yaml = OCS(**rules_yaml_file)
+        rules_yaml.create()
+        logger.info("IngressNodeFirewall Rules created successfully")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -35,6 +35,9 @@ TEMPLATE_MULTICLUSTER_DIR = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "multicluster"
 TEMPLATE_DEPLOYMENT_DIR_CNV = os.path.join(TEMPLATE_DIR, "cnv-deployment")
 TEMPLATE_DEPLOYMENT_DIR_METALLB = os.path.join(TEMPLATE_DIR, "metallb-deployment")
 TEMPLATE_DEPLOYMENT_DIR_NMSTATE = os.path.join(TEMPLATE_DIR, "nmstate-deployment")
+TEMPLATE_DEPLOYMENT_DIR_INF = os.path.join(
+    TEMPLATE_DIR, "ingress-node-firewall-deployment"
+)
 TEMPLATE_CEPH_DIR = os.path.join(TEMPLATE_DIR, "ceph")
 TEMPLATE_CSI_DIR = os.path.join(TEMPLATE_DIR, "CSI")
 TEMPLATE_CSI_LVM_DIR = os.path.join(TEMPLATE_CSI_DIR, "lvm")
@@ -2912,3 +2915,12 @@ ENTER_KEY = chr(13)
 
 # Large size chunk IO
 CHUNK = os.path.join(TEMPLATE_WORKLOAD_DIR, "helper_scripts/chunk.py")
+
+# Ingress Node Firewall related constants
+INGRESS_NODE_FIREWALL_NAMESPACE = "openshift-ingress-node-firewall"
+INGRESS_NODE_FIREWALL_CSV_NAME = "ingress-node-firewall"
+INF_NAMESPACE_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_INF, "namespace.yaml")
+INF_OPERATORGROUP_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_INF, "operatorgroup.yaml")
+INF_SUBSCRIPTION_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_INF, "subscription.yaml")
+INF_CONFIG_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_INF, "config.yaml")
+INF_RULES_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_INF, "rules.yaml")

--- a/ocs_ci/templates/ingress-node-firewall-deployment/config.yaml
+++ b/ocs_ci/templates/ingress-node-firewall-deployment/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: ingressnodefirewall.openshift.io/v1alpha1
+kind: IngressNodeFirewallConfig
+metadata:
+  name: ingressnodefirewallconfig
+  namespace: openshift-ingress-node-firewall
+spec:
+  nodeSelector: {}

--- a/ocs_ci/templates/ingress-node-firewall-deployment/namespace.yaml
+++ b/ocs_ci/templates/ingress-node-firewall-deployment/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.24
+  name: openshift-ingress-node-firewall

--- a/ocs_ci/templates/ingress-node-firewall-deployment/operatorgroup.yaml
+++ b/ocs_ci/templates/ingress-node-firewall-deployment/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ingress-node-firewall-operators
+  namespace: openshift-ingress-node-firewall

--- a/ocs_ci/templates/ingress-node-firewall-deployment/rules.yaml
+++ b/ocs_ci/templates/ingress-node-firewall-deployment/rules.yaml
@@ -1,0 +1,10 @@
+apiVersion: ingressnodefirewall.openshift.io/v1alpha1
+kind: IngressNodeFirewall
+metadata:
+  name: ingressnodefirewall
+spec:
+  interfaces:
+  - br-ex
+  nodeSelector:
+    matchLabels: {}
+  ingress: {}

--- a/ocs_ci/templates/ingress-node-firewall-deployment/subscription.yaml
+++ b/ocs_ci/templates/ingress-node-firewall-deployment/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ingress-node-firewall
+  namespace: openshift-ingress-node-firewall
+spec:
+  name: ingress-node-firewall
+  channel: stable
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
There is a requirement to be able to restrict SSH access to the OCP nodes. For that reason, we can install Ingress Node Firewall and configure rules to allow SSH access only from configured subnets.

This PR introduces two new `ENV_DATA` configuration variables:
* `restrict_ssh_access_to_nodes` - Deploy and configure Ingress Node Firewall Operator to restrict SSH access to nodes.
* `allow_ssh_access_from_subnets` - Defines a list of subnets wit allowed SSH access to nodes.

[OCSQE-2491](https://url.corp.redhat.com/edacc37)
