### PR TITLE
[4.18] Test bucket replication with versioning - minor refactor to existing test + advanced tests

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2953,16 +2953,22 @@ def upload_obj_versions(mcg_obj, awscli_pod, bucket_name, obj_key, amount=1, siz
         mcg_obj (MCG): MCG object
         awscli_pod (Pod): Pod object where AWS CLI is installed
         bucket_name (str): Name of the bucket
-        obj_key (str): Object key
+        obj_key (str): S3 path to the object in the bucket
         amount (int): Number of versions to create
         size (str): Size of the object. I.E 1M
 
     """
-    file_dir = os.path.join("/tmp", str(uuid4()))
-    awscli_pod.exec_cmd_on_pod(f"mkdir {file_dir}")
+    prefix = os.path.dirname(obj_key)  # Might be empty
+    file_dir = os.path.join("/tmp", bucket_name, prefix, str(uuid4()))
+    awscli_pod.exec_cmd_on_pod(f"mkdir -p {file_dir}")
+
+    logger.info(f"Uploading {amount} versions to {bucket_name}")
+
+    etags = []
 
     for i in range(amount):
-        file_path = os.path.join(file_dir, f"{obj_key}_{i}")
+        obj_name_without_prefix = os.path.basename(obj_key)
+        file_path = os.path.join(file_dir, f"{obj_name_without_prefix}_{i}")
         awscli_pod.exec_cmd_on_pod(
             command=f"dd if=/dev/urandom of={file_path} bs={size} count=1"
         )
@@ -2974,6 +2980,8 @@ def upload_obj_versions(mcg_obj, awscli_pod, bucket_name, obj_key, amount=1, siz
             out_yaml_format=False,
         )
 
+    return etags
+
 
 def get_obj_versions(mcg_obj, awscli_pod, bucket_name, obj_key):
     """
@@ -2983,7 +2991,7 @@ def get_obj_versions(mcg_obj, awscli_pod, bucket_name, obj_key):
         mcg_obj (MCG): MCG object
         awscli_pod (Pod): Pod object where AWS CLI is installed
         bucket_name (str): Name of the bucket
-        obj_key (str): Object key
+        obj_key (str): S3 path to the object in the bucket
 
     Returns:
         list: List of dictionaries containing the versions data
@@ -3006,3 +3014,71 @@ def get_obj_versions(mcg_obj, awscli_pod, bucket_name, obj_key):
             d["ETag"] = d["ETag"].strip('"')
 
     return versions_dicts
+
+
+def compare_object_versions(mcg_obj, awscli_pod, bucket_a, bucket_b, obj_key):
+    """
+    Compare the versions of an object in two different buckets
+
+    Args:
+        mcg_obj (MCG): MCG object
+        awscli_pod (Pod): Pod object where AWS CLI is installed
+        bucket_a (str): Name of the first bucket
+        bucket_b (str): Name of the second bucket
+        obj_key (str): S3 path to the object in the bucket
+
+    Returns:
+        bool: True if the versions match, False otherwise
+    """
+    logger.info(f"Comparing the versions of {obj_key} in {bucket_a} and {bucket_b}")
+
+    source_versions = get_obj_versions(mcg_obj, awscli_pod, bucket_a, obj_key)
+    source_etags = [v["ETag"] for v in source_versions]
+    target_versions = get_obj_versions(mcg_obj, awscli_pod, bucket_b, obj_key)
+    target_etags = [v["ETag"] for v in target_versions]
+    if source_etags != target_etags:
+        logger.warning(
+            (
+                f"The versions of {obj_key} in {bucket_a} and {bucket_b} do not match:"
+                f"{source_etags} != {target_etags}"
+            )
+        )
+        return False
+    logger.info(f"The versions of {obj_key} in {bucket_a} and {bucket_b} match")
+    return True
+
+
+def wait_for_object_versions_match(
+    mcg_obj, awscli_pod, bucket_a, bucket_b, obj_key, timeout=600
+):
+    """
+    Verify that the versions of an object in two different buckets match within a timeout
+
+    Args:
+        mcg_obj (MCG): MCG object
+        awscli_pod (Pod): Pod object where AWS CLI is installed
+        bucket_a (str): Name of the first bucket
+        bucket_b (str): Name of the second bucket
+        obj_key (str): Full S3 path to the object
+        timeout (int): The maximum time in seconds to wait for the versions to match
+
+    Raises:
+        TimeoutExpiredError: If the versions do not match within the timeout
+    """
+    try:
+        for versions_are_same in TimeoutSampler(
+            timeout=timeout,
+            sleep=30,
+            func=compare_object_versions,
+            mcg_obj=mcg_obj,
+            awscli_pod=awscli_pod,
+            bucket_a=bucket_a,
+            bucket_b=bucket_b,
+            obj_key=obj_key,
+        ):
+            if versions_are_same:
+                break
+    except TimeoutExpiredError as e:
+        err_msg = f"The versions of {obj_key} in {bucket_a} and {bucket_b} did not match within {timeout} seconds"
+        logger.error(err_msg)
+        raise TimeoutExpiredError(f"{str(e)}\n\n{err_msg}")

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -197,20 +197,17 @@ class TestReplicationWithVersioning(MCGTest):
             )
 
         # 4. Verify the versions were replicated to their targets in the same order
