### PR TITLE
allow login to OCP via provided OCP URL and kubeadmin password

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -45,6 +45,8 @@ run it belongs here.
 * `cluster_dir_full_path` - cluster dir full path on NFS share starting with `/mnt/`
 * `run_id` - Timestamp ID that is used for log directory naming
 * `kubeconfig_location` - Filepath (under the cluster path) where the kubeconfig is located
+* `kubeadmin_password` - kubeadmin password used as alternative way to login to the OCP cluster if kubeconfig is not available
+* `ocp_url` - OCP Cluster URL (api or console) used to login to OCP cluster if kubeconfig is not available
 * `cli_params` - Dict that holds onto all CLI parameters
 * `client_version` - OCP client version
 * `bin_dir` - Directory where binaries are downloaded to

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -16,6 +16,10 @@ RUN:
   log_dir: "/tmp"
   run_id: null  # this will be redefined in the execution
   kubeconfig_location: 'auth/kubeconfig' # relative from cluster_dir
+  # kubeadmin_password: '' # kubeadmin password used as alternative way to
+  # login to the OCP cluster (if kubeconfig is not available)
+  # ocp_url: '' # OCP Cluster URL (api or console) used to login to OCP cluster
+  # if kubeconfig is not available
   cli_params: {}  # this will be filled with CLI parameters data
   # If the client version ends with .nightly, the version will be exposed
   # to the latest accepted OCP nightly build version

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -548,24 +548,27 @@ def process_cluster_cli_params(config):
     if not os.path.isfile(kubeconfig_path) and not get_cli_param(
         config, "deploy", default=False
     ):
-        if os.environ.get("KUBEADMIN_PASSWORD") and os.environ.get("OCP_URL"):
+        if ocsci_config.RUN.get("kubeadmin_password") and ocsci_config.RUN.get(
+            "ocp_url"
+        ):
             log.info(
                 "Generating kubeconfig file from provided kubeadmin password and OCP URL"
             )
             # check and correct OCP URL (change it to API url if console url provided and add port if needed
-            ocp_api_url = os.environ.get("OCP_URL").replace(
+            ocp_api_url = ocsci_config.RUN.get("ocp_url").replace(
                 "console-openshift-console.apps", "api"
             )
             if ":6443" not in ocp_api_url:
                 ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
 
             cmd = (
-                f"oc login --username {ocsci_config.RUN['username']} --password {os.environ['KUBEADMIN_PASSWORD']} "
+                f"oc login --username {ocsci_config.RUN['username']} "
+                f"--password {ocsci_config.RUN['kubeadmin_password']} "
                 f"{ocp_api_url} "
                 f"--kubeconfig {kubeconfig_path} "
                 "--insecure-skip-tls-verify=true"
             )
-            result = exec_cmd(cmd, secrets=(os.environ["KUBEADMIN_PASSWORD"],))
+            result = exec_cmd(cmd, secrets=(ocsci_config.RUN["kubeadmin_password"],))
             if result.returncode:
                 log.warning(f"executed command: {cmd}")
                 log.warning(f"returncode: {result.returncode}")
@@ -575,7 +578,7 @@ def process_cluster_cli_params(config):
                 log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
         else:
             log.warning(
-                "Kubeconfig doesn't exists and KUBEADMIN_PASSWORD and OCP_URL "
+                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
                 "environment variables were not provided."
             )
 

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -28,6 +28,7 @@ from ocs_ci.ocs.constants import (
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
+    ConfigurationError,
     ResourceNotFoundError,
 )
 from ocs_ci.ocs.cluster import check_clusters
@@ -541,12 +542,14 @@ def process_cluster_cli_params(config):
     if not os.path.exists(cluster_path):
         os.makedirs(cluster_path)
 
-    # create kubconfig if doesn't exists and OCP url and kubeadmin password is provided
+    # create kubeconfig if doesn't exists and OCP url and kubeadmin password is provided
     kubeconfig_path = os.path.join(
         cluster_path, ocsci_config.RUN["kubeconfig_location"]
     )
-    if not os.path.isfile(kubeconfig_path) and not get_cli_param(
-        config, "deploy", default=False
+    if not os.path.isfile(kubeconfig_path) and not (
+        get_cli_param(config, "deploy", default=False)
+        or get_cli_param(config, "teardown", default=False)
+        or get_cli_param(config, "kubeconfig")
     ):
         if ocsci_config.RUN.get("kubeadmin_password") and ocsci_config.RUN.get(
             "ocp_url"
@@ -577,7 +580,7 @@ def process_cluster_cli_params(config):
             else:
                 log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
         else:
-            log.warning(
+            raise ConfigurationError(
                 "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
                 "environment variables were not provided."
             )

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -35,6 +35,7 @@ from ocs_ci.ocs.resources.ocs import get_version_info
 from ocs_ci.ocs import utils
 from ocs_ci.utility.utils import (
     dump_config_to_file,
+    exec_cmd,
     get_ceph_version,
     get_cluster_name,
     get_cluster_version,
@@ -539,6 +540,45 @@ def process_cluster_cli_params(config):
     cluster_path = os.path.expanduser(cluster_path)
     if not os.path.exists(cluster_path):
         os.makedirs(cluster_path)
+
+    # create kubconfig if doesn't exists and OCP url and kubeadmin password is provided
+    kubeconfig_path = os.path.join(
+        cluster_path, ocsci_config.RUN["kubeconfig_location"]
+    )
+    if not os.path.isfile(kubeconfig_path) and not get_cli_param(
+        config, "deploy", default=False
+    ):
+        if os.environ.get("KUBEADMIN_PASSWORD") and os.environ.get("OCP_URL"):
+            log.info(
+                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
+            )
+            # check and correct OCP URL (change it to API url if console url provided and add port if needed
+            ocp_api_url = os.environ.get("OCP_URL").replace(
+                "console-openshift-console.apps", "api"
+            )
+            if ":6443" not in ocp_api_url:
+                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
+
+            cmd = (
+                f"oc login --username {ocsci_config.RUN['username']} --password {os.environ['KUBEADMIN_PASSWORD']} "
+                f"{ocp_api_url} "
+                f"--kubeconfig {kubeconfig_path} "
+                "--insecure-skip-tls-verify=true"
+            )
+            result = exec_cmd(cmd, secrets=(os.environ["KUBEADMIN_PASSWORD"],))
+            if result.returncode:
+                log.warning(f"executed command: {cmd}")
+                log.warning(f"returncode: {result.returncode}")
+                log.warning(f"stdout: {result.stdout}")
+                log.warning(f"stderr: {result.stderr}")
+            else:
+                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
+        else:
+            log.warning(
+                "Kubeconfig doesn't exists and KUBEADMIN_PASSWORD and OCP_URL "
+                "environment variables were not provided."
+            )
+
     # Importing here cause once the function is invoked we have already config
     # loaded, so this is OK to import once you sure that config is loaded.
     from ocs_ci.ocs.openshift_ops import OCP


### PR DESCRIPTION
If `kubeconfig` file is not provided and there is `OCP_URL` and `KUBEADMIN_PASSWORD` environment variables set, it tries to login to the OCP cluster via the provided OCP URL and `kubeadmin` password and create `kubeconfig`.

This will be helpful for tests execution in environments where the `kubeconfig` is not available and rest of the automation rely on OCP URL and `kubeadmin` password.