### PR TITLE
Use the RGW internal endpoint when creating RGW based MCG S3Compatible Backingstores and Namespacestores

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -937,7 +937,7 @@ def oc_create_rgw_backingstore(cld_mgr, backingstore_name, uls_name, region):
         "type": "s3-compatible",
         "s3Compatible": {
             "targetBucket": uls_name,
-            "endpoint": cld_mgr.rgw_client.endpoint,
+            "endpoint": cld_mgr.rgw_client.s3_internal_endpoint,
             "signatureVersion": "v2",
             "secret": {
                 "name": cld_mgr.rgw_client.secret.name,
@@ -961,7 +961,7 @@ def cli_create_rgw_backingstore(mcg_obj, cld_mgr, backingstore_name, uls_name, r
     """
     mcg_obj.exec_mcg_cmd(
         f"backingstore create s3-compatible {backingstore_name} "
-        f"--endpoint {cld_mgr.rgw_client.endpoint} "
+        f"--endpoint {cld_mgr.rgw_client.s3_internal_endpoint} "
         f"--access-key {cld_mgr.rgw_client.access_key} "
         f"--secret-key {cld_mgr.rgw_client.secret_key} "
         f"--target-bucket {uls_name}",

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -96,6 +96,7 @@ class CloudManager(ABC):
                 "SECRET_PREFIX": "RGW",
                 "DATA_PREFIX": "AWS",
                 "ENDPOINT": endpoint,
+                "S3_INTERNAL_ENDPOINT": rgw_conn.s3_internal_endpoint,
                 "RGW_ACCESS_KEY_ID": access_key,
                 "RGW_SECRET_ACCESS_KEY": secret_key,
             }
@@ -219,6 +220,7 @@ class S3Client(CloudClient):
         key_id = auth_dict.get(f"{self.secret_prefix}_ACCESS_KEY_ID")
         access_key = auth_dict.get(f"{self.secret_prefix}_SECRET_ACCESS_KEY")
         self.endpoint = auth_dict.get("ENDPOINT") or endpoint
+        self.s3_internal_endpoint = auth_dict.get("S3_INTERNAL_ENDPOINT") or None
         self.region = auth_dict.get("REGION")
         self.access_key = key_id
         self.secret_key = access_key

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -233,7 +233,7 @@ def cli_create_namespacestore(
         ),
         constants.RGW_PLATFORM: lambda: (
             f"s3-compatible {nss_name} "
-            f"--endpoint {get_attr_chain(cld_mgr, 'rgw_client.endpoint')} "
+            f"--endpoint {get_attr_chain(cld_mgr, 'rgw_client.s3_internal_endpoint')} "
             f"--access-key {get_attr_chain(cld_mgr, 'rgw_client.access_key')} "
             f"--secret-key {get_attr_chain(cld_mgr, 'rgw_client.secret_key')} "
             f"--target-bucket {uls_name}"
@@ -322,7 +322,7 @@ def oc_create_namespacestore(
             "type": "s3-compatible",
             "s3Compatible": {
                 "targetBucket": uls_name,
-                "endpoint": get_attr_chain(cld_mgr, "rgw_client.endpoint"),
+                "endpoint": get_attr_chain(cld_mgr, "rgw_client.s3_internal_endpoint"),
                 "signatureVersion": "v2",
                 "secret": {
                     "name": get_attr_chain(cld_mgr, "rgw_client.secret.name"),

--- a/ocs_ci/ocs/resources/rgw.py
+++ b/ocs_ci/ocs/resources/rgw.py
@@ -25,7 +25,7 @@ class RGW(object):
             kind="storageclass", namespace=namespace, resource_name=sc_name
         )
         self.s3_internal_endpoint = (
-            self.storageclass.get().get("parameters").get("endpoint")
+            f"https://{constants.RGW_SERVICE_INTERNAL_MODE}.{self.namespace}.svc:443"
         )
         self.region = self.storageclass.get().get("parameters").get("region")
         # Todo: Implement retrieval in cases where CephObjectStoreUser is available
@@ -71,10 +71,6 @@ class RGW(object):
                 resource_name=constants.RGW_ROUTE_INTERNAL_MODE
             )
             endpoint = f"http://{endpoint['status']['ingress'][0]['host']}"
-
-            # In disconnected and proxy deployments use the internal address
-            if config.DEPLOYMENT.get("disconnected") or config.DEPLOYMENT.get("proxy"):
-                endpoint = f"https://{constants.RGW_SERVICE_INTERNAL_MODE}.{self.namespace}.svc:443"
 
         creds_secret_obj = secret_ocp_obj.get(secret_name)
         access_key = base64.b64decode(


### PR DESCRIPTION
Fixes #11481

Using the internal RGW endpoint when creating MCG BS/NSS works for all deployment types, including disconnected and proxy