### PR TITLE
use ocp-network-split from red-hat-storage org fork - release-4.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://gitlab.com/mbukatov/ocp-network-split.git@v0.3.0#egg=ocp-network-split
+-e git+https://github.com/red-hat-storage/ocp-network-split.git#egg=ocp-network-split
 -e .


### PR DESCRIPTION
Use `ocp-network-split` from our fork https://github.com/red-hat-storage/ocp-network-split.git, because it contains important fix.

Backport of https://github.com/red-hat-storage/ocs-ci/pull/10505