-        wait_for_object_versions_match(
-            mcg_obj,
-            awscli_pod,
-            bucket_a.name,
-            bucket_b.name,
-            obj_key=f"{a_to_b_prefix}/{obj_key}",
-        )
-        wait_for_object_versions_match(
-            mcg_obj,
-            awscli_pod,
-            bucket_b.name,
-            bucket_a.name,
-            obj_key=f"{b_to_a_prefix}/{obj_key}",
-        )
+        for first_bucket, second_bucket, prefix in [
+            (bucket_a.name, bucket_b.name, a_to_b_prefix),
+            (bucket_b.name, bucket_a.name, b_to_a_prefix),
+        ]:
+            wait_for_object_versions_match(
+                mcg_obj,
+                awscli_pod,
+                first_bucket,
+                second_bucket,
+                obj_key=f"{prefix}/{obj_key}",
+            )
 
     @tier3
     @polarion_id("OCS-6345")

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -310,7 +310,11 @@ class TestReplicationWithVersioning(MCGTest):
                 raise UnexpectedBehaviour(
                     f"Expected a single version, got: {target_versions}"
                 )
-            target_version_etag = target_versions[0]["ETag"]
+            target_version_etag = (
+                target_versions[0].get("ETag")
+                if target_versions and isinstance(target_versions[0], dict)
+                else None
+            )
             if target_version_etag == latest_version_etag:
                 logger.info("Only the later version was replicated as expected")
                 break

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -80,7 +80,7 @@ class TestReplicationWithVersioning(MCGTest):
             Returns:
                 list(Bucket): The created buckets
             """
-            # Using the OC interface allows patching a repli policy on the OBC
+            # Using the OC interface allows patching a replication policy on the OBC
             buckets = bucket_factory(amount, "OC")
             for bucket in buckets:
                 put_bucket_versioning_via_awscli(

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -1,5 +1,5 @@
-import json
 import logging
+import os
 from uuid import uuid4
 
 import pytest
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     runs_on_provider,
     tier1,
+    tier2,
+    tier3,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
@@ -18,8 +20,9 @@ from ocs_ci.ocs.bucket_utils import (
     put_bucket_versioning_via_awscli,
     update_replication_policy,
     upload_obj_versions,
+    wait_for_object_versions_match,
 )
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources.mcg_replication_policy import ReplicationPolicyWithVersioning
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -46,16 +49,16 @@ class TestReplicationWithVersioning(MCGTest):
             new_delay_in_miliseconds (function): A function to add env vars to the noobaa-core pod
         """
         new_delay_in_miliseconds = 60 * 1000
