### PR TITLE
add jira mark DFBUGS-1284

### DIFF
--- a/tests/functional/pod_and_daemons/test_mgr_enable_rook_backend_module.py
+++ b/tests/functional/pod_and_daemons/test_mgr_enable_rook_backend_module.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     tier2,
     brown_squad,
+    jira,
 )
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
 @brown_squad
 @skipif_external_mode
 @skipif_ocs_version("<4.15")
+@jira("DFBUGS-1284")
 @bugzilla("2274165")
 @pytest.mark.polarion_id("OCS-6240")
 class TestMgrRookModule(ManageTest):


### PR DESCRIPTION
Added jira mark "[DFBUGS-1284](https://issues.redhat.com//browse/DFBUGS-1284)" for https://github.com/red-hat-storage/ocs-ci/blob/master/tests/functional/pod_and_daemons/test_mgr_enable_rook_backend_module.py

stop failures with output due to a known issue. [Mgr crash]

{ "backtrace": [ " File \"/usr/share/ceph/mgr/orchestrator/_interface.py\", line 796, in get_prometheus_access_info\n raise NotImplementedError()", "NotImplementedError" ], "ceph_version": "19.2.0-53.el9cp", "crash_id": "2025-01-01T12:19:36.669894Z_2ab3c979-3a1d-43ea-9376-3c2367607b88", "entity_name": "mgr.a", "mgr_module": "rook", "mgr_module_caller": "ActivePyModule::dispatch_remote get_prometheus_access_info", "mgr_python_exception": "NotImplementedError", "os_id": "rhel", "os_name": "Red Hat Enterprise Linux", "os_version": "9.5 (Plow)", "os_version_id": "9.5", "process_name": "ceph-mgr", "stack_sig": "fbef79885373e73786fa85056f0aec529777e1c95da236d061b1cf4ffa7fe197", "timestamp": "2025-01-01T12:19:36.669894Z", "utsname_hostname": "rook-ceph-mgr-a-84cdf5d58c-2wfrz", "utsname_machine": "x86_64", "utsname_release": "5.14.0-427.50.1.el9_4.x86_64", "utsname_sysname": "Linux", "utsname_version": "#1 SMP PREEMPT_DYNAMIC Wed Dec 18 13:06:23 EST 2024" }
