### PR TITLE
Adding 4 new test cases and a support for nss creation for gcp platform

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -282,7 +282,7 @@ def oc_create_namespacestore(
         nss_tup (tuple): A tuple containing the NSFS namespacestore details, in this order:
             pvc_name (str): Name of the PVC that will host the namespace filesystem
             pvc_size (int): Size in Gi of the PVC that will host the namespace filesystem
-            sub_path (str): The path to a sub directory inside the PVC FS which the NSS will use as the root directory
+            sub_path (str): The path to a subdirectory inside the PVC FS which the NSS will use as the root directory
             fs_backend (str): The file system backend type - CEPH_FS | GPFS | NFSv4. Defaults to None.
 
     """

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -245,6 +245,11 @@ def cli_create_namespacestore(
             f"--secret-key {get_attr_chain(cld_mgr, 'ibmcos_client.secret_key')} "
             f"--target-bucket {uls_name}"
         ),
+        constants.GCP_PLATFORM: lambda: (
+            f"google-cloud-storage {nss_name} "
+            f"--private-key-json-file {constants.GOOGLE_CREDS_JSON_PATH} "
+            f"--target-bucket {uls_name}"
+        ),
         constants.NAMESPACE_FILESYSTEM: lambda: (
             f"nsfs {nss_name} "
             f"--pvc-name {uls_name} "

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -150,6 +150,61 @@ class TestNamespace(MCGTest):
                 {
                     "interface": "CLI",
                     "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"aws": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    pytest.mark.polarion_id("OCS-6353"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"azure": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    pytest.mark.polarion_id("OCS-6354"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"ibmcos": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    on_prem_platform_required,
+                    pytest.mark.polarion_id("OCS-6355"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"gcp": [(1, None)]},
+                    },
+                },
+                marks=[
+                    tier1,
+                    pytest.mark.polarion_id("OCS-6356"),
+                ],
+            ),
+            pytest.param(
+                {
+                    "interface": "CLI",
+                    "namespace_policy_dict": {
                         "type": "Cache",
                         "ttl": 300000,
                         "namespacestore_dict": {
@@ -251,6 +306,10 @@ class TestNamespace(MCGTest):
             "Azure-OC-Single",
             "RGW-OC-Single",
             "RGW-CLI-Single",
+            "AWS-CLI-Single",
+            "AZURE-CLI-Single",
+            "IBM-CLI-Single",
+            "GCP-CLI-Single",
             "RGW-CLI-Cache",
             "RGW-CLI-Multi",
             "IBM-OC-Single",


### PR DESCRIPTION
This PR handles requirements specified in https://github.com/red-hat-storage/ocs-ci/issues/11129 and there are 4 new test cases which were added: 

1) CLI NSS creation over Azure
2) CLI NSS creation over IBMCOS
3) CLI NSS creation over AWS
4) CLI NSS creation over GCP

In order to support creation of NSS over GCP a support was added to namespacestore.py. 