### PR TITLE
test_ceph_osd_slow_ops_alert minimize osd complient time

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -140,7 +140,7 @@ class TestCephOSDSlowOps(object):
         Set preconditions to trigger CephOSDSlowOps
         """
         self.test_pass = None
-        reduced_osd_complaint_time = 0.1
+        reduced_osd_complaint_time = 0.02
 
         set_osd_op_complaint_time(reduced_osd_complaint_time)
 
@@ -218,7 +218,7 @@ class TestCephOSDSlowOps(object):
         the I/O operations per second (IOPS) in the queue within the time defined by the osd_op_complaint_time
         parameter. By default, this parameter is set to 30 seconds.
 
-        1. As precondition test setup is to reduce osd_op_complaint_time to 0.1 to prepare condition
+        1. As precondition test setup is to reduce osd_op_complaint_time to 0.02 (200 ms) to prepare condition
         to get CephOSDSlowOps
         2. Run workload_fio_storageutilization gradually filling up the storage up to full_ratio % in a background
         2.1 Validate the CephOSDSlowOps fired, if so check an alert message and finish the test


### PR DESCRIPTION
reduced osd_op_complaint_time from default 30 sec to 200 ms 
if this will not stabilized - we will need to add check per osd, that it took action and minimize further

check from logs:
`ceph daemon osd.<id> config show | grep osd_op_complaint_time`

check directly:
`ceph config get osd.3 osd_op_complaint_time`

monitor slow requests:
`ceph health detail`

Fixes: #9643