### PR TITLE
Fix resource wrong status exception

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1092,6 +1092,7 @@ def pvc_factory_fixture(request, project_factory):
         status=constants.STATUS_BOUND,
         volume_mode=None,
         size_unit="Gi",
+        wait_for_resource_status_timeout=60,
     ):
         """
         Args:
@@ -1114,6 +1115,8 @@ def pvc_factory_fixture(request, project_factory):
             volume_mode (str): Volume mode for PVC.
                 eg: volume_mode='Block' to create rbd `block` type volume
             size_unit (str): PVC size unit, eg: "Mi"
+            wait_for_resource_status_timeout (int): Wait in seconds until the
+                desired PVC status is reached.
 
         Returns:
             object: helpers.create_pvc instance.
@@ -1152,7 +1155,9 @@ def pvc_factory_fixture(request, project_factory):
             assert pvc_obj, "Failed to create PVC"
 
         if status:
-            helpers.wait_for_resource_state(pvc_obj, status)
+            helpers.wait_for_resource_state(
+                pvc_obj, status, timeout=wait_for_resource_status_timeout
+            )
         pvc_obj.storageclass = storageclass
         pvc_obj.project = project
         pvc_obj.access_mode = access_mode

--- a/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
@@ -127,7 +127,7 @@ class TestEncryptedPVCNOExpansionOption(ManageTest):
             storageclass=sc_obj,
             size=pvc_size,
             status=constants.STATUS_BOUND,
-            wait_for_resource_status_timeout=180,
+            wait_for_resource_status_timeout=120,
         )
 
         pod_obj = pod_factory(pvc=pvc_obj)

--- a/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
@@ -127,6 +127,7 @@ class TestEncryptedPVCNOExpansionOption(ManageTest):
             storageclass=sc_obj,
             size=pvc_size,
             status=constants.STATUS_BOUND,
+            wait_for_resource_status_timeout=180,
         )
 
         pod_obj = pod_factory(pvc=pvc_obj)


### PR DESCRIPTION
This intermittent issue caused the test to exit with a `ResourceWrongStatusException` Upon checking the logs, I found the wait_for_resource_state function has a default timeout of 60s. It reported the PVC as ‘Pending’, but the must-gather logs showed it in ‘Bound’. This suggests the PVC sometimes takes longer to bind. I’ve increased the timeout to 120s (from the default 60s) to resolve this.

test exited due to PVC status in not reached to 'Bound' status.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-==-=-=-=-=-=-=-=-=
```
E           ocs_ci.ocs.exceptions.ResourceWrongStatusException: Resource pvc-test-47565298be334d8eb0f2cc0c9f0887e describe output: Name:          pvc-test-47565298be334d8eb0f2cc0c9f0887e
E           Namespace:     namespace-test-13715505cce745548e9586ab8
E           StorageClass:  storageclass-test-rbd-4903ee88b680471dac
E           Status:        Pending
E           Volume:
E           Labels:        
E           Annotations:   volume.beta.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
E                          volume.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
E           Finalizers:    [kubernetes.io/pvc-protection]
E           Capacity:
E           Access Modes:
E           VolumeMode:    Filesystem
E           Used By:       
E           Events:
E             Type    Reason                Age               From                         Message
E             ----    ------                ----              ----                         -------
E             Normal  ExternalProvisioning  7s (x6 over 62s)  persistentvolume-controller  Waiting for a volume to be created either by the external provisioner 'openshift-storage.rbd.csi.ceph.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
```

Must gather logs showing the status as `Bound`

```
pvc-65424f08-93ad-4907-be45-0c1237353145   5Gi        RWO            Delete           Bound      namespace-test-13715505cce745548e9586ab8/pvc-test-47565298be334d8eb0f2cc0c9f0887e   storageclass-test-rbd-4903ee88b680471dac   <unset>                          57s

```

