### PR TITLE
ignore failure in Ingress Node Firewall deployment - release-4.16

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -740,7 +740,12 @@ class Deployment(object):
             config.ENV_DATA.get("restrict_ssh_access_to_nodes", False)
             and version.get_semantic_ocp_version_from_config() >= version.VERSION_4_16
         ):
-            restrict_ssh_access_to_nodes()
+            try:
+                restrict_ssh_access_to_nodes()
+            except Exception as err:
+                logger.warning(
+                    f"Ingress Node Firewall deployment and SSH access to nodes restriction failed: {err}"
+                )
 
     def label_and_taint_nodes(self):
         """

--- a/ocs_ci/deployment/ingress_node_firewall.py
+++ b/ocs_ci/deployment/ingress_node_firewall.py
@@ -162,7 +162,7 @@ class IngressNodeFirewallInstaller(object):
 
         """
         for csv in TimeoutSampler(
-            timeout=900,
+            timeout=1800,
             sleep=15,
             func=get_csvs_start_with_prefix,
             csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,


### PR DESCRIPTION
- extend timeout for Ingress Node Firewall deployment
- ignore any failure in the deployment and configuration, to not break whole deployment

This is backport of https://github.com/red-hat-storage/ocs-ci/pull/10471