### PR TITLE
Update numpy version to 1.23.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "google-cloud-storage==2.6.0",
         "google-auth==2.14.1",
         "elasticsearch==8.11.1",
-        "numpy==1.22.4",
+        "numpy==1.23.2",
         "pandas==1.5.2",
         "tabulate==0.9.0",
         "python-ipmi==0.4.2",


### PR DESCRIPTION
This change is necessary to support python 3.11. This got missed as a part of the initial work somehow.