### PR TITLE
Add another error message when getting the IBMCloud Baremetal servers

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -5209,3 +5209,41 @@ def configure_cephcluster_params_in_storagecluster_cr(params, default_values=Fal
             f' "value": {parameter_value}}}]'
         )
         storagecluster_obj.patch(params=param, format_type="json")
+
+
+def get_cephfs_sc_name():
+    """
+    Get the cephfs storage class name.
+
+    Returns:
+        str: The cephfs storage class name.
+
+    Raises:
+        ValueError: If the cephfs storage class name hasn't been found.
+    """
+    sc_names = get_all_storageclass_names()
+    cephfs_sc_names = [name for name in sc_names if constants.CEPHFS_INTERFACE in name]
+    if not cephfs_sc_names:
+        raise ValueError(
+            "Didn't find the cephfs storageclass in the storageclass names"
+        )
+    else:
+        return cephfs_sc_names[0]
+
+
+def get_rbd_sc_name():
+    """
+    Get the rbd storage class name.
+
+    Returns:
+        str: The rbd storage class name.
+
+    Raises:
+        ValueError: If the rbd storage class name hasn't been found.
+    """
+    sc_names = get_all_storageclass_names()
+    rbd_sc_names = [name for name in sc_names if constants.RBD_INTERFACE in name]
+    if not rbd_sc_names:
+        raise ValueError("Didn't find the rbd storageclass in the storageclass names")
+    else:
+        return rbd_sc_names[0]

--- a/ocs_ci/ocs/scale_lib.py
+++ b/ocs_ci/ocs/scale_lib.py
@@ -125,8 +125,10 @@ class FioPodScale(object):
 
         logger.info(f"Start creating {pvc_count} PVC of 2 types RBD-RWO & FS-RWX")
         if is_hci_cluster():
-            cephfs_sc_obj = constants.DEFAULT_STORAGECLASS_CLIENT_CEPHFS
-            rbd_sc_obj = constants.DEFAULT_STORAGECLASS_CLIENT_RBD
+            # Since sometimes the client storageclass names are different for different client types,
+            # get the current client storageclass names
+            cephfs_sc_obj = helpers.get_cephfs_sc_name()
+            rbd_sc_obj = helpers.get_rbd_sc_name()
         else:
             cephfs_sc_obj = constants.DEFAULT_STORAGECLASS_CEPHFS
             rbd_sc_obj = constants.DEFAULT_STORAGECLASS_RBD

--- a/ocs_ci/utility/ibmcloud_bm.py
+++ b/ocs_ci/utility/ibmcloud_bm.py
@@ -75,9 +75,10 @@ class IBMCloudBM(object):
             return run_cmd(cmd, secrets, timeout, ignore_error, **kwargs)
         except CommandFailed as ex:
             login_error_messages = [
-                "Error: Failed to get",
+                "Failed to get",
                 "Access Denied",
                 "Please login",
+                "token is expired",
             ]
             # Check if we need to re-login to IBM Cloud account
             if any([error_msg in str(ex) for error_msg in login_error_messages]):


### PR DESCRIPTION
The PR fixes the following:

- Modify and add new login error messages that may happen when getting the IBMCloud Baremetal Server list. 
- Since sometimes the client storageclass names differ for different client types, get the current storageclass names when creating resources using "scale_lib".