### PR TITLE
make platform_nodes.BaremetalNodes independent on BM environment

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -2103,16 +2103,30 @@ class BaremetalNodes(NodesBase):
         """
         self.baremetal.start_baremetal_machines(nodes, wait=wait)
 
-    def restart_nodes(self, nodes, force=True):
+    def restart_nodes(self, nodes, wait=True, force=True):
         """
         Restart Baremetal Machine
 
         Args:
             nodes (list): The OCS objects of the nodes
+            wait (bool): NOT IMPLEMENTED! True if need to wait till the restarted OCP node
+                reaches READY state. False otherwise
             force (bool): True for force BM stop, False otherwise
 
         """
+        # TODO: handle wait parameter
         self.baremetal.restart_baremetal_machines(nodes, force=force)
+
+    def restart_nodes_by_stop_and_start(self, nodes, force=True):
+        """
+        Restart Bare Metal Machines
+
+        Args:
+            nodes (list): The OCS objects of the nodes
+            force (bool): True for force machine stop, False otherwise
+
+        """
+        self.baremetal.restart_baremetal_machines_by_stop_and_start(nodes, force=force)
 
     def restart_nodes_by_stop_and_start_teardown(self):
         """
@@ -2120,18 +2134,15 @@ class BaremetalNodes(NodesBase):
 
         """
         self.cluster_nodes = get_node_objs()
-        bms = self.baremetal.get_nodes_ipmi_ctx(self.cluster_nodes)
         stopped_bms = [
             bm
-            for bm in bms
+            for bm in self.cluster_nodes
             if self.baremetal.get_power_status(bm) == constants.VM_POWERED_OFF
         ]
 
         if stopped_bms:
             logger.info(f"The following BMs are powered off: {stopped_bms}")
-            self.baremetal.start_baremetal_machines_with_ipmi_ctx(stopped_bms)
-        for bm in bms:
-            bm.session.close()
+            self.baremetal.start_baremetal_machines(stopped_bms)
 
     def get_data_volumes(self):
         raise NotImplementedError("Get data volume functionality is not implemented")

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -9,6 +9,7 @@ from ocs_ci.ocs.constants import VM_POWERED_OFF, VM_POWERED_ON
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.node import wait_for_nodes_status, get_worker_nodes, get_master_nodes
 from ocs_ci.ocs.ocp import OCP, wait_for_cluster_connectivity
+from ocs_ci.utility import ibmcloud_bm
 from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,127 @@ logger = logging.getLogger(__name__)
 class BAREMETAL(object):
     """
     wrapper for Baremetal
