### PR TITLE
Stabilize and adjust `test_bucket_notifications`

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -1035,3 +1035,19 @@ class AMQ(object):
         switch_to_default_rook_cluster_project()
         run_cmd(f"oc delete project {kafka_namespace}")
         self.ns_obj.wait_for_delete(resource_name=kafka_namespace, timeout=90)
+
+    def check_amq_cluster_exists(self):
+        """
+        Check if amq cluster exists
+
+        Returns:
+            bool: True if amq cluster exists
+
+        """
+        try:
+            self.ns_obj.get(resource_name=constants.AMQ_NAMESPACE)
+            return True
+        except CommandFailed as cf:
+            if "NotFound" in str(cf):
+                return False
+            raise cf

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -6,6 +6,7 @@ import re
 
 import tempfile
 from time import sleep
+import time
 
 import boto3
 from botocore.client import ClientError
@@ -27,8 +28,10 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import (
+    get_noobaa_pods,
     get_pods_having_label,
     Pod,
+    wait_for_pods_to_be_running,
 )
 from ocs_ci.utility import templating, version
 from ocs_ci.utility.retry import retry
@@ -934,13 +937,20 @@ class MCG:
         return result
 
     @property
+    def status(self):
+        """
+        Expose the status check of NooBaa as a property
+        """
+        return self._status()
+
+    @staticmethod
     @retry(
         exception_to_check=(CommandFailed, KeyError, subprocess.TimeoutExpired),
         tries=10,
         delay=6,
         backoff=1,
     )
-    def status(self):
+    def _status():
         """
         Verify the status of NooBaa, and its default backing store and bucket class
 
@@ -949,13 +959,14 @@ class MCG:
 
         """
         # Get noobaa status
-        get_noobaa = OCP(kind="noobaa", namespace=self.namespace).get(
+        namespace = config.ENV_DATA["cluster_namespace"]
+        get_noobaa = OCP(kind="noobaa", namespace=namespace).get(
             resource_name=NOOBAA_RESOURCE_NAME
         )
-        get_default_bs = OCP(kind="backingstore", namespace=self.namespace).get(
+        get_default_bs = OCP(kind="backingstore", namespace=namespace).get(
             resource_name=DEFAULT_NOOBAA_BACKINGSTORE
         )
-        get_default_bc = OCP(kind="bucketclass", namespace=self.namespace).get(
+        get_default_bc = OCP(kind="bucketclass", namespace=namespace).get(
             resource_name=DEFAULT_NOOBAA_BUCKETCLASS
         )
         return (
@@ -964,6 +975,37 @@ class MCG:
             == get_default_bc["status"]["phase"]
             == STATUS_READY
         )
+
+    @staticmethod
+    def wait_for_ready_status(timeout=600):
+        """
+        Wait for NooBaa's resources to reach the 'Ready' status
+
+        Args:
+            timeout (int): Number of seconds to wait for the status
+
+        Raises:
+            TimeoutExpiredError: If the status is not reached within the timeout
+        """
+        starttime = time.time()
+        nb_pods = [pod.name for pod in get_noobaa_pods()]
+        wait_for_pods_to_be_running(
+            namespace=config.ENV_DATA["cluster_namespace"],
+            pod_names=nb_pods,
+            timeout=timeout,
+            sleep=10,
+        )
+        timeout = int(timeout - (time.time() - starttime))
+        try:
+            for mcg_status_ready in TimeoutSampler(
+                timeout=timeout, sleep=30, func=MCG._status
+            ):
+                if mcg_status_ready:
+                    return
+        except TimeoutExpiredError as e:
+            raise TimeoutExpiredError(
+                e, f"NooBaa health is not OK after {timeout} seconds"
+            )
 
     def get_mcg_cli_version(self):
         """


### PR DESCRIPTION
**Changes made:**

1. Setup and teardown of the AMQ cluster that is used to setup Kafka takes a long time (~5 mins). This hinders the debugging and development process. 

To fix this issue I've enabled local re-running of the test without destroying and re-creating the AMQ cluster - just use `run-ci` with the --`dev-mode` option. 

Note that this will affect PR verifications on an existing cluster the AMQ cluster is already set up, so to bypass this one needs to destroy the cluster manually:
```
$ oc delete namespace myproject
$ oc delete all -l app=strimzi
```

2. Added  a retry to the fetching of the PVC in `enable_bucket_notifs_on_cr` - the test would often fail on new clusters because MCG was still creating the PVC when we were trying to read the resource.

3. Adjust `put-bucket-notification` to use `<secret-name>/<config_json_file_name>` under `Topic` instead of just `<config_json_file_name>`. See https://github.com/noobaa/noobaa-operator/pull/1515/files for details.

4. Replace the `CephCluster().wait_for_noobaa_health_ok()` costly health check with the tighter `MCG.wait_for_ready_status()`. Note that this required a workaround to use the existing `MCG::status` method in a static manner.

5. Make the wait optional at `enable_bucket_notifs_on_cr` and `put_bucket_notification` (this is particularly useful in the more advanced tests that are still in draft).

6. Adjust `get_events` - MCG now sends one unstructured notification to the topic to test it (`test notification`), so this adjustments makes sure we're only reading the JSON lines.

7. Skip the test on environments where network access is limited since the setup requires cloning an external repo.

8. Improve the error logging in `test_bucket_notifications` 
