### PR TITLE
WORKAROUND: add possibility to mark disks as ssd

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -335,7 +335,7 @@ higher priority).
 * `skip_upgrade_checks` - If set to true Rook won't perform any upgrade checks on Ceph daemons during an upgrade.
 * `continue_upgrade_after_checks_even_if_not_healthy` -  if set to true Rook will continue the OSD daemon upgrade process even if the PGs are not clean.
 * `upgrade_osd_requires_healthy_pgs` - If set to true OSD upgrade process won't start until PGs are healthy.
-
+* `workaround_mark_disks_as_ssd` - WORKAROUND: mark disks sd* as SSD (not rotational (`0` in `/sys/block/sd*/queue/rotational`)
 
 #### UPGRADE
 

--- a/conf/README.md
+++ b/conf/README.md
@@ -335,7 +335,7 @@ higher priority).
 * `skip_upgrade_checks` - If set to true Rook won't perform any upgrade checks on Ceph daemons during an upgrade.
 * `continue_upgrade_after_checks_even_if_not_healthy` -  if set to true Rook will continue the OSD daemon upgrade process even if the PGs are not clean.
 * `upgrade_osd_requires_healthy_pgs` - If set to true OSD upgrade process won't start until PGs are healthy.
-* `workaround_mark_disks_as_ssd` - WORKAROUND: mark disks sd* as SSD (not rotational (`0` in `/sys/block/sd*/queue/rotational`)
+* `workaround_mark_disks_as_ssd` - WORKAROUND: mark disks as SSD (not rotational - `0` in `/sys/block/*d*/queue/rotational`)
 
 #### UPGRADE
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -116,6 +116,7 @@ from ocs_ci.ocs.utils import (
 from ocs_ci.utility.deployment import (
     create_external_secret,
     get_and_apply_icsp_from_catalog,
+    workaround_mark_disks_as_ssd,
 )
 from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility import (
@@ -631,6 +632,9 @@ class Deployment(object):
             log_cli_level (str): log level for installer (default: DEBUG)
         """
         self.do_deploy_ocp(log_cli_level)
+
+        if config.ENV_DATA.get("workaround_mark_disks_as_ssd"):
+            workaround_mark_disks_as_ssd()
 
         # TODO: use temporary directory for all temporary files of
         # ocs-deployment, not just here in this particular case

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2990,3 +2990,8 @@ METAIO = os.path.join(TEMPLATE_WORKLOAD_DIR, "helper_scripts/meta_data_io.py")
 FILE_CREATOR_IO = os.path.join(
     TEMPLATE_WORKLOAD_DIR, "helper_scripts/file_creator_io.py"
 )
+
+# workaround: marking disks as ssd
+MC_WORKAROUND_SSD = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_OCP, "workaround-ssd-machine-config.yaml"
+)

--- a/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
+++ b/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
@@ -12,7 +12,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCmZvciBkZXYgaW4gL3N5cy9ibG9jay9zZCovcXVldWUvcm90YXRpb25hbCA7IGRvCiAgZWNobyAwID4gJHtkZXZ9CmRvbmUK
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCmZvciBkZXYgaW4gL3N5cy9ibG9jay8qZCovcXVldWUvcm90YXRpb25hbCA7IGRvCiAgZWNobyAwID4gJHtkZXZ9CmRvbmUK
         group:
           name: root
         mode: 500

--- a/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
+++ b/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    # machineconfiguration.openshift.io/role: worker
+  name: 99-workaround-ssd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCmZvciBkZXYgaW4gL3N5cy9ibG9jay9zZCovcXVldWUvcm90YXRpb25hbCA7IGRvCiAgZWNobyAwID4gJHtkZXZ9CmRvbmUK
+        group:
+          name: root
+        mode: 500
+        path: /etc/workaround-ssd.sh
+        user:
+          name: root
+    systemd:
+      units:
+      - contents: '[Unit]
+
+          Description=WORKAROUND: force disks to behave as SSD
+
+          [Service]
+
+          Type=oneshot
+
+          RemainAfterExit=yes
+
+          Restart=no
+
+          ExecStart=/usr/bin/bash -c "/etc/workaround-ssd.sh"
+
+          User=root
+
+          Group=root
+
+
+          [Install]
+
+          WantedBy=multi-user.target
+
+          '
+        name: workaround-ssd.service
+        enabled: true

--- a/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
+++ b/ocs_ci/templates/ocp-deployment/workaround-ssd-machine-config.yaml
@@ -3,8 +3,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    # machineconfiguration.openshift.io/role: worker
-  name: 99-workaround-ssd
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-workaround-ssd
 spec:
   config:
     ignition:

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -13,6 +13,7 @@ import requests
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import ExternalClusterDetailsException
+from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import (
     create_directory_path,
@@ -200,3 +201,17 @@ def get_ocp_release_image_from_installer():
     for line in proc.stdout.decode().split("\n"):
         if "release image" in line:
             return line.split(" ")[2].strip()
+
+
+def workaround_mark_disks_as_ssd():
+    """
+    This function creates MachineConfig defining new service `workaround-ssd`, which configures all sd* disks as SSD
+    (not rotational).
+    This is useful for example on some Bare metal servers where are SSD disks not properly recognized as SSD, because of
+    wrong RAID controller configuration or issue.
+    """
+    logger.info("WORKAROUND: mark disks as ssd (non rotational)")
+    mc_yaml_file = templating.load_yaml(constants.MC_WORKAROUND_SSD)
+    mc_yaml = OCS(**mc_yaml_file)
+    mc_yaml.create()
+    logger.info("WORKAROUND: disks marked as ssd (non rotational)")

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -214,4 +214,5 @@ def workaround_mark_disks_as_ssd():
     mc_yaml_file = templating.load_yaml(constants.MC_WORKAROUND_SSD)
     mc_yaml = OCS(**mc_yaml_file)
     mc_yaml.create()
+    wait_for_machineconfigpool_status("all")
     logger.info("WORKAROUND: disks marked as ssd (non rotational)")

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -12,7 +12,7 @@ import requests
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import ExternalClusterDetailsException
+from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import (
@@ -210,9 +210,15 @@ def workaround_mark_disks_as_ssd():
     This is useful for example on some Bare metal servers where are SSD disks not properly recognized as SSD, because of
     wrong RAID controller configuration or issue.
     """
-    logger.info("WORKAROUND: mark disks as ssd (non rotational)")
-    mc_yaml_file = templating.load_yaml(constants.MC_WORKAROUND_SSD)
-    mc_yaml = OCS(**mc_yaml_file)
-    mc_yaml.create()
-    wait_for_machineconfigpool_status("all")
-    logger.info("WORKAROUND: disks marked as ssd (non rotational)")
+    try:
+        logger.info("WORKAROUND: mark disks as ssd (non rotational)")
+        mc_yaml_file = templating.load_yaml(constants.MC_WORKAROUND_SSD)
+        mc_yaml = OCS(**mc_yaml_file)
+        mc_yaml.create()
+        wait_for_machineconfigpool_status("all")
+        logger.info("WORKAROUND: disks marked as ssd (non rotational)")
+    except CommandFailed as err:
+        if "AlreadyExists" in str(err):
+            logger.info("Workaround already applied.")
+        else:
+            raise err

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -205,7 +205,7 @@ def get_ocp_release_image_from_installer():
 
 def workaround_mark_disks_as_ssd():
     """
-    This function creates MachineConfig defining new service `workaround-ssd`, which configures all sd* disks as SSD
+    This function creates MachineConfig defining new service `workaround-ssd`, which configures all disks as SSD
     (not rotational).
     This is useful for example on some Bare metal servers where are SSD disks not properly recognized as SSD, because of
     wrong RAID controller configuration or issue.


### PR DESCRIPTION
This PR add possibility to create MachineConfig  defining new service `workaround-ssd`, which configures all sd* disks as SSD (not rotational).
This is useful for example on some Bare metal servers where are SSD disks not properly recognized as SSD, because of     wrong RAID controller configuration or issue.
