### PR TITLE
Skip test_securityContext_in_Crashcollector test in external mode deployment

### DIFF
--- a/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
+++ b/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
@@ -4,6 +4,7 @@ import yaml
 from ocs_ci.framework.testlib import ManageTest, bugzilla, tier1, green_squad
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import skipif_external_mode
 
 logger = logging.getLogger(__name__)
 # The below expected keys and names are gathered from pods with safe security.
@@ -53,6 +54,7 @@ class TestSecretsAndSecurityContext(ManageTest):
     @tier1
     @green_squad
     @bugzilla("2180732")
+    @skipif_external_mode
     def test_securityContext_in_Crashcollector(self):
         """
         Testing security context of rook-ceph-crash-collector pods, in a


### PR DESCRIPTION
The `test_securityContext_in_Crashcollector` test will not work in an external mode setup because the crashcollector pods are not being spun up. Therefore, the test is being skipped in the case of external mode.