### PR TITLE
Add kubevirt as plugin to DataProtectionApplication

### DIFF
--- a/ocs_ci/templates/DR/dpa_discovered_apps.yaml
+++ b/ocs_ci/templates/DR/dpa_discovered_apps.yaml
@@ -15,4 +15,5 @@ spec:
       defaultPlugins:
         - openshift
         - aws
+        - kubevirt
       noDefaultBackupLocation: true


### PR DESCRIPTION
This is required for [RHSTOR-6413](https://issues.redhat.com/browse/RHSTOR-6413)