### PR TITLE
generate and update multicluster config on flight

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -794,8 +794,12 @@ def create_cluster_dir(cluster_name):
     Returns:
         str: Path to the kubeconfig directory
     """
-    from ocs_ci.ocs.constants import CLUSTERS_PATH
 
-    path = os.path.join(CLUSTERS_PATH, cluster_name, "openshift-cluster-dir")
+    path = os.path.join(
+        config.ENV_DATA["cluster_path"],
+        "clusters",
+        cluster_name,
+        "openshift-cluster-dir",
+    )
     os.makedirs(path, exist_ok=True)
     return path

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -50,6 +50,27 @@ def get_hosted_cluster_names():
     return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip().split()
 
 
+def get_available_hosted_clusters_to_ocp_ver_dict():
+    """
+    Get available HyperShift hosted clusters with their versions
+
+    Returns:
+        dict: hosted clusters available with their versions. Example: {'cl-418-x': '4.18.7', 'cl-418-c': '4.19.0'}
+    """
+    logger.info("Getting HyperShift hosted clusters available")
+    cmd = (
+        "oc get hostedclusters -n clusters -o json | "
+        "jq -r '.items[] | "
+        'select(.metadata.annotations["hypershift.openshift.io/HasBeenAvailable"] == "true") | '
+        '"\\(.metadata.name)|\\(.status.version.history[0].version)"\''
+    )
+    out = exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
+    if not out:
+        return {}
+    result = dict(line.split("|") for line in out.splitlines())
+    return result
+
+
 def kubeconfig_exists_decorator(func):
     """
     Decorator to check if the kubeconfig exists before executing the decorated method
@@ -170,6 +191,19 @@ def get_hosted_cluster_type(cluster_name=None):
         kind=constants.HOSTED_CLUSTERS, namespace="clusters", resource_name=cluster_name
     )
     return ocp_hosted_cluster_obj.get()["spec"]["platform"]["type"].lower()
+
+
+def get_current_nodepool_size(name):
+    """
+    Get existing nodepool of HyperShift hosted cluster
+    Args:
+        name (str): name of the cluster
+    Returns:
+         str: number of nodes in the nodepool
+    """
+    logger.info(f"Getting existing nodepool of HyperShift hosted cluster {name}")
+    cmd = f"oc get --namespace clusters nodepools | awk '$1==\"{name}\" {{print $4}}'"
+    return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
 
 
 class HyperShiftBase:
@@ -490,20 +524,6 @@ class HyperShiftBase:
         )
         return validation_passed
 
-    def get_current_nodepool_size(self, name):
-        """
-        Get existing nodepool of HyperShift hosted cluster
-        Args:
-            name (str): name of the cluster
-        Returns:
-             int: number of nodes in the nodepool
-        """
-        logger.info(f"Getting existing nodepool of HyperShift hosted cluster {name}")
-        cmd = (
-            f"oc get --namespace clusters nodepools | awk '$1==\"{name}\" {{print $4}}'"
-        )
-        return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
-
     def worker_nodes_deployed(self, name: str):
         """
         Check if worker nodes are deployed for HyperShift hosted cluster
@@ -513,9 +533,7 @@ class HyperShiftBase:
              bool: True if worker nodes are deployed, False otherwise
         """
         logger.info(f"Checking if worker nodes are deployed for cluster {name}")
