### PR TITLE
Add an alternate way to verify if the IBM cloud BM machines are stopped

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -3250,7 +3250,7 @@ class IBMCloudBMNodes(NodesBase):
                 )
             except CommandFailed as err:
                 # Consider the situation where the cluster is not accessible after nodes are down,
-                # example: when all nods are off
+                # example: when all the nodes are off
                 if "Unable to connect to the server" in str(err):
                     logger.info(
                         f"Unable to connect to the server to check the nodes NotReady status. "

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -3257,7 +3257,7 @@ class IBMCloudBMNodes(NodesBase):
                         f"Trying alternate method to verify nodes {node_names} has stopped"
                     )
                     machines_not_off = (
-                        self.ibmcloud_bm.check_if_machines_are_off_from_sensor_data(
+                        self.ibmcloud_bm.get_machines_that_are_not_off_from_sensor_data(
                             machines
                         )
                     )

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -29,6 +29,7 @@ from ocs_ci.ocs.exceptions import (
     VolumePathNotFoundException,
     UnsupportedOSType,
     UnavailableResourceException,
+    CommandFailed,
 )
 from ocs_ci.framework import config, merge_dict
 from ocs_ci.ocs.machinepool import (
@@ -3243,9 +3244,28 @@ class IBMCloudBMNodes(NodesBase):
         self.ibmcloud_bm.stop_machines(machines)
         if wait:
             node_names = [n.name for n in nodes]
-            wait_for_nodes_status(
-                node_names, constants.NODE_NOT_READY, timeout=180, sleep=5
-            )
+            try:
+                wait_for_nodes_status(
+                    node_names, constants.NODE_NOT_READY, timeout=180, sleep=5
+                )
+            except CommandFailed as err:
+                # Consider the situation where the cluster is not accessible after nodes are down,
+                # example: when all nods are off
+                if "Unable to connect to the server" in str(err):
+                    logger.info(
+                        f"Unable to connect to the server to check the nodes NotReady status. "
+                        f"Trying alternate method to verify nodes {node_names} has stopped"
+                    )
+                    machines_not_off = (
+                        self.ibmcloud_bm.check_if_machines_are_off_from_sensor_data(
+                            machines
+                        )
+                    )
+                    assert (
+                        machines_not_off
+                    ), f"Nodes corresponding to the machines {machines_not_off} are not off."
+                else:
+                    raise
 
     def start_nodes(self, nodes, wait=True):
         """

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -3261,7 +3261,7 @@ class IBMCloudBMNodes(NodesBase):
                             machines
                         )
                     )
-                    assert (
+                    assert not (
                         machines_not_off
                     ), f"Nodes corresponding to the machines {machines_not_off} are not off."
                 else:

--- a/ocs_ci/utility/ibmcloud_bm.py
+++ b/ocs_ci/utility/ibmcloud_bm.py
@@ -167,3 +167,22 @@ class IBMCloudBM(object):
         """
         self.stop_machines(machines)
         self.start_machines(machines)
+
+    def check_if_machines_are_off_from_sensor_data(self, machines):
+        """
+        Retrieve a server’s hardware state via its internal sensors and check if RPM Sensor data is present.
+        Data from RPM sensors won't be available if the machine is off. To be used only as an alternate method.
+        A command resulting in the power status of the machine is not available.
+
+        Args:
+            machines (list): List of the IBMCLoud Bare metal machines objects
+
+        Returns:
+            list: List of machines which are not off
+        """
+        machines_not_off = []
+        for m in machines:
+            # Use json output because without json the output will have the title "RPM Sensor"
+            cmd = f"sensor {m['id']} --output json"
+            if "RPM Sensor" in self.run_ibmcloud_bm_cmd(cmd):
+                machines_not_off.append(m)

--- a/ocs_ci/utility/ibmcloud_bm.py
+++ b/ocs_ci/utility/ibmcloud_bm.py
@@ -168,11 +168,12 @@ class IBMCloudBM(object):
         self.stop_machines(machines)
         self.start_machines(machines)
 
-    def check_if_machines_are_off_from_sensor_data(self, machines):
+    def get_machines_that_are_not_off_from_sensor_data(self, machines):
         """
         Retrieve a server’s hardware state via its internal sensors and check if RPM Sensor data is present.
-        Data from RPM sensors won't be available if the machine is off. To be used only as an alternate method.
-        A command resulting in the power status of the machine is not available.
+        Data from RPM sensors won't be available if the machine is OFF. To be used only as an alternate method.
+        A command resulting in the power status of the machine is not available. This method is not recommended to
+        identify the machines that are ON and functional
 
         Args:
             machines (list): List of the IBMCLoud Bare metal machines objects

--- a/tests/libtest/test_ibm_cloud_bm.py
+++ b/tests/libtest/test_ibm_cloud_bm.py
@@ -1,0 +1,33 @@
+import logging
+import pytest
+
+from ocs_ci.ocs.platform_nodes import IBMCloudBMNodes
+from ocs_ci.framework.testlib import libtest
+from ocs_ci.ocs import node
+from ocs_ci.framework.pytest_customization.marks import (
+    provider_client_platform_required,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def teardown(request):
+    def finalizer():
+        logger.info("Running restart_nodes_by_stop_and_start_teardown")
+        ibmcloud = IBMCloudBMNodes()
+        ibmcloud.restart_nodes_by_stop_and_start_teardown()
+
+    request.addfinalizer(finalizer)
+
+
+@libtest
+@provider_client_platform_required
+def test_restart_nodes_by_stop_and_start():
+    """
+    Check basic consistency in platform handling.
+    """
+    ibmcloud = IBMCloudBMNodes()
+    worker_nodes = node.get_nodes(node_type="worker")
+    ibmcloud.restart_nodes_by_stop_and_start(worker_nodes)

--- a/tests/libtest/test_ibm_cloud_bm.py
+++ b/tests/libtest/test_ibm_cloud_bm.py
@@ -1,9 +1,9 @@
 import logging
 import pytest
 
+from ocs_ci.ocs.node import get_all_nodes, get_node_objs
 from ocs_ci.ocs.platform_nodes import IBMCloudBMNodes
 from ocs_ci.framework.testlib import libtest
-from ocs_ci.ocs import node
 from ocs_ci.framework.pytest_customization.marks import (
     provider_client_platform_required,
 )
@@ -26,8 +26,9 @@ def teardown(request):
 @provider_client_platform_required
 def test_restart_nodes_by_stop_and_start():
     """
-    Check basic consistency in platform handling.
+    Test all nodes stop and start in  IBM Cloud Bare Metal platform
     """
     ibmcloud = IBMCloudBMNodes()
-    worker_nodes = node.get_nodes(node_type="worker")
-    ibmcloud.restart_nodes_by_stop_and_start(worker_nodes)
+    nodes = get_all_nodes()
+    node_objs = get_node_objs(nodes)
+    ibmcloud.restart_nodes_by_stop_and_start(node_objs)

--- a/tests/libtest/test_ibm_cloud_bm.py
+++ b/tests/libtest/test_ibm_cloud_bm.py
@@ -12,23 +12,27 @@ from ocs_ci.framework.pytest_customization.marks import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(autouse=True)
-def teardown(request):
-    def finalizer():
-        logger.info("Running restart_nodes_by_stop_and_start_teardown")
-        ibmcloud = IBMCloudBMNodes()
-        ibmcloud.restart_nodes_by_stop_and_start_teardown()
-
-    request.addfinalizer(finalizer)
-
-
 @libtest
 @provider_client_platform_required
-def test_restart_nodes_by_stop_and_start():
+class TestIbmCloudBmNodes:
     """
-    Test all nodes stop and start in  IBM Cloud Bare Metal platform
+    Test node operations in IBM Cloud Bare Metal platform
     """
-    ibmcloud = IBMCloudBMNodes()
-    nodes = get_all_nodes()
-    node_objs = get_node_objs(nodes)
-    ibmcloud.restart_nodes_by_stop_and_start(node_objs)
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        def finalizer():
+            logger.info("Running restart_nodes_by_stop_and_start_teardown")
+            ibmcloud = IBMCloudBMNodes()
+            ibmcloud.restart_nodes_by_stop_and_start_teardown()
+
+        request.addfinalizer(finalizer)
+
+    def test_restart_nodes_by_stop_and_start(self):
+        """
+        Test all nodes stop and start in IBM Cloud Bare Metal platform
+        """
+        ibmcloud = IBMCloudBMNodes()
+        nodes = get_all_nodes()
+        node_objs = get_node_objs(nodes)
+        ibmcloud.restart_nodes_by_stop_and_start(node_objs)


### PR DESCRIPTION
IBMCloudBMNodes stop_nodes method is waiting for node NotReady status after powering off the machines. In certain cases, the cluster will not be accessible after the nodes are down. In such cases, added an alternate way to check if the machine is powered off.

Used the output from sensor data to check if the RPM sensor data is available. This is not available if the machine is off.

Fixes #11732 
