### PR TITLE
4.15 automation [OCS-5576]: Fail prometheus and verify that the alert still exists after recovering it.

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
@@ -21,6 +21,7 @@ from ocs_ci.ocs.resources.pod import (
     get_operator_pods,
     get_osd_pods,
     delete_pods,
+    get_prometheus_pods,
 )
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.utility import prometheus
@@ -211,6 +212,21 @@ class TestMdsMemoryAlerts(E2ETest):
             if osd_pod_running_node_name == active_mds_node_name:
                 delete_pods([pod_obj])
         log.info("Validating the alert after the OSD pod restart")
+        assert self.active_mds_alert_values(threading_lock)
+
+    @pytest.mark.polarion_id("OCS-5576")
+    def test_mds_cache_alert_after_recovering_prometheus_from_failures(
+        self, run_metadata_io_with_cephfs, threading_lock
+    ):
+        """
+        This test function verifies the mds cache alert and fails the prometheus.
+        It also verifies the alert after recovering prometheus from failures.
+
+        """
+        assert self.active_mds_alert_values(threading_lock)
+        log.info("Bring down the prometheus")
+        list_of_prometheus_pod_obj = get_prometheus_pods()
+        delete_pods(list_of_prometheus_pod_obj)
         assert self.active_mds_alert_values(threading_lock)
 
     @pytest.mark.polarion_id("OCS-5577")


### PR DESCRIPTION
Automated below test case:

[RHSTOR-4798](https://issues.redhat.com//browse/RHSTOR-4798) Fail prometheus and verify that the alert still exists after recovering it.

1. Deploy cluster and run workloads.
2. Run IO pods to fill MDS memory to 95%.
3. Now, the alert is triggered to increase memory limit. Don't take any action on the alert.
4. Fail Prometheus, and recover it.
5. Make sure that the alert is still firing after recovering Prometheus.