### PR TITLE
Upgrade boto3 version and add dynamic boto3 region change for AWS buckets to `cloud_manager.py`

### DIFF
--- a/ocs_ci/ocs/resources/boto3_wrapper.py
+++ b/ocs_ci/ocs/resources/boto3_wrapper.py
@@ -1,0 +1,176 @@
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+logger = logging.getLogger(name=__file__)
+
+
+class BaseBoto3Wrapper:
+    """
+    A base class for wrapping the boto3 S3 client to allow for method-level adjustments
+    """
+
+    def __init__(
+        self,
+        verify=True,
+        endpoint_url=None,
+        access_key=None,
+        secret_key=None,
+        region_name=None,
+        *args,
+        **kwargs,
+    ):
+        self.verify = verify
+        self.endpoint_url = endpoint_url
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.region_name = region_name
+
+        # Create both client and resource
+        self._initialize_client_and_resource()
+        self._wrap_methods()
+
+    def _initialize_client_and_resource(self):
+        """
+        Initialize both client and resource interfaces
+        """
+        common_params = {
+            "verify": self.verify,
+            "endpoint_url": self.endpoint_url,
+            "aws_access_key_id": self.access_key,
+            "aws_secret_access_key": self.secret_key,
+            "region_name": self.region_name,
+        }
+
+        self.boto3_client = boto3.client("s3", **common_params)
+        self.boto3_resource = boto3.resource("s3", **common_params)
+        self.buckets = self.boto3_resource.buckets
+        self.meta = self.boto3_resource.meta
+
+    def _wrap_methods(self):
+        """
+        Wraps callable methods with error handling and region adjustment
+        """
+        # Wrap client methods
+        for method_name in dir(self.boto3_client):
+            if callable(
+                getattr(self.boto3_client, method_name)
+            ) and not method_name.startswith("_"):
+                wrapped_method = self._create_wrapper(self.boto3_client, method_name)
+                setattr(self, method_name, wrapped_method)
+
+    def _create_wrapper(self, obj, method_name):
+        """
+        A default wrapper function that does nothing.
+        This is a placeholder and a demonstration of how to wrap methods.
+        """
+        method = getattr(obj, method_name)
+
+        def wrapper(*args, **kwargs):
+            return method(*args, **kwargs)
+
+        return wrapper
+
+    def Bucket(self, name):
+        return self.boto3_resource.Bucket(name)
+
+
+class Boto3WrapperForAWS(BaseBoto3Wrapper):
+    """
+    Wraps boto3 S3 client and resource to handle region-specific issues,
+    such as the 301 Moved Permanently error.
+    """
+
+    def __init__(
+        self,
+        verify=True,
+        endpoint_url=None,
+        access_key=None,
+        secret_key=None,
+        region_name=None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            verify=verify,
+            endpoint_url=endpoint_url,
+            access_key=access_key,
+            secret_key=secret_key,
+            region_name=region_name,
+            *args,
+            **kwargs,
+        )
+        self.default_region = region_name
+        self.default_endpoint = endpoint_url
+
+    def _create_wrapper(self, obj, method_name):
+        """
+        Creates a wrapper function that handles the 301 error and updates the region
+        if necessary.
+        """
+        method = getattr(obj, method_name)
+
+        def wrapper(*args, **kwargs):
+            try:
+                return method(*args, **kwargs)
+            except ClientError as e:
+                response_md = e.response.get("ResponseMetadata", {})
+                error_code = e.response.get("Error", {}).get("Code")
+
+                if response_md.get("HTTPStatusCode") == 301:
+                    region = response_md.get("HTTPHeaders", {}).get(
+                        "x-amz-bucket-region"
+                    )
+                    # A specific region and endpoint are required
+                    self.update_region_and_endpoint(region)
+
+                elif error_code == "IllegalLocationConstraintException":
+                    # The defaults are required
+                    self.update_region_and_endpoint(None)
+
+                else:
+                    logger.error(f"ClientError: {e}")
+                    raise
+
+                # Common retry logic for both region change cases
+                new_method = getattr(self.boto3_client, method_name)
+                return new_method(*args, **kwargs)
+
+        return wrapper
+
+    def Bucket(self, name):
+        try:
+            return self.boto3_resource.Bucket(name)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "301":
+                region = e.response["ResponseMetadata"]["HTTPHeaders"][
+                    "x-amz-bucket-region"
+                ]
+                logger.info(
+                    f"Bucket is in {region} but client is using {self.endpoint_url} "
+                )
+
+                # Retry with the new resource
+                self.update_region_and_endpoint(region)
+                return self.boto3_resource.Bucket(name)
+
+            else:
+                logger.error(f"ClientError: {e}")
+                raise
+
+    def update_region_and_endpoint(self, region):
+        """
+        Update the region for the S3 client and resource.
+
+        Args:
+            region (str): The new region to set.
+        """
+        self.region_name = region if region else self.default_region
+        self.endpoint_url = (
+            f"https://s3.{region}.amazonaws.com" if region else self.default_endpoint
+        )
+        logger.info(f"Updating to region and endpoint: {region}, {self.endpoint_url}")
+        self._initialize_client_and_resource()
+        self._wrap_methods()

