### PR TITLE
TestNodeReplacementTwice: Machine not found error

### DIFF
--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -348,6 +348,7 @@ class TestNodeReplacementTwice(ManageTest):
         log.info("Clear crash warnings and osd removal leftovers")
         clear_crash_warning_and_osd_removal_leftovers()
 
+    @skipif_ibm_cloud_managed
     def test_nodereplacement_twice(self):
         for i in range(2):
             # Get random node name for replacement


### PR DESCRIPTION
Skipping test case TestNodeReplacementTwice: Machine not found error