### PR TITLE
[ROSA HCP] test_db_scc correct service acc namespace

### DIFF
--- a/tests/functional/object/mcg/test_mcg_resources_disruptions.py
+++ b/tests/functional/object/mcg/test_mcg_resources_disruptions.py
@@ -183,7 +183,9 @@ class TestMCGResourcesDisruptions(MCGTest):
         # Teardown function to revert back the scc changes made
         def finalizer():
             scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
-            service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
+            service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT.replace(
+                "openshift-storage", config.ENV_DATA["cluster_namespace"]
+            )
             pod_obj = pod.Pod(
                 **pod.get_pods_having_label(
                     label=self.labels_map["noobaa_db"],
@@ -238,7 +240,9 @@ class TestMCGResourcesDisruptions(MCGTest):
 
         """
         scc_name = constants.NOOBAA_DB_SERVICE_ACCOUNT_NAME
-        service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT
+        service_account = constants.NOOBAA_DB_SERVICE_ACCOUNT.replace(
+            "openshift-storage", config.ENV_DATA["cluster_namespace"]
+        )
         pod_obj = pod.Pod(
             **pod.get_pods_having_label(
                 label=self.labels_map["noobaa_db"],


### PR DESCRIPTION
prevent failure with output: 

```
[2024-11-25T21:25:03.352Z]         log.info(f"Verifying {service_account} was added to the anyuid scc")
[2024-11-25T21:25:03.352Z] >       assert helpers.validate_scc_policy(
[2024-11-25T21:25:03.352Z]             sa_name=scc_name,
[2024-11-25T21:25:03.352Z]             namespace=config.ENV_DATA["cluster_namespace"],
[2024-11-25T21:25:03.352Z]             scc_name=constants.ANYUID,
[2024-11-25T21:25:03.352Z]         ), "SA name is not present in anyuid scc"
[2024-11-25T21:25:03.352Z] [1m[31mE       AssertionError: SA name is not present in anyuid scc[0m
[2024-11-25T21:25:03.352Z] [1m[31mE       assert False[0m
[2024-11-25T21:25:03.352Z] [1m[31mE        +  where False = <function validate_scc_policy at 0x7fb730d11670>(sa_name='noobaa-db', namespace='odf-storage', scc_name='anyuid')[0m
[2024-11-25T21:25:03.352Z] [1m[31mE        +    where <function validate_scc_policy at 0x7fb730d11670> = helpers.validate_scc_policy[0m
[2024-11-25T21:25:03.352Z] [1m[31mE        +    and   'anyuid' = constants.ANYUID[0m
[2024-11-25T21:25:03.352Z] 
[2024-11-25T21:25:03.352Z] [1m[31mtests/functional/object/mcg/test_mcg_resources_disruptions.py[0m:275: AssertionError
[2024-11-25T21:25:03.352Z] 
```