### PR TITLE
add skipp collecting data on CP for managed_cp. test_capacity_recovery

### DIFF
--- a/ocs_ci/ocs/perftests.py
+++ b/ocs_ci/ocs/perftests.py
@@ -96,7 +96,10 @@ class PASTest(BaseTest):
 
         self.get_osd_info()
 
-        self.get_node_info(node_type="master")
+        if config.ENV_DATA.get("deployment_type") != constants.MANAGED_CP_DEPL_TYPE:
+            self.get_node_info(node_type="master")
+        else:
+            log.info("No master nodes in a managed control plane clusters")
         self.get_node_info(node_type="worker")
 
     def teardown(self):


### PR DESCRIPTION
We don't have access to master nodes in a managed control plane clusters, such as ROSA HCP.
We need to stop collecting data from master nodes, to prevent index errors while listing data from these nodes;

It affects tests/functional/pv/pv_services/test_ceph_capacity_recovery.py::TestCephCapacityRecovery::test_capacity_recovery

[2024-11-23T08:19:40.087Z]     def get_node_info(self, node_type="master"):
[2024-11-23T08:19:40.087Z]         """
[2024-11-23T08:19:40.087Z]         Getting node type hardware information and update the main environment
[2024-11-23T08:19:40.087Z]         dictionary.
[2024-11-23T08:19:40.087Z]     
[2024-11-23T08:19:40.087Z]         Args:
[2024-11-23T08:19:40.087Z]             node_type (str): the node type to collect data about,
[2024-11-23T08:19:40.087Z]               can be : master / worker - the default is master
[2024-11-23T08:19:40.087Z]     
[2024-11-23T08:19:40.087Z]         """
[2024-11-23T08:19:40.087Z]         if node_type == "master":
[2024-11-23T08:19:40.087Z]             nodes = node.get_master_nodes()
[2024-11-23T08:19:40.087Z]         elif node_type == "worker":
[2024-11-23T08:19:40.087Z]             nodes = node.get_worker_nodes()
[2024-11-23T08:19:40.087Z]         else:
[2024-11-23T08:19:40.087Z]             log.warning(f"Node type ({node_type}) is invalid")
[2024-11-23T08:19:40.087Z]             return
[2024-11-23T08:19:40.087Z]     
[2024-11-23T08:19:40.087Z]         oc_cmd = OCP(namespace=config.ENV_DATA["cluster_namespace"])
[2024-11-23T08:19:40.087Z]         self.environment[f"{node_type}_nodes_num"] = len(nodes)
[2024-11-23T08:19:40.087Z]         self.environment[f"{node_type}_nodes_cpu_num"] = oc_cmd.exec_oc_debug_cmd(
[2024-11-23T08:19:40.087Z] >           node=nodes[0],
[2024-11-23T08:19:40.087Z]             cmd_list=["lscpu | grep '^CPU(s):' | awk '{print $NF}'"],
[2024-11-23T08:19:40.087Z]         ).rstrip()
[2024-11-23T08:19:40.087Z] [1m[31mE       IndexError: list index out of range[0m
[2024-11-23T08:19:40.087Z] 
[2024-11-23T08:19:40.087Z] [1m[31m/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/ocs/perftests.py[0m:258: IndexError
[2024-11-23T08:19:40.087Z] 
