### PR TITLE
Ceph health check during teardown after node restart for test_detach_attach_worker_volume

### DIFF
--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -35,7 +35,7 @@ from ocs_ci.utility.aws import AWSTimeoutException
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.ocs import osd_operations
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +129,9 @@ class TestDiskFailures(ManageTest):
             logger.info("Deleting the ocs-osd-removal pods")
             pod_names = get_pod_name_by_pattern("ocs-osd-removal-job-")
             delete_pods(get_pod_objs(pod_names))
+
+            assert ceph_health_check(), "Ceph cluster health is not OK"
+            logger.info("Ceph cluster health is OK during teardown")
 
         request.addfinalizer(finalizer)
 


### PR DESCRIPTION
Fixes #10884 

Since node restart code already exists in the teardown which would mount the disk on the node (if not already), by checking ceph health we are allowing the cluster to recover. If ceph recovers, other tests would not be skipped and we would have progress on the currently skipped tests.