### PR TITLE
fix wait for supported-versionslonger cm

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -188,7 +188,7 @@ class MCEInstaller(object):
 
         if not configmaps_obj.check_resource_existence(
             should_exist=True,
-            timeout=60,
+            timeout=120,
             resource_name=constants.SUPPORTED_VERSIONS_CONFIGMAP,
         ):
             raise UnavailableResourceException(


### PR DESCRIPTION
make check_resource_existence for supported-versions cm longer
prevent failure: 

``` 
2025-03-31 14:12:26  08:12:26 - MainThread - ocs_ci.ocs.ocp - WARNING  - Failed to get resource: supported-versions of kind: ConfigMap, selector: None, Error: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n hypershift get ConfigMap supported-versions -n hypershift -o yaml.
2025-03-31 14:12:26  Error is Error from server (NotFound): configmaps "supported-versions" not found
2025-03-31 14:12:26  
2025-03-31 14:12:26  08:12:26 - MainThread - ocs_ci.ocs.ocp - WARNING  - Number of attempts to get resource reached!
2025-03-31 14:12:26  08:12:26 - MainThread - ocs_ci.ocs.ocp - INFO  - Resource: 'supported-versions', selector: 'None' was not found.
2025-03-31 14:12:26  08:12:26 - MainThread - ocs_ci.ocs.ocp - ERROR  -  did not reach the expected state within the time limit.
```

```
2025-03-31 14:12:26  08:12:26 - MainThread - ocs_ci.ocs.ocp - ERROR  -  did not reach the expected state within the time limit.
is surely 2 seconds before:
  creationTimestamp: "2025-03-31T12:12:28Z"
```