### PR TITLE
Stabilize MDSCPUUsageHigh alert test case

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -563,14 +563,6 @@ skipif_vsphere_ipi = pytest.mark.skipif(
     reason="Test will not run on vSphere IPI cluster",
 )
 
-skipif_vsphere_upi = pytest.mark.skipif(
-    (
-        config.ENV_DATA["platform"].lower() == "vsphere"
-        and config.ENV_DATA["deployment_type"].lower() == "upi"
-    ),
-    reason="Test will not run on vSphere UPI cluster",
-)
-
 skipif_tainted_nodes = pytest.mark.skipif(
     config.DEPLOYMENT.get("infra_nodes") is True
     or config.DEPLOYMENT.get("ocs_operator_nodes_to_taint") > 0,

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -563,6 +563,14 @@ skipif_vsphere_ipi = pytest.mark.skipif(
     reason="Test will not run on vSphere IPI cluster",
 )
 
+skipif_vsphere_upi = pytest.mark.skipif(
+    (
+        config.ENV_DATA["platform"].lower() == "vsphere"
+        and config.ENV_DATA["deployment_type"].lower() == "upi"
+    ),
+    reason="Test will not run on vSphere UPI cluster",
+)
+
 skipif_tainted_nodes = pytest.mark.skipif(
     config.DEPLOYMENT.get("infra_nodes") is True
     or config.DEPLOYMENT.get("ocs_operator_nodes_to_taint") > 0,

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -2,7 +2,13 @@ import logging
 import pytest
 
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework.pytest_customization.marks import blue_squad, skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    skipif_ocs_version,
+    skipif_vsphere_ipi,
+    skipif_vsphere_upi,
+    skipif_disconnected_cluster,
+)
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import cluster, constants
@@ -85,6 +91,9 @@ def active_mds_alert_values(threading_lock):
 @tier2
 @blue_squad
 @skipif_ocs_version("<4.18")
+@skipif_vsphere_ipi  # Skip on vsphere due to latency issues with hardware used.
+@skipif_vsphere_upi  # This test will give accurate results on BM,AWS,Azure and IBM cloud only.
+@skipif_disconnected_cluster
 class TestMdsCpuAlerts(E2ETest):
     @pytest.fixture(scope="function", autouse=True)
     def teardown(self, request):
@@ -98,7 +107,9 @@ class TestMdsCpuAlerts(E2ETest):
         request.addfinalizer(finalizer)
 
     @pytest.mark.polarion_id("OCS-5581")
-    def test_alert_triggered(self, run_file_creator_io_with_cephfs, threading_lock):
+    def test_mds_cpu_alert_triggered(
+        self, run_file_creator_io_with_cephfs, threading_lock
+    ):
         """
         This test case is to verify the alert for MDS cpu high usage for only vertical scaling,
         alert for Horizontal scaling is skipped as it is not easy to achieve the rate(ceph_mds_request)>=1000.

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -5,9 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.pytest_customization.marks import (
     blue_squad,
     skipif_ocs_version,
-    skipif_vsphere_ipi,
-    skipif_vsphere_upi,
-    skipif_disconnected_cluster,
+    aws_platform_required,
+    baremetal_deployment_required,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.helpers import helpers
@@ -90,10 +89,9 @@ def active_mds_alert_values(threading_lock):
 
 @tier2
 @blue_squad
-@skipif_ocs_version("<4.18")
-@skipif_vsphere_ipi  # Skip on vsphere due to latency issues with hardware used.
-@skipif_vsphere_upi  # This test will give accurate results on BM,AWS,Azure and IBM cloud only.
-@skipif_disconnected_cluster
+@skipif_ocs_version("<4.15")
+@aws_platform_required
+@baremetal_deployment_required
 class TestMdsCpuAlerts(E2ETest):
     @pytest.fixture(scope="function", autouse=True)
     def teardown(self, request):


### PR DESCRIPTION
This test case was failing due to insufficient load on the Vsphere clusters. It is common to encounter backend bottlenecks in Vsphere clusters, often caused by hardware-related latency issues. I have successfully tested the same scenario on BM, AWS, and IBM Cloud, where it functions as expected. Since this is a performance-related test case, it is crucial to run it on hardware that ensures minimal latency. To avoid unnecessary test failures, I have added a skip marker for Vsphere and disconnected cluster modes.

Fixing Ocs-ci issue #11334