+    """
+
+    def __init__(self):
+        """
+        Initialize the variables required
+
+        """
+        self.srv_details = config.ENV_DATA["baremetal"]["servers"]
+        if any(
+            [
+                self.srv_details[srv].get("mgmt_provider", "ipmitool") == "ipmitool"
+                for srv in self.srv_details
+            ]
+        ):
+            self.bm_ipmi = BaremetalIPMI()
+        if any(
+            [
+                self.srv_details[srv].get("mgmt_provider", "ipmitool") == "ibmcloud"
+                for srv in self.srv_details
+            ]
+        ):
+            self.bm_ibmcloud = ibmcloud_bm.IBMCloudBM()
+
+    def get_power_status(self, node):
+        """
+        Get BM Power status
+
+        Args:
+
+        Returns: (bool): bm power status
+
+        """
+        # return VM_POWERED_ON if chassis_status.power_on else VM_POWERED_OFF
+        mgmt_provider = self.srv_details[node.name].get("mgmt_provider", "ipmitool")
+        if mgmt_provider == "ipmitool":
+            return self.bm_ipmi.get_power_status(node)
+        elif mgmt_provider == "ibmcloud":
+            machine = self.bm_ibmcloud.get_machines_by_names([node.name])[0]
+            return self.bm_ibmcloud.get_power_status(machine)
+
+    def stop_baremetal_machines(self, baremetal_machine, force=True):
+        """
+        Stop Baremetal Machines
+
+        Args:
+            baremetal_machine (list): BM objects
+            force (bool): True for BM ungraceful power off, False for
+                graceful BM shutdown
+
+        Raises:
+            UnexpectedBehaviour: If baremetal machine is still up
+
+        """
+        for node in baremetal_machine:
+            mgmt_provider = self.srv_details[node.name].get("mgmt_provider", "ipmitool")
+            if mgmt_provider == "ipmitool":
+                self.bm_ipmi.stop_baremetal_machine(node, force=force)
+            elif mgmt_provider == "ibmcloud":
+                machines = self.bm_ibmcloud.get_machines_by_names([node.name])
+                self.bm_ibmcloud.stop_machines(machines)
+
+    def start_baremetal_machines(self, baremetal_machine, wait=True):
+        """
+        Start Baremetal Machines
+
+        Args:
+            baremetal_machine (list): BM objects
+            wait (bool): Wait for BMs to start
+
+        """
+        for node in baremetal_machine:
+            mgmt_provider = self.srv_details[node.name].get("mgmt_provider", "ipmitool")
+            if mgmt_provider == "ipmitool":
+                self.bm_ipmi.start_baremetal_machine(node, wait=wait)
+            elif mgmt_provider == "ibmcloud":
+                machines = self.bm_ibmcloud.get_machines_by_names([node.name])
+                # TODO: implement wait
+                self.bm_ibmcloud.start_machines(machines)
+
+        wait_for_cluster_connectivity(tries=400)
+        wait_for_nodes_status(
+            node_names=get_master_nodes(), status=constants.NODE_READY, timeout=800
+        )
+        wait_for_nodes_status(
+            node_names=get_worker_nodes(), status=constants.NODE_READY, timeout=800
+        )
+
+    def restart_baremetal_machines(self, baremetal_machine, force=True):
+        """
+
+        Restart Baremetal Machines
+
+        Args:
+            baremetal_machine (list): BM objects
+            force (bool): True for BM ungraceful power off, False for
+                graceful BM shutdown
+
+        """
+        self.stop_baremetal_machines(baremetal_machine, force=force)
+        self.start_baremetal_machines(baremetal_machine)
+
+    def restart_baremetal_machines_by_stop_and_start(
+        self, baremetal_machine, force=True
+    ):
+        """
+
+        Restart Baremetal Machines
+
+        Args:
+            baremetal_machine (list): BM objects
+            force (bool): True for BM ungraceful power off, False for
+                graceful BM shutdown
+
+        """
+        self.stop_baremetal_machines(baremetal_machine, force=force)
+        self.start_baremetal_machines(baremetal_machine)
+
+
+class BaremetalIPMI(object):
+    """
+    Class for controlling Bare Metal servers through IPMI
     """
 
     def __init__(self):
@@ -47,16 +169,17 @@ class BAREMETAL(object):
         ipmi.target = pyipmi.Target(ipmb_address=defaults.IPMI_IPMB_ADDRESS)
         return ipmi
 
-    def get_power_status(self, ipmi_ctx):
+    def get_power_status(self, node):
         """
         Get BM Power status
 
         Args:
-            ipmi_ctx (object) : Ipmi host handler
+            node (object) : Node object
 
         Returns: (bool): bm power status
 
         """
+        ipmi_ctx = self.get_nodes_ipmi_ctx([node])[0]
         chassis_status = ipmi_ctx.get_chassis_status()
         return VM_POWERED_ON if chassis_status.power_on else VM_POWERED_OFF
 
@@ -71,18 +194,19 @@ class BAREMETAL(object):
             bool: True if machine is down, False otherwise
 
         """
+        # TODO: verify/fix this method for IBM Cloud BM servers
         result = exec_cmd(cmd=f"ping {node.name} -c 10", ignore_error=True)
         if result.returncode == 0:
             return False
         else:
             return True
 
-    def stop_baremetal_machines(self, baremetal_machine, force=True):
+    def stop_baremetal_machine(self, baremetal_machine, force=True):
         """
-        Stop Baremetal Machines
+        Stop Baremetal Machine
 
         Args:
-            baremetal_machine (list): BM objects
+            baremetal_machine: BM object
             force (bool): True for BM ungraceful power off, False for
                 graceful BM shutdown
 
@@ -90,141 +214,83 @@ class BAREMETAL(object):
             UnexpectedBehaviour: If baremetal machine is still up
 
         """
