### PR TITLE
VolumeSynchronizationDelay alert on the DR dashboard due to sync delays

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -589,12 +589,10 @@ metrics_for_external_mode_required = pytest.mark.skipif(
     reason="Metrics is not enabled for external mode OCS <4.6",
 )
 
-rdr_ui_failover_config_required = pytest.mark.skipif(
-    not config.RUN.get("rdr_failover_via_ui"), reason="RDR UI failover config needed"
-)
-
-rdr_ui_relocate_config_required = pytest.mark.skipif(
-    not config.RUN.get("rdr_relocate_via_ui"), reason="RDR UI relocate config needed"
+rdr_ui = pytest.mark.skipif(
+    not config.RUN.get("rdr_failover_via_ui")
+    or not config.RUN.get("rdr_relocate_via_ui"),
+    reason="RDR UI failover or relocate config needed",
 )
 
 # Filter warnings

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1178,6 +1178,15 @@ acm_configuration_4_18 = {
         By.XPATH,
     ),
     "close-action-modal": ("button[aria-label='Close']", By.CSS_SELECTOR),
+    "critical-alert": ("#alert-toggle-critical", By.CSS_SELECTOR),
+    "volsyncdelayalert1": (
+        "(//span[contains(text(),'VolumeSynchronizationDelay')])[1]",
+        By.XPATH,
+    ),
+    "volsyncdelayalert2": (
+        "(//span[contains(text(),'VolumeSynchronizationDelay')])[2]",
+        By.XPATH,
+    ),
 }
 
 add_capacity = {

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1178,13 +1178,22 @@ acm_configuration_4_18 = {
         By.XPATH,
     ),
     "close-action-modal": ("button[aria-label='Close']", By.CSS_SELECTOR),
-    "critical-alert": ("#alert-toggle-critical", By.CSS_SELECTOR),
+    "warning-alert": ("//*[@id='alert-toggle-warning']", By.XPATH),
+    "critical-alert": ("//*[@id='alert-toggle-critical']", By.XPATH),
+    "volsyncdelaywarningalert1": (
+        "(//span[@class='mco-status-card__alert-item-header'][normalize-space()='VolumeSynchronizationDelay'])[1]",
+        By.XPATH,
+    ),
+    "volsyncdelaywarningalert2": (
+        "(//span[@class='mco-status-card__alert-item-header'][normalize-space()='VolumeSynchronizationDelay'])[2]",
+        By.XPATH,
+    ),
     "volsyncdelayalert1": (
-        "(//span[contains(text(),'VolumeSynchronizationDelay')])[1]",
+        "(//span[@class='mco-status-card__alert-item-header'])[1]",
         By.XPATH,
     ),
     "volsyncdelayalert2": (
-        "(//span[contains(text(),'VolumeSynchronizationDelay')])[2]",
+        "(//span[@class='mco-status-card__alert-item-header'])[2]",
         By.XPATH,
     ),
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ from ocs_ci.ocs.exceptions import (
     StorageClassNotDeletedFromUI,
     ResourceNotDeleted,
     MissingDecoratorError,
+    MissingRequiredConfigKeyError,
 )
 from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implementation
 from ocs_ci.ocs.node import get_node_objs, schedule_nodes
@@ -5191,7 +5192,11 @@ def setup_acm_ui(request):
 
 def setup_acm_ui_fixture(request):
     if not ocsci_config.RUN.get("dr_action_via_ui"):
-        return
+        log.error(
+            "'dr_action_via_ui' params are missing, please pass conf/ocsci/dr_ui.yaml config to "
+            "run UI tests on Regional DR setup"
+        )
+        return MissingRequiredConfigKeyError
     restore_ctx_index = ocsci_config.cur_index
     ocsci_config.switch_acm_ctx()
     driver = login_to_acm()

--- a/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
@@ -6,8 +6,7 @@ from time import sleep
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     rdr,
-    rdr_ui_failover_config_required,
-    rdr_ui_relocate_config_required,
+    rdr_ui,
     turquoise_squad,
 )
 from ocs_ci.framework.testlib import tier3, skipif_ocs_version
@@ -27,6 +26,7 @@ logger = logging.getLogger(__name__)
 @tier3
 @turquoise_squad
 @skipif_ocs_version("<4.13")
+@rdr_ui
 class TestNegativeFailoverRelocate:
     """
     Test Failover/Relocate action to same cluster where workloads are already  running
@@ -34,7 +34,6 @@ class TestNegativeFailoverRelocate:
 
     """
 
