### PR TITLE
get also kubectl binary when extracting oc from image

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1127,6 +1127,10 @@ def get_openshift_client(
                     "No backups exist and new binary was unable to be verified."
                 )
 
+        if not os.path.exists("kubectl"):
+            log.info("Creating kubectl link to oc binary.")
+            os.link("oc", "kubectl")
+
         # return to the previous working directory
         os.chdir(previous_dir)
 


### PR DESCRIPTION
- `kubectl` binary is used by some 3rd party scripts (e.g. ACM deployment script)
- in case that downloading of openshift-client from openshift-release-artifacts doesn't work and `oc` binary is extracted from an image, we have to specifically extract also the `kubectl` binary