### PR TITLE
storage claim removal

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -216,7 +216,9 @@ VOLUME_REPLICATION_GROUP = "VolumeReplicationGroup"
 RECLAIMSPACECRONJOB = "reclaimspacecronjob"
 LVMCLUSTER = "odf-lvmcluster"
 LVMSCLUSTER = "lvmscluster"
+# Deprecated in favour of StorageClaim starting from 4.16
 STORAGECLASSCLAIM = "StorageClassClaim"
+# Deprecated and data moved to StorageClient starting from 4.19
 STORAGECLAIM = "StorageClaim"
 STORAGECONSUMER = "StorageConsumer"
 MACHINEHEALTHCHECK = "machinehealthcheck"

--- a/ocs_ci/ocs/resources/storage_client.py
+++ b/ocs_ci/ocs/resources/storage_client.py
@@ -11,6 +11,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.utils import enable_console_plugin
+from ocs_ci.ocs.version import if_version
 from ocs_ci.utility import templating, version
 from ocs_ci.utility.retry import retry
 from ocs_ci.helpers.managed_services import (
@@ -297,6 +298,7 @@ class StorageClient:
             )
             self.ocp_obj.exec_oc_cmd(f"apply -f {storage_classclaim_data_yaml.name}")
 
+    @if_version("<4.19")
     @retry(AssertionError, 20, 10, 1)
     def verify_storage_claim_status(
         self,

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -2346,9 +2346,9 @@ def verify_consumer_resources():
     ocs_version = version.get_semantic_ocs_version_from_config()
 
     # Verify the default Storageclassclaims
-    if ocs_version >= version.VERSION_4_11:
+    if version.VERSION_4_16 <= ocs_version < version.VERSION_4_19:
         storage_class_claim = OCP(
-            kind=constants.STORAGECLASSCLAIM,
+            kind=constants.STORAGECLAIM,
             namespace=config.ENV_DATA["cluster_namespace"],
         )
         for sc_claim in [

--- a/ocs_ci/ocs/resources/storageclassclaim.py
+++ b/ocs_ci/ocs/resources/storageclassclaim.py
@@ -10,6 +10,7 @@ from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.version import if_version
 from ocs_ci.utility import templating
 
 log = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ class StorageClassClaim(OCS):
         return self.data.get("spec").get("type")
 
 
+@if_version("<4.19")
 def create_storageclassclaim(
     interface_type,
     storage_class_claim_name=None,

--- a/tests/functional/storageclass/test_storageclassclaim.py
+++ b/tests/functional/storageclass/test_storageclassclaim.py
@@ -20,11 +20,15 @@ log = logging.getLogger(__name__)
 @yellow_squad
 @tier1
 @polarion_id("OCS-4628")
-@skipif_ocs_version("<4.11")
+@skipif_ocs_version(["<4.11", ">4.16"])
 @pc_or_ms_consumer_required
 class TestStorageClassClaim(ManageTest):
     """
     Tests to verify storageclassclaim
+
+    ! Important. StorageClassClaim was deprecated in ODF 4.16 in favor of StorageClaim.
+    ! StorageClaim was deprecated in ODF 4.19 with data stored in StorageClient
+    ! To delete when reached EOL of ODF 4.16
     """
 
     def test_verify_storageclassclaim(


### PR DESCRIPTION
With change in this dev PR https://github.com/red-hat-storage/ocs-client-operator/pull/302 we are removing use of StorageClaim.
Important! StorageClaim on upgraded clusters will not be automatically removed, but will stop to reconcile