### PR TITLE
add managed platforms to exclusion and stop collect rgw-data for test

### DIFF
--- a/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
+++ b/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
@@ -3,6 +3,7 @@ import time
 import pytest
 import re
 
+from ocs_ci.ocs.constants import MANAGED_SERVICE_PLATFORMS
 from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.cluster import ceph_health_check
@@ -134,7 +135,10 @@ class TestRookCephLogRotate(ManageTest):
             pod.get_ceph_daemon_id(pod.get_mon_pods()[0]),
             "ceph-mon.",
         ]
-        if config.ENV_DATA["platform"].lower() in constants.CLOUD_PLATFORMS:
+        if config.ENV_DATA["platform"].lower() in (
+            *constants.CLOUD_PLATFORMS,
+            *MANAGED_SERVICE_PLATFORMS,
+        ):
             self.podtype_id["rgw"] = [
                 pod.get_rgw_pods,
                 pod.get_ceph_daemon_id(pod.get_rgw_pods()[0]),


### PR DESCRIPTION
avoid getting error on ROSA HCP and managed platforms, where RGW pods do not exist

```
[2024-12-03T22:30:03.082Z] [31mFAILED[0m
[2024-12-03T22:30:03.082Z] _______________ TestRookCephLogRotate.test_rook_ceph_log_rotate ________________
[2024-12-03T22:30:03.082Z] 
[2024-12-03T22:30:03.082Z] self = <tests.functional.z_cluster.test_rook_ceph_log_rotate.TestRookCephLogRotate object at 0x7fe517ca1790>
[2024-12-03T22:30:03.082Z] 
[2024-12-03T22:30:03.082Z]     def test_rook_ceph_log_rotate(self):
[2024-12-03T22:30:03.082Z]         """
[2024-12-03T22:30:03.082Z]         Test Process:
[2024-12-03T22:30:03.082Z]             1.Verify the number of MGR,MDS,OSD,MON,RGW logs
[2024-12-03T22:30:03.082Z]             2.Add logCollector to spec section on Storagecluster
[2024-12-03T22:30:03.082Z]             3.Write 500M to MGR,MDS,OSD,MON,RGW
[2024-12-03T22:30:03.082Z]             4.Verify new log created
[2024-12-03T22:30:03.082Z]             5.Delete logCollector from Storagecluster
[2024-12-03T22:30:03.082Z]     
[2024-12-03T22:30:03.082Z]         """
[2024-12-03T22:30:03.082Z]         self.podtype_id = dict()
[2024-12-03T22:30:03.082Z]         self.podtype_id["mgr"] = [
[2024-12-03T22:30:03.082Z]             pod.get_mgr_pods,
[2024-12-03T22:30:03.082Z]             pod.get_ceph_daemon_id(pod.get_mgr_pods()[0]),
[2024-12-03T22:30:03.082Z]             "ceph-mgr.",
[2024-12-03T22:30:03.082Z]         ]
[2024-12-03T22:30:03.082Z]         self.podtype_id["osd"] = [
[2024-12-03T22:30:03.082Z]             pod.get_osd_pods,
[2024-12-03T22:30:03.082Z]             pod.get_ceph_daemon_id(pod.get_osd_pods()[0]),
[2024-12-03T22:30:03.082Z]             "ceph-osd.",
[2024-12-03T22:30:03.082Z]         ]
[2024-12-03T22:30:03.082Z]         self.podtype_id["mon"] = [
[2024-12-03T22:30:03.082Z]             pod.get_mon_pods,
[2024-12-03T22:30:03.082Z]             pod.get_ceph_daemon_id(pod.get_mon_pods()[0]),
[2024-12-03T22:30:03.082Z]             "ceph-mon.",
[2024-12-03T22:30:03.082Z]         ]
[2024-12-03T22:30:03.082Z]         if config.ENV_DATA["platform"].lower() in constants.CLOUD_PLATFORMS:
[2024-12-03T22:30:03.082Z]             self.podtype_id["rgw"] = [
[2024-12-03T22:30:03.082Z]                 pod.get_rgw_pods,
[2024-12-03T22:30:03.082Z] >               pod.get_ceph_daemon_id(pod.get_rgw_pods()[0]),
[2024-12-03T22:30:03.082Z]                 "ceph-client.rgw.ocs.storagecluster.cephobjectstore.a",
[2024-12-03T22:30:03.082Z]             ]
[2024-12-03T22:30:03.082Z] [1m[31mE           IndexError: list index out of range[0m
[2024-12-03T22:30:03.082Z] 
[2024-12-03T22:30:03.082Z] [1m[31m/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/tests/functional/z_cluster/test_rook_ceph_log_rotate.py[0m:140: IndexError
```