### PR TITLE
add @retry to mirror_index_image_via_oc_mirror

### DIFF
--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, NotFoundError
 from ocs_ci.ocs.resources.catalog_source import CatalogSource, disable_default_sources
 from ocs_ci.utility.deployment import get_and_apply_icsp_from_catalog
 from ocs_ci.utility import templating
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
     create_directory_path,
     exec_cmd,
@@ -215,6 +216,7 @@ def prune_and_mirror_index_image(
     return cs_file
 
 
+@retry((CommandFailed,), tries=3, delay=10, backoff=2)
 def mirror_index_image_via_oc_mirror(index_image, packages, icsp=None):
     """
     Mirror all images required for ODF deployment and testing to mirror

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -216,7 +216,7 @@ def prune_and_mirror_index_image(
     return cs_file
 
 
-@retry((CommandFailed,), tries=3, delay=10, backoff=2)
+@retry((CommandFailed, NotFoundError), tries=3, delay=10, backoff=2)
 def mirror_index_image_via_oc_mirror(index_image, packages, icsp=None):
     """
     Mirror all images required for ODF deployment and testing to mirror


### PR DESCRIPTION
The aim of this change is to prevent failures like this: https://url.corp.redhat.com/41607b4
```
[2025-03-31T09:12:21.070Z] E               error: unable to retrieve source image registry.redhat.io/odf4/odf-cosi-sidecar-rhel9 manifest sha256:c510d8c75abb7aa0c60d05ede47c4b12bdc4491b1520cc007cccba5f5cf5057b: received unexpected HTTP status: 502 Bad Gateway
[2025-03-31T09:12:21.070Z] E               error: an error occurred during planning
[2025-03-31T09:12:21.070Z] 
[2025-03-31T09:12:21.070Z] ocs_ci/utility/utils.py:722: CommandFailed
```

This approach will most probably not solve all possible issues with mirroring packages via oc mirror command, the main reason is that we are not able to apply ICSP/IDMS rules during the mirroring process via `oc mirror` command, so some of the images from `ocs-registry` are not actually available (which causes failure of the oc mirror command which we have to ignore) and we have to mirror them separately one by one.
