### PR TITLE
Remove must-gather parameter -pc for clients

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1192,8 +1192,6 @@ def _collect_ocs_logs(
             ocs_must_gather_image_and_tag = mirror_image(
                 ocs_must_gather_image_and_tag, cluster_config
             )
-        if cluster_config.ENV_DATA.get("cluster_type") == constants.HCI_CLIENT:
-            ocs_flags = ocs_flags + " -pc" if ocs_flags else " /usr/bin/gather -pc"
 
         mg_output = run_must_gather(
             ocs_log_dir_path,


### PR DESCRIPTION
Remove client specific parameter "-pc" when collecting must-gather from client cluster. This enables must-gather to collect all resources including client specific resources.