### PR TITLE
[ROSA HCP] storage encryption. fix namespace issue

### DIFF
--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -418,12 +418,14 @@ class Vault(KMS):
             token_data = templating.load_yaml(constants.EXTERNAL_VAULT_KMS_TOKEN)
             # token has to base64 encoded (with padding)
             token_data["data"]["token"] = encode(self.vault_path_token)
+            token_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
             self.create_resource(token_data, prefix="token")
 
         # create ocs-kms-connection-details
         connection_data = templating.load_yaml(
             constants.EXTERNAL_VAULT_KMS_CONNECTION_DETAILS
         )
+        connection_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
         connection_data["data"]["VAULT_ADDR"] = os.environ["VAULT_ADDR"]
         if Version.coerce(config.ENV_DATA["ocs_version"]) >= Version.coerce("4.10"):
             connection_data["data"]["VAULT_AUTH_METHOD"] = self.vault_auth_method


### PR DESCRIPTION
fix the error

```
2025-01-15 17:26:02  10:26:02 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc create -f /tmp/clientkeyrshnu5m_
2025-01-15 17:26:03  10:26:02 - MainThread - ocs_ci.utility.templating - INFO  - apiVersion: v1
2025-01-15 17:26:03  data:
2025-01-15 17:26:03    token: '*****'
2025-01-15 17:26:03  kind: Secret
2025-01-15 17:26:03  metadata:
2025-01-15 17:26:03    name: ocs-kms-token
2025-01-15 17:26:03    namespace: openshift-storage
2025-01-15 17:26:03  type: Opaque
2025-01-15 17:26:03  
2025-01-15 17:26:03  10:26:02 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc create -f /tmp/tokenq0lo5hay
2025-01-15 17:26:03  10:26:03 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): error when creating "/tmp/tokenq0lo5hay": namespaces "openshift-storage" not found
2025-01-15 17:26:03  
2025-01-15 17:26:03  10:26:03 - MainThread - ocs_ci.deployment.deployment - ERROR  - Error during execution of command: oc create -f /tmp/tokenq0lo5hay.
2025-01-15 17:26:03  Error is Error from server (NotFound): error when creating "/tmp/tokenq0lo5hay": namespaces "openshift-storage" not found

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> Error trace >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 
2025-01-15 17:29:14          if deploy:
2025-01-15 17:29:14              # Deploy cluster
2025-01-15 17:29:14  >           deployer.deploy_cluster(log_cli_level)
2025-01-15 17:29:14  
2025-01-15 17:29:14  tests/conftest.py:1955: 
2025-01-15 17:29:14  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-01-15 17:29:14  ocs_ci/deployment/deployment.py:706: in deploy_cluster
2025-01-15 17:29:14      self.do_deploy_ocs()
2025-01-15 17:29:14  ocs_ci/deployment/deployment.py:374: in do_deploy_ocs
2025-01-15 17:29:14      self.deploy_ocs()
2025-01-15 17:29:14  ocs_ci/deployment/rosa.py:282: in deploy_ocs
2025-01-15 17:29:14      super(ROSA, self).deploy_ocs()
2025-01-15 17:29:14  ocs_ci/deployment/deployment.py:2026: in deploy_ocs
2025-01-15 17:29:14      self.deploy_ocs_via_operator(image)
2025-01-15 17:29:14  ocs_ci/deployment/deployment.py:1337: in deploy_ocs_via_operator
2025-01-15 17:29:14      kms.deploy()
2025-01-15 17:29:14  ocs_ci/utility/kms.py:140: in deploy
2025-01-15 17:29:14      self.deploy_vault_external()
2025-01-15 17:29:14  ocs_ci/utility/kms.py:168: in deploy_vault_external
2025-01-15 17:29:14      self.create_ocs_vault_resources()
2025-01-15 17:29:14  ocs_ci/utility/kms.py:421: in create_ocs_vault_resources
2025-01-15 17:29:14      self.create_resource(token_data, prefix="token")
2025-01-15 17:29:14  ocs_ci/utility/kms.py:95: in create_resource
2025-01-15 17:29:14      run_cmd(f"oc create -f {resource_data_yaml.name}", timeout=300)
2025-01-15 17:29:14  ocs_ci/utility/utils.py:488: in run_cmd
2025-01-15 17:29:14      completed_process = exec_cmd(
...
2025-01-15 17:29:14  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc create -f /tmp/tokenq0lo5hay.
2025-01-15 17:29:14  E               Error is Error from server (NotFound): error when creating "/tmp/tokenq0lo5hay": namespaces "openshift-storage" not found
```