### PR TITLE
Intransit encryption enable disable operation

### DIFF
--- a/tests/functional/encryption/test_intransit_encryption_sanity.py
+++ b/tests/functional/encryption/test_intransit_encryption_sanity.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
-
+import time
 from ocs_ci.ocs.resources.storage_cluster import (
-    # in_transit_encryption_verification,
     set_in_transit_encryption,
     get_in_transit_encryption_config_state,
 )
@@ -15,24 +14,27 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_pods
-
+from concurrent.futures import ThreadPoolExecutor
 
 log = logging.getLogger(__name__)
 
 
 @green_squad
 @skipif_hci_provider_and_client
+@skipif_ocs_version("<4.18")
 class TestInTransitEncryptionSanity:
     @pytest.fixture(autouse=True)
     def set_encryption_at_teardown(self, request):
-        def teardown():
-            if config.ENV_DATA.get("in_transit_encryption"):
-                set_in_transit_encryption()
-            else:
-                set_in_transit_encryption(enabled=False)
+        """
+        Fixture to restore encryption state and clean up resources after the test.
+        """
 
-            # deleting the pod if any
-            for pod_obj in self.cephfs_pods + self.rbd_pods:
+        def teardown():
+            initial_state = config.ENV_DATA.get("in_transit_encryption", False)
+            set_in_transit_encryption(enabled=initial_state)
+
+            # Deleting pods if any exist
+            for pod_obj in getattr(self, "all_pods", []):
                 pod_obj.delete()
 
         request.addfinalizer(teardown)
@@ -41,123 +43,98 @@ class TestInTransitEncryptionSanity:
         """
         Toggles the in-transit encryption state on the cluster.
         """
-        encryption_state = get_in_transit_encryption_config_state()
-        new_state = not encryption_state
+        current_state = get_in_transit_encryption_config_state()
+        new_state = not current_state
 
         log.info(
-            f"In-transit encryption is currently {'enabled' if encryption_state else 'disabled'} on the cluster."
+            f"Toggling in-transit encryption from "
+            f"{'enabled' if current_state else 'disabled'} to "
+            f"{'enabled' if new_state else 'disabled'}."
         )
 
         result = set_in_transit_encryption(enabled=new_state)
-
+        assert result, "Failed to toggle in-transit encryption state."
         log.info(
-            f"In-transit encryption state is now {'enabled' if new_state else 'disabled'}."
+            f"In-transit encryption is now {'enabled' if new_state else 'disabled'}."
         )
         return result
 
     @tier1
-    @skipif_ocs_version("<4.18")
     @pytest.mark.polarion_id("OCS-4861")
     def test_intransit_encryption_enable_disable_statetransition(
         self, multi_pvc_factory, pod_factory
     ):
         """
-        The test does the following:
-        1. Enable in-transit Encryption if not Enabled.
-        2. Verify in-transit Encryption is Enable on setup.
-        3. Disable Encryption
-        4. Verify in-transit encryption configuration is removed.
-        5. Enable encryption Again and verify it.
-        6. Verify in-transit encryption config is exists.
+        Test to validate in-transit encryption enable-disable state transitions.
 
+        Steps:
+        1. Create a cephfs, rpd pvcs with different access mode.
+        2. Change in-transit Encryption state.
+        3. Create a pods and attach the PVC to it.
+        4. Start IO from  All pods.
+        5. During the IO running on the pod toggle intransit encryption state.
         """
-        access_modes_cephfs = [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]
-        access_modes_rbd = [
-            f"{constants.ACCESS_MODE_RWO}-Block",
-            f"{constants.ACCESS_MODE_RWX}-Block",
-        ]
         size = 5
+        access_modes = {
+            constants.CEPHBLOCKPOOL: [
+                f"{constants.ACCESS_MODE_RWO}-Block",
+                f"{constants.ACCESS_MODE_RWX}-Block",
+            ],
+            constants.CEPHFILESYSTEM: [
+                constants.ACCESS_MODE_RWO,
+                constants.ACCESS_MODE_RWX,
+            ],
+        }
 
