### PR TITLE
DisableStorageClass and DisableSnapshotClass fields are deprecated

### DIFF
--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster.yaml
@@ -13,16 +13,11 @@ spec:
   flexibleScaling: true
   hostNetwork: true
   managedResources:
-    cephBlockPools:
-      disableSnapshotClass: true
-      disableStorageClass: true
-      reconcileStrategy: ignore
+    cephBlockPools: {}
     cephCluster: {}
     cephConfig: {}
     cephDashboard: {}
-    cephFilesystems:
-      disableSnapshotClass: true
-      disableStorageClass: true
+    cephFilesystems: {}
     cephNonResilientPools: {}
     cephObjectStoreUsers: {}
     cephObjectStores:

--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_updated.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_updated.yaml
@@ -12,15 +12,11 @@ spec:
   flexibleScaling: true
   hostNetwork: true
   managedResources:
-    cephBlockPools:
-      disableSnapshotClass: true
-      disableStorageClass: true
+    cephBlockPools: {}
     cephCluster: {}
     cephConfig: {}
     cephDashboard: {}
-    cephFilesystems:
-      disableSnapshotClass: true
-      disableStorageClass: true
+    cephFilesystems: {}
     cephNonResilientPools: {}
     cephObjectStoreUsers: {}
     cephObjectStores:


### PR DESCRIPTION
following changes from https://github.com/red-hat-storage/ocs-operator/pull/3037 we deprecated fields that will not be in use in Converged deployments in ocs-ci:4.19