### PR TITLE
Add the noobaa-core SA to the trust policy for STS deployments

### DIFF
--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2546,6 +2546,7 @@ def create_and_attach_sts_role():
     namespace = config.ENV_DATA.get("cluster_namespace")
     service_account_name_1 = "noobaa"
     service_account_name_2 = "noobaa-endpoint"
+    service_account_name_3 = "noobaa-core"
     aws_account_id = aws.get_caller_identity()
     resp = exec_cmd("oc get authentication cluster -ojson")
     auth_cluster_dict = json.loads(resp.stdout)
@@ -2568,6 +2569,7 @@ def create_and_attach_sts_role():
                         f"{oidc_provider}:sub": [
                             f"system:serviceaccount:{namespace}:{service_account_name_1}",
                             f"system:serviceaccount:{namespace}:{service_account_name_2}",
+                            f"system:serviceaccount:{namespace}:{service_account_name_3}",
                         ]
                     }
                 },


### PR DESCRIPTION
4.17 STS deployments requires an addition to the associated AWS Role, `system:serviceaccount:openshift-storage:noobaa-core`: 
```
{
    “Version”: “2012-10-17",
    “Statement”: [
        {
            “Effect”: “Allow”,
            “Principal”: {
                “Federated”: “arn:aws:iam::123456789123:oidc-provider/mybucket-oidc.s3.us-east-2.amazonaws.com”
            },
            “Action”: “sts:AssumeRoleWithWebIdentity”,
            “Condition”: {
                “StringEquals”: {
                    “mybucket-oidc.s3.us-east-2.amazonaws.com:sub”: [
                        “system:serviceaccount:openshift-storage:noobaa”,
                        “system:serviceaccount:openshift-storage:noobaa-endpoint”,
                        “system:serviceaccount:openshift-storage:noobaa-core” 
                    ]
                }
            }
        }
    ]
}
```

See https://bugzilla.redhat.com/show_bug.cgi?id=2322124 for more details.