### PR TITLE
Mark test_prometheus_rule_failures as flaky

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
@@ -1,5 +1,6 @@
 import logging
 
+from flaky import flaky
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
@@ -36,6 +37,7 @@ def test_alerting_works(threading_lock):
 @pytest.mark.polarion_id("OCS-2503")
 @bugzilla("1897674")
 @tier1
+@flaky(max_runs=3)
 def test_prometheus_rule_failures(threading_lock):
     """
     There should be no PrometheusRuleFailures alert when OCS is configured.


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/11134
Reruns test_prometheus_rule_failures if failed to prevent disruption from previous test case