### PR TITLE
[Provider mode] Update the verification of the number of CephFS, RBD pods and owner verification of deployments and daemonsets

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -229,6 +229,7 @@ DEFALUT_DEVICE_CLASS = "ssd"
 VM = "vm"
 HOSTED_CLUSTERS = "hostedclusters"
 OPERATOR_KIND = "Operator"
+DRIVER = "Driver"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -560,6 +560,10 @@ MANAGED_FUSION_ALERTMANAGER_LABEL = "alertmanager=managed-fusion-alertmanager"
 MANAGED_FUSION_AWS_DATA_GATHER = "name=aws-data-gather"
 MANAGED_FUSION_PROMETHEUS_LABEL = "prometheus=managed-fusion-prometheus"
 UX_BACKEND_SERVER_LABEL = "app=ux-backend-server"
+CEPHFS_NODEPLUGIN_LABEL = "app=openshift-storage.cephfs.csi.ceph.com-nodeplugin"
+RBD_NODEPLUGIN_LABEL = "app=openshift-storage.rbd.csi.ceph.com-nodeplugin"
+CEPHFS_CTRLPLUGIN_LABEL = "app=openshift-storage.cephfs.csi.ceph.com-ctrlplugin"
+RBD_CTRLPLUGIN_LABEL = "app=openshift-storage.rbd.csi.ceph.com-ctrlplugin"
 
 # Noobaa Deployments and Statefulsets
 NOOBAA_OPERATOR_DEPLOYMENT = "noobaa-operator"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -790,13 +790,15 @@ def ocs_install_verification(
     )
 
     if ocs_version >= version.VERSION_4_17 and hci_cluster:
+        cephfs_driver_name = f"{namespace}.cephfs.csi.ceph.com"
+        rbd_driver_name = f"{namespace}.rbd.csi.ceph.com"
         provisioner_deployment_and_owner_names = {
-            f"{constants.CEPHFS_PROVISIONER}-ctrlplugin": constants.CEPHFS_PROVISIONER,
-            f"{constants.RBD_PROVISIONER}-ctrlplugin": constants.RBD_PROVISIONER,
+            f"{cephfs_driver_name}-ctrlplugin": cephfs_driver_name,
+            f"{rbd_driver_name}-ctrlplugin": rbd_driver_name,
         }
         nodeplugin_daemonset_and_owner_names = {
-            f"{constants.CEPHFS_PROVISIONER}-nodeplugin": constants.CEPHFS_PROVISIONER,
-            f"{constants.RBD_PROVISIONER}--nodeplugin": constants.RBD_PROVISIONER,
+            f"{cephfs_driver_name}-nodeplugin": cephfs_driver_name,
+            f"{rbd_driver_name}--nodeplugin": rbd_driver_name,
         }
         csi_owner_kind = constants.DRIVER
     else:

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -253,6 +253,15 @@ def ocs_install_verification(
                 constants.MDS_APP_LABEL: 2,
             }
         )
+    elif consumer_cluster or client_cluster:
+        resources_dict.update(
+            {
+                constants.CSI_CEPHFSPLUGIN_LABEL: number_of_worker_nodes,
+                constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL: 2,
+                constants.CSI_RBDPLUGIN_LABEL: number_of_worker_nodes,
+                constants.CSI_RBDPLUGIN_PROVISIONER_LABEL: 2,
+            }
+        )
     elif not config.DEPLOYMENT["external_mode"]:
         resources_dict.update(
             {

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -253,7 +253,7 @@ def ocs_install_verification(
                 constants.MDS_APP_LABEL: 2,
             }
         )
-    elif consumer_cluster or client_cluster:
+    elif client_cluster and (ocs_version < version.VERSION_4_17):
         resources_dict.update(
             {
                 constants.CSI_CEPHFSPLUGIN_LABEL: number_of_worker_nodes,
@@ -311,10 +311,6 @@ def ocs_install_verification(
         )
         # In provider mode, add the new name and label that replaces the provisioner and plugin pods
         if hci_cluster:
-            del resources_dict[constants.CSI_CEPHFSPLUGIN_LABEL]
-            del resources_dict[constants.CSI_RBDPLUGIN_LABEL]
-            del resources_dict[constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL]
-            del resources_dict[constants.CSI_RBDPLUGIN_PROVISIONER_LABEL]
             resources_dict.update(
                 {
                     constants.CEPHFS_NODEPLUGIN_LABEL: number_of_worker_nodes,

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -806,7 +806,7 @@ def ocs_install_verification(
         }
         nodeplugin_daemonset_and_owner_names = {
             f"{constants.CEPHFS_PROVISIONER}-nodeplugin": constants.CEPHFS_PROVISIONER,
-            f"{constants.RBD_PROVISIONER}--nodeplugin": constants.RBD_PROVISIONER,
+            f"{constants.RBD_PROVISIONER}-nodeplugin": constants.RBD_PROVISIONER,
         }
         csi_owner_kind = constants.DRIVER
     else:


### PR DESCRIPTION
The name, label and ownerreference of provisioner and plugin pods has changed in provider mode.
The name prefix and label of these pods are replaced with the name of the respective drivers.
The change is currently applicable in provider and client clusters only.