### PR TITLE
fetch storage ns from config

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1089,7 +1089,7 @@ class Deployment(object):
         # patch OLM YAML with the namespace
         olm_ns_op_group_data = list(templating.load_yaml(constants.OLM_YAML, True))
 
-        if self.namespace != constants.OPENSHIFT_STORAGE_NAMESPACE:
+        if self.namespace != config.ENV_DATA["cluster_namespace"]:
 
             for cr in olm_ns_op_group_data:
                 if cr["kind"] == "Namespace":

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -923,7 +923,7 @@ class HostedODF(HypershiftHostedOCP):
              str: onboarding token key
         """
         secret_ocp_obj = ocp.OCP(
-            kind=constants.SECRET, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            kind=constants.SECRET, namespace=config.ENV_DATA["cluster_namespace"]
         )
 
         key = (
@@ -1174,7 +1174,7 @@ class HostedODF(HypershiftHostedOCP):
         """
         Get the provider address
         """
-        ocp = OCP(namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        ocp = OCP(namespace=config.ENV_DATA["cluster_namespace"])
         storage_provider_endpoint = ocp.exec_oc_cmd(
             (
                 "get storageclusters.ocs.openshift.io -o jsonpath={'.items[*].status.storageProviderEndpoint'}"
@@ -1224,7 +1224,7 @@ class HostedODF(HypershiftHostedOCP):
         else:
             ocp = OCP(
                 kind=constants.STORAGECLAIM,
-                namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                namespace=config.ENV_DATA["cluster_namespace"],
                 cluster_kubeconfig=self.cluster_kubeconfig,
             )
 
@@ -1311,7 +1311,7 @@ class HostedODF(HypershiftHostedOCP):
         else:
             ocp = OCP(
                 kind=constants.STORAGECLAIM,
-                namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                namespace=config.ENV_DATA["cluster_namespace"],
                 cluster_kubeconfig=self.cluster_kubeconfig,
             )
 

--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -271,7 +271,7 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
         if self.ocs_version >= version.VERSION_4_16:
             # Validate native client is created in openshift-storage namespace
             self.deployment.wait_for_csv(
-                self.ocs_client_operator, constants.OPENSHIFT_STORAGE_NAMESPACE
+                self.ocs_client_operator, config.ENV_DATA["cluster_namespace"]
             )
 
             # Verify native storageclient is created successfully

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -614,7 +614,7 @@ def create_ceph_block_pool(
 
 
 def create_ceph_file_system(
-    cephfs_name=None, label=None, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+    cephfs_name=None, label=None, namespace=config.ENV_DATA["cluster_namespace"]
 ):
     """
     Create a Ceph file system

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1090,7 +1090,7 @@ def check_pv_backingstore_status(
 
 def check_pv_backingstore_type(
     backingstore_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
-    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    namespace=config.ENV_DATA["cluster_namespace"],
 ):
     """
     check if existing pv backing store is in READY state

--- a/ocs_ci/ocs/replica_one.py
+++ b/ocs_ci/ocs/replica_one.py
@@ -13,7 +13,6 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.constants import (
     DEFAULT_CEPHBLOCKPOOL,
     DEFAULT_STORAGE_CLUSTER,
-    OPENSHIFT_STORAGE_NAMESPACE,
     OSD_APP_LABEL,
     CEPHBLOCKPOOL,
     STORAGECLASS,
@@ -141,7 +140,9 @@ def scaledown_deployment(deployment_names: list[str]) -> None:
 
     """
     log.info("Starts Scaledown deployments")
-    deployment_obj = OCP(kind=DEPLOYMENT, namespace=OPENSHIFT_STORAGE_NAMESPACE)
+    deployment_obj = OCP(
+        kind=DEPLOYMENT, namespace=config.ENV_DATA["cluster_namespace"]
+    )
     for deployment in deployment_names:
         deployment_obj.exec_oc_cmd(f"scale deployment {deployment} --replicas=0")
         log.info(f"scaling to 0: {deployment}")
@@ -221,7 +222,7 @@ def modify_replica1_osd_count(new_osd_count):
     """
     storage_cluster = OCP(kind=STORAGECLUSTER, name=DEFAULT_STORAGE_CLUSTER)
     storage_cluster.exec_oc_cmd(
-        f"patch storagecluster {DEFAULT_STORAGE_CLUSTER} -n {OPENSHIFT_STORAGE_NAMESPACE} "
+        f"patch storagecluster {DEFAULT_STORAGE_CLUSTER} -n {config.ENV_DATA['cluster_namespace']} "
         f'--type json --patch \'[{{"op": "replace", "path": '
         f'"/spec/managedResources/cephNonResilientPools/count", "value": {new_osd_count} }}]\''
     )

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -792,7 +792,7 @@ def get_ceph_tools_pod(skip_creating_pod=False, wait=False, namespace=None):
         cluster_kubeconfig = config.ENV_DATA.get("provider_kubeconfig", "")
 
     if cluster_kubeconfig:
-        namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+        namespace = config.ENV_DATA["cluster_namespace"]
     else:
         namespace = namespace or config.ENV_DATA["cluster_namespace"]
 
@@ -1566,7 +1566,7 @@ def run_io_and_verify_mount_point(pod_obj, bs="10M", count="950"):
 
 def get_pods_having_label(
     label,
-    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    namespace=config.ENV_DATA["cluster_namespace"],
     retry=0,
     cluster_config=None,
     statuses=None,
@@ -3716,7 +3716,7 @@ def get_mon_pod_by_pvc_name(pvc_name: str):
     return Pod(**mon_pod_ocp)
 
 
-def get_debug_pods(debug_nodes, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE):
+def get_debug_pods(debug_nodes, namespace=config.ENV_DATA["cluster_namespace"]):
     """
     Get debug pods created for the nodes in debug
 
@@ -3741,7 +3741,7 @@ def get_debug_pods(debug_nodes, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
 
 
 def wait_for_pods_deletion(
-    label, timeout=120, sleep=5, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+    label, timeout=120, sleep=5, namespace=config.ENV_DATA["cluster_namespace"]
 ):
     """
     Wait for the pods with particular label to be deleted

--- a/ocs_ci/ocs/resources/stretchcluster.py
+++ b/ocs_ci/ocs/resources/stretchcluster.py
@@ -5,6 +5,7 @@ import time
 
 from datetime import timedelta
 
+from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.node import get_nodes_having_label, get_ocs_nodes, get_node_objs
 from ocs_ci.ocs.resources.ocs import OCS
@@ -542,7 +543,7 @@ class StretchCluster(OCS):
         Reset connection scores for all the mon's
 
         """
-        mon_pods = get_mon_pods(namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
         for pod_obj in mon_pods:
             mon_pod_id = get_mon_pod_id(pod_obj)
             cmd = f"ceph daemon mon.{mon_pod_id} connection scores reset"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from ocs_ci.deployment.cnv import CNVInstaller
 from ocs_ci.deployment import factory as dep_factory
 from ocs_ci.deployment.helpers.hypershift_base import HyperShiftBase
 from ocs_ci.deployment.hosted_cluster import HostedClients
-from ocs_ci.framework import config as ocsci_config, Config
+from ocs_ci.framework import config as ocsci_config, Config, config
 import ocs_ci.framework.pytest_customization.marks
 from ocs_ci.framework.pytest_customization.marks import (
     deployment,
@@ -8026,7 +8026,7 @@ def scale_noobaa_resources(request):
         storagecluster_obj = OCP(
             kind=constants.STORAGECLUSTER,
             resource_name=constants.DEFAULT_STORAGE_CLUSTER,
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            namespace=config.ENV_DATA["cluster_namespace"],
         )
 
         scale_endpoint_pods_param = (
@@ -8343,7 +8343,7 @@ def scale_noobaa_db_pod_pv_size(request):
                 get_pods_having_label(
                     label=label,
                     retry=5,
-                    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                    namespace=config.ENV_DATA["cluster_namespace"],
                 )
             )
 
@@ -8368,7 +8368,7 @@ def scale_noobaa_db_pod_pv_size(request):
                 get_pods_having_label(
                     label=label,
                     retry=5,
-                    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                    namespace=config.ENV_DATA["cluster_namespace"],
                 )
             )
 

--- a/tests/cross_functional/ui/test_odf_topology.py
+++ b/tests/cross_functional/ui/test_odf_topology.py
@@ -123,9 +123,7 @@ class TestODFTopology(object):
             interface=constants.CEPHBLOCKPOOL,
             access_mode=constants.ACCESS_MODE_RWO,
             status=constants.STATUS_BOUND,
-            project=OCP(
-                kind="Project", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
-            ),
+            project=OCP(kind="Project", namespace=config.ENV_DATA["cluster_namespace"]),
         )
         pod_obj = helpers.create_pod(
             interface_type=constants.CEPHBLOCKPOOL,

--- a/tests/functional/object/mcg/test_bucket_delete_using_obc_creds.py
+++ b/tests/functional/object/mcg/test_bucket_delete_using_obc_creds.py
@@ -2,6 +2,7 @@ import base64
 import boto3
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     bugzilla,
@@ -15,7 +16,6 @@ from ocs_ci.ocs.resources.bucket_policy import HttpResponseParser
 from ocs_ci.ocs.ocp import OCP
 import botocore.exceptions as boto3exception
 from ocs_ci.ocs.constants import (
-    OPENSHIFT_STORAGE_NAMESPACE,
     SECRET,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -41,7 +41,7 @@ def test_bucket_delete_using_obc_creds(mcg_obj, bucket_factory):
     logger.info("Creating OBC")
     bucket = bucket_factory(amount=1, interface="OC")[0].name
     # Fetch OBC credentials
-    secret_ocp_obj = OCP(kind=SECRET, namespace=OPENSHIFT_STORAGE_NAMESPACE)
+    secret_ocp_obj = OCP(kind=SECRET, namespace=config.ENV_DATA["cluster_namespace"])
     obc_secret_obj = secret_ocp_obj.get(bucket)
     obc_access_key = base64.b64decode(
         obc_secret_obj.get("data").get("AWS_ACCESS_KEY_ID")

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     tier4a,
@@ -200,7 +201,7 @@ class TestMultiRegion(MCGTest):
         bucket = bucket_factory(1, "OC", bucketclass=bucket_class)[0]
         bucketclass_obj = ocp.OCP(
             kind=constants.BUCKETCLASS,
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            namespace=config.ENV_DATA["cluster_namespace"],
             resource_name=bucket.bucketclass.name,
         )
         # Patch bucket class to update placement from "Spread" to "Mirror"

--- a/tests/functional/object/mcg/test_noobaa_db_pg_expansion.py
+++ b/tests/functional/object/mcg/test_noobaa_db_pg_expansion.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.utility import utils
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
@@ -40,7 +41,7 @@ class TestNoobaaDbPgExpansion:
 
         try:
             ceph_toolbox = get_ceph_tools_pod(
-                namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+                namespace=config.ENV_DATA["cluster_namespace"]
             )
         except (AssertionError, CephToolBoxNotFoundException) as ex:
             raise CommandFailed(ex)
@@ -74,7 +75,7 @@ class TestNoobaaDbPgExpansion:
 
         # Verify default backingstore is in ready state or not
         default_bs = OCP(
-            kind=constants.BACKINGSTORE, namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            kind=constants.BACKINGSTORE, namespace=config.ENV_DATA["cluster_namespace"]
         ).get(resource_name=constants.DEFAULT_NOOBAA_BACKINGSTORE)
         assert (
             default_bs["status"]["phase"] == constants.STATUS_READY

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -373,7 +373,7 @@ class TestPvPool:
         # the backingstore has reached Rejected state
         pv_bs_obj = OCP(
             kind=constants.BACKINGSTORE,
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            namespace=config.ENV_DATA["cluster_namespace"],
             resource_name=pv_backingstore.name,
         )
         assert pv_bs_obj.wait_for_resource(

--- a/tests/functional/object/mcg/test_s3_regenerate_creds.py
+++ b/tests/functional/object/mcg/test_s3_regenerate_creds.py
@@ -1,5 +1,6 @@
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     bugzilla,
@@ -9,7 +10,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     mcg,
 )
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
 
@@ -37,14 +37,14 @@ def test_s3_regenerate_creds(mcg_obj, project_factory):
     logger.info(f"Creating OBC {obc_name}")
     mcg_obj.exec_mcg_cmd(
         cmd=f"obc create {obc_name} --app-namespace {proj_name}",
-        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        namespace=config.ENV_DATA["cluster_namespace"],
     )
     ocp_obj.get(resource_name=obc_name)
 
     # regenerate credential
     mcg_obj.exec_mcg_cmd(
         cmd=f"obc regenerate {obc_name} --app-namespace {proj_name}",
-        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        namespace=config.ENV_DATA["cluster_namespace"],
         use_yes=True,
     )
     logger.info("Successfully regenerated s3 credentials")

--- a/tests/functional/object/mcg/test_virtual_hosted_buckets.py
+++ b/tests/functional/object/mcg/test_virtual_hosted_buckets.py
@@ -1,9 +1,8 @@
 import logging
 
-
+from ocs_ci.framework import config
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
     write_random_objects_in_pod,
@@ -45,7 +44,7 @@ class TestVirtualHostedBuckets:
         # create a route for the bucket create above
         s3_route_data = OCP(
             kind="route",
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            namespace=config.ENV_DATA["cluster_namespace"],
             resource_name="s3",
         ).get()
         host_base = f'{s3_route_data["spec"]["host"]}'

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -2,9 +2,9 @@ import time
 import logging
 import pytest
 
+from ocs_ci.framework import config
 from ocs_ci.framework.testlib import BaseTest
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.constants import OPENSHIFT_STORAGE_NAMESPACE
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     tier2,
@@ -161,7 +161,7 @@ class TestPodsCsiLogRotation(BaseTest):
 
         """
         csi_interface_plugin_pod_objs = pod.get_all_pods(
-            namespace=OPENSHIFT_STORAGE_NAMESPACE, selector=[pod_selector]
+            namespace=config.ENV_DATA["cluster_namespace"], selector=[pod_selector]
         )
 
         # check on the first pod

--- a/tests/functional/storageclass/test_replica1.py
+++ b/tests/functional/storageclass/test_replica1.py
@@ -25,7 +25,6 @@ from ocs_ci.ocs.constants import (
     VOLUME_MODE_BLOCK,
     CSI_RBD_RAW_BLOCK_POD_YAML,
     DEFALUT_DEVICE_CLASS,
-    OPENSHIFT_STORAGE_NAMESPACE,
 )
 from ocs_ci.helpers.helpers import create_pvc
 from ocs_ci.utility.utils import validate_dict_values, compare_dictionaries
@@ -92,7 +91,9 @@ class TestReplicaOne:
 
         for osd in osd_names:
             pod = OCP(
-                kind=POD, namespace=OPENSHIFT_STORAGE_NAMESPACE, resource_name=osd
+                kind=POD,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=osd,
             )
             pod.wait_for_resource(condition=STATUS_RUNNING, column="STATUS")
 
@@ -103,7 +104,9 @@ class TestReplicaOne:
         yield
         log.info("Teardown function called")
         storage_cluster = replica1_setup
-        cephblockpools = OCP(kind=CEPHBLOCKPOOL, namespace=OPENSHIFT_STORAGE_NAMESPACE)
+        cephblockpools = OCP(
+            kind=CEPHBLOCKPOOL, namespace=config.ENV_DATA["cluster_namespace"]
+        )
         set_non_resilient_pool(storage_cluster, enable=False)
         delete_replica_1_sc()
         log.info("StorageClass Deleted")


### PR DESCRIPTION
- address multiple issues when we rely on "openshift-storage" namespace existence.
- default config has this value set to "openshift-storage" but storage namespace is custom
- prevent failures on ROSA clusters, where "openshift" and "redhat" prefixes are not allowed