### PR TITLE
Adding a new test case for rgw namespacestore created with cli

### DIFF
--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -37,6 +37,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     on_prem_platform_required,
+    jira,
 )
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 from uuid import uuid4
@@ -133,7 +134,11 @@ class TestBucketIO(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, on_prem_platform_required],
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    jira("DFBUGS-1035", run=False),
+                ],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -19,7 +19,6 @@ from ocs_ci.framework.testlib import (
     tier1,
     tier2,
     performance,
-    jira,
 )
 from ocs_ci.utility.utils import exec_nb_db_query
 from ocs_ci.ocs import constants

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -19,6 +19,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     tier2,
     performance,
+    jira,
 )
 from ocs_ci.utility.utils import exec_nb_db_query
 from ocs_ci.ocs import constants
@@ -122,10 +123,24 @@ class TestBucketIO(MCGTest):
                 ],
                 marks=[tier1, on_prem_platform_required],
             ),
+            pytest.param(
+                *[
+                    "CLI",
+                    {
+                        "interface": "CLI",
+                        "namespace_policy_dict": {
+                            "type": "Single",
+                            "namespacestore_dict": {"rgw": [(1, None)]},
+                        },
+                    },
+                ],
+                marks=[tier1, on_prem_platform_required],
+            ),
         ],
         ids=[
             "RGW-OC-1",
             "RGW-CLI-1",
+            "RGW-CLI-NSS-1",
         ],
     )
     @flaky


### PR DESCRIPTION
This PR contains additional test case for testing writing to bucket created on RGW namespacestore created with CLI. 

Adding the original bug for context: https://issues.redhat.com/browse/DFBUGS-1035