### PR TITLE
Check that the ceph-csi version matches the OCP version on the hosted clusters

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1691,6 +1691,7 @@ ARO_MASTER_SUBNET = "master-subnet"
 ARO_WORKER_SUBNET_ADDRESS_PREFIXES = "10.0.2.0/23"
 ARO_MASTER_SUBNET_ADDRESS_PREFIXES = "10.0.0.0/23"
 CLIENT_OPERATOR_CONFIGMAP = "ocs-client-operator-config"
+CLIENT_OPERATOR_CSI_IMAGES = "ocs-client-operator-csi-images"
 
 # UI Deployment constants
 HTPASSWD_SECRET_NAME = "htpass-secret"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -60,7 +60,11 @@ from ocs_ci.ocs.node import (
     add_disk_stretch_arbiter,
 )
 from ocs_ci.ocs.version import get_ocp_version
-from ocs_ci.utility.version import get_semantic_version, VERSION_4_11
+from ocs_ci.utility.version import (
+    get_semantic_version,
+    VERSION_4_11,
+    get_semantic_ocp_running_version,
+)
 from ocs_ci.helpers.helpers import (
     get_secret_names,
     get_cephfs_name,
@@ -75,7 +79,12 @@ from ocs_ci.utility import (
 )
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.rgwutils import get_rgw_count
-from ocs_ci.utility.utils import run_cmd, TimeoutSampler, convert_device_size
+from ocs_ci.utility.utils import (
+    run_cmd,
+    TimeoutSampler,
+    convert_device_size,
+    extract_image_urls,
+)
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.helpers.helpers import storagecluster_independent_check
 
@@ -2890,3 +2899,32 @@ def validate_non_resilient_pool(storage_cluster: StorageCluster) -> bool:
         return True
 
     return False
+
+
+def get_csi_images_for_client_ocp_version(ocp_version=None):
+    """
+    Get the csi images of the specified ocp version
+
+    Args:
+        ocp_version (str): The ocp version of the csi images. If not provided,
+            it will get the current ocp cluster version
+
+    Returns:
+        list: The list of the csi images of the specified ocp version
+
+    """
+    configmap_obj = ocp.OCP(
+        kind=constants.CONFIGMAP,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.CLIENT_OPERATOR_CSI_IMAGES,
+    )
+    csi_images = configmap_obj.data.get("data").get("csi-images.yaml")
+
+    if not ocp_version:
+        ocp_version = str(get_semantic_ocp_running_version())
+
+    log.info(f"The cluster ocp version is {ocp_version}")
+    first_str, last_str = f"v{ocp_version}", "version"
+    csi_ocp_version_images = csi_images.split(first_str)[1].split(last_str)[0]
+    csi_ocp_version_images_urls = extract_image_urls(csi_ocp_version_images)
+    return csi_ocp_version_images_urls

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5147,3 +5147,19 @@ def compare_dictionaries(
                 differences[key] = (value1, value2)
     log.info(f"Differences: {differences}")
     return differences
+
+
+def extract_image_urls(string_data):
+    """
+    Extract all image URLs from the string.
+
+    Args:
+        string_data (str): The string data that contains the image URLs to extract.
+
+    Returns:
+        list: List of image URLs found in the string, or an empty list if none are found.
+
+    """
+    # Find all URLs that start with 'registry.redhat.io'
+    image_urls = re.findall(r'registry\.redhat\.io[^\s"]+', string_data)
+    return image_urls

--- a/tests/functional/provider_mode/test_ceph_csi_image_versions.py
+++ b/tests/functional/provider_mode/test_ceph_csi_image_versions.py
@@ -1,0 +1,71 @@
+import logging
+import pytest
+
+from ocs_ci.framework.testlib import (
+    acceptance,
+    provider_client_platform_required,
+    tier1,
+    ManageTest,
+)
+from ocs_ci.framework import config
+from ocs_ci.ocs.resources.pod import get_ceph_csi_ctrl_pods, get_container_images
+from ocs_ci.framework.pytest_customization.marks import yellow_squad
+from ocs_ci.ocs.resources.storage_cluster import get_csi_images_for_client_ocp_version
+
+
+log = logging.getLogger(__name__)
+
+
+@yellow_squad
+@tier1
+@acceptance
+@provider_client_platform_required
+class TestCephCSIImageVersions(ManageTest):
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """
+        Save the original index
+        """
+        self.orig_index = config.cur_index
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Switch to the original cluster index
+        """
+
+        def finalizer():
+            log.info("Switch to the original cluster index")
+            config.switch_ctx(self.orig_index)
+
+        request.addfinalizer(finalizer)
+
+    def test_client_clusters_csi_image_versions(self):
+        """
+        The test will perform the following:
+        1. Iterate over the clients
+        2. Get the ceph csi ctrl pods container images of the client
+        3. Get the csi images for the client OCP version
+        4. Check that the ceph csi ctr pod container images exist in the csi images
+
+        """
+        client_indices = config.get_consumer_indexes_list()
+        for client_i in client_indices:
+            config.switch_ctx(client_i)
+            ceph_csi_ctrl_pods = get_ceph_csi_ctrl_pods()
+            # Get the ceph csi ctrl pods container images of the client
+            pods_container_images = set()
+            for p in ceph_csi_ctrl_pods:
+                pods_container_images.update(get_container_images(p))
+
+            csi_images_for_client_ocp_version = set(
+                get_csi_images_for_client_ocp_version()
+            )
+            log.info(f"Ceph csi ctrl pods container images: {pods_container_images}")
+            log.info(
+                f"csi images of client ocp version: {csi_images_for_client_ocp_version}"
+            )
+            assert pods_container_images.issubset(csi_images_for_client_ocp_version), (
+                f"The ceph csi ctrl pod container images {pods_container_images} are not exist "
+                f"in the csi images {csi_images_for_client_ocp_version}"
+            )

--- a/tests/functional/provider_mode/test_ceph_csi_image_versions.py
+++ b/tests/functional/provider_mode/test_ceph_csi_image_versions.py
@@ -40,6 +40,7 @@ class TestCephCSIImageVersions(ManageTest):
 
         request.addfinalizer(finalizer)
 
+    @pytest.mark.polarion_id("OCS-6248")
     def test_client_clusters_csi_image_versions(self):
         """
         The test will perform the following:


### PR DESCRIPTION
Check that the ceph-csi version matches the OCP version on the hosted clusters.
The test will perform the following:
  1. Iterate over the clients
  2. Get the ceph csi ctrl pods container images of the client
  3. Get the csi images for the client OCP version
  4. Check that the ceph csi ctr pod container images exist in the csi images of the client OCP version
