### PR TITLE
`test_bucket_policy.py` - create all the buckets via OC instead of S3

### DIFF
--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -395,7 +395,7 @@ class TestS3BucketPolicy(MCGTest):
         email = user_name + "@mail.com"
 
         # Creating a s3 bucket
-        s3_bucket = bucket_factory(amount=1, interface="S3")[0]
+        s3_bucket = bucket_factory(amount=1, interface="OC")[0]
 
         # Creating a random user account
         if version.get_semantic_ocs_version_from_config() < version.VERSION_4_12:
@@ -1087,7 +1087,7 @@ class TestS3BucketPolicy(MCGTest):
         Tests public bucket website access
         """
         # Creating a S3 bucket to host website
-        s3_bucket = bucket_factory(amount=1, interface="S3")
+        s3_bucket = bucket_factory(amount=1, interface="OC")
 
         # Creating random S3 users
         users = []


### PR DESCRIPTION
Looking at many regression runs - tests in `test_bucket_policy.py` that create the bucket via OC instead of S3 seem to never face instability around the creation/deletion of the bucket.

This is simply a workaround for https://github.com/red-hat-storage/ocs-ci/issues/11344 in these specific tests that are not focused around bucket creation.
