### PR TITLE
Change wording of obc creation rule

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3134,7 +3134,7 @@ UI_INPUT_RULES_OBJECT_BUCKET_CLAIM = {
     "rule1": UI_INPUT_RULES_GENERAL["rule4"],
     "rule2": UI_INPUT_RULES_GENERAL["rule1"],
     "rule3": UI_INPUT_RULES_GENERAL["rule2"],
-    "rule4": UI_INPUT_RULES_GENERAL["rule3"],
+    "rule4": "Cannot be used before within the same namespace",
 }
 
 UI_INPUT_RULES_NAMESPACE_STORE = {

--- a/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
+++ b/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
@@ -377,7 +377,7 @@ class CreateResourceForm(PageNavigator):
                 text,
             )
 
-        allowed_chars = string.ascii_lowercase + string.digits + "-."
+        allowed_chars = string.ascii_lowercase + string.digits + "-"
         allowed_chars = replace_consecutive_symbols(allowed_chars, "-")
         allowed_chars = replace_consecutive_symbols(allowed_chars, ".")
 


### PR DESCRIPTION
fixes failing test_error_improvements.py::TestErrorMessageImprovements::test_obc_creation_rules as the wording of the 'not used before' rule changed in 4.19 https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/48762/consoleFull