### PR TITLE
skip the test

### DIFF
--- a/tests/functional/pv/pv_services/test_pvc_evict_ceph_clients.py
+++ b/tests/functional/pv/pv_services/test_pvc_evict_ceph_clients.py
@@ -35,6 +35,7 @@ class TestPvcEvictCephClients:
             pytest.param(
                 "same",
                 marks=[
+                    pytest.mark.skip(reason="This test is invalid"),
                     pytest.mark.bugzilla("1901499"),
                     pytest.mark.polarion_id("OCS-3985"),
                 ],


### PR DESCRIPTION
Added skip marker to the invalid test scenario.

The test fails because of this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2269108. This is not an issue but the expected behaviour. So, after discussing it with Mahesh, who automated it, I decided to skip the test.