### PR TITLE
`test_obj_owner_in_obc_buckets[ibmcos-nss]` - skip in KMS deployments

### DIFF
--- a/tests/functional/object/mcg/test_obj_owner_md.py
+++ b/tests/functional/object/mcg/test_obj_owner_md.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
+    skipif_kms_deployment,
     tier2,
 )
 from ocs_ci.ocs import constants
@@ -183,6 +184,7 @@ class TestObjOwnerMD(MCGTest):
                         "namespacestore_dict": {"ibmcos": [(1, None)]},
                     },
                 },
+                marks=[skipif_kms_deployment],
             ),
         ],
         ids=[


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/10561 in regards to this test.