### PR TITLE
Adding a new test for csi logs rotation feature

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -655,6 +655,40 @@ class Pod(OCS):
         resource_name = resource_name if resource_name else self.name
         return self.ocp.wait_for_delete(resource_name, timeout=timeout)
 
+    def get_logs_details_on_pod(self, logs_dir):
+        """
+        Gets csi pod log files details
+
+        Args:
+            logs_dir (str): Directory where the logs are looked for
+
+        Returns:
+            gz_logs_num (int): Number of compressed log files
+            current_log_file_size (int) Size of the current log file
+        """
+
+        all_logs = (
+            self.exec_cmd_on_pod(
+                command=f"-- ls -l {logs_dir}",
+                container_name="log-collector",
+                out_yaml_format=False,
+                shell=True,
+            )
+            .strip()
+            .split("\n")
+        )
+        gz_logs_num = 0
+        current_log_file_size = 0
+
+        for log_file in all_logs[1:]:  # ignore 'total' line
+            file_details = log_file.split()
+            file_name = "".join(file_details[8:])
+            if file_name.endswith(".gz"):  # archived compressed log
+                gz_logs_num = gz_logs_num + 1
+            if file_name.endswith(".log"):  # current log file
+                current_log_file_size = file_details[4]
+        return gz_logs_num, current_log_file_size
+
 
 # Helper functions for Pods
 

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -655,7 +655,7 @@ class Pod(OCS):
         resource_name = resource_name if resource_name else self.name
         return self.ocp.wait_for_delete(resource_name, timeout=timeout)
 
-    def get_logs_details_on_pod(self, logs_dir, log_file_name):
+    def get_csi_pod_log_details(self, logs_dir, log_file_name):
         """
         Gets csi pod log files details
 

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -655,12 +655,13 @@ class Pod(OCS):
         resource_name = resource_name if resource_name else self.name
         return self.ocp.wait_for_delete(resource_name, timeout=timeout)
 
-    def get_logs_details_on_pod(self, logs_dir):
+    def get_logs_details_on_pod(self, logs_dir, log_file_name):
         """
         Gets csi pod log files details
 
         Args:
             logs_dir (str): Directory where the logs are looked for
+            log_file_name (str): Current log file name
 
         Returns:
             gz_logs_num (int): Number of compressed log files
@@ -683,9 +684,11 @@ class Pod(OCS):
         for log_file in all_logs[1:]:  # ignore 'total' line
             file_details = log_file.split()
             file_name = "".join(file_details[8:])
-            if file_name.endswith(".gz"):  # archived compressed log
+            if file_name.startswith(log_file_name) and file_name.endswith(
+                ".gz"
+            ):  # archived compressed log
                 gz_logs_num = gz_logs_num + 1
