### PR TITLE
fix typo in retrieve_verification_mode

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1566,7 +1566,8 @@ def retrieve_verification_mode():
         verify = True
     elif (
         config.DEPLOYMENT.get("use_custom_ingress_ssl_cert")
-        and config.DEPLOYMENT["custom_ssl_cert_provider"] == "ocs-ci-ca"
+        and config.DEPLOYMENT["custom_ssl_cert_provider"]
+        == constants.SSL_CERT_PROVIDER_OCS_QE_CA
     ):
         verify = get_root_ca_cert()
     else:


### PR DESCRIPTION
This typo breaks some tests when OCS-QE CA Ingress certificate is used.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/11012