### PR TITLE
[release-4.15 backport] Separate the cloning logic from `override_default_backingstore_fixture`

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1954,15 +1954,6 @@ BACKINGSTORE_TYPE_GOOGLE = "google-cloud-storage"
 BACKINGSTORE_TYPE_PV_POOL = "pv-pool"
 BACKINGSTORE_TYPE_IBMCOS = "ibm-cos"
 
-BS_TYPE_TO_PLATFORM_NAME_MAPPING = {
-    BACKINGSTORE_TYPE_AWS: "aws",
-    BACKINGSTORE_TYPE_AZURE: "azure",
-    BACKINGSTORE_TYPE_GOOGLE: "gcp",
-    BACKINGSTORE_TYPE_PV_POOL: "pv",
-    BACKINGSTORE_TYPE_S3_COMP: "rgw",
-    BACKINGSTORE_TYPE_IBMCOS: "ibmcos",
-}
-
 
 # Squads assignment
 # Tests are assigned to Squads based on patterns matching test path.

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -20,6 +20,8 @@ from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
     ObjectsStillBeingDeletedException,
     CommandFailed,
+    UnavailableResourceException,
+    UnknownCloneTypeException,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.framework import config
@@ -409,3 +411,79 @@ def backingstore_factory(request, cld_mgr, mcg_obj, cloud_uls_factory):
     request.addfinalizer(backingstore_cleanup)
 
     return _create_backingstore
+
+
+def clone_bs_dict_from_backingstore(
+    protype_backingstore_name,
+    namespace=None,
+):
+    """
+    Create a backingstore of the same kind and specs as an existing backingstore.
+
+    Args:
+        protype_backingstore_name (str): Name of the existing backingstore to clone
+        backingstore_factory (function): an backingstore factory instance
+        mcg_obj (MCG): MCG object containing data and utils related to MCG
+        method(str): Method to use for creating the backingstore (oc or cli)
+        namespace (str): Namespace of the backingstore to clone
+
+    Raises:
+        UnavailableResourceException: If the backingstore to clone does not exist
+        UnaknownCloneTypeException: If the prototype backingstore is of an unknown type
+
+    Returns:
+        clone_bs_dict (dict): A dictionary containing the specs needed to create a copy of the
+        prototype backingstore
+
+    """
+    if not namespace:
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+    # Validate the prototype backingstore exists
+    protoype_backingstore = OCP(
+        kind="backingstore",
+        namespace=namespace,
+        resource_name=protype_backingstore_name,
+    )
+    if not protoype_backingstore.data:
+        raise UnavailableResourceException(
+            f"Backingstore {protype_backingstore_name} does not exist"
+        )
+
+    # Determine from the prototype the kind and specs of the new backingstore
+    prototype_bs_platform_name = protoype_backingstore.data["spec"]["type"]
+    clone_bs_dict = {}
+
+    if prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_AWS:
+        target_region = protoype_backingstore.data["spec"]["awsS3"]["region"]
+        clone_bs_dict = {"aws": [(1, target_region)]}
+
+    elif prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_AZURE:
+        clone_bs_dict = {"azure": [(1, None)]}
+
+    elif prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_GOOGLE:
+        clone_bs_dict = {"gcp": [(1, None)]}
+
+    elif prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_IBMCOS:
+        clone_bs_dict = {"ibmcos": [(1, None)]}
+
+    elif prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_S3_COMP:
+        clone_bs_dict = {"rgw": [(1, None)]}
+
+    elif prototype_bs_platform_name == constants.BACKINGSTORE_TYPE_PV_POOL:
+        pvpool_storageclass = (
+            constants.THIN_CSI_STORAGECLASS
+            if config.ENV_DATA["mcg_only_deployment"]
+            else constants.DEFAULT_STORAGECLASS_RBD
+        )
+        prototype_pvpool_data = protoype_backingstore.data["spec"]["pvPool"]
+        num_volumes = prototype_pvpool_data["numVolumes"]
+        size_str = prototype_pvpool_data["resources"]["requests"]["storage"]
+        prototype_pv_size = int(size_str[:-2])  # Remove the 'Gi' suffix
+        clone_pv_size = max(constants.MIN_PV_BACKINGSTORE_SIZE_IN_GB, prototype_pv_size)
+        clone_bs_dict = {"pv": [(num_volumes, clone_pv_size, pvpool_storageclass)]}
+
+    else:
+        raise UnknownCloneTypeException(prototype_bs_platform_name)
+
+    return clone_bs_dict

--- a/tests/libtest/test_clone_backingstore.py
+++ b/tests/libtest/test_clone_backingstore.py
@@ -1,0 +1,36 @@
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import libtest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.backingstore import clone_bs_dict_from_backingstore
+
+
+@libtest
+def test_clone_backingstore(mcg_obj, backingstore_factory):
+    """
+    Test the functionality of clone_bs_dict_from_backingstore
+
+    """
+    platform_to_bucketclass_dicts = {
+        constants.BACKINGSTORE_TYPE_AWS: {"aws": [(1, "eu-central-1")]},
+        constants.BACKINGSTORE_TYPE_AZURE: {"azure": [(1, None)]},
+        constants.BACKINGSTORE_TYPE_IBMCOS: {"ibmcos": [(1, None)]},
+        constants.BACKINGSTORE_TYPE_PV_POOL: {
+            "pv": [(1, 35, constants.DEFAULT_STORAGECLASS_RBD)]
+        },
+    }
+    for type, bucketclass_dict in platform_to_bucketclass_dicts.items():
+        prototype_backingstore = backingstore_factory("oc", bucketclass_dict)[0].name
+        prototype_bs_dict = clone_bs_dict_from_backingstore(prototype_backingstore)
+        clone_bs_name = backingstore_factory("oc", prototype_bs_dict)[0].name
+
+        # Check the health of the clone
+        mcg_obj.check_backingstore_state(clone_bs_name, constants.BS_OPTIMAL)
+
+        # Check if type is the same as the prototype's
+        clone_backingstore_data = OCP(
+            kind="backingstore",
+            resource_name=clone_bs_name,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        ).data
+        assert clone_backingstore_data["spec"]["type"] == type


### PR DESCRIPTION
release-4.15 backport of #9515