### PR TITLE
[4.17] Add advanced Guaranteed Bucket Logs to `test_bucket_logs.py`

### DIFF
--- a/ocs_ci/ocs/resources/bucket_logging_manager.py
+++ b/ocs_ci/ocs/resources/bucket_logging_manager.py
@@ -414,27 +414,34 @@ class BucketLoggingManager:
             )
             raise
 
-    def get_bucket_logs(self, logs_bucket, source_bucket=None):
+    def get_bucket_logs(self, logs_bucket, source_bucket=None, prefix=""):
         """
         Get the logs from a logs bucket
 
         Args:
             logs_bucket(str): Name of the logs bucket
             source_bucket(str|optional): Filter logs by source bucket
+            prefix(str|optional): Look for logs under a specific prefix
 
         Returns:
             list: A list of dicts, deserialized from the JSON logs
         """
         logs = []
+
         log_objs = list_objects_from_bucket(
+            prefix=f"{prefix}/" if prefix else "",
             pod_obj=self.awscli_pod,
             target=logs_bucket,
             s3_obj=self.mcg_obj,
         )
+
+        s3_bucket_path = f"s3://{logs_bucket}"
+        s3_bucket_path += f"/{prefix}" if prefix else ""
+
         for log_obj in log_objs:
             log_file_str = self.awscli_pod.exec_cmd_on_pod(
                 craft_s3_command(
-                    f"cp s3://{logs_bucket}/{log_obj} -",
+                    f"cp {s3_bucket_path}/{log_obj} -",
                     mcg_obj=self.mcg_obj,
                 ),
                 out_yaml_format=False,


### PR DESCRIPTION
This is a follow-up PR to https://github.com/red-hat-storage/ocs-ci/pull/10228 which adds the remaining test cases for the [MCG Guaranteed Bucket Logs feature](https://url.corp.redhat.com/28902c3):
- test_multiple_gbl_setups
- test_logs_bucket_sharing
- test_gbl_with_prefix