### PR TITLE
Ensure that get_current_test_marks doesn't return non-relevant marks for utility tests such as test_failure_propagator

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -666,6 +666,9 @@ yellow_squad = pytest.mark.yellow_squad
 # Ignore test during squad decorator check in pytest collection
 ignore_owner = pytest.mark.ignore_owner
 
+# Marks to identify tests that only serve as utility for ocs-ci
+ocs_ci_utility = pytest.mark.ocs_ci_utility
+
 # Marks to identify the cluster type in which the test case should run
 runs_on_provider = pytest.mark.runs_on_provider
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -66,6 +66,7 @@ markers =
     rdr: marker for RDR related tests
     mdr: marker for MDR related tests
     ignore_owner: marker to ignore test during squad decorator check in pytest collection
+    ocs_ci_utility: marker for tests that only serve as utility for ocs-ci
     mcg: marker for MCG related tests
     rgw: marker for RGW related tests
     skipif_ocp_version: marker we use for skipping tests on particular OCP version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8587,6 +8587,11 @@ def update_current_active_test_marks_global(request):
 
     """
     marks = [mark.name for mark in request.node.iter_markers()]
+
+    # Utility tests might have other marks only to trigger them so they should be ignored
+    if "ocs_ci_utility" in marks:
+        marks = ["ocs_ci_utility"]
+
     ocs_ci.framework.pytest_customization.marks.current_test_marks = marks
 
 

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -20,6 +20,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     workloads,
     performance,
     scale,
+    ocs_ci_utility,
 )
 
 log = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ log = logging.getLogger(__name__)
 @workloads
 @performance
 @scale
+@ocs_ci_utility
 class TestFailurePropagator:
     """
     Test class for failure propagator test case


### PR DESCRIPTION
Fixes: #11511