### PR TITLE
Increasing bucket deletion timeout - fix to issue#11846

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -230,7 +230,7 @@ class ObjectBucket(ABC):
             # Increase the timeout to 15 minutes if the test is tier4
             timeout = 120
             if any("tier4" in mark for mark in get_current_test_marks()):
-                timeout = 600
+                timeout = 900
             self.verify_deletion(timeout)
         if original_context:
             config.switch_ctx(original_context)

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -228,9 +228,9 @@ class ObjectBucket(ABC):
             verify = True
         if verify:
             # Increase the timeout to 15 minutes if the test is tier4
-            timeout = 60
+            timeout = 120
             if any("tier4" in mark for mark in get_current_test_marks()):
-                timeout *= 15
+                timeout = 600
             self.verify_deletion(timeout)
         if original_context:
             config.switch_ctx(original_context)


### PR DESCRIPTION
The test_bucket_list test case was occasionally failing due to deletion timeout of 60 secs. 
Github issue: 
https://github.com/red-hat-storage/ocs-ci/issues/11846

The timeout was increased to 120sec.

The second timeout for tier4 remains 15 mins ( in seconds). 