### PR TITLE
Use hci keyworkd instead of odf_provider_mode_deployment to identify the cluster configuration

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -90,7 +90,7 @@ class OCP(object):
         if (
             (not cluster_kubeconfig)
             and config.multicluster
-            and config.ENV_DATA.get("odf_provider_mode_deployment", False)
+            and "hci_" in config.ENV_DATA["platform"]
             and len(config.get_provider_cluster_indexes()) == 1
             and kind.lower() in constants.PROVIDER_CLUSTER_RESOURCE_KINDS
         ):


### PR DESCRIPTION
Fixes #11972 
This expects ENV_DATA key 'odf_provider_mode_deployment' which is now commonly used in deployment job only and not in test runs. Use the string 'hci_' to check in ENV_DATA.platform to confirm the cluster is provider mode.