-    @rdr_ui_failover_config_required
     @pytest.mark.polarion_id("OCS-4746")
     def test_failover_to_same_cluster(
         self,
@@ -82,7 +81,6 @@ class TestNegativeFailoverRelocate:
             assert result, "Failover negative scenario test via ACM UI failed"
             logger.info("Failover negative scenario test via ACM UI passed")
 
-    @rdr_ui_relocate_config_required
     @pytest.mark.polarion_id("OCS-4747")
     def test_relocate_to_same_cluster(self, setup_acm_ui, dr_workload):
         """

--- a/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     turquoise_squad,
-    rdr_ui_failover_config_required,
+    rdr_ui,
 )
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
-@rdr_ui_failover_config_required
+@rdr_ui
 @skipif_ocs_version("<4.16")
 class TestRDRMonitoringDashboardUI:
     """

--- a/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.helpers.dr_helpers_ui import (
     failover_relocate_ui,
+    verify_drpolicy_ui,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
@@ -348,3 +349,202 @@ class TestRDRWarningAndAlerting:
                         avoid_stale=True,
                     )
                     logger.info("Action modal closed successfully")
+
+    def test_rdr_volumesyncronizationdelayalert(
+        self, setup_acm_ui, dr_workload, scale_up_deployment
+    ):
+        """
+        Test to verify that "VolumeSynchronizationDelay" critical level alert is fired on the DR dashboard
+        when the lastGroupSyncTime is lagging behind 3x the sync interval or more for a particular DR protected workload
+
+        No DR action is performed in this test case. We scale down rbd-mirror daemon deployment on the secondary cluster
+        and mds daemons on the primary cluster and scale them up back to their original count.
+
+        """
+
+        config.switch_acm_ctx()
+        # Enable MCO console plugin needed for DR dashboard
+        enable_mco_console_plugin()
+
+        workload_names = []
+        rdr_workload = dr_workload(
+            num_of_subscription=1,
+            num_of_appset=0,
+            pvc_interface=constants.CEPHBLOCKPOOL,
+        )
+        workload_names.append(f"{rdr_workload[0].workload_name}-1")
+        dr_workload(
+            num_of_subscription=0,
+            num_of_appset=1,
+            pvc_interface=constants.CEPHFILESYSTEM,
+        )
+        workload_names.append(f"{rdr_workload[1].workload_name}-1-cephfs")
+
+        logger.info(f"Workload names are {workload_names}")
+
+        dr_helpers.set_current_primary_cluster_context(
+            rdr_workload[0].workload_namespace
+        )
+
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload[0].workload_namespace
+        )
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
+            rdr_workload[0].workload_namespace
+        )
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            rdr_workload[0].workload_namespace, rdr_workload[0].workload_type
+        )
+
+        config.switch_acm_ctx()
+        acm_obj = AcmAddClusters()
+        page_nav = ValidationUI()
+
+        ocp_version = get_ocp_version()
+        acm_loc = locators[ocp_version]["acm_page"]
+
+        page_nav.refresh_web_console()
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        drpc_subscription = DRPC(namespace=rdr_workload[0].workload_namespace)
+        drpc_appset = DRPC(
+            namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+            resource_name=f"{rdr_workload[1].appset_placement_name}-drpc",
+        )
+        drpc_objs = [drpc_subscription, drpc_appset]
+        before_failover_last_group_sync_time = []
+        for obj in drpc_objs:
+            before_failover_last_group_sync_time.append(
+                dr_helpers.verify_last_group_sync_time(obj, scheduling_interval)
+            )
+        logger.info("Verified lastGroupSyncTime")
+        logger.info(
+            "Scale down rbd-mirror deployment on the secondary cluster and mds deployments on the primary cluster"
+        )
+        config.switch_to_cluster_by_name(secondary_cluster_name)
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.RBD_MIRROR_DAEMON_DEPLOYMENT, replica_count=0
+        )
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.MDS_DAEMON_DEPLOYMENT_ONE, replica_count=0
+        )
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.MDS_DAEMON_DEPLOYMENT_TWO, replica_count=0
+        )
+        config.switch_acm_ctx()
+        logger.info(f"Waiting for {wait_time * 60} seconds to allow alert to appear")
+        sleep(wait_time * 60)
+        verify_drpolicy_ui(acm_obj, scheduling_interval=scheduling_interval)
+        logger.info("Click on Critical alerts")
+        critical_alert = acm_loc["critical-alert"].get_attribute("aria-expanded")
+        logger.info(f"Critical alert state: {critical_alert}")
+        if not critical_alert:
+            self.do_click(
+                locator=acm_loc["critical-alert"],
+                avoid_stale=True,
+                enable_screenshot=True,
+            )
+        alert_1 = acm_obj.wait_until_expected_text_is_found(
+            locator=acm_loc["volsyncdelayalert1"],
+            expected_text="VolumeSynchronizationDelay",
+            timeout=120,
+        )
+        if alert_1:
+            logger.info(
+                "Critical level 'VolumeSynchronizationDelay' alert found on the DR dashboard"
+            )
+        else:
+            logger.error(
+                "Critical level 'VolumeSynchronizationDelay' alert not found on the DR dashboard"
+            )
+            raise NoAlertPresentException
+
+        alert_2 = acm_obj.wait_until_expected_text_is_found(
+            locator=acm_loc["volsyncdelayalert2"],
+            expected_text="VolumeSynchronizationDelay",
+            timeout=120,
+        )
+        if alert_2:
+            logger.info(
+                "Critical level 'VolumeSynchronizationDelay' alert found on the DR dashboard"
+            )
+        else:
+            logger.error(
+                "Critical level 'VolumeSynchronizationDelay' alert not found on the DR dashboard"
+            )
+            raise NoAlertPresentException
+
+        logger.info(
+            "Scale up rbd-mirror deployment on the secondary cluster and mds deployments on the primary cluster"
+        )
+        config.switch_to_cluster_by_name(secondary_cluster_name)
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.RBD_MIRROR_DAEMON_DEPLOYMENT, replica_count=1
+        )
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.MDS_DAEMON_DEPLOYMENT_ONE, replica_count=1
+        )
+        helpers.modify_deployment_replica_count(
+            deployment_name=constants.MDS_DAEMON_DEPLOYMENT_TWO, replica_count=1
+        )
+        logger.info(
+            f"Waiting for {wait_time * 60} seconds to allow warning alert to disappear"
+        )
+        sleep(wait_time * 60)
+
+        for obj, initial_last_group_sync_time in zip(
+            drpc_objs, before_failover_last_group_sync_time
+        ):
+            dr_helpers.verify_last_group_sync_time(
+                obj, scheduling_interval, initial_last_group_sync_time
+            )
+        logger.info("lastGroupSyncTime updated after pods are recovered")
+
+        config.switch_acm_ctx()
+        # Allow additional time for alert to disappear
+        logger.info("Allowing additional time for alert to disappear")
+        time.sleep(120)
+        verify_drpolicy_ui(acm_obj, scheduling_interval=scheduling_interval)
+        logger.info("Click on Critical alerts")
+        critical_alert = acm_loc["critical-alert"].get_attribute("aria-expanded")
+        logger.info(f"Critical alert state: {critical_alert}")
+        if not critical_alert:
+            self.do_click(
+                locator=acm_loc["critical-alert"],
+                avoid_stale=True,
+                enable_screenshot=True,
+            )
+        alert_1 = acm_obj.wait_until_expected_text_is_found(
+            locator=acm_loc["volsyncdelayalert1"],
+            expected_text="VolumeSynchronizationDelay",
+            timeout=120,
+        )
+        if alert_1:
+            logger.error(
+                "Critical level 'VolumeSynchronizationDelay' alert is still being fired on the DR dashboard"
+            )
+            raise UnexpectedBehaviour
+        else:
+            logger.info(
+                "Critical level 'VolumeSynchronizationDelay' alert disappeared from the DR dashboard"
+            )
+
+        alert_2 = acm_obj.wait_until_expected_text_is_found(
+            locator=acm_loc["volsyncdelayalert2"],
+            expected_text="VolumeSynchronizationDelay",
+            timeout=120,
+        )
+        if alert_2:
+            logger.error(
+                "Critical level 'VolumeSynchronizationDelay' alert is still being fired on the DR dashboard"
+            )
+            raise UnexpectedBehaviour
+        else:
+            logger.info(
+                "Critical level 'VolumeSynchronizationDelay' alert disappeared from the DR dashboard"
+            )

