### PR TITLE
[ROSA HCP] exclude external dns if unavailable in CLI

### DIFF
--- a/ocs_ci/ocs/ui/odf_topology.py
+++ b/ocs_ci/ocs/ui/odf_topology.py
@@ -139,6 +139,8 @@ def get_node_details_cli(node_name) -> dict:
     _address_dict = {item["type"]: item["address"] for item in _addresses}
     node_details["addresses"] = (
         f"External IP: {_address_dict.get('ExternalIP')}; "
+        if _address_dict.get("ExternalIP")
+        else ""
         f"Hostname: {_address_dict.get('Hostname')}; "
         f"Internal IP: {_address_dict.get('InternalIP')}"
     )

--- a/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
@@ -1023,7 +1023,12 @@ class OdfTopologyNodesView(TopologyTab):
             for detail_name, loc in filtered_dict.items():
                 if detail_name == "details_sidebar_node_addresses":
                     node_addresses = self.get_elements(loc)
-                    addresses_txt = [el.text for el in node_addresses]
+                    # exclude Internal DNS from addresses, it is applicable only for specific platforms
+                    addresses_txt = [
+                        el.text
+                        for el in node_addresses
+                        if not el.text.startswith("Internal DNS")
+                    ]
                     addresses_txt = "; ".join(addresses_txt)
                     details_dict[
                         detail_name.split("details_sidebar_node_", 1)[-1].strip()


### PR DESCRIPTION
fix the issue when CLI has no value on public ip for the node. It also not shown on UI in this case. Test fails by adding expected External IP : "None"
failed run: https://url.corp.redhat.com/332b831