### PR TITLE
<CLOSED LOOP>bz-2302575 Attachment of OBCs to/from the deployment

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1055,6 +1055,9 @@ FIO_S3 = os.path.join(TEMPLATE_FIO_DIR, "config_s3.fio")
 # Openshift infra yamls:
 RSYNC_POD_YAML = os.path.join(TEMPLATE_OPENSHIFT_INFRA_DIR, "rsync-pod.yaml")
 MACHINESET_YAML = os.path.join(TEMPLATE_OPENSHIFT_INFRA_DIR, "machine-set.yaml")
+DEPLOYMENT_CONF_OBC_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "deployment-conf-obc.yaml"
+)
 MACHINESET_YAML_AZURE = os.path.join(
     TEMPLATE_OPENSHIFT_INFRA_DIR, "machineset-azure.yaml"
 )

--- a/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/object_bucket_claims_tab.py
@@ -184,3 +184,74 @@ class ObjectBucketClaimsTab(ObjectStorage, CreateResourceForm):
         self.select_project(config.ENV_DATA["cluster_namespace"])
 
         self.delete_resource(delete_via, obc_name)
+
+    def attach_deployment_to_obc_ui(self, deployment, obc_name):
+        """
+        Attach deployment to obc
+
+        Args:
+            deployment (str): Name of the deployment to attach with
+            obc_name (str): Name of the obc to be attached
+
+        """
+        self.navigate_object_bucket_claims_page()
+        self.select_openshift_storage_default_project()
+        logger.info("Click on search bar")
+        self.do_click(self.generic_locators["search_resource_field"])
+        logger.info("Clear existing text from search bar if any")
+        self.do_clear(self.generic_locators["search_resource_field"])
+        logger.info("Enter the obc to be searched")
+        self.do_send_keys(self.generic_locators["search_resource_field"], text=obc_name)
+        logger.info("Click on the kebab menu")
+        self.do_click(self.obc_loc["kebab_action"])
+        logger.info("Select attach to deployment option")
+        self.do_click(self.obc_loc["attach_to_deployment"])
+        logger.info("Click on the dropdown and search for the existing deployment")
+        odf_deployment_dropdown = self.find_an_element_by_xpath(
+            "/html/body/div[5]/div/div/div/div/div[2]/button"
+        )
+        self.driver.execute_script("arguments[0].click();", odf_deployment_dropdown)
+        self.do_click(self.obc_loc["search_bar"])
+        self.do_send_keys(self.obc_loc["search_bar"], text=deployment)
+        logger.info("Select the deployment and attach it")
+        self.do_click(self.obc_loc["odf_resource_item"])
+        self.do_click(self.obc_loc["attach"])
+
+    def attach_obc_to_deployment_ui(self, deployment, obc_name):
+        """
+        Attach obc to deployment
+
+        Args:
+            deployment (str): Name of the deployment
+            obc_name (str): Name of the obc to attach
+
+        """
+        self.navigate_deployments_page()
+        self.select_openshift_storage_default_project()
+        logger.info("Click on search bar")
+        self.do_click(self.generic_locators["search_resource_field"])
+        logger.info("Clear existing text from search bar if any")
+        self.do_clear(self.generic_locators["search_resource_field"])
+        logger.info("Enter the obc to be searched")
+        self.do_send_keys(
+            self.generic_locators["search_resource_field"], text=deployment
+        )
+        logger.info("Click the kebab menu")
+        self.do_click(self.obc_loc["kebab_action"])
+        logger.info("Add Storage")
+        self.do_click(self.obc_loc["add_storage"])
+        logger.info("Check ObjectBucketClaim option")
+        self.do_click(self.obc_loc["obc_radiobutton"])
+        logger.info("Select use existing claim")
+        self.do_click(self.obc_loc["use_existing_claim"])
+        logger.info("Click on the dropdown menu")
+        obc_dropdown = self.find_an_element_by_xpath(
+            "/html[1]/body[1]/div[2]/div[1]/div[1]/div[1]/div[1]/div[1]/div[1]/main[1]"
+            "/div[1]/div[1]/div[1]/div[1]/div[1]/section[1]/div[1]/form[1]/div[1]/div[1]/div[2]/div[2]/div[1]/button[1]"
+        )
+        self.driver.execute_script("arguments[0].click();", obc_dropdown)
+        logger.info("Search for the existing obc and click on it")
+        self.do_click(self.obc_loc["search_bar"])
+        self.do_send_keys(self.obc_loc["search_bar"], text=obc_name)
+        self.do_click(self.obc_loc["odf_resource_item"])
+        self.do_click(self.generic_locators["submit_form"])

--- a/ocs_ci/ocs/ui/page_objects/page_navigator.py
+++ b/ocs_ci/ocs/ui/page_objects/page_navigator.py
@@ -348,6 +348,15 @@ class PageNavigator(BaseUI):
         self.choose_expanded_mode(mode=True, locator=self.page_nav["Workloads"])
         self.do_click(locator=self.page_nav["Pods"], enable_screenshot=False)
 
