### PR TITLE
requested_cap_breakdown: replace busybox with ubi8 for disconected clusters

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -99,6 +99,7 @@ CHRONY_TEMPLATE = os.path.join(
 HUGE_PAGES_TEMPLATE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "huge_pages.yaml")
 NAMESPACE_TEMPLATE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "namespace.yaml")
 BUSYBOX_TEMPLATE = os.path.join(TEMPLATE_DIR, "ocp-deployment", "busybox.yaml")
+UBI8_TEMPLATE = os.path.join(TEMPLATE_DIR, "app-deployments", "ubi8-simple.yaml")
 NETWORK_POLICY_PROVIDER_TO_CLIENT_TEMPLATE = os.path.join(
     TEMPLATE_DIR, "ocs-deployment", "provider-mode", "network_policy_provider_mode.yaml"
 )

--- a/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
@@ -656,7 +656,10 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
                   and the values are booleans indicating whether the deviation was detected or not.
         """
 
-        node_with_test_app, _ = self.workload_ui.deploy_app()
+        test_app_depl_name = "topology-test-app"
+        node_with_test_app, _ = self.workload_ui.deploy_app(
+            depl_name=test_app_depl_name
+        )
         sleep_time = 30
         logger.info(f"give {sleep_time}sec to render on ODF Topology view")
         time.sleep(sleep_time)
@@ -749,8 +752,8 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
             if not sorted(deployments_names_list_cli) == sorted(
                 deployments_names_list_ui
             ):
-                self.take_screenshot()
-                self.copy_dom()
+                self.take_screenshot("cli_ui_depl_missmatch")
+                self.copy_dom("cli_ui_depl_missmatch")
                 logger.error(
                     f"deployments of the node '{node_name}' from UI do not match deployments from CLI\n"
                     f"deployments_list_cli = '{sorted(deployments_names_list_cli)}'\n"
@@ -758,12 +761,11 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
                 )
                 topology_deviation[f"{node_name}__deployments_not_equal"] = True
 
-            test_app_depl_name = self.workload_ui.get_depl_name()
             if node_name == node_with_test_app and (
                 test_app_depl_name not in deployments_names_list_ui
             ):
-                self.take_screenshot()
-                self.copy_dom()
+                self.take_screenshot("test_app_not_in_node")
+                self.copy_dom("test_app_not_in_node")
                 logger.error(
                     f"test-app deployment '{test_app_depl_name}' deployed on the node '{node_with_test_app}' "
                     f"during the test was not found in UI"

--- a/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
@@ -656,7 +656,7 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
                   and the values are booleans indicating whether the deviation was detected or not.
         """
 
-        node_with_busybox, _ = self.workload_ui.deploy_busybox()
+        node_with_test_app, _ = self.workload_ui.deploy_app()
         sleep_time = 30
         logger.info(f"give {sleep_time}sec to render on ODF Topology view")
         time.sleep(sleep_time)
@@ -758,33 +758,33 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
                 )
                 topology_deviation[f"{node_name}__deployments_not_equal"] = True
 
