### PR TITLE
get_avg_consumption_from_ui fix

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/block_and_file.py
+++ b/ocs_ci/ocs/ui/page_objects/block_and_file.py
@@ -257,5 +257,11 @@ class BlockAndFile(StorageSystemDetails):
         average = float(
             re.search(r"-?\d+\.*\d*", collected_tpl_of_days_and_avg[1]).group()
         )
+
+        """
+        If the displayed UI size is in MiB then convert into GiB
+        """
+        if re.search('MiB$', collected_tpl_of_days_and_avg[1]):
+            average /= (2**10)
         logger.info(f"'Average of storage consumption per day' from the UI : {average}")
         return average


### PR DESCRIPTION
The ‘Average’ value in the widget (UI) can be in GiB or MiB.
If the value is in MiB the test fails since the MiB is compared to GiB.
The check and conversion to GiB is necessary.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/11510