### PR TITLE
Improve vrg discovered app

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -520,7 +520,11 @@ def check_vrg_state(state, namespace, resource_name):
         bool: True if VRG is in expected state or was deleted, False otherwise
 
     """
-    vrg_obj = ocp.OCP(kind=constants.VOLUME_REPLICATION_GROUP, namespace=namespace, resource_name=resource_name)
+    vrg_obj = ocp.OCP(
+        kind=constants.VOLUME_REPLICATION_GROUP,
+        namespace=namespace,
+        resource_name=resource_name,
+    )
     if resource_name:
         vrg_list = vrg_obj.get()
     else:
@@ -623,7 +627,7 @@ def wait_for_replication_resources_creation(
         func=check_vrg_state,
         state="primary",
         namespace=vrg_namespace,
-        resource_name=vrg_name
+        resource_name=vrg_name,
     )
     if not sample.wait_for_func_status(result=True):
         error_msg = "VRG hasn't reached expected state primary within the time limit."

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -489,7 +489,7 @@ def check_vr_state(state, namespace):
         return False
 
 
-def check_vrg_existence(namespace, vrg_name=None):
+def check_vrg_existence(namespace, vrg_name=""):
     """
     Check if VRG resource exists in the given namespace
 
@@ -498,8 +498,6 @@ def check_vrg_existence(namespace, vrg_name=None):
         vrg_name (str): Name of VRG
 
     """
-    if not vrg_name:
-        vrg_name = ""
     vrg_list = (
         ocp.OCP(
             kind=constants.VOLUME_REPLICATION_GROUP,

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -507,7 +507,7 @@ def check_vrg_existence(namespace):
         return False
 
 
-def check_vrg_state(state, namespace, resource_name):
+def check_vrg_state(state, namespace, resource_name=None):
     """
     Check if VRG in the given namespace is in expected state
 

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -498,15 +498,22 @@ def check_vrg_existence(namespace, vrg_name=""):
         vrg_name (str): Name of VRG
 
     """
-    vrg_list = (
-        ocp.OCP(
-            kind=constants.VOLUME_REPLICATION_GROUP,
-            namespace=namespace,
-            resource_name=vrg_name,
+    try:
+
+        vrg_list = (
+            ocp.OCP(
+                kind=constants.VOLUME_REPLICATION_GROUP,
+                namespace=namespace,
+                resource_name=vrg_name,
+            )
+            .get()
+            .get("items")
         )
-        .get()
-        .get("items")
-    )
+    except CommandFailed as e:
+        if f'Error from server (NotFound): volumereplicationgroups.ramendr.openshift.io "{vrg_name}" not found' in str(e):
+            logger.info(f"VRG {vrg_name} not found in namespace {namespace}.")
+            vrg_list = []
+
     if len(vrg_list) > 0:
         return True
     else:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -507,20 +507,24 @@ def check_vrg_existence(namespace):
         return False
 
 
-def check_vrg_state(state, namespace):
+def check_vrg_state(state, namespace, resource_name):
     """
     Check if VRG in the given namespace is in expected state
 
     Args:
         state (str): The VRG state to check for (e.g. 'primary', 'secondary')
         namespace (str): the namespace of the VRG resources
