### PR TITLE
Fix configmap name to whitelist metrics needed for ACM observability on DR monitoring dashboard 

### DIFF
--- a/ocs_ci/templates/DR/observability-metrics-configmap.yaml
+++ b/ocs_ci/templates/DR/observability-metrics-configmap.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mp-custom-allowlist
+  name: observability-metrics-custom-allowlist
   namespace: open-cluster-management-observability
 data:
   metrics_list.yaml: |


### PR DESCRIPTION
Since the existing configmap name is incorrect, metrics are not getting whitelisted and data is not reflecting on the graphs.