### PR TITLE
Workaround: freeze older version of marshmallow==3.26.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setup(
         "certbot==3.0.0",
         "certbot-dns-route53==3.0.0",
         "openshift-python-wrapper==11.0.45",
+        # new version of marshmallow 4.0.0 seems to be broken, failing with error:
+        # TypeError: __init__() got an unexpected keyword argument 'default'
+        "marshmallow==3.26.1",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
The new version of `marshmallow` (4.0.0) seems to be broken, any execution of run-ci command is failing with following traceback:
```
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
    self.parse(args)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1283, in parse
    self._preparse(args, addopts=addopts)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1172, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_manager.py", line 421, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/importlib_metadata/__init__.py", line 189, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
    exec(co, module.__dict__)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pytest_jira.py", line 22, in <module>
    from issue_model import JiraIssue, JiraIssueSchema
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
    exec(co, module.__dict__)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/issue_model.py", line 40, in <module>
    class JiraIssueSchema(Schema):
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/issue_model.py", line 44, in JiraIssueSchema
    issuetype = fields.Nested(Type(), default=None)
  File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/marshmallow/fields.py", line 522, in __init__
    super().__init__(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'default'
```

The root cause seems to be related to incompatibility with pytest-jira plugin - created an issue there: https://github.com/rhevm-qe-automation/pytest_jira/issues/153
Once it will be fixed, we want to revert this workaround and bump the version of pytest-jira plugin.