### PR TITLE
add-hyperconverged-into-dependencies

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -336,7 +336,10 @@ higher priority).
             * `node_network_configuration_policy_destination_route` - The destination route of NodeNetworkConfigurationPolicy CR
 * `hcp_version` - version of HCP client to be deployed on machine running the tests
 * `metallb_version` - MetalLB operator version to install
-* `install_hypershift_upstream` - Install hypershift from upstream or not (Default: false). Necessary for unreleased OCP/CNV versions
+* `deploy_acm_hub_cluster` - Deploy ACM hub cluster or not (Default: false)
+* `cnv_deployment` - Deploy CNV or not (Default: false) necessary for Converged clusters with hosted clients
+* `mce_deployment` - Deploy MCE or not (Default: false)
+* `deploy_hyperconverged` - Deploy hyperconverged operator or not (Default: false).  Necessary for Converged clusters with hosted clients with unreleased OCP version
 * `clusters` - section for hosted clusters
     * `<cluster name>` - name of the cluster
       * `hosted_cluster_path` - path to the cluster directory to store auth_path, credentials files or cluster related files

--- a/conf/README.md
+++ b/conf/README.md
@@ -349,6 +349,7 @@ higher priority).
       * `hosted_odf_registry` - registry for hosted ODF (default: quay.io/rhceph-dev/ocs-registry)
       * `hosted_odf_version` - version of ODF to be deployed on hosted clusters
       * `cp_availability_policy` - "HighlyAvailable" or "SingleReplica"; if not provided the default value is "SingleReplica"
+      * `storage_quota` - storage quota for the hosted cluster
 * `wait_timeout_for_healthy_osd_in_minutes` - timeout waiting for healthy OSDs before continuing upgrade (see https://bugzilla.redhat.com/show_bug.cgi?id=2276694 for more details)
 * `osd_maintenance_timeout` - is a duration in minutes that determines how long an entire failureDomain like region/zone/host will be held in noout
 * `odf_provider_mode_deployment` - True if you would like to enable provider mode deployment.

--- a/conf/README.md
+++ b/conf/README.md
@@ -338,7 +338,6 @@ higher priority).
 * `metallb_version` - MetalLB operator version to install
 * `deploy_acm_hub_cluster` - Deploy ACM hub cluster or not (Default: false)
 * `cnv_deployment` - Deploy CNV or not (Default: false) necessary for Converged clusters with hosted clients
-* `mce_deployment` - Deploy MCE or not (Default: false)
 * `deploy_hyperconverged` - Deploy hyperconverged operator or not (Default: false).  Necessary for Converged clusters with hosted clients with unreleased OCP version
 * `clusters` - section for hosted clusters
     * `<cluster name>` - name of the cluster

--- a/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
+++ b/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
@@ -11,7 +11,6 @@ DEPLOYMENT:
   metallb_operator: true
   cnv_latest_stable: true
   local_storage: true
-  mce_deployment: false # use when unreleased version on Clients is needed
   deploy_hyperconverged: false # use when unreleased version on Clients is needed
 ENV_DATA:
   platform: "hci_baremetal"
@@ -21,6 +20,7 @@ ENV_DATA:
   acm_hub_channel: "release-2.10" # this is an example, please provide the desired version
   hcp_version: "4.16" # this is an example, please provide the desired version
   metallb_version: "4.16" # this is an example, please provide the desired version
+  deploy_mce: false # second option to enable multicluster setup; used instead of ACM
   clusters: # the list of the Hosted clusters and their configuration. If field does not exist HostedClsuter installation will be skipped
     hcp415-bm3-e: # the field name is the name of the Hosted cluster
       hosted_cluster_path: "~/clusters/hcp416-bm3-e/openshift-cluster-dir" # path to store auth_path dir or cluster related files

--- a/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
+++ b/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
@@ -32,6 +32,7 @@ ENV_DATA:
       setup_storage_client: true # if true, the Storage Client will be created and verification will be performed
       nodepool_replicas: 3 # number of worker nodes created for Hosted cluster
       cp_availability_policy: "HighlyAvailable" # this field is optional, if not provided the default value is "SingleReplica"
+      storage_quota: 100  # int. 100 means "100Gi". this field is optional, if not provided client will have unlimited storage quota
     hcp415-bm3-f:
       hosted_cluster_path: "~/clusters/hcp416-bm3-f/openshift-cluster-dir" # path to store auth_path dir or cluster related files
       ocp_version:  "4.15.10" # this is an example, please provide the desired OCP version

--- a/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
+++ b/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
@@ -11,6 +11,8 @@ DEPLOYMENT:
   metallb_operator: true
   cnv_latest_stable: true
   local_storage: true
+  mce_deployment: false # use when unreleased version on Clients is needed
+  deploy_hyperconverged: false # use when unreleased version on Clients is needed
 ENV_DATA:
   platform: "hci_baremetal"
   cluster_type: "provider" # it is necessary to run the Hosted clusters deployment on the Provider cluster

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -464,7 +464,7 @@ class Deployment(object):
         """
         if config.ENV_DATA["skip_ocs_deployment"]:
 
-            if config.DEPLOYMENT.get("deploy_mce"):
+            if config.ENV_DATA.get("deploy_mce"):
                 mce_installer = MCEInstaller()
                 mce_installer.deploy_mce()
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -459,11 +459,14 @@ class Deployment(object):
     def do_deploy_mce(self):
         """
         Deploy Multicluster Engine
