### PR TITLE
Change the STS deployment tests to tier1

### DIFF
--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier2,
+    tier1,
     sts_deployment_required,
     red_squad,
     mcg,
@@ -35,12 +35,12 @@ class TestSTSBucket:
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier2],
+                marks=[tier1],
             ),
             pytest.param(
                 *[None],
                 marks=[
-                    tier2,
+                    tier1,
                 ],
             ),
         ],


### PR DESCRIPTION
[test_sts_bucket_ops[AWS-STS-NEW] and test_sts_bucket_ops[AWS-STS-DEFAULT]](https://github.com/red-hat-storage/ocs-ci/blob/38dde91ca805f1fad8d0d618f57f42eaf5245d13/tests/functional/object/mcg/test_sts_bucket.py) have still not been ran by our pipeline, even though many STS deployments have triggered.

The issue is that the vast majority (maybe all?) of the triggered STS-deployment-runs have been a tier1 run. Due to recent changes, I believe that we should increase the frequency of these two tests.