### PR TITLE
[ROSA HCP] prep for production CI jobs

### DIFF
--- a/conf/deployment/aws/rosa_hcp_1az_3w_m5.12x.yaml
+++ b/conf/deployment/aws/rosa_hcp_1az_3w_m5.12x.yaml
@@ -3,8 +3,6 @@ DEPLOYMENT:
   sts_enabled: true
   force_download_ocm_cli: true
   force_download_rosa_cli: true
-  ocm_cli_version: '0.1.67'
-  rosa_cli_version: '1.2.45'
   live_deployment: true
   customized_deployment_storage_class: 'gp3-csi'
 RUN:

--- a/conf/deployment/aws/rosa_hcp_1az_6w_m5.2x.yaml
+++ b/conf/deployment/aws/rosa_hcp_1az_6w_m5.2x.yaml
@@ -3,8 +3,6 @@ DEPLOYMENT:
   sts_enabled: true
   force_download_ocm_cli: true
   force_download_rosa_cli: true
-  ocm_cli_version: '0.1.67'
-  rosa_cli_version: '1.2.45'
   live_deployment: true
   customized_deployment_storage_class: 'gp3-csi'
 RUN:

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -99,7 +99,7 @@ class ROSAOCP(BaseOCPDeployment):
                 self.cluster_name, config.ENV_DATA["machine_pool"]
             )
             machinepool_details.wait_replicas_ready(
-                target_replicas=config.ENV_DATA["worker_replicas"], timeout=1200
+                target_replicas=config.ENV_DATA["worker_replicas"], timeout=2400
             )
             if node_labels := config.ENV_DATA.get("node_labels"):
                 if machinepool_id := config.ENV_DATA.get("machine_pool"):

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -120,7 +120,7 @@ DEPLOYMENT:
   # STS in CCO manual mode
   sts_enabled: false
   ocm_cli_version: '0.1.75'
-  rosa_cli_version: '1.2.45'
+  rosa_cli_version: '1.2.49'
 
 
 

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1601,25 +1601,59 @@ def get_current_oc_version():
     return oc_dict.get("openshiftVersion")
 
 
+def check_cluster_operator_versions(target_image, operator_upgrade_timeout):
+    """
+    Check if all cluster operators are upgraded to the target image.
+    Function will wait for the operator upgrade to complete.
+    In case of sample fail, it will log the operator that is not upgraded yet.
+    In case of timeout reached, it will raise TimeoutExpiredError.
+
+    Args:
+        target_image (str): target image to be upgraded
+        operator_upgrade_timeout (int): timeout for operator upgrade
+    """
+    cluster_operators = get_all_cluster_operators()
+    for ocp_operator in cluster_operators:
+        for sampler in TimeoutSampler(
+            timeout=operator_upgrade_timeout,
+            sleep=60,
+            func=confirm_cluster_operator_version,
+            target_version=target_image,
+            cluster_operator=ocp_operator,
+        ):
+            if sampler:
+                log.info(f"{ocp_operator} upgrade is completed!")
+                break
+            else:
+                log.info(f"{ocp_operator} upgrade is not completed yet!")
+
+
 def get_cluster_operator_version(cluster_operator_name):
     """
-    Get image version of selected cluster operator
+    Get the version of the "operator" component from a ClusterOperator resource.
 
     Args:
         cluster_operator_name (str): ClusterOperator name
 
     Returns:
-        str: cluster operator version: ClusterOperator image version
-
+        str: Cluster Operator version if found, otherwise None
     """
     ocp = OCP(kind="ClusterOperator")
     operator_info = ocp.get(cluster_operator_name)
     log.debug(f"operator info: {operator_info}")
-    operator_status = operator_info.get("status")
-    version = operator_status.get("versions")[0]["version"]
-    version = version.rstrip("_openshift")
+    operator_status = operator_info.get("status", {})
+    versions = operator_status.get("versions", [])
 
