### PR TITLE
Fix guaranteed bucket logs tests

### DIFF
--- a/ocs_ci/ocs/resources/bucket_logging_manager.py
+++ b/ocs_ci/ocs/resources/bucket_logging_manager.py
@@ -472,7 +472,7 @@ class BucketLoggingManager:
         # The http_status field is 102 for intent logs
         if check_intent:
             for op, obj in expected_ops:
-                expected_ops_set.append(f"{op}-{obj}-102")
+                expected_ops_set.add(f"{op}-{obj}-102")
 
         # Parse the logs into a set of strings with the same format
         logs_set = {

--- a/tests/functional/object/mcg/test_bucket_logs.py
+++ b/tests/functional/object/mcg/test_bucket_logs.py
@@ -248,7 +248,7 @@ class TestBucketLogs(MCGTest):
         expected_ops = []
         for obj_key in obj_keys:
             for op in ["PUT", "DELETE", "GET", "HEAD"]:
-                expected_ops.append((op, f"{source_bucket}/{obj_key}"))
+                expected_ops.append((op, f"/{source_bucket}/{obj_key}"))
 
         assert blm.verify_logs_integrity(
             bucket_logs, expected_ops, check_intent=True


### PR DESCRIPTION
A small fix to `ocs-ci/tests/functional/object/mcg/test_bucket_logs.py::TestBucketLogs::test_bucket_logs_integrity`:

- Fix the use of `append` to `add` on the `expected_ops_set` at `BucketLoggingManager:verify_logs_integrity`
- Update the expectation for incoming logs to start with a forward-slash at `test_bucket_logs_integrity`