### PR TITLE
Fixes incorrect comparison for test_bucket_used_bytes_metric

### DIFF
--- a/tests/functional/object/mcg/test_noobaa_prometheus.py
+++ b/tests/functional/object/mcg/test_noobaa_prometheus.py
@@ -29,7 +29,7 @@ def get_bucket_used_bytes_metric(bucket_name, threading_lock):
     )
     if len(response.get("data").get("result")) == 0:
         raise ReturnedEmptyResponseException
-    elif response.get("data").get("result")[0].get("value")[1] == 0:
+    elif response.get("data").get("result")[0].get("value")[1] == "0":
         raise ReturnedEmptyResponseException
     else:
         value = response.get("data").get("result")[0].get("value")


### PR DESCRIPTION
Fixes #9489 

Response receiving to method:
`
19:30:27 - MainThread - mcg.test_noobaa_prometheus - INFO  - {'status': 'success', 'data': {'resultType': 'vector', 'result': [{'metric': {'__name__': 'NooBaa_bucket_used_bytes', 'bucket_name': 's3-bucket-2617cd552c404b46833d0f2712abd0', 'container': 'core', 'endpoint': 'mgmt', 'instance': '10.131.0.27:8080', 'job': 'noobaa-mgmt', 'namespace': 'openshift-storage', 'pod': 'noobaa-core-0', 'service': 'noobaa-mgmt'}, 'value': [1726754427.034, '0']}]}}
`

The type of `'value': [1726754427.034, '0']` is `str` and it is getting compared with `int 0` in below test
tests/functional/object/mcg/test_noobaa_prometheus.py::TestNoobaaaPrometheus::test_bucket_used_bytes_metric


