### PR TITLE
ignore failure in Ingress Node Firewall deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -759,7 +759,12 @@ class Deployment(object):
             ibmcloud.label_nodes_region()
         # configure Ingress Node Firewall and restrict SSH access to nodes
         if config.ENV_DATA.get("restrict_ssh_access_to_nodes", False):
-            restrict_ssh_access_to_nodes()
+            try:
+                restrict_ssh_access_to_nodes()
+            except Exception as err:
+                logger.warning(
+                    f"Ingress Node Firewall deployment and SSH access to nodes restriction failed: {err}"
+                )
 
     def label_and_taint_nodes(self):
         """

--- a/ocs_ci/deployment/ingress_node_firewall.py
+++ b/ocs_ci/deployment/ingress_node_firewall.py
@@ -162,7 +162,7 @@ class IngressNodeFirewallInstaller(object):
 
         """
         for csv in TimeoutSampler(
-            timeout=900,
+            timeout=1800,
             sleep=15,
             func=get_csvs_start_with_prefix,
             csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,


### PR DESCRIPTION
- extend timeout for Ingress Node Firewall deployment
- ignore any failure in the deployment and configuration, to not break whole deployment