-            if file_name.endswith(".log"):  # current log file
+            if file_name == log_file_name:  # current log file
                 current_log_file_size = file_details[4]
         return gz_logs_num, current_log_file_size
 

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -1,0 +1,95 @@
+import time
+import logging
+
+from ocs_ci.framework.testlib import BaseTest
+from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
+from ocs_ci.framework.pytest_customization.marks import green_squad, tier1
+
+log = logging.getLogger(__name__)
+LOGS_DIR_NAME = "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/node-plugin/"
+CURRENT_LOG_NAME = "csi-cephfsplugin.log"
+WAIT_FOR_ROTATION_TIME = 1200  # seconds
+
+@green_squad
+@tier1
+class TestPodsCsiLogRotation(BaseTest):
+    def get_logs_details_on_pod(self, pod_obj):
+        """
+        Gets csi pod log files details
+
+        Args:
+            pod_obj (obj): Pod which log files should be investigated
+
+        Returns:
+            gz_logs_num (int): Number of compressed log files
+            current_log_file_size (int) Size of the current log file
+        """
+
+        all_logs = (
+            pod_obj.exec_cmd_on_pod(
+                command=f"-- ls -l {LOGS_DIR_NAME}",
+                container_name="log-collector",
+                out_yaml_format=False,
+                shell=True,
+            )
+            .strip()
+            .split("\n")
+        )
+        gz_logs_num = 0
+        current_log_file_size = 0
+
+        for log_file in all_logs[1:]:  # ignore 'total' line
+            file_details = log_file.split()
+            file_name = "".join(file_details[8:])
+            if file_name.endswith(".gz"):
+                gz_logs_num = gz_logs_num + 1
+            if file_name == CURRENT_LOG_NAME:
+                current_log_file_size = file_details[4]
+        return gz_logs_num, current_log_file_size
+
+    def test_pods_csi_log_rotation(self):
+        """
+        Tests that the log files on pod are rotated correctly
+
+        """
+        log.info("Testing logs rotation on pod.")
+
+        csi_cephfsplugin_pod_objs = pod.get_all_pods(
+            namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=["csi-cephfsplugin"]
+        )
+
+        # check on the first pod
+        pod_obj = csi_cephfsplugin_pod_objs[0]
+        gz_logs_num, current_log_file_size = self.get_logs_details_on_pod(pod_obj)
+        log.info(
+            f"Number of compressed logs = {gz_logs_num}, current log file size = {current_log_file_size}"
+        )
+
+        # pump current log file size
+        pod_obj.exec_cmd_on_pod(
+            command=f"-- truncate -s 560M {LOGS_DIR_NAME + CURRENT_LOG_NAME}",
+            container_name="log-collector",
+            out_yaml_format=False,
+            shell=True,
+        )
+
+        time.sleep(10)  # wait fo make sure that the truncate had its effect
+        current_log_file_size = self.get_logs_details_on_pod(pod_obj)[1]
+        log.info(f"Current log file size after truncate is = {current_log_file_size}")
+
+        time.sleep(WAIT_FOR_ROTATION_TIME)  # sleep for time needed for logs rotation
+        new_gz_logs_num, new_current_log_file_size = self.get_logs_details_on_pod(
+            pod_obj
+        )
+        log.info(
+            f"New number of gz = {new_gz_logs_num}, new current log file size = {new_current_log_file_size}"
+        )
+
+        if gz_logs_num < 7:  # max number of gz logs
+            # test that new compressed file was added
+            assert new_gz_logs_num == gz_logs_num + 1
+        else:
+            # the number of compressed file was already at maximum, so test that the old current log was compressed
+            # and the new one has smaller size
+            assert new_current_log_file_size < current_log_file_size

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -18,11 +18,11 @@ SLEEP_BETWEEN_TRIES = 300  # seconds
 @brown_squad
 @tier2
 class TestPodsCsiLogRotation(BaseTest):
