### PR TITLE
add vsphere upi compact mode configs and related automation

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_compact_mode_3m_0w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_compact_mode_3m_0w.yaml
@@ -1,0 +1,12 @@
+---
+# This config will work on vSphere DC-ECO, DC-CP, DC-PS and vSphere7 DC-CP
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 0
+  master_replicas: 3
+  master_num_cpus: '16'
+  master_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_compact_mode_3m_0w_disconnected.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_compact_mode_3m_0w_disconnected.yaml
@@ -1,0 +1,13 @@
+---
+# This config will work on vSphere DC-ECO, DC-CP, DC-PS and vSphere7 DC-CP
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  disconnected: true
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 0
+  master_replicas: 3
+  master_num_cpus: '16'
+  master_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -960,6 +960,17 @@ class VSPHEREUPI(VSPHEREBASE):
             for each_file in files_to_remove:
                 os.remove(each_file)
 
+            # configure spec.mastersSchedulable in cluster-scheduler-02-config.yml
+            if config.ENV_DATA["worker_replicas"] == 0:
+                cluster_scheduler_config = os.path.join(
+                    self.cluster_path, "manifests", "cluster-scheduler-02-config.yml"
+                )
+                with open(cluster_scheduler_config, "r") as f:
+                    cluster_scheduler_config_obj = yaml.safe_load(f.read())
+                cluster_scheduler_config_obj["spec"]["mastersSchedulable"] = True
+                with open(cluster_scheduler_config, "w") as f:
+                    f.write(yaml.safe_dump(cluster_scheduler_config_obj))
+
         def create_ignitions(self):
             """
             Creates the ignition files
@@ -1107,6 +1118,9 @@ class VSPHEREUPI(VSPHEREBASE):
                     lb = LoadBalancer()
                     lb.rename_haproxy_conf_and_reload()
                     lb.remove_boostrap_in_proxy()
+                    if config.ENV_DATA["worker_replicas"] == 0:
+                        # compact-mode deployment: add master nodes as backend servers for ingress
+                        lb.compact_mode_route_ingress_trafic_to_control_plane_nodes()
                     lb.restart_haproxy()
 
                 # remove bootstrap node

--- a/ocs_ci/utility/load_balancer.py
+++ b/ocs_ci/utility/load_balancer.py
@@ -143,6 +143,20 @@ class LoadBalancer(object):
                 )
                 self.lb.exec_cmd(cmd)
 
+    def compact_mode_route_ingress_trafic_to_control_plane_nodes(self):
+        """
+        This is applicable only for compact mode deployment.
+        Configure haproxy to route ingress traffic to control plane nodes.
+        """
+        master_ips = get_module_ip(self.terraform_state_file, constants.CONTROL_PLANE)
+        for node in master_ips:
+            for section, port in (("router-http", 80), ("router-https", 443)):
+                cmd = (
+                    f"sudo sed -i '/^backend {section}$/a \\    server {node} {node}:{port} check' "
+                    f"{constants.HAPROXY_LOCATION}"
+                )
+                self.lb.exec_cmd(cmd)
+
     def rename_haproxy(self):
         """
         Rename haproxy configuration file from haproxy.conf to haproxy.cfg


### PR DESCRIPTION
Config for compact mode upi deployment on vsphere:
- set `mastersSchedulable` to `true`
- configure haproxy to route ingress traffic to control plane nodes

Based on: https://docs.openshift.com/container-platform/4.17/installing/installing_vsphere/installing-vsphere-three-node.html

Related to [OCSQE-2983](https://url.corp.redhat.com/37017b7)