### PR TITLE
[Red Squad] - Remove obsolete and redundant tests

### DIFF
--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -48,22 +48,6 @@ class TestBucketCreationAndDeletion(MCGTest):
                 ],
             ),
             pytest.param(
-                *[100, "S3", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1823"),
-                ],
-            ),
-            pytest.param(
-                *[1000, "S3", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1824"),
-                ],
-            ),
-            pytest.param(
                 *[3, "OC", None],
                 marks=[
                     tier1,
@@ -104,22 +88,6 @@ class TestBucketCreationAndDeletion(MCGTest):
                 ],
             ),
             pytest.param(
-                *[100, "CLI", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1825"),
-                ],
-            ),
-            pytest.param(
-                *[1000, "CLI", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1828"),
-                ],
-            ),
-            pytest.param(
                 *[
                     1,
                     "OC",
@@ -148,15 +116,11 @@ class TestBucketCreationAndDeletion(MCGTest):
         ],
         ids=[
             "3-S3-DEFAULT-BACKINGSTORE",
-            "100-S3-DEFAULT-BACKINGSTORE",
-            "1000-S3-DEFAULT-BACKINGSTORE",
             "3-OC-DEFAULT-BACKINGSTORE",
             "10-OC-DEFAULT-BACKINGSTORE",
             "100-OC-DEFAULT-BACKINGSTORE",
             "1000-OC-DEFAULT-BACKINGSTORE",
             "3-CLI-DEFAULT-BACKINGSTORE",
-            "100-CLI-DEFAULT-BACKINGSTORE",
-            "1000-CLI-DEFAULT-BACKINGSTORE",
             "1-OC-PVPOOL",
             "1-CLI-PVPOOL",
         ],

--- a/tests/functional/object/mcg/test_bucket_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_deletion.py
@@ -76,13 +76,6 @@ class TestBucketDeletion(MCGTest):
             ),
             pytest.param(
                 *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
                     "CLI",
                     {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 ],
@@ -106,7 +99,6 @@ class TestBucketDeletion(MCGTest):
             "OC-AWS",
             "OC-AZURE",
             "OC-GCP",
-            "OC-IBMCOS",
             "CLI-IBMCOS",
             "CLI-AWS-STS",
         ],

--- a/tests/functional/object/mcg/test_multicloud.py
+++ b/tests/functional/object/mcg/test_multicloud.py
@@ -84,7 +84,7 @@ class TestMultiCloud(MCGTest):
             "IBMCOS-OC-1",
         ],
     )