-    def logs_were_rotated(
+    def check_for_log_rotation_successful(
         self, pod_obj, gz_logs_num, current_log_file_size, logs_dir, log_file_name
     ):
         """
-        Gets csi pod log files details
+        Checks if the logs were rotated successfully
 
         Args:
             pod_obj (obj): Pod which log files should be investigated
@@ -85,7 +85,7 @@ class TestPodsCsiLogRotation(BaseTest):
             for result in TimeoutSampler(
                 WAIT_FOR_ROTATION_TIME,
                 SLEEP_BETWEEN_TRIES,
-                self.logs_were_rotated,
+                self.check_for_log_rotation_successful,
                 pod_obj=pod_obj,
                 gz_logs_num=gz_logs_num,
                 current_log_file_size=current_log_file_size,

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -4,14 +4,15 @@ import logging
 from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
-from ocs_ci.framework.pytest_customization.marks import green_squad, tier1
+from ocs_ci.framework.pytest_customization.marks import brown_squad, tier1
 
 log = logging.getLogger(__name__)
 LOGS_DIR_NAME = "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/node-plugin/"
 CURRENT_LOG_NAME = "csi-cephfsplugin.log"
 WAIT_FOR_ROTATION_TIME = 1200  # seconds
 
-@green_squad
+
+@brown_squad
 @tier1
 class TestPodsCsiLogRotation(BaseTest):
     def get_logs_details_on_pod(self, pod_obj):

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -5,49 +5,45 @@ from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
 from ocs_ci.framework.pytest_customization.marks import brown_squad, tier1
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
 log = logging.getLogger(__name__)
 LOGS_DIR_NAME = "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/node-plugin/"
 CURRENT_LOG_NAME = "csi-cephfsplugin.log"
 WAIT_FOR_ROTATION_TIME = 1200  # seconds
+SLEEP_BETWEEN_TRIES = 300  # seconds
 
 
 @brown_squad
 @tier1
 class TestPodsCsiLogRotation(BaseTest):
-    def get_logs_details_on_pod(self, pod_obj):
+    def logs_were_rotated(self, pod_obj, gz_logs_num, current_log_file_size):
         """
         Gets csi pod log files details
 
         Args:
             pod_obj (obj): Pod which log files should be investigated
+            gz_logs_num (int): Last known number of compressed log files
+            current_log_file_size (int) Last known size of the current log file
 
         Returns:
-            gz_logs_num (int): Number of compressed log files
-            current_log_file_size (int) Size of the current log file
+            bool: True if the log files were rotated
         """
-
-        all_logs = (
-            pod_obj.exec_cmd_on_pod(
-                command=f"-- ls -l {LOGS_DIR_NAME}",
-                container_name="log-collector",
-                out_yaml_format=False,
-                shell=True,
-            )
-            .strip()
-            .split("\n")
+        new_gz_logs_num, new_current_log_file_size = pod_obj.get_logs_details_on_pod(
+            LOGS_DIR_NAME
         )
-        gz_logs_num = 0
-        current_log_file_size = 0
+        log.info(
+            f"New number of gz = {new_gz_logs_num}, new current log file size = {new_current_log_file_size}"
+        )
 
-        for log_file in all_logs[1:]:  # ignore 'total' line
-            file_details = log_file.split()
-            file_name = "".join(file_details[8:])
-            if file_name.endswith(".gz"):
-                gz_logs_num = gz_logs_num + 1
-            if file_name == CURRENT_LOG_NAME:
-                current_log_file_size = file_details[4]
-        return gz_logs_num, current_log_file_size
+        if gz_logs_num < 7:  # max number of gz logs
+            # test that new compressed file was added
+            return new_gz_logs_num == gz_logs_num + 1
+        else:
+            # the number of compressed file was already at maximum, so test that the old current log was compressed
+            # and the new one has smaller size
+            return new_current_log_file_size < current_log_file_size
 
     def test_pods_csi_log_rotation(self):
         """
@@ -62,7 +58,9 @@ class TestPodsCsiLogRotation(BaseTest):
 
         # check on the first pod
         pod_obj = csi_cephfsplugin_pod_objs[0]
-        gz_logs_num, current_log_file_size = self.get_logs_details_on_pod(pod_obj)
+        gz_logs_num, current_log_file_size = pod_obj.get_logs_details_on_pod(
+            LOGS_DIR_NAME
+        )
         log.info(
             f"Number of compressed logs = {gz_logs_num}, current log file size = {current_log_file_size}"
         )
@@ -76,21 +74,20 @@ class TestPodsCsiLogRotation(BaseTest):
         )
 
         time.sleep(10)  # wait fo make sure that the truncate had its effect
-        current_log_file_size = self.get_logs_details_on_pod(pod_obj)[1]
+        current_log_file_size = pod_obj.get_logs_details_on_pod(LOGS_DIR_NAME)[1]
         log.info(f"Current log file size after truncate is = {current_log_file_size}")
 
-        time.sleep(WAIT_FOR_ROTATION_TIME)  # sleep for time needed for logs rotation
-        new_gz_logs_num, new_current_log_file_size = self.get_logs_details_on_pod(
-            pod_obj
-        )
-        log.info(
-            f"New number of gz = {new_gz_logs_num}, new current log file size = {new_current_log_file_size}"
-        )
-
-        if gz_logs_num < 7:  # max number of gz logs
-            # test that new compressed file was added
-            assert new_gz_logs_num == gz_logs_num + 1
-        else:
-            # the number of compressed file was already at maximum, so test that the old current log was compressed
-            # and the new one has smaller size
-            assert new_current_log_file_size < current_log_file_size
+        try:
+            for result in TimeoutSampler(
+                WAIT_FOR_ROTATION_TIME,
+                SLEEP_BETWEEN_TRIES,
+                self.logs_were_rotated,
+                pod_obj=pod_obj,
+                gz_logs_num=gz_logs_num,
+                current_log_file_size=current_log_file_size,
+            ):
+                if result:
+                    break
+            log.info("The logs were rotated correctly")
+        except TimeoutExpiredError:
+            assert False, "The logs were not rotated"

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -18,7 +18,9 @@ SLEEP_BETWEEN_TRIES = 300  # seconds
 @brown_squad
 @tier2
 class TestPodsCsiLogRotation(BaseTest):