-        rbd_pvcs = multi_pvc_factory(
-            interface=constants.CEPHBLOCKPOOL,
-            access_modes=access_modes_rbd,
-            size=size,
-            num_of_pvc=2,
-        )
-        assert rbd_pvcs, "Failed to create custom_rbd_pvcs PVC"
-
-        cephfs_pvcs = multi_pvc_factory(
-            interface=constants.CEPHFILESYSTEM,
-            access_modes=access_modes_cephfs,
-            size=size,
-            num_of_pvc=2,
-        )
-        assert cephfs_pvcs, "Failed to create custom_cephfs_pvcs PVC"
-
-        log.info("Changing intransit encryption state")
-        assert (
-            self.toggle_intransit_encryption_state()
-        ), " Failed to change intransit encryption state."
-
-        self.rbd_pods = create_pods(
-            pvc_objs=rbd_pvcs,
-            pod_factory=pod_factory,
-            interface=constants.CEPHBLOCKPOOL,
-            pods_for_rwx=2,  # Create 2 pods for each RWX PVC
-            status=constants.STATUS_RUNNING,
-        )
-        assert self.rbd_pods
-
-        self.cephfs_pods = create_pods(
-            pvc_objs=cephfs_pvcs,
-            pod_factory=pod_factory,
-            interface=constants.CEPHFILESYSTEM,  # Specify CephFS as the interface
-            pods_for_rwx=2,  # Create 2 pods for each RWX PVC
-            status=constants.STATUS_RUNNING,
-        )
-        assert self.cephfs_pods
-
-        log.info("Changing intransit encryption state")
-        assert (
-            self.toggle_intransit_encryption_state()
-        ), " Failed to change intransit encryption state."
-
-        import threading
-        import time
-
-        thrlist = []
-
-        for pod_obj in self.rbd_pods + self.cephfs_pods:
-            thr = threading.Thread(
-                target=pod_obj.run_io(storage_type="fs", size="1G", runtime=60)
+        # Create PVCs for CephBlockPool and CephFS
+        pvc_objects = {
+            interface: multi_pvc_factory(
+                interface=interface,
+                access_modes=modes,
+                size=size,
+                num_of_pvc=2,
             )
-            thrlist.append(thr)
+            for interface, modes in access_modes.items()
+        }
 
-        for th in thrlist:
-            th.start()
+        for interface, pvcs in pvc_objects.items():
+            assert pvcs, f"Failed to create PVCs for {interface}."
 
-        for i in range(2):
-            log.info("Changing intransit encryption state")
-            assert (
-                self.toggle_intransit_encryption_state()
-            ), " Failed to change intransit encryption state."
-            time.sleep(10)
+        # Toggle encryption state
+        assert (
+            self.toggle_intransit_encryption_state()
+        ), "Failed to change in-transit encryption state."
 
-        for th in thrlist:
-            th.join()
+        # Create pods for each interface
+        self.all_pods = []
+        for interface, pvcs in pvc_objects.items():
+            pods = create_pods(
+                pvc_objs=pvcs,
+                pod_factory=pod_factory,
+                interface=interface,
+                pods_for_rwx=2,  # Create 2 pods for each RWX PVC
+                status=constants.STATUS_RUNNING,
+            )
+            assert pods, f"Failed to create pods for {interface}."
+            self.all_pods.extend(pods)
 
-        # log.info("Verifying the in-transit encryption is disabled.")
-        # with pytest.raises(ValueError):
-        #     assert (
-        #         not in_transit_encryption_verification()
-        #     ), "In-transit Encryption was expected to be disabled, but it's enabled in the setup."
+        # Perform I/O on all pods using ThreadPoolExecutor
+        with ThreadPoolExecutor() as executor:
+            futures = [
+                executor.submit(
+                    pod_obj.run_io, storage_type="fs", size="1G", runtime=60
+                )
+                for pod_obj in self.all_pods
+            ]
 
-        # if config.ENV_DATA.get("in_transit_encryption"):
-        #     log.info("Re-enabling in-transit encryption.")
-        #     set_in_transit_encryption()
+            # Toggle encryption state during I/O operations
+            for _ in range(2):
+                log.info("Toggling encryption state during I/O.")
+                assert (
+                    self.toggle_intransit_encryption_state()
+                ), "Failed to change in-transit encryption state."
+                time.sleep(10)
 
-        #     # Verify that encryption is enabled again after re-enabling it
-        #     log.info(
-        #         "Verifying the in-transit encryption config after enabling the cluster."
-        #     )
-        #     assert in_transit_encryption_verification()
+            # Wait for I/O operations to complete
+            for future in futures:
+                future.result()

--- a/tests/functional/encryption/test_intransit_encryption_sanity.py
+++ b/tests/functional/encryption/test_intransit_encryption_sanity.py
@@ -11,16 +11,17 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     green_squad,
     skipif_hci_provider_and_client,
-    cloud_platform_required,
 )
 from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.helpers.helpers import create_pods
+
 
 log = logging.getLogger(__name__)
 
 
 @green_squad
 @skipif_hci_provider_and_client
