### PR TITLE
quick syntax fix

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -343,7 +343,7 @@ class OCSUpgrade(object):
         if (
             (live_deployment and upgrade_in_same_source)
             or (managed_ibmcloud_platform and not use_upstream_mg_image)
-            or config["ENV_DATA"].get("platform") == constants.ROSA_HCP_PLATFORM
+            or config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
         ):
             update_live_must_gather_image()
         elif use_upstream_mg_image:


### PR DESCRIPTION
Fix to avoid error: 

> 2024-09-17 15:11:11          if (
> 2024-09-17 15:11:11              (live_deployment and upgrade_in_same_source)
> 2024-09-17 15:11:11              or (managed_ibmcloud_platform and not use_upstream_mg_image)
> 2024-09-17 15:11:11  >           or config["ENV_DATA"].get("platform") == constants.ROSA_HCP_PLATFORM
> 2024-09-17 15:11:11          ):
> 2024-09-17 15:11:11  E       TypeError: 'MultiClusterConfig' object is not subscriptable
> 2024-09-17 15:11:11  
> 2024-09-17 15:11:11  ocs_ci/ocs/ocs_upgrade.py:346: TypeError

https://github.com/red-hat-storage/ocs-ci/pull/10466/files#r1763307854