-        new_env_var_touples = [
+        new_env_var_tuples = [
             (constants.BUCKET_REPLICATOR_DELAY_PARAM, new_delay_in_miliseconds),
             (constants.BUCKET_LOG_REPLICATOR_DELAY_PARAM, new_delay_in_miliseconds),
         ]
-        add_env_vars_to_noobaa_core_class(new_env_var_touples)
+        add_env_vars_to_noobaa_core_class(new_env_var_tuples)
 
     @pytest.fixture()
-    def buckets_with_versioning(self, bucket_factory, mcg_obj, awscli_pod_session):
+    def make_buckets_with_versioning(self, bucket_factory, mcg_obj, awscli_pod_session):
         """
-        Prepare two buckets with versioning enabled
+        A factory that creates versioned MCG buckets
 
         Args:
             bucket_factory: Fixture for creating new buckets
@@ -63,44 +66,190 @@ class TestReplicationWithVersioning(MCGTest):
             awscli_pod_session: The session-scoped AWSCLI pod
 
         Returns:
-            Tuple of two buckets: source and target
+            function: The factory function
         """
-        # Using the OC interface allows patching a repli policy on the OBC
-        bucket_a = bucket_factory(1, "OC")[0]
-        bucket_b = bucket_factory(1, "OC")[0]
 
-        put_bucket_versioning_via_awscli(mcg_obj, awscli_pod_session, bucket_a.name)
-        put_bucket_versioning_via_awscli(mcg_obj, awscli_pod_session, bucket_b.name)
+        def _factory(amount):
+            """
+            Create versioned buckets
 
-        return bucket_a, bucket_b
+            Args:
+                amount (int): The number of buckets to create
 
-    @tier1
-    @polarion_id("OCS-6294")
+            Returns:
+                list(Bucket): The created buckets
+            """
+            # Using the OC interface allows patching a repli policy on the OBC
+            buckets = bucket_factory(amount, "OC")
+            for bucket in buckets:
+                put_bucket_versioning_via_awscli(
+                    mcg_obj, awscli_pod_session, bucket.name
+                )
+            return buckets
+
+        return _factory
+
+    @pytest.mark.parametrize(
+        argnames="bucket_pairs_amount",
+        argvalues=[
+            pytest.param(1, marks=[tier1, polarion_id("OCS-6294")]),
+            pytest.param(2, marks=[tier2, polarion_id("OCS-6343")]),
+        ],
+        ids=["single_bucket_pair", "multiple_bucket_pairs"],
+    )
     def test_bucket_replication_with_versioning(
         self,
         awscli_pod,
         mcg_obj,
-        buckets_with_versioning,
+        make_buckets_with_versioning,
+        bucket_pairs_amount,
     ):
         """
-        1. Create two buckets and enable versioning on both
-        2. Set a bucket replication policy with versioning enabled on the source bucket
-        3. Write some versions to the source bucket
-        4. Verify the versions were replicated to the target bucket in the same order
+        1. Create source and target buckets with versioning enabled
+        2. Set bucket replication policies with versioning enabled on the source buckets
+        3. Write some versions to the source buckets
+        4. Verify the versions were replicated to the target buckets in the same order
+        """
+        obj_key = "test_obj_" + str(uuid4())[:4]
+        versions_amount = 5
+        bucket_pairs = []
+
+        # 1. Create source and target buckets with versioning enabled
+        for _ in range(bucket_pairs_amount):
+            source_bucket, target_bucket = make_buckets_with_versioning(2)
+            bucket_pairs.append((source_bucket, target_bucket))
+
+        # 2. Set bucket replication policies with versioning enabled on the source buckets
+        for source_bucket, target_bucket in bucket_pairs:
+            replication_policy = ReplicationPolicyWithVersioning(
+                target_bucket=target_bucket.name
+            )
+            update_replication_policy(source_bucket.name, replication_policy.to_dict())
+
+        # 3. Write some versions to the source buckets
+        for source_bucket, _ in bucket_pairs:
+            upload_obj_versions(
+                mcg_obj,
+                awscli_pod,
+                source_bucket.name,
+                obj_key=obj_key,
+                amount=versions_amount,
+            )
+            source_etags = get_obj_versions(
+                mcg_obj, awscli_pod, source_bucket.name, obj_key
+            )
+            logger.info(f"Uploaded versions with etags: {source_etags}")
+
+        # 4. Verify the versions were replicated to the target buckets in the same order
+        for source_bucket, target_bucket in bucket_pairs:
+            wait_for_object_versions_match(
+                mcg_obj,
+                awscli_pod,
+                source_bucket.name,
+                target_bucket.name,
+                obj_key,
+            )
+        logger.info("All the versions were replicated successfully")
+
+    @tier2
+    @polarion_id("OCS-6344")
+    def test_bidirectional_replication_with_versioning(
+        self,
+        awscli_pod,
+        mcg_obj,
+        make_buckets_with_versioning,
+    ):
+        """
+        1. Create two buckets with versioning enabled
+        2. Set bucket replication with versioning on both buckets
+        3. Write some versions to each bucket
+        4. Verify the versions were replicated to their targets in the same order
+        """
+        obj_key = "test_obj_" + str(uuid4())[:4]
+        versions_amount = 5
+        a_to_b_prefix = "a_to_b"
+        b_to_a_prefix = "b_to_a"
+
+        # 1. Create two buckets with versioning enabled
+        bucket_a, bucket_b = make_buckets_with_versioning(2)
+
+        # 2. Set bucket replication with versioning on both buckets
+        replication_policy = ReplicationPolicyWithVersioning(
+            target_bucket=bucket_b.name, prefix=a_to_b_prefix
+        )
+        update_replication_policy(bucket_a.name, replication_policy.to_dict())
+
+        replication_policy = ReplicationPolicyWithVersioning(
+            target_bucket=bucket_a.name, prefix=b_to_a_prefix
+        )
+        update_replication_policy(bucket_b.name, replication_policy.to_dict())
+
+        # 3. Write some versions to each bucket
+        for bucket in (bucket_a, bucket_b):
+            prefix = a_to_b_prefix if bucket == bucket_a else b_to_a_prefix
+            upload_obj_versions(
+                mcg_obj,
+                awscli_pod,
+                bucket.name,
+                obj_key=os.path.join(prefix, obj_key),
+                amount=versions_amount,
+            )
+
+        # 4. Verify the versions were replicated to their targets in the same order
+        wait_for_object_versions_match(
+            mcg_obj,
+            awscli_pod,
+            bucket_a.name,
+            bucket_b.name,
+            obj_key=f"{a_to_b_prefix}/{obj_key}",
+        )
+        wait_for_object_versions_match(
+            mcg_obj,
+            awscli_pod,
+            bucket_b.name,
+            bucket_a.name,
+            obj_key=f"{b_to_a_prefix}/{obj_key}",
+        )
+
+    @tier3
+    @polarion_id("OCS-6345")
+    def test_bucket_replication_with_versioning_suspension(
+        self,
+        awscli_pod,
+        mcg_obj,
+        make_buckets_with_versioning,
+    ):
+        """
+        1. Create a source and target bucket with versioning enabled
+        2. Set a bucket replication policy with versioning enabled from the source to the target
+        3. Suspend the versioning on the source bucket
+        4. Write some versions to the source bucket
+        5. Wait and verify that only the latest version was replicated to the target bucket
+        6. Enable versioning on the source bucket and suspend the versioning on the target bucket
+        7. Write versions to the source bucket under a different object key
+        8. Wait to verify that only the latest version was uploaded to the target bucket
+        9. Enable versioning on the target bucket
+        10. Upload new versions under a different object key to the source bucket
+        11. Wait and verify that all the versions were replicated to the target bucket
         """
         obj_key = "test_obj_" + str(uuid4())[:4]
         versions_amount = 5
 
-        # 1. Create two buckets and enable versioning on both
-        source_bucket, target_bucket = buckets_with_versioning
+        # 1. Create a source and target bucket with versioning enabled
+        source_bucket, target_bucket = make_buckets_with_versioning(2)
 
-        # 2. Set a bucket replication policy with versioning enabled on the source bucket
+        # 2. Set a bucket replication policy with versioning enabled from the source to the target
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=target_bucket.name
         )
         update_replication_policy(source_bucket.name, replication_policy.to_dict())
 