-            busybox_depl_name = self.workload_ui.get_busybox_depl_name()
-            if node_name == node_with_busybox and (
-                busybox_depl_name not in deployments_names_list_ui
+            test_app_depl_name = self.workload_ui.get_depl_name()
+            if node_name == node_with_test_app and (
+                test_app_depl_name not in deployments_names_list_ui
             ):
                 self.take_screenshot()
                 self.copy_dom()
                 logger.error(
-                    f"busybox deployment '{busybox_depl_name}' deployed on the node '{node_with_busybox}' "
+                    f"test-app deployment '{test_app_depl_name}' deployed on the node '{node_with_test_app}' "
                     f"during the test was not found in UI"
                 )
                 topology_deviation["added_deployment_not_found"] = True
-            elif node_name == node_with_busybox and (
-                busybox_depl_name in deployments_names_list_ui
+            elif node_name == node_with_test_app and (
+                test_app_depl_name in deployments_names_list_ui
             ):
-                self.workload_ui.delete_busybox(busybox_depl_name)
+                self.workload_ui.delete_depl(test_app_depl_name)
                 sleep_time = 30
                 logger.info(
-                    f"delete '{busybox_depl_name}' deployment from cluster, give {sleep_time}sec to update ODF "
+                    f"delete '{test_app_depl_name}' deployment from cluster, give {sleep_time}sec to update ODF "
                     "Topology and verify deployment was removed"
                 )
                 time.sleep(sleep_time)
 
                 deployment_topology = self.nodes_view.nav_into_node(
-                    node_name_option=node_with_busybox
+                    node_name_option=node_with_test_app
                 )
 
-                # zoom out Topology view before trying to find busybox deployment
+                # zoom out Topology view before trying to find test-app deployment
                 if len(deployments_names_list_ui) < 6:
                     zoom_out_times = 1
                 elif len(deployments_names_list_ui) < 12:
@@ -794,19 +794,19 @@ class TopologyTab(DataFoundationDefaultTab, AbstractTopologyView):
                 for i in range(1, zoom_out_times + 1):
                     self.zoom_out_view()
 
-                # check deployed during the test deployment is present
-                if not deployment_topology.is_entity_present(busybox_depl_name):
+                # check that the test-app deployment is present
+                if not deployment_topology.is_entity_present(test_app_depl_name):
                     logger.info(
-                        f"Deployment '{busybox_depl_name}' was successfully removed from ODF Topology view"
+                        f"Deployment '{test_app_depl_name}' was successfully removed from ODF Topology view"
                     )
                 else:
                     logger.error(
-                        f"busybox deployment '{busybox_depl_name}' deployed on the node '{node_with_busybox}' "
+                        f"test-app deployment '{test_app_depl_name}' deployed on the node '{node_with_test_app}' "
                         f"during the test was not removed from ODF Topology"
                     )
                     self.take_screenshot()
                     self.copy_dom()
-                    topology_deviation[f"{busybox_depl_name}__not_removed"] = True
+                    topology_deviation[f"{test_app_depl_name}__not_removed"] = True
                 deployment_topology.nav_back_main_topology_view()
         return topology_deviation
 

--- a/ocs_ci/ocs/ui/workload_ui.py
+++ b/ocs_ci/ocs/ui/workload_ui.py
@@ -65,24 +65,6 @@ class WorkloadUi(metaclass=SingletonMeta):
         with open(app_path) as file_stream:
             self.depl_cr = yaml.safe_load(file_stream)
 
-    def get_depl_name(self):
-        """
-        Retrieves the name of the testing app deployment.
-
-        Returns:
-            str: Name of the deployment.
-        """
-        return self.depl_cr["metadata"]["name"]
-
-    def set_depl_name(self, name):
-        """
-        Sets the name of the testing app deployment in the original YAML.
-
-        Args:
-            name (str): New name for the testing app deployment.
-        """
-        self.depl_cr["metadata"]["name"] = name
-
     def deploy_app(
         self,
         node: str = None,
@@ -140,9 +122,13 @@ class WorkloadUi(metaclass=SingletonMeta):
             if not namespace:
                 namespace = config.ENV_DATA["cluster_namespace"]
 
+            yaml_string = yaml.dump(depl_dict, default_flow_style=False, indent=2)
+            logger.info(f"Deploying app with yaml:\n{yaml_string}")
+
             yaml.dump(depl_dict, temp_file, default_flow_style=False)
             temp_file.flush()
             occli = OCP()
+
             occli.apply(temp_file.name)
 
         app_scaled_up = self.wait_app_scaled_up(60, depl_name, namespace)
@@ -202,13 +188,13 @@ class WorkloadUi(metaclass=SingletonMeta):
 
         for depl_obj in self.deployment_list:
             if depl_name == depl_obj.name:
-                bb_depl = depl_obj
+                the_depl = depl_obj
                 break
         else:
             logger.error(f"no deployment with the given name {depl_name} found")
             return None
-        res = bb_depl.delete(wait=True, force=force)
-        self.deployment_list.remove(bb_depl)
+        res = the_depl.delete(wait=True, force=force)
+        self.deployment_list.remove(the_depl)
         return res
 
     def delete_all_deployments(self):

--- a/ocs_ci/templates/app-deployments/ubi8-simple.yaml
+++ b/ocs_ci/templates/app-deployments/ubi8-simple.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ubi-test
+  namespace: {}
+spec:
+  selector:
+    matchLabels:
+      app: test-deployment-ubi
+  template:
+    metadata:
+      labels:
+        app: test-deployment-ubi
+    spec:
+      containers:
+        - name: ubi
+          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+          command: ["sleep", "360000"]

--- a/tests/functional/ui/test_capacity_breakdown_ui.py
+++ b/tests/functional/ui/test_capacity_breakdown_ui.py
@@ -190,12 +190,12 @@ class TestCapacityBreakdownUI(ManageTest):
                     capacity,
                 )
 
-        # deploy busybox and attach different pvcs to it
+        # deploy test app and attach different pvcs to it
         for data_struct in PvcCapacityDeploymentList():
-            _, data_struct.deployment = WorkloadUi().deploy_busybox(
+            _, data_struct.deployment = WorkloadUi().deploy_app(
                 namespace=namespace,
                 pvc_name=data_struct.pvc_obj.name,
-                depl_name=f"busybox-{data_struct.capacity_size}gi-{time.time_ns() // 1_000_000}",
+                depl_name=f"ubi8-{data_struct.capacity_size}gi-{time.time_ns() // 1_000_000}",
             )
 
         # fill attached PVC's with data
@@ -226,7 +226,7 @@ class TestCapacityBreakdownUI(ManageTest):
         # update of the ui comes by portions. For example, the large PVC will be updated by parts, first it's filled
         # with 1Gi, then 2.5Gi, etc. This process is random, so we give a time to update the UI
         logger.info(
-            "finished deploying busybox, wait 180 sec to update the UI of the management-console"
+            "finished deploying testing apps, wait 180 sec to update the UI of the management-console"
         )
         time.sleep(180)
 


### PR DESCRIPTION
Fix the problem with containers unavailable on disconnected clusters:
```
[2025-02-02T13:54:30.118Z] 08:54:29 - MainThread - ocs_ci.ocs.ui.workload_ui - [32mINFO[0m  - Run IO on pod busybox-1gi-1738504443067-798b6b5495-qklft
[2025-02-02T13:54:30.118Z] 08:54:29 - MainThread - ocs_ci.utility.utils - [32mINFO[0m  - Executing command: oc -n project-ui-54b8b3e820a649f187b42d53d2d2b rsh busybox-1gi-1738504443067-798b6b5495-qklft dd if=/dev/urandom of=/tmp/testfile bs=64M count=16
[2025-02-02T13:54:30.371Z] 08:54:30 - MainThread - ocs_ci.utility.utils - [33mWARNING[0m  - Command stderr: error: unable to upgrade connection: container not found ("busybox")
```
RP link: https://url.corp.redhat.com/fdcd710 