### PR TITLE
add rosa_hcp to node_cls_map

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -95,6 +95,7 @@ class PlatformNodesFactory:
             "ibm_cloud": IBMCloud,
             "vsphere_ipi": VMWareIPINodes,
             "rosa": AWSNodes,
+            "rosa_hcp": AWSNodes,
             "vsphere_upi": VMWareUPINodes,
             "fusion_aas": AWSNodes,
             "hci_baremetal": IBMCloudBMNodes,


### PR DESCRIPTION
fix issue:

```
2024-09-17 20:09:21      @pytest.fixture()
2024-09-17 20:09:21      def nodes():
2024-09-17 20:09:21          """
2024-09-17 20:09:21          Return an instance of the relevant platform nodes class
2024-09-17 20:09:21          (e.g. AWSNodes, VMWareNodes) to be later used in the test
2024-09-17 20:09:21          for nodes related operations, like nodes restart,
2024-09-17 20:09:21          detach/attach volume, etc.
2024-09-17 20:09:21      
2024-09-17 20:09:21          """
2024-09-17 20:09:21          factory = platform_nodes.PlatformNodesFactory()
2024-09-17 20:09:21  >       nodes = factory.get_nodes_platform()
2024-09-17 20:09:21  
...
2024-09-17 20:09:21  >       return self.cls_map[platform]()
2024-09-17 20:09:21  E       KeyError: 'rosa_hcp'
2024-09-17 20:09:21  
2024-09-17 20:09:21  ocs_ci/ocs/platform_nodes.py:120: KeyError
```