### PR TITLE
add workaround for issues with uefi boot order

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -334,6 +334,8 @@ higher priority).
             * `node_network_configuration_policy_ip` - The ip address of NodeNetworkConfigurationPolicy CR
             * `node_network_configuration_policy_prefix_length` - The subnetmask of NodeNetworkConfigurationPolicy CR
             * `node_network_configuration_policy_destination_route` - The destination route of NodeNetworkConfigurationPolicy CR
+            * `fix_uefi_boot_order_first_option` - string identifying the PXE boot option which should be set to first place, if defined
+                (this is a workaround for UEFI boot order getting changed on some servers during the OCP deployment)
 * `hcp_version` - version of HCP client to be deployed on machine running the tests
 * `metallb_version` - MetalLB operator version to install
 * `deploy_acm_hub_cluster` - Deploy ACM hub cluster or not (Default: false)

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -25,6 +25,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, RhcosImageNotFound, TimeoutExpi
 from ocs_ci.ocs.node import get_nodes
 from ocs_ci.ocs.openshift_ops import OCP
 from ocs_ci.utility import ibmcloud_bm
+from ocs_ci.utility.baremetal import update_uefi_boot_order
 from ocs_ci.utility.bootstrap import gather_bootstrap
 from ocs_ci.utility.connection import Connection
 from ocs_ci.utility.csr import wait_for_all_nodes_csr_and_approve, approve_pending_csr
@@ -1097,6 +1098,17 @@ class BAREMETALAI(BAREMETALBASE):
             # install the OCP cluster
             self.ai_cluster.install_cluster()
 
+            # workaround for UEFI boot order issue (make sure that PXE boot is on first place)
+            for machine in master_nodes + worker_nodes:
+                if self.srv_details[machine].get("fix_uefi_boot_order_first_option"):
+                    update_uefi_boot_order(
+                        first_option_string=self.srv_details[machine].get(
+                            "fix_uefi_boot_order_first_option"
+                        ),
+                        ocp_node=machine,
+                        ignore_error=True,
+                    )
+
         def create_dns_records(self):
             """
             Configure DNS records for api and ingress
@@ -1169,6 +1181,21 @@ class BAREMETALAI(BAREMETALBASE):
                 machine (str): Machine Name
 
             """
