### PR TITLE
[RHSTOR-6624] - Missing MCG Lifecycle Configuration rules: basic tests and utils

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2441,10 +2441,10 @@ def expire_objects_in_bucket(bucket_name, object_keys=[], prefix=""):
 
 def expire_multipart_upload(upload_id):
     """
-    Expire multipart upload in a bucket by changing their creation date to one year back.
+    Expire a multipart upload by changing its creation date to one year back.
 
     Args:
-        bucket (str): The name of the bucket where the multipart upload parts reside
+        upload_id (str): The ID of the multipart upload to expire (unique across all buckets)
     """
     one_year_ago = time.time() - 60 * 60 * 24 * 365
 

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2439,25 +2439,6 @@ def expire_objects_in_bucket(bucket_name, object_keys=[], prefix=""):
     )
 
 
-def expire_parts(upload_id):
-    """
-    Expire multipart upload parts in a bucket by changing their creation date to one year back.
-
-    Args:
-        upload_id (str): The ID of the multipart upload
-
-    """
-    one_year_ago = time.time() - 60 * 60 * 24 * 365
-    psql_query = (
-        "UPDATE objectmultiparts "
-        "SET data = jsonb_set(data, '{create_time}', "
-        f"to_jsonb(to_timestamp({one_year_ago}))) "
-        f"WHERE data->>'obj' = '{upload_id}'"
-    )
-    psql_query += ";"
-    exec_nb_db_query(psql_query)
-
-
 def expire_multipart_upload(upload_id):
     """
     Expire multipart upload in a bucket by changing their creation date to one year back.

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2439,7 +2439,7 @@ def expire_objects_in_bucket(bucket_name, object_keys=[], prefix=""):
     )
 
 
-def expire_multipart_upload(upload_id):
+def expire_multipart_upload_in_noobaa_db(upload_id):
     """
     Expire a multipart upload by changing its creation date to one year back.
 

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -198,3 +198,32 @@ class ExpirationRule(LifecycleRule):
                 "ExpiredObjectDeleteMarker"
             ] = self.expire_solo_delete_markers
         return rule_dict
+
+
+class AbortIncompleteMultipartUploadRule(LifecycleRule):
+    """
+    A class for handling the parsing of an MCG object expiration rule
+    """
+
+    def __init__(
+        self,
+        days_after_initiation,
+        filter=LifecycleFilter(),
+        is_enabled=True,
+    ):
+        """
+        Constructor method for the class
+
+        Args:
+            days_after_initiation (int): Number of days after which the multipart upload will be aborted
+            filter (LifecycleFilter): Optional object filter
+        """
+        super().__init__(filter=filter, is_enabled=is_enabled)
+        self.days_after_initiation = days_after_initiation
+
+    def as_dict(self):
+        rule_dict = super().as_dict()
+        rule_dict["AbortIncompleteMultipartUpload"] = {
+            "DaysAfterInitiation": self.days_after_initiation
+        }
+        return rule_dict

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -227,3 +227,45 @@ class AbortIncompleteMultipartUploadRule(LifecycleRule):
             "DaysAfterInitiation": self.days_after_initiation
         }
         return rule_dict
+
+
+class NoncurrentVersionExpirationRule(LifecycleRule):
+    """
+    A class for handling the parsing of an MCG non-current version expiration rule
+    """
+
+    def __init__(
+        self,
+        non_current_days=None,
+        newer_non_current_versions=None,
+        filter=LifecycleFilter(),
+        is_enabled=True,
+    ):
+        """
+        Constructor method for the class
+
+        Args:
+            non_current_days (int): Number of days after which the non-current version will expire
+            newer_non_current_versions (int): Number of newer non-current versions to retain
+            filter (LifecycleFilter): Optional object filter
+            is_enabled (bool): Whether the rule is enabled or not
+        """
+        super().__init__(filter=filter, is_enabled=is_enabled)
+        self.non_current_days = non_current_days
+        self.newer_non_current_versions = newer_non_current_versions
+        if not self.non_current_days and not self.newer_non_current_versions:
+            raise ValueError(
+                "Either non_current_days or newer_non_current_versions must be set"
+            )
+
+    def as_dict(self):
+        rule_dict = super().as_dict()
+
+        d = {}
+        if self.non_current_days is not None:
+            d["NoncurrentDays"] = self.non_current_days
+        if self.newer_non_current_versions is not None:
+            d["NewerNoncurrentVersions"] = self.newer_non_current_versions
+        rule_dict["NoncurrentVersionExpiration"] = d
+
+        return rule_dict

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -27,6 +27,13 @@ class LifecyclePolicy:
                 raise TypeError(f"Rule {rule} is not of type LifecycleRule")
 
     def as_dict(self):
