### PR TITLE
remove elasticsearch operator for 4.19

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2341,9 +2341,20 @@ DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION[
     "odf-dependencies",
 ]
 
-DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.19"] = (
-    DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.18"]
-)
+DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.19"] = [
+    "cluster-logging",
+    # elasticsearch-operator seems to be removed from redhat-operator-index:v4.19
+    # "elasticsearch-operator",
+    # we might need to uncomment next line, if we would like to use it in
+    # disconnected deployment:
+    # "lvms-operator",
+    "mcg-operator",
+    "ocs-operator",
+    "odf-csi-addons-operator",
+    "odf-multicluster-orchestrator",
+    "odf-operator",
+    # "odf-prometheus-operator",
+]
 
 # PSI-openstack constants
 NOVA_CLNT_VERSION = "2.0"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2353,6 +2353,7 @@ DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.19"] = [
     "odf-csi-addons-operator",
     "odf-multicluster-orchestrator",
     "odf-operator",
+    "odf-dependencies",
     # "odf-prometheus-operator",
 ]
 


### PR DESCRIPTION
it seems to be not available in redhat-operator-index:v4.19