### PR TITLE
Adds condition for skipping BS creation on IBM cloud for FIPS enabled cluster

### DIFF
--- a/tests/functional/object/mcg/test_multicloud.py
+++ b/tests/functional/object/mcg/test_multicloud.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import tier1
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.framework.pytest_customization.marks import (
@@ -55,6 +56,9 @@ class TestMultiCloud(MCGTest):
         """
         Test MCG backingstore creation
         """
+        _, value = backingstore_tup
+        if config.ENV_DATA.get("fips") == "true" and "ibmcos" in value:
+            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
 
         backingstore_factory(*backingstore_tup)
 

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -7,6 +7,7 @@ from zipfile import ZipFile
 import pytest
 from flaky import flaky
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     vsphere_platform_required,
     skip_inconsistent,
@@ -205,6 +206,20 @@ class TestBucketIO(MCGTest):
             awscli_pod_session (pod): A pod running the AWSCLI tools
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
+
+        if (
+            config.ENV_DATA.get("fips") == "true"
+            and "ibmcos" in bucketclass_dict["backingstore_dict"]
+        ):
+            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
+
+        if (
+            config.ENV_DATA.get("fips") == "true"
+            and bucketclass_dict is None
+            and config.ENV_DATA["platform"].lower() == "ibm_cloud"
+        ):
+            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
+
         download_dir = AWSCLI_TEST_OBJ_DIR
         file_size = int(
             awscli_pod_session.exec_cmd_on_pod(
@@ -268,6 +283,19 @@ class TestBucketIO(MCGTest):
             awscli_pod_session (pod): A pod running the AWSCLI tools
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
+        if (
+            config.ENV_DATA.get("fips") == "true"
+            and "ibmcos" in bucketclass_dict["backingstore_dict"]
+        ):
+            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
+
+        if (
+            config.ENV_DATA.get("fips") == "true"
+            and bucketclass_dict is None
+            and config.ENV_DATA["platform"].lower() == "ibm_cloud"
+        ):
+            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
+
         download_dir = AWSCLI_TEST_OBJ_DIR
         bucketname = bucket_factory(1, bucketclass=bucketclass_dict)[0].name
         full_object_path = f"s3://{bucketname}"


### PR DESCRIPTION
Fixes #10561 

Log link where run skipped IBM cloud backed backingStore creation for FIPS enabled cluster:
https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/45315/console