-        # 3. Write some versions to the source bucket
+        # 3. Suspend the versioning on the source bucket
+        put_bucket_versioning_via_awscli(
+            mcg_obj, awscli_pod, source_bucket.name, status="Suspended"
+        )
+
+        # 4. Write some versions to the source bucket
         upload_obj_versions(
             mcg_obj,
             awscli_pod,
@@ -108,41 +257,88 @@ class TestReplicationWithVersioning(MCGTest):
             obj_key=obj_key,
             amount=versions_amount,
         )
+
+        # 5. Wait and verify that only the latest version was replicated to the target bucket
         source_versions = get_obj_versions(
             mcg_obj, awscli_pod, source_bucket.name, obj_key
         )
-        source_etags = [v["ETag"] for v in source_versions]
-        logger.info(f"Uploaded versions with etags: {source_etags}")
+        assert (
+            len(source_versions) == 1
+        ), f"Expected a single version on a suspended bucket, got: {source_versions}"
+        wait_for_object_versions_match(
+            mcg_obj,
+            awscli_pod,
+            source_bucket.name,
+            target_bucket.name,
+            obj_key=obj_key,
+        )
 
-        # 4. Verify the versions were replicated to the target bucket in the same order
-        last_target_etags = None
-        try:
-            for target_versions in TimeoutSampler(
-                timeout=TIMEOUT,
-                sleep=30,
-                func=get_obj_versions,
-                mcg_obj=mcg_obj,
-                awscli_pod=awscli_pod,
-                bucket_name=target_bucket.name,
-                obj_key=obj_key,
-            ):
-                target_etags = [v["ETag"] for v in target_versions]
-                if source_etags == target_etags:
-                    logger.info(
-                        f"Source and target etags match: {source_etags} == {target_etags}"
-                    )
-                    break
-                logger.warning(
-                    f"Source and target etags do not match: {source_etags} != {target_etags}"
+        # 6. Enable versioning on the source bucket and suspend the versioning on the target bucket
+        put_bucket_versioning_via_awscli(
+            mcg_obj, awscli_pod, source_bucket.name, status="Enabled"
+        )
+        put_bucket_versioning_via_awscli(
+            mcg_obj, awscli_pod, target_bucket.name, status="Suspended"
+        )
+
+        # 7. Write versions to the source bucket under a different object key
+        obj_key = "test_obj_" + str(uuid4())[:4]
+        upload_obj_versions(
+            mcg_obj,
+            awscli_pod,
+            source_bucket.name,
+            obj_key=obj_key,
+            amount=versions_amount,
+        )
+
+        # 8. Wait to verify that only the latest version was uploaded to the target bucket
+        source_versions = get_obj_versions(
+            mcg_obj, awscli_pod, source_bucket.name, obj_key
+        )
+        latest_version_etag = source_versions[0]["ETag"]
+
+        for target_versions in TimeoutSampler(
+            timeout=300,
+            sleep=30,
+            func=get_obj_versions,
+            mcg_obj=mcg_obj,
+            awscli_pod=awscli_pod,
+            bucket_name=target_bucket.name,
+            obj_key=obj_key,
+        ):
+            if len(target_versions) > 1:
+                raise UnexpectedBehaviour(
+                    f"Expected a single version, got: {target_versions}"
                 )
-                last_target_etags = target_etags
-        except TimeoutExpiredError as e:
-            err_msg = (
-                f"Source and target etags do not match after {TIMEOUT} seconds:\n"
-                f"Source etags:\n{json.dumps(source_etags, indent=2)}\n"
-                f"Target etags:\n{json.dumps(last_target_etags, indent=2)}"
-            )
-            logger.error(err_msg)
-            raise TimeoutExpiredError(f"{str(e)}\n\n{err_msg}")
+            target_version_etag = target_versions[0]["ETag"]
+            if target_version_etag == latest_version_etag:
+                logger.info("Only the later version was replicated as expected")
+                break
+            else:
+                logger.warning(
+                    f"Expected the latest version {latest_version_etag}, got: {target_version_etag}"
+                )
 
-        logger.info("All versions were replicated successfully")
+        # 9. Enable versioning on the target bucket
+        put_bucket_versioning_via_awscli(
+            mcg_obj, awscli_pod, target_bucket.name, status="Enabled"
+        )
+
+        # 10. Upload new versions under a different object key to the source bucket
+        obj_key = "test_obj_" + str(uuid4())[:4]
+        upload_obj_versions(
+            mcg_obj,
+            awscli_pod,
+            source_bucket.name,
+            obj_key=obj_key,
+            amount=versions_amount,
+        )
+
+        # 11. Wait and verify that all the versions were replicated to the target bucket
+        wait_for_object_versions_match(
+            mcg_obj,
+            awscli_pod,
+            source_bucket.name,
+            target_bucket.name,
+            obj_key=obj_key,
+        )


### PR DESCRIPTION
- Add utility functions that deal with the comparison of object versions between two buckets
- Generalize `test_bucket_replication_with_versioning` to support multiple pairs and make the original a test case the case for `bucket_pairs_amount==1` (`test_bucket_replication_with_versioning` --> `test_bucket_replication_with_versioning[single_bucket_pair]`)
- Add `test_bucket_replication_with_versioning[multiple_bucket_pairs]`
- Add `test_bidirectional_replication_with_versioning`
- Add `test_bucket_replication_with_versioning_suspension`