### PR TITLE
use ocp-network-split from red-hat-storage org fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.3.0#egg=ocp-network-split
+-e git+https://github.com/red-hat-storage/ocp-network-split.git#egg=ocp-network-split
 -e .

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "ovirt-engine-sdk-python==4.4.11",
         "junitparser==3.1.0",
         "flaky==3.7.0",
-        "ocp-network-split==0.3.0",
+        "ocp-network-split",
         "pyopenssl==24.0.0",
         "pyparsing==2.4.7",
         "mysql-connector-python==8.0.27",


### PR DESCRIPTION
Use `ocp-network-split` from our fork https://github.com/red-hat-storage/ocp-network-split.git, because it contains important fix.