### PR TITLE
Add validation of pod deletion

### DIFF
--- a/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
@@ -20,7 +20,11 @@ from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
     UnexpectedBehaviour,
 )
-from ocs_ci.ocs.resources.pod import get_file_path, check_file_existence, delete_pods
+from ocs_ci.ocs.resources.pod import (
+    get_file_path,
+    check_file_existence,
+    delete_pods,
+)
 from ocs_ci.helpers.helpers import fetch_used_size
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -256,6 +260,10 @@ class TestRbdSpaceReclaim(ManageTest):
         # Delete the pod
         log.info(f"Deleting the pod {pod_obj}")
         delete_pods([pod_obj])
+
+        # Validation of pod deletion
+        log.info(f"Validate the deletion of pod - {pod_obj.name}")
+        pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
 
         # Create ReclaimSpaceJob
         reclaim_space_job = pvc_obj.create_reclaim_space_job()


### PR DESCRIPTION
This PR addresses the issue [9560](https://github.com/red-hat-storage/ocs-ci/issues/9560)

In this test, reclaim space job was created immediately after the deletion of app pod, which caused the reclaim space job failure.
There was a miss to validate pod deletion prior to the creation of the reclaim space job. This PR adds the validation of pod deletion.