### PR TITLE
Provisioner and plugin label change for provider mode

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -14,7 +14,6 @@ from ocs_ci.deployment.helpers.hypershift_base import (
 from ocs_ci.deployment.metallb import MetalLBInstaller
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
-from ocs_ci.helpers.helpers import get_node_plugin_label
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.constants import HCI_PROVIDER_CLIENT_PLATFORMS
 from ocs_ci.ocs.exceptions import (
@@ -1385,7 +1384,7 @@ class HostedODF(HypershiftHostedOCP):
         )
         return ocp.check_resource_existence(
             timeout=self.timeout_check_resources_exist_sec,
-            selector=get_node_plugin_label(constants.CEPHFILESYSTEM),
+            selector=helpers.get_node_plugin_label(constants.CEPHFILESYSTEM),
             should_exist=True,
         )
 

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -14,6 +14,7 @@ from ocs_ci.deployment.helpers.hypershift_base import (
 from ocs_ci.deployment.metallb import MetalLBInstaller
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
+from ocs_ci.helpers.helpers import get_node_plugin_label
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.constants import HCI_PROVIDER_CLIENT_PLATFORMS
 from ocs_ci.ocs.exceptions import (
@@ -1384,7 +1385,7 @@ class HostedODF(HypershiftHostedOCP):
         )
         return ocp.check_resource_existence(
             timeout=self.timeout_check_resources_exist_sec,
-            selector="app=csi-cephfsplugin",
+            selector=get_node_plugin_label(constants.CEPHFILESYSTEM),
             should_exist=True,
         )
 

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -136,6 +136,12 @@ class Disruptions:
         if self.resource == "ocs_provider_server":
             self.resource_obj = [pod.get_ocs_provider_server_pod()]
             self.selector = constants.PROVIDER_SERVER_LABEL
+        if self.resource == "ceph_csi_controller_manager":
+            self.resource_obj = [pod.get_ceph_csi_controller_manager()]
+            self.selector = constants.CEPH_CSI_CONTROLLER_MANAGER_LABEL
+        if self.resource == "ocs_client_operator_controller_manager":
+            self.resource_obj = [pod.get_ocs_client_operator_controller_manager()]
+            self.selector = constants.OCS_CLIENT_OPERATOR_LABEL
 
         self.resource_count = resource_count or len(self.resource_obj)
 

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -50,6 +50,7 @@ class Disruptions:
             # If the platform is Managed Services, then the ceph pods will be present in the provider cluster.
             # Consumer cluster will be the primary cluster context in a multicluster run. Setting 'cluster_kubeconfig'
             # attribute to use as the value of the parameter '--kubeconfig' in the 'oc' commands to get ceph pods.
+            log.info(f"Setting provider kubeconfig for the resource {self.resource}")
             provider_kubeconfig = os.path.join(
                 config.clusters[config.get_provider_index()].ENV_DATA["cluster_path"],
                 config.clusters[config.get_provider_index()].RUN.get(

--- a/ocs_ci/helpers/disruption_helpers.py
+++ b/ocs_ci/helpers/disruption_helpers.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 
+from ocs_ci.helpers.helpers import get_provisioner_label, get_node_plugin_label
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework import config
@@ -81,17 +82,17 @@ class Disruptions:
             self.selector = constants.MDS_APP_LABEL
         if self.resource == "cephfsplugin":
             self.resource_obj = pod.get_plugin_pods(interface=constants.CEPHFILESYSTEM)
-            self.selector = constants.CSI_CEPHFSPLUGIN_LABEL
+            self.selector = get_node_plugin_label(constants.CEPHFILESYSTEM)
         if self.resource == "rbdplugin":
             self.resource_obj = pod.get_plugin_pods(interface=constants.CEPHBLOCKPOOL)
-            self.selector = constants.CSI_RBDPLUGIN_LABEL
+            self.selector = get_node_plugin_label(constants.CEPHBLOCKPOOL)
         if self.resource == "cephfsplugin_provisioner":
             self.resource_obj = [
                 pod.get_plugin_provisioner_leader(
                     interface=constants.CEPHFILESYSTEM, leader_type=leader_type
                 )
             ]
-            self.selector = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+            self.selector = get_provisioner_label(constants.CEPHFILESYSTEM)
             resource_count = len(pod.get_cephfsplugin_provisioner_pods())
         if self.resource == "rbdplugin_provisioner":
             self.resource_obj = [
@@ -99,7 +100,7 @@ class Disruptions:
                     interface=constants.CEPHBLOCKPOOL, leader_type=leader_type
                 )
             ]
-            self.selector = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+            self.selector = get_provisioner_label(constants.CEPHBLOCKPOOL)
             resource_count = len(pod.get_rbdfsplugin_provisioner_pods())
         if self.resource == "operator":
             self.resource_obj = pod.get_operator_pods()

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -28,7 +28,11 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
+<<<<<<< HEAD
 from ocs_ci.ocs.utils import get_non_acm_cluster_config, get_pod_name_by_pattern
+=======
+from ocs_ci.ocs.cluster import is_hci_cluster
+>>>>>>> f1e948313 (Provisioner and plugin pod label change in provider mode)
 from ocs_ci.ocs.utils import mirror_image
 from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
@@ -5366,3 +5370,55 @@ def update_volsync_channel():
             logger.error(
                 f"Pod volsync-controller-manager not in {constants.STATUS_RUNNING} after 300 seconds"
             )
+
+
+def get_provisioner_label(interface):
+    """
+    Identify the csi provisioner label based on deployment mode and version
+
+    Args:
+        interface(str): CephFileSystem or CephBlockPool
+
+    Returns:
+        str: Label of the pod
+    """
+    if (
+        is_hci_cluster()
+        and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17
+    ):
+        if interface == constants.CEPHFILESYSTEM:
+            label = constants.CEPHFS_CTRLPLUGIN_LABEL
+        elif interface == constants.CEPHBLOCKPOOL:
+            label = constants.RBD_CTRLPLUGIN_LABEL
+    else:
+        if interface == constants.CEPHFILESYSTEM:
+            label = constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+        elif interface == constants.CEPHBLOCKPOOL:
+            label = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+    return label
+
+
+def get_node_plugin_label(interface):
+    """
+    Identify the csi plugin label based on deployment mode and version
+
+    Args:
+        interface(str): CephFileSystem or CephBlockPool
+
+    Returns:
+        str: Label of the pod
+    """
+    if (
+        is_hci_cluster()
+        and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17
+    ):
+        if interface == constants.CEPHFILESYSTEM:
+            label = constants.CEPHFS_NODEPLUGIN_LABEL
+        elif interface == constants.CEPHBLOCKPOOL:
+            label = constants.RBD_NODEPLUGIN_LABEL
+    else:
+        if interface == constants.CEPHFILESYSTEM:
+            label = constants.CSI_CEPHFSPLUGIN_LABEL
+        elif interface == constants.CEPHBLOCKPOOL:
+            label = constants.CSI_RBDPLUGIN_LABEL
+    return label

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -5378,10 +5378,9 @@ def get_provisioner_label(interface):
     Returns:
         str: Label of the pod
     """
-    from ocs_ci.ocs.cluster import is_hci_cluster
 
     if (
-        is_hci_cluster()
+        config.ENV_DATA["platform"].lower() in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17
     ):
         if interface == constants.CEPHFILESYSTEM:
@@ -5406,10 +5405,9 @@ def get_node_plugin_label(interface):
     Returns:
         str: Label of the pod
     """
-    from ocs_ci.ocs.cluster import is_hci_cluster
 
     if (
-        is_hci_cluster()
+        config.ENV_DATA["platform"].lower() in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17
     ):
         if interface == constants.CEPHFILESYSTEM:

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -28,11 +28,7 @@ from ocs_ci.helpers.proxy import (
     get_cluster_proxies,
     update_container_with_proxy_env,
 )
-<<<<<<< HEAD
 from ocs_ci.ocs.utils import get_non_acm_cluster_config, get_pod_name_by_pattern
-=======
-from ocs_ci.ocs.cluster import is_hci_cluster
->>>>>>> f1e948313 (Provisioner and plugin pod label change in provider mode)
 from ocs_ci.ocs.utils import mirror_image
 from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
@@ -5382,6 +5378,8 @@ def get_provisioner_label(interface):
     Returns:
         str: Label of the pod
     """
+    from ocs_ci.ocs.cluster import is_hci_cluster
+
     if (
         is_hci_cluster()
         and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17
@@ -5408,6 +5406,8 @@ def get_node_plugin_label(interface):
     Returns:
         str: Label of the pod
     """
+    from ocs_ci.ocs.cluster import is_hci_cluster
+
     if (
         is_hci_cluster()
         and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_17

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -583,7 +583,7 @@ CEPH_OBJECT_CONTROLLER_DETECT_VERSION_LABEL = (
 )
 CSI_ADDONS_CONTROLLER_MANAGER_LABEL = "app.kubernetes.io/name=csi-addons"
 CEPH_CSI_CONTROLLER_MANAGER_LABEL = "control-plane=ceph-csi-op-controller-manager"
-
+OCS_CLIENT_OPERATOR_LABEL = "app=ocs-client-operator"
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"
 DEFAULT_DEVICESET_LSO_PVC_NAME = "ocs-deviceset-localblock"
 DEFAULT_MON_PVC_NAME = "rook-ceph-mon"

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -19,6 +19,7 @@ from ocs_ci.deployment.helpers.external_cluster_helpers import (
     get_external_cluster_client,
 )
 from ocs_ci.deployment.helpers.odf_deployment_helpers import get_required_csvs
+from ocs_ci.helpers.helpers import get_provisioner_label, get_node_plugin_label
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
 from ocs_ci.ocs.defaults import (
@@ -177,19 +178,21 @@ def verify_image_versions(old_images, upgrade_version, version_before_upgrade):
     if not config.ENV_DATA.get("mcg_only_deployment"):
         verify_pods_upgraded(
             old_images,
-            selector=constants.CSI_CEPHFSPLUGIN_LABEL,
+            selector=get_node_plugin_label(constants.CEPHFILESYSTEM),
             count=number_of_worker_nodes,
-        )
-        verify_pods_upgraded(
-            old_images, selector=constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL, count=2
         )
         verify_pods_upgraded(
             old_images,
-            selector=constants.CSI_RBDPLUGIN_LABEL,
+            selector=get_provisioner_label(constants.CEPHFILESYSTEM),
+            count=2,
+        )
+        verify_pods_upgraded(
+            old_images,
+            selector=get_node_plugin_label(constants.CEPHBLOCKPOOL),
             count=number_of_worker_nodes,
         )
         verify_pods_upgraded(
-            old_images, selector=constants.CSI_RBDPLUGIN_PROVISIONER_LABEL, count=2
+            old_images, selector=get_provisioner_label(constants.CEPHBLOCKPOOL), count=2
         )
     if not (
         config.DEPLOYMENT.get("external_mode")

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -17,7 +17,6 @@ from threading import Thread
 import base64
 from semantic_version import Version
 
-from ocs_ci.helpers.helpers import get_provisioner_label, get_node_plugin_label
 from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.ocp import get_images, OCP, verify_images_upgraded
 from ocs_ci.helpers import helpers
@@ -855,12 +854,12 @@ def get_csi_provisioner_pod(interface):
         Pod object: The provisioner pod object based on iterface
     """
     selector = (
-        get_provisioner_label(constants.CEPHBLOCKPOOL)
+        helpers.get_provisioner_label(constants.CEPHBLOCKPOOL)
         if (
             interface == constants.CEPHBLOCKPOOL
             or interface == constants.CEPHBLOCKPOOL_THICK
         )
-        else get_provisioner_label(constants.CEPHFILESYSTEM)
+        else helpers.get_provisioner_label(constants.CEPHFILESYSTEM)
     )
     ocp_pod_obj = OCP(
         kind=constants.POD,
@@ -1700,7 +1699,9 @@ def get_pod_count(label, namespace=None):
 
 
 def get_cephfsplugin_provisioner_pods(
-    cephfsplugin_provisioner_label=get_provisioner_label(constants.CEPHFILESYSTEM),
+    cephfsplugin_provisioner_label=helpers.get_provisioner_label(
+        constants.CEPHFILESYSTEM
+    ),
     namespace=None,
 ):
     """
@@ -1723,7 +1724,7 @@ def get_cephfsplugin_provisioner_pods(
 
 
 def get_rbdfsplugin_provisioner_pods(
-    rbdplugin_provisioner_label=get_provisioner_label(constants.CEPHBLOCKPOOL),
+    rbdplugin_provisioner_label=helpers.get_provisioner_label(constants.CEPHBLOCKPOOL),
     namespace=None,
 ):
     """
@@ -1944,9 +1945,9 @@ def get_plugin_pods(interface, namespace=None):
         list : csi-cephfsplugin pod objects or csi-rbdplugin pod objects
     """
     if interface == constants.CEPHFILESYSTEM:
-        plugin_label = get_node_plugin_label(constants.CEPHFILESYSTEM)
+        plugin_label = helpers.get_node_plugin_label(constants.CEPHFILESYSTEM)
     if interface == constants.CEPHBLOCKPOOL:
-        plugin_label = get_node_plugin_label(constants.CEPHBLOCKPOOL)
+        plugin_label = helpers.get_node_plugin_label(constants.CEPHBLOCKPOOL)
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     plugins_info = get_pods_having_label(plugin_label, namespace)
     plugin_pods = [Pod(**plugin) for plugin in plugins_info]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -3910,7 +3910,7 @@ def get_ceph_csi_controller_manager(
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     ceph_csi_controller_manager = get_pods_having_label(label, namespace)
-    return Pod(**ceph_csi_controller_manager[0])
+    return [Pod(**pod) for pod in ceph_csi_controller_manager]
 
 
 def get_ocs_client_operator_controller_manager(
@@ -3929,4 +3929,4 @@ def get_ocs_client_operator_controller_manager(
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     ocs_client_operator_controller_manager = get_pods_having_label(label, namespace)
-    return Pod(**ocs_client_operator_controller_manager[0])
+    return [Pod(**pod) for pod in ocs_client_operator_controller_manager]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -17,6 +17,7 @@ from threading import Thread
 import base64
 from semantic_version import Version
 
+from ocs_ci.helpers.helpers import get_provisioner_label, get_node_plugin_label
 from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.ocp import get_images, OCP, verify_images_upgraded
 from ocs_ci.helpers import helpers
@@ -854,12 +855,12 @@ def get_csi_provisioner_pod(interface):
         Pod object: The provisioner pod object based on iterface
     """
     selector = (
-        "app=csi-rbdplugin-provisioner"
+        get_provisioner_label(constants.CEPHBLOCKPOOL)
         if (
             interface == constants.CEPHBLOCKPOOL
             or interface == constants.CEPHBLOCKPOOL_THICK
         )
-        else "app=csi-cephfsplugin-provisioner"
+        else get_provisioner_label(constants.CEPHFILESYSTEM)
     )
     ocp_pod_obj = OCP(
         kind=constants.POD,
@@ -1699,7 +1700,7 @@ def get_pod_count(label, namespace=None):
 
 
 def get_cephfsplugin_provisioner_pods(
-    cephfsplugin_provisioner_label=constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+    cephfsplugin_provisioner_label=get_provisioner_label(constants.CEPHFILESYSTEM),
     namespace=None,
 ):
     """
@@ -1722,7 +1723,7 @@ def get_cephfsplugin_provisioner_pods(
 
 
 def get_rbdfsplugin_provisioner_pods(
-    rbdplugin_provisioner_label=constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+    rbdplugin_provisioner_label=get_provisioner_label(constants.CEPHBLOCKPOOL),
     namespace=None,
 ):
     """
@@ -1943,9 +1944,9 @@ def get_plugin_pods(interface, namespace=None):
         list : csi-cephfsplugin pod objects or csi-rbdplugin pod objects
     """
     if interface == constants.CEPHFILESYSTEM:
-        plugin_label = constants.CSI_CEPHFSPLUGIN_LABEL
+        plugin_label = get_node_plugin_label(constants.CEPHFILESYSTEM)
     if interface == constants.CEPHBLOCKPOOL:
-        plugin_label = constants.CSI_RBDPLUGIN_LABEL
+        plugin_label = get_node_plugin_label(constants.CEPHBLOCKPOOL)
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     plugins_info = get_pods_having_label(plugin_label, namespace)
     plugin_pods = [Pod(**plugin) for plugin in plugins_info]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -3892,3 +3892,41 @@ def get_container_images(pod_obj):
         raise ValueError(f"Didn't find images for the pod {pod_obj.name} containers")
 
     return images
+
+
+def get_ceph_csi_controller_manager(
+    label=constants.CEPH_CSI_CONTROLLER_MANAGER_LABEL, namespace=None
+):
+    """
+    Get ceph-csi-controller-manager pod from the cluster
+
+    Args:
+        label (str): Label associated with ceph-csi-controller-manager pod
+        namespace (str): Namespace in which ceph-csi-controller-manager pod is residing
+
+    Returns:
+        Pod: Pod object of ceph-csi-controller-manager pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    ceph_csi_controller_manager = get_pods_having_label(label, namespace)
+    return Pod(**ceph_csi_controller_manager[0])
+
+
+def get_ocs_client_operator_controller_manager(
+    label=constants.OCS_CLIENT_OPERATOR_LABEL, namespace=None
+):
+    """
+    Get ocs-client-operator-controller-manager pod from the cluster
+
+    Args:
+        label (str): Label associated with ocs-client-operator-controller-manager pod
+        namespace (str): Namespace in which ocs-client-operator-controller-manager pod is residing
+
+    Returns:
+        Pod: Pod object of ocs-client-operator-controller-manager pod
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    ocs_client_operator_controller_manager = get_pods_having_label(label, namespace)
+    return Pod(**ocs_client_operator_controller_manager[0])

--- a/ocs_ci/utility/metadata_utils.py
+++ b/ocs_ci/utility/metadata_utils.py
@@ -5,6 +5,7 @@ Module that contains all operations related to add metadata feature in a cluster
 
 import logging
 from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.retry import retry
@@ -84,14 +85,14 @@ def enable_metadata(
     # Check csi-cephfsplugin provisioner and csi-rbdplugin-provisioner pods are up and running
     assert pod_obj.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector=constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(constants.CEPHFILESYSTEM),
         dont_allow_other_resources=True,
         timeout=60,
     ), "Pods are not in running status"
 
     assert pod_obj.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector=constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(constants.CEPHBLOCKPOOL),
         dont_allow_other_resources=True,
         timeout=60,
     ), "Pods are not in running status"
@@ -144,14 +145,14 @@ def disable_metadata(
     # Check csi-cephfsplugin provisioner and csi-rbdplugin-provisioner pods are up and running
     assert pod_obj.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector=constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(constants.CEPHFILESYSTEM),
         dont_allow_other_resources=True,
         timeout=60,
     ), "Pods are not in running status"
 
     assert pod_obj.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector=constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(constants.CEPHBLOCKPOOL),
         dont_allow_other_resources=True,
         timeout=60,
     ), "Pods are not in running status"

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -40,6 +40,7 @@ from tempfile import NamedTemporaryFile, mkdtemp, TemporaryDirectory
 from jinja2 import FileSystemLoader, Environment
 from ocs_ci.framework import config
 from ocs_ci.framework import GlobalVariables as GV
+from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
@@ -2114,8 +2115,8 @@ def get_csi_versions():
     from ocs_ci.ocs.ocp import OCP
 
     for provisioner in [
-        constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
-        constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+        get_provisioner_label(constants.CEPHFILESYSTEM),
+        get_provisioner_label(constants.CEPHBLOCKPOOL),
     ]:
         ocp_pod_obj = OCP(
             kind=constants.POD,

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -40,7 +40,6 @@ from tempfile import NamedTemporaryFile, mkdtemp, TemporaryDirectory
 from jinja2 import FileSystemLoader, Environment
 from ocs_ci.framework import config
 from ocs_ci.framework import GlobalVariables as GV
-from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
@@ -2113,6 +2112,7 @@ def get_csi_versions():
     csi_versions = {}
     # importing here to avoid circular imports
     from ocs_ci.ocs.ocp import OCP
+    from ocs_ci.helpers.helpers import get_provisioner_label
 
     for provisioner in [
         get_provisioner_label(constants.CEPHFILESYSTEM),

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -4,7 +4,6 @@ import time
 import os
 import socket
 
-from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import nfs_utils
 from ocs_ci.utility.utils import exec_cmd
 from ocs_ci.framework import config
@@ -1351,7 +1350,7 @@ class TestNfsEnable(ManageTest):
         # Wait untill cephfsplugin provisioner pods recovery
         self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector=get_provisioner_label(constants.CEPHFILESYSTEM),
+            selector=helpers.get_provisioner_label(constants.CEPHFILESYSTEM),
             resource_count=len(cephfsplugin_provisioner_pod_objs),
             timeout=3600,
             sleep=5,

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -4,7 +4,7 @@ import time
 import os
 import socket
 
-
+from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import nfs_utils
 from ocs_ci.utility.utils import exec_cmd
 from ocs_ci.framework import config
@@ -1351,7 +1351,7 @@ class TestNfsEnable(ManageTest):
         # Wait untill cephfsplugin provisioner pods recovery
         self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector="app=csi-cephfsplugin-provisioner",
+            selector=get_provisioner_label(constants.CEPHFILESYSTEM),
             resource_count=len(cephfsplugin_provisioner_pod_objs),
             timeout=3600,
             sleep=5,

--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import metadata_utils
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
@@ -989,14 +990,14 @@ class TestMetadata(ManageTest):
         # Check csi-cephfsplugin provisioner and csi-rbdplugin-provisioner pods are up and running
         assert self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector="app=csi-cephfsplugin-provisioner",
+            selector=get_provisioner_label(constants.CEPHFILESYSTEM),
             dont_allow_other_resources=True,
             timeout=60,
         )
 
         assert self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector="app=csi-rbdplugin-provisioner",
+            selector=get_provisioner_label(constants.CEPHBLOCKPOOL),
             dont_allow_other_resources=True,
             timeout=60,
         )

--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
 
-from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import metadata_utils
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
@@ -990,14 +989,14 @@ class TestMetadata(ManageTest):
         # Check csi-cephfsplugin provisioner and csi-rbdplugin-provisioner pods are up and running
         assert self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector=get_provisioner_label(constants.CEPHFILESYSTEM),
+            selector=helpers.get_provisioner_label(constants.CEPHFILESYSTEM),
             dont_allow_other_resources=True,
             timeout=60,
         )
 
         assert self.pod_obj.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            selector=get_provisioner_label(constants.CEPHBLOCKPOOL),
+            selector=helpers.get_provisioner_label(constants.CEPHBLOCKPOOL),
             dont_allow_other_resources=True,
             timeout=60,
         )

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -373,6 +373,7 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
             }
 
         if is_hci_cluster():
+            del pod_functions["operator"]
             pod_functions["ceph_csi_controller_manager"] = partial(
                 get_ceph_csi_controller_manager
             )

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -26,6 +26,8 @@ from ocs_ci.ocs.resources.pod import (
     get_cephfsplugin_provisioner_pods,
     get_rbdfsplugin_provisioner_pods,
     get_operator_pods,
+    get_ocs_client_operator_controller_manager,
+    get_ceph_csi_controller_manager,
 )
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.helpers import (
@@ -369,6 +371,14 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 "rbdplugin_provisioner": partial(get_rbdfsplugin_provisioner_pods),
                 "operator": partial(get_operator_pods),
             }
+
+        if is_hci_cluster():
+            pod_functions["ceph_csi_controller_manager"] = partial(
+                get_ceph_csi_controller_manager
+            )
+            pod_functions["ocs_client_operator_controller_manager"] = partial(
+                get_ocs_client_operator_controller_manager
+            )
 
         # Disruption object for each pod type
         disruption_ops = [

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
+from ocs_ci.ocs.cluster import is_hci_cluster
 from ocs_ci.ocs.resources.pvc import delete_pvcs
 from ocs_ci.ocs.resources.pod import (
     get_mds_pods,
@@ -258,6 +259,15 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 "osd",
                 "mds",
             ]
+
+        if is_hci_cluster():
+            ceph_csi_pods_to_delete.remove("operator")
+            ceph_csi_pods_to_delete.extend(
+                [
+                    "ceph_csi_controller_manager",
+                    "ocs_client_operator_controller_manager",
+                ]
+            )
 
         (
             pvc_objs,

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -50,6 +50,7 @@ from ocs_ci.helpers.helpers import (
     remove_label_from_worker_node,
     storagecluster_independent_check,
     verify_pdb_mon,
+    get_provisioner_label,
 )
 from ocs_ci.helpers import helpers
 
@@ -157,11 +158,11 @@ class TestNodesMaintenance(ManageTest):
         # check csi-cephfsplugin-provisioner's and csi-rbdplugin-provisioner's
         # are ready, see BZ #2162504
         provis_pods = get_pods_having_label(
-            constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+            get_provisioner_label(constants.CEPHFILESYSTEM),
             config.ENV_DATA["cluster_namespace"],
         )
         provis_pods += get_pods_having_label(
-            constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
+            get_provisioner_label(constants.CEPHBLOCKPOOL),
             config.ENV_DATA["cluster_namespace"],
         )
         provis_pod_names = [p["metadata"]["name"] for p in provis_pods]

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -50,7 +50,6 @@ from ocs_ci.helpers.helpers import (
     remove_label_from_worker_node,
     storagecluster_independent_check,
     verify_pdb_mon,
-    get_provisioner_label,
 )
 from ocs_ci.helpers import helpers
 
@@ -158,11 +157,11 @@ class TestNodesMaintenance(ManageTest):
         # check csi-cephfsplugin-provisioner's and csi-rbdplugin-provisioner's
         # are ready, see BZ #2162504
         provis_pods = get_pods_having_label(
-            get_provisioner_label(constants.CEPHFILESYSTEM),
+            helpers.get_provisioner_label(constants.CEPHFILESYSTEM),
             config.ENV_DATA["cluster_namespace"],
         )
         provis_pods += get_pods_having_label(
-            get_provisioner_label(constants.CEPHBLOCKPOOL),
+            helpers.get_provisioner_label(constants.CEPHBLOCKPOOL),
             config.ENV_DATA["cluster_namespace"],
         )
         provis_pod_names = [p["metadata"]["name"] for p in provis_pods]

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -23,6 +23,7 @@ from ocs_ci.helpers.helpers import (
     wait_for_ct_pod_recovery,
     get_pv_names,
     storagecluster_independent_check,
+    get_provisioner_label,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import ServiceUnavailable
@@ -229,9 +230,9 @@ class TestNodesRestart(ManageTest):
 
         # Wait for the provisioner pod to get to running status
         selector = (
-            constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+            get_provisioner_label(constants.CEPHBLOCKPOOL)
             if (interface == "rbd")
-            else constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+            else get_provisioner_label(constants.CEPHFILESYSTEM)
         )
 
         # Wait for the provisioner pod to reach Terminating status

--- a/tests/functional/z_cluster/test_no_liveness_probe.py
+++ b/tests/functional/z_cluster/test_no_liveness_probe.py
@@ -1,12 +1,12 @@
 # BZ2142901 Automated Test
 
 from logging import getLogger
+
+from ocs_ci.helpers.helpers import get_provisioner_label, get_node_plugin_label
 from ocs_ci.ocs.constants import (
-    CSI_CEPHFSPLUGIN_LABEL,
     POD,
-    CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
-    CSI_RBDPLUGIN_LABEL,
-    CSI_RBDPLUGIN_PROVISIONER_LABEL,
+    CEPHFILESYSTEM,
+    CEPHBLOCKPOOL,
 )
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
@@ -36,22 +36,22 @@ def test_no_liveness_container():
     csi_plugin_pod = OCP(
         kind=POD,
         namespace=config.ENV_DATA["cluster_namespace"],
-        selector=CSI_CEPHFSPLUGIN_LABEL,
+        selector=get_node_plugin_label(CEPHFILESYSTEM),
     )
     csi_prov_pod = OCP(
         kind=POD,
         namespace=config.ENV_DATA["cluster_namespace"],
-        selector=CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(CEPHFILESYSTEM),
     )
     rbd_plugin_pod = OCP(
         kind=POD,
         namespace=config.ENV_DATA["cluster_namespace"],
-        selector=CSI_RBDPLUGIN_LABEL,
+        selector=get_node_plugin_label(CEPHBLOCKPOOL),
     )
     rbd_prov_pod = OCP(
         kind=POD,
         namespace=config.ENV_DATA["cluster_namespace"],
-        selector=CSI_RBDPLUGIN_PROVISIONER_LABEL,
+        selector=get_provisioner_label(CEPHBLOCKPOOL),
     )
     for pods in (csi_plugin_pod, rbd_plugin_pod, rbd_prov_pod, csi_prov_pod):
         assert LIVENESS_CONTAINER not in get_containers_names_by_pod(

--- a/tests/functional/z_cluster/test_scc.py
+++ b/tests/functional/z_cluster/test_scc.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import templating, utils
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from datetime import datetime
@@ -67,8 +68,8 @@ class TestSCC:
         # Delete csi-provisioner and noobaa db pods
         labels = [
             constants.NOOBAA_DB_LABEL_47_AND_ABOVE,
-            constants.CSI_RBDPLUGIN_PROVISIONER_LABEL,
-            constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL,
+            get_provisioner_label(constants.CEPHBLOCKPOOL),
+            get_provisioner_label(constants.CEPHFILESYSTEM),
         ]
         pods = list()
         for label in labels:

--- a/tests/functional/z_cluster/test_scc.py
+++ b/tests/functional/z_cluster/test_scc.py
@@ -3,7 +3,6 @@ import pytest
 import time
 
 from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import get_provisioner_label
 from ocs_ci.utility import templating, utils
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from datetime import datetime
@@ -68,8 +67,8 @@ class TestSCC:
         # Delete csi-provisioner and noobaa db pods
         labels = [
             constants.NOOBAA_DB_LABEL_47_AND_ABOVE,
-            get_provisioner_label(constants.CEPHBLOCKPOOL),
-            get_provisioner_label(constants.CEPHFILESYSTEM),
+            helpers.get_provisioner_label(constants.CEPHBLOCKPOOL),
+            helpers.get_provisioner_label(constants.CEPHFILESYSTEM),
         ]
         pods = list()
         for label in labels:


### PR DESCRIPTION
In provider mode, from 4.17 the label of the Csi provisioner and plugin node has changed. Created new functions that identifies the cluster type and version and set the label accordingly.