-        return self.get_current_nodepool_size(name) == self.get_desired_nodepool_size(
-            name
-        )
+        return get_current_nodepool_size(name) == self.get_desired_nodepool_size(name)
 
     def get_desired_nodepool_size(self, name: str):
         """
@@ -764,3 +782,20 @@ class HyperShiftBase:
             return False
         logger.info(cmd_res.stdout.decode("utf-8").splitlines())
         return True
+
+
+def create_cluster_dir(cluster_name):
+    """
+    Create the kubeconfig directory for the cluster
+
+    Args:
+        cluster_name (str): Name of the cluster
+
+    Returns:
+        str: Path to the kubeconfig directory
+    """
+    from ocs_ci.ocs.constants import CLUSTERS_PATH
+
+    path = os.path.join(CLUSTERS_PATH, cluster_name, "openshift-cluster-dir")
+    os.makedirs(path, exist_ok=True)
+    return path

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -396,8 +396,9 @@ class HostedClients(HyperShiftBase):
         Provided cluster_names_paths_dict will always be a default source of cluster names and paths
 
         Args:
-            cluster_names_paths_dict (dict): Optional argument. Function will download all kubeconfigs to specified in
-            configuration folders or download specific clusters kubeconfig to specified in arguments folder
+            cluster_names_paths_dict (dict): Optional argument. The function will download all kubeconfigs
+            to the folders specified in the configuration, or download a specific cluster's kubeconfig
+            to the folder provided as an argument.
 
         Returns:
             list: the list of hosted cluster kubeconfig paths

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -1601,8 +1601,9 @@ def hypershift_cluster_factory(
         hosted_cluster_conf_on_provider = {"ENV_DATA": {"clusters": {}}}
         for cluster_name in cluster_names:
             # this configuration is necessary to deploy hosted cluster, but not for running tests with multicluster job
+            cluster_path = create_cluster_dir(cluster_name)
             hosted_cluster_conf_on_provider["ENV_DATA"]["clusters"][cluster_name] = {
-                "hosted_cluster_path": f"~/clusters/{cluster_name}/openshift-cluster-dir",
+                "hosted_cluster_path": cluster_path,
                 "ocp_version": ocp_version,
                 "cpu_cores_per_hosted_cluster": 8,
                 "memory_per_hosted_cluster": "12Gi",

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -337,6 +337,8 @@ HOSTED_CLUSTER_AGENT = "agent"
 NON_HOSTED_CLUSTER = "non_hosted"
 
 # provider mode constants
+CLUSTERS_PATH = os.path.join(os.path.expanduser("~"), "clusters")
+
 PROVIDER_MODE_OCS_DEPLOYMENT_PATH = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "provider-mode"
 )

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -336,9 +336,6 @@ HOSTED_CLUSTER_KUBEVIRT = "kubevirt"
 HOSTED_CLUSTER_AGENT = "agent"
 NON_HOSTED_CLUSTER = "non_hosted"
 
-# provider mode constants
-CLUSTERS_PATH = os.path.join(os.path.expanduser("~"), "clusters")
-
 PROVIDER_MODE_OCS_DEPLOYMENT_PATH = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "provider-mode"
 )

--- a/tests/libtest/test_provider_create_hosted_cluster.py
+++ b/tests/libtest/test_provider_create_hosted_cluster.py
@@ -169,7 +169,7 @@ class TestProviderHosted(object):
     @runs_on_provider
     @hci_provider_required
     def test_create_hosted_cluster_with_fixture(
-        self, create_hypershift_clusters, destroy_hosted_cluster
+        self, create_hypershift_clusters_push_config, destroy_hosted_cluster
     ):
         """
         Test create hosted cluster with fixture
@@ -182,7 +182,7 @@ class TestProviderHosted(object):
         ocp_version = get_latest_release_version()
         nodepool_replicas = 2
 
-        create_hypershift_clusters(
+        create_hypershift_clusters_push_config(
             cluster_names=[cluster_name],
             ocp_version=ocp_version,
             odf_version=odf_version,
@@ -202,7 +202,7 @@ class TestProviderHosted(object):
     @runs_on_provider
     @hci_provider_required
     def test_create_destroy_hosted_cluster_with_fixture(
-        self, create_hypershift_clusters, destroy_hosted_cluster
+        self, create_hypershift_clusters_push_config, destroy_hosted_cluster
     ):
         """
         Test create hosted cluster with fixture and destroy cluster abruptly
@@ -217,7 +217,7 @@ class TestProviderHosted(object):
         ocp_version = get_latest_release_version()
         nodepool_replicas = 2
 
-        create_hypershift_clusters(
+        create_hypershift_clusters_push_config(
             cluster_names=[cluster_name],
             ocp_version=ocp_version,
             odf_version=odf_version,


### PR DESCRIPTION
### Generic solution aligned task 

This PR does: 
1. rework for fixture create_hypershift_clusters, splitting it to 3 different fixtures:
a) create_hypershift_clusters_push_config - will create hosted cluster with default preferences, provision it with similar OCP and ODF versions that Provider has
b) create_config_of_existing_hosted_clusters - will add config only if cluster exist in deployment but multicluster config does not
c) refresh_hosted_config - will replace configs of existing clusters with newly generated

2.  rework for fixture destroy_hosted_cluster, splitting it to 2 different fixtures
a) destroy_hosted_cluster
b) hosted_cluster_remove_config
 **it allows us to remove config during test suit execution, when hitting unhealthy cluster** 
 
-----

Pr is a necessary rework that partially allows us to run all tests dynamically editing a MultiCluster config, updating it with desired state and prevent cascade skip of the execution when one of the clusters is unhealthy. 

**Combining use of these fixtures we can run the execution agnostic of the mode—whether it's Internal, Converged, or Converged with clients and even change mode from Internal to Converged with clients.**

* 20/4/2025 - tested in python console 