### PR TITLE
fix kubeconfig path for hosted clusters

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -590,7 +590,7 @@ class HyperShiftBase:
         """
 
         path_abs = os.path.expanduser(hosted_cluster_path)
-        auth_path = os.path.join(path_abs, "auth_path")
+        auth_path = os.path.join(path_abs, "auth")
         os.makedirs(auth_path, exist_ok=True)
         kubeconfig_path = os.path.join(auth_path, "kubeconfig")
 

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -364,7 +364,7 @@ class HypershiftHostedOCP(HyperShiftBase, MetalLBInstaller, CNVInstaller, Deploy
                 config.ENV_DATA["clusters"].get(self.name).get("hosted_cluster_path")
             )
             self.cluster_kubeconfig = os.path.expanduser(
-                os.path.join(cluster_path, "auth_path", "kubeconfig")
+                os.path.join(cluster_path, "auth", "kubeconfig")
             )
         else:
             # avoid throwing an exception if the cluster path is not found for some reason


### PR DESCRIPTION
- create kubeconfig for hosted clusters in "standard" location (`auth/`  directory instead `auth_path/`)