### PR TITLE
set IBM cloud managed OSD size to minimum requirement

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1756,7 +1756,15 @@ class Deployment(object):
         ocs_version = version.get_semantic_ocs_version_from_config()
         disable_noobaa = config.COMPONENTS.get("disable_noobaa", False)
         noobaa_cmd_arg = f"--param ignoreNoobaa={str(disable_noobaa).lower()}"
-        device_size = int(config.ENV_DATA.get("device_size", defaults.DEVICE_SIZE))
+        device_size = int(
+            config.ENV_DATA.get("device_size", defaults.DEVICE_SIZE_IBM_CLOUD_MANAGED)
+        )
+        if device_size < defaults.DEVICE_SIZE_IBM_CLOUD_MANAGED:
+            logger.warning(
+                f"OSD size provided is less than the minimum required 512Gi."
+                f" Setting OSD device size to {defaults.DEVICE_SIZE_IBM_CLOUD_MANAGED}"
+            )
+            device_size = defaults.DEVICE_SIZE_IBM_CLOUD_MANAGED
         osd_size_arg = f"--param osdSize={device_size}Gi"
         cmd = (
             f"ibmcloud ks cluster addon enable openshift-data-foundation --cluster {clustername} -f --version "

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -37,6 +37,7 @@ PROMETHEUS_ROUTE = "prometheus-k8s"
 
 # Default device size in Gigs
 DEVICE_SIZE = 100
+DEVICE_SIZE_IBM_CLOUD_MANAGED = 512
 
 OCS_OPERATOR_NAME = "ocs-operator"
 ODF_OPERATOR_NAME = "odf-operator"


### PR DESCRIPTION
set IBM cloud managed OSD size to minimum requirement 512Gi

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)