### PR TITLE
extend timeout in mce check_supported_versions

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -188,7 +188,7 @@ class MCEInstaller(object):
 
         if not configmaps_obj.check_resource_existence(
             should_exist=True,
-            timeout=60,
+            timeout=120,
             resource_name=constants.SUPPORTED_VERSIONS_CONFIGMAP,
         ):
             raise UnavailableResourceException(


### PR DESCRIPTION
Trying to extend the timeout for `check_resource_existence` in `mce` `check_supported_versions`, because the deployment is failing like this:
```
08:12:26 - MainThread - ocs_ci.ocs.ocp - WARNING  - Failed to get resource: supported-versions of kind: ConfigMap, selector: None, Error: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n hypershift get ConfigMap supported-versions -n hypershift -o yaml.
Error is Error from server (NotFound): configmaps "supported-versions" not found

08:12:26 - MainThread - ocs_ci.ocs.ocp - WARNING  - Number of attempts to get resource reached!
08:12:26 - MainThread - ocs_ci.ocs.ocp - INFO  - Resource: 'supported-versions', selector: 'None' was not found.
08:12:26 - MainThread - ocs_ci.ocs.ocp - ERROR  -  did not reach the expected state within the time limit.
```

While the resource seems to be created two seconds after the check (the log above is using different timezone than the cluster itself):

```
$  oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n hypershift get ConfigMap supported-versions -n hypershift -o yaml
apiVersion: v1
data:
  server-version: 5337df1bbc15958173d877e70260f63ec0a25002
  supported-versions: '{"versions":["4.18","4.17","4.16","4.15","4.14"]}'
kind: ConfigMap
metadata:
  creationTimestamp: "2025-03-31T12:12:28Z"
  labels:
    hypershift.openshift.io/supported-versions: "true"
  name: supported-versions
  namespace: hypershift
  resourceVersion: "61120" 
  uid: 2064cd85-d4b6-43bf-9133-80fe424d8050
```