+        Shall run on OCP deployment phase
 
         """
-        if config.DEPLOYMENT.get("deploy_mce"):
-            mce_installer = MCEInstaller()
-            mce_installer.deploy_mce()
+        if config.ENV_DATA["skip_ocs_deployment"]:
+
+            if config.DEPLOYMENT.get("deploy_mce"):
+                mce_installer = MCEInstaller()
+                mce_installer.deploy_mce()
 
     def do_deploy_oadp(self):
         """
@@ -641,6 +644,21 @@ class Deployment(object):
                 check_cnv_ready = True
             CNVInstaller().deploy_cnv(check_cnv_deployed, check_cnv_ready)
 
+    def do_deploy_hyperconverged(self):
+        """
+        Deploy HyperConverged Operator and resources that works instead of CNV operator.
+        Should run on OCP deployment phase
+        """
+        if config.ENV_DATA["skip_ocs_deployment"]:
+
+            if config.ENV_DATA.get(
+                "deploy_hyperconverged"
+            ) and not config.DEPLOYMENT.get("cnv_deployment"):
+                from ocs_ci.deployment.hyperconverged import HyperConverged
+
+                hyperconverged = HyperConverged()
+                hyperconverged.deploy_hyperconverged()
+
     def do_deploy_metallb(self):
         """
         Deploy MetalLB
@@ -739,6 +757,7 @@ class Deployment(object):
         self.do_deploy_odf_provider_mode()
         self.do_deploy_mce()
         self.do_deploy_cnv()
+        self.do_deploy_hyperconverged()
         self.do_deploy_metallb()
         self.do_deploy_hosted_clusters()
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -462,15 +462,8 @@ class Deployment(object):
 
         """
         if config.DEPLOYMENT.get("deploy_mce"):
-            if config.ENV_DATA.get("skip_mce_check_if_present"):
-                check_mce_deployed = False
-                check_mce_ready = False
-            else:
-                check_mce_deployed = True
-                check_mce_ready = True
             mce_installer = MCEInstaller()
-            mce_installer.deploy_mce(check_mce_deployed, check_mce_ready)
-            mce_installer.validate_mce_deployment()
+            mce_installer.deploy_mce()
 
     def do_deploy_oadp(self):
         """

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -260,9 +260,12 @@ class HyperShiftBase:
                 f"hypershift binary download failed to path:{self.hypershift_binary_path}"
             )
 
-    def download_hcp_binary_with_podman(self):
+    def _download_hcp_binary_with_podman(self):
         """
         Download hcp binary to bin_dir
