### PR TITLE
Fixed tests failure test_secrets_in_env_variables

### DIFF
--- a/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
+++ b/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
@@ -14,6 +14,7 @@ EXPECTED_KEYS = {
     "ceph-username",
     "ceph-secret",
     "token",
+    "dmcrypt-key",
 }
 EXPECTED_NAMES = {"rook-ceph-config", "rook-ceph-mon", "ocs-kms-token"}
 

--- a/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
+++ b/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
@@ -9,11 +9,9 @@ logger = logging.getLogger(__name__)
 # The below expected keys and names are gathered from pods with safe security.
 EXPECTED_KEYS = {
     "mon_initial_members",
-    "mon_host",
     "fsid",
     "ceph-username",
     "ceph-secret",
-    "token",
 }
 EXPECTED_NAMES = {"rook-ceph-config", "rook-ceph-mon", "ocs-kms-token"}
 

--- a/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
+++ b/tests/functional/pv/pv_encryption/test_secrets_on_pods.py
@@ -9,9 +9,11 @@ logger = logging.getLogger(__name__)
 # The below expected keys and names are gathered from pods with safe security.
 EXPECTED_KEYS = {
     "mon_initial_members",
+    "mon_host",
     "fsid",
     "ceph-username",
     "ceph-secret",
+    "token",
 }
 EXPECTED_NAMES = {"rook-ceph-config", "rook-ceph-mon", "ocs-kms-token"}
 


### PR DESCRIPTION
As per the comment in BZ: https://ibm.biz/BdGBA6 , "dmcrypt-key" appeared in the env variable in case KMIP kms is configured