-    return version
+    # dependant operators may have different versioning than operator itself
+    # determine the version of the operator by looking for the "operator" component
+    for version_info in versions:
+        if version_info.get("name") == "operator":
+            return version_info.get("version").rstrip("_openshift")
+
+    log.warning(
+        f"Operator version not found for ClusterOperator {cluster_operator_name}"
+    )
+    return None
 
 
 def get_all_cluster_operators():

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -31,7 +31,7 @@ from ocs_ci.utility.managedservice import (
 from ocs_ci.utility.openshift_dedicated import get_cluster_details
 from ocs_ci.utility.retry import catch_exceptions
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
-from ocs_ci.utility.version import get_latest_rosa_version
+from ocs_ci.utility.version import get_latest_rosa_ocp_version
 
 logger = logging.getLogger(name=__file__)
 rosa = config.AUTH.get("rosa", {})
@@ -80,7 +80,7 @@ def create_cluster(cluster_name, version, region):
             f"Selecting latest rosa version for deployment"
         )
         logger.info(f"Looking for z-stream version of {version}")
-        rosa_ocp_version = get_latest_rosa_version(version)
+        rosa_ocp_version = get_latest_rosa_ocp_version(version)
         logger.info(f"Using OCP version {rosa_ocp_version}")
 
     if rosa_hcp:
@@ -1208,6 +1208,8 @@ def upgrade_rosa_cluster(cluster_name, version):
     """
     Upgrade the ROSA cluster to the given version
     ! important ! rosa cli version drops error in case if --control-plane parameter is not used
+    ! important ! upgrade is not performed automatically in case of ROSA clusters, especially in case of HCP;
+    Upgrade is controlled by the Hive Operator; schedule depends on a Control Plane Queue
 
     Args:
         cluster_name (str): The cluster name
@@ -1215,4 +1217,5 @@ def upgrade_rosa_cluster(cluster_name, version):
 
     """
     cmd = f"rosa upgrade cluster --cluster {cluster_name} --control-plane --version {version} --mode auto --yes"
-    utils.run_cmd(cmd, timeout=2400)
+    proc = exec_cmd(cmd, timeout=2400, text=True)
+    logger.info(f"Upgrade cluster command output:\n {proc.stdout.strip()}")

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -14,7 +14,6 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     ManagedServiceAddonDeploymentError,
-    UnsupportedPlatformVersionError,
     ConfigurationError,
     ResourceWrongStatusException,
     TimeoutExpiredError,
@@ -32,6 +31,7 @@ from ocs_ci.utility.managedservice import (
 from ocs_ci.utility.openshift_dedicated import get_cluster_details
 from ocs_ci.utility.retry import catch_exceptions
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
+from ocs_ci.utility.version import get_latest_rosa_version
 
 logger = logging.getLogger(name=__file__)
 rosa = config.AUTH.get("rosa", {})
@@ -79,6 +79,7 @@ def create_cluster(cluster_name, version, region):
             f"is not valid ROSA OCP version. "
             f"Selecting latest rosa version for deployment"
         )
+        logger.info(f"Looking for z-stream version of {version}")
         rosa_ocp_version = get_latest_rosa_version(version)
         logger.info(f"Using OCP version {rosa_ocp_version}")
 
@@ -343,36 +344,6 @@ def get_rosa_service_details(cluster):
     # Todo : update this function when -o json get supported in rosa services command
     # TODO : need exception handling
     return json.loads(service_info)
-
-
-def get_latest_rosa_version(version):
-    """
-    Returns latest available z-stream version available for ROSA.
-
-    Args:
-        version (str): OCP version in format `x.y`
-
-    Returns:
-        str: Latest available z-stream version
-
-    """
-    cmd = "rosa list versions"
-    output = utils.run_cmd(cmd, timeout=1800)
-    logger.info(f"Looking for z-stream version of {version}")
-    rosa_version = None
-    for line in output.splitlines():
-        match = re.search(f"^{version}\\.(\\d+) ", line)
-        if match:
-            rosa_version = match.group(0).rstrip()
-            break
-    if rosa_version is None:
-        logger.error(f"Could not find any version of {version} available for ROSA")
-        logger.info("Try providing an older version of OCP with --ocp-version")
-        logger.info("Latest OCP versions available for ROSA are:")
-        for i in range(3):
-            logger.info(f"{output.splitlines()[i + 1]}")
-        raise UnsupportedPlatformVersionError
-    return rosa_version
 
 
 def validate_ocp_version(version):
