### PR TITLE
object-bucket-renaming-in-UI

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -690,7 +690,9 @@ page_nav = {
     "volumesnapshotclasses_page": ("VolumeSnapshotClasses", By.LINK_TEXT),
     "volumesnapshotcontents_page": ("VolumeSnapshotContents", By.LINK_TEXT),
     "object_buckets_tab": (
-        "//a[normalize-space()='Object Buckets'] | //span[normalize-space()='Object Buckets']/..",
+        "//a[normalize-space()='Object Buckets'] "
+        "| //span[normalize-space()='Object Buckets']/.. "
+        "| //span[normalize-space()='Buckets']/..",
         By.XPATH,
     ),
     "object_storage": ("//a[normalize-space()='Object Storage']", By.XPATH),


### PR DESCRIPTION
stop failing OBC related tests, due to 4.18 renaming