### PR TITLE
Skip test_cross_class_different_pool_clone_snap_restore test for external mode

### DIFF
--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     post_upgrade,
     skipif_managed_service,
     skipif_hci_provider_and_client,
+    skipif_external_mode,
 )
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from tests.fixtures import create_project
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 @tier2
 @post_upgrade
 @skipif_managed_service
+@skipif_external_mode
 @skipif_hci_provider_and_client
 @pytest.mark.usefixtures(
     create_project.__name__,


### PR DESCRIPTION
Skipping test `test_cross_class_different_pool_clone_snap_restore` for external mode setup.

For more details refer this comment: https://github.com/red-hat-storage/ocs-ci/issues/11221#issuecomment-2619283669