--- a/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     turquoise_squad,
     polarion_id,
+    rdr_ui,
 )
 from ocs_ci.helpers import dr_helpers, helpers
 from ocs_ci.ocs import constants
@@ -89,6 +90,7 @@ def scale_up_deployment(request):
 @rdr
 @tier1
 @turquoise_squad
+@rdr_ui
 class TestRDRWarningAndAlerting:
     """
     Test class for RDR Warning and Alerting

--- a/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
@@ -39,8 +39,8 @@ logger = logging.getLogger(__name__)
 
 def modify_deployment_count(status=""):
     """
-    We scale down rbd-mirror daemon deployment on the secondary cluster and mds daemons on the primary cluster
-    and scale them back to their original count
+    We scale down rbd-mirror daemon deployment on the secondary managed cluster and mds daemons on the primary managed
+    cluster and scale them back to their original count
 
     Args:
         status (str): "down" by default sets replica count to 0, anything else like "up" will set it back to 1

--- a/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
@@ -347,12 +347,6 @@ class TestRDRWarningAndAlerting:
                     )
                     logger.info("Action modal closed successfully")
 
-    @polarion_id("OCS-5304")
-    @polarion_id("OCS-5305")
-    @polarion_id("OCS-5311")
-    @polarion_id("OCS-5312")
-    @polarion_id("OCS-5329")
-    @polarion_id("OCS-5330")
     @polarion_id("OCS-5348")
     @skipif_ocs_version("<4.14")
     def test_rdr_volumesyncronizationdelayalert(


### PR DESCRIPTION
Test to verify that "VolumeSynchronizationDelay" warning level alert is fired on the DR dashboard when the lastGroupSyncTime is lagging behind 2x or critical level alert when this value is behind 3x the sync interval defined in DRPolicy applied to a particular workload.
      
No DR action is performed in this test case. We scale down rbd-mirror daemon deployment on the secondary cluster and mds daemons on the primary cluster and scale them up back to their original count.

Also added and updated the name to marker to `@rdr_ui` as per my discussion with @sidhant-agrawal 