### PR TITLE
Stabilize object expiration system test

### DIFF
--- a/tests/cross_functional/conftest.py
+++ b/tests/cross_functional/conftest.py
@@ -510,7 +510,8 @@ def noobaa_db_backup_and_recovery(
             ), f"Failed to scale up the statefulset {constants.NOOBAA_DB_STATEFULSET}"
 
         try:
-            restore_pvc_objs[0].delete()
+            for pvc_obj in restore_pvc_objs:
+                pvc_obj.delete()
         except CommandFailed as ex:
             if f'"{restore_pvc_objs[0].name}" not found' not in str(ex):
                 raise ex

--- a/tests/cross_functional/system_test/test_object_expiration.py
+++ b/tests/cross_functional/system_test/test_object_expiration.py
@@ -6,6 +6,7 @@ import pytest
 
 from ocs_ci.helpers.e2e_helpers import create_muliple_types_provider_obcs
 from botocore.exceptions import ClientError
+
 from ocs_ci.utility.retry import retry
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs import constants
@@ -68,7 +69,7 @@ class TestObjectExpiration:
         reduce_expiration_interval(interval=2)
 
         # Creating S3 bucket
-        bucket = bucket_factory()[0].name
+        bucket = retry(ClientError, tries=3, delay=10)(bucket_factory)()[0].name
         object_key = "ObjKey-" + str(uuid.uuid4().hex)
         obj_data = "Random data" + str(uuid.uuid4().hex)
         expiration_days = 1
@@ -182,6 +183,7 @@ class TestObjectExpiration:
         bucket_factory,
         noobaa_db_backup_and_recovery,
         node_drain_teardown,
+        node_restart_teardown,
     ):
         """
         Test object expiration feature when there are some sort of disruption to the noobaa

--- a/tests/cross_functional/system_test/test_object_expiration_system.py
+++ b/tests/cross_functional/system_test/test_object_expiration_system.py
@@ -39,7 +39,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
-class TestObjectExpiration:
+class TestObjectExpirationSystemTest:
     @pytest.fixture(autouse=True)
     def init_sanity(self):
         """


### PR DESCRIPTION
Fixes:
- Bucket creation failure because of noobaa pod restart from patch
- Teardown function for Noobaa db backup and recovery fixture
- Add node restart teardown factory to the test hence making sure at teardown all the nodes are up and ready