### PR TITLE
A fix to test_namespace_bucket_creation_crd[RGW-CLI-Cache] failure 

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -771,7 +771,7 @@ class MCG:
             self.exec_mcg_cmd(cmd)
         elif namespace_policy_type == constants.NAMESPACE_POLICY_TYPE_CACHE.lower():
             cmd += f" --hub-resource={namestores_name_str}"
-            cmd += " --backingstores=constants.DEFAULT_NOOBAA_BACKINGSTORE"
+            cmd += f" --backingstores={constants.DEFAULT_NOOBAA_BACKINGSTORE}"
             if "ttl" in namespace_policy:
                 cmd += f" --ttl=={namespace_policy['ttl']}"
             self.exec_mcg_cmd(cmd)


### PR DESCRIPTION
This PR contains a fix following a failure of test_namespace_bucket_creation_crd[RGW-CLI-Cache]

Report Portal link: https://polarion.engineering.redhat.com/polarion/#/project/OpenShiftContainerStorage/workitem?id=OCS-6338

The problem in that line of code is that it’s not injecting the value of the constant variable constants.DEFAULT_NOOBAA_BACKINGSTORE into the string as you intended - it’s just using the string “constants.DEFAULT_NOOBAA_BACKINGSTORE” in the mcg-cli command. 

The result is this error:
E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/data/mcg-cli bucketclass create namespace-bucketclass cache cli-bucketclass-9634d20140c2433b905feba1 --hub-resource=rgw-ns-store-543fab0b5acd4d21b8e81ed3c64 --backingstores=constants.DEFAULT_NOOBAA_BACKINGSTORE -n openshift-storage.
E               Error is #x1B[36mINFO#x1B[0m[0000]  Exists: NooBaa "noobaa"
E               #x1B[36mINFO#x1B[0m[0000] creating namespace store array &{Type:Cache Single: Multi: Cache:0xc00058ad80} from namespace policy
E               #x1B[36mINFO#x1B[0m[0000] created namespace store array successfully [rgw-ns-store-543fab0b5acd4d21b8e81ed3c64]
E               #x1B[36mINFO#x1B[0m[0000]  Exists: NamespaceStore "rgw-ns-store-543fab0b5acd4d21b8e81ed3c64"
E               #x1B[36mINFO#x1B[0m[0000]  Exists: NamespaceStore "rgw-ns-store-543fab0b5acd4d21b8e81ed3c64"
E               #x1B[36mINFO#x1B[0m[0000]  Not Found: BackingStore "constants.DEFAULT_NOOBAA_BACKINGSTORE"
E               #x1B[31mFATA#x1B[0m[0000]  Could not get BackingStore "constants.DEFAULT_NOOBAA_BACKINGSTORE" in namespace "openshift-storage"