### PR TITLE
Workaround: freeze older version of marshmallow==3.26.1 - backport to 4.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,9 @@ setup(
         "pytest-jira==0.3.21",
         "certbot==3.0.0",
         "certbot-dns-route53==3.0.0",
+        # new version of marshmallow 4.0.0 seems to be broken, failing with error:
+        # TypeError: __init__() got an unexpected keyword argument 'default'
+        "marshmallow==3.26.1",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This is a backport of https://github.com/red-hat-storage/ocs-ci/pull/11933

because of issue:
  https://github.com/rhevm-qe-automation/pytest_jira/issues/153