-    def logs_were_rotated(self, pod_obj, gz_logs_num, current_log_file_size, logs_dir):
+    def logs_were_rotated(
+        self, pod_obj, gz_logs_num, current_log_file_size, logs_dir, log_file_name
+    ):
         """
         Gets csi pod log files details
 
@@ -27,12 +29,13 @@ class TestPodsCsiLogRotation(BaseTest):
             gz_logs_num (int): Last known number of compressed log files
             current_log_file_size (int) Last known size of the current log file
             logs_dir (str): Logs directory on this pod
+            log_file_name (str): Current log file name
 
         Returns:
             bool: True if the log files were rotated
         """
         new_gz_logs_num, new_current_log_file_size = pod_obj.get_logs_details_on_pod(
-            logs_dir
+            logs_dir, log_file_name
         )
         log.info(
             f"New number of gz = {new_gz_logs_num}, new current log file size = {new_current_log_file_size}"
@@ -45,6 +48,55 @@ class TestPodsCsiLogRotation(BaseTest):
             # the number of compressed file was already at maximum, so test that the old current log was compressed
             # and the new one has smaller size
             return new_current_log_file_size < current_log_file_size
+
+    def pump_logs_and_wait_for_rotation(self, pod_obj, logs_dir, log_file_name):
+        """
+        Tests that the log files on pod are rotated correctly
+
+        Args:
+            pod_obj (str): Pod object which is tested
+            logs_dir (str): Logs directory on this pod
+            log_file_name (str) Current log file name
+
+        """
+        log.info(f"Testing log {log_file_name} rotation on pod {pod_obj.name}")
+        gz_logs_num, current_log_file_size = pod_obj.get_logs_details_on_pod(
+            logs_dir, log_file_name
+        )
+        log.info(
+            f"Number of compressed logs = {gz_logs_num}, current log file size = {current_log_file_size}"
+        )
+
+        # pump current log file size
+        pod_obj.exec_cmd_on_pod(
+            command=f"-- truncate -s 560M {logs_dir + log_file_name}",
+            container_name="log-collector",
+            out_yaml_format=False,
+            shell=True,
+        )
+
+        time.sleep(10)  # wait fo make sure that the truncate had its effect
+        current_log_file_size = pod_obj.get_logs_details_on_pod(
+            logs_dir, log_file_name
+        )[1]
+        log.info(f"Current log file size after truncate is = {current_log_file_size}")
+
+        try:
+            for result in TimeoutSampler(
+                WAIT_FOR_ROTATION_TIME,
+                SLEEP_BETWEEN_TRIES,
+                self.logs_were_rotated,
+                pod_obj=pod_obj,
+                gz_logs_num=gz_logs_num,
+                current_log_file_size=current_log_file_size,
+                logs_dir=logs_dir,
+                log_file_name=log_file_name,
+            ):
+                if result:
+                    break
+            log.info("The logs were rotated correctly")
+        except TimeoutExpiredError:
+            assert False, "The logs were not rotated"
 
     @pytest.mark.parametrize(
         argnames=["pod_selector", "logs_dir", "log_file_name"],
@@ -75,7 +127,6 @@ class TestPodsCsiLogRotation(BaseTest):
             log_file_name (str) Current log file name
 
         """
-        log.info("Testing logs rotation on pod.")
 
         csi_interface_plugin_pod_objs = pod.get_all_pods(
             namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=[pod_selector]
@@ -83,35 +134,45 @@ class TestPodsCsiLogRotation(BaseTest):
 
         # check on the first pod
         pod_obj = csi_interface_plugin_pod_objs[0]
-        gz_logs_num, current_log_file_size = pod_obj.get_logs_details_on_pod(logs_dir)
-        log.info(
-            f"Number of compressed logs = {gz_logs_num}, current log file size = {current_log_file_size}"
+        self.pump_logs_and_wait_for_rotation(pod_obj, logs_dir, log_file_name)
+
+    @pytest.mark.parametrize(
+        argnames=["pod_selector", "logs_dir", "log_file_name"],
+        argvalues=[
+            pytest.param(
+                *[
+                    "csi-cephfsplugin-provisioner",
+                    "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/controller-plugin/",
+                    "csi-cephfsplugin.log",
+                ],
+            ),
+            pytest.param(
+                *[
+                    "csi-rbdplugin-provisioner",
+                    "/var/lib/rook/openshift-storage.rbd.csi.ceph.com/log/controller-plugin/",
+                    "csi-rbdplugin.log",
+                ],
+            ),
+        ],
+    )
+    def test_provisioner_pods_csi_log_rotation(
+        self, pod_selector, logs_dir, log_file_name
+    ):
+        """
+        Tests that the both log files on provisioner pod are rotated correctly.
+
+        Args:
+            pod_selector (str): Pod selector according to the interface
+            logs_dir (str): Logs directory on this pod
+            log_file_name (str) Current log file name
+
+        """
+        ADDTIONAL_CSI_LOG_FILE = "csi-addons.log"
+        csi_interface_plugin_pod_objs = pod.get_all_pods(
+            namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=[pod_selector]
         )
 
-        # pump current log file size
-        pod_obj.exec_cmd_on_pod(
-            command=f"-- truncate -s 560M {logs_dir + log_file_name}",
-            container_name="log-collector",
-            out_yaml_format=False,
-            shell=True,
-        )
-
-        time.sleep(10)  # wait fo make sure that the truncate had its effect
-        current_log_file_size = pod_obj.get_logs_details_on_pod(logs_dir)[1]
-        log.info(f"Current log file size after truncate is = {current_log_file_size}")
-
-        try:
-            for result in TimeoutSampler(
-                WAIT_FOR_ROTATION_TIME,
-                SLEEP_BETWEEN_TRIES,
-                self.logs_were_rotated,
-                pod_obj=pod_obj,
-                gz_logs_num=gz_logs_num,
-                current_log_file_size=current_log_file_size,
-                logs_dir=logs_dir,
-            ):
-                if result:
-                    break
-            log.info("The logs were rotated correctly")
-        except TimeoutExpiredError:
-            assert False, "The logs were not rotated"
+        # check on the first pod
+        pod_obj = csi_interface_plugin_pod_objs[0]
+        self.pump_logs_and_wait_for_rotation(pod_obj, logs_dir, log_file_name)
+        self.pump_logs_and_wait_for_rotation(pod_obj, logs_dir, ADDTIONAL_CSI_LOG_FILE)

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -1,24 +1,24 @@
 import time
 import logging
+import pytest
 
 from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
-from ocs_ci.framework.pytest_customization.marks import brown_squad, tier1
+from ocs_ci.framework.pytest_customization.marks import brown_squad, tier2
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
 log = logging.getLogger(__name__)
-LOGS_DIR_NAME = "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/node-plugin/"
-CURRENT_LOG_NAME = "csi-cephfsplugin.log"
+
 WAIT_FOR_ROTATION_TIME = 1200  # seconds
 SLEEP_BETWEEN_TRIES = 300  # seconds
 
 
 @brown_squad
-@tier1
+@tier2
 class TestPodsCsiLogRotation(BaseTest):
-    def logs_were_rotated(self, pod_obj, gz_logs_num, current_log_file_size):
+    def logs_were_rotated(self, pod_obj, gz_logs_num, current_log_file_size, logs_dir):
         """
         Gets csi pod log files details
 
@@ -26,12 +26,13 @@ class TestPodsCsiLogRotation(BaseTest):
             pod_obj (obj): Pod which log files should be investigated
             gz_logs_num (int): Last known number of compressed log files
             current_log_file_size (int) Last known size of the current log file
+            logs_dir (str): Logs directory on this pod
 
         Returns:
             bool: True if the log files were rotated
         """
         new_gz_logs_num, new_current_log_file_size = pod_obj.get_logs_details_on_pod(
-            LOGS_DIR_NAME
+            logs_dir
         )
         log.info(
             f"New number of gz = {new_gz_logs_num}, new current log file size = {new_current_log_file_size}"
@@ -45,36 +46,58 @@ class TestPodsCsiLogRotation(BaseTest):
             # and the new one has smaller size
             return new_current_log_file_size < current_log_file_size
 
-    def test_pods_csi_log_rotation(self):
+    @pytest.mark.parametrize(
+        argnames=["pod_selector", "logs_dir", "log_file_name"],
+        argvalues=[
+            pytest.param(
+                *[
+                    "csi-cephfsplugin",
+                    "/var/lib/rook/openshift-storage.cephfs.csi.ceph.com/log/node-plugin/",
+                    "csi-cephfsplugin.log",
+                ],
+            ),
+            pytest.param(
+                *[
+                    "csi-rbdplugin",
+                    "/var/lib/rook/openshift-storage.rbd.csi.ceph.com/log/node-plugin/",
+                    "csi-rbdplugin.log",
+                ],
+            ),
+        ],
+    )
+    def test_pods_csi_log_rotation(self, pod_selector, logs_dir, log_file_name):
         """
         Tests that the log files on pod are rotated correctly
+
+        Args:
+            pod_selector (str): Pod selector according to the interface
+            logs_dir (str): Logs directory on this pod
+            log_file_name (str) Current log file name
 
         """
         log.info("Testing logs rotation on pod.")
 
-        csi_cephfsplugin_pod_objs = pod.get_all_pods(
-            namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=["csi-cephfsplugin"]
+        csi_interface_plugin_pod_objs = pod.get_all_pods(
+            namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=[pod_selector]
         )
 
         # check on the first pod
-        pod_obj = csi_cephfsplugin_pod_objs[0]
-        gz_logs_num, current_log_file_size = pod_obj.get_logs_details_on_pod(
-            LOGS_DIR_NAME
-        )
+        pod_obj = csi_interface_plugin_pod_objs[0]
+        gz_logs_num, current_log_file_size = pod_obj.get_logs_details_on_pod(logs_dir)
         log.info(
             f"Number of compressed logs = {gz_logs_num}, current log file size = {current_log_file_size}"
         )
 
         # pump current log file size
         pod_obj.exec_cmd_on_pod(
-            command=f"-- truncate -s 560M {LOGS_DIR_NAME + CURRENT_LOG_NAME}",
+            command=f"-- truncate -s 560M {logs_dir + log_file_name}",
             container_name="log-collector",
             out_yaml_format=False,
             shell=True,
         )
 
         time.sleep(10)  # wait fo make sure that the truncate had its effect
-        current_log_file_size = pod_obj.get_logs_details_on_pod(LOGS_DIR_NAME)[1]
+        current_log_file_size = pod_obj.get_logs_details_on_pod(logs_dir)[1]
         log.info(f"Current log file size after truncate is = {current_log_file_size}")
 
         try:
@@ -85,6 +108,7 @@ class TestPodsCsiLogRotation(BaseTest):
                 pod_obj=pod_obj,
                 gz_logs_num=gz_logs_num,
                 current_log_file_size=current_log_file_size,
+                logs_dir=logs_dir,
             ):
                 if result:
                     break

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -5,7 +5,12 @@ import pytest
 from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
-from ocs_ci.framework.pytest_customization.marks import brown_squad, tier2
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    tier2,
+    post_upgrade,
+    skipif_ocs_version,
+)
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
@@ -16,6 +21,8 @@ SLEEP_BETWEEN_TRIES = 300  # seconds
 
 
 @brown_squad
+@post_upgrade
+@skipif_ocs_version("<4.17")
 @tier2
 class TestPodsCsiLogRotation(BaseTest):
     def check_for_log_rotation_successful(


### PR DESCRIPTION
This PR contains a new functional test tests/functional/pod_and_daemons/test_csi_logs_rotation.py to verify proper log rotation of csi plugin pods in openshift-storage namespace ( https://issues.redhat.com/browse/OCSQE-2149 ) 