### PR TITLE
Skip external KMS encryption tests if discunnect env deployed

### DIFF
--- a/tests/functional/encryption/test_encryption_keyrotation.py
+++ b/tests/functional/encryption/test_encryption_keyrotation.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     vault_kms_deployment_required,
 )
+from ocs_ci.framework.testlib import skipif_disconnected_cluster
 from ocs_ci.helpers.keyrotation_helper import (
     NoobaaKeyrotation,
     OSDKeyrotation,
@@ -242,6 +243,7 @@ class TestEncryptionKeyrotation:
 @encryption_at_rest_required
 @vault_kms_deployment_required
 @skipif_external_mode
+@skipif_disconnected_cluster
 class TestOSDKeyrotationWithKMS:
     @pytest.fixture(autouse=True)
     def setup(

--- a/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     vault_kms_deployment_required,
 )
+from ocs_ci.framework.testlib import skipif_disconnected_cluster
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +115,7 @@ class PVKeyrotationTestBase:
     argvalues=argvalues,
 )
 @vault_kms_deployment_required
+@skipif_disconnected_cluster
 class TestDisablePVKeyrotationOperation(PVKeyrotationTestBase):
     @pytest.mark.polarion_id("OCS-6323")
     def test_disable_pv_keyrotation_globally(self, setup_common):


### PR DESCRIPTION
SKIP encryption external KMS config tests in case if disconnect environment. 