### PR TITLE
Renamed deprecated_test_start_pre_upgrade_pod_io under Brown squad

### DIFF
--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -51,7 +51,9 @@ def test_storage_pods_running(multiregion_mirror_setup_session):
 @pre_upgrade
 @brown_squad
 @ignore_leftovers
-def test_start_pre_upgrade_pod_io(pause_cluster_load, pre_upgrade_pods_running_io):
+def deprecated_test_start_pre_upgrade_pod_io(
+    pause_cluster_load, pre_upgrade_pods_running_io
+):
     """
     Confirm that there are pods created before upgrade.
     """


### PR DESCRIPTION
As part of the initiative "Efficiency: Identify and remove redundant/unwanted tests - within and across the ocs-ci test suites" 
Test `test_start_pre_upgrade_pod_io` is being marked as deprecated after discussing it with @fbalak. 
Quoting him for future reference:-
```
There is currently run io in bg during upgrade that conflicted with those tests. It would be good to refactor io workloads for upgrade but until there is such initiative it can be removed.
```

Refer spreadsheet- https://url.corp.redhat.com/63d158c