### PR TITLE
Fix test TestDebugVerbosityOfCephComponents

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -116,3 +116,8 @@ class ODFCliRunner:
             "ERROR",
         ), f"log level {log_level} is not supported"
         return self.run_command(f" operator rook set ROOK_LOG_LEVEL {log_level}")
+
+    def run_set_ceph_log_level(self, service: str, log_level: str, subsystem: str):
+        return self.run_command(
+            f" set ceph log-level {service} {subsystem} {log_level}"
+        )

--- a/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
+++ b/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from ocs_ci.helpers.helpers import odf_cli_set_log_level, get_ceph_log_level
+from ocs_ci.helpers.helpers import get_ceph_log_level
 from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import tier1
@@ -12,6 +12,10 @@ log = logging.getLogger(__name__)
 @brown_squad
 @tier1
 class TestDebugVerbosityOfCephComponents:
+    @pytest.fixture(autouse=True)
+    def setup(self, odf_cli_setup):
+        self.odf_cli_runner = odf_cli_setup
+
     @pytest.mark.polarion_id("OCS-5417")
     @pytest.mark.parametrize(
         argnames=["service", "subsystem"],
@@ -39,10 +43,14 @@ class TestDebugVerbosityOfCephComponents:
 
             if log_level > 99:
                 with pytest.raises(CommandFailed):
-                    odf_cli_set_log_level(service, log_level, subsystem)
+                    self.odf_cli_runner.run_set_ceph_log_level(
+                        service, log_level, subsystem
+                    )
                     log.info("Log level beyond the limit was not set as expected.")
             else:
-                assert odf_cli_set_log_level(service, log_level, subsystem)
+                assert self.odf_cli_runner.run_set_ceph_log_level(
+                    service, log_level, subsystem
+                )
                 assert log_level == get_ceph_log_level(
                     service, subsystem
                 ), f"Log level set by ODF CLI ({log_level}) does not match with the value reported by Ceph"


### PR DESCRIPTION
- [x] use generic odf-cli class in the test
- [x] Fixed binary download
- [x] Fix issue [10444](https://github.com/red-hat-storage/ocs-ci/issues/10444)