### PR TITLE
fix retry for validate_pdb_creation function

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1282,7 +1282,7 @@ def count_cluster_osd():
     return osd_count
 
 
-@retry(PDBNotCreatedException, tries=9, backoff=2)
+@retry((PDBNotCreatedException, AssertionError), tries=9, backoff=2)
 def validate_pdb_creation():
     """
     Validate creation of PDBs for MON, MDS and OSD pods.


### PR DESCRIPTION
The `validate_pdb_creation` function can raise both `PDBNotCreatedException` and `AssertionError` exceptions.

This should prevent failures like this: https://url.corp.redhat.com/ec8e179
```
2025-03-13 13:52:31  08:52:31 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-storage get PodDisruptionBudget  -n openshift-storage -o yaml
2025-03-13 13:52:31  08:52:31 - MainThread - ocs_ci.deployment.deployment - ERROR  - rook-ceph-osd was not created
...
2025-03-13 14:23:42      @retry(PDBNotCreatedException, tries=9, backoff=2)
2025-03-13 14:23:42      def validate_pdb_creation():
...
2025-03-13 14:23:42          for required, given in zip(pdb_required, pdb_list):
2025-03-13 14:23:42  >           assert required == given, f"{required} was not created"
2025-03-13 14:23:42  E           AssertionError: rook-ceph-osd was not created
2025-03-13 14:23:42  
2025-03-13 14:23:42  ocs_ci/ocs/cluster.py:1331: AssertionError
```

The ` rook-ceph-osd` PodDisruptionBudget was created 1-2 minutes after the check.