### PR TITLE
`test_object_actions` - double the sleep from 60 seconds to 120

### DIFF
--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -307,8 +307,8 @@ class TestS3BucketPolicy(MCGTest):
         # Hardcoded sleep is needed because we lack a confirmation mechanism
         # we could wait for - even the get-policy result has been observed to be
         # unreliable in confirming whether they policy is actually taking effect
-        logger.info("Waiting for 60 seconds for the policy to take effect")
-        time.sleep(60)
+        logger.info("Waiting for 120 seconds for the policy to take effect")
+        time.sleep(120)
 
         # Get Policy
         logger.info(f"Getting Bucket policy on bucket: {obc_obj.bucket_name}")


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/10982

Since adding a 60 seconds sleep in https://github.com/red-hat-storage/ocs-ci/pull/9447 reduced the hit ratio from 20% (according to https://github.com/red-hat-storage/ocs-ci/issues/9446) to ~5%, then there's room to believe this is still a race condition issue that more timeout will solve.