### PR TITLE
Preserve the working directory during log collection

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1343,6 +1343,7 @@ def collect_ocs_logs(
         ocs_flags (str): flags to ocs must gather command for example ["-- /usr/bin/gather -cs"]
 
     """
+    cwd = os.getcwd()
     results = list()
     with ThreadPoolExecutor() as executor:
         for cluster in ocsci_config.clusters:
@@ -1393,6 +1394,8 @@ def collect_ocs_logs(
             log.error("Must-gather collection failed")
             log.error(e)
             raise
+        finally:
+            os.chdir(cwd)
 
 
 def collect_prometheus_metrics(


### PR DESCRIPTION
Fixes: #8934 

This PR introduces a change to ensure that the working directory is preserved during the execution of the `collect_ocs_logs`
