### PR TITLE
Expand user in path for traceback log

### DIFF
--- a/ocs_ci/framework/main.py
+++ b/ocs_ci/framework/main.py
@@ -22,7 +22,7 @@ def signal_term_handler(sig, frame):
     print(f"Got SIGTERM: {sig}")
     if hasattr(framework.config, "RUN"):
         framework.config.RUN["aborted"] = True
-    logdir = framework.config.RUN["log_dir"]
+    logdir = os.path.expanduser(framework.config.RUN["log_dir"])
     with open(os.path.join(logdir, "traceback.log"), "w") as f:
         faulthandler.dump_traceback(file=f)
     global kill_counter


### PR DESCRIPTION
Fixes issue:
```
2024-10-11 16:49:22      def signal_term_handler(sig, frame):
2024-10-11 16:49:22          print(f"Got SIGTERM: {sig}")
2024-10-11 16:49:22          if hasattr(framework.config, "RUN"):
2024-10-11 16:49:22              framework.config.RUN["aborted"] = True
2024-10-11 16:49:22          logdir = framework.config.RUN["log_dir"]
2024-10-11 16:49:22  >       with open(os.path.join(logdir, "traceback.log"), "w") as f:
2024-10-11 16:49:22  E       FileNotFoundError: [Errno 2] No such file or directory: '~/current-cluster-dir/logs/traceback.log'
2024-10-11 16:49:22  
2024-10-11 16:49:22  ocs_ci/framework/main.py:26: FileNotFoundError

```