### PR TITLE
Update MCG's bucket notification connection secret scheme for Kafka

### DIFF
--- a/ocs_ci/ocs/resources/bucket_notifications_manager.py
+++ b/ocs_ci/ocs/resources/bucket_notifications_manager.py
@@ -225,7 +225,9 @@ class BucketNotificationsManager:
         conn_file_name = ""
 
         kafka_conn_config = {
-            "metadata.broker.list": constants.KAFKA_ENDPOINT,
+            "kafka_options_object": {
+                "metadata.broker.list": constants.KAFKA_ENDPOINT,
+            },
             "notification_protocol": "kafka",
             "topic": topic,
             "name": conn_name,


### PR DESCRIPTION
MCG's bucket notification connection secret scheme for Kafka is getting updated in https://github.com/noobaa/noobaa-core/pull/8889 - this change is simply catching up to the change.