### PR TITLE
test_detach_attach_worker_volume add jira ticket to prevent cascade skips

### DIFF
--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, jira
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -143,6 +143,7 @@ class TestDiskFailures(ManageTest):
         """
         self.sanity_helpers = Sanity()
 
+    @jira("DFBUGS-849")
     @skipif_managed_service
     @skipif_ibm_cloud
     @skipif_hci_provider_and_client


### PR DESCRIPTION
test_detach_attach_worker_volume makes cascade skips because of a bug https://issues.redhat.com/browse/DFBUGS-1038

Prevent failure: 

```
[2024-12-10T19:37:11.198Z] tests/functional/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_detach_attach_worker_volume 
[2024-12-10T19:37:11.198Z] [1m-------------------------------- live log setup --------------------------------[0m
[2024-12-10T19:37:11.198Z] 14:37:11 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - testrun_name: dosypenk-OCS4-17-Downstream-OCP4-17-ROSA_HCP-MANAGED_CP-1AZ-RHCOS-0M-3W-tier4a
[2024-12-10T19:37:11.198Z] 14:37:11 - MainThread - tests.conftest - [32mINFO[0m  - Checking for Ceph Health OK 
[2024-12-10T19:37:11.198Z] 14:37:11 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-tools -o yaml
[2024-12-10T19:37:11.755Z] 14:37:11 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-tools -o yaml
[2024-12-10T19:37:12.312Z] 14:37:12 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - These are the ceph tool box pods: ['rook-ceph-tools-58c64c465f-hcwqs']
[2024-12-10T19:37:12.312Z] 14:37:12 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod rook-ceph-tools-58c64c465f-hcwqs -n odf-storage
[2024-12-10T19:37:12.870Z] 14:37:12 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:17.017Z] 14:37:16 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - Pod name: rook-ceph-tools-58c64c465f-hcwqs
[2024-12-10T19:37:17.017Z] 14:37:16 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - Pod status: Running
[2024-12-10T19:37:17.017Z] 14:37:16 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc -n odf-storage rsh rook-ceph-tools-58c64c465f-hcwqs ceph health
[2024-12-10T19:37:18.894Z] 14:37:18 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Ceph cluster health is HEALTH_OK.
[2024-12-10T19:37:18.894Z] 14:37:18 - MainThread - tests.conftest - [32mINFO[0m  - Ceph health check passed at setup
[2024-12-10T19:37:18.894Z] 14:37:18 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: ['oc', 'login', '-u', 'cluster-admin', '-p', '*****']
[2024-12-10T19:37:22.146Z] 14:37:21 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-monitoring whoami --show-token
[2024-12-10T19:37:22.146Z] 14:37:21 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-monitoring get Route prometheus-k8s -n openshift-monitoring -o yaml
[2024-12-10T19:37:23.067Z] 14:37:22 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get CephCluster  -n odf-storage -o yaml
[2024-12-10T19:37:23.625Z] 14:37:23 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get CephFilesystem  -n odf-storage -o yaml
[2024-12-10T19:37:24.189Z] 14:37:23 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get CephBlockPool  -n odf-storage -o yaml
[2024-12-10T19:37:24.773Z] 14:37:24 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:28.924Z] 14:37:28 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-mon -o yaml
[2024-12-10T19:37:29.178Z] 14:37:29 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod rook-ceph-mon-a-56685c5cc9-4j54z -n odf-storage
[2024-12-10T19:37:29.734Z] 14:37:29 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:33.881Z] 14:37:33 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod rook-ceph-mon-b-844bbbbbb9-gv5pm -n odf-storage
[2024-12-10T19:37:33.881Z] 14:37:33 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:38.030Z] 14:37:37 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod rook-ceph-mon-c-cd85b96f5-55gdg -n odf-storage
[2024-12-10T19:37:38.030Z] 14:37:37 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:42.177Z] 14:37:41 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-mds -o yaml
[2024-12-10T19:37:42.431Z] 14:37:42 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-mgr -o yaml
[2024-12-10T19:37:43.788Z] 14:37:43 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-osd -o yaml
[2024-12-10T19:37:44.710Z] 14:37:44 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=noobaa -o yaml
[2024-12-10T19:37:45.631Z] 14:37:45 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-rgw -o yaml
[2024-12-10T19:37:53.694Z] 14:37:53 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-tools -o yaml
[2024-12-10T19:37:54.251Z] 14:37:54 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=app=rook-ceph-tools -o yaml
[2024-12-10T19:37:54.808Z] 14:37:54 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - These are the ceph tool box pods: ['rook-ceph-tools-58c64c465f-hcwqs']
[2024-12-10T19:37:54.808Z] 14:37:54 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod rook-ceph-tools-58c64c465f-hcwqs -n odf-storage
[2024-12-10T19:37:55.061Z] 14:37:55 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:37:59.210Z] 14:37:58 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - Pod name: rook-ceph-tools-58c64c465f-hcwqs
[2024-12-10T19:37:59.210Z] 14:37:58 - MainThread - ocs_ci.ocs.resources.pod - [32mINFO[0m  - Pod status: Running
[2024-12-10T19:37:59.210Z] 14:37:58 - MainThread - ocs_ci.ocs.cluster - [32mINFO[0m  - port=3300
[2024-12-10T19:37:59.210Z] 14:37:58 - MainThread - ocs_ci.ocs.cluster - [32mINFO[0m  - port=3300
[2024-12-10T19:37:59.210Z] 14:37:58 - MainThread - ocs_ci.ocs.cluster - [32mINFO[0m  - port=3300
[2024-12-10T19:37:59.211Z] 14:37:58 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get CephCluster ocs-storagecluster-cephcluster -n odf-storage -o yaml
[2024-12-10T19:37:59.211Z] 14:37:59 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get CephFilesystem ocs-storagecluster-cephfilesystem -n odf-storage -o yaml
[2024-12-10T19:37:59.778Z] 14:37:59 - MainThread - ocs_ci.ocs.cluster - [32mINFO[0m  - Number of mons = 3
[2024-12-10T19:37:59.778Z] 14:37:59 - MainThread - ocs_ci.ocs.cluster - [32mINFO[0m  - Number of mds = 2
[2024-12-10T19:37:59.778Z] 14:37:59 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=noobaa-operator=deployment -o yaml
[2024-12-10T19:38:00.352Z] 14:38:00 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage --selector=noobaa-core=noobaa -o yaml
[2024-12-10T19:38:01.273Z] 14:38:00 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node  -o yaml
[2024-12-10T19:38:01.830Z] 14:38:01 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node  --selector=node-role.kubernetes.io/worker -o yaml
[2024-12-10T19:38:02.753Z] 14:38:02 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node  --selector=node-role.kubernetes.io/master -o yaml
[2024-12-10T19:38:03.312Z] 14:38:03 - MainThread - ocs_ci.ocs.ocp - [32mINFO[0m  - Waiting for a resource(s) of kind Pod identified by name 'noobaa-operator-6c9f68b974-qjkvb' using selector None at column name STATUS to reach desired condition Running
[2024-12-10T19:38:03.312Z] 14:38:03 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod noobaa-operator-6c9f68b974-qjkvb -n odf-storage -o yaml
[2024-12-10T19:38:04.233Z] 14:38:03 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod noobaa-operator-6c9f68b974-qjkvb -n odf-storage
[2024-12-10T19:38:04.791Z] 14:38:04 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Pod  -n odf-storage -o yaml
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.ocs.ocp - [32mINFO[0m  - status of noobaa-operator-6c9f68b974-qjkvb at STATUS reached condition!
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.helpers.helpers - [32mINFO[0m  - Pod noobaa-operator-6c9f68b974-qjkvb reached state Running
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/data/mcg-cli version -n odf-storage
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.utility.utils - [33mWARNING[0m  - Command stderr: [36mINFO[0m[0000] CLI version: 5.17.0                          
[2024-12-10T19:38:08.941Z] [36mINFO[0m[0000] noobaa-image: noobaa/noobaa-core:master-20240520 
[2024-12-10T19:38:08.941Z] [36mINFO[0m[0000] operator-image: noobaa/noobaa-operator:5.17.0 
[2024-12-10T19:38:08.941Z] 
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-ingress-operator get secret router-ca -n openshift-ingress-operator -o yaml
[2024-12-10T19:38:08.941Z] 14:38:08 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get noobaa  -n odf-storage -o yaml
[2024-12-10T19:38:09.194Z] 14:38:09 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get noobaa  -n odf-storage -o yaml
[2024-12-10T19:38:09.752Z] 14:38:09 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get secret noobaa-admin -n odf-storage -o yaml
[2024-12-10T19:38:10.309Z] 14:38:10 - MainThread - /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/ocs/resources/mcg.py - [32mINFO[0m  - Sending MCG RPC query via mcg-cli:
[2024-12-10T19:38:10.309Z] auth_api create_auth {'role': 'admin', 'system': 'noobaa', 'email': '*****', 'password': '*****'}
[2024-12-10T19:38:10.309Z] 14:38:10 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/data/mcg-cli api auth_api create_auth '{"role": "admin", "system": "noobaa", "email": "*****", "password": "*****"}' -ojson -n odf-storage
[2024-12-10T19:38:12.813Z] 14:38:12 - MainThread - ocs_ci.utility.utils - [33mWARNING[0m  - Command stderr: [36mINFO[0m[0001] ✅ Exists: NooBaa "noobaa"                    
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0001] ✅ Exists: Service "noobaa-mgmt"              
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0001] ✅ Exists: Secret "noobaa-operator"           
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0001] ✅ Exists: Secret "noobaa-admin"              
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0002] ✈️  RPC: auth.create_auth() Request: map[email:***** password:***** role:admin system:noobaa] 
[2024-12-10T19:38:12.813Z] [33mWARN[0m[0002] RPC: GetConnection creating connection to wss://localhost:43071/rpc/ 0xc000da1980 
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0002] RPC: Connecting websocket (0xc000da1980) &{RPC:0xc0009b5ef0 Address:wss://localhost:43071/rpc/ State:init WS:<nil> PendingRequests:map[] NextRequestID:0 Lock:{state:1 sema:0} ReconnectDelay:0s cancelPings:<nil>} 
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0002] RPC: Connected websocket (0xc000da1980) &{RPC:0xc0009b5ef0 Address:wss://localhost:43071/rpc/ State:init WS:<nil> PendingRequests:map[] NextRequestID:0 Lock:{state:1 sema:0} ReconnectDelay:0s cancelPings:<nil>} 
[2024-12-10T19:38:12.813Z] [36mINFO[0m[0002] ✅ RPC: auth.create_auth() Response OK: took 62.3ms 
[2024-12-10T19:38:12.813Z] 
[2024-12-10T19:38:13.067Z] 14:38:12 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get Deployment  -n odf-storage --selector=app=rook-ceph-rgw -o yaml
[2024-12-10T19:38:13.321Z] 14:38:13 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get StorageClass ocs-external-storagecluster-ceph-rgw -n odf-storage -o yaml
[2024-12-10T19:38:13.878Z] 14:38:13 - MainThread - ocs_ci.utility.utils - [33mWARNING[0m  - Command stderr: Error from server (NotFound): storageclasses.storage.k8s.io "ocs-external-storagecluster-ceph-rgw" not found
[2024-12-10T19:38:13.878Z] 
[2024-12-10T19:38:13.878Z] 14:38:13 - MainThread - ocs_ci.ocs.ocp - [33mWARNING[0m  - Failed to get resource: ocs-external-storagecluster-ceph-rgw of kind: StorageClass, selector: None, Error: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get StorageClass ocs-external-storagecluster-ceph-rgw -n odf-storage -o yaml.
[2024-12-10T19:38:13.878Z] Error is Error from server (NotFound): storageclasses.storage.k8s.io "ocs-external-storagecluster-ceph-rgw" not found
[2024-12-10T19:38:13.878Z] 
[2024-12-10T19:38:13.878Z] 14:38:13 - MainThread - ocs_ci.ocs.ocp - [33mWARNING[0m  - Number of attempts to get resource reached!
[2024-12-10T19:38:13.878Z] 14:38:13 - MainThread - ocs_ci.framework.pytest_customization.reports - [32mINFO[0m  - duration reported by tests/functional/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_detach_attach_worker_volume immediately after test execution: 62.71
[2024-12-10T19:38:13.878Z] [1m-------------------------------- live log call ---------------------------------[0m
[2024-12-10T19:38:13.878Z] 14:38:13 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolumeClaim  -n odf-storage -o yaml
[2024-12-10T19:38:14.435Z] 14:38:14 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get storagecluster ocs-storagecluster -n odf-storage -o yaml
[2024-12-10T19:38:14.992Z] 14:38:14 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolumeClaim ocs-deviceset-0-data-07qmg2 -n odf-storage -o yaml
[2024-12-10T19:38:15.549Z] 14:38:15 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolume pvc-f9395a48-6a30-4d9f-9c38-9bade8a20c81 -n odf-storage -o yaml
[2024-12-10T19:38:16.107Z] 14:38:15 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolumeClaim ocs-deviceset-1-data-0vbnfs -n odf-storage -o yaml
[2024-12-10T19:38:16.665Z] 14:38:16 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolume pvc-680d0251-d50c-4bdc-afc5-1119360bce0c -n odf-storage -o yaml
[2024-12-10T19:38:16.919Z] 14:38:16 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolumeClaim ocs-deviceset-2-data-0vxm6d -n odf-storage -o yaml
[2024-12-10T19:38:17.477Z] 14:38:17 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n odf-storage get PersistentVolume pvc-8c6222c1-6a6c-4801-9cde-66b14dd1a351 -n odf-storage -o yaml
[2024-12-10T19:38:18.035Z] 14:38:17 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get PersistentVolume pvc-f9395a48-6a30-4d9f-9c38-9bade8a20c81 -o yaml
[2024-12-10T19:38:18.288Z] 14:38:18 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get PersistentVolume pvc-680d0251-d50c-4bdc-afc5-1119360bce0c -o yaml
[2024-12-10T19:38:18.846Z] 14:38:18 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get PersistentVolume pvc-8c6222c1-6a6c-4801-9cde-66b14dd1a351 -o yaml
[2024-12-10T19:38:20.204Z] 14:38:19 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get node  -o yaml
[2024-12-10T19:38:20.761Z] 14:38:20 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node ip-10-0-0-105.us-west-2.compute.internal -o yaml
[2024-12-10T19:38:21.681Z] 14:38:21 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node ip-10-0-0-156.us-west-2.compute.internal -o yaml
[2024-12-10T19:38:22.238Z] 14:38:22 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node ip-10-0-0-202.us-west-2.compute.internal -o yaml
[2024-12-10T19:38:22.794Z] 14:38:22 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get Node ip-10-0-0-241.us-west-2.compute.internal -o yaml
[2024-12-10T19:38:23.352Z] 14:38:23 - MainThread - /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/utility/aws.py - [32mINFO[0m  - Detaching volume: vol-0c9f49b80e9e92fdc Instance: i-0cc91d6f6f25c7458
[2024-12-10T19:38:29.912Z] 14:38:28 - MainThread - tests.functional.z_cluster.nodes.test_disk_failures - [32mINFO[0m  - Volume ec2.Volume(id='vol-0c9f49b80e9e92fdc') is deattached successfully
[2024-12-10T19:38:29.912Z] 14:38:28 - MainThread - ocs_ci.ocs.platform_nodes - [32mINFO[0m  - EBS volume vol-0c9f49b80e9e92fdc attachments are: []
[2024-12-10T19:38:29.912Z] 14:38:28 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Going to sleep for 3 seconds before next iteration
[2024-12-10T19:38:32.416Z] 14:38:32 - MainThread - ocs_ci.ocs.platform_nodes - [32mINFO[0m  - EBS volume vol-0c9f49b80e9e92fdc attachments are: []
... < WAITING > 
[2024-12-10T19:43:25.853Z] 14:43:25 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Going to sleep for 3 seconds before next iteration
[2024-12-10T19:43:29.104Z] 14:43:28 - MainThread - ocs_ci.ocs.platform_nodes - [31m[1mERROR[0m  - Volume vol-0c9f49b80e9e92fdc failed to be attached to an EC2 instance
[2024-12-10T19:43:29.104Z] 14:43:28 - MainThread - ocs_ci.framework.pytest_customization.reports - [32mINFO[0m  - duration reported by tests/functional/z_cluster/nodes/test_disk_failures.py::TestDiskFailures::test_detach_attach_worker_volume immediately after test execution: 315.0
[2024-12-10T19:43:29.104Z] [31mFAILED[0m
[2024-12-10T19:43:29.104Z] ______________ TestDiskFailures.test_detach_attach_worker_volume _______________
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z] self = <tests.functional.z_cluster.nodes.test_disk_failures.TestDiskFailures object at 0x7f9ec5227a00>
[2024-12-10T19:43:29.104Z] nodes = <ocs_ci.ocs.platform_nodes.ROSAHCPNode object at 0x7f9ed9458730>
[2024-12-10T19:43:29.104Z] pvc_factory = <function pvc_factory_fixture.<locals>.factory at 0x7f9f0626e0d0>
[2024-12-10T19:43:29.104Z] pod_factory = <function pod_factory_fixture.<locals>.factory at 0x7f9f0626e280>
[2024-12-10T19:43:29.104Z] bucket_factory = <function bucket_factory_fixture.<locals>._create_buckets at 0x7f9f06451dc0>
[2024-12-10T19:43:29.104Z] rgw_bucket_factory = None
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z]     @skipif_managed_service
[2024-12-10T19:43:29.104Z]     @skipif_ibm_cloud
[2024-12-10T19:43:29.104Z]     @skipif_hci_provider_and_client
[2024-12-10T19:43:29.104Z]     @cloud_platform_required
[2024-12-10T19:43:29.104Z]     @pytest.mark.polarion_id("OCS-1085")
[2024-12-10T19:43:29.104Z]     @bugzilla("1825675")
[2024-12-10T19:43:29.104Z]     def test_detach_attach_worker_volume(
[2024-12-10T19:43:29.104Z]         self, nodes, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
[2024-12-10T19:43:29.104Z]     ):
[2024-12-10T19:43:29.104Z]         """
[2024-12-10T19:43:29.104Z]         Detach and attach worker volume
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         - Detach the data volume from one of the worker nodes
[2024-12-10T19:43:29.104Z]         - Wait for the volumes to be re-attached back to the worker node
[2024-12-10T19:43:29.104Z]         - Validate cluster functionality, without checking cluster and Ceph
[2024-12-10T19:43:29.104Z]           health (as one node volume is detached, the cluster will be
[2024-12-10T19:43:29.104Z]           unhealthy) by creating resources and running IO
[2024-12-10T19:43:29.104Z]         - Restart the node so the volume will get re-mounted
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         """
[2024-12-10T19:43:29.104Z]         # Get a data volume
[2024-12-10T19:43:29.104Z]         data_volume = nodes.get_data_volumes()[0]
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         # Get the worker node according to the volume attachment
[2024-12-10T19:43:29.104Z]         worker = nodes.get_node_by_attached_volume(data_volume)
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         # Detach volume and wait for the volume to attach
[2024-12-10T19:43:29.104Z] >       self.detach_volume_and_wait_for_attach(nodes, data_volume, worker)
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z] [1m[31mtests/functional/z_cluster/nodes/test_disk_failures.py[0m:173: 
[2024-12-10T19:43:29.104Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z] self = <tests.functional.z_cluster.nodes.test_disk_failures.TestDiskFailures object at 0x7f9ec5227a00>
[2024-12-10T19:43:29.104Z] nodes = <ocs_ci.ocs.platform_nodes.ROSAHCPNode object at 0x7f9ed9458730>
[2024-12-10T19:43:29.104Z] data_volume = ec2.Volume(id='vol-0c9f49b80e9e92fdc')
[2024-12-10T19:43:29.104Z] worker_node = <ocs_ci.ocs.resources.ocs.OCS object at 0x7f9edb655b20>
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z]     def detach_volume_and_wait_for_attach(self, nodes, data_volume, worker_node):
[2024-12-10T19:43:29.104Z]         """
[2024-12-10T19:43:29.104Z]         Detach an EBS volume from an AWS instance and wait for the volume
[2024-12-10T19:43:29.104Z]         to be re-attached
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         Args:
[2024-12-10T19:43:29.104Z]             node (OCS): The OCS object representing the node
[2024-12-10T19:43:29.104Z]             data_volume (Volume): The ec2 volume to delete
[2024-12-10T19:43:29.104Z]             worker_node (OCS): The OCS object of the EC2 instance
[2024-12-10T19:43:29.104Z]     
[2024-12-10T19:43:29.104Z]         """
[2024-12-10T19:43:29.104Z]         try:
[2024-12-10T19:43:29.104Z]             # Detach volume (logging is done inside the function)
[2024-12-10T19:43:29.104Z]             nodes.detach_volume(data_volume, worker_node)
[2024-12-10T19:43:29.104Z]         except AWSTimeoutException as e:
[2024-12-10T19:43:29.104Z]             if "Volume state: in-use" in e:
[2024-12-10T19:43:29.104Z]                 logger.info(
[2024-12-10T19:43:29.104Z]                     f"Volume {data_volume} is still attached to worker, detach did not complete"
[2024-12-10T19:43:29.104Z]                     f" node {worker_node}"
[2024-12-10T19:43:29.104Z]                 )
[2024-12-10T19:43:29.104Z]                 raise
[2024-12-10T19:43:29.104Z]         else:
[2024-12-10T19:43:29.104Z]             """
[2024-12-10T19:43:29.104Z]             Wait for worker volume to be re-attached automatically
[2024-12-10T19:43:29.104Z]             to the node
[2024-12-10T19:43:29.104Z]             """
[2024-12-10T19:43:29.104Z]             logger.info(f"Volume {data_volume} is deattached successfully")
[2024-12-10T19:43:29.104Z]             if config.ENV_DATA.get("platform", "").lower() == constants.AWS_PLATFORM:
[2024-12-10T19:43:29.104Z]                 logger.info(
[2024-12-10T19:43:29.104Z]                     f"For {constants.AWS_PLATFORM} platform, attaching volume manually"
[2024-12-10T19:43:29.104Z]                 )
[2024-12-10T19:43:29.104Z]                 nodes.attach_volume(volume=data_volume, node=worker_node)
[2024-12-10T19:43:29.104Z]             else:
[2024-12-10T19:43:29.104Z] >               assert nodes.wait_for_volume_attach(data_volume), (
[2024-12-10T19:43:29.104Z]                     f"Volume {data_volume} failed to be re-attached to worker "
[2024-12-10T19:43:29.104Z]                     f"node {worker_node.name}"
[2024-12-10T19:43:29.104Z]                 )
[2024-12-10T19:43:29.104Z] [1m[31mE               AssertionError: Volume ec2.Volume(id='vol-0c9f49b80e9e92fdc') failed to be re-attached to worker node ip-10-0-0-105.us-west-2.compute.internal[0m
[2024-12-10T19:43:29.104Z] [1m[31mE               assert False[0m
[2024-12-10T19:43:29.104Z] [1m[31mE                +  where False = <bound method AWSNodes.wait_for_volume_attach of <ocs_ci.ocs.platform_nodes.ROSAHCPNode object at 0x7f9ed9458730>>(ec2.Volume(id='vol-0c9f49b80e9e92fdc'))[0m
[2024-12-10T19:43:29.104Z] [1m[31mE                +    where <bound method AWSNodes.wait_for_volume_attach of <ocs_ci.ocs.platform_nodes.ROSAHCPNode object at 0x7f9ed9458730>> = <ocs_ci.ocs.platform_nodes.ROSAHCPNode object at 0x7f9ed9458730>.wait_for_volume_attach[0m
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z] [1m[31mtests/functional/z_cluster/nodes/test_disk_failures.py[0m:85: AssertionError
[2024-12-10T19:43:29.104Z] 
[2024-12-10T19:43:29.104Z] [1m------------------------------ live log teardown -------------------------------[0m
```