-    def test_multicloud_backingstore_deletion(
+    def deprecated_test_multicloud_backingstore_deletion(
         self, backingstore_factory, backingstore_tup
     ):
         """

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -86,7 +86,9 @@ class TestNamespace(MCGTest):
         ],
     )
     @pytest.mark.polarion_id("OCS-2255")
-    def test_namespace_store_creation_crd(self, namespace_store_factory, nss_tup):
+    def deprecated_test_namespace_store_creation_crd(
+        self, namespace_store_factory, nss_tup
+    ):
         """
         Test namespace store creation using the MCG CRDs.
         """

--- a/tests/functional/object/mcg/test_object_integrity.py
+++ b/tests/functional/object/mcg/test_object_integrity.py
@@ -64,10 +64,6 @@ class TestObjectIntegrity(MCGTest):
                 marks=[tier1, skipif_disconnected_cluster],
             ),
             pytest.param(
-                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1, skipif_disconnected_cluster],
-            ),
-            pytest.param(
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -92,7 +88,6 @@ class TestObjectIntegrity(MCGTest):
             "AZURE-OC-1",
             "GCP-OC-1",
             "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
             "AWS-OC-Cache",
         ],
     )
@@ -130,7 +125,7 @@ class TestObjectIntegrity(MCGTest):
 
     @pytest.mark.polarion_id("OCS-1945")
     @tier2
-    def test_empty_file_integrity(
+    def deprecated_test_empty_file_integrity(
         self, mcg_obj, awscli_pod, bucket_factory, test_directory_setup
     ):
         """

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -18,7 +18,6 @@ from ocs_ci.framework.testlib import (
     MCGTest,
     tier1,
     tier2,
-    acceptance,
     performance,
 )
 from ocs_ci.utility.utils import exec_nb_db_query
@@ -102,45 +101,6 @@ class TestBucketIO(MCGTest):
         argnames="interface,bucketclass_dict",
         argvalues=[
             pytest.param(
-                *["S3", None],
-                marks=[tier1, acceptance],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {
-                        "interface": "OC",
-                        "backingstore_dict": {"aws": [(1, "eu-central-1")]},
-                    },
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"azure": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *["OC", {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}}],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "CLI",
-                    {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
                 *[
                     "OC",
                     {"interface": "OC", "backingstore_dict": {"rgw": [(1, None)]}},
@@ -156,12 +116,6 @@ class TestBucketIO(MCGTest):
             ),
         ],
         ids=[
-            "DEFAULT-BACKINGSTORE",
-            "AWS-OC-1",
-            "AZURE-OC-1",
-            "GCP-OC-1",
-            "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
             "RGW-OC-1",
             "RGW-CLI-1",
         ],
@@ -221,10 +175,6 @@ class TestBucketIO(MCGTest):
                 marks=[tier1],
             ),
             pytest.param(
-                {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
-            ),
-            pytest.param(
                 {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 marks=[tier1],
             ),
@@ -234,7 +184,6 @@ class TestBucketIO(MCGTest):
             "AWS-OC-1",
             "AZURE-OC-1",
             "GCP-OC-1",
-            "IBMCOS-OC-1",
             "IBMCOS-CLI-1",
         ],
     )
@@ -292,10 +241,6 @@ class TestBucketIO(MCGTest):
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 marks=[tier1],
             ),
-            pytest.param(
-                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
-            ),
         ],
         ids=[
             "DEFAULT-BACKINGSTORE",
@@ -303,7 +248,6 @@ class TestBucketIO(MCGTest):
             "AZURE-OC-1",
             "GCP-OC-1",
             "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
         ],
     )
     def test_mcg_data_compression(
@@ -333,7 +277,9 @@ class TestBucketIO(MCGTest):
     @tier2
     @performance
     @skip_inconsistent
-    def test_data_reduction_performance(self, mcg_obj, awscli_pod, bucket_factory):
+    def depricated_test_data_reduction_performance(
+        self, mcg_obj, awscli_pod, bucket_factory
+    ):
         """
         Test data reduction performance
         """
@@ -474,7 +420,6 @@ class TestBucketIO(MCGTest):
         change_the_noobaa_log_level,
         test_directory_setup,
     ):
-
         """
         This test checks if the activity logs are being logged
         in the activitylogs table for every object upload and

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -277,7 +277,7 @@ class TestBucketIO(MCGTest):
     @tier2
     @performance
     @skip_inconsistent
-    def depricated_test_data_reduction_performance(
+    def deprecated_test_data_reduction_performance(
         self, mcg_obj, awscli_pod, bucket_factory
     ):
         """

--- a/tests/functional/upgrade/test_noobaa.py
+++ b/tests/functional/upgrade/test_noobaa.py
@@ -183,7 +183,7 @@ def test_start_upgrade_mcg_io(mcg_workload_job):
 @bugzilla("1874243")
 @mcg
 @red_squad
-def test_upgrade_mcg_io(mcg_workload_job):
+def deprecated_test_upgrade_mcg_io(mcg_workload_job):
     """
     Confirm that there is MCG workload job running after upgrade.
     """

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -136,7 +136,7 @@ def test_pod_log_after_upgrade():
 @pytest.mark.polarion_id("OCS-2666")
 @mcg
 @red_squad
-def test_noobaa_service_mon_after_ocs_upgrade():
+def deprecated_test_noobaa_service_mon_after_ocs_upgrade():
     """
     Verify 'noobaa-service-monitor' does not exist after OCS upgrade.
 


### PR DESCRIPTION
As part of the initiative to remove obsolete or redundant tests in OCS-CI, it was agreed that Red Squad will remove the tests from the following spreadsheet: https://url.corp.redhat.com/6011089

