### PR TITLE
Add new production configuration for job intransit encryption

### DIFF
--- a/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_6w_intransit_encryption.yaml
+++ b/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_6w_intransit_encryption.yaml
@@ -1,0 +1,16 @@
+---
+# This config is suppose to work on most of DCs we have.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'ipi'
+  worker_replicas: 6
+  master_replicas: 3
+  master_num_cpus: '16'
+  master_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  in_transit_encryption: true
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-4690'


### PR DESCRIPTION
qe-trigger-vsphere-ipi-intransit-encryption-1az-rhcos-vsan-3m-6w

Related ticket:
https://issues.redhat.com/browse/OCSQE-2963