### PR TITLE
Adding a retry after setting the bucket policy on the bucket to fix issue #11410 

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import boto3
 from botocore.handlers import disable_signing
+import botocore.exceptions as boto3exception
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -1303,6 +1304,7 @@ def delete_bucket_policy(s3_obj, bucketname):
     return s3_obj.s3_client.delete_bucket_policy(Bucket=bucketname)
 
 
+@retry(boto3exception.ClientError, tries=4, delay=15)
 def s3_put_object(
     s3_obj, bucketname, object_key, data, content_type="", content_encoding=""
 ):
@@ -2511,7 +2513,6 @@ def get_nb_bucket_stores(mcg_obj, bucket_name):
     else:
         tiers = [d["tier"] for d in bucket_data["tiering"]["tiers"]]
         for tier in tiers:
-
             # Retry to get the tier data as it might not be available immediately
             retry_send_rpc_query = retry(CommandFailed, tries=5, delay=5, backoff=1)(
                 mcg_obj.send_rpc_query
@@ -3195,7 +3196,6 @@ def verify_objs_deleted_from_objmds(bucket_name, timeout=600, sleep=30):
     """
 
     def _check_objs_deletion():
-
         bucket_id = exec_nb_db_query(
             f"select data->>'_id' as ID from buckets where data->>'name'='{bucket_name}'"
         )[0].strip()


### PR DESCRIPTION
This PR contains a fix to https://github.com/red-hat-storage/ocs-ci/issues/11410.

During a discussion with @sagihirshfeld the following came up :

We had many tests in test_bucket_policy.py that failed in a similar way, and they stopped failing once we added a wait of some sort after setting the bucket policy on the bucket. Either via hardcoded sleep or by using retry on the failing operation:
https://github.com/red-hat-storage/ocs-ci/issues/10982
https://github.com/red-hat-storage/ocs-ci/issues/9013
https://github.com/red-hat-storage/ocs-ci/issues/8156

Therefore this PR contains adding retries for setting bucket policy.