### PR TITLE
Adding a retry after setting the bucket policy on the bucket to fix issue #11410

### DIFF
--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -324,10 +324,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: Put Object"
 
@@ -434,10 +431,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing object on bucket: {s3_bucket.name} by admin")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             mcg_obj, s3_bucket.name, object_key, data
         ), "Failed: PutObject"
 
@@ -495,10 +489,7 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             s3_obj=obc_obj,
             bucketname=obc_obj.bucket_name,
             object_key="index.html",
@@ -506,10 +497,7 @@ class TestS3BucketPolicy(MCGTest):
             content_type="text/html",
         ), "Failed: PutObject"
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             s3_obj=obc_obj,
             bucketname=obc_obj.bucket_name,
             object_key="error.html",
@@ -659,10 +647,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing an object on bucket: {obc_obj.bucket_name} by Admin")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             mcg_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: PutObject"
 
@@ -804,11 +789,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Writing object on bucket: {obc_obj.bucket_name} with User: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-
-        assert retry_s3_put_object(
+        assert s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: Put Object"
 
@@ -944,11 +925,7 @@ class TestS3BucketPolicy(MCGTest):
         # Verify put Object is allowed.
         logger.info(f"Put Object to the bucket: {obc_obj.bucket_name} ")
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-
-        assert retry_s3_put_object(
+        assert s3_put_object(
             mcg_obj,
             obc_obj.bucket_name,
             object_key,
@@ -1004,11 +981,7 @@ class TestS3BucketPolicy(MCGTest):
         if effect == "Allow":
             # Put Object is allowed
             logger.info("Writing index data to the bucket")
-
-            retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-                s3_put_object
-            )
-            assert retry_s3_put_object(
+            assert s3_put_object(
                 s3_obj=obc_obj1,
                 bucketname=obc_obj.bucket_name,
                 object_key="index.html",
@@ -1105,10 +1078,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on the bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed to put Object"
 
@@ -1159,10 +1129,7 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             s3_obj=mcg_obj,
             bucketname=s3_bucket[0].name,
             object_key="index.html",
@@ -1170,10 +1137,7 @@ class TestS3BucketPolicy(MCGTest):
             content_type="text/html",
         ), "Failed: PutObject"
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
-            s3_put_object
-        )
-        assert retry_s3_put_object(
+        assert s3_put_object(
             s3_obj=mcg_obj,
             bucketname=s3_bucket[0].name,
             object_key="error.html",

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -923,7 +923,12 @@ class TestS3BucketPolicy(MCGTest):
 
         # Verify put Object is allowed.
         logger.info(f"Put Object to the bucket: {obc_obj.bucket_name} ")
-        assert s3_put_object(
+
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=10)(
+            s3_put_object
+        )
+
+        assert retry_s3_put_object(
             mcg_obj,
             obc_obj.bucket_name,
             object_key,

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -924,7 +924,7 @@ class TestS3BucketPolicy(MCGTest):
         # Verify put Object is allowed.
         logger.info(f"Put Object to the bucket: {obc_obj.bucket_name} ")
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=10)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
             s3_put_object
         )
 
@@ -984,7 +984,11 @@ class TestS3BucketPolicy(MCGTest):
         if effect == "Allow":
             # Put Object is allowed
             logger.info("Writing index data to the bucket")
-            assert s3_put_object(
+
+            retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+                s3_put_object
+            )
+            assert retry_s3_put_object(
                 s3_obj=obc_obj1,
                 bucketname=obc_obj.bucket_name,
                 object_key="index.html",

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -324,7 +324,10 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: Put Object"
 
@@ -431,7 +434,10 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing object on bucket: {s3_bucket.name} by admin")
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             mcg_obj, s3_bucket.name, object_key, data
         ), "Failed: PutObject"
 
@@ -489,14 +495,21 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             s3_obj=obc_obj,
             bucketname=obc_obj.bucket_name,
             object_key="index.html",
             data=index,
             content_type="text/html",
         ), "Failed: PutObject"
-        assert s3_put_object(
+
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             s3_obj=obc_obj,
             bucketname=obc_obj.bucket_name,
             object_key="error.html",
@@ -646,7 +659,10 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing an object on bucket: {obc_obj.bucket_name} by Admin")
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             mcg_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: PutObject"
 
@@ -788,7 +804,11 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Writing object on bucket: {obc_obj.bucket_name} with User: {obc_obj.obc_account}"
         )
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+
+        assert retry_s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed: Put Object"
 
@@ -1085,7 +1105,10 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on the bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             obc_obj, obc_obj.bucket_name, object_key, data
         ), "Failed to put Object"
 
@@ -1136,14 +1159,21 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        assert s3_put_object(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             s3_obj=mcg_obj,
             bucketname=s3_bucket[0].name,
             object_key="index.html",
             data=index,
             content_type="text/html",
         ), "Failed: PutObject"
-        assert s3_put_object(
+
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            s3_put_object
+        )
+        assert retry_s3_put_object(
             s3_obj=mcg_obj,
             bucketname=s3_bucket[0].name,
             object_key="error.html",

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -1,4 +1,5 @@
 import logging
+import logging
 import time
 
 import pytest
@@ -324,7 +325,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -434,7 +435,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing object on bucket: {s3_bucket.name} by admin")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -495,7 +496,7 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -506,7 +507,7 @@ class TestS3BucketPolicy(MCGTest):
             content_type="text/html",
         ), "Failed: PutObject"
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -659,7 +660,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin writes an object to bucket
         logger.info(f"Writing an object on bucket: {obc_obj.bucket_name} by Admin")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -804,7 +805,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Writing object on bucket: {obc_obj.bucket_name} with User: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
 
@@ -944,7 +945,7 @@ class TestS3BucketPolicy(MCGTest):
         # Verify put Object is allowed.
         logger.info(f"Put Object to the bucket: {obc_obj.bucket_name} ")
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
 
@@ -1005,7 +1006,7 @@ class TestS3BucketPolicy(MCGTest):
             # Put Object is allowed
             logger.info("Writing index data to the bucket")
 
-            retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+            retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
                 s3_put_object
             )
             assert retry_s3_put_object(
@@ -1105,7 +1106,7 @@ class TestS3BucketPolicy(MCGTest):
         logger.info(
             f"Adding object on the bucket: {obc_obj.bucket_name} using user: {obc_obj.obc_account}"
         )
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -1159,7 +1160,7 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketWebsite"
 
         logger.info("Writing index and error data to the bucket")
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(
@@ -1170,7 +1171,7 @@ class TestS3BucketPolicy(MCGTest):
             content_type="text/html",
         ), "Failed: PutObject"
 
-        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=100)(
+        retry_s3_put_object = retry(boto3exception.ClientError, tries=4, delay=15)(
             s3_put_object
         )
         assert retry_s3_put_object(

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -1,5 +1,4 @@
 import logging
-import logging
 import time
 
 import pytest


### PR DESCRIPTION
This PR contains a fix to https://github.com/red-hat-storage/ocs-ci/issues/11410. 

During a discussion with @sagihirshfeld the following came up :
 
We had many tests in test_bucket_policy.py that failed in a similar way, and they stopped failing once we added a wait of some sort after setting the bucket policy on the bucket. Either via hardcoded sleep or by using retry on the failing operation:
https://github.com/red-hat-storage/ocs-ci/issues/10982
https://github.com/red-hat-storage/ocs-ci/issues/9013
https://github.com/red-hat-storage/ocs-ci/issues/8156

Therefore this PR contains adding retries for setting bucket policy.