### PR TITLE
[ROSA HCP] skip tests related to master nodes operations

### DIFF
--- a/tests/functional/workloads/app/amq/test_amq_node_reboot_and_shutdown.py
+++ b/tests/functional/workloads/app/amq/test_amq_node_reboot_and_shutdown.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_vsphere_ipi,
     skipif_ibm_cloud,
     magenta_squad,
+    skipif_rosa_hcp,
 )
 from ocs_ci.framework.testlib import E2ETest, workloads, ignore_leftovers
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -80,7 +81,10 @@ class TestAMQNodeReboot(E2ETest):
         argnames=["node_type"],
         argvalues=[
             pytest.param(*["worker"], marks=pytest.mark.polarion_id("OCS-1282")),
-            pytest.param(*["master"], marks=pytest.mark.polarion_id("OCS-1281")),
+            pytest.param(
+                *["master"],
+                marks=[pytest.mark.polarion_id("OCS-1281"), skipif_rosa_hcp],
+            ),
         ],
     )
     def test_amq_after_rebooting_node(self, node_type, nodes, amq_setup):

--- a/tests/functional/workloads/app/couchbase/test_couchbase_node_reboot.py
+++ b/tests/functional/workloads/app/couchbase/test_couchbase_node_reboot.py
@@ -5,7 +5,7 @@ import pytest
 
 from ocs_ci.ocs import ocp
 from ocs_ci.helpers.sanity_helpers import Sanity
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, skipif_rosa_hcp
 from ocs_ci.framework.testlib import (
     E2ETest,
     workloads,
@@ -51,7 +51,9 @@ class TestCouchBaseNodeReboot(E2ETest):
         argnames=["pod_name_of_node"],
         argvalues=[
             pytest.param(*["osd"], marks=pytest.mark.polarion_id("OCS-776")),
-            pytest.param(*["master"], marks=pytest.mark.polarion_id("OCS-783")),
+            pytest.param(
+                *["master"], marks=[pytest.mark.polarion_id("OCS-783"), skipif_rosa_hcp]
+            ),
             pytest.param(*["couchbase"], marks=pytest.mark.polarion_id("OCS-776")),
         ],
     )

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -279,7 +279,10 @@ class TestNodesMaintenance(ManageTest):
         argnames=["nodes_type"],
         argvalues=[
             pytest.param(*["worker"], marks=pytest.mark.polarion_id("OCS-1273")),
-            pytest.param(*["master"], marks=pytest.mark.polarion_id("OCS-1271")),
+            pytest.param(
+                *["master"],
+                marks=[pytest.mark.polarion_id("OCS-1271"), skipif_rosa_hcp],
+            ),
         ],
     )
     def test_2_nodes_maintenance_same_type(self, nodes_type):


### PR DESCRIPTION
the platform is forbidding operations with master nodes. master nodes are not available for customer