### PR TITLE
WIP IPI disk removal when cluster is destroyed

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1604,6 +1604,14 @@ class VSPHEREIPI(VSPHEREBASE):
             template_folder = get_infra_id(self.cluster_path)
         else:
             logger.warning("metadata.json file doesn't exist.")
+        vsphere = VSPHERE(
+            config.ENV_DATA["vsphere_server"],
+            config.ENV_DATA["vsphere_user"],
+            config.ENV_DATA["vsphere_password"],
+        )
+        all_vms = vsphere.get_vms_by_string(config.ENV_DATA["cluster_name"])
+        for vm in all_vms:
+            vsphere.remove_disks_with_main_disk(vm)
 
         try:
             run_cmd(

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -818,6 +818,36 @@ class VSPHERE(object):
             if hasattr(device.backing, "fileName") and device.unitNumber != 0
         ]
 
+    def remove_disks_with_main_disk(self, vm):
+        """
+        Removes all disks for a VM
+
+        Args:
+            vm (vim.VirtualMachine): VM instance
+
+        """
+        extra_disk_unit_numbers = self.get_used_unit_number_with_all_unit_number(vm)
+        if extra_disk_unit_numbers:
+            for each_disk_unit_number in extra_disk_unit_numbers:
+                self.remove_disk(vm=vm, identifier=each_disk_unit_number)
+
+    def get_used_unit_number_with_all_unit_number(self, vm):
+        """
+        Gets the used unit numbers including main disk for a VM
+
+        Args:
+            vm (vim.VirtualMachine): VM instance
+
+        Returns:
+            list: list of unit numbers
+
+        """
+        return [
+            device.unitNumber
+            for device in vm.config.hardware.device
+            if hasattr(device.backing, "fileName")
+        ]
+
     def check_folder_exists(self, name, cluster, dc):
         """
         Checks whether folder exists in Templates
@@ -1742,3 +1772,16 @@ class VSPHERE(object):
         volume_path = vstorage_object.config.backing.filePath
         logger.debug(f"File path for volume {volume_id} is `{volume_path}`")
         return volume_path
+
+    def get_vms_by_string(self, str_to_match):
+        content = self.get_content
+        container = content.rootFolder
+        view_type = [vim.VirtualMachine]
+        recursive = True
+
+        container_view = content.viewManager.CreateContainerView(
+            container, view_type, recursive
+        )
+        vms = [vm for vm in container_view.view if str_to_match in vm.name]
+        container_view.Destroy()
+        return vms


### PR DESCRIPTION
It seems when we do destroy IPI cluster we use openshift-install destroy cluster which leaves all vmdk files in the datastore. 
This PR should resolve the problem.