### PR TITLE
Adjust the exec_nb_db_query function to the new MCG DB implementation

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -690,6 +690,9 @@ NOOBAA_CORE_POD = "noobaa-core-0"
 NOOBAA_DB_SECRET = "noobaa-db"
 NOOBAA_S3_SERVING_CERT = "noobaa-s3-serving-cert"
 
+# NooBaa DB CNPG
+NB_DB_PRIMARY_POD_LABEL = "cnpg.io/instanceRole=primary"
+
 # Auth Yaml
 OCSCI_DATA_BUCKET = "ocs-ci-data"
 AUTHYAML = "auth.yaml"


### PR DESCRIPTION
In 4.19 we now have two noobaa-db pods:
```
$ oc get pods | grep noobaa-db
noobaa-db-pg-cluster-1                                            1/1     Running     0               2d17h
noobaa-db-pg-cluster-2                                            1/1     Running     0               2d17h
```
These are managed by the Cloudnative-pg operator (CNPG) that have been utilized by MCG.

Under CNPG's management there is always one primary pod - changes made to it are replicated to the secondary pod(s), and we can run PGSQL commands on it exactly like we could when we had only one.

This PR adds a simple utility function to fetch the primary noobaa-db pod, and uses it from the existing `exec_nb_db_query` function.