### PR TITLE
Adding a new test case for bucketclass NSS creation with Cache  via CLI

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -766,7 +766,7 @@ class MCG:
             self.exec_mcg_cmd(cmd)
         elif namespace_policy_type == constants.NAMESPACE_POLICY_TYPE_CACHE.lower():
             cmd += f" --hub-resource={namestores_name_str}"
-            cmd += " --backingstores=noobaa-default-backing-store"
+            cmd += " --backingstores=constants.DEFAULT_NOOBAA_BACKINGSTORE"
             if "ttl" in namespace_policy:
                 cmd += f" --ttl=={namespace_policy['ttl']}"
             self.exec_mcg_cmd(cmd)

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -757,17 +757,24 @@ class MCG:
             namespacestore.name for namespacestore in namespacestores
         ]
         namestores_name_str = f"{','.join(namestores_name_list)}"
+
         namespace_policy_type = namespace_policy["type"].lower()
-        if namespace_policy_type != constants.NAMESPACE_POLICY_TYPE_SINGLE.lower():
+        cmd = f"bucketclass create namespace-bucketclass {namespace_policy_type} {name}"
+
+        if namespace_policy_type == constants.NAMESPACE_POLICY_TYPE_SINGLE.lower():
+            cmd += f" --resource={namestores_name_str}"
+            self.exec_mcg_cmd(cmd)
+        elif namespace_policy_type == constants.NAMESPACE_POLICY_TYPE_CACHE.lower():
+            cmd += f" --hub-resource={namestores_name_str}"
+            cmd += " --backingstores=noobaa-default-backing-store"
+            if "ttl" in namespace_policy:
+                cmd += f" --ttl=={namespace_policy['ttl']}"
+            self.exec_mcg_cmd(cmd)
+        else:
             raise NotImplementedError(
                 f"Cli creating of bucketclass on namespacestore "
                 f"with policy {namespace_policy_type} is not implemented yet"
             )
-
-        self.exec_mcg_cmd(
-            f"bucketclass create namespace-bucketclass {namespace_policy_type} "
-            f"--resource={namestores_name_str} {name}"
-        )
 
     def check_if_mirroring_is_done(self, bucket_name, timeout=300):
         """

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -143,7 +143,7 @@ class TestNamespace(MCGTest):
                 marks=[
                     tier1,
                     on_prem_platform_required,
-                    pytest.mark.polarion_id("OCS-2407"),
+                    pytest.mark.polarion_id("OCS-6339"),
                 ],
             ),
             pytest.param(
@@ -160,7 +160,7 @@ class TestNamespace(MCGTest):
                 marks=[
                     tier1,
                     on_prem_platform_required,
-                    pytest.mark.polarion_id("OCS-2407"),
+                    pytest.mark.polarion_id("OCS-6338"),
                 ],
             ),
             pytest.param(

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -151,7 +151,7 @@ class TestNamespace(MCGTest):
                     "interface": "CLI",
                     "namespace_policy_dict": {
                         "type": "Cache",
-                        "ttl": 180,
+                        "ttl": 300000,
                         "namespacestore_dict": {
                             "rgw": [(1, None)],
                         },

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -148,6 +148,23 @@ class TestNamespace(MCGTest):
             ),
             pytest.param(
                 {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
+                        "type": "Cache",
+                        "ttl": 180,
+                        "namespacestore_dict": {
+                            "rgw": [(1, None)],
+                        },
+                    },
+                },
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    pytest.mark.polarion_id("OCS-2407"),
+                ],
+            ),
+            pytest.param(
+                {
                     "interface": "OC",
                     "namespace_policy_dict": {
                         "type": "Single",
@@ -218,6 +235,7 @@ class TestNamespace(MCGTest):
             "Azure-OC-Single",
             "RGW-OC-Single",
             "RGW-CLI-Single",
+            "RGW-CLI-Cache",
             "IBM-OC-Single",
             "AWS+Azure-OC-Multi",
             "AWS+AWS-OC-Multi",


### PR DESCRIPTION
This PR contains adding a new test case for bucketclass NSS creation with Cache  via CLI, following issue #https://github.com/red-hat-storage/ocs-ci/issues/11128 from the backlog. 