### PR TITLE
update locators test_validate_topology_configuration

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
@@ -911,8 +911,10 @@ class OdfTopologyNodesView(TopologyTab):
 
         :return: name of the cluster such as 'ocs-storagecluster'
         """
-        cluster_name_el = self.get_elements(self.topology_loc["node_group_name"])[0]
-        return cluster_name_el.text.split("\n")[1]
+        cluster_name_el = self.get_elements(self.topology_loc["topology_node_parent"])[
+            0
+        ]
+        return cluster_name_el.text
 
     @retry(TimeoutException)
     def nav_into_node(

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1842,7 +1842,8 @@ topology = {
     "node_label": ("//*[@class='pf-topology__node__label']", By.XPATH),
     # status is in class name of the node_status_axis one from pf-m-warning / pf-m-danger / pf-m-success
     "node_status_class_axis": (
-        "//*[@class='pf-topology__node__label']//*[contains(text(), '{}')]/parent::*/parent::*/parent::*/parent::*",
+        "//*[@class='pf-topology__node__label']//*[contains(text(), '{}')]"
+        "/ancestor::*[starts-with(@class, 'pf-topology__node ')]",
         By.XPATH,
     ),
     "select_entity": (
@@ -1854,9 +1855,12 @@ topology = {
         "//*[contains(text(), '{}')]/../../../..",
         By.XPATH,
     ),
+    # this is complex locator, it is used to find node with specific name and via its ancestor find the arrow to enter
+    # to click and show the node topology
     "enter_into_entity_arrow": (
-        "(//*[@class='pf-topology__node__label']//*[contains(text(), '{}')]/parent::*/parent::*/parent::*/parent::*"
-        "//*[@class='pf-topology__node__decorator'])[2]",
+        "//*[contains(text(), '{}')]"
+        "/ancestor::*[starts-with(@class, 'pf-topology__node ')]"
+        "//*[@class='pf-topology__node__decorator' and @role='button' and not(@aria-label)]",
         By.XPATH,
     ),
     "cluster_state_ready": (
@@ -1870,6 +1874,14 @@ topology = {
     # node_group_name may be 'zone-<num>' or 'rack-<num>'
     "node_group_name": (
         "//*[@data-kind='node' and @data-type='group' and not (@transform)]",
+        By.XPATH,
+    ),
+    # topology node parent, that aggregates n of nodes or n of deployments
+    # may be ocs-storagecluster or name of the node
+    "topology_node_parent": (
+        "//*[@class='pf-topology__group__label' "
+        "and *[contains(@class, 'pf-topology__node__label__badge')] "
+        "and *[contains(@class, 'pf-topology__node__label__icon')] ]",
         By.XPATH,
     ),
     "zoom_out": ("zoom-out", By.ID),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1851,8 +1851,8 @@ topology = {
         By.XPATH,
     ),
     "entity_box_select_indicator": (
-        "//*[@class='pf-topology__node__label']"
-        "//*[contains(text(), '{}')]/../../../..",
+        "//*[@class='pf-topology__node__label']//*[contains(text(), '{}')]"
+        "/ancestor::*[starts-with(@class, 'pf-topology__node ')]",
         By.XPATH,
     ),
     # this is complex locator, it is used to find node with specific name and via its ancestor find the arrow to enter
@@ -1871,9 +1871,11 @@ topology = {
         "//*[@class='pf-topology__group odf-topology__group odf-topology__group-state--error']",
         By.XPATH,
     ),
-    # node_group_name may be 'zone-<num>' or 'rack-<num>'
+    # node_group_name may be 'zone-<num>' or 'rack-<num>', exclude other elements that are not node groups
     "node_group_name": (
-        "//*[@data-kind='node' and @data-type='group' and not (@transform)]",
+        "//*[@data-kind='node' and @data-type='group' "
+        "and not(@transform) "
+        "and *[contains(@class, 'odf-topology__group--zone')]]",
         By.XPATH,
     ),
     # topology node parent, that aggregates n of nodes or n of deployments


### PR DESCRIPTION
locators have been changed, data-id removed with ODF 4.18. 
Improve locators with multiple parents, to fix:

```
_locator = ("(//[@class='pf-topology__node__label']//[contains(text(), 'j031vi1cv30t3-czpjd-master-0')]/parent::/parent::/parent::/parent:://*[@class='pf-topology__node__decorator'])[2]", 'xpath')
_timeout = 60, _enable_screenshot = True, _copy_dom = False


def _do_click(_locator, _timeout=30, _enable_screenshot=False, _copy_dom=False):
    # wait for page fully loaded only if an element was not located
    # prevents needless waiting and frequent crushes on ODF Overview page,
    # when metrics and alerts frequently updated
    if not self.get_elements(_locator):
        self.page_has_loaded()
    screenshot = (
        ocsci_config.UI_SELENIUM.get("screenshot") and enable_screenshot
    )
    if screenshot:
        self.take_screenshot()
    if _copy_dom:
        self.copy_dom()

    wait = WebDriverWait(self.driver, timeout)
    try:
        if (
            version.get_semantic_version(get_ocp_version(), True)
            <= version.VERSION_4_11
        ):
            element = wait.until(
                ec.element_to_be_clickable((locator[1], locator[0]))
            )
        else:

          element = wait.until(
                ec.visibility_of_element_located((locator[1], locator[0]))
            )

ocs_ci/ocs/ui/base_ui.py:205: 

```