### PR TITLE
Verify the NooBaa DB PostreSQL version at upgrade

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -824,9 +824,9 @@ def create_storage_class(
     sc_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
     for key in ["node-stage", "provisioner", "controller-expand"]:
         sc_data["parameters"][f"csi.storage.k8s.io/{key}-secret-name"] = secret_name
-        sc_data["parameters"][f"csi.storage.k8s.io/{key}-secret-namespace"] = (
-            config.ENV_DATA["cluster_namespace"]
-        )
+        sc_data["parameters"][
+            f"csi.storage.k8s.io/{key}-secret-namespace"
+        ] = config.ENV_DATA["cluster_namespace"]
 
     if annotations:
         sc_data["metadata"]["annotations"] = annotations
@@ -2989,12 +2989,12 @@ def collect_performance_stats(dir_name):
 
     performance_stats["master_node_utilization"] = master_node_utilization_from_adm_top
     performance_stats["worker_node_utilization"] = worker_node_utilization_from_adm_top
-    performance_stats["master_node_utilization_from_oc_describe"] = (
-        master_node_utilization_from_oc_describe
-    )
-    performance_stats["worker_node_utilization_from_oc_describe"] = (
-        worker_node_utilization_from_oc_describe
-    )
+    performance_stats[
+        "master_node_utilization_from_oc_describe"
+    ] = master_node_utilization_from_oc_describe
+    performance_stats[
+        "worker_node_utilization_from_oc_describe"
+    ] = worker_node_utilization_from_oc_describe
 
     file_name = os.path.join(log_dir_path, "performance")
     with open(file_name, "w") as outfile:
@@ -4957,9 +4957,9 @@ def configure_node_network_configuration_policy_on_all_worker_nodes():
         node_network_configuration_policy["spec"]["nodeSelector"][
             "kubernetes.io/hostname"
         ] = worker_node_name
-        node_network_configuration_policy["metadata"]["name"] = (
-            worker_network_configuration["node_network_configuration_policy_name"]
-        )
+        node_network_configuration_policy["metadata"][
+            "name"
+        ] = worker_network_configuration["node_network_configuration_policy_name"]
         node_network_configuration_policy["spec"]["desiredState"]["interfaces"][0][
             "ipv4"
         ]["address"][0]["ip"] = worker_network_configuration[

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -28,8 +28,9 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
-from ocs_ci.ocs.utils import get_non_acm_cluster_config, get_pod_name_by_pattern
 from ocs_ci.ocs.utils import (
+    get_non_acm_cluster_config,
+    get_pod_name_by_pattern,
     mirror_image,
     get_expected_nb_db_psql_version,
     get_nb_db_psql_version_from_image,

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -7,6 +7,7 @@ import time
 
 from selenium.webdriver.common.by import By
 from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import verify_nb_db_psql_version
 from ocs_ci.deployment.deployment import (
     create_catalog_source,
     create_ocs_secret,
@@ -753,8 +754,6 @@ def run_ocs_upgrade(
         upgrade_ocs.get_parsed_versions()[1],
         upgrade_ocs.version_before_upgrade,
     )
-
-    from ocs_ci.helpers.helpers import verify_nb_db_psql_version
 
     verify_nb_db_psql_version()
 

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -754,6 +754,10 @@ def run_ocs_upgrade(
         upgrade_ocs.version_before_upgrade,
     )
 
+    from ocs_ci.helpers.helpers import verify_nb_db_psql_version
+
+    verify_nb_db_psql_version()
+
     # update external secrets
     if config.DEPLOYMENT["external_mode"]:
         upgrade_version = version.get_semantic_version(upgrade_version, True)

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1944,6 +1944,7 @@ def query_nb_db_psql_version():
         UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
                              NooBaa DB pod
     """
+
     try:
         raw_output = exec_nb_db_query("SELECT version();")[0]
     except IndexError:
@@ -1953,14 +1954,14 @@ def query_nb_db_psql_version():
 
 def get_expected_nb_db_psql_version():
     """
-    Get the expected NooBaa DB version from the NooBaa CR
+        Get the expected NooBaa DB version from the NooBaa CR
 
-    Returns:
-        str: The expected NooBaa DB version
+        Returns:
+            str: The expected NooBaa DB version
 
     Raises:
-        ResourceNotFoundError: If the NooBaa CR was not found
-        UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
+            ResourceNotFoundError: If the NooBaa CR was not found
+            UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
     """
 
     nb_cr_obj = OCP(

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -24,8 +24,13 @@ from ocs_ci.framework import config as ocsci_config, config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.external_ceph import RolesContainer, Ceph, CephNode
 from ocs_ci.ocs.clients import WinNode
-from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
-from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    ExternalClusterDetailsException,
+    ResourceNotFoundError,
+    UnexpectedBehaviour,
+)
+from ocs_ci.ocs.ocp import OCP, get_images
 from ocs_ci.ocs.openstack import CephVMNode
 from ocs_ci.ocs.parallel import parallel
 from ocs_ci.ocs.resources.ocs import OCS
@@ -34,6 +39,7 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
     create_directory_path,
+    exec_nb_db_query,
     mirror_image,
     run_cmd,
     get_oadp_version,
@@ -1890,3 +1896,88 @@ def get_dr_operator_versions():
             if submariner_operator_version:
                 versions_dic["submariner_version"] = submariner_operator_version
     return versions_dic
+
+
+def get_nb_db_psql_version_from_image():
+    """
+    Get the NooBaa DB PostgreSQL version from the image name in the NooBaa DB statefulset
+
+    Returns:
+       str: The NooBaa DB PostgreSQL version
+
+    Raises:
+        ResourceNotFoundError: If the NooBaa DB statefulset is not available
+        UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
+                             NooBaa DB statefulset image
+
+    """
+    nb_db_sts_obj = OCP(
+        kind=constants.STATEFULSET,
+        namespace=ocsci_config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.NOOBAA_DB_STATEFULSET,
+    )
+    if not nb_db_sts_obj.data:
+        raise ResourceNotFoundError(
+            f"NooBaa DB statefulset {constants.NOOBAA_DB_STATEFULSET} not found"
+        )
+
+    try:
+        images = get_images(nb_db_sts_obj.data)
+        psql_img = next(iter(images.values()))  # Only one image is expected
+        re_match = re.search(r"postgresql-(\d+(\.\d+)*)", psql_img)
+        return re_match.group(1)
+    except Exception as e:
+        raise UnexpectedBehaviour(
+            f"Failed to extract the NooBaa DB version from its stateful set: {e}"
+        )
+
+
+def query_nb_db_psql_version():
+    """
+    Query the NooBaa DB for its PostgreSQL version
+
+    Returns:
+        str: The NooBaa DB version
+
+    Raises:
+        ResourceNotFoundError: If the NooBaa DB pod was not found
+        UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
+                             NooBaa DB pod
+    """
+    try:
+        raw_output = exec_nb_db_query("SELECT version();")[0]
+    except IndexError:
+        raise UnexpectedBehaviour("Failed to query the NooBaa DB for its version")
+    return re.search(r"PostgreSQL (\S+)", raw_output).group(1)
+
+
+def get_expected_nb_db_psql_version():
+    """
+    Get the expected NooBaa DB version from the NooBaa CR
+
+    Returns:
+        str: The expected NooBaa DB version
+
+    Raises:
+        ResourceNotFoundError: If the NooBaa CR was not found
+        UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
+    """
+
+    nb_cr_obj = OCP(
+        kind=constants.NOOBAA_RESOURCE_NAME,
+        namespace=ocsci_config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.NOOBAA_RESOURCE_NAME,
+    )
+    if not nb_cr_obj:
+        raise ResourceNotFoundError(
+            f"NooBaa CR {constants.NOOBAA_RESOURCE_NAME} not found"
+        )
+
+    try:
+        psql_image = nb_cr_obj.data["spec"]["dbImage"]
+        re_match = re.search(r"postgresql-(\d+(\.\d+)*)", psql_image)
+        return re_match.group(1)
+    except Exception as e:
+        raise UnexpectedBehaviour(
+            f"Failed to extract the NooBaa DB version from the NooBaa CR: {e}"
+        )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -46,6 +46,7 @@ from ocs_ci.ocs.exceptions import (
     ClientDownloadError,
     CommandFailed,
     ConfigurationError,
+    ResourceNotFoundError,
     TagNotFoundException,
     TimeoutException,
     TimeoutExpiredError,
@@ -4982,16 +4983,25 @@ def exec_nb_db_query(query):
     Returns:
         list of str: The query result rows
 
+    Raises:
+        ResourceNotFoundError: If no NooBaa DB pod is found
+
     """
     # importing here to avoid circular imports
     from ocs_ci.ocs.resources import pod
 
-    nb_db_pod = pod.Pod(
-        **pod.get_pods_having_label(
-            label=constants.NOOBAA_DB_LABEL_47_AND_ABOVE,
-            namespace=config.ENV_DATA["cluster_namespace"],
-        )[0]
-    )
+    try:
+        nb_db_pod = pod.Pod(
+            **pod.get_pods_having_label(
+                label=constants.NOOBAA_DB_LABEL_47_AND_ABOVE,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            )[0]
+        )
+    except IndexError:
+        raise ResourceNotFoundError(
+            f"The NooBaa DB pod with label {constants.NOOBAA_DB_LABEL_47_AND_ABOVE} "
+            f"was not found in namespace {config.ENV_DATA['cluster_namespace']}"
+        )
 
     response = nb_db_pod.exec_cmd_on_pod(
         command=f'psql -U postgres -d nbcore -c "{query}"',

--- a/tests/libtest/test_nb_db_psql_version.py
+++ b/tests/libtest/test_nb_db_psql_version.py
@@ -1,0 +1,15 @@
+import pytest
+from ocs_ci.framework.testlib import libtest
+from ocs_ci.helpers.helpers import verify_nb_db_psql_version
+
+
+@libtest
+@pytest.mark.parametrize(
+    "check_image",
+    [
+        False,
+        True,
+    ],
+)
+def test_nb_db_psql_version(check_image):
+    verify_nb_db_psql_version(check_image_name_version=check_image)


### PR DESCRIPTION
Noticeable changes made:

1. Added three util functions:

- `get_nb_db_psql_version_from_image`: extract the version from the image name in the noobaa-db-pg statefulset. The equivalent of:
```
 oc -n openshift-storage get statefulsets.apps noobaa-db-pg -o yaml | grep image:

    image: .../postgresql-12@sha256:28ab5b075817fb23ac1b8619371c858d39205d962309de35dea4434a95d67ee2
```

- `query_nb_db_psql_version`: Extract the version from the DB itself. The equivalent of:
```
$ oc -n openshift-storage exec noobaa-db-pg-0 -- psql -t  -c "SELECT substring(version() from 'PostgreSQL ([0-9\.]+)')"
15.6
```

- `get_expected_nb_db_psql_version`: Extract the PostreSQL version that's listed at the NooBaa CR, which by [the noobaa-db reocvery KCS](https://access.redhat.com/articles/7079321), seems to set the expectation. This util function is the equivalent of the following command:
```
oc -n openshift-storage get noobaa noobaa -o jsonpath='{$.spec.dbImage}'
.../postgresql-15@sha256:e0e8977ab6bd347218a3c8da305ebe75bfd2483c63fb63a93147051684626e88
```

2. Added the `verify_nb_db_psql_version` helper function, and added it to the verification in `run_ocs_upgrade`.

3. Added a libtest to test `verify_nb_db_psql_version`