### PR TITLE
Skip MCG object expiration tests in external PostgreSQL noobaa-db deployments

### DIFF
--- a/tests/functional/object/mcg/test_object_expiration.py
+++ b/tests/functional/object/mcg/test_object_expiration.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     runs_on_provider,
     mcg,
+    skipif_noobaa_external_pgsql,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.framework.testlib import skipif_ocs_version
@@ -41,6 +42,7 @@ PROP_SLEEP_TIME = 10
 @mcg
 @red_squad
 @runs_on_provider
+@skipif_noobaa_external_pgsql
 class TestObjectExpiration(MCGTest):
     """
     Tests suite for object expiration


### PR DESCRIPTION
Adds the `skipif_noobaa_external_pgsql` decorator to the TestObjectExpiration class. These tests make queries to the noobaa-db in order to change the creation date of objects.

Fixes: #9889