@@ -1231,3 +1202,16 @@ def rosa_delete_htpasswd_idp(
         raise CommandFailed("Failed to delete IDP")
     else:
         logger.info(f"response\n: {resp.stdout.decode('utf-8').splitlines()}")
+
+
+def upgrade_rosa_cluster(cluster_name, version):
+    """
+    Upgrade the ROSA cluster to the given version
+
+    Args:
+        cluster_name (str): The cluster name
+        version (str): The version to upgrade the cluster
+
+    """
+    cmd = f"rosa upgrade cluster --cluster {cluster_name} --version {version} --mode auto --yes"
+    utils.run_cmd(cmd, timeout=2400)

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -1207,11 +1207,12 @@ def rosa_delete_htpasswd_idp(
 def upgrade_rosa_cluster(cluster_name, version):
     """
     Upgrade the ROSA cluster to the given version
+    ! important ! rosa cli version drops error in case if --control-plane parameter is not used
 
     Args:
         cluster_name (str): The cluster name
         version (str): The version to upgrade the cluster
 
     """
-    cmd = f"rosa upgrade cluster --cluster {cluster_name} --version {version} --mode auto --yes"
+    cmd = f"rosa upgrade cluster --cluster {cluster_name} --control-plane --version {version} --mode auto --yes"
     utils.run_cmd(cmd, timeout=2400)

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -1217,5 +1217,5 @@ def upgrade_rosa_cluster(cluster_name, version):
 
     """
     cmd = f"rosa upgrade cluster --cluster {cluster_name} --control-plane --version {version} --mode auto --yes"
-    proc = exec_cmd(cmd, timeout=2400, text=True)
-    logger.info(f"Upgrade cluster command output:\n {proc.stdout.strip()}")
+    proc = exec_cmd(cmd, timeout=2400)
+    logger.info(f"Upgrade cluster command output:\n {proc.stdout.decode().strip()}")

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -360,9 +360,9 @@ def get_next_ocp_version_rosa(version):
     return str(next_version)
 
 
-def get_latest_rosa_version(version):
+def get_latest_rosa_ocp_version(version):
     """
-    Returns latest available z-stream version available for ROSA.
+    Returns latest z-stream version available for ROSA.
 
     Args:
         version (str): OCP version in format `x.y`

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -8,7 +8,10 @@ from semantic_version import Version
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import defaults
-from ocs_ci.ocs.exceptions import WrongVersionExpression
+from ocs_ci.ocs.exceptions import (
+    WrongVersionExpression,
+    UnsupportedPlatformVersionError,
+)
 from ocs_ci.ocs import constants
 
 
@@ -292,3 +295,110 @@ def get_volsync_operator_version(namespace=constants.SUBMARINER_OPERATOR_NAMESPA
         if "volsync" in csv["metadata"]["name"]:
             # extract version string
             return csv["spec"]["version"]
+
+
+def get_ocp_versions_rosa():
+    """
+    Get the list of available versions for ROSA.
+
+    Returns:
+        str: a list of available versions for ROSA in string format
+    """
+    from ocs_ci.utility.utils import exec_cmd
+
+    cmd = "rosa list versions"
+    output = exec_cmd(cmd, timeout=1800)
+    return output.stdout.decode()
+
+
+def ocp_version_available_on_rosa(version):
+    """
+    Check if requested version is available on ROSA for upgrade
+
+    Args:
+        version (str): OCP version in format `x.y.z`
+
+    Returns:
+        bool: True if version is supported, False otherwise
+    """
+    output = get_ocp_versions_rosa()
+    return True if version in output else False
+
+
+def get_next_ocp_version_rosa(version):
+    """
+    Get the next available minor version for ROSA.
+
+    Args:
+        version (str): OCP version in format `x.y.z`
+
+    Returns:
+        str: Next available version for ROSA
+
+    """
+    # This should return a list of versions in `x.y.z` format in string representation
+    output = get_ocp_versions_rosa()
+
+    current_version = Version(version)
+    next_version = None
+
+    for line in output.splitlines():
+        try:
+            available_version = Version(line.split()[0])
+            if available_version > current_version:
+                next_version = available_version
+                break
+        except ValueError:
+            # Skipping invalid version
+            pass
+
+    if next_version is None:
+        raise UnsupportedPlatformVersionError(
+            f"Could not find any next version after {version} available for ROSA"
+        )
+
+    return str(next_version)
+
+
+def get_latest_rosa_version(version):
+    """
+    Returns latest available z-stream version available for ROSA.
+
+    Args:
+        version (str): OCP version in format `x.y`
+
+    Returns:
+        str: Latest available z-stream version
+
+    """
+    output = get_ocp_versions_rosa()
+    rosa_version = None
+    for line in output.splitlines():
+        match = re.search(f"^{version}\\.(\\d+) ", line)
+        if match:
+            rosa_version = match.group(0).rstrip()
+            break
+    if rosa_version is None:
+        error_msg = (
+            f"Could not find any version of {version} available for ROSA. "
+            f"Try providing an older version of OCP with --ocp-version. "
+            f"Latest OCP versions available for ROSA are: \n"
+        )
+        for i in range(3):
+            error_msg += f"{output.splitlines()[i + 1]}"
+        raise UnsupportedPlatformVersionError(error_msg)
+    return rosa_version
+
+
+def drop_z_version(version_str):
+    """
+    Drops the z (patch) version from a semantic version string.
+
+    Args:
+        version_str (str): Version string in the format `x.y.z` or `x.y`
+
+    Returns:
+        str: Version string in the format `x.y`
+    """
+    version = Version.coerce(version_str)
+    return f"{version.major}.{version.minor}"

--- a/tests/functional/upgrade/test_upgrade_ocp.py
+++ b/tests/functional/upgrade/test_upgrade_ocp.py
@@ -171,7 +171,7 @@ class TestUpgradeOCP(ManageTest):
                     ocp_upgrade_version = get_latest_ocp_version(channel=ocp_channel)
                     ocp_arch = config.UPGRADE["ocp_arch"]
                     target_image = f"{ocp_upgrade_version}-{ocp_arch}"
-                    logger.info(f"Target image: {target_image}")
+            logger.info(f"Target image: {target_image}")
 
             image_path = config.UPGRADE["ocp_upgrade_path"]
             cluster_operators = ocp.get_all_cluster_operators()

--- a/tests/functional/upgrade/test_upgrade_ocp.py
+++ b/tests/functional/upgrade/test_upgrade_ocp.py
@@ -9,6 +9,7 @@ from semantic_version import Version
 from ocs_ci.ocs import ocp
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CephHealthException
+from ocs_ci.ocs.ocp import check_cluster_operator_versions
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 from ocs_ci.deployment.disconnected import mirror_ocp_release_images
 from ocs_ci.framework import config
@@ -229,18 +230,7 @@ class TestUpgradeOCP(ManageTest):
                     continue
                 ver = ocp.get_cluster_operator_version(ocp_operator)
                 logger.info(f"current {ocp_operator} version: {ver}")
-                for sampler in TimeoutSampler(
-                    timeout=operator_upgrade_timeout,
-                    sleep=60,
-                    func=ocp.confirm_cluster_operator_version,
-                    target_version=target_image,
-                    cluster_operator=ocp_operator,
-                ):
-                    if sampler:
-                        logger.info(f"{ocp_operator} upgrade is completed!")
-                        break
-                    else:
-                        logger.info(f"{ocp_operator} upgrade is not completed yet!")
+                check_cluster_operator_versions(target_image, operator_upgrade_timeout)
 
             # resume a MachineHealthCheck resource
             if get_semantic_ocp_running_version() > VERSION_4_8 and not rosa_platform:

--- a/tests/functional/upgrade/test_upgrade_ocp.py
+++ b/tests/functional/upgrade/test_upgrade_ocp.py
@@ -38,7 +38,7 @@ from ocs_ci.utility.multicluster import MDRClusterUpgradeParametrize
 from ocs_ci.utility.version import (
     get_semantic_ocp_running_version,
     VERSION_4_8,
-    get_latest_rosa_version,
+    get_latest_rosa_ocp_version,
     ocp_version_available_on_rosa,
     drop_z_version,
 )
@@ -154,7 +154,9 @@ class TestUpgradeOCP(ManageTest):
                     # check, if ver is not available on rosa then get the latest version available on ROSA
                     if not ocp_version_available_on_rosa(latest_ocp_ver):
                         version_major_minor = drop_z_version(latest_ocp_ver)
-                        latest_ocp_ver = get_latest_rosa_version(version_major_minor)
+                        latest_ocp_ver = get_latest_rosa_ocp_version(
+                            version_major_minor
+                        )
                     target_image = latest_ocp_ver
             else:
                 # Handle non-ROSA upgrade logic
@@ -205,6 +207,10 @@ class TestUpgradeOCP(ManageTest):
                 upgrade_rosa_cluster(config.ENV_DATA["cluster_name"], target_image)
 
             # Wait for upgrade
+            # ROSA Upgrades Are Controlled by the Hive Operator
+            # HCP Clusters use a Control Plane Queue to manage the upgrade process
+            # upgrades on ROSA clusters does not start immediately after the upgrade command but scheduled
+            operator_upgrade_timeout = 4000 if not rosa_platform else 8000
             for ocp_operator in cluster_operators:
                 logger.info(f"Checking upgrade status of {ocp_operator}:")
                 # ############ Workaround for issue 2624 #######
@@ -224,28 +230,29 @@ class TestUpgradeOCP(ManageTest):
                 ver = ocp.get_cluster_operator_version(ocp_operator)
                 logger.info(f"current {ocp_operator} version: {ver}")
                 for sampler in TimeoutSampler(
-                    timeout=4000,
+                    timeout=operator_upgrade_timeout,
                     sleep=60,
                     func=ocp.confirm_cluster_operator_version,
                     target_version=target_image,
                     cluster_operator=ocp_operator,
                 ):
                     if sampler:
-                        logger.info(f"{ocp_operator} upgrade completed!")
+                        logger.info(f"{ocp_operator} upgrade is completed!")
                         break
                     else:
-                        logger.info(f"{ocp_operator} upgrade did not completed yet!")
+                        logger.info(f"{ocp_operator} upgrade is not completed yet!")
 
             # resume a MachineHealthCheck resource
             if get_semantic_ocp_running_version() > VERSION_4_8 and not rosa_platform:
                 resume_machinehealthcheck()
 
             # post upgrade validation: check cluster operator status
+            operator_ready_timeout = 2700 if not rosa_platform else 5400
             cluster_operators = ocp.get_all_cluster_operators()
             for ocp_operator in cluster_operators:
                 logger.info(f"Checking cluster status of {ocp_operator}")
                 for sampler in TimeoutSampler(
-                    timeout=2700,
+                    timeout=operator_ready_timeout,
                     sleep=60,
                     func=ocp.verify_cluster_operator_status,
                     cluster_operator=ocp_operator,
@@ -256,8 +263,11 @@ class TestUpgradeOCP(ManageTest):
                         logger.info(f"{ocp_operator} status is not valid")
             # Post upgrade validation: check cluster version status
             logger.info("Checking clusterversion status")
+            cluster_version_timeout = 900 if not rosa_platform else 1800
             for sampler in TimeoutSampler(
-                timeout=900, sleep=15, func=ocp.validate_cluster_version_status
+                timeout=cluster_version_timeout,
+                sleep=15,
+                func=ocp.validate_cluster_version_status,
             ):
                 if sampler:
                     logger.info("Upgrade Completed Successfully!")

--- a/tests/functional/upgrade/test_upgrade_ocp.py
+++ b/tests/functional/upgrade/test_upgrade_ocp.py
@@ -141,7 +141,8 @@ class TestUpgradeOCP(ManageTest):
 
             if rosa_platform:
                 # Handle ROSA-specific upgrade logic
-                # If ROSA environment, Nightly builds are not supported
+                # On ROSA environment, Nightly builds are not supported.
+                # rosa cli uses only "X.Y.Z" format for the version (builds and images are not supported)
                 # If not provided ocp_upgrade_version - get the latest released version of the channel.
                 # If provided - check availability and use the provided version in format "X.Y.Z"
                 if ocp_upgrade_version and ocp_version_available_on_rosa(
@@ -150,9 +151,11 @@ class TestUpgradeOCP(ManageTest):
                     target_image = ocp_upgrade_version
                 else:
                     latest_ocp_ver = get_latest_ocp_version(channel=ocp_channel)
+                    # check, if ver is not available on rosa then get the latest version available on ROSA
                     if not ocp_version_available_on_rosa(latest_ocp_ver):
                         version_major_minor = drop_z_version(latest_ocp_ver)
-                        target_image = get_latest_rosa_version(version_major_minor)
+                        latest_ocp_ver = get_latest_rosa_version(version_major_minor)
+                    target_image = latest_ocp_ver
             else:
                 # Handle non-ROSA upgrade logic
                 if ocp_upgrade_version:


### PR DESCRIPTION
- remove OCM and ROSA cli versions to make automation fetch the latest ones 
- modify ocp upgrade to work on ROSA HCP
- add version utilities