+        resource_name (str): Name of VRG resource
 
     Returns:
         bool: True if VRG is in expected state or was deleted, False otherwise
 
     """
-    vrg_obj = ocp.OCP(kind=constants.VOLUME_REPLICATION_GROUP, namespace=namespace)
-    vrg_list = vrg_obj.get().get("items")
+    vrg_obj = ocp.OCP(kind=constants.VOLUME_REPLICATION_GROUP, namespace=namespace, resource_name=resource_name)
+    if resource_name:
+        vrg_list = vrg_obj.get()
+    else:
+        vrg_list = vrg_obj.get().get("items")
 
     # Skip state check if resource was deleted
     if len(vrg_list) == 0 and state.lower() == "secondary":
@@ -531,10 +535,13 @@ def check_vrg_state(state, namespace):
         else:
             logger.info("VRG resource not found")
             return False
-
-    vrg_name = vrg_list[0]["metadata"]["name"]
-    desired_state = vrg_list[0]["spec"]["replicationState"]
-    current_state = vrg_list[0]["status"]["state"]
+    if resource_name:
+        vrg_list_index = vrg_list
+    else:
+        vrg_list_index = vrg_list[0]
+    vrg_name = vrg_list_index["metadata"]["name"]
+    desired_state = vrg_list_index["spec"]["replicationState"]
+    current_state = vrg_list_index["status"]["state"]
     logger.info(
         f"VRG: {vrg_name} desired state is {desired_state}, current state is {current_state}"
     )
@@ -549,7 +556,7 @@ def check_vrg_state(state, namespace):
 
 
 def wait_for_replication_resources_creation(
-    vr_count, namespace, timeout, discovered_apps=False
+    vr_count, namespace, timeout, discovered_apps=False, vrg_name=None
 ):
     """
     Wait for replication resources to be created
@@ -560,6 +567,7 @@ def wait_for_replication_resources_creation(
         timeout (int): time in seconds to wait for VR or ReplicationSource resources to be created
             or reach expected state
         discovered_apps (bool): If true then deployed workload is discovered_apps
+        vrg_name (str): Name of VRG
 
     Raises:
         TimeoutExpiredError: In case replication resources not created
@@ -615,6 +623,7 @@ def wait_for_replication_resources_creation(
         func=check_vrg_state,
         state="primary",
         namespace=vrg_namespace,
+        resource_name=vrg_name
     )
     if not sample.wait_for_func_status(result=True):
         error_msg = "VRG hasn't reached expected state primary within the time limit."
@@ -709,6 +718,7 @@ def wait_for_all_resources_creation(
     timeout=900,
     skip_replication_resources=False,
     discovered_apps=False,
+    vrg_name=None,
 ):
     """
     Wait for workload and replication resources to be created
@@ -720,6 +730,7 @@ def wait_for_all_resources_creation(
         timeout (int): time in seconds to wait for resource creation
         skip_replication_resources (bool): if true vr status wont't be check
         discovered_apps (bool): If true then deployed workload is discovered_apps
+        vrg_name (str): Name of VRG
 
 
     """
@@ -741,7 +752,7 @@ def wait_for_all_resources_creation(
     )
     if not skip_replication_resources:
         wait_for_replication_resources_creation(
-            pvc_count, namespace, timeout, discovered_apps
+            pvc_count, namespace, timeout, discovered_apps, vrg_name
         )
 
 

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -535,8 +535,10 @@ def check_vrg_state(state, namespace, resource_name=None):
     )
     if resource_name:
         vrg_list = vrg_obj.get(resource_name=resource_name)
+        vrg_list_index = vrg_list
     else:
-        vrg_list = vrg_obj.get().get("items")
+        vrg_list_zero_index = vrg_list = vrg_obj.get().get("items")
+        vrg_list_index = vrg_list_zero_index[0]
 
     # Skip state check if resource was deleted
     if len(vrg_list) == 0 and state.lower() == "secondary":
@@ -547,10 +549,6 @@ def check_vrg_state(state, namespace, resource_name=None):
         else:
             logger.info("VRG resource not found")
             return False
-    if resource_name:
-        vrg_list_index = vrg_list
-    else:
-        vrg_list_index = vrg_list[0]
     vrg_name = vrg_list_index["metadata"]["name"]
     desired_state = vrg_list_index["spec"]["replicationState"]
     current_state = vrg_list_index["status"]["state"]

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -545,8 +545,8 @@ def check_vrg_state(state, namespace, resource_name=None):
         vrg_list = vrg_obj.get(resource_name=resource_name)
         vrg_list_index = vrg_list
     else:
