### PR TITLE
lower ingress node firewall timeout to 15 minutes

### DIFF
--- a/ocs_ci/deployment/ingress_node_firewall.py
+++ b/ocs_ci/deployment/ingress_node_firewall.py
@@ -162,7 +162,7 @@ class IngressNodeFirewallInstaller(object):
 
         """
         for csv in TimeoutSampler(
-            timeout=1800,
+            timeout=900,
             sleep=15,
             func=get_csvs_start_with_prefix,
             csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,


### PR DESCRIPTION
I've changed this timeout to 30 minutes in the previous PR, because I wasn't exactly sure about the root cause of failures during deployment (my initial assumption was, that it takes longer than expected). But since the reason is missing Ingress Node firewall Operator in the OCP 4.17 catalog source, it doesn't make much sense to uselessly extend the deployment time, while 15 minutes should be enough for normal deployment.