### PR TITLE
wrap s3 benchmark-tool - ns in hostname fixed

### DIFF
--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -37,6 +37,9 @@ class Warp(object):
         self.bucket_name = None
         self.warp_cr = templating.load_yaml(constants.WARP_OBJ_YAML)
         self.host = self.warp_cr["host"]
+        # avoid failing DNS server to resolve hostname, when running on cluster with custom storage namespace
+        if config.ENV_DATA["cluster_namespace"] not in self.host:
+            self.host = f"s3.{config.ENV_DATA['cluster_namespace']}.svc"
         self.duration = self.warp_cr["duration"]
         self.concurrent = self.warp_cr["concurrent"]
         self.obj_size = self.warp_cr["obj.size"]

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -36,10 +36,8 @@ class Warp(object):
         self.ocp_obj = OCP(namespace=self.namespace)
         self.bucket_name = None
         self.warp_cr = templating.load_yaml(constants.WARP_OBJ_YAML)
-        self.host = self.warp_cr["host"]
         # avoid failing DNS server to resolve hostname, when running on cluster with custom storage namespace
-        if config.ENV_DATA["cluster_namespace"] not in self.host:
-            self.host = f"s3.{config.ENV_DATA['cluster_namespace']}.svc"
+        self.host = f"s3.{config.ENV_DATA['cluster_namespace']}.svc"
         self.duration = self.warp_cr["duration"]
         self.concurrent = self.warp_cr["concurrent"]
         self.obj_size = self.warp_cr["obj.size"]


### PR DESCRIPTION
The hostname for wrap s3 benchmark-tool is now dynamic, tuned to a storage namespace.

test run Pass: https://url.corp.redhat.com/218b7dc