### PR TITLE
add skipif ibm cloud managed in more ui tests

### DIFF
--- a/tests/functional/ui/test_alert_text.py
+++ b/tests/functional/ui/test_alert_text.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     tier2,
     ui,
+    skipif_ibm_cloud_managed,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import is_hci_provider_cluster
@@ -76,6 +77,7 @@ def alerts_expected():
 
 @tier2
 @black_squad
+@skipif_ibm_cloud_managed
 @skipif_mcg_only
 @skipif_hci_client
 @polarion_id("OCS-5509")

--- a/tests/functional/ui/test_capacity_breakdown_ui.py
+++ b/tests/functional/ui/test_capacity_breakdown_ui.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     black_squad,
     runs_on_provider,
+    skipif_ibm_cloud_managed,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
@@ -128,6 +129,7 @@ class TestCapacityBreakdownUI(ManageTest):
     @ui
     @black_squad
     @tier3
+    @skipif_ibm_cloud_managed
     @polarion_id("OCS-5122")
     def test_requested_capacity_breakdown(
         self, setup_ui_class, teardown_project_factory

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     ibmcloud_platform_required,
     ui,
+    skipif_ibm_cloud_managed,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -310,6 +311,7 @@ class TestResizeOSD(ManageTest):
     @pytest.mark.order("last")
     @polarion_id("OCS-5800")
     @ui
+    @skipif_ibm_cloud_managed
     def test_ui_storage_size_post_resize_osd(self, setup_ui_session):
         """
         Test the new total storage size is reflected in the UI post resize osd


### PR DESCRIPTION
we do not have access to create lkubeadmin credentials and login to management-console on IBM Cloud
Usually we see:

FileNotFoundError: [Errno 2] No such file or directory: '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeadmin-password'
Report Portal https://url.corp.redhat.com/686f7ce