### PR TITLE
Skip status-reporter type of pod in rpm package collection

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -600,6 +600,7 @@ NB_DB_NAME_46_AND_BELOW = "noobaa-db-0"
 NB_DB_NAME_47_AND_ABOVE = "noobaa-db-pg-0"
 REPORT_STATUS_TO_PROVIDER_POD = "report-status-to-provider-"
 ROOK_CEPH_OSD_PREPARE = "rook-ceph-osd-prepare"
+STATUS_REPORTER = "status-reporter"
 
 # Pod label
 MON_APP_LABEL = "app=rook-ceph-mon"

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1931,6 +1931,7 @@ def collect_pod_container_rpm_package(dir_name):
             constants.CONTROLLER_DETECT_VERSION_NAME,
             constants.OSD_KEY_ROTATION_POD_NAME,
             constants.ROOK_CEPH_DETECT_VERSION_POD_NAME,
+            constants.STATUS_REPORTER,
         )
         if any(pod in pod_obj.name for pod in ignore_pods):
             continue


### PR DESCRIPTION
The pods with name "status-reporter" will have its expected state as Completed and may automatically removed from the cluster. By the time of getting RPM package after collecting the pod list, these pods might have gone from the cluster. This will trigger NotFound error.
Fixes #11626 