### PR TITLE
Verify IPv6 Connectivity Between Rook-Ceph-Exporter and OCP Prometheus

### DIFF
--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -289,7 +289,6 @@ def test_provider_metrics_available(threading_lock):
 
 @blue_squad
 @tier1
-@bugzilla("2297285")
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6796")
 def test_monitoring_ip_connectivity(threading_lock):

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -306,9 +306,12 @@ def test_monitoring_ipv6(threading_lock):
     )
     prometheus_pod_obj = None
     for pod_obj in pod_obj_list:
-        if "prometheus-k8s" in pod_obj.name:
-            prometheus_pod_obj = pod_obj
-            break
+        try:
+            if "prometheus-k8s" in pod_obj.name:
+                prometheus_pod_obj = pod_obj
+                break
+        except Exception as e:
+            logger.info(e)
     assert (
         prometheus_pod_obj is not None
     ), "Prometheus pod not found in the monitoring namespace"

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -291,18 +291,18 @@ def test_provider_metrics_available(threading_lock):
 @tier1
 @bugzilla("2297285")
 @skipif_external_mode
-@pytest.mark.polarion_id("OCS-XXX")
-def test_monitoring_ipv6(threading_lock):
+@pytest.mark.polarion_id("OCS-6796")
+def test_monitoring_ip_connectivity(threading_lock):
     """
     Procedure:
-    1. Retrieves the IPv6 addresses of rook-ceph-exporter pods.
+    1. Retrieves the IPv4/6 addresses of rook-ceph-exporter pods.
     2. Logs into the prometheus-k8s pod in the openshift-monitoring namespace.
     3. Checks connectivity using curl to fetch metrics from each exporter's /metrics endpoint.
     4. Asserts that the expected Ceph metric is present in the response.
 
     """
     exporter_pods = pod.get_pods_having_label(constants.EXPORTER_APP_LABEL)
-    ipv6_addresses = [pod_obj["status"]["podIP"] for pod_obj in exporter_pods]
+    ip_addresses = [pod_obj["status"]["podIP"] for pod_obj in exporter_pods]
     pod_obj_list = pod.get_all_pods(
         namespace=defaults.OCS_MONITORING_NAMESPACE, selector_label=["prometheus"]
     )
@@ -314,11 +314,11 @@ def test_monitoring_ipv6(threading_lock):
     assert (
         prometheus_pod_obj is not None
     ), "Prometheus pod not found in the monitoring namespace"
-    for ipv6_address in ipv6_addresses:
+    for ip_address in ip_addresses:
         formatted_ip = (
-            f"[{ipv6_address}]"
-            if ipaddress.ip_address(ipv6_address).version == 6
-            else ipv6_address
+            f"[{ip_address}]"
+            if ipaddress.ip_address(ip_address).version == 6
+            else ip_address
         )
         cmd = (
             f"oc rsh -n {defaults.OCS_MONITORING_NAMESPACE} {prometheus_pod_obj.name} "
@@ -327,4 +327,4 @@ def test_monitoring_ipv6(threading_lock):
         out = run_cmd(cmd=cmd)
         assert (
             "ceph_AsyncMessenger_Worker_msgr_connection" in out
-        ), f"Expected Ceph metric not found in output for IP {ipv6_address}"
+        ), f"Expected Ceph metric not found in output for IP {ip_address}"

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -289,6 +289,7 @@ def test_provider_metrics_available(threading_lock):
 @blue_squad
 @tier1
 @bugzilla("2297285")
+@skipif_external_mode
 @pytest.mark.polarion_id("OCS-XXX")
 def test_monitoring_ipv6(threading_lock):
     """
@@ -306,12 +307,9 @@ def test_monitoring_ipv6(threading_lock):
     )
     prometheus_pod_obj = None
     for pod_obj in pod_obj_list:
-        try:
-            if "prometheus-k8s" in pod_obj.name:
-                prometheus_pod_obj = pod_obj
-                break
-        except Exception as e:
-            logger.info(e)
+        if "prometheus-k8s" in pod_obj.name:
+            prometheus_pod_obj = pod_obj
+            break
     assert (
         prometheus_pod_obj is not None
     ), "Prometheus pod not found in the monitoring namespace"

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -5,6 +5,7 @@ check that OCS Monitoring is configured and available as expected.
 """
 
 import logging
+import ipaddress
 
 import pytest
 
@@ -314,9 +315,14 @@ def test_monitoring_ipv6(threading_lock):
         prometheus_pod_obj is not None
     ), "Prometheus pod not found in the monitoring namespace"
     for ipv6_address in ipv6_addresses:
+        formatted_ip = (
+            f"[{ipv6_address}]"
+            if ipaddress.ip_address(ipv6_address).version == 6
+            else ipv6_address
+        )
         cmd = (
             f"oc rsh -n {defaults.OCS_MONITORING_NAMESPACE} {prometheus_pod_obj.name} "
-            f"curl -vv http://[{ipv6_address}]:9926/metrics"
+            f"curl -vv http://{formatted_ip}:9926/metrics"
         )
         out = run_cmd(cmd=cmd)
         assert (


### PR DESCRIPTION
### **Description:**  
This PR introduces a test to verify the connectivity of `rook-ceph-exporter` pods to OpenShift Prometheus over **IPv6**.  

#### **Test Procedure:**  
1. Retrieve the **IPv6 addresses** of `rook-ceph-exporter` pods.  
2. Identify the `prometheus-k8s` pod in the **openshift-monitoring** namespace.  
3. Use `curl` from within the `prometheus-k8s` pod to access the `/metrics` endpoint of each exporter via IPv6.  
4. Verify that the response contains the expected Ceph metric: **`ceph_AsyncMessenger_Worker_msgr_connection`**.  

