### PR TITLE
Server doesn't have a resource type "Machine" issue fixed in IBM cloud managed platform

### DIFF
--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -23,6 +23,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ms_consumer,
     skipif_hci_client,
     brown_squad,
+    skipif_ibm_cloud_managed,
 )
 from ocs_ci.helpers.helpers import verify_storagecluster_nodetopology
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -278,6 +279,7 @@ class TestNodeReplacement(ManageTest):
         """
         self.sanity_helpers = Sanity()
 
+    @skipif_ibm_cloud_managed
     def test_nodereplacement_proactive(self):
         """
         Knip-894 Node Replacement proactive(without IO running)


### PR DESCRIPTION
Server doesn't have a resource type "Machine" issue fixed in IBM cloud managed platform