### PR TITLE
Fixing teardown when existing performance profile is None

### DIFF
--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -214,12 +214,16 @@ class TestProfileDefaultValuesCheck(ManageTest):
                 )
 
             log.info("Reverting profile changes")
-            ptch = f'{{"spec": {{"resourceProfile":"{exist_performance_profile}"}}}}'
+	    if(exist_performance_profile == None):
+                log.info("Existing performance profile is None, Hence skipping reverting profile change")
+		pass
+	    else:
+                ptch = f'{{"spec": {{"resourceProfile":"{exist_performance_profile}"}}}}'
 
-            # Reverting the performance profile back to the original
-            ptch_cmd = (
-                f"oc patch storagecluster {storage_cluster.data.get('metadata').get('name')}"
-                f" -n {namespace}  --type merge --patch '{ptch}'"
-            )
-            run_cmd(ptch_cmd)
-            verify_storage_cluster()
+                # Reverting the performance profile back to the original
+                ptch_cmd = (
+                    f"oc patch storagecluster {storage_cluster.data.get('metadata').get('name')}"
+                    f" -n {namespace}  --type merge --patch '{ptch}'"
+                )
+                run_cmd(ptch_cmd)
+                verify_storage_cluster()


### PR DESCRIPTION
This PR fixes issue https://github.com/red-hat-storage/ocs-ci/issues/11467