### PR TITLE
Fix oc debug PodSecurity violation by setting namespace to 'default'

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1225,7 +1225,9 @@ class Deployment(object):
                 for node in worker_nodes:
                     for interface in interfaces:
                         ip_link_cmd = f"ip link set promisc on {interface}"
-                        node_obj.exec_oc_debug_cmd(node=node, cmd_list=[ip_link_cmd])
+                        node_obj.exec_oc_debug_cmd(
+                            node=node, cmd_list=[ip_link_cmd], namespace="default"
+                        )
 
             if create_public_net:
                 nad_to_load = constants.MULTUS_PUBLIC_NET_YAML

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = flake8 ocs_ci tests
 
 [flake8]
 basepython = python3
-ignore = E203, E402, E741, W503
+ignore = E203, E402, E741, W503, F824
 enable-extensions = M511
 exclude =
     venv,

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = flake8 ocs_ci tests
 
 [flake8]
 basepython = python3
-ignore = E203, E402, E741, W503, F824
+ignore = E203, E402, E741, W503
 enable-extensions = M511
 exclude =
     venv,


### PR DESCRIPTION
Fix #11775 
Set the namespace="default" in exec_oc_debug_cmd to avoid PodSecurity violations in restricted namespaces like openshift-storage. The debug command now runs successfully using the default namespace.

Debug node on openshift-storage before OCS installation:
```
$ oc debug nodes/compute-0 --to-namespace=openshift-storage  -- chroot /host /bin/bash -c "ip link set promisc on ens224 || echo \'CMD FAILED\';" --overwrite
error: PodSecurity violation error:
Ensure the target namespace has the appropriate security level set or consider creating a dedicated privileged namespace using:
	"oc create ns <namespace> -o yaml | oc label -f - security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite".

Original error:
pods "compute-0-debug-cnh2x" is forbidden: violates PodSecurity "restricted:latest": host namespaces (hostNetwork=true, hostPID=true, hostIPC=true), privileged (container "container-00" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "container-00" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "container-00" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "container-00" must set securityContext.runAsNonRoot=true), runAsUser=0 (container "container-00" must not set runAsUser=0), seccompProfile (pod or container "container-00" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Debug node on `deafult` namespace:
```
$  oc debug nodes/compute-0 --to-namespace=default  -- chroot /host /bin/bash -c "ip link set promisc on ens224 || echo 'CMD FAILED'; "
Starting pod/compute-0-debug-zxqg7 ...
To use host binaries, run `chroot /host`

Removing debug pod ...

```