### PR TITLE
Adding support in creation of bucket class with mcg cli and a new test case for creation of rgw namespacestore using mcg-cli 

### DIFF
--- a/ocs_ci/ocs/resources/bucketclass.py
+++ b/ocs_ci/ocs/resources/bucketclass.py
@@ -140,7 +140,6 @@ def bucket_class_factory(
                         },
                     }
                 else:
-                    # TODO: Implement support for Single-tiered NS bucketclass
                     namespace_policy["read_resources"] = [
                         nss.name for nss in namespacestores
                     ]

--- a/ocs_ci/ocs/resources/bucketclass.py
+++ b/ocs_ci/ocs/resources/bucketclass.py
@@ -209,10 +209,12 @@ def bucket_class_factory(
         interfaces[interface.lower()](
             name=bucket_class_name,
             backingstores=backingstores,
+            namespacestores=namespacestores,
             placement_policy=placement_policy,
             namespace_policy=namespace_policy,
             replication_policy=replication_policy,
         )
+
         bucket_class_object = BucketClass(
             bucket_class_name,
             backingstores,

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -713,7 +713,9 @@ class MCG:
 
         """
         if backingstores:  # bucket class is over backingstore
-            backingstore_name_list = [backingstore.name for backingstore in backingstores]
+            backingstore_name_list = [
+                backingstore.name for backingstore in backingstores
+            ]
             backingstores = f" --backingstores {','.join(backingstore_name_list)}"
             placement_policy = f" --placement {placement_policy}"
             placement_type = (
@@ -723,7 +725,8 @@ class MCG:
             )
             if (
                 replication_policy is not None
-                and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_12
+                and version.get_semantic_ocs_version_from_config()
+                >= version.VERSION_4_12
             ):
                 replication_policy = {"rules": replication_policy}
             with tempfile.NamedTemporaryFile(
@@ -741,7 +744,9 @@ class MCG:
                     f"bucketclass create {placement_type}{name}{backingstores}{placement_policy}{replication_policy}"
                 )
         elif namespacestores:  # bucket class is over namespacestores
-            namestores_name_list = [namespacestore.name for namespacestore in namespacestores]
+            namestores_name_list = [
+                namespacestore.name for namespacestore in namespacestores
+            ]
             namestores_name_str = f"{','.join(namestores_name_list)}"
             namespace_policy_type = namespace_policy["type"].lower()
             self.exec_mcg_cmd(

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -697,7 +697,7 @@ class MCG:
         replication_policy=None,
     ):
         """
-        Creates a new NooBaa bucket class using the noobaa cli over either backingstores
+        Creates a new NooBaa bucket class using the noobaa cli over backingstores
         Args:
             name (str): The name to be given to the bucket class
             backingstores (list): The backing stores to use as part of the policy.
@@ -758,6 +758,12 @@ class MCG:
         ]
         namestores_name_str = f"{','.join(namestores_name_list)}"
         namespace_policy_type = namespace_policy["type"].lower()
+        if namespace_policy_type != constants.NAMESPACE_POLICY_TYPE_SINGLE:
+            raise NotImplementedError(
+                f"Cli creating of bucketclass on namespacestpre "
+                f"with policy {namespace_policy_type} is not implemented yet"
+            )
+
         self.exec_mcg_cmd(
             f"bucketclass create namespace-bucketclass {namespace_policy_type} "
             f"--resource={namestores_name_str} {name}"

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -699,7 +699,7 @@ class MCG:
         replication_policy=None,
     ):
         """
-        Creates a new NooBaa bucket class using the noobaa cli over either backing store pr namespace stores
+        Creates a new NooBaa bucket class using the noobaa cli over either backingstores or namespace stores
         Args:
             name (str): The name to be given to the bucket class
             backingstores (list): The backing stores to use as part of the policy. If None, namespacestores are used

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -712,7 +712,7 @@ class MCG:
             OCS: The bucket class resource
 
         """
-        if backingstores: # bucket class is over backingstore
+        if backingstores:  # bucket class is over backingstore
             backingstore_name_list = [backingstore.name for backingstore in backingstores]
             backingstores = f" --backingstores {','.join(backingstore_name_list)}"
             placement_policy = f" --placement {placement_policy}"
@@ -740,12 +740,13 @@ class MCG:
                 self.exec_mcg_cmd(
                     f"bucketclass create {placement_type}{name}{backingstores}{placement_policy}{replication_policy}"
                 )
-        elif namespacestores: # bucket class is over namespacestores
+        elif namespacestores:  # bucket class is over namespacestores
             namestores_name_list = [namespacestore.name for namespacestore in namespacestores]
             namestores_name_str = f"{','.join(namestores_name_list)}"
             namespace_policy_type = namespace_policy["type"].lower()
             self.exec_mcg_cmd(
-                f"bucketclass create namespace-bucketclass {namespace_policy_type} --resource={namestores_name_str} {name}"
+                f"bucketclass create namespace-bucketclass {namespace_policy_type} "
+                f"--resource={namestores_name_str} {name}"
             )
         else:
             assert False, "No backingstores or namespacestores provided"

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -758,9 +758,9 @@ class MCG:
         ]
         namestores_name_str = f"{','.join(namestores_name_list)}"
         namespace_policy_type = namespace_policy["type"].lower()
-        if namespace_policy_type != constants.NAMESPACE_POLICY_TYPE_SINGLE:
+        if namespace_policy_type != constants.NAMESPACE_POLICY_TYPE_SINGLE.lower():
             raise NotImplementedError(
-                f"Cli creating of bucketclass on namespacestpre "
+                f"Cli creating of bucketclass on namespacestore "
                 f"with policy {namespace_policy_type} is not implemented yet"
             )
 

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -134,6 +134,20 @@ class TestNamespace(MCGTest):
             ),
             pytest.param(
                 {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"rgw": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    pytest.mark.polarion_id("OCS-2407"),
+                ],
+            ),
+            pytest.param(
+                {
                     "interface": "OC",
                     "namespace_policy_dict": {
                         "type": "Single",
@@ -203,6 +217,7 @@ class TestNamespace(MCGTest):
             "AWS-OC-Single",
             "Azure-OC-Single",
             "RGW-OC-Single",
+            "RGW-CLI-Single",
             "IBM-OC-Single",
             "AWS+Azure-OC-Multi",
             "AWS+AWS-OC-Multi",


### PR DESCRIPTION
This PR implements the following enhancement to cli_create_bucketclass method : in the past it was creating only backingstore with mcg-cli and from now on it will be able to create a bucketclass with mcg-cli command also for namespacestore. 

Following this enhancement it was possible to add a new test case which implements creation of namespacestore and bucketclass for rgw using mcg-cli commands. 

In the next PR I will implement automation of https://issues.redhat.com/browse/DFBUGS-1035 ( creating namespacestore and bucketclass on rgw bucket and writing IO to this bucket). 