### PR TITLE
add jira mark DFBUGS-410

### DIFF
--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     skipif_disconnected_cluster,
     external_mode_required,
+    jira,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.ocp import OCP
@@ -46,6 +47,7 @@ class TestErrorMessageImprovements(ManageTest):
         backing_store_tab.check_error_messages()
 
     @mcg
+    @jira("DFBUGS-410")
     @bugzilla("2193109")
     @polarion_id("OCS-4867")
     def test_obc_creation_rules(self, setup_ui_class):


### PR DESCRIPTION
stop failures with output due to a known issue:

```
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
[2024-11-25T22:54:37.069Z] | rule                                                                 | check_func                                          | check_status   |
[2024-11-25T22:54:37.069Z] +======================================================================+=====================================================+================+
[2024-11-25T22:54:37.069Z] |                                                                      | _check_all_rules_exist                              | True           |
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
[2024-11-25T22:54:37.069Z] | No more than 253 characters                                          | _check_max_length_backing_store_rule                | True           |
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
[2024-11-25T22:54:37.069Z] | Starts and ends with a lowercase letter or number                    | _check_start_end_char_rule                          | True           |
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
[2024-11-25T22:54:37.069Z] | Only lowercase letters, numbers, non-consecutive periods, or hyphens | _check_only_lower_case_numbers_periods_hyphens_rule | True           |
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
[2024-11-25T22:54:37.069Z] | Cannot be used before                                                | _check_obc_cannot_be_used_before                    | False          |
[2024-11-25T22:54:37.069Z] +----------------------------------------------------------------------+-----------------------------------------------------+----------------+
```