-        vrg_list_zero_index = vrg_list = vrg_obj.get().get("items")
-        vrg_list_index = vrg_list_zero_index[0]
+        vrg_list = vrg_obj.get().get("items")
+        vrg_list_index = vrg_list[0]
 
     # Skip state check if resource was deleted
     if len(vrg_list) == 0 and state.lower() == "secondary":

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -510,7 +510,10 @@ def check_vrg_existence(namespace, vrg_name=""):
             .get("items")
         )
     except CommandFailed as e:
-        if f'Error from server (NotFound): volumereplicationgroups.ramendr.openshift.io "{vrg_name}" not found' in str(e):
+        if (
+            f'Error from server (NotFound): volumereplicationgroups.ramendr.openshift.io "{vrg_name}" not found'
+            in str(e)
+        ):
             logger.info(f"VRG {vrg_name} not found in namespace {namespace}.")
             vrg_list = []
 

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -1161,7 +1161,7 @@ class BusyboxDiscoveredApps(DRWorkload):
             self.workload_pod_count,
             self.workload_namespace,
             discovered_apps=True,
-            vrg_name=self.discovered_apps_placement_name
+            vrg_name=self.discovered_apps_placement_name,
         )
 
     def create_placement(self):

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -1161,6 +1161,7 @@ class BusyboxDiscoveredApps(DRWorkload):
             self.workload_pod_count,
             self.workload_namespace,
             discovered_apps=True,
+            vrg_name=self.discovered_apps_placement_name
         )
 
     def create_placement(self):

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -1293,6 +1293,7 @@ class BusyboxDiscoveredApps(DRWorkload):
                 namespace=self.workload_namespace,
                 discovered_apps=True,
                 workload_cleanup=True,
+                vrg_name=self.discovered_apps_placement_name,
             )
             run_cmd(f"oc delete project {self.workload_namespace}")
 

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -90,6 +90,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             old_primary=primary_cluster_name_before_failover,
             workload_namespace=cnv_workloads[0].workload_namespace,
             workload_dir=cnv_workloads[0].workload_dir,
+            vrg_name=cnv_workloads[0].discovered_apps_placement_name,
         )
 
         # Verify resources creation on secondary cluster (failoverCluster)

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -99,6 +99,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             cnv_workloads[0].workload_pod_count,
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
+            vrg_name=cnv_workloads[0].discovered_apps_placement_name
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,
@@ -161,6 +162,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             cnv_workloads[0].workload_pod_count,
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
+            vrg_name=cnv_workloads[0].discovered_apps_placement_name
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -99,7 +99,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             cnv_workloads[0].workload_pod_count,
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
-            vrg_name=cnv_workloads[0].discovered_apps_placement_name
+            vrg_name=cnv_workloads[0].discovered_apps_placement_name,
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,
@@ -162,7 +162,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             cnv_workloads[0].workload_pod_count,
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
-            vrg_name=cnv_workloads[0].discovered_apps_placement_name
+            vrg_name=cnv_workloads[0].discovered_apps_placement_name,
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -79,6 +79,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             rdr_workload.workload_pod_count,
             rdr_workload.workload_namespace,
             discovered_apps=True,
+            vrg_name=rdr_workload.discovered_apps_placement_name
         )
 
         # Doing Relocate

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -79,7 +79,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             rdr_workload.workload_pod_count,
             rdr_workload.workload_namespace,
             discovered_apps=True,
-            vrg_name=rdr_workload.discovered_apps_placement_name
+            vrg_name=rdr_workload.discovered_apps_placement_name,
         )
 
         # Doing Relocate

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -70,6 +70,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             old_primary=primary_cluster_name_before_failover,
             workload_namespace=rdr_workload.workload_namespace,
             workload_dir=rdr_workload.workload_dir,
+            vrg_name=rdr_workload.discovered_apps_placement_name,
         )
 
         # Verify resources creation on secondary cluster (failoverCluster)


### PR DESCRIPTION
All the discovered apps vrg are created in `openshift-dr-ops` to make it compatible for the future. We should individually check for VRG that belong to the given workload and not check for all VRG in that NS. This PR will fix this problem 