### PR TITLE
add skip_if_rosa_hcp

### DIFF
--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -27,7 +27,7 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp
 from ocs_ci.framework.testlib import (
     tier1,
     tier2,
@@ -128,7 +128,10 @@ class TestNodesMaintenance(ManageTest):
         argnames=["node_type"],
         argvalues=[
             pytest.param(*["worker"], marks=pytest.mark.polarion_id("OCS-1269")),
-            pytest.param(*["master"], marks=pytest.mark.polarion_id("OCS-1272")),
+            pytest.param(
+                *["master"],
+                marks=[pytest.mark.polarion_id("OCS-1272"), skipif_rosa_hcp],
+            ),
         ],
     )
     def test_node_maintenance(


### PR DESCRIPTION
address failure with stuck trace:

```
[2024-11-22T11:39:24.366Z] >       assert typed_nodes, f"Failed to find a {node_type} node for the test"
[2024-11-22T11:39:24.366Z] [1m[31mE       AssertionError: Failed to find a master node for the test[0m
[2024-11-22T11:39:24.366Z] [1m[31mE       assert [][0m
[2024-11-22T11:39:24.366Z] 
[2024-11-22T11:39:24.366Z] [1m[31mtests/functional/z_cluster/nodes/test_nodes_maintenance.py[0m:154: AssertionError
```
execution failure: https://url.corp.redhat.com/0d04066