### PR TITLE
[release-4.17] exclude NOOBAA_PSQL_12_IMAGE for image verification after upgrade

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1703,6 +1703,7 @@ MIRROR_OPENSHIFT_USER_FILE = "mirror_openshift_user"
 MIRROR_OPENSHIFT_PASSWORD_FILE = "mirror_openshift_password"
 NOOBAA_POSTGRES_CONFIGMAP = "noobaa-postgres-config"
 NOOBAA_POSTGRES_SECRET = "noobaa-pgsql-secret"
+NOOBAA_POSTGRES_12_VERSION = 12
 ROOK_CEPH_OPERATOR = "rook-ceph-operator"
 ROOK_CEPH_CSI_CONFIG = "rook-ceph-csi-config"
 PDBSTATEMAP = "rook-ceph-pdbstatemap"

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1448,19 +1448,31 @@ def get_images(data, images=None):
     return images
 
 
-def verify_images_upgraded(old_images, object_data):
+def verify_images_upgraded(old_images, object_data, ignore_psql_12_verification=False):
     """
     Verify that all images in ocp object are upgraded.
 
     Args:
        old_images (set): Set with old images.
        object_data (dict): OCP object yaml data.
+       ignore_psql_12_verification (bool): If True, psql 12 image is removed from current_images for verification
 
     Raises:
         NonUpgradedImagesFoundError: In case the images weren't upgraded.
 
     """
     current_images = get_images(object_data)
+    # from 4.15, noobaa-operator pod has NOOBAA_PSQL_12_IMAGE along with NOOBAA_DB_IMAGE
+    if (
+        ignore_psql_12_verification
+        and "noobaa_psql_12" in current_images
+        and constants.NOOBAA_OPERATOR_DEPLOYMENT
+        in object_data.get("metadata").get("name")
+    ):
+        log.info(
+            f'deleting noobaa_psql_12 image from current images for {object_data.get("metadata").get("name")}'
+        )
+        del current_images["noobaa_psql_12"]
     not_upgraded_images = set(
         [image for image in current_images.values() if image in old_images]
     )

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -42,7 +42,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
     mcg_only_install_verification,
     ocs_install_verification,
 )
-from ocs_ci.ocs.utils import setup_ceph_toolbox
+from ocs_ci.ocs.utils import setup_ceph_toolbox, get_expected_nb_db_psql_version
 from ocs_ci.utility import version
 from ocs_ci.utility.reporting import update_live_must_gather_image
 from ocs_ci.utility.rgwutils import get_rgw_count
@@ -152,12 +152,17 @@ def verify_image_versions(old_images, upgrade_version, version_before_upgrade):
             "minCount", constants.MIN_NB_ENDPOINT_COUNT_POST_DEPLOYMENT
         )
         noobaa_pods = default_noobaa_pods + min_endpoints
+    noobaa_db_psql_version = get_expected_nb_db_psql_version()
+    ignore_psql_12_verification = True
+    if int(noobaa_db_psql_version) == constants.NOOBAA_POSTGRES_12_VERSION:
+        ignore_psql_12_verification = False
     try:
         verify_pods_upgraded(
             old_images,
             selector=constants.NOOBAA_APP_LABEL,
             count=noobaa_pods,
             timeout=1020,
+            ignore_psql_12_verification=ignore_psql_12_verification,
         )
     except TimeoutException as ex:
         if upgrade_version >= parse_version("4.7"):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2174,7 +2174,9 @@ def wait_for_noobaa_pods_running(timeout=300, sleep=10):
     sampler.wait_for_func_status(True)
 
 
-def verify_pods_upgraded(old_images, selector, count=1, timeout=720):
+def verify_pods_upgraded(
+    old_images, selector, count=1, timeout=720, ignore_psql_12_verification=False
+):
     """
     Verify that all pods do not have old image.
 
@@ -2183,6 +2185,7 @@ def verify_pods_upgraded(old_images, selector, count=1, timeout=720):
        selector (str): Selector (e.g. app=ocs-osd)
        count (int): Number of resources for selector.
        timeout (int): Timeout in seconds to wait for pods to be upgraded.
+       ignore_psql_12_verification (bool): If True, psql 12 image is removed from current_images for verification
 
     Raises:
         TimeoutException: If the pods didn't get upgraded till the timeout.
@@ -2210,7 +2213,7 @@ def verify_pods_upgraded(old_images, selector, count=1, timeout=720):
                 )
             for pod in pods:
                 pod_obj = pod.get()
-                verify_images_upgraded(old_images, pod_obj)
+                verify_images_upgraded(old_images, pod_obj, ignore_psql_12_verification)
                 current_pod_images = get_images(pod_obj)
                 for container_name, container_image in current_pod_images.items():
                     if container_name not in pod_images:

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -24,7 +24,12 @@ from ocs_ci.framework import config as ocsci_config, config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.external_ceph import RolesContainer, Ceph, CephNode
 from ocs_ci.ocs.clients import WinNode
-from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    ExternalClusterDetailsException,
+    ResourceNotFoundError,
+    UnexpectedBehaviour,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.openstack import CephVMNode
 from ocs_ci.ocs.parallel import parallel
@@ -1904,3 +1909,33 @@ def get_dr_operator_versions():
             if submariner_operator_version:
                 versions_dic["submariner_version"] = submariner_operator_version
     return versions_dic
+
+
+def get_expected_nb_db_psql_version():
+    """
+        Get the expected NooBaa DB version from the NooBaa CR
+        Returns:
+            str: The expected NooBaa DB version
+    Raises:
+            ResourceNotFoundError: If the NooBaa CR was not found
+            UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the
+    """
+
+    nb_cr_obj = OCP(
+        kind=constants.NOOBAA_RESOURCE_NAME,
+        namespace=ocsci_config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.NOOBAA_RESOURCE_NAME,
+    )
+    if not nb_cr_obj:
+        raise ResourceNotFoundError(
+            f"NooBaa CR {constants.NOOBAA_RESOURCE_NAME} not found"
+        )
+
+    try:
+        psql_image = nb_cr_obj.data["spec"]["dbImage"]
+        re_match = re.search(r"postgresql-(\d+(\.\d+)*)", psql_image)
+        return re_match.group(1)
+    except Exception as e:
+        raise UnexpectedBehaviour(
+            f"Failed to extract the NooBaa DB version from the NooBaa CR: {e}"
+        )

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1913,9 +1913,11 @@ def get_dr_operator_versions():
 
 def get_expected_nb_db_psql_version():
     """
-        Get the expected NooBaa DB version from the NooBaa CR
-        Returns:
-            str: The expected NooBaa DB version
+    Get the expected NooBaa DB version from the NooBaa CR
+
+    Returns:
+        str: The expected NooBaa DB version
+
     Raises:
             ResourceNotFoundError: If the NooBaa CR was not found
             UnexpectedBehaviour: If the NooBaa DB version could not be extracted from the


### PR DESCRIPTION
cherry-pick of https://github.com/red-hat-storage/ocs-ci/pull/10723

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)