### PR TITLE
add bz number to test_stop_start_node_validate_topology

### DIFF
--- a/tests/cross_functional/ui/test_odf_topology.py
+++ b/tests/cross_functional/ui/test_odf_topology.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ui,
     skipif_hci_provider_or_client,
     runs_on_provider,
+    jira,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import get_nodes, get_node_names
@@ -254,7 +255,7 @@ class TestODFTopology(object):
             )
 
     @tier4a
-    @bugzilla("2322173")
+    @jira("DFBUGS-418")
     @bugzilla("2242132")
     @ignore_leftovers
     @polarion_id("OCS-4905")

--- a/tests/cross_functional/ui/test_odf_topology.py
+++ b/tests/cross_functional/ui/test_odf_topology.py
@@ -254,6 +254,7 @@ class TestODFTopology(object):
             )
 
     @tier4a
+    @bugzilla("2322173")
     @bugzilla("2242132")
     @ignore_leftovers
     @polarion_id("OCS-4905")


### PR DESCRIPTION
stop failures upon missing CephNodeDown alert  