### PR TITLE
upd due to new tag in ocs registry

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3520,6 +3520,7 @@ def get_ocs_version_from_image(image):
             .lstrip("rc-")
             .lstrip("upgrade-")
             .lstrip("latest-konflux")
+            .lstrip("konflux-upgrade-")
         )
         version = Version.coerce(version)
         return "{major}.{minor}".format(major=version.major, minor=version.minor)


### PR DESCRIPTION
new tag added, this PR is to fix parsing issue.

Verified in console:

```
image = "quay.io/rhceph-dev/ocs-registry:latest-konflux-upgrade-4.19"
version = (
    image.rsplit(":", 1)[1]
    .lstrip("latest-")
    .lstrip("stable-")
    .lstrip("rc-")
    .lstrip("upgrade-")
    .lstrip("latest-konflux")
    .lstrip("konflux-upgrade-")
)
version
'4.19'
```