+            # workaround for UEFI boot order issue (make sure that PXE boot is on first place)
+            if self.srv_details[machine].get("fix_uefi_boot_order_first_option"):
+                update_uefi_boot_order(
+                    first_option_string=self.srv_details[machine].get(
+                        "fix_uefi_boot_order_first_option"
+                    ),
+                    host={
+                        "host": self.srv_details[machine]["public_ip"],
+                        "user": "core",
+                        "private_key": os.path.expanduser(
+                            config.DEPLOYMENT["ssh_key_private"]
+                        ),
+                    },
+                    ignore_error=True,
+                )
             if self.srv_details[machine].get("mgmt_provider", "ipmitool") == "ipmitool":
                 secrets = [
                     self.srv_details[machine]["mgmt_username"],

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -262,7 +262,7 @@ def update_uefi_boot_order(
         first_option_string (str): String identifying the boot option which should be set to first place
         ocp_node (str): OCP Node name used to access the server via oc debug command
         host (dict): configuration of the server to make ssh connection or None
-                the dict could contain following keys: host, user and private_key or password
+            the dict could contain following keys: host, user and private_key or password
         ignore_error (bool): If True, do not raise an exception if the command fails for some reason.
 
     Raises:

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -344,7 +344,7 @@ def update_uefi_boot_order(
     boot_order_list.remove(selected_option)
     boot_order_list.insert(0, selected_option)
 
-    cmd = f"efibootmgr --bootorder {','.join(boot_order_list)}"
+    cmd = f"sudo efibootmgr --bootorder {','.join(boot_order_list)}"
     try:
         efi_cfg_str = run_command(cmd)
     except Exception as ex:

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pyipmi
 import pyipmi.interfaces
@@ -9,6 +10,7 @@ from ocs_ci.ocs.constants import VM_POWERED_OFF, VM_POWERED_ON
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.node import wait_for_nodes_status, get_worker_nodes, get_master_nodes
 from ocs_ci.ocs.ocp import OCP, wait_for_cluster_connectivity
+from ocs_ci.utility.connection import Connection
 from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 
 logger = logging.getLogger(__name__)
@@ -244,3 +246,110 @@ class BAREMETAL(object):
                 )
                 node_ipmi_ctx.append(ipmi_ctx)
         return node_ipmi_ctx
+
+
+def update_uefi_boot_order(
+    first_option_string=None, ocp_node=None, host=None, ignore_error=False
+):
+    """
+    Update UEFI boot order (using efibootmgr) to set option containing first_option_string to first place.
+    Depending on the ocp_node and host parameters, it tries to access the node via oc debug command (if ocp_node
+    parameter is provided) or via ssh (as core user) if host (hostname or IP) is provided.
+    Parameter ocp_node have precedence before host parameter, which means that if both parameters are provided, it
+    will try to use only the oc debug access.
+
+    Args:
+        first_option_string (str): String identifying the boot option which should be set to first place
+        ocp_node (str): OCP Node name used to access the server via oc debug command
+        host (dict): configuration of the server to make ssh connection or None
+                the dict could contain following keys: host, user and private_key or password
+        ignore_error (bool): If True, do not raise an exception if the command fails for some reason.
+
+    Raises:
+        UnexpectedBehaviour: If parsing of output from efibootmgr command fails
+
+    """
+
+    def run_command(cmd):
+        if ocp_node:
+            ocp_obj = OCP()
+            out = ocp_obj.exec_oc_debug_cmd(
+                node=ocp_node, cmd_list=[cmd], namespace=constants.DEFAULT_NAMESPACE
+            )
+            logger.info(f"Command '{cmd}' output: {out}")
+            return out
+        elif host:
+            private_key = (
+                os.path.expanduser(host.get("private_key"))
+                if host.get("private_key")
+                else None
+            )
+            ssh = Connection(
+                host=host["host"],
+                user=host.get("user", "core"),
+                password=host.get("password"),
+                private_key=private_key,
+                stdout=True,
+            )
+            _, out, _ = ssh.exec_cmd(cmd)
+            return out
+
+    if not ocp_node and not host:
+        raise ValueError(
+            "update_uefi_boot_order: one of 'ocp_node' and 'host' parameters have to be provided"
+        )
+
+    try:
+        efi_cfg_str = run_command("efibootmgr")
+    except Exception as ex:
+        logger.info(f"Failed to run command 'efibootmgr': {ex}")
+        if ignore_error:
+            return
+        else:
+            raise ex
+    boot_order = None
+    selected_option = None
+    for line in efi_cfg_str.splitlines():
+        if line.startswith("BootOrder:"):
+            boot_order = line.split(":")[1].strip()
+        if line.startswith("Boot") and first_option_string in line:
+            selected_option = line.split()[0].rstrip("*").removeprefix("Boot")
+
+    if not boot_order:
+        msg = f"Unable to parse output from efibootmgr - BootOrder: line not found:\n{efi_cfg_str}"
+        logger.error(msg)
+        if ignore_error:
+            return
+        else:
+            raise UnexpectedBehaviour(msg)
+    if not selected_option:
+        msg = (
+            "Unable to parse output from efibootmgr - "
+            f"Boot line with first_option_string ('{first_option_string}') not found:\n{efi_cfg_str}"
+        )
+        logger.error(msg)
+        if ignore_error:
+            return
+        else:
+            raise UnexpectedBehaviour(msg)
+
+    boot_order_list = boot_order.split(",")
+    if boot_order_list[0] == selected_option:
+        logger.debug(
+            f"No change in UEFI boot order needed, '{selected_option}' is already on first place: "
+            f"{boot_order}"
+        )
+        return
+
+    boot_order_list.remove(selected_option)
+    boot_order_list.insert(0, selected_option)
+
+    cmd = f"efibootmgr --bootorder {','.join(boot_order_list)}"
+    try:
+        efi_cfg_str = run_command(cmd)
+    except Exception as ex:
+        logger.info(f"Failed to run command '{cmd}': {ex}")
+        if ignore_error:
+            return
+        else:
+            raise ex


### PR DESCRIPTION
We are facing an issue with one of the baremetal servers, that UEFI boot order getting changed during OCP deployment and PXE boot is not on first place which leads to an issue during the next deployment.
This workaround will try to change the boot order using `efibootmgr` command and set PXE boot on the first place.