### PR TITLE
mustgather for rosa hcp. change the image regestry

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -340,8 +340,10 @@ class OCSUpgrade(object):
             and config.ENV_DATA["deployment_type"] == "managed"
         )
         use_upstream_mg_image = managed_ibmcloud_platform and not upgrade_in_same_source
-        if (live_deployment and upgrade_in_same_source) or (
-            managed_ibmcloud_platform and not use_upstream_mg_image
+        if (
+            (live_deployment and upgrade_in_same_source)
+            or (managed_ibmcloud_platform and not use_upstream_mg_image)
+            or config["ENV_DATA"].get("platform") == constants.ROSA_HCP_PLATFORM
         ):
             update_live_must_gather_image()
         elif use_upstream_mg_image:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6416,9 +6416,12 @@ def set_live_must_gather_images(pytestconfig):
             "Live must gather image is not supported in Managed Service platforms"
         )
         return
+    rosa_hcp_platform = (
+        ocsci_config.ENV_DATA["platform"].lower() == constants.ROSA_HCP_PLATFORM
+    )
     # As we cannot use internal build of must gather for IBM Cloud platform
     # we will use live must gather image as a W/A.
-    if live_deployment or managed_ibmcloud_platform:
+    if live_deployment or managed_ibmcloud_platform or rosa_hcp_platform:
         update_live_must_gather_image()
     # For non GAed version of ODF as a W/A we need to use upstream must gather image
     # for IBM Cloud platform


### PR DESCRIPTION
fix failures like bellow

```
oc adm must-gather --image=quay.io/rhceph-dev/ocs-must-gather:latest-4.16 --dest-dir=/tmp/tmpabk43f_b_ocs_logs/dosypenk-59hcp/ocs_must_gather
[must-gather      ] OUT Using must-gather plug-in image: quay.io/rhceph-dev/ocs-must-gather:latest-4.16
When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:
ClusterID: a9a5c73f-ffeb-4249-93e1-986c1b38a189
ClusterVersion: Stable at "4.16.9"
ClusterOperators:
        clusteroperator/insights is not available (Reporting was not allowed: your Red Hat account is not enabled for remote support or your token has expired: {"errors":[{"status":401,"detail":"UHC services authentication failed","meta":{"response_by":"gateway"}}]}
) because Reporting was not allowed: your Red Hat account is not enabled for remote support or your token has expired: {"errors":[{"status":401,"detail":"UHC services authentication failed","meta":{"response_by":"gateway"}}]}

        clusteroperator/authentication is missing
        clusteroperator/cloud-credential is missing
        clusteroperator/cluster-autoscaler is missing
        clusteroperator/config-operator is missing
        clusteroperator/etcd is missing
        clusteroperator/machine-api is missing
        clusteroperator/machine-approver is missing
        clusteroperator/machine-config is missing
        clusteroperator/marketplace is missing


[must-gather      ] OUT namespace/openshift-must-gather-cvv7n created
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-zp6vk created
[must-gather      ] OUT pod for plug-in image quay.io/rhceph-dev/ocs-must-gather:latest-4.16 created
[must-gather-hrrf8] OUT gather did not start: unable to pull image: ImagePullBackOff: Back-off pulling image "quay.io/rhceph-dev/ocs-must-gather:latest-4.16"
[must-gather      ] OUT namespace/openshift-must-gather-cvv7n deleted
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-zp6vk deleted


Error running must-gather collection:
    gather did not start for pod must-gather-hrrf8: unable to pull image: ImagePullBackOff: Back-off pulling image "quay.io/rhceph-dev/ocs-must-gather:latest-4.16"

Falling back to `oc adm inspect clusteroperators.v1.config.openshift.io` to collect basic cluster information.
Gathering data for ns/openshift-console-operator...
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
Gathering data for ns/openshift-console...
Gathering data for ns/openshift-cluster-storage-operator... 
```