-@cloud_platform_required
 class TestInTransitEncryptionSanity:
     @pytest.fixture(autouse=True)
     def set_encryption_at_teardown(self, request):
@@ -32,10 +33,30 @@ class TestInTransitEncryptionSanity:
 
         request.addfinalizer(teardown)
 
+    def toggle_intransit_encryption_state(self):
+        """
+        Toggles the in-transit encryption state on the cluster.
+        """
+        encryption_state = get_in_transit_encryption_config_state()
+        new_state = not encryption_state
+
+        log.info(
+            f"In-transit encryption is currently {'enabled' if encryption_state else 'disabled'} on the cluster."
+        )
+
+        result = set_in_transit_encryption(enabled=new_state)
+
+        log.info(
+            f"In-transit encryption state is now {'enabled' if new_state else 'disabled'}."
+        )
+        return result
+
     @tier1
-    @skipif_ocs_version("<4.13")
+    @skipif_ocs_version("<4.18")
     @pytest.mark.polarion_id("OCS-4861")
-    def test_intransit_encryption_enable_disable_statetransition(self):
+    def test_intransit_encryption_enable_disable_statetransition(
+        self, multi_pvc_factory, pod_factory
+    ):
         """
         The test does the following:
         1. Enable in-transit Encryption if not Enabled.
@@ -46,19 +67,67 @@ class TestInTransitEncryptionSanity:
         6. Verify in-transit encryption config is exists.
 
         """
-        if not get_in_transit_encryption_config_state():
-            if config.ENV_DATA.get("in_transit_encryption"):
-                pytest.fail("In-transit encryption is not enabled on the setup")
-            else:
-                set_in_transit_encryption()
+        access_modes_cephfs = [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]
+        access_modes_rbd = [
+            f"{constants.ACCESS_MODE_RWO}-Block",
+            f"{constants.ACCESS_MODE_RWX}-Block",
+        ]
+        size = 5
 
-        log.info("Verifying the in-transit encryption is enable on setup.")
-        assert in_transit_encryption_verification()
+        rbd_pvcs = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            access_modes=access_modes_rbd,
+            size=size,
+            num_of_pvc=2,
+        )
+        assert rbd_pvcs, "Failed to create custom_rbd_pvcs PVC"
 
-        log.info("Disabling the in-transit encryption.")
-        set_in_transit_encryption(enabled=False)
+        cephfs_pvcs = multi_pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            access_modes=access_modes_cephfs,
+            size=size,
+            num_of_pvc=2,
+        )
+        assert cephfs_pvcs, "Failed to create custom_cephfs_pvcs PVC"
 
+        log.info("Changing intransit encryption state")
+        assert (
+            self.toggle_intransit_encryption_state()
+        ), " Failed to change intransit encryption state."
+
+        rbd_pods = create_pods(
+            pvc_objs=rbd_pvcs,
+            pod_factory=pod_factory,
+            interface=constants.CEPHBLOCKPOOL,
+            pods_for_rwx=2,  # Create 2 pods for each RWX PVC
+            status=constants.STATUS_RUNNING,
+        )
+        assert rbd_pods
+
+        cephfs_pods = create_pods(
+            pvc_objs=cephfs_pvcs,
+            pod_factory=pod_factory,
+            interface=constants.CEPHFILESYSTEM,  # Specify CephFS as the interface
+            pods_for_rwx=2,  # Create 2 pods for each RWX PVC
+            status=constants.STATUS_RUNNING,
+        )
+        assert cephfs_pods
+
+        log.info("Changing intransit encryption state")
+        assert (
+            self.toggle_intransit_encryption_state()
+        ), " Failed to change intransit encryption state."
+
+        # if not get_in_transit_encryption_config_state():
+        #     if config.ENV_DATA.get("in_transit_encryption"):
+        #         pytest.fail("In-transit encryption is not enabled on the setup")
+        #     else:
+        #         set_in_transit_encryption()
+
+        # log.info("Verifying the in-transit encryption is enable on setup.")
+        # assert in_transit_encryption_verification()
         # Verify that encryption is actually disabled by checking that a ValueError is raised.
+
         log.info("Verifying the in-transit encryption is disabled.")
         with pytest.raises(ValueError):
             assert (


### PR DESCRIPTION
        Test to validate in-transit encryption enable-disable state transitions.
```
        Steps:
        1. Create a cephfs, rpd pvcs with different access mode.
        2. Change in-transit Encryption state.
        3. Create a pods and attach the PVC to it.
        4. Start IO from  All pods.
        5. During the IO running on the pod toggle intransit encryption state.
       ```