+
+        !!! This method is not used in the code, but it is kept for reference !!!
+        Use install_hcp_and_hypershift_from_git instead
         """
         if self.hcp_binary_exists():
             logger.info(

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -632,6 +632,11 @@ class HostedODF(HypershiftHostedOCP):
             constants.PROVIDER_MODE_STORAGE_CLIENT
         )
         self.storage_client_name = storage_client_data["metadata"]["name"]
+        self.storage_quota = (
+            config.ENV_DATA.get("clusters", {})
+            .get(self.name, {})
+            .get("storage_quota", None)
+        )
 
     @kubeconfig_exists_decorator
     def exec_oc_cmd(self, cmd, timeout=300, ignore_error=False, **kwargs):
@@ -976,7 +981,11 @@ class HostedODF(HypershiftHostedOCP):
         )
 
         try:
-            token = generate_onboarding_token(private_key=decoded_key)
+            token = generate_onboarding_token(
+                private_key=decoded_key,
+                use_ticketgen_with_quota=True,
+                storage_quota=self.storage_quota,
+            )
         except Exception as e:
             logger.error(f"Error during onboarding token generation: {e}")
             token = ""

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -534,7 +534,6 @@ class HypershiftHostedOCP(
             self.update_hcp_binary()
         if deploy_mce and not deploy_acm_hub:
             self.deploy_mce()
-            self.validate_mce_deployment()
 
         # Enable central infrastructure management service for agent
         if config.DEPLOYMENT.get("hosted_cluster_platform") == "agent":

--- a/ocs_ci/deployment/hyperconverged.py
+++ b/ocs_ci/deployment/hyperconverged.py
@@ -1,0 +1,217 @@
+import logging
+import semantic_version
+
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.deployment import Deployment
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.ocs.utils import get_pod_name_by_pattern
+from ocs_ci.ocs.version import get_ocp_version
+from ocs_ci.utility import templating
+from ocs_ci.ocs.resources.catalog_source import CatalogSource
+
+logger = logging.getLogger(__name__)
+
+
+class HyperConverged:
+    """
+    This class represent HyperConverged and contains all related methods we need to do with it.
+    Hyperconverged Operator is used instead of unreleased CNV, to overcome catalogsource limitations on Client clusters
+    """
+
+    def __init__(self):
+        self.namespace = constants.HYPERCONVERGED_NAMESPACE
+        self.ns_obj = OCP(kind=constants.NAMESPACES)
+        self.operator_group = OCP(
+            kind=constants.OPERATOR_GROUP, namespace=self.namespace
+        )
+        self.catsrc = OCP(
+            kind=constants.CATSRC, namespace=constants.MARKETPLACE_NAMESPACE
+        )
+        self.subs = OCP(kind=constants.PROVIDER_SUBSCRIPTION, namespace=self.namespace)
+        # type of hyperconverged becomes available after the Hyperconverged operator is deployed
+        self.hyperconverged = None
+        self.ocp_version = get_ocp_version()
+
+    def create_hyperconverged_namespace(self):
+        """
+        Creates the namespace for hyperconverged resources
+
+        """
+        if not self.ns_obj.is_exist(
+            resource_name=self.namespace,
+        ):
+            logger.info(
+                f"Creating namespace {self.namespace} for hyperconverged resources"
+            )
+            namespace_yaml_file = templating.load_yaml(
+                constants.HYPERCONVERGED_NAMESPACE_YAML
+            )
+            namespace_yaml = OCS(**namespace_yaml_file)
+            namespace_yaml.create()
+        else:
+            logger.info(f"{self.namespace} already exists")
+        return self.ns_obj.check_resource_existence(
+            should_exist=True, resource_name=self.namespace
+        )
+
+    def create_operator_group(self):
+        """
+        Creates operator group for hyperconverged resources
+
+        """
+        logger.info("Creating operator group for hyperconverged resources")
+
+        if not self.operator_group.is_exist(
+            resource_name=constants.HYPERCONVERGED_OPERATOR_GROUP_NAME
+        ):
+            operator_group_yaml_file = templating.load_yaml(
+                constants.HYPERCONVERGED_OPERATOR_GROUP_YAML
+            )
+            operator_group_yaml = OCS(**operator_group_yaml_file)
+            operator_group_yaml.create()
+        return self.operator_group.check_resource_existence(
+            should_exist=True,
+            resource_name=constants.HYPERCONVERGED_OPERATOR_GROUP_NAME,
+        )
+
+    def create_catalog_source(self):
+        """
+        Creates catalog source for hyperconverged resources
+        ! No customization by purpose. Will always align with branch default image that is set in the default config.
+        """
+        logger.info("Check if catalog source already exist")
+        if not self.catsrc.is_exist(
+            resource_name=constants.HYPERCONVERGED_CATALOGSOURCE
+        ):
+            catalog_source_yaml_file = templating.load_yaml(
+                constants.HYPERVERGED_CATALOGSOURCE_YAML
+            )
+            hyperconverged_version = get_hyperconverged_corresponding_version(
+                self.ocp_version
+            )
+            catalog_source_yaml_file["spec"]["image"] = catalog_source_yaml_file[
+                "spec"
+            ]["image"].format(hyperconverged_version=hyperconverged_version)
+            catalog_source_yaml = OCS(**catalog_source_yaml_file)
+            catalog_source_yaml.create()
+        self.catsrc.check_resource_existence(
+            should_exist=True, resource_name=constants.HYPERCONVERGED_CATALOGSOURCE
+        )
+        catalog_source_yaml = CatalogSource(
+            constants.HYPERCONVERGED_CATALOGSOURCE, constants.MARKETPLACE_NAMESPACE
+        )
+        catalog_source_yaml.wait_for_state("READY")
+
+    def create_subscription(self):
+        """
+        Creates subscription for hyperconverged operator
+
+        """
+        logger.info("Check if subscription already exist")
+        if not self.subs.is_exist(resource_name=constants.HYPERCONVERGED_SUBSCRIPTION):
+            subscription_yaml_data = templating.load_yaml(
+                constants.HYPERCONVERGED_SUBSCRIPTION_YAML
+            )
+            hyperconverged_version = get_hyperconverged_corresponding_version(
+                self.ocp_version
+            )
+            subscription_yaml_data["spec"]["channel"] = subscription_yaml_data["spec"][
+                "channel"
+            ].format(hyperconverged_version=hyperconverged_version)
+            subscription_obj = OCS(**subscription_yaml_data)
+            subscription_obj.create()
+        self.subs.check_resource_existence(
+            should_exist=True, resource_name=constants.HYPERCONVERGED_SUBSCRIPTION
+        )
+
+        pod_names = get_pod_name_by_pattern(
+            "hco-operator", self.namespace
+        ) + get_pod_name_by_pattern("virt-operator", self.namespace)
+        wait_for_pods_to_be_running(namespace=self.namespace, pod_names=pod_names)
+
+    def create_hyperconverged_instance(self):
+        """
+        Create Hyperconverged instance
+        """
+        self.hyperconverged = OCP(
+            kind=constants.HYPERCONVERGED_KIND, namespace=self.namespace
+        )
+        if not self.hyperconverged.is_exist(
+            resource_name=constants.HYPERCONVERGED_NAME
+        ):
+            hyperconverged_instance_yaml_file = templating.load_yaml(
+                constants.HYPERCONVERGED_YAML
+            )
+            hyperconverged_instance_yaml = OCS(**hyperconverged_instance_yaml_file)
+            hyperconverged_instance_yaml.create()
+        self.hyperconverged.check_resource_existence(
+            should_exist=True, resource_name=constants.HYPERCONVERGED_NAME
+        )
+        # wait for pods to be up and running
+        deployments = ["virt-api", "virt-controller", "virt-exporterproxy"]
+
+        for resource_name in deployments:
+            depl_ocp_obj = OCP(
+                kind=constants.DEPLOYMENT,
+                namespace=self.namespace,
+                resource_name=resource_name,
+            )
+            deployment_obj = Deployment(
+                **depl_ocp_obj.get(retry=60, wait=10, dont_raise=True)
+            )
+            deployment_obj.wait_for_available_replicas(timeout=600)
+
+    def deploy_hyperconverged(self):
+        """
+        Deploy Hyperconverged Operator and resources
+        """
+        # avoid mix in MRO calling explicitly the method of own class
+        HyperConverged.create_hyperconverged_namespace(self)
+        HyperConverged.create_operator_group(self)
+        HyperConverged.create_catalog_source(self)
+        HyperConverged.create_subscription(self)
+        HyperConverged.create_hyperconverged_instance(self)
+
+
+def get_hyperconverged_corresponding_version(ocp_version: str) -> str:
+    """
+    Given an OCP version, return the corresponding Hyperconverged version.
+
+    Rule:
+    - Hyperconverged Major = OCP Major - 3
+    - Hyperconverged Minor = OCP Minor - 4
+
+    Args:
+        ocp_version: OCP version as a string (e.g., "4.18")
+    Returns:
+        Corresponding Hyperconverged version as a string (e.g., "1.14")
+    """
+    ocp_semver = semantic_version.Version(
+        ocp_version + ".0"
+    )  # Ensure valid semantic versioning
+    hyperconverged_major = ocp_semver.major - 3
+    hyperconverged_minor = ocp_semver.minor - 4
+
+    return f"{hyperconverged_major}.{hyperconverged_minor}"
+
+
+def get_ocp_corresponding_version(hyperconverged_version: str) -> str:
+    """
+    Given a Hyperconverged version, return the corresponding OCP version.
+
+    Rule:
+    - OCP Major = Hyperconverged Major + 3
+    - OCP Minor = Hyperconverged Minor + 4
+
+    Args:
+        hyperconverged_version: Hyperconverged version as a string (e.g., "1.14")
+    Returns:
+        Corresponding OCP version as a string (e.g., "4.18")
+    """
+    hyperconverged_semver = semantic_version.Version(hyperconverged_version + ".0")
+    ocp_major = hyperconverged_semver.major + 3
+    ocp_minor = hyperconverged_semver.minor + 4
+
+    return f"{ocp_major}.{ocp_minor}"

--- a/ocs_ci/deployment/hyperconverged.py
+++ b/ocs_ci/deployment/hyperconverged.py
@@ -1,7 +1,7 @@
 import logging
 import semantic_version
 
-from ocs_ci.ocs.exceptions import HyperConvergedNotDeployedException
+from ocs_ci.ocs.exceptions import HyperConvergedNotDeployedException, CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.deployment import Deployment
@@ -11,6 +11,7 @@ from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.version import get_ocp_version
 from ocs_ci.utility import templating
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import wait_custom_resource_defenition_available
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,10 @@ class HyperConverged:
                 constants.HYPERCONVERGED_YAML
             )
             hyperconverged_instance_yaml = OCS(**hyperconverged_instance_yaml_file)
-            hyperconverged_instance_yaml.create()
+            retry(CommandFailed, tries=10, delay=60)(
+                hyperconverged_instance_yaml.create
+            )()
+
         self.hyperconverged.check_resource_existence(
             should_exist=True, resource_name=constants.HYPERCONVERGED_NAME
         )

--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -239,6 +239,7 @@ class MCEInstaller(object):
             qe_app_registry.icsp()
             qe_app_registry.catalog_source()
             self.create_mce_namespace()
+            self.create_multiclusterengine_operatorgroup()
             self.create_mce_subscription()
             if not wait_custom_resource_defenition_available(
                 constants.MULTICLUSTER_ENGINE_CRD
@@ -246,7 +247,6 @@ class MCEInstaller(object):
                 raise MultiClusterEngineNotDeployedException(
                     f"crd {constants.MULTICLUSTER_ENGINE_CRD} is unavailable"
                 )
-            self.create_multiclusterengine_operatorgroup()
 
         # check whether mce instance is created, if it is installed but mce don't pass validation we can not heal it in
         # script here, hence no sense for full validation of mce

--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -15,11 +15,16 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import (
     run_cmd,
     exec_cmd,
+    wait_custom_resource_defenition_available,
 )
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.deployment import Deployment
 from ocs_ci.utility.utils import get_running_ocp_version
-from ocs_ci.ocs.exceptions import CommandFailed, UnavailableResourceException
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    UnavailableResourceException,
+    MultiClusterEngineNotDeployedException,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +240,12 @@ class MCEInstaller(object):
             qe_app_registry.catalog_source()
             self.create_mce_namespace()
             self.create_mce_subscription()
+            if not wait_custom_resource_defenition_available(
+                constants.MULTICLUSTER_ENGINE_CRD
+            ):
+                raise MultiClusterEngineNotDeployedException(
+                    f"crd {constants.MULTICLUSTER_ENGINE_CRD} is unavailable"
+                )
             self.create_multiclusterengine_operatorgroup()
 
         # check whether mce instance is created, if it is installed but mce don't pass validation we can not heal it in

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -241,6 +241,10 @@ ENV_DATA:
   rhel8_template: 'rhel87_ocs4qe'
   # ACM HUB deployment
   deploy_acm_hub_cluster: false
+  # HyperConverged deployment
+  deploy_hyperconverged: false
+  # mce deployment
+  deploy_mce: false
 
   # Managed service git stat  default configurations
   # Managed StorageCluster size in TiB

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -123,6 +123,10 @@ DEPLOYMENT:
   rosa_cli_version: '1.2.49'
   # Multicluster engine
   deploy_mce: false
+  # ! Pay attention. stable-2.8 is not available until OCP 4.18 becomes available
+  mce_channel: "stable-2.8"
+  # catalogsource format of image with tag; latest unreleased, that is supported by OCP 4.18
+  mce_image: ""
 
 
 
@@ -232,9 +236,6 @@ ENV_DATA:
   rhel7.9_worker_ami: 'ami-058a93d58c5797698'
   rhel8.4_worker_ami: 'ami-074bab065c112399f'
   cluster_type: ""
-  # Provider mode dependencies checks during deployment for presence
-  skip_mce_check_if_present: false
-  skip_cnv_check_if_present: false
 
   # RHEL template which are used for vSphere platform
   rhel7_template: 'rhel79_ocs4qe'
@@ -243,8 +244,6 @@ ENV_DATA:
   deploy_acm_hub_cluster: false
   # HyperConverged deployment
   deploy_hyperconverged: false
-  # mce deployment
-  deploy_mce: false
 
   # Managed service git stat  default configurations
   # Managed StorageCluster size in TiB

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -506,6 +506,34 @@ DEFAULT_EXTERNAL_MODE_VOLUMESNAPSHOTCLASS_RBD = (
 DEFAULT_VOLUMESNAPSHOTCLASS_CEPHFS_MS_PC = f"{DEFAULT_CLUSTERNAME}-cephfs"
 DEFAULT_VOLUMESNAPSHOTCLASS_RBD_MS_PC = f"{DEFAULT_CLUSTERNAME}-ceph-rbd"
 
+# hyperconverged defaults
+HYPERCONVERGED_NAMESPACE = "kubevirt-hyperconverged"
+# MCE_NAMESPACE_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_namespace.yaml")
+TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED = os.path.join(
+    TEMPLATE_DIR, "hyperconverged-deployment"
+)
+HYPERCONVERGED_NAMESPACE_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged_namespace.yaml"
+)
+HYPERCONVERGED_OPERATOR_GROUP_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged_operator_group.yaml"
+)
+HYPERCONVERGED_OPERATOR_GROUP_NAME = "hyperconverged-operator-group"
+HYPERCONVERGED_CATALOGSOURCE = "hyperconverged-catalogsource"
+HYPERVERGED_CATALOGSOURCE_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged-catsrc.yaml"
+)
+HYPERCONVERGED_SUBSCRIPTION = "community-kubevirt-hyperconverged"
+HYPERCONVERGED_SUBSCRIPTION_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged_subscription.yaml"
+)
+HYPERCONVERGED_KIND = "HyperConverged"
+HYPERCONVERGED_NAME = "kubevirt-hyperconverged"
+HYPERCONVERGED_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged.yaml"
+)
+
+
 # CNV deployment constants
 CNV_NAMESPACE = "openshift-cnv"
 CNV_QUAY_NIGHTLY_IMAGE = "quay.io/openshift-cnv/nightly-catalog"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -249,6 +249,7 @@ EXTERNAL_CLUSTER_SCRIPT_CONFIG = "rook-ceph-external-cluster-script-config"
 ENCRYPTIONKEYROTATIONCRONJOB = "encryptionkeyrotationcronjobs.csiaddons.openshift.io"
 ENCRYPTIONKEYROTATIONJOB = "encryptionkeyrotationjobs.csiaddons.openshift.io"
 DEFAULT_CEPH_DEVICECLASS = "defaultCephDeviceClass"
+CRD_KIND = "CustomResourceDefinition"
 
 # Provisioners
 AWS_EFS_PROVISIONER = "openshift.org/aws-efs"
@@ -532,6 +533,7 @@ HYPERCONVERGED_NAME = "kubevirt-hyperconverged"
 HYPERCONVERGED_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED, "hyperconverged.yaml"
 )
+HYPERCONVERGED_CRD = "hyperconvergeds.hco.kubevirt.io"
 
 
 # CNV deployment constants
@@ -2811,6 +2813,7 @@ MCE_RESOURCE_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_resource.yaml
 MCE_OPERATOR_GROUP_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_operatorgroup.yaml"
 )
+MULTICLUSTER_ENGINE_CRD = "multiclusterengines.multicluster.openshift.io"
 HYPERSHIFT_NAMESPACE = "hypershift"
 SUPPORTED_VERSIONS_CONFIGMAP = "supported-versions"
 IMAGE_OVERRIDE_JSON = os.path.join(TEMPLATE_DEPLOYMENT_DIR_MCE, "image-override.json")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2806,6 +2806,7 @@ MCE_SUBSCRIPTION_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_subscription.yaml"
 )
 MCE_OPERATOR = "multicluster-engine"
+MCE_OPERATOR_OPERATOR_NAME_WITH_NS = f"{MCE_OPERATOR}.{MCE_NAMESPACE}"
 MCE_RESOURCE_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_resource.yaml")
 MCE_OPERATOR_GROUP_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_MCE, "mce_operatorgroup.yaml"

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -687,6 +687,14 @@ class HyperConvergedHealthException(Exception):
     pass
 
 
+class HyperConvergedNotDeployedException(Exception):
+    pass
+
+
+class MultiClusterEngineNotDeployedException(Exception):
+    pass
+
+
 class OpenShiftAPIResponseException(Exception):
     def __init__(self, response):
         self.response = response

--- a/ocs_ci/ocs/resources/deployment.py
+++ b/ocs_ci/ocs/resources/deployment.py
@@ -105,7 +105,7 @@ class Deployment(OCS):
         cmd = f"rollout undo {self.kind}/{resource_name} --to-revision={revision}"
         self.ocp.exec_oc_cmd(cmd)
 
-    def wait_for_available_replicas(self, timeout=15, sleep=3):
+    def wait_for_available_replicas(self, timeout=360, sleep=3):
         """
         Wait for number of available replicas reach number of desired replicas.
 
