### PR TITLE
remove spec field allowRemoteStorageConsumers from checks

### DIFF
--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -768,13 +768,12 @@ def verify_faas_provider_storagecluster(sc_data):
         sc_data (dict): storagecluster data dictionary
 
     """
-    if version.get_semantic_ocs_version_from_config() > version.VERSION_4_18:
-        pass
-    else:
+    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_19:
         log.info(
             f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
         )
         assert sc_data["spec"]["allowRemoteStorageConsumers"]
+
     log.info(f"hostNetwork: {sc_data['spec']['hostNetwork']}")
     assert sc_data["spec"]["hostNetwork"]
     expressions = sc_data["spec"]["labelSelector"]["matchExpressions"]

--- a/ocs_ci/helpers/managed_services.py
+++ b/ocs_ci/helpers/managed_services.py
@@ -750,7 +750,7 @@ def verify_faas_provider_storagecluster(sc_data):
     """
     Verify provider storagecluster
 
-    1. allowRemoteStorageConsumers: true
+    1. allowRemoteStorageConsumers: true (for ODF versions lesser than 4.19)
     2. hostNetwork: true
     3. matchExpressions:
         key: node-role.kubernetes.io/worker
@@ -768,10 +768,13 @@ def verify_faas_provider_storagecluster(sc_data):
         sc_data (dict): storagecluster data dictionary
 
     """
-    log.info(
-        f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
-    )
-    assert sc_data["spec"]["allowRemoteStorageConsumers"]
+    if version.get_semantic_ocs_version_from_config() > version.VERSION_4_18:
+        pass
+    else:
+        log.info(
+            f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
+        )
+        assert sc_data["spec"]["allowRemoteStorageConsumers"]
     log.info(f"hostNetwork: {sc_data['spec']['hostNetwork']}")
     assert sc_data["spec"]["hostNetwork"]
     expressions = sc_data["spec"]["labelSelector"]["matchExpressions"]

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -2370,7 +2370,7 @@ def verify_managed_secrets():
 def verify_provider_storagecluster(sc_data):
     """
     Verify that storagecluster of the provider passes the following checks:
-    1. allowRemoteStorageConsumers: true
+    1. allowRemoteStorageConsumers: true (for ODF versions lesser than 4.19)
     2. hostNetwork: true
     3. matchExpressions:
     key: node-role.kubernetes.io/worker
@@ -2385,10 +2385,13 @@ def verify_provider_storagecluster(sc_data):
     Args:
         sc_data (dict): storagecluster data dictionary
     """
-    log.info(
-        f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
-    )
-    assert sc_data["spec"]["allowRemoteStorageConsumers"]
+    if version.get_semantic_ocs_version_from_config() > version.VERSION_4_18:
+        pass
+    else:
+        log.info(
+            f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
+        )
+        assert sc_data["spec"]["allowRemoteStorageConsumers"]
     log.info(f"hostNetwork: {sc_data['spec']['hostNetwork']}")
     assert sc_data["spec"]["hostNetwork"]
     expressions = sc_data["spec"]["labelSelector"]["matchExpressions"]

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -2385,13 +2385,12 @@ def verify_provider_storagecluster(sc_data):
     Args:
         sc_data (dict): storagecluster data dictionary
     """
-    if version.get_semantic_ocs_version_from_config() > version.VERSION_4_18:
-        pass
-    else:
+    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_19:
         log.info(
             f"allowRemoteStorageConsumers: {sc_data['spec']['allowRemoteStorageConsumers']}"
         )
         assert sc_data["spec"]["allowRemoteStorageConsumers"]
+
     log.info(f"hostNetwork: {sc_data['spec']['hostNetwork']}")
     assert sc_data["spec"]["hostNetwork"]
     expressions = sc_data["spec"]["labelSelector"]["matchExpressions"]

--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ocs-storagecluster
   namespace: openshift-storage
 spec:
-  allowRemoteStorageConsumers: true
   arbiter: {}
   encryption:
     kms: {}


### PR DESCRIPTION
Following dev PR https://github.com/red-hat-storage/ocs-operator/pull/3019 we are removing spec field `allowRemoteStorageConsumers` 
Slack thread created to remove doubts about FaaS usage of that field
https://ibm-systems-storage.slack.com/archives/C081L5H77H7/p1741711111645139