### PR TITLE
Ignore the storageclient-status-reporter pod leftovers

### DIFF
--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -114,6 +114,9 @@ def assign_get_values(env_status_dict, key, kind=None, exclude_labels=None):
             if name.startswith(constants.REPORT_STATUS_TO_PROVIDER_POD):
                 log.debug(f"ignoring item: {name}")
                 continue
+            if name.startswith("storageclient") and constants.STATUS_REPORTER in name:
+                log.debug(f"ignoring item: {name}")
+                continue
         if item.get("kind") == constants.NAMESPACE:
             name = item.get("metadata").get("generateName")
             if name == "openshift-must-gather-":


### PR DESCRIPTION
Due to the new convergence changes in 4.19 a cronjob is consistently creating and destroying a pod in order to report the client status:
```
storageclient-737342087af10580-status-reporter-29065673-nhwnk     0/1     Completed           0               63s
storageclient-737342087af10580-status-reporter-29065673-nhwnk     0/1     Completed           0               63s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Pending             0               0s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Pending             0               0s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Pending             0               0s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     ContainerCreating   0               0s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     ContainerCreating   0               0s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Completed           0               1s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Completed           0               2s
storageclient-737342087af10580-status-reporter-29065675-5z8v8     0/1     Completed           0               3s
storageclient-737342087af10580-status-reporter-29065674-f9w4r     0/1     Completed           0               63s
storageclient-737342087af10580-status-reporter-29065674-f9w4r     0/1     Completed           0               63s
```
This causes `ResourceLeftoversException` since it's likely to start right before and after a test suite (test class). 

This PR makes sure we ignore these false-negative leftovers. 

* Note that this PR doesn't address the job itself that's being created on each interval (which in turns creates the pod). There's no need to address it because we're not tracking jobs:
https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/utility/environment_check.py/#L171-L180