### PR TITLE
improve destroy rosa hcp cluster

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -26,6 +26,7 @@ from ocs_ci.utility.rosa import (
     get_associated_oidc_config_id,
     delete_account_roles,
     wait_console_url,
+    destroy_rosa_cluster,
 )
 from ocs_ci.utility.utils import (
     ceph_health_check,
@@ -149,7 +150,10 @@ class ROSAOCP(BaseOCPDeployment):
             log_step(f"Destroying ROSA cluster. Hosted CP: {rosa_hcp}")
             delete_status = rosa.destroy_appliance_mode_cluster(self.cluster_name)
             if not delete_status:
-                ocm.destroy_cluster(self.cluster_name)
+                if rosa_hcp:
+                    destroy_rosa_cluster(self.cluster_name)
+                else:
+                    ocm.destroy_cluster(self.cluster_name)
             log_step("Waiting for ROSA cluster to be uninstalled")
             sample = TimeoutSampler(
                 timeout=14400,

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -28,6 +28,7 @@ from ocs_ci.utility.managedservice import (
     generate_onboarding_token,
     get_storage_provider_endpoint,
 )
+from ocs_ci.utility.openshift_dedicated import get_cluster_details
 from ocs_ci.utility.retry import catch_exceptions
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
@@ -890,6 +891,23 @@ def destroy_appliance_mode_cluster(cluster):
         if "deleting service" in service_status:
             logger.info("Rosa service status is 'deleting service'")
             break
+    return True
+
+
+def destroy_rosa_cluster(cluster, best_effort=True):
+    """
+    Delete rosa cluster
+
+    Parameters:
+        cluster (str): name of the cluster
+        best_effort (bool): If True (true), ignore errors and continue with the deletion of the cluster
+    """
+    external_id = get_cluster_details(cluster)["external_id"]
+    cmd = f"ocm delete cluster {external_id} -p best_effort={str(best_effort).lower()} --yes"
+    proc = exec_cmd(cmd, timeout=1200)
+    if proc.returncode != 0:
+        raise CommandFailed(f"Failed to delete cluster: {proc.stderr.decode().strip()}")
+    logger.info(f"{proc.stdout.decode().strip()}")
     return True
 
 

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -902,7 +902,7 @@ def destroy_rosa_cluster(cluster, best_effort=True):
         cluster (str): name of the cluster
         best_effort (bool): If True (true), ignore errors and continue with the deletion of the cluster
     """
-    external_id = get_cluster_details(cluster)["external_id"]
+    external_id = get_cluster_details(cluster)["id"]
     cmd = f"ocm delete cluster {external_id} -p best_effort={str(best_effort).lower()}"
     proc = exec_cmd(cmd, timeout=1200)
     if proc.returncode != 0:

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -903,7 +903,7 @@ def destroy_rosa_cluster(cluster, best_effort=True):
         best_effort (bool): If True (true), ignore errors and continue with the deletion of the cluster
     """
     external_id = get_cluster_details(cluster)["external_id"]
-    cmd = f"ocm delete cluster {external_id} -p best_effort={str(best_effort).lower()} --yes"
+    cmd = f"ocm delete cluster {external_id} -p best_effort={str(best_effort).lower()}"
     proc = exec_cmd(cmd, timeout=1200)
     if proc.returncode != 0:
         raise CommandFailed(f"Failed to delete cluster: {proc.stderr.decode().strip()}")


### PR DESCRIPTION
With this PR we perform steps suggested by a Customer Support

> Most recent comment: On 2024-12-08 09:33:29, Mchugh, Brendan commented:
> "Hello,
> 
> I am looking at this case on behalf of Red Hat Global Support Services in EMEA region and I will assist you through this issue for now.
> 
> It seems the cluster was misidentified as deleted due to being in the Stage environment while we work predominantly via support cases with clusters in the Production environment.
> 
> 
> Can you please try having the owner "[fbalak@redhat.com](mailto:fbalak@redhat.com)" deleting the cluster using the ocm CLI from the cluster owning account 7129148 with the best_effort=true parameter as outlined in the following article. [1]
> 
> In addition you will need to add the --url stage parameter to the ocm login command to ensure the correct environment is selected.
> 
>  login to the stage environement
> $ ocm login --token="<TOKEN>" --url stage
> 
> get the internal clusterid from the describe output for the cluster 
> $ ocm describe cluster 298b80a7-94dc-4cc7-9dc1-a937563e8bc9
> 
> perform the delete on the internal clusterid with the "best_effort=true" parameter
> $ ocm delete cluster "2fac28tjclnvobgrt8l34624g33eg1m1" -p best_effort=true
>

Added separate utility function for rosa, and if `rosa_hcp` add `-p besteffort=true` to a delete command

fixes: #11004