### PR TITLE
storage request removal

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -279,7 +279,7 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                 check_phase_of_rados_namespace()
             ), "The radosnamespace is not in Ready phase"
 
-            # Validate storageclassrequests created
+            # Validate storageclasses created
             storage_class_classes = get_all_storageclass_names()
             for storage_class in self.storage_class_claims:
                 assert (

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -5877,6 +5877,9 @@ def find_cephblockpoolradosnamespace(storageclient_uid=None):
     Find the cephblockpoolradosnamespace related to a storageclient. This should run on provider cluster in a
         provider mode setup.
 
+    ! Important. from 4.19 onwards, the StorageRequest is deprecated.
+    ! rns will be fetched from configmap of storageConsumer
+
     Args:
         storageclient_id(string): The uid of the storageclient for which the cephblockpoolradosnamespace to be fetched
 
@@ -5931,6 +5934,9 @@ def find_cephfilesystemsubvolumegroup(storageclient_uid=None):
     """
     Find the cephfilesystemsubvolumegroup related to a storageclient. This should run on provider cluster in a
         provider mode setup.
+
+    ! Important. from 4.19 onwards, the StorageRequest is deprecated.
+    ! cephfilesystemsubvolumegroup will be fetched from configmap of storageConsumer
 
     Args:
         storageclient_id(string): The uid of the storageclient for which the cephfilesystemsubvolumegroup to be fetched

--- a/ocs_ci/ocs/resources/storage_client.py
+++ b/ocs_ci/ocs/resources/storage_client.py
@@ -11,6 +11,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.utils import enable_console_plugin
+from ocs_ci.ocs.version import if_version
 from ocs_ci.utility import templating, version
 from ocs_ci.utility.retry import retry
 from ocs_ci.helpers.managed_services import (
@@ -329,6 +330,7 @@ class StorageClient:
                     ), "storageclaim is not in expected status"
         log.info(sc_claim)
 
+    @if_version("<4.19")
     @retry(AssertionError, 20, 10, 1)
     def verify_storagerequest_exists(
         self, storageclient_name=None, namespace=config.ENV_DATA["cluster_namespace"]
@@ -375,8 +377,8 @@ class StorageClient:
             expected_storageclient_status (str): expected storageclient phase; default value is 'Connected'
 
         Returns:
-            storagerequest_phase (bool): returns true if the
-                    storagerequest_phase == expected_storageclient_status
+            storageclient_phase (bool): returns true if the
+                    storageclient_phase == expected_storageclient_status
 
         """
         if not namespace:

--- a/tests/libtest/test_provider_create_hosted_cluster.py
+++ b/tests/libtest/test_provider_create_hosted_cluster.py
@@ -335,7 +335,7 @@ class TestProviderHosted(object):
             check_phase_of_rados_namespace()
         ), "The radosnamespace is not in Ready phase"
 
-        # Validate storageclassrequests created
+        # Validate storageclasses created
         storage_class_classes = get_all_storageclass_names()
         storage_class_claims = [
             constants.CEPHBLOCKPOOL_SC,


### PR DESCRIPTION
With change in this dev PR https://github.com/red-hat-storage/ocs-client-operator/pull/302 we are removing use of StorageRequest.
Important! StorageRequest on upgraded clusters will not be automatically removed, but will stop to reconcile