### PR TITLE
fix test_obc_creation_and_deletion test

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -2,6 +2,9 @@ import random
 import string
 import time
 
+from retry import retry
+from selenium.common.exceptions import TimeoutException
+
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
@@ -162,6 +165,16 @@ class ObjectBucketClaimsTab(ObjectStorage, CreateResourceForm):
         self.do_click(self.generic_locators["submit_form"])
 
         return ResourcePage()
+
+    @retry(TimeoutException, tries=3, delay=5, backoff=1)
+    def select_bucket_class(self, bucketclass):
+        """
+        Select a bucket class from the dropdown
+        """
+        logger.info("Select BucketClass")
+        self.do_click(self.obc_loc["bucketclass_dropdown"])
+        self.do_send_keys(self.obc_loc["bucketclass_text_field"], bucketclass)
+        self.do_click(self.generic_locators["first_dropdown_option"])
 
     def select_openshift_storage_default_project(self):
         """

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -156,10 +156,7 @@ class ObjectBucketClaimsTab(ObjectStorage, CreateResourceForm):
         )
 
         if bucketclass:
-            logger.info("Select BucketClass")
-            self.do_click(self.obc_loc["bucketclass_dropdown"])
-            self.do_send_keys(self.obc_loc["bucketclass_text_field"], bucketclass)
-            self.do_click(self.generic_locators["first_dropdown_option"])
+            self.select_bucket_class(bucketclass)
 
         logger.info("Create OBC")
         self.do_click(self.generic_locators["submit_form"])


### PR DESCRIPTION
Fix issue with this stack trace:

```
self = ObjectBucketClaimsTab Web Page
locator = ('input[placeholder="Select BucketClass"],input[class="pf-c-form-control pf-m-search"], input[id="search-bar"], input[data-test="name-filter-input"]', 'css selector')
text = 'noobaa-default-bucket-class', timeout = 30


def do_send_keys(self, locator, text, timeout=30):
    """
    Send text to element on OpenShift Console

    locator (tuple): (GUI element needs to operate on (str), type (By))
    text (str): Send text to element
    timeout (int): Looks for a web element repeatedly until timeout (sec) happens.

    """
    # wait for page fully loaded only if an element was not located
    # prevents needless waiting and frequent crushes on ODF Overview page,
    # when metrics and alerts frequently updated
    if not self.get_elements(locator):
        self.page_has_loaded()
    wait = WebDriverWait(self.driver, timeout)
    try:
        if (
            version.get_semantic_version(get_ocp_version(), True)
            <= version.VERSION_4_11
        ):
            element = wait.until(
                ec.presence_of_element_located((locator[1], locator[0]))
            )
        else:

          element = wait.until(
                ec.visibility_of_element_located((locator[1], locator[0]))
            )

ocs_ci/ocs/ui/base_ui.py:287: 



self = <selenium.webdriver.support.wait.WebDriverWait (session="ebc617a4f8f2236e09eb507e8939c85c")>
method = <selenium.webdriver.support.expected_conditions.visibility_of_element_located object at 0x7f04d8380f40>
message = ''


def until(self, method, message=''):
    """Calls the method provided with the driver as an argument until the \
    return value is not False."""
    screen = None
    stacktrace = None

    end_time = time.time() + self._timeout
    while True:
        try:
            value = method(self._driver)
            if value:
                return value
        except self._ignored_exceptions as exc:
            screen = getattr(exc, 'screen', None)
            stacktrace = getattr(exc, 'stacktrace', None)
        time.sleep(self._poll)
        if time.time() > end_time:
            break

  raise TimeoutException(message, screen, stacktrace)
E       selenium.common.exceptions.TimeoutException: Message:



venv/lib64/python3.9/site-packages/selenium/webdriver/support/wait.py:80: TimeoutException


During handling of the above exception, another exception occurred:


self = <test_mcg_ui.TestObcUserInterface object at 0x7f050f6ab4c0>
setup_ui_class_factory = <function setup_ui_class_factory..factory at 0x7f04d8556430>
storageclass = 'openshift-storage.noobaa.io'
bucketclass = 'noobaa-default-bucket-class', delete_via = 'Actions'
verify_ob_removal = True


@ui
@tier1
@runs_on_provider
@bugzilla("2097772")
@pytest.mark.parametrize(
    argnames=["storageclass", "bucketclass", "delete_via", "verify_ob_removal"],
    argvalues=[
        pytest.param(
            *[
                "openshift-storage.noobaa.io",
                "noobaa-default-bucket-class",
                "three_dots",
                True,
            ],
            marks=[pytest.mark.polarion_id("OCS-4698"), mcg],
        ),
        pytest.param(
            *[
                "openshift-storage.noobaa.io",
                "noobaa-default-bucket-class",
                "Actions",
                True,
            ],
            marks=[pytest.mark.polarion_id("OCS-2542"), mcg],
        ),
        pytest.param(
            *[
                "ocs-storagecluster-ceph-rgw",
                None,
                "three_dots",
                True,
            ],
            marks=[pytest.mark.polarion_id("OCS-4845"), on_prem_platform_required],
        ),
    ],
)
def test_obc_creation_and_deletion(
    self,
    setup_ui_class_factory,
    storageclass,
    bucketclass,
    delete_via,
    verify_ob_removal,
):
    """
    Test creation and deletion of an OBC via the UI

    The test covers BZ #2097772 Introduce tooltips for contextual information
    The test covers BZ #2175685 RGW OBC creation via the UI is blocked by "Address form errors to proceed"
    """
    setup_ui_class_factory()

    obc_name = create_unique_resource_name(
        resource_description="ui", resource_type="obc"
    )

    obc_ui_obj = ObjectBucketClaimsTab()

    if (
        config.DEPLOYMENT["external_mode"]
        and storageclass == "ocs-storagecluster-ceph-rgw"
    ):
        storageclass = "ocs-external-storagecluster-ceph-rgw"

  obc_page = obc_ui_obj.create_obc_ui(obc_name, storageclass, bucketclass)

tests/functional/object/mcg/ui/test_mcg_ui.py:362: 



ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py:158: in create_obc_ui
    self.do_send_keys(self.obc_loc["bucketclass_text_field"], bucketclass)



self = ObjectBucketClaimsTab Web Page
locator = ('input[placeholder="Select BucketClass"],input[class="pf-c-form-control pf-m-search"], input[id="search-bar"], input[data-test="name-filter-input"]', 'css selector')
text = 'noobaa-default-bucket-class', timeout = 30


def do_send_keys(self, locator, text, timeout=30):
    """
    Send text to element on OpenShift Console

    locator (tuple): (GUI element needs to operate on (str), type (By))
    text (str): Send text to element
    timeout (int): Looks for a web element repeatedly until timeout (sec) happens.

    """
    # wait for page fully loaded only if an element was not located
    # prevents needless waiting and frequent crushes on ODF Overview page,
    # when metrics and alerts frequently updated
    if not self.get_elements(locator):
        self.page_has_loaded()
    wait = WebDriverWait(self.driver, timeout)
    try:
        if (
            version.get_semantic_version(get_ocp_version(), True)
            <= version.VERSION_4_11
        ):
            element = wait.until(
                ec.presence_of_element_located((locator[1], locator[0]))
            )
        else:
            element = wait.until(
                ec.visibility_of_element_located((locator[1], locator[0]))
            )
        element.send_keys(text)
    except TimeoutException as e:
        self.take_screenshot()
        self.copy_dom()
        logger.error(e)

      raise TimeoutException(
            f"Failed to find the element ({locator[1]},{locator[0]})"
        )
E           selenium.common.exceptions.TimeoutException: Message: Failed to find the element (css selector,input[placeholder="Select BucketClass"],input[class="pf-c-form-control pf-m-search"], input[id="search-bar"], input[data-test="name-filter-input"])

```