### PR TITLE
[Release 4.18] System test automation for bucket replication with versioning

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2123,6 +2123,9 @@ def get_replication_policy(bucket_name):
     Args:
         bucket_name (str): Name of the bucket
 
+    Returns:
+        Dict: replication policy
+
     """
     return OCP(
         kind="obc",
@@ -2763,7 +2766,7 @@ def upload_random_objects_to_source_and_wait_for_replication(
     """
 
     logger.info(f"Randomly generating {amount} object/s")
-    for i in range(num_versions):
+    for _ in range(num_versions):
         obj_list = write_random_objects_in_pod(
             io_pod=mockup_logger.awscli_pod,
             file_dir=file_dir,

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3259,9 +3259,9 @@ def verify_objs_deleted_from_objmds(bucket_name, timeout=600, sleep=30):
     logger.info("All the objects are marked expired")
 
 
-def verify_deletion_marker(mcg_obj, awscli_pod, bucket_name, object_key):
+def verify_soft_deletion(mcg_obj, awscli_pod, bucket_name, object_key):
     """
-    Verify if deletion marker exists for the given object key
+    Verify if deletion marker exists and IsLatest for the given object key
 
     Args:
         mcg_obj (MCG): MCG object

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2117,7 +2117,13 @@ def update_replication_policy(bucket_name, replication_policy_dict):
 
 
 def get_replication_policy(bucket_name):
+    """
+    Get the replication policy on a bucket
 
+    Args:
+        bucket_name (str): Name of the bucket
+
+    """
     return OCP(
         kind="obc",
         namespace=config.ENV_DATA["cluster_namespace"],

--- a/ocs_ci/ocs/resources/mcg_replication_policy.py
+++ b/ocs_ci/ocs/resources/mcg_replication_policy.py
@@ -38,15 +38,18 @@ class LogBasedReplicationPolicy(McgReplicationPolicy, ABC):
         self,
         destination_bucket,
         sync_deletions=False,
+        sync_versions=False,
         prefix="",
     ):
         super().__init__(destination_bucket, prefix)
         self.sync_deletions = sync_deletions
+        self.sync_versions = sync_versions
 
     @abstractmethod
     def to_dict(self):
         dict = super().to_dict()
         dict["rules"][0]["sync_deletions"] = self.sync_deletions
+        dict["rules"][0]["sync_versions"] = self.sync_versions
         dict["log_replication_info"] = {}
 
         return dict
@@ -65,8 +68,9 @@ class AwsLogBasedReplicationPolicy(LogBasedReplicationPolicy):
         logs_bucket="",
         prefix="",
         logs_location_prefix="",
+        sync_versions=False,
     ):
-        super().__init__(destination_bucket, sync_deletions, prefix)
+        super().__init__(destination_bucket, sync_deletions, sync_versions, prefix)
         self.logs_bucket = logs_bucket
         self.logs_location_prefix = logs_location_prefix
 

--- a/ocs_ci/ocs/resources/mockup_bucket_logger.py
+++ b/ocs_ci/ocs/resources/mockup_bucket_logger.py
@@ -108,6 +108,12 @@ class MockupBucketLogger:
         Uploads randomly generated objects to the bucket and upload a matching
         mockup log
 
+        Args:
+            bucket_name (str): Name of the bucket
+            file_dir (str): File directory where the objects are present
+            obj_list (list): List of the objects
+            prefix (str): Prefix under which object needs to be uploaded
+
         """
 
         logger.info(

--- a/ocs_ci/ocs/resources/mockup_bucket_logger.py
+++ b/ocs_ci/ocs/resources/mockup_bucket_logger.py
@@ -101,6 +101,28 @@ class MockupBucketLogger:
 
         self._upload_mockup_logs(bucket_name, [obj_name], "PUT")
 
+    def upload_random_objects_and_log(
+        self, bucket_name, file_dir, obj_list, prefix=None
+    ):
+        """
+        Uploads randomly generated objects to the bucket and upload a matching
+        mockup log
+
+        """
+
+        logger.info(
+            f"Uploading randomly generated objects from {file_dir} to {bucket_name}"
+        )
+        prefix = prefix if prefix else ""
+        sync_object_directory(
+            self.awscli_pod,
+            file_dir,
+            f"s3://{bucket_name}/{prefix}",
+            self.mcg_obj,
+        )
+
+        self._upload_mockup_logs(bucket_name=bucket_name, obj_list=obj_list, op="PUT")
+
     def delete_objs_and_log(self, bucket_name, objs, prefix=""):
         """
         Delete list of objects from the MCG bucket and write

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8277,9 +8277,17 @@ def change_lifecycle_batch_size(
 
 @pytest.fixture()
 def reduce_replication_delay(add_env_vars_to_noobaa_core_class):
+    """
+    Fixture to reduce the replication cycle delay
+
+    """
 
     def factory(interval=1):
+        """
+        Factory function to reduce the replication
+        cycle delay
 
+        """
         new_delay_in_milliseconfs = interval * 60 * 1000
         new_env_var_touples = [
             (constants.BUCKET_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconfs),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,8 @@ from ocs_ci.ocs.benchmark_operator_fio import get_file_size, BenchmarkOperatorFI
 from ocs_ci.ocs.bucket_utils import (
     craft_s3_command,
     put_bucket_policy,
+    update_replication_policy,
+    put_bucket_versioning_via_awscli,
 )
 from ocs_ci.ocs.constants import FUSION_CONF_DIR
 from ocs_ci.ocs.cnv.virtual_machine import VirtualMachine, VMCloner
@@ -8225,6 +8227,70 @@ def reduce_expiration_interval(add_env_vars_to_noobaa_core_class):
 
 
 @pytest.fixture()
+def change_lifecycle_schedule_min(add_env_vars_to_noobaa_core_class):
+    """
+    Change the lifecycle schedule minute. i.e, that is delay between
+    the each run when lifecycle expiration is identfied.
+
+    """
+
+    def factory(interval):
+        """
+        Args:
+            interval (int): New interval in minute/s
+
+        """
+        new_interval_in_milliseconds = 60 * interval * 1000
+        add_env_vars_to_noobaa_core_class(
+            [(constants.LIFECYCLE_SCHED_MINUTES, new_interval_in_milliseconds)]
+        )
+
+    return factory
+
+
+@pytest.fixture()
+def change_lifecycle_batch_size(
+    add_env_vars_to_noobaa_core_class, add_env_vars_to_noobaa_endpoint_class
+):
+    """
+    Change the batch size for the object lifecycle
+    by modifying the environment variable LIFECYCLE_BATCH_SIZE
+
+    """
+
+    def factory(new_lifecycle_batch_size):
+        """
+        Args:
+            new_lifecycle_batch_size (int): New value for the lifecycle batch size
+
+        """
+        add_env_vars_to_noobaa_core_class(
+            [(constants.LIFECYCLE_BATCH_SIZE_PARAM, new_lifecycle_batch_size)]
+        )
+
+        add_env_vars_to_noobaa_endpoint_class(
+            [(constants.LIFECYCLE_BATCH_SIZE_PARAM, new_lifecycle_batch_size)]
+        )
+
+    return factory
+
+
+@pytest.fixture()
+def reduce_replication_delay(add_env_vars_to_noobaa_core_class):
+
+    def factory(interval=1):
+
+        new_delay_in_milliseconfs = interval * 60 * 1000
+        new_env_var_touples = [
+            (constants.BUCKET_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconfs),
+            (constants.BUCKET_LOG_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconfs),
+        ]
+        add_env_vars_to_noobaa_core_class(new_env_var_touples)
+
+    return factory
+
+
+@pytest.fixture()
 def reset_conn_score():
     """
     This is a fixture that will reset the connections scores for
@@ -8551,21 +8617,34 @@ def aws_log_based_replication_setup(
     """
     A fixture to set up standard log-based replication with deletion sync.
 
-    Args:
-        awscli_pod_session(Pod): A pod running the AWS CLI
-        mcg_obj_session(MCG): An MCG object
-        bucket_factory: A bucket factory fixture
-
-    Returns:
-        MockupBucketLogger: A MockupBucketLogger object
-        Bucket: The source bucket
-        Bucket: The target bucket
-
     """
 
     reduce_replication_delay_setup()
 
-    def factory(bucketclass_dict=None):
+    def factory(
+        bucketclass_dict=None,
+        prefix_source="",
+        prefix_target="",
+        bidirectional=False,
+        deletion_sync=True,
+        enable_versioning=False,
+    ):
+        """
+        A fixture to set up standard log-based replication with deletion sync.
+
+        Args:
+            bucketclass_dict (Dict): Dictionary representing bucketclass parameters
+            bidirectional (Bool): True if you want to setup bi-directional replication
+                                  otherwise False
+            deletion_sync (Bool): True if you want to setup deletion sync otherwise False
+
+        Returns:
+            MockupBucketLogger: A MockupBucketLogger object
+            Bucket: The source bucket
+            Bucket: The target bucket
+
+        """
+
         log.info("Starting log-based replication setup")
         if bucketclass_dict is None:
             bucketclass_dict = {
@@ -8578,27 +8657,60 @@ def aws_log_based_replication_setup(
                 },
             }
         target_bucket = bucket_factory(bucketclass=bucketclass_dict)[0]
+        if enable_versioning:
+            put_bucket_versioning_via_awscli(
+                mcg_obj_session, awscli_pod_session, target_bucket.name
+            )
 
-        mockup_logger = MockupBucketLogger(
+        mockup_logger_source = MockupBucketLogger(
             awscli_pod=awscli_pod_session,
             mcg_obj=mcg_obj_session,
             bucket_factory=bucket_factory,
             platform=constants.AWS_PLATFORM,
             region=constants.DEFAULT_AWS_REGION,
         )
-        replication_policy = AwsLogBasedReplicationPolicy(
+        replication_policy_source = AwsLogBasedReplicationPolicy(
             destination_bucket=target_bucket.name,
-            sync_deletions=True,
-            logs_bucket=mockup_logger.logs_bucket_uls_name,
+            sync_deletions=deletion_sync,
+            logs_bucket=mockup_logger_source.logs_bucket_uls_name,
+            prefix=prefix_source,
+            sync_versions=enable_versioning,
         )
 
         source_bucket = bucket_factory(
-            1, bucketclass=bucketclass_dict, replication_policy=replication_policy
+            1,
+            bucketclass=bucketclass_dict,
+            replication_policy=replication_policy_source,
         )[0]
+        if enable_versioning:
+            put_bucket_versioning_via_awscli(
+                mcg_obj_session, awscli_pod_session, source_bucket.name
+            )
+
+        mockup_logger_target = None
+        if bidirectional:
+            mockup_logger_target = MockupBucketLogger(
+                awscli_pod=awscli_pod_session,
+                mcg_obj=mcg_obj_session,
+                bucket_factory=bucket_factory,
+                platform=constants.AWS_PLATFORM,
+                region=constants.DEFAULT_AWS_REGION,
+            )
+
+            replication_policy_target = AwsLogBasedReplicationPolicy(
+                destination_bucket=source_bucket.name,
+                sync_deletions=deletion_sync,
+                logs_bucket=mockup_logger_target.logs_bucket_uls_name,
+                prefix=prefix_target,
+                sync_versions=enable_versioning,
+            )
+            update_replication_policy(
+                target_bucket.name, replication_policy_target.to_dict()
+            )
 
         log.info("log-based replication setup complete")
 
-        return mockup_logger, source_bucket, target_bucket
+        return mockup_logger_source, mockup_logger_target, source_bucket, target_bucket
 
     return factory
 

--- a/tests/cross_functional/conftest.py
+++ b/tests/cross_functional/conftest.py
@@ -368,7 +368,8 @@ def noobaa_db_backup(request, snapshot_factory):
 
         """
         for pvc_obj in restore_pvc_objs:
-            pvc_obj.delete()
+            if pvc_obj.ocp.get(resource_name=pvc_obj.name, dont_raise=True):
+                pvc_obj.delete()
 
     request.addfinalizer(teardown)
     return factory

--- a/tests/cross_functional/conftest.py
+++ b/tests/cross_functional/conftest.py
@@ -362,6 +362,15 @@ def noobaa_db_backup(request, snapshot_factory):
         )
         return restore_pvc_objs, snap_obj
 
+    def teardown():
+        """
+        Teardown code to delete the restore pvc objects
+
+        """
+        for pvc_obj in restore_pvc_objs:
+            pvc_obj.delete()
+
+    request.addfinalizer(teardown)
     return factory
 
 

--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -21,6 +21,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     magenta_squad,
     mcg,
     polarion_id,
+    skipif_aws_creds_are_missing,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
 from ocs_ci.ocs.bucket_utils import (
@@ -422,6 +424,8 @@ class TestLogBasedReplicationWithDisruptions:
 @mcg
 @magenta_squad
 @system_test
+@skipif_aws_creds_are_missing
+@skipif_disconnected_cluster
 class TestMCGReplicationWithVersioningSystemTest:
 
     @retry(CommandFailed, tries=7, delay=30)

--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -419,6 +419,9 @@ class TestLogBasedReplicationWithDisruptions:
         logger.info("No issues seen with the MCG bg feature validation")
 
 
+@mcg
+@magenta_squad
+@system_test
 class TestMCGReplicationWithVersioningSystemTest:
 
     @retry(CommandFailed, tries=7, delay=30)
@@ -433,6 +436,21 @@ class TestMCGReplicationWithVersioningSystemTest:
         prefix,
         num_versions=1,
     ):
+        """
+        Upload random objects to the bucket and retry if fails with
+        CommandFailed exception.
+
+        Args:
+            mcg_obj_session (MCG): MCG object
+            source_bucket (OBC): Bucket object
+            target_bucket (OBC): Bucket object
+            mockup_logger (MockupLogger): Mockup logger object
+            file_dir (str): Source for generating objects
+            pattern (str): File object pattern
+            prefix (str): Prefix under which objects need to be uploaded
+            num_versions (int): Number of object versions
+
+        """
         upload_random_objects_to_source_and_wait_for_replication(
             mcg_obj_session,
             source_bucket,


### PR DESCRIPTION
This PR covers the system test automation for the ODF 4.18 feature "MCG Bucket Replication - Support versioning"

Original PR (#11111  ) raised against master (release-4.19 as of today) is closed because of the change in noobaa db HA implementation. This would break many of the MCG system test regression runs as the step to perform Noobaa db backup and recovery will be completely revamped.