### PR TITLE
Test that the external mode script from the CSV is equal to the external mode script from the configmap

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -10,6 +10,7 @@ import tempfile
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import defaults, constants
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import (
     ExternalClusterExporterRunFailed,
     ExternalClusterRGWEndPointMissing,
@@ -34,8 +35,6 @@ from ocs_ci.utility.utils import (
     download_file,
     wait_for_machineconfigpool_status,
 )
-from ocs_ci.ocs.ocp import OCP
-
 
 logger = logging.getLogger(__name__)
 
@@ -488,7 +487,7 @@ def get_exporter_script_from_configmap():
 
     """
     logger.info(
-        f"Get the exporter script for configmap: {constants.EXTERNAL_CLUSTER_SCRIPT_CONFIG}"
+        f"Get the exporter script from configmap: {constants.EXTERNAL_CLUSTER_SCRIPT_CONFIG}"
     )
     config_map = OCP(
         kind="configmap",

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -9,7 +9,7 @@ import re
 import tempfile
 
 from ocs_ci.framework import config
-from ocs_ci.ocs import defaults
+from ocs_ci.ocs import defaults, constants
 from ocs_ci.ocs.exceptions import (
     ExternalClusterExporterRunFailed,
     ExternalClusterRGWEndPointMissing,
@@ -34,6 +34,8 @@ from ocs_ci.utility.utils import (
     download_file,
     wait_for_machineconfigpool_status,
 )
+from ocs_ci.ocs.ocp import OCP
+
 
 logger = logging.getLogger(__name__)
 
@@ -476,16 +478,35 @@ class ExternalCluster(object):
         return True if user in rgw_user_list else False
 
 
-def generate_exporter_script():
+def get_exporter_script_from_configmap():
     """
-    Generates exporter script for RHCS cluster
+    Get the external exporter script from the configmap.
+    From 4.18 we can get the external exporter script from the configmap
 
     Returns:
-        str: path to the exporter script
+        str: The exporter script from the configmap
 
     """
-    logger.info("generating external exporter script")
-    # generate exporter script through packagemanifest
+    logger.info(
+        f"Get the exporter script for configmap: {constants.EXTERNAL_CLUSTER_SCRIPT_CONFIG}"
+    )
+    config_map = OCP(
+        kind="configmap",
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.EXTERNAL_CLUSTER_SCRIPT_CONFIG,
+    )
+    exporter_script = config_map.data.get("data", {}).get("script")
+    return exporter_script
+
+
+def get_exporter_script_from_csv():
+    """
+    Get the external exporter script from the csv.
+
+    Returns:
+        str: The exporter script from the csv
+
+    """
     ocs_version = version.get_semantic_ocs_version_from_config()
     operator_name = defaults.ROOK_CEPH_OPERATOR
 
@@ -500,19 +521,59 @@ def generate_exporter_script():
     csv_name = get_csv_name_start_with_prefix(
         csv_prefix=operator_name, namespace=config.ENV_DATA["cluster_namespace"]
     )
+    exporter_script = ""
     for each_csv in ocs_operator_data["status"]["channels"]:
         if each_csv["currentCSV"] == csv_name:
             logger.info(f"exporter script for csv: {each_csv['currentCSV']}")
             if ocs_version >= version.VERSION_4_16:
-                encoded_script = each_csv["currentCSVDesc"]["annotations"][
+                exporter_script = each_csv["currentCSVDesc"]["annotations"][
                     "externalClusterScript"
                 ]
             else:
-                encoded_script = each_csv["currentCSVDesc"]["annotations"][
+                exporter_script = each_csv["currentCSVDesc"]["annotations"][
                     "external.features.ocs.openshift.io/export-script"
                 ]
             break
 
+    return exporter_script
+
+
+def get_exporter_script(use_configmap=False):
+    """
+    Get the external exporter script encoded
+
+    Args:
+        use_configmap (bool): If True, we will use the configmap to get the external
+            exporter script. Otherwise, if False, we will get it from the CSV.
+
+    Returns:
+        str: The external exporter script
+
+    """
+    logger.info("Get the external exporter script")
+    if use_configmap:
+        # From 4.18 we can get the external exporter script from the configmap
+        exporter_script = get_exporter_script_from_configmap()
+    else:
+        exporter_script = get_exporter_script_from_csv()
+
+    return exporter_script
+
+
+def generate_exporter_script(use_configmap=False):
+    """
+    Generates exporter script for RHCS cluster
+
+    Args:
+        use_configmap (bool): If True, we will use the configmap to get the external
+            exporter script. Otherwise, if False, we will get it from the CSV.
+
+    Returns:
+        str: path to the exporter script
+
+    """
+    logger.info("Generating external exporter script")
+    encoded_script = get_exporter_script(use_configmap)
     # decode the exporter script and write to file
     external_script = decode(encoded_script)
     external_cluster_details_exporter = tempfile.NamedTemporaryFile(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -239,6 +239,7 @@ OPERATOR_KIND = "Operator"
 DRIVER = "Driver"
 IMAGECONTENTSOURCEPOLICY_KIND = "ImageContentSourcePolicy"
 NOOBAA_ACCOUNT = "NoobaaAccount"
+EXTERNAL_CLUSTER_SCRIPT_CONFIG = "rook-ceph-external-cluster-script-config"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"

--- a/tests/functional/external_mode/test_external_mode_script.py
+++ b/tests/functional/external_mode/test_external_mode_script.py
@@ -3,6 +3,7 @@ import filecmp
 
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
+    external_mode_required,
     post_ocs_upgrade,
 )
 from ocs_ci.framework.testlib import (
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 @brown_squad
 @tier1
 @skipif_ocs_version("<4.18")
+@external_mode_required
 class TestExternalModeScript(ManageTest):
     """
     Test module related to the external mode script

--- a/tests/functional/external_mode/test_external_mode_script.py
+++ b/tests/functional/external_mode/test_external_mode_script.py
@@ -1,0 +1,39 @@
+import logging
+import filecmp
+
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_ocs_version,
+    post_ocs_upgrade,
+)
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    brown_squad,
+    tier1,
+)
+from ocs_ci.deployment.helpers.external_cluster_helpers import generate_exporter_script
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@tier1
+@skipif_ocs_version("<4.18")
+class TestExternalModeScript(ManageTest):
+    """
+    Test module related to the external mode script
+
+    """
+
+    @post_ocs_upgrade
+    def test_csv_script_equal_to_configmap_script(self):
+        """
+        Test that the external mode script from the CSV is equal to the external mode script
+        from the configmap.
+
+        """
+        file_name1 = generate_exporter_script(use_configmap=False)
+        file_name2 = generate_exporter_script(use_configmap=True)
+        assert filecmp.cmp(
+            file_name1, file_name2, shallow=False
+        ), f"Files {file_name1} and {file_name2} are different"
+        log.info(f"The files {file_name1} and {file_name2} are equal")


### PR DESCRIPTION
From 4.18, we can get the external exporter script from the configmap. However, we still have the option to get the external exporter script from the CSV. We test in the PR that both options are valid and equal.
See more details in the feature: https://issues.redhat.com/browse/RHSTOR-6397.