### PR TITLE
fix external_cluster_helpers.upload_rgw_cert_ca

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -167,6 +167,7 @@ class ExternalCluster(object):
             remote_rgw_cert_ca_path,
             self.user,
             self.password,
+            self.ssh_key,
         )
         return remote_rgw_cert_ca_path
 


### PR DESCRIPTION
- add missing `key_file` parameter