+    def navigate_deployments_page(self):
+        """
+        Navigate to Deployments Page
+
+        """
+        logger.info("Navigate to Deployments Page")
+        self.choose_expanded_mode(mode=True, locator=self.page_nav["Workloads"])
+        self.do_click(locator=self.page_nav["Deployments"], enable_screenshot=False)
+
     def navigate_block_pool_page(self):
         """
         Navigate to block pools page

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -502,6 +502,43 @@ obc = {
         'button[data-test="namespacestore-create-button"]',
         By.CSS_SELECTOR,
     ),
+    "kebab_action": (
+        "//button[contains(@class, 'pf-v5-c-menu-toggle pf-m-plain')]",
+        By.XPATH,
+    ),
+    "attach_to_deployment": (
+        'button[id="ATTACH_DEPLOYMENT"]',
+        By.CSS_SELECTOR,
+    ),
+    "attach": (
+        'button[data-test="attach-action"]',
+        By.CSS_SELECTOR,
+    ),
+    "odf_deployment_dropdown": (".text-muted", By.CSS_SELECTOR),
+    "search_bar": (
+        'input[id="search-bar"], input[value=""]',
+        By.CSS_SELECTOR,
+    ),
+    "odf_resource_item": (
+        'a[data-test="dropdown-menu-item-link"]',
+        By.CSS_SELECTOR,
+    ),
+    "add_storage": (
+        'li[data-test-action="Add storage"]',
+        By.CSS_SELECTOR,
+    ),
+    "obc_radiobutton": (
+        'input[name="ObjectBucketClaim"]',
+        By.CSS_SELECTOR,
+    ),
+    "use_existing_claim": (
+        'input[id="exists"]',
+        By.CSS_SELECTOR,
+    ),
+    "select_obc_dropdown": (
+        'button[id="class="pf-v5-c-dropdown__toggle"]',
+        By.CSS_SELECTOR,
+    ),
 }
 
 pvc = {
@@ -700,6 +737,7 @@ page_nav = {
     "dashboards_page": ("Dashboards", By.LINK_TEXT),
     "Workloads": ("//button[text()='Workloads']", By.XPATH),
     "Pods": ("Pods", By.LINK_TEXT),
+    "Deployments": ("Deployments", By.LINK_TEXT),
     "quickstarts": ('a[href="/quickstart"]', By.CSS_SELECTOR),
     "block_pool_link": (
         'a[data-test-id="horizontal-link-Block Pools"]',

--- a/ocs_ci/templates/ocs-deployment/deployment-conf-obc.yaml
+++ b/ocs_ci/templates/ocs-deployment/deployment-conf-obc.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: obc-deployment
+  namespace: openshift-storage
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: obc-deployment
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: obc-deployment
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
+        imagePullPolicy: Always
+        name: container
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/tests/functional/ui/test_attach_obc_in_two_ways_ui.py
+++ b/tests/functional/ui/test_attach_obc_in_two_ways_ui.py
@@ -1,0 +1,63 @@
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import black_squad
+from ocs_ci.ocs.ui.page_objects.object_bucket_claims_tab import ObjectBucketClaimsTab
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    ui,
+    bugzilla,
+    polarion_id,
+    tier1,
+    ignore_leftovers,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@ui
+@tier1
+@black_squad
+@bugzilla("2302575")
+@polarion_id("OCS-6267")
+@ignore_leftovers
+class TestAttachOBCTwoWaysUi(ManageTest):
+    """
+    1. Validate if the user is able to attach deployment to the existing OBC
+    2. Validate if the user is able to attach OBC to the existing deployment
+
+    """
+
+    def test_attach_obcs_and_deployments(
+        self, setup_ui_class, obc_deployment_factory_fixture, bucket_factory
+    ):
+        """
+        Test Steps consists of 2 workflows to attach storage
+
+        flow 1:
+        1) click Storage → Object Storage → Object Bucket Claims.
+        2) Click the Action menu (⋮) next to the OBC you created.
+        3) From the drop-down menu, select Attach to Deployment.
+        4) Select the desired deployment from the Deployment Name list,
+        5) then click Attach.
+
+        flow 2:
+        1) Click Workloads -> Deployments ->
+        2) Click for the Action menu (⋮) next to the Deployment you created
+        3) From the drop-down menu, select Add storage.
+        4) Select ObjectBucketClaim and use existing claim
+        5) Click the desired OBC and click create
+
+        """
+        obc_obj = ObjectBucketClaimsTab()
+        deployment = obc_deployment_factory_fixture(number_of_deployments=2)
+        obcs = bucket_factory(
+            amount=2,
+            interface="OC",
+        )
+        assert obc_obj.attach_deployment_to_obc_ui(
+            deployment=deployment[0]["metadata"]["name"], obc_name=obcs[0].name
+        ), "Failed to attach deployment to obc"
+        assert obc_obj.attach_obc_to_deployment_ui(
+            deployment=deployment[1]["metadata"]["name"], obc_name=obcs[1].name
+        ), "Failed to attach obc to the deployment"


### PR DESCRIPTION
Automation of BZ https://bugzilla.redhat.com/show_bug.cgi?id=2302575

        Test Steps consists of 2 workflows to attach storage
        flow 1:
        1) click Storage → Object Storage → Object Bucket Claims.
        2) Click the Action menu (⋮) next to the OBC you created.
        3) From the drop-down menu, select Attach to Deployment.
        4) Select the desired deployment from the Deployment Name list,
        5) then click Attach.
        flow 2:
        1) Click Workloads -> Deployments ->
        2) Click for the Action menu (⋮) next to the Deployment you created
        3) From the drop-down menu, select Add storage.
        4) Select ObjectBucketClaim and use existing claim
        5) Click the desired OBC and click create