@@ -133,7 +133,9 @@ class Deployment(OCS):
             )
             return available_replicas
 
-        for available_replicas in TimeoutSampler(360, 2, func=_get_available_replicas):
+        for available_replicas in TimeoutSampler(
+            timeout, sleep, func=_get_available_replicas
+        ):
             if available_replicas == desired_replicas:
                 logger.info(
                     f"Deployment {self.name} reached "

--- a/ocs_ci/templates/hyperconverged-deployment/hyperconverged-catsrc.yaml
+++ b/ocs_ci/templates/hyperconverged-deployment/hyperconverged-catsrc.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hyperconverged-catalogsource
+  namespace: openshift-marketplace
+spec:
+  image: 'quay.io/kubevirt/hyperconverged-cluster-index:{hyperconverged_version}.0-unstable'
+  sourceType: grpc

--- a/ocs_ci/templates/hyperconverged-deployment/hyperconverged.yaml
+++ b/ocs_ci/templates/hyperconverged-deployment/hyperconverged.yaml
@@ -1,0 +1,5 @@
+kind: HyperConverged
+apiVersion: hco.kubevirt.io/v1beta1
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: kubevirt-hyperconverged

--- a/ocs_ci/templates/hyperconverged-deployment/hyperconverged_namespace.yaml
+++ b/ocs_ci/templates/hyperconverged-deployment/hyperconverged_namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-hyperconverged
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/ocs_ci/templates/hyperconverged-deployment/hyperconverged_operator_group.yaml
+++ b/ocs_ci/templates/hyperconverged-deployment/hyperconverged_operator_group.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: hyperconverged-operator-group
+  namespace: kubevirt-hyperconverged

--- a/ocs_ci/templates/hyperconverged-deployment/hyperconverged_subscription.yaml
+++ b/ocs_ci/templates/hyperconverged-deployment/hyperconverged_subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: community-kubevirt-hyperconverged
+  namespace: kubevirt-hyperconverged
+spec:
+  # candidate-v1.14 is the latest version of the kubevirt-hyperconverged operator that supports OCP 4.18,
+  # 1.15 is the latest version that supports OCP 4.19
+  # rule is OCP version - 3.4
+  channel: candidate-v{hyperconverged_version}
+  installPlanApproval: Automatic
+  name: community-kubevirt-hyperconverged
+  source: hyperconverged-catalogsource
+  sourceNamespace: openshift-marketplace

--- a/ocs_ci/templates/mce-deployment/mce_catsrc.yaml
+++ b/ocs_ci/templates/mce-deployment/mce_catsrc.yaml
@@ -4,5 +4,6 @@ metadata:
   name: mce-catalogsource
   namespace: openshift-marketplace
 spec:
-  image: quay.io:443/acm-d/mce-custom-registry:2.13.0-DOWNSTREAM-2025-02-25-05-34-41
+  # latest version of the catalog image for OCP 4.18
+  image: quay.io:443/acm-d/mce-custom-registry:2.8-latest
   sourceType: grpc

--- a/ocs_ci/templates/mce-deployment/mce_subscription.yaml
+++ b/ocs_ci/templates/mce-deployment/mce_subscription.yaml
@@ -4,8 +4,8 @@ metadata:
   name: multicluster-engine
   namespace: multicluster-engine
 spec:
-  channel: stable
+  channel: stable-2.8
   installPlanApproval: Automatic
   name: multicluster-engine
-  source: mce-catalogsource
+  source: qe-app-registry
   sourceNamespace: openshift-marketplace

--- a/ocs_ci/templates/mce-deployment/mce_subscription.yaml
+++ b/ocs_ci/templates/mce-deployment/mce_subscription.yaml
@@ -3,9 +3,12 @@ kind: Subscription
 metadata:
   name: multicluster-engine
   namespace: multicluster-engine
+  labels:
+    operators.coreos.com/multicluster-engine.multicluster-engine: ""
 spec:
   channel: stable-2.8
   installPlanApproval: Automatic
   name: multicluster-engine
   source: qe-app-registry
   sourceNamespace: openshift-marketplace
+  startingCSV: multicluster-engine.v2.8.0

--- a/ocs_ci/utility/managedservice.py
+++ b/ocs_ci/utility/managedservice.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import stat
+from pathlib import Path
 
 from tempfile import NamedTemporaryFile
 
@@ -12,7 +13,12 @@ from ocs_ci.utility.utils import download_file, exec_cmd
 logger = logging.getLogger(__name__)
 
 
-def generate_onboarding_token(private_key: str = None):
+def generate_onboarding_token(
+    private_key: str = None,
+    use_ticketgen_with_quota: bool = False,
+    subject_role: str = None,
+    storage_quota: int = None,
+):
     """
     Generate Onboarding token for consumer cluster via following steps:
 
@@ -27,6 +33,9 @@ def generate_onboarding_token(private_key: str = None):
 
     Args:
         private_key (str): private key for Managed Service
+        use_ticketgen_with_quota (bool): If True, the ticketgen.sh script will be run with -q flag
+        subject_role (str): Role of the subject, this role has a default in ticketgen-with-quota.sh - ocs-client
+        storage_quota (int): Quota for the storage cluster
 
     Raises:
         CommandFailed: In case the script ticketgen.sh fails.
@@ -38,12 +47,31 @@ def generate_onboarding_token(private_key: str = None):
     """
     logger.debug("Generate onboarding token for ODF to ODF deployment")
     ticketgen_script_path = os.path.join(constants.DATA_DIR, "ticketgen.sh")
-    # download ticketgen.sh script
-    logger.debug("Download and prepare ticketgen.sh script")
-    download_file(
-        "https://raw.githubusercontent.com/red-hat-storage/ocs-operator/main/hack/ticketgen/ticketgen.sh",
-        ticketgen_script_path,
-    )
+
+    if not use_ticketgen_with_quota:
+        logger.debug("Download and prepare ticketgen.sh script")
+        download_file(
+            "https://raw.githubusercontent.com/red-hat-storage/ocs-operator/main/hack/ticketgen/ticketgen.sh",
+            ticketgen_script_path,
+        )
+        if not Path(ticketgen_script_path).exists():
+            raise FileNotFoundError(
+                f"Failed to download ticketgen.sh script to {ticketgen_script_path}"
+            )
+    else:
+        logger.info("using ticketgen.sh script with --quota flag")
+        script_path = (
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "bash"
+            / "ticketgen-with-quota.sh"
+        )
+        if not script_path.exists():
+            raise FileNotFoundError(
+                f"Failed to find ticketgen-with-quota.sh script in {script_path}"
+            )
+        ticketgen_script_path = str(script_path)
+
     # add execute permission to the ticketgen.sh script
     current_file_permissions = os.stat(ticketgen_script_path)
     os.chmod(
@@ -67,13 +95,34 @@ def generate_onboarding_token(private_key: str = None):
             '  private_key: "..."\n'
             '  public_key: "..."'
         )
+
+    script_cmd = f"{ticketgen_script_path}"
+
+    if use_ticketgen_with_quota:
+
+        from ocs_ci.ocs.ocp import OCP
+
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        uid = sc_obj.get()["items"][0]["metadata"]["uid"]
+        script_cmd += f" -c {uid} "
+
+        if subject_role:
+            script_cmd += f" -r {subject_role}"
+        if storage_quota:
+            script_cmd += f" -q {storage_quota}"
+
     with NamedTemporaryFile(
         mode="w", prefix="private", suffix=".pem", delete=True
     ) as key_file:
         key_file.write(private_key)
         key_file.flush()
         logger.debug("Generate Onboarding token")
-        ticketgen_result = exec_cmd(f"{ticketgen_script_path} {key_file.name}")
+        script_cmd += f" {key_file.name}"
+        ticketgen_result = exec_cmd(script_cmd)
+
     ticketgen_output = ticketgen_result.stdout.decode()
     if ticketgen_result.stderr:
         raise CommandFailed(

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5389,3 +5389,30 @@ def create_config_ini_file(params):
     log.info(f"config.ini file for cluster is located at {config_ini_file.name}")
 
     return config_ini_file.name
+
+
+def wait_custom_resource_defenition_available(crd_name, timeout=600):
+    """
+    Wait for the custom resource definition to be available
+
+    Args:
+        crd_name (str): Name of the custom resource definition
+        timeout (int): Time in seconds to wait for the CRD to be available
+    Returns:
+        bool: True if CRD is available, False otherwise
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    wait = 10
+    retry_num = timeout // wait
+    crd_obj = OCP(kind=constants.CRD_KIND)
+    return bool(
+        crd_obj.get(
+            resource_name=crd_name,
+            out_yaml_format=False,
+            retry=retry_num,
+            wait=wait,
+            dont_raise=True,
+        )
+    )

--- a/tests/libtest/test_provider_create_hosted_cluster.py
+++ b/tests/libtest/test_provider_create_hosted_cluster.py
@@ -346,8 +346,6 @@ class TestProviderHosted(object):
                 storage_class in storage_class_classes
             ), "Storage classes ae not created as expected"
 
-    @runs_on_provider
-    @hci_provider_required
     def test_deploy_mce(self):
         """
         Test deploy mce without installting acm

--- a/tests/libtest/test_provider_create_hosted_cluster.py
+++ b/tests/libtest/test_provider_create_hosted_cluster.py
@@ -56,7 +56,16 @@ class TestProviderHosted(object):
         logger.info("Test deploy hosted OCP on provider platform")
         cluster_name = list(config.ENV_DATA["clusters"].keys())[-1]
 
-        HypershiftHostedOCP(cluster_name).deploy_ocp()
+        hypershift_hosted = HypershiftHostedOCP(cluster_name)
+        hypershift_hosted.deploy_dependencies(
+            deploy_acm_hub=True,
+            deploy_cnv=True,
+            deploy_metallb=True,
+            download_hcp_binary=True,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
+        )
+        hypershift_hosted.deploy_ocp()
 
     @hci_provider_required
     def test_provider_deploy_OCP_hosted_skip_cnv_and_lb(self):
@@ -67,10 +76,16 @@ class TestProviderHosted(object):
             "Test deploy hosted OCP on provider platform with metallb and cnv ready"
         )
         cluster_name = list(config.ENV_DATA["clusters"].keys())[-1]
-
-        HypershiftHostedOCP(cluster_name).deploy_ocp(
-            deploy_cnv=False, deploy_metallb=False, download_hcp_binary=True
+        hypershift_hosted = HypershiftHostedOCP(cluster_name)
+        hypershift_hosted.deploy_dependencies(
+            deploy_acm_hub=True,
+            deploy_cnv=False,
+            deploy_metallb=False,
+            download_hcp_binary=True,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
         )
+        hypershift_hosted.deploy_ocp()
 
     @hci_provider_required
     def test_provider_deploy_OCP_hosted_skip_cnv(self):
@@ -80,7 +95,16 @@ class TestProviderHosted(object):
         logger.info("Test deploy hosted OCP on provider platform with cnv ready")
         cluster_name = list(config.ENV_DATA["clusters"].keys())[-1]
 
-        HypershiftHostedOCP(cluster_name).deploy_ocp(deploy_cnv=False)
+        hypershift_hosted = HypershiftHostedOCP(cluster_name)
+        hypershift_hosted.deploy_dependencies(
+            deploy_acm_hub=True,
+            deploy_cnv=False,
+            deploy_metallb=True,
+            download_hcp_binary=True,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
+        )
+        HypershiftHostedOCP(cluster_name).deploy_ocp()
 
     @hci_provider_required
     def test_provider_deploy_OCP_hosted_multiple(self):
@@ -113,6 +137,7 @@ class TestProviderHosted(object):
         Test install ODF on hosted cluster
         """
         logger.info("Deploy hosted OCP on provider platform multiple times")
+
         HostedClients().do_deploy()
 
     @runs_on_provider
@@ -224,6 +249,8 @@ class TestProviderHosted(object):
             deploy_cnv=False,
             deploy_metallb=False,
             download_hcp_binary=False,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
         )
         assert validate_acm_hub_install(), "ACM not installed or MCE not configured"
 
@@ -240,6 +267,8 @@ class TestProviderHosted(object):
             deploy_cnv=True,
             deploy_metallb=False,
             download_hcp_binary=False,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
         )
         assert hypershift_hosted.cnv_hyperconverged_installed(), "CNV not installed"
 
@@ -256,6 +285,8 @@ class TestProviderHosted(object):
             deploy_cnv=False,
             deploy_metallb=True,
             download_hcp_binary=False,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
         )
         assert hypershift_hosted.metallb_instance_created(), "Metallb not installed"
 
@@ -272,6 +303,8 @@ class TestProviderHosted(object):
             deploy_cnv=False,
             deploy_metallb=False,
             download_hcp_binary=True,
+            deploy_hyperconverged=False,
+            deploy_mce=False,
         )
         assert hypershift_hosted.hcp_binary_exists(), "HCP binary not downloaded"
 
@@ -327,14 +360,42 @@ class TestProviderHosted(object):
             deploy_metallb=False,
             download_hcp_binary=False,
             deploy_mce=True,
+            deploy_hyperconverged=False,
         )
 
     @hci_provider_required
-    def test_provider_deploy_OCP_hosted_skip_acm(self):
+    def test_provider_deploy_ocp_hosted_skip_acm(self):
         """
         Test deploy hosted OCP on provider platform with cnv ready beforehand
+        ! Suitable for released version of OCP only (no mce and hyperconverged)
         """
         logger.info("Test deploy hosted OCP on provider platform with cnv ready")
         cluster_name = list(config.ENV_DATA["clusters"].keys())[-1]
+        hypershift_hosted = HypershiftHostedOCP(cluster_name)
 
-        HypershiftHostedOCP(cluster_name).deploy_ocp(deploy_acm_hub=False)
+        hypershift_hosted.deploy_dependencies(
+            deploy_acm_hub=False,
+            deploy_cnv=True,
+            deploy_metallb=True,
+            download_hcp_binary=True,
+            deploy_mce=False,
+            deploy_hyperconverged=False,
+        )
+
+        HypershiftHostedOCP(cluster_name).deploy_ocp()
+
+    def test_deploy_hyperconverged(self):
+        """
+        Test deploy hyperconverged operator
+        ! Hyperconverged is used instead of unreleased CNV, to overcome catalogsource limitations on client clusters
+        """
+        logger.info("Test deploy hyperconverged operator")
+        hypershift_hosted = HypershiftHostedOCP("dummy")
+        hypershift_hosted.deploy_dependencies(
+            deploy_acm_hub=False,
+            deploy_cnv=False,
+            deploy_metallb=False,
+            download_hcp_binary=False,
+            deploy_mce=False,
+            deploy_hyperconverged=True,
+        )


### PR DESCRIPTION
In past we had a problem with deploying ODF on Hosted Client clusters that were deployed with latest unreleased CVN and latest unreleased ACM.
The nature of the problem was not determined, but installing upstream hyperconverged along with upstream mce proved to be sustainable. 
This PR is also giving us a backdoor option, when CNV ureleased version is still not available and upstream HCO is already been populated via unstable index-tag of quay.io/kubevirt/hyperconverged-cluster-index

Link to the issue: https://issues.redhat.com/browse/OCPBUGS-32196  
Link to verification run: https://privatebin.corp.redhat.com/?08e39cfadafad0c6#E5JtjD7BpRWhLi22Jobta6U3FX6hJ3RfgUJZcAvqjsUT

Added int parameter in configuration `ENV_DATA.clusters.<cluster_name>.storage_quota`. Default value - no storage_quota, meaning storage for this client is unlimited
