### PR TITLE
[release-4.16] Delete leftover dns records when destroying ibmcloud clusters

### DIFF
--- a/ocs_ci/deployment/ibmcloud.py
+++ b/ocs_ci/deployment/ibmcloud.py
@@ -228,6 +228,7 @@ class IBMCloudIPI(CloudDeploymentBase):
             self.delete_volumes(resource_group)
             self.delete_leftover_resources(resource_group)
             self.delete_resource_group(resource_group)
+            ibmcloud.delete_dns_records(self.cluster_name)
         except Exception as ex:
             logger.error(f"During IBM Cloud cleanup some exception occurred {ex}")
             raise

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -956,3 +956,47 @@ def find_free_network_subnets(subnet_cidr, network_prefix=27):
         if is_free:
             logger.info(f"Free set of subnets found: {possible_subnets}")
             return possible_subnets
+
+
+def delete_dns_records(cluster_name):
+    """
+    Delete DNS records leftover from cluster destroy.
+
+    Args:
+        cluster_name (str): Name of the cluster, used to filter DNS records
+
+    """
+    dns_domain_id = config.ENV_DATA["base_domain_id"]
+    cis_instance_name = config.ENV_DATA["cis_instance_name"]
+    ids_to_delete = []
+    page = 1
+
+    logger.info(f"Setting cis instance to {cis_instance_name}")
+    run_ibmcloud_cmd(f"ibmcloud cis instance-set {cis_instance_name}")
+
+    while True:
+        out = run_ibmcloud_cmd(
+            f"ibmcloud cis dns-records {dns_domain_id} --per-page 1000 --page {page} --output json"
+        )
+        records = json.loads(out)
+        if not records:
+            logger.info("Reached end of pagination")
+            break
+
+        filter_string = f".{cluster_name}."
+        logger.info(f"Searching for records with string: {filter_string}")
+        for record in records:
+            if filter_string in record["name"]:
+                logger.info(f"Found {record['name']}, marking for deletion")
+                ids_to_delete.append(record["id"])
+        page += 1
+
+    logger.info(f"Records to delete: {ids_to_delete}")
+    for record_id in ids_to_delete:
+        logger.info(f"Deleting DNS record: {record_id}")
+        try:
+            run_ibmcloud_cmd(
+                f"ibmcloud cis dns-record-delete {dns_domain_id} {record_id}"
+            )
+        except CommandFailed:
+            logger.exception("Failed to delete CIS leftovers")


### PR DESCRIPTION
Delete leftover dns records when destroying ibmcloud clusters