### PR TITLE
Add rosa-ocp-version endpoint

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-For full usage run: `run-ci --help`
+Usage of `run-ci` command and other tools provided by ocs-ci repository.
 
 # usage for getting various ocs image versions
 
@@ -48,6 +48,61 @@ argument to get tag for 4.8 version (if no version provided, the OCS-CI default
 will be used).
 
 The quay access_token is required to be set in data/auth.yaml file.
+
+# Usage for rosa-ocp-version tool
+
+For full usage run: `rosa-ocp-version --help`:
+```bash
+$ rosa-ocp-version -h
+usage: rosa-ocp-version [-h] [--debug] [--get-available-versions] [--check-available-version OCP_VERSION] --ocsci-conf OCSCI_CONF
+
+Get information about available OCP versions from ROSA
+
+options:
+  -h, --help            show this help message and exit
+  --debug, -d           Print logging messages (mainly useful for debugging).
+  --get-available-versions, -a
+                        Get all available OCP versions from ROSA
+  --check-available-version OCP_VERSION, -c OCP_VERSION
+                        Check if provided OCP version is available in ROSA, if available, returns latest z-stream version
+  --ocsci-conf OCSCI_CONF
+                        OCM Credentials configuration file in yaml format. Example file: --- AUTH: openshiftdedicated: token: '<TOKEN>'
+```
+
+## Get list of all available OCP versions in ROSA
+
+```bash
+$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --get-available-versions
+4.17.14
+4.17.12
+4.17.11
+4.17.10
+4.17.9
+4.17.8
+4.17.7
+4.17.6
+4.17.5
+4.17.4
+...
+```
+
+## check if provided OCP version is available in ROSA
+
+```bash
+$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --check-available-version 4.17
+4.17.14
+$ echo $?
+0
+
+$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --check-available-version 4.18
+Version 4.18 not available in ROSA.
+$ echo $?
+255
+```
+
+# Usage for run-ci tool
+
+For full usage run: `run-ci --help`
 
 ## Required configuration
 

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -2,9 +2,9 @@
 """
 Module for version related util functions.
 """
-
 import re
 from semantic_version import Version
+import yaml
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import defaults
@@ -297,18 +297,26 @@ def get_volsync_operator_version(namespace=constants.SUBMARINER_OPERATOR_NAMESPA
             return csv["spec"]["version"]
 
 
-def get_ocp_versions_rosa():
+def get_ocp_versions_rosa(yaml_format=False):
     """
     Get the list of available versions for ROSA.
+
+    Args:
+        yaml_format (bool): Use yaml output from rosa command and parse it as yaml.
 
     Returns:
         str: a list of available versions for ROSA in string format
     """
     from ocs_ci.utility.utils import exec_cmd
 
-    cmd = "rosa list versions"
-    output = exec_cmd(cmd, timeout=1800)
-    return output.stdout.decode()
+    yaml_arg = "-o yaml" if yaml_format else ""
+
+    cmd = f"rosa list versions {yaml_arg}"
+    output = exec_cmd(cmd, timeout=1800).stdout.decode()
+    if yaml_format:
+        return yaml.safe_load(output)
+    else:
+        return output
 
 
 def ocp_version_available_on_rosa(version):

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
             "vsphere-cleanup=ocs_ci.cleanup.vsphere.cleanup:vsphere_cleanup",
             "ocs-build=ocs_ci.utility.ocs_build:main",
             "get-ssl-cert=ocs_ci.utility.ssl_certs:main",
+            "rosa-ocp-version=ocs_ci.utility.rosa:rosa_ocp_version_endpoint",
         ],
     },
     zip_safe=True,


### PR DESCRIPTION
This endpoint will allow us to get list of all available OCP versions from ROSA and also check if particular OCP version is available there (and get the latest z-stream version for that OCP version).

This is the help for the new endpoint:
```
$ rosa-ocp-version -h
usage: rosa-ocp-version [-h] [--debug] [--get-available-versions] [--check-available-version OCP_VERSION] --ocsci-conf OCSCI_CONF

Get information about available OCP versions from ROSA

options:
  -h, --help            show this help message and exit
  --debug, -d           Print logging messages (mainly useful for debugging).
  --get-available-versions, -a
                        Get all available OCP versions from ROSA
  --check-available-version OCP_VERSION, -c OCP_VERSION
                        Check if provided OCP version is available in ROSA, if available, returns latest z-stream version
  --ocsci-conf OCSCI_CONF
                        OCM Credentials configuration file in yaml format. Example file: --- AUTH: openshiftdedicated: token: '<TOKEN>'
```

There are two ways how to use `rosa-ocp-version` command:
* to get list of all available OCP versions in ROSA:
```
$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --get-available-versions
4.17.14
4.17.12
4.17.11
4.17.10
4.17.9
4.17.8
4.17.7
4.17.6
4.17.5
4.17.4
...
```
* and to check if provided OCP version is available in ROSA:
```
$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --check-available-version 4.17
4.17.14
$ echo $?
0

$ rosa-ocp-version --ocsci-conf path/to/credentials-file.yaml --check-available-version 4.18
Version 4.18 not available in ROSA.
$ echo $?
255
```

Additionally there is `-d` / `--debug` parameter which enables printing of logging messages useful for debugging.
