### PR TITLE
include rgw existance test case for cloud platforms

### DIFF
--- a/tests/functional/object/rgw/conftest.py
+++ b/tests/functional/object/rgw/conftest.py
@@ -20,6 +20,8 @@ def pytest_collection_modifyitems(items):
         or version.get_semantic_ocs_version_from_config() < version.VERSION_4_5
     ):
         for item in items.copy():
+            if "object/rgw/test_rgw_pod_existence.py" in str(item.fspath):
+                continue
             if "object/rgw" in str(item.fspath):
                 log.debug(
                     f"Test {item} is removed from the collected items"


### PR DESCRIPTION
test_rgw_pod_existence.py test case make sure we don't have rgw existance in cloud platforms

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)