### PR TITLE
try-exept_on_close_browser

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -13,6 +13,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
     StaleElementReferenceException,
     ElementClickInterceptedException,
+    InvalidSessionIdException,
 )
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
@@ -1029,9 +1030,14 @@ def close_browser():
 
     """
     logger.info("Close browser")
-    take_screenshot("close_browser")
-    copy_dom("close_browser")
-    SeleniumDriver().quit()
+    try:
+        take_screenshot("close_browser")
+        copy_dom("close_browser")
+        SeleniumDriver().quit()
+    except InvalidSessionIdException:
+        # when browser session is closed unexpectedly or session timeout occurs take_screenshot or copy_dom will fail
+        logger.error("InvalidSessionIdException occurred")
+        pass
     SeleniumDriver.remove_instance()
     time.sleep(10)
     garbage_collector_webdriver()


### PR DESCRIPTION
fix to address cascade failures, when chtome browser closed but we still want to close it properly

```
def finalizer():

  close_browser()

tests/conftest.py:4931: 

ocs_ci/ocs/ui/base_ui.py:1021: in close_browser
    take_screenshot("close_browser")
ocs_ci/ocs/ui/base_ui.py:774: in take_screenshot
    SeleniumDriver().save_screenshot(filename)
venv/lib64/python3.9/site-packages/selenium/webdriver/remote/webdriver.py:1055: in save_screenshot
    return self.get_screenshot_as_file(filename)
venv/lib64/python3.9/site-packages/selenium/webdriver/remote/webdriver.py:1032: in get_screenshot_as_file
    png = self.get_screenshot_as_png()
venv/lib64/python3.9/site-packages/selenium/webdriver/remote/webdriver.py:1064: in get_screenshot_as_png
    return base64.b64decode(self.get_screenshot_as_base64().encode('ascii'))
venv/lib64/python3.9/site-packages/selenium/webdriver/remote/webdriver.py:1074: in get_screenshot_as_base64
    return self.execute(Command.SCREENSHOT)['value']
venv/lib64/python3.9/site-packages/selenium/webdriver/remote/webdriver.py:321: in execute
    self.error_handler.check_response(response)
```


https://reportportal-ocs4.apps.ocp-c1.prod.psi.redhat.com/ui/#ocs/launches/678/24822/1202203/1202229/log?logParams=history%3D1104308%26page.page%3D1