### PR TITLE
Ignore rook-ceph-osd-key-rotation leftovers

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -593,6 +593,7 @@ NOOBAA_DEFAULT_BACKINGSTORE_LABEL = "pool=noobaa-default-backing-store"
 ROOK_CEPH_DETECT_VERSION_LABEL = "app=rook-ceph-detect-version"
 CEPH_FILE_CONTROLLER_DETECT_VERSION_LABEL = "app=ceph-file-controller-detect-version"
 CONTROLLER_DETECT_VERSION_NAME = "controller-detect-version"
+OSD_KEY_ROTATION_POD_NAME = "rook-ceph-osd-key-rotation"
 CEPH_OBJECT_CONTROLLER_DETECT_VERSION_LABEL = (
     "app=ceph-object-controller-detect-version"
 )

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -108,6 +108,9 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             if constants.CONTROLLER_DETECT_VERSION_NAME in name:
                 log.debug(f"ignoring item: {name}")
                 continue
+            if constants.OSD_KEY_ROTATION_POD_NAME in name:
+                log.debug(f"ignoring item: {name}")
+                continue
             if name.startswith(constants.REPORT_STATUS_TO_PROVIDER_POD):
                 log.debug(f"ignoring item: {name}")
                 continue


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/11323

Note that I've used @petr-balogh's approach from https://github.com/red-hat-storage/ocs-ci/pull/11198