### PR TITLE
baremetal AI deployment: support uefi boot mode

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1023,12 +1023,13 @@ class BAREMETALAI(BAREMETALBASE):
             )
 
             # upload ipxe config to httpd server (helper_node)
+            discovery_ipxe_file_dest = (
+                f"{self.bm_config['bm_httpd_document_root']}/ipxe/"
+                f"{self.bm_config['env_name']}/discovery.ipxe"
+            )
             self.helper_node_handler.upload_file(
                 ipxe_config_file,
-                (
-                    f"{self.bm_config['bm_httpd_document_root']}/ipxe/"
-                    f"{self.bm_config['env_name']}/discovery.ipxe"
-                ),
+                discovery_ipxe_file_dest,
             )
             ipxe_file_url = (
                 f"http://{self.bm_config['bm_httpd_provision_server']}/ipxe/"
@@ -1082,6 +1083,11 @@ class BAREMETALAI(BAREMETALBASE):
                     pxelinux_cfg_file,
                     f"{self.bm_config['bm_tftp_base_dir']}/pxelinux.cfg/{dest_cfg_file_name}",
                 )
+            # rename the discovery.ipxe file to continue boot from disk on UEFI boot mode systems
+            cmd = f"mv {discovery_ipxe_file_dest} {discovery_ipxe_file_dest}.backup"
+            assert (
+                self.helper_node_handler.exec_cmd(cmd=cmd)[0] == 0
+            ), "Failed to rename discovery.ipxe file"
 
             # update discovered hosts (configure hostname and role)
             self.ai_cluster.update_hosts_config(


### PR DESCRIPTION
- avoid boot loop to discovery mode for server in uefi boot mode by renaming discovery.ipxe file