### PR TITLE
Increased retries to validate ceph health metrics is updated on prometheus pod during mgr running node reboot.

### DIFF
--- a/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
@@ -42,7 +42,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 log = logging.getLogger(__name__)
 
 
-@retry(AssertionError, tries=30, delay=3, backoff=1)
+@retry(AssertionError, tries=60, delay=3, backoff=1)
 def wait_to_update_mgrpod_info_prometheus_pod(threading_lock):
     """
     Validates the ceph health metrics is updated on prometheus pod


### PR DESCRIPTION
Fixed #11616 

Problem: Script used to timeout while checking for Ceph health after node reboot.

Solution: Increased the retries from 30 to 60, its passing now. Tested multiple times, working fine.