### PR TITLE
Deprecate test_object_bucket_size

### DIFF
--- a/tests/functional/object/rgw/test_object_bucket_size.py
+++ b/tests/functional/object/rgw/test_object_bucket_size.py
@@ -70,7 +70,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
 @bugzilla("1880748")
 @skipif_mcg_only
 @tier1
-def test_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
+def deprecated_test_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
     """
     Test to verify object bucket(backed by RGW) available size
 


### PR DESCRIPTION
Fixes: #9697

This test verifies the output of the `read_bucket` RPC method in on-prem deployments. However, using RPC's is no longer supported as a customer-facing feature so we can't expect fixes for it.