### PR TITLE
fix log output from exec_cmd

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -683,7 +683,10 @@ def exec_cmd(
         cmd = list_insert_at_position(cmd, kube_index, ["--kubeconfig"])
         cmd = list_insert_at_position(cmd, kube_index + 1, [kubeconfig_path])
     try:
-        masked_cmd = shlex.join(mask_secrets(cmd, secrets))
+        if kwargs.get("shell"):
+            masked_cmd = mask_secrets(cmd, secrets)
+        else:
+            masked_cmd = shlex.join(mask_secrets(cmd, secrets))
         log.info(f"Executing command: {masked_cmd}")
         if threading_lock and cmd[0] == "oc":
             threading_lock.acquire(timeout=lock_timeout)


### PR DESCRIPTION
Fix "Executing command: " log message from `exec_cmd` with `shell=True`.

The output without this fix looks like this:
```
2025-04-24 11:23:57  05:23:57 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: c d ' ' / t m p / t m p x l i a f k _ g ' ' '&' '&' ' ' m a k e ' ' h y p e r s h i f t ' ' p r o d u c t - c l i
```
