### PR TITLE
Increase default noobaa pod count by 1 due to cnpg pod

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -142,6 +142,9 @@ def verify_image_versions(old_images, upgrade_version, version_before_upgrade):
     default_noobaa_pods = 3
     noobaa_pods = default_noobaa_pods
     noobaa_pod_obj = get_noobaa_pods()
+    if upgrade_version >= parse_version("4.19"):
+        log.info("Increased default noobaa pod count by 1 due to cnpg pod")
+        default_noobaa_pods += 1
     if (
         config.ENV_DATA.get("mcg_only_deployment")
         and config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM


### PR DESCRIPTION
From 4.19, new pod "cnpg-controller-manager-84bfbc5b49-c2zxc" was added. So increased the noobaa default pod count by 1.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)