-        for node in baremetal_machine:
-            if force:
-                if self.srv_details[node.name]:
-                    ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.srv_details[node.name]["mgmt_console"],
-                        user=self.srv_details[node.name]["mgmt_username"],
-                        password=self.srv_details[node.name]["mgmt_password"],
-                    )
-                    logger.info(f"Powering Off {node.name}")
-                    ipmi_ctx.chassis_control_power_down()
-            else:
-                ocp = OCP(kind="node")
-                ocp.exec_oc_debug_cmd(
-                    node=node.name, cmd_list=["shutdown now"], timeout=60
+        if force:
+            if self.srv_details[baremetal_machine.name]:
+                ipmi_ctx = self.get_ipmi_ctx(
+                    host=self.srv_details[baremetal_machine.name]["mgmt_console"],
+                    user=self.srv_details[baremetal_machine.name]["mgmt_username"],
+                    password=self.srv_details[baremetal_machine.name]["mgmt_password"],
                 )
-                if self.srv_details[node.name]:
-                    ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.srv_details[node.name]["mgmt_console"],
-                        user=self.srv_details[node.name]["mgmt_username"],
-                        password=self.srv_details[node.name]["mgmt_password"],
+                logger.info(f"Powering Off {baremetal_machine.name}")
+                ipmi_ctx.chassis_control_power_down()
+        else:
+            ocp = OCP(kind="node")
+            ocp.exec_oc_debug_cmd(
+                node=baremetal_machine.name, cmd_list=["shutdown now"], timeout=60
+            )
+            if self.srv_details[baremetal_machine.name]:
+                for status in TimeoutSampler(
+                    600, 5, self.get_power_status, baremetal_machine
+                ):
+                    logger.info(
+                        f"Waiting for Baremetal Machine {baremetal_machine.name} to power off"
+                        f"Current Baremetal status: {status}"
                     )
-                    for status in TimeoutSampler(
-                        600, 5, self.get_power_status, ipmi_ctx
-                    ):
+                    if status == VM_POWERED_OFF:
                         logger.info(
-                            f"Waiting for Baremetal Machine {node.name} to power off"
-                            f"Current Baremetal status: {status}"
+                            f"Baremetal Machine {baremetal_machine.name} reached poweredOff status"
                         )
-                        if status == VM_POWERED_OFF:
-                            logger.info(
-                                f"Baremetal Machine {node.name} reached poweredOff status"
-                            )
-                            break
+                        break
         logger.info("Verifing machine is down")
         ret = TimeoutSampler(
             timeout=300,
             sleep=3,
             func=self.verify_machine_is_down,
-            node=node,
+            node=baremetal_machine,
         )
         logger.info(ret)
         if not ret.wait_for_func_status(result=True):
-            raise UnexpectedBehaviour("Machine {node.name} is still Running")
+            raise UnexpectedBehaviour(
+                "Machine {baremetal_machine.name} is still Running"
+            )
 
-    def start_baremetal_machines_with_ipmi_ctx(self, ipmi_ctxs, wait=True):
+    def start_baremetal_machine(self, baremetal_machine, wait=True):
         """
-        Start Baremetal Machines using Ipmi ctx
+        Start Baremetal Machine
 
         Args:
-            ipmi_ctxs (list): List of BM ipmi_ctx
-            wait (bool): Wait for BMs to start
+            baremetal_machine: BM objects
+            wait (bool): Wait for BM to start
 
         """
-        for ipmi_ctx in ipmi_ctxs:
+        if self.srv_details[baremetal_machine.name]:
+            ipmi_ctx = self.get_ipmi_ctx(
+                host=self.srv_details[baremetal_machine.name]["mgmt_console"],
+                user=self.srv_details[baremetal_machine.name]["mgmt_username"],
+                password=self.srv_details[baremetal_machine.name]["mgmt_password"],
+            )
+            logger.info(f"Powering On {baremetal_machine.name}")
             ipmi_ctx.chassis_control_power_up()
-
         if wait:
-            for ipmi_ctx in ipmi_ctxs:
-                for status in TimeoutSampler(600, 5, self.get_power_status, ipmi_ctx):
+            if self.srv_details[baremetal_machine.name]:
+                ipmi_ctx = self.get_ipmi_ctx(
+                    host=self.srv_details[baremetal_machine.name]["mgmt_console"],
+                    user=self.srv_details[baremetal_machine.name]["mgmt_username"],
+                    password=self.srv_details[baremetal_machine.name]["mgmt_password"],
+                )
+                for status in TimeoutSampler(
+                    600, 5, self.get_power_status, baremetal_machine
+                ):
                     logger.info(
-                        f"Waiting for Baremetal Machine to power on. "
+                        f"Waiting for Baremetal Machine {baremetal_machine.name} to power on. "
                         f"Current Baremetal status: {status}"
                     )
                     if status == VM_POWERED_ON:
-                        logger.info("Baremetal Machine reached poweredOn status")
-                        break
-
-        wait_for_cluster_connectivity(tries=400)
-        wait_for_nodes_status(
-            node_names=get_master_nodes(), status=constants.NODE_READY, timeout=800
-        )
-        wait_for_nodes_status(
-            node_names=get_worker_nodes(), status=constants.NODE_READY, timeout=800
-        )
-
-    def start_baremetal_machines(self, baremetal_machine, wait=True):
-        """
-        Start Baremetal Machines
-
-        Args:
-            baremetal_machine (list): BM objects
-            wait (bool): Wait for BMs to start
-
-        """
-        for node in baremetal_machine:
-            if self.srv_details[node.name]:
-                ipmi_ctx = self.get_ipmi_ctx(
-                    host=self.srv_details[node.name]["mgmt_console"],
-                    user=self.srv_details[node.name]["mgmt_username"],
-                    password=self.srv_details[node.name]["mgmt_password"],
-                )
-                logger.info(f"Powering On {node.name}")
-                ipmi_ctx.chassis_control_power_up()
-            if wait:
-                if self.srv_details[node.name]:
-                    ipmi_ctx = self.get_ipmi_ctx(
-                        host=self.srv_details[node.name]["mgmt_console"],
-                        user=self.srv_details[node.name]["mgmt_username"],
-                        password=self.srv_details[node.name]["mgmt_password"],
-                    )
-                    for status in TimeoutSampler(
-                        600, 5, self.get_power_status, ipmi_ctx
-                    ):
                         logger.info(
-                            f"Waiting for Baremetal Machine {node.name} to power on. "
-                            f"Current Baremetal status: {status}"
+                            f"Baremetal Machine {baremetal_machine.name} reached poweredOn status"
                         )
-                        if status == VM_POWERED_ON:
-                            logger.info(
-                                f"Baremetal Machine {node.name} reached poweredOn status"
-                            )
-                            ipmi_ctx.session.close()
-                            break
-
-        wait_for_cluster_connectivity(tries=400)
-        wait_for_nodes_status(
-            node_names=get_master_nodes(), status=constants.NODE_READY, timeout=800
-        )
-        wait_for_nodes_status(
-            node_names=get_worker_nodes(), status=constants.NODE_READY, timeout=800
-        )
-
-    def restart_baremetal_machines(self, baremetal_machine, force=True):
-        """
-
-        Restart Baremetal Machines
-
-        Args:
-            baremetal_machine (list): BM objects
-            force (bool): True for BM ungraceful power off, False for
-                graceful BM shutdown
-
-        """
-        self.stop_baremetal_machines(baremetal_machine, force=force)
-        self.start_baremetal_machines(baremetal_machine)
+                        ipmi_ctx.session.close()
+                        break
 
     def get_nodes_ipmi_ctx(self, baremetal_machine):
         """

--- a/ocs_ci/utility/ibmcloud_bm.py
+++ b/ocs_ci/utility/ibmcloud_bm.py
@@ -9,6 +9,7 @@ import logging
 import time
 
 from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.utility.retry import retry
@@ -115,6 +116,23 @@ class IBMCloudBM(object):
         """
         machine_list = self.get_all_machines()
         return [m for m in machine_list if m["hostname"] in machine_names]
+
+    def get_power_status(self, machine):
+        """
+        Get the power status of the machine.
+
+        Args:
+            machine (str): IBMCloud Bare metal machine object to get status from.
+
+        Returns:
+            Get the machines in the IBMCloud Bare metal machines that have the given machine names
+
+        """
+        return (
+            constants.VM_POWERED_ON
+            if machine["hardwareStatus"]["status"] == "ACTIVE"
+            else constants.VM_POWERED_OFF
+        )
 
     def stop_machines(self, machines):
         """

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "numpy==1.23.2",
         "pandas==1.5.2",
         "tabulate==0.9.0",
-        "python-ipmi==0.4.2",
+        "python-ipmi==0.5.7",
         "scipy==1.12.0",
         "PrettyTable==0.7.2",
         "azure-common==1.1.28",


### PR DESCRIPTION
- support both ipmitool and ibmcloud managed BM enviroments in platform_nodes.BaremetalNodes
- update python-ipmi to 0.5.7 to fix issues on python 3.9 and higher