### PR TITLE
Update disk cleanup to remove metadata at different locations

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1349,6 +1349,12 @@ def clean_disk(worker, namespace=constants.DEFAULT_NAMESPACE):
             logger.info(out)
             out = ocp_obj.exec_oc_debug_cmd(
                 node=worker.name,
+                cmd_list=[f"blockdev --rereadpt /dev/{lsblk_device['name']}"],
+                namespace=namespace,
+            )
+            logger.info(out)
+            out = ocp_obj.exec_oc_debug_cmd(
+                node=worker.name,
                 cmd_list=[f"sgdisk --zap-all /dev/{lsblk_device['name']}"],
                 namespace=namespace,
             )
@@ -1378,6 +1384,12 @@ def clean_disk(worker, namespace=constants.DEFAULT_NAMESPACE):
             out = ocp_obj.exec_oc_debug_cmd(
                 node=worker.name,
                 cmd_list=dd_cmd2,
+                namespace=namespace,
+            )
+            logger.info(out)
+            out = ocp_obj.exec_oc_debug_cmd(
+                node=worker.name,
+                cmd_list=[f"dd if=/dev/zero of=\"/dev/{lsblk_device['name']}\""],
                 namespace=namespace,
             )
             logger.info(out)

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1391,6 +1391,7 @@ def clean_disk(worker, namespace=constants.DEFAULT_NAMESPACE):
                 node=worker.name,
                 cmd_list=[f"dd if=/dev/zero of=\"/dev/{lsblk_device['name']}\""],
                 namespace=namespace,
+                timeout=5400,
             )
             logger.info(out)
 


### PR DESCRIPTION
With 4.18, bluestore replicates its metadata at multiple places on the device (at 0 / 1Gb / 10Gb / 100Gb / 1000Gb etc).
This has to be cleaned up before installing any other version of ODF once 4.18 is installed on the same machines.