### PR TITLE
Ignore noobaa-endpoint pods leftovers on `test_mcg_namespace_lifecycle_crd.py`

### DIFF
--- a/tests/functional/object/mcg/lifecycle/test_mcg_namespace_lifecyle_crd.py
+++ b/tests/functional/object/mcg/lifecycle/test_mcg_namespace_lifecyle_crd.py
@@ -7,6 +7,7 @@ import pytest
 import botocore.exceptions as boto3exception
 
 from ocs_ci.framework.pytest_customization.marks import (
+    ignore_leftover_label,
     skipif_aws_creds_are_missing,
     skipif_managed_service,
     red_squad,
@@ -63,6 +64,7 @@ def setup_base_objects(awscli_pod, origin_dir, amount=2):
 @skipif_managed_service
 @skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.7")
+@ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)
 class TestMcgNamespaceLifecycleCrd(E2ETest):
     """
     Test MCG namespace resource/bucket lifecycle


### PR DESCRIPTION
The noobaa-endpoint pods scale up and down for various reasons, resulting in meaningless ResourceLeftoversException like this one:  https://url.corp.redhat.com/c55bc10

This has already been accounted for MCGTests: https://github.com/red-hat-storage/ocs-ci/blob/4dce31957cb78fe15f3b772dd19aa7f4d6b16622/ocs_ci/framework/testlib.py, but the tests here are E2E's.