### PR TITLE
StorageCluster changes. DisableStorageClass and DisableSnapshotClass removed

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -8,6 +8,11 @@ import time
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, ocp, defaults
+from ocs_ci.ocs.constants import (
+    OCS_STORAGE_CLUSTER_CONVERGED_YAML,
+    OCS_STORAGE_CLUSTER_YAML,
+    OCS_STORAGE_CLUSTER_UPDATED_YAML,
+)
 from ocs_ci.ocs.rados_utils import (
     verify_cephblockpool_status,
     check_phase_of_rados_namespace,
@@ -175,10 +180,7 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
             timeout=600,
         )
 
-        if (
-            self.ocs_version < version.VERSION_4_16
-            and self.ocs_version >= version.VERSION_4_14
-        ):
+        if self.ocs_version in [version.VERSION_4_14, version.VERSION_4_15]:
             # Disable ROOK_CSI_ENABLE_CEPHFS and ROOK_CSI_ENABLE_RBD
             disable_CEPHFS_RBD_CSI = '{"data":{"ROOK_CSI_ENABLE_CEPHFS":"false", "ROOK_CSI_ENABLE_RBD":"false"}}'
             assert self.config_map_obj.patch(
@@ -210,58 +212,45 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
             resource_name=constants.DEFAULT_STORAGE_CLUSTER
         )
         if not is_storagecluster:
-            if (
-                self.ocs_version < version.VERSION_4_16
-                and self.ocs_version >= version.VERSION_4_14
-            ):
-                storage_cluster_data = templating.load_yaml(
-                    constants.OCS_STORAGE_CLUSTER_YAML
-                )
-                storage_cluster_data = add_encryption_details_to_cluster_data(
-                    storage_cluster_data
-                )
-                storage_cluster_data = add_in_transit_encryption_to_cluster_data(
-                    storage_cluster_data
-                )
-                storage_cluster_data["spec"]["storageDeviceSets"][0][
-                    "replica"
-                ] = no_of_worker_nodes
 
-                if self.platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
-                    storage_cluster_data["spec"]["storageDeviceSets"][0][
-                        "count"
-                    ] = number_of_disks_available
-
-                templating.dump_data_to_temp_yaml(
-                    storage_cluster_data, constants.OCS_STORAGE_CLUSTER_YAML
-                )
-                self.ocp_obj.exec_oc_cmd(
-                    f"apply -f {constants.OCS_STORAGE_CLUSTER_YAML}"
-                )
+            # define storage cluster path to cr, based on ocs version
+            if self.ocs_version in [version.VERSION_4_14, version.VERSION_4_15]:
+                storage_cluster_path = OCS_STORAGE_CLUSTER_YAML
+            elif self.ocs_version in [
+                version.VERSION_4_16,
+                version.VERSION_4_17,
+                version.VERSION_4_18,
+            ]:
+                storage_cluster_path = OCS_STORAGE_CLUSTER_UPDATED_YAML
             else:
-                storage_cluster_data = templating.load_yaml(
-                    constants.OCS_STORAGE_CLUSTER_UPDATED_YAML
-                )
-                storage_cluster_data = add_encryption_details_to_cluster_data(
-                    storage_cluster_data
-                )
-                storage_cluster_data = add_in_transit_encryption_to_cluster_data(
-                    storage_cluster_data
-                )
-                storage_cluster_data["spec"]["storageDeviceSets"][0][
-                    "replica"
-                ] = no_of_worker_nodes
+                storage_cluster_path = OCS_STORAGE_CLUSTER_CONVERGED_YAML
+            storage_cluster_data = templating.load_yaml(storage_cluster_path)
 
-                if self.platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
-                    storage_cluster_data["spec"]["storageDeviceSets"][0][
-                        "count"
-                    ] = number_of_disks_available
-                templating.dump_data_to_temp_yaml(
-                    storage_cluster_data, constants.OCS_STORAGE_CLUSTER_UPDATED_YAML
-                )
-                self.ocp_obj.exec_oc_cmd(
-                    f"apply -f {constants.OCS_STORAGE_CLUSTER_UPDATED_YAML}"
-                )
+            # configure storage cluster data based on platform and configuration
+            storage_cluster_data = add_encryption_details_to_cluster_data(
+                storage_cluster_data
+            )
+            storage_cluster_data = add_in_transit_encryption_to_cluster_data(
+                storage_cluster_data
+            )
+            storage_cluster_data["spec"]["storageDeviceSets"][0][
+                "replica"
+            ] = no_of_worker_nodes
+
+            if self.platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
+                storage_cluster_data["spec"]["storageDeviceSets"][0][
+                    "count"
+                ] = number_of_disks_available
+
+            # configure dynamic namespace
+            storage_cluster_data["metadata"]["namespace"] = config.ENV_DATA[
+                "cluster_namespace"
+            ]
+
+            templating.dump_data_to_temp_yaml(
+                storage_cluster_data, storage_cluster_path
+            )
+            self.ocp_obj.exec_oc_cmd(f"apply -f {storage_cluster_path}")
 
         # Creating toolbox pod
         setup_ceph_toolbox()

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -354,6 +354,9 @@ MACHINE_CONFIG_YAML = os.path.join(
 OCS_STORAGE_CLUSTER_YAML = os.path.join(
     PROVIDER_MODE_OCS_DEPLOYMENT_PATH, "ocs_storagecluster.yaml"
 )
+OCS_STORAGE_CLUSTER_CONVERGED_YAML = os.path.join(
+    PROVIDER_MODE_OCS_DEPLOYMENT_PATH, "ocs_storagecluster_converged.yaml"
+)
 OCS_STORAGE_CLUSTER_UPDATED_YAML = os.path.join(
     PROVIDER_MODE_OCS_DEPLOYMENT_PATH, "ocs_storagecluster_updated.yaml"
 )

--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
@@ -1,0 +1,50 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  allowRemoteStorageConsumers: true
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  flexibleScaling: true
+  hostNetwork: true
+  managedResources:
+    cephBlockPools: {}
+    cephCluster: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephNonResilientPools: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores:
+      hostNetwork: false
+    cephRBDMirror: {}
+    cephToolbox: {}
+  mirroring: {}
+  monDataDirHostPath: /var/lib/rook
+  nodeTopologies: {}
+  providerAPIServerServiceType: NodePort
+  storageDeviceSets:
+  - config: {}
+    count: 4
+    dataPVCTemplate:
+      metadata: {}
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 256Gi
+        storageClassName: localblock
+
+        volumeMode: Block
+      status: {}
+    deviceClass: ssd
+    name: local-storage-deviceset
+    placement: {}
+    preparePlacement: {}
+    replica: 3
+    resources: {}


### PR DESCRIPTION
following changes from https://github.com/red-hat-storage/ocs-operator/pull/3037 we deprecated fields that will not be in use in Converged deployments in ocs-ci:4.19