### PR TITLE
Workaround: freeze older version of marshmallow==3.26.1 (backport 4.17)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ setup(
         "psycopg2-binary==2.9.9",
         "azure-keyvault-secrets==4.8.0",
         "pytest-jira==0.3.21",
+        # new version of marshmallow 4.0.0 seems to be broken, failing with error:
+        # TypeError: __init__() got an unexpected keyword argument 'default'
+        "marshmallow==3.26.1",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This is backport of https://github.com/red-hat-storage/ocs-ci/pull/11933