+        """
+        Returns the lifecycle policy as a dictionary that matches
+        the expected S3 lifecycle policy JSON format.
+
+        Note that the objects in self.rules are expected to have their own
+        as_dict() implementation.
+        """
         return {"Rules": [rule.as_dict() for rule in self.rules]}
 
     def __str__(self):
@@ -62,6 +69,10 @@ class LifecycleFilter:
         self.maxBytes = maxBytes
 
     def as_dict(self):
+        """
+        Returns the rule as a dictionary that matches
+        the expected S3 lifecycle policy JSON format
+        """
         list_of_tag_dicts = []
 
         # Initially add any criteria under the "And" key
@@ -123,6 +134,10 @@ class LifecycleRule(ABC):
         self._id = f"rule-{uuid.uuid4().hex[:8]}"
 
     def as_dict(self):
+        """
+        Returns the rule as a dictionary that matches
+        the expected S3 lifecycle policy JSON format
+        """
         rule_dict = {
             "Filter": self.filter.as_dict(),
             "ID": self._id,
@@ -182,6 +197,10 @@ class ExpirationRule(LifecycleRule):
         self.expired_object_delete_marker = expired_object_delete_marker
 
     def as_dict(self):
+        """
+        Returns the rule as a dictionary that matches
+        the expected S3 lifecycle policy JSON format
+        """
         rule_dict = super().as_dict()
 
         d = {}
@@ -222,11 +241,16 @@ class AbortIncompleteMultipartUploadRule(LifecycleRule):
         Args:
             days_after_initiation (int): Number of days after which the multipart upload will be aborted
             filter (LifecycleFilter): Optional object filter
+            is_enabled (bool): Whether the rule is enabled or not
         """
         super().__init__(filter=filter, is_enabled=is_enabled)
         self.days_after_initiation = days_after_initiation
 
     def as_dict(self):
+        """
+        Returns the rule as a dictionary that matches
+        the expected S3 lifecycle policy JSON format
+        """
         rule_dict = super().as_dict()
         rule_dict["AbortIncompleteMultipartUpload"] = {
             "DaysAfterInitiation": self.days_after_initiation
@@ -264,6 +288,10 @@ class NoncurrentVersionExpirationRule(LifecycleRule):
             )
 
     def as_dict(self):
+        """
+        Returns the rule as a dictionary that matches
+        the expected S3 lifecycle policy JSON format
+        """
         rule_dict = super().as_dict()
 
         d = {}

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -17,7 +17,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     change_versions_creation_date_in_noobaa_db,
     create_multipart_upload,
-    expire_multipart_upload,
+    expire_multipart_upload_in_noobaa_db,
     get_obj_versions,
     list_multipart_upload,
     list_objects_from_bucket,
@@ -126,7 +126,7 @@ class TestLifecycleConfiguration(MCGTest):
         )
 
         # 5. Manually expire the parts and the multipart-upload
-        expire_multipart_upload(upload_id)
+        expire_multipart_upload_in_noobaa_db(upload_id)
 
         # 6. Wait for the parts and multipart-upload to expire
         for http_response in TimeoutSampler(

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -1,0 +1,133 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    red_squad,
+    runs_on_provider,
+    mcg,
+    skipif_noobaa_external_pgsql,
+)
+from ocs_ci.framework.testlib import MCGTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import (
+    create_multipart_upload,
+    expire_multipart_upload,
+    expire_parts,
+    list_multipart_upload,
+    list_uploaded_parts,
+    upload_parts,
+)
+
+
+logger = logging.getLogger(__name__)
+
+PROP_SLEEP_TIME = 10
+
+
+@mcg
+@red_squad
+@runs_on_provider
+@skipif_noobaa_external_pgsql
+class TestObjectExpiration(MCGTest):
+    """
+    Tests suite for lifecycle configurations on MCG
+
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def reduce_expiration_interval(self, add_env_vars_to_noobaa_core_class):
+        """
+        Reduce the interval in which the lifecycle background worker is running
+
+        """
+        new_interval_in_miliseconds = 60 * 1000
+        add_env_vars_to_noobaa_core_class(
+            [(constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds)]
+        )
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-6541")
+    def test_abort_incomplete_multipart_upload(
+        self, mcg_obj, bucket_factory, awscli_pod, test_directory_setup
+    ):
+        """
+        1. Create an MCG S3 bucket
+        2. Set lifecycle configuration to abort incomplete multipart uploads after 1 day
+        3. Create a multipart upload for the bucket
+        4. Upload a few parts
+        5. Manually expire the parts
+        6. Wait for the parts to expire
+        7. Manually expire the multipart upload itself
+        8. Wait for the multipart-upload to expire
+        """
+        parts_amount = 5
+        key = "test_obj"
+        origin_dir = test_directory_setup.origin_dir
+        res_dir = test_directory_setup.result_dir
+
+        # 1. Create a bucket
+        bucket = bucket_factory(interface="OC")[0].name
+
+        # 2. Set lifecycle configuration
+        # TODO: Uncomment once the feature is available for testing
+        # lifecycle_policy = LifecyclePolicy(AbortIncompleteMultipartUploadRule(days=1))
+        # mcg_obj.s3_client.put_bucket_lifecycle_configuration(
+        #     Bucket=bucket, LifecycleConfiguration=lifecycle_policy.as_dict()
+        # )
+
+        # 3. Create a multipart upload
+        upload_id = create_multipart_upload(mcg_obj, bucket, key)
+
+        # 4. Upload a few parts
+        awscli_pod.exec_cmd_on_pod(
+            f'sh -c "dd if=/dev/urandom of={origin_dir}/{key} bs=1MB count={parts_amount}; '
+            f'split -b 1m  {origin_dir}/{key} {res_dir}/part"'
+        )
+        parts = awscli_pod.exec_cmd_on_pod(f'sh -c "ls -1 {res_dir}"').split()
+        upload_parts(
+            mcg_obj,
+            awscli_pod,
+            bucket,
+            key,
+            res_dir,
+            upload_id,
+            parts,
+        )
+
+        # 5. Manually expire the parts
+        expire_parts(upload_id)
+        list_uploaded_parts(mcg_obj, bucket, key, upload_id)
+
+        # 6. Wait for the parts to expire
+        # TODO: Uncomment once the feature is available for testing
+        # for parts_dict in TimeoutSampler(
+        #     timeout=180,
+        #     sleep=PROP_SLEEP_TIME,
+        #     func=list_uploaded_parts,
+        #     s3_obj=mcg_obj,
+        #     bucketname=bucket,
+        #     object_key=key,
+        #     upload_id=upload_id,
+        # ):
+        #     if len(parts_dict) == 0:
+        #         break
+        #     logger.warning(f"Parts have not expired yet: \n{parts_dict}")
+
+        # 7. Manually expire the multipart upload itself
+        expire_multipart_upload(upload_id)
+        list_multipart_upload(mcg_obj, bucket)
+
+        # 8. Wait for the multipart-upload to expire
+        # TODO: Uncomment once the feature is available for testing
+        # for upload in TimeoutSampler(
+        #     timeout=180,
+        #     sleep=PROP_SLEEP_TIME,
+        #     func=list_multipart_upload,
+        #     s3_obj=mcg_obj,
+        #     bucketname=bucket,
+        # ):
+        #     if len(upload) == 0:
+        #         break
+        #     logger.warning(f"Upload has not expired yet: \n{upload}")

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -59,6 +59,10 @@ class TestLifecycleConfiguration(MCGTest):
         """
         Reduce the interval in which the lifecycle background worker is running
 
+        Args:
+            add_env_vars_to_noobaa_core_class (function): Factory fixture for adding environment variables
+            to the noobaa-core statefulset
+
         """
         new_interval_in_miliseconds = 60 * 1000
         add_env_vars_to_noobaa_core_class(

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import json
 import logging
 from time import sleep
 
@@ -17,28 +18,30 @@ from ocs_ci.ocs.bucket_utils import (
     change_versions_creation_date_in_noobaa_db,
     create_multipart_upload,
     expire_multipart_upload,
-    expire_parts,
     get_obj_versions,
     list_multipart_upload,
-    list_uploaded_parts,
+    list_objects_from_bucket,
     put_bucket_versioning_via_awscli,
+    s3_delete_object,
+    s3_list_object_versions,
     upload_obj_versions,
     upload_parts,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.resources.mcg_lifecycle_policies import (
     AbortIncompleteMultipartUploadRule,
+    ExpirationRule,
     LifecyclePolicy,
     NoncurrentVersionExpirationRule,
 )
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import TimeoutSampler, exec_nb_db_query
 
 
 logger = logging.getLogger(__name__)
 
 PROP_SLEEP_TIME = 10
 TIMEOUT_SLEEP_DURATION = 30
-TIMEOUT_THRESHOLD = 420
+TIMEOUT_THRESHOLD = 600
 
 
 @mcg
@@ -59,7 +62,10 @@ class TestLifecycleConfiguration(MCGTest):
         """
         new_interval_in_miliseconds = 60 * 1000
         add_env_vars_to_noobaa_core_class(
-            [(constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds)]
+            [
+                (constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds),
+                (constants.LIFECYCLE_SCHED_MINUTES, 1),
+            ]
         )
 
     @tier1
@@ -72,11 +78,12 @@ class TestLifecycleConfiguration(MCGTest):
         2. Set lifecycle configuration to abort incomplete multipart uploads after 1 day
         3. Create a multipart upload for the bucket
         4. Upload a few parts
-        5. Manually expire the parts and the multipart-upload
-        6. Wait for the parts and multipart-upload to expire
+        5. Manually expire the multipart-upload
+        6. Wait for the multipart-upload to expire
+        7. Verify that the parts were deleted at the noobaa-db
         """
         parts_amount = 5
-        key = "test_obj"
+        key = "test_obj_123"
         origin_dir = test_directory_setup.origin_dir
         res_dir = test_directory_setup.result_dir
 
@@ -115,49 +122,47 @@ class TestLifecycleConfiguration(MCGTest):
         )
 
         # 5. Manually expire the parts and the multipart-upload
-        expire_parts(upload_id)
         expire_multipart_upload(upload_id)
 
-        # 7. Wait for the parts and multipart-upload to expire
-        # TODO: Unify this part(?)
-        for parts_dict in TimeoutSampler(
-            timeout=TIMEOUT_THRESHOLD,
-            sleep=PROP_SLEEP_TIME,
-            func=list_uploaded_parts,
-            s3_obj=mcg_obj,
-            bucketname=bucket,
-            object_key=key,
-            upload_id=upload_id,
-        ):
-            if len(parts_dict) == 0:
-                break
-            logger.warning(f"Parts have not expired yet: \n{parts_dict}")
-
-        for upload in TimeoutSampler(
+        # 6. Wait for the parts and multipart-upload to expire
+        for http_response in TimeoutSampler(
             timeout=TIMEOUT_THRESHOLD,
             sleep=TIMEOUT_SLEEP_DURATION,
             func=list_multipart_upload,
             s3_obj=mcg_obj,
             bucketname=bucket,
         ):
-            if len(upload) == 0:
+            if "Uploads" not in http_response or len(http_response["Uploads"]) == 0:
                 break
-            logger.warning(f"Upload has not expired yet: \n{upload}")
+            logger.warning(f"Upload has not expired yet: \n{http_response}")
+
+        # 7. Verify that the parts were deleted at the noobaa-db
+        bucket_id = exec_nb_db_query(
+            f"SELECT _id FROM buckets WHERE data->>'name' = '{bucket}'",
+        )[0].strip()
+        multiparts_md_list = exec_nb_db_query(
+            f"SELECT data FROM objectmultiparts WHERE data->>'bucket' = '{bucket_id}'"
+        )
+        for md_string in multiparts_md_list:
+            md = json.loads(md_string)
+            assert (
+                "deleted" in md
+            ), f"Multipart upload was not expired as expected: {md}"
 
     @tier1
     @pytest.mark.polarion_id("OCS-6559")
-    def test_noncurrent_version_expiration_non_current_days(
-        self, mcg_obj, bucket_factory, awscli_pod
-    ):
+    def test_noncurrent_version_expiration(self, mcg_obj, bucket_factory, awscli_pod):
         """
         1. Create an MCG bucket with versioning enabled
-        2. Set lifecycle configuration to delete non-current versions after 5 days
+        2. Set lifecycle configuration to delete non-current versions after 5 days and
+        keep 7 newer non-current versions
         3. Upload versions
         4. Manually set the age of each version to be one day older than its successor
-        5. Wait for the older versions to expire
+        5. Wait for versions to expire
         """
         key = "test_obj"
         older_versions_amount = 5
+        newer_versions_amount = 7
 
         # 1. Create an MCG bucket with versioning enabled
         bucket = bucket_factory(interface="OC")[0].name
@@ -165,7 +170,10 @@ class TestLifecycleConfiguration(MCGTest):
 
         # 2. Set lifecycle configuration
         lifecycle_policy = LifecyclePolicy(
-            NoncurrentVersionExpirationRule(non_current_days=5)
+            NoncurrentVersionExpirationRule(
+                non_current_days=older_versions_amount,
+                newer_non_current_versions=newer_versions_amount,
+            )
         )
         mcg_obj.s3_client.put_bucket_lifecycle_configuration(
             Bucket=bucket, LifecycleConfiguration=lifecycle_policy.as_dict()
@@ -205,10 +213,13 @@ class TestLifecycleConfiguration(MCGTest):
                 ).timestamp(),
             )
 
-        # 5. Wait for the older versions to expire
-        original = set(version_ids)
-        older = set(version_ids[-older_versions_amount:])
-        newer = original - older
+        # 5. Wait for versions to expire
+        # While older_versions_amount versions qualify for deletion due to
+        # NoncurrentDays, the lifecycle policy should keep the NewerNoncurrentVersions
+        # amount of versions.
+        expected_remaining = set(
+            version_ids[: newer_versions_amount + 1]
+        )  # +1 for the current version
 
         for versions in TimeoutSampler(
             timeout=TIMEOUT_THRESHOLD,
@@ -220,21 +231,135 @@ class TestLifecycleConfiguration(MCGTest):
             obj_key=key,
         ):
             remaining = {v["VersionId"] for v in versions}
-            if remaining == newer:
-                logger.info("Only the older versions expired as expected")
+
+            # Expected end result
+            if remaining == expected_remaining:
+                logger.info("Only the expected versions remained")
                 break
-            elif not (newer <= remaining):
+
+            # Newer versions were deleted
+            elif not (expected_remaining <= remaining):
                 raise UnexpectedBehaviour(
                     (
-                        "Some newer versions were deleted when they shouldn't have!"
-                        f"Newer versions that were deleted: {newer - remaining}"
+                        "Some versions were deleted when they shouldn't have!"
+                        f"Versions that were deleted: {expected_remaining - remaining}"
                     )
                 )
+
+            # Some older versions are yet to be deleted
             else:
                 logger.warning(
                     (
                         "Some older versions have not expired yet:\n"
                         f"Remaining: {remaining}\n"
-                        f"Versions yet to expire: {remaining - newer}"
+                        f"Versions yet to expire: {remaining - expected_remaining}"
                     )
                 )
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-6802")
+    def test_expired_object_delete_marker(self, mcg_obj, bucket_factory, awscli_pod):
+        """
+        1. Create an MCG bucket with versioning enabled
+        2. Set onto the bucket a lifecycle configuration with ExpiredObjectDeleteMarker set to true
+        3. Upload a few versions for the same object
+        4. Delete the object, resulting in the creation of a delete marker
+        5. Verify the creation of the delete marker
+        6. Delete all the non-delete-marker versions by their VersionId
+        7. Wait for the delete marker to get deleted
+        8. Verify that the object no longer shows when listing the bucket
+        """
+        key = "test_obj"
+
+        # 1. Create an MCG bucket with versioning enabled
+        bucket = bucket_factory(interface="OC")[0].name
+        put_bucket_versioning_via_awscli(mcg_obj, awscli_pod, bucket)
+
+        # 2. Set lifecycle configuration
+        lifecycle_policy = LifecyclePolicy(
+            ExpirationRule(expired_object_delete_marker=True)
+        )
+        mcg_obj.s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket, LifecycleConfiguration=lifecycle_policy.as_dict()
+        )
+        logger.info(
+            f"Sleeping for {PROP_SLEEP_TIME} seconds to let the policy propagate"
+        )
+        sleep(PROP_SLEEP_TIME)
+
+        # 3. Upload a few versions for the same object
+        upload_obj_versions(
+            mcg_obj,
+            awscli_pod,
+            bucket,
+            key,
+            amount=5,
+        )
+
+        # 4. Delete the object, resulting in the creation of a delete marker
+        s3_delete_object(
+            mcg_obj,
+            bucket,
+            key,
+        )
+
+        # 5. Verify the creation of the delete marker
+        raw_versions = s3_list_object_versions(
+            mcg_obj,
+            bucket,
+            key,
+        )
+        delete_markers = raw_versions.get("DeleteMarkers", [])
+        assert (
+            len(delete_markers) == 1 and delete_markers[0]["IsLatest"]
+        ), "Object was deleted but delete marker was not created"
+
+        # 6. Delete all the non-delete-marker versions by their VersionId
+        version_ids = [
+            v["VersionId"] for v in get_obj_versions(mcg_obj, awscli_pod, bucket, key)
+        ]
+        for v_id in version_ids:
+            s3_delete_object(
+                s3_obj=mcg_obj,
+                bucketname=bucket,
+                object_key=key,
+                versionid=v_id,
+            )
+
+        # 7. Wait for the delete marker to get deleted
+        for raw_versions in TimeoutSampler(
+            timeout=TIMEOUT_THRESHOLD,
+            sleep=TIMEOUT_SLEEP_DURATION,
+            func=s3_list_object_versions,
+            s3_obj=mcg_obj,
+            bucketname=bucket,
+            prefix=key,
+        ):
+            delete_markers = raw_versions.get("DeleteMarkers", [])
+            if len(delete_markers) == 0:
+                logger.info("Delete marker expired as expected")
+                break
+            else:
+                logger.warning(
+                    (
+                        "Delete marker has not expired yet:\n"
+                        f"Remaining: {delete_markers}\n"
+                    )
+                )
+
+        # 8. Verify that the object no longer shows when listing the bucket
+        objects_listed = list_objects_from_bucket(
+            pod_obj=awscli_pod,
+            target=bucket,
+            s3_obj=mcg_obj,
+        )
+        assert len(objects_listed) == 0, "Object still shows when listing the bucket"
+
+        versions_listed = s3_list_object_versions(
+            mcg_obj,
+            bucket,
+        )
+        assert key not in str(
+            versions_listed
+        ), "Object still shows when listing the bucket versions"
+        logger.info("Object was deleted as expected")


### PR DESCRIPTION
This PR adds the happy path coverage for the additional S3 lifecycle configuration options that are being added to MCG in https://issues.redhat.com/browse/RHSTOR-6624:
- `test_abort_incomplete_multipart_upload` - tests the option to auto-abort multipart uploads that have not been completed within a certain number of days
- `test_noncurrent_version_expiration` - tests the option to expire non-current versions based on time and the number of existing versions
- `test_expired_object_delete_marker` - tests the option to automatically delete delete markers when no current version of the object exists 