--- a/ocs_ci/ocs/resources/boto3_wrapper.py
+++ b/ocs_ci/ocs/resources/boto3_wrapper.py
@@ -16,16 +16,16 @@ class BaseBoto3Wrapper:
         self,
         verify=True,
         endpoint_url=None,
-        access_key=None,
-        secret_key=None,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
         region_name=None,
         *args,
         **kwargs,
     ):
         self.verify = verify
         self.endpoint_url = endpoint_url
-        self.access_key = access_key
-        self.secret_key = secret_key
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
         self.region_name = region_name
 
         # Create both client and resource
@@ -39,8 +39,8 @@ class BaseBoto3Wrapper:
         common_params = {
             "verify": self.verify,
             "endpoint_url": self.endpoint_url,
-            "aws_access_key_id": self.access_key,
-            "aws_secret_access_key": self.secret_key,
+            "aws_access_key_id": self.aws_access_key_id,
+            "aws_secret_access_key": self.aws_secret_access_key,
             "region_name": self.region_name,
         }
 
@@ -87,8 +87,8 @@ class Boto3WrapperForAWS(BaseBoto3Wrapper):
         self,
         verify=True,
         endpoint_url=None,
-        access_key=None,
-        secret_key=None,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
         region_name=None,
         *args,
         **kwargs,
@@ -96,8 +96,8 @@ class Boto3WrapperForAWS(BaseBoto3Wrapper):
         super().__init__(
             verify=verify,
             endpoint_url=endpoint_url,
-            access_key=access_key,
-            secret_key=secret_key,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
             region_name=region_name,
             *args,
             **kwargs,

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -237,8 +237,8 @@ class S3Client(CloudClient):
         self.client = s3_client_wrapper(
             verify=verify,
             endpoint_url=self.endpoint,
-            access_key=self.access_key,
-            secret_key=self.secret_key,
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
             region=self.region,
         )
         self.secret = self.create_s3_secret(self.secret_prefix, self.data_prefix)
@@ -453,13 +453,13 @@ class GoogleClient(CloudClient):
 
     def verify_uls_exists(self, uls_name):
         """
-        Verifies whether a Underlying Storage with the given uls_name exists
+            Verifies whether a Underlying Storage with the given uls_name exists
 
         Args:
-           uls_name (str): The Underlying Storage name to be verified
+               uls_name (str): The Underlying Storage name to be verified
 
-        Returns:
-             bool: True if Underlying Storage exists, False otherwise
+            Returns:
+                 bool: True if Underlying Storage exists, False otherwise
 
         """
         try:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -27,6 +27,7 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedPlatformError,
 )
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.boto3_wrapper import Boto3WrapperForAWS
 from ocs_ci.ocs.resources.pod import (
     get_noobaa_pods,
     get_pods_having_label,
@@ -162,8 +163,7 @@ class MCG:
                 self.aws_access_key,
             ) = self.request_aws_credentials()
 
-            self.aws_s3_resource = boto3.resource(
-                "s3",
+            self.aws_s3_resource = Boto3WrapperForAWS(
                 endpoint_url="https://s3.amazonaws.com",
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_access_key,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pyyaml>=4.2b1",
         "jinja2==3.1.6",
         "openshift==0.11.2",
-        "boto3==1.24.96",
+        "boto3==1.37.24",
         "munch==2.5.0",
         "pytest-progress==1.2.5",
         "pytest==6.2.5",

--- a/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 
-import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
@@ -18,6 +17,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import bucket_utils
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.boto3_wrapper import Boto3WrapperForAWS
 
 logger = logging.getLogger(__name__)
 
@@ -461,8 +461,7 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         obj_versions = []
         version_key = "ObjKey-" + str(uuid.uuid4().hex)
         total_versions = 10
-        aws_s3_resource = boto3.resource(
-            "s3",
+        aws_s3_client = Boto3WrapperForAWS(
             endpoint_url=constants.MCG_NS_AWS_ENDPOINT,
             aws_access_key_id=cld_mgr.aws_client.access_key,
             aws_secret_access_key=cld_mgr.aws_client.secret_key,
@@ -475,7 +474,6 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         )[0]
         ns_bucket = ns_buc.name
         namespace_res = ns_buc.bucketclass.namespacestores[0].uls_name
-        aws_s3_client = aws_s3_resource.meta.client
 
         # Put, Get bucket versioning and verify
         logger.info(f"Enabling bucket versioning on resource bucket: {namespace_res}")


### PR DESCRIPTION
Fixes: #9294

Changes:
- Upgrade boto3 to the latest version
- Under `cloud_manager.py::S3Client` - use a wrapper class that uses boto3 via composition to dynamically recreate the boto3 client/resource when commands are failing due to region issues.
- Standardize the use of the new wrapper class under `cloud_manager.py::S3Client`

Note that IBMCOS and RGW buckets are both also managed by instances of the `cloud_manager.py::S3Client` class, and that these changes were made so the way they are managed is not affected.