### PR TITLE
Skip test cases which require tool box in MCG Only deployment

### DIFF
--- a/tests/cross_functional/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
+++ b/tests/cross_functional/scale/upgrade/test_upgrade_with_scaled_rgw_obc.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     pre_upgrade,
     post_upgrade,
     skipif_managed_service,
+    skipif_mcg_only,
     skipif_bm,
     skipif_external_mode,
     vsphere_platform_required,
@@ -41,6 +42,7 @@ obc_scaled_data_file = f"{log_path}/obc_scale_rgw_data_file.yaml"
 @skipif_external_mode
 @skipif_bm
 @skipif_managed_service
+@skipif_mcg_only
 @pytest.mark.polarion_id("OCS-3987")
 def test_scale_obc_rgw_pre_upgrade(tmp_path, mcg_job_factory, timeout=60):
     """

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 @pre_upgrade
 @tier2
 @skipif_managed_service
+@skipif_mcg_only
 @skipif_hci_provider_and_client
 def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
     """

--- a/tests/functional/pod_and_daemons/test_mgr_pods.py
+++ b/tests/functional/pod_and_daemons/test_mgr_pods.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     post_ocs_upgrade,
     polarion_id,
     skipif_external_mode,
+    skipif_mcg_only,
 )
 from ocs_ci.ocs import exceptions
 from ocs_ci.ocs.resources import pod
@@ -82,6 +83,7 @@ class TestMgrPods(BaseTest):
         log.info(f"Name entries in mgr metadata: {mgr_metadata_names}")
 
     @green_squad
+    @skipif_mcg_only
     @polarion_id("OCS-5438")
     def test_two_mgr_daemons_and_failure(self):
         """
@@ -140,6 +142,7 @@ class TestMgrPods(BaseTest):
 
     @polarion_id("OCS-5439")
     @green_squad
+    @skipif_mcg_only
     def test_mgr_pod_reboot(self):
         """
         - Deoloy OCP and ODF

--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     polarion_id,
     post_upgrade,
     skipif_managed_service,
+    skipif_mcg_only,
     skipif_hci_provider_and_client,
     skipif_external_mode,
 )
@@ -42,6 +43,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
             pytest.param(*[constants.CEPHFILESYSTEM]),
         ],
     )
+    @skipif_mcg_only
     @polarion_id("OCS-5872")
     @polarion_id("OCS-5873")
     def test_cross_class_same_pool_clone_snap_restore(
@@ -179,6 +181,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
             pytest.param(*[constants.CEPHFILESYSTEM], 2, 3, False),
         ],
     )
+    @skipif_mcg_only
     @polarion_id("OCS-5871")
     @polarion_id("OCS-5874")
     @polarion_id("OCS-5875")

--- a/tests/functional/upgrade/test_configuration.py
+++ b/tests/functional/upgrade/test_configuration.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     pre_upgrade,
     post_upgrade,
     brown_squad,
+    skipif_mcg_only,
     tier1,
 )
 from ocs_ci.ocs import constants
@@ -48,6 +49,7 @@ def pre_upgrade_crush_map():
 
 @pre_upgrade
 @brown_squad
+@skipif_mcg_only
 def test_load_crush_map(pre_upgrade_crush_map):
     """
     Load CRUSH map.
@@ -57,6 +59,7 @@ def test_load_crush_map(pre_upgrade_crush_map):
 
 @post_upgrade
 @brown_squad
+@skipif_mcg_only
 @pytest.mark.polarion_id("OCS-1936")
 def test_crush_map_unchanged(pre_upgrade_crush_map):
     """


### PR DESCRIPTION
There are few test cases failed in run https://url.corp.redhat.com/7148982 due to CephToolBoxNotFoundException. In MCG Only deployment, ceph cluster doesn't exist, so skipping those test cases for MCG Only deployment.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)