### PR TITLE
Increase timeout when creating PVC from snapshot in test test_pvc_snapshot

### DIFF
--- a/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
@@ -141,7 +141,7 @@ class TestPvcSnapshot(ManageTest):
             restore_pvc_yaml=restore_pvc_yaml,
         )
         helpers.wait_for_resource_state(
-            restore_pvc_obj, constants.STATUS_BOUND, timeout=90
+            restore_pvc_obj, constants.STATUS_BOUND, timeout=180
         )
         restore_pvc_obj.reload()
         teardown_factory(restore_pvc_obj)


### PR DESCRIPTION
The PVC creation from snapshot took more time to reach Bound state. Increased the timeout to 180 seconds to avoid failure.
Test : tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py::TestPvcSnapshot::test_pvc_snapshot
Fixes #11600 

