### PR TITLE
Pr 11864

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -540,7 +540,10 @@ class MultiClusterConfig:
         If there are no client contexts available then use simple nullcontext to not break
         functionality and still execute the code on current cluster.
         """
-        indexes = config.get_consumer_indexes_list()
+        try:
+            indexes = config.get_consumer_indexes_list()
+        except ClusterNotFoundException:
+            indexes = None
         if indexes:
             return [self.RunWithConfigContext(index) for index in indexes]
         else:

--- a/ocs_ci/framework/exceptions.py
+++ b/ocs_ci/framework/exceptions.py
@@ -38,3 +38,7 @@ class InvalidDeploymentType(Exception):
 
 class ClusterNotAccessibleError(Exception):
     pass
+
+
+class ClusterKubeconfigNotFoundError(Exception):
+    pass

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -395,7 +395,9 @@ hci_provider_and_client_required = pytest.mark.skipif(
 )
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
-    client_indexes = [pytest.param(idx) for idx in config.get_consumer_indexes_list()]
+    client_indexes = [
+        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
+    ]
     run_on_all_clients = pytest.mark.parametrize(
         argnames=["cluster_index"], argvalues=client_indexes
     )

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -395,8 +395,11 @@ hci_provider_and_client_required = pytest.mark.skipif(
 )
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
+    client_indexes = [
+        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
+    ]
     run_on_all_clients = pytest.mark.parametrize(
-        argnames=["cluster_index"], argvalues=config.get_consumer_indexes_list()
+        argnames=["cluster_index"], argvalues=client_indexes
     )
 except ClusterNotFoundException:
     pass

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -399,7 +399,7 @@ try:
         pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
     ]
     run_on_all_clients = pytest.mark.parametrize(
-        argnames=["cluster_index"], argvalues=client_indexes
+        argnames=["cluster_index"], argvalues=client_indexes, indirect=True
     )
 except ClusterNotFoundException:
     pass

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from funcy import compose
 
+from ocs_ci.ocs.exceptions import ClusterNotFoundException
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import (
     ORDER_BEFORE_OCS_UPGRADE,
@@ -392,6 +393,13 @@ hci_provider_and_client_required = pytest.mark.skipif(
     ),
     reason="Test runs ONLY on Fusion HCI provider and client clusters",
 )
+run_on_all_clients = pytest.mark.run_on_all_clients
+try:
+    run_on_all_clients = pytest.mark.parametrize(
+        argnames=["cluster_index"], argvalues=config.get_consumer_indexes_list()
+    )
+except ClusterNotFoundException:
+    pass
 kms_config_required = pytest.mark.skipif(
     (
         config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -393,6 +393,8 @@ hci_provider_and_client_required = pytest.mark.skipif(
     ),
     reason="Test runs ONLY on Fusion HCI provider and client clusters",
 )
+# when run_on_all_clients marker is used, there needs to be added cluster_index
+# parameter to the test to prevent any issues with the test parametrization
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
     client_indexes = [

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -395,9 +395,7 @@ hci_provider_and_client_required = pytest.mark.skipif(
 )
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
-    client_indexes = [
-        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
-    ]
+    client_indexes = [pytest.param(idx) for idx in config.get_consumer_indexes_list()]
     run_on_all_clients = pytest.mark.parametrize(
         argnames=["cluster_index"], argvalues=client_indexes
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,8 +557,6 @@ def pytest_runtest_setup(item):
     before any fixture runs
 
     """
-    log.warning("runtest")
-    log.warning(ocsci_config.multicluster)
     if ocsci_config.multicluster and ocsci_config.UPGRADE.get("upgrade", False):
         for mark in item.iter_markers():
             if mark.name == "config_index":
@@ -566,11 +564,11 @@ def pytest_runtest_setup(item):
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
         for mark in item.iter_markers():
-            log.warning(mark)
-            if mark.name == "run_on_all_clients":
-                context = item.callspec.params.get("cluster_index")
-                log.info(f"Switching the test context to index: {context}")
-                ocsci_config.switch_ctx(context)
+            if mark.name == "parametrize":
+                if item.callspec.params.get("cluster_index"):
+                    context = item.callspec.params.get("cluster_index")
+                    log.info(f"Switching the test context to index: {context}")
+                    ocsci_config.switch_ctx(context)
 
 
 def pytest_fixture_setup(fixturedef, request):
@@ -581,7 +579,6 @@ def pytest_fixture_setup(fixturedef, request):
     """
     # If this is the first fixture getting loaded then its the right time
     # to switch context
-    log.warning("fixture")
     if ocsci_config.multicluster and ocsci_config.UPGRADE.get("upgrade", ""):
         if request.fixturenames.index(fixturedef.argname) == 0:
             for mark in request.node.iter_markers():
@@ -589,10 +586,11 @@ def pytest_fixture_setup(fixturedef, request):
                     ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
-            log.warning(mark)
-            if mark.name == "run_on_all_clients":
-                context = request.node.callspec.params.get("cluster_index")
-                ocsci_config.switch_ctx(context)
+            if mark.name == "parametrize":
+                if request.node.callspec.params.get("cluster_index"):
+                    context = request.node.callspec.params.get("cluster_index")
+                    log.info(f"Switching the test context to index: {context}")
+                    ocsci_config.switch_ctx(context)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,6 +557,8 @@ def pytest_runtest_setup(item):
     before any fixture runs
 
     """
+    log.warning("runtest")
+    log.warning(ocsci_config.multicluster)
     if ocsci_config.multicluster and ocsci_config.UPGRADE.get("upgrade", False):
         for mark in item.iter_markers():
             if mark.name == "config_index":
@@ -564,6 +566,7 @@ def pytest_runtest_setup(item):
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
         for mark in item.iter_markers():
+            log.warning(mark)
             if mark.name == "run_on_all_clients":
                 context = item.callspec.params.get("cluster_index")
                 log.info(f"Switching the test context to index: {context}")
@@ -578,6 +581,7 @@ def pytest_fixture_setup(fixturedef, request):
     """
     # If this is the first fixture getting loaded then its the right time
     # to switch context
+    log.warning("fixture")
     if ocsci_config.multicluster and ocsci_config.UPGRADE.get("upgrade", ""):
         if request.fixturenames.index(fixturedef.argname) == 0:
             for mark in request.node.iter_markers():
@@ -585,6 +589,7 @@ def pytest_fixture_setup(fixturedef, request):
                     ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
+            log.warning(mark)
             if mark.name == "run_on_all_clients":
                 context = request.node.callspec.params.get("cluster_index")
                 ocsci_config.switch_ctx(context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,7 +570,7 @@ def pytest_runtest_setup(item):
                 ocsci_config.switch_ctx(context)
 
 
-def pytest_fixture_setup(fixturedef, request):
+def pytest_fixture_setup(fixturedef, request, item):
     """
     In case of multicluster upgrade scenarios, we want to make sure that before running
     any fixture related to the testcase we need to switch the cluster context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,7 +570,7 @@ def pytest_runtest_setup(item):
                 ocsci_config.switch_ctx(context)
 
 
-def pytest_fixture_setup(fixturedef, request, item):
+def pytest_fixture_setup(fixturedef, request):
     """
     In case of multicluster upgrade scenarios, we want to make sure that before running
     any fixture related to the testcase we need to switch the cluster context
@@ -584,9 +584,9 @@ def pytest_fixture_setup(fixturedef, request, item):
                 if mark.name == "config_index":
                     ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
-        for mark in item.iter_markers():
+        for mark in request.node.iter_markers():
             if mark.name == "run_on_all_clients":
-                context = item.callspec.params.get("cluster_index")
+                context = request.node.callspec.params.get("cluster_index")
                 ocsci_config.switch_ctx(context)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,7 +563,9 @@ def pytest_runtest_setup(item):
                 log.info(f"Switching the test context to index: {mark.args[0]}")
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
+        log.warning(item.callspec.params)
         for mark in item.iter_markers():
+            log.warning(mark)
             if mark.name == "parametrize":
                 if item.callspec.params.get("cluster_index"):
                     context = item.callspec.params.get("cluster_index")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -560,8 +560,14 @@ def pytest_runtest_setup(item):
     if ocsci_config.multicluster and ocsci_config.UPGRADE.get("upgrade", False):
         for mark in item.iter_markers():
             if mark.name == "config_index":
-                log.info("Switching the test context to index: {mark.args[0]}")
+                log.info(f"Switching the test context to index: {mark.args[0]}")
                 ocsci_config.switch_ctx(mark.args[0])
+    if ocsci_config.multicluster:
+        for mark in item.iter_markers():
+            if mark.name == "run_on_all_clients":
+                context = item.callspec.params.get("cluster_index")
+                log.info(f"Switching the test context to index: {context}")
+                ocsci_config.switch_ctx(context)
 
 
 def pytest_fixture_setup(fixturedef, request):
@@ -577,6 +583,11 @@ def pytest_fixture_setup(fixturedef, request):
             for mark in request.node.iter_markers():
                 if mark.name == "config_index":
                     ocsci_config.switch_ctx(mark.args[0])
+    if ocsci_config.multicluster:
+        for mark in item.iter_markers():
+            if mark.name == "run_on_all_clients":
+                context = item.callspec.params.get("cluster_index")
+                ocsci_config.switch_ctx(context)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,9 +563,7 @@ def pytest_runtest_setup(item):
                 log.info(f"Switching the test context to index: {mark.args[0]}")
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
-        log.warning(item.callspec.params)
         for mark in item.iter_markers():
-            log.warning(mark)
             if mark.name == "parametrize":
                 if item.callspec.params.get("cluster_index"):
                     context = item.callspec.params.get("cluster_index")
@@ -581,7 +579,7 @@ def pytest_runtest_setup(item):
 
 def pytest_fixture_setup(fixturedef, request):
     """
-    In case of multicluster upgrade scenarios, we want to make sure that before running
+    In case of multicluster scenarios, we want to make sure that before running
     any fixture related to the testcase we need to switch the cluster context
 
     """
@@ -599,6 +597,18 @@ def pytest_fixture_setup(fixturedef, request):
                     context = request.node.callspec.params.get("cluster_index")
                     log.info(f"Switching the fixture context to index: {context}")
                     ocsci_config.switch_ctx(context)
+
+
+def pytest_fixture_post_finalizer(fixturedef, request):
+    """
+    In case of multicluster scenarios, we want to make sure that context is restored
+    after fixture is finished.
+    """
+    if ocsci_config.multicluster:
+        for mark in request.node.iter_markers():
+            if mark.name == "parametrize":
+                if request.node.callspec.params.get("cluster_index"):
+                    ocsci_config.reset_ctx()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -596,13 +596,7 @@ def pytest_fixture_setup(fixturedef, request):
                 if request.node.callspec.params.get("cluster_index"):
                     context = request.node.callspec.params.get("cluster_index")
                     log.info(f"Switching the fixture context to index: {context}")
-                    original_idx = ocsci_config.cur_index
                     ocsci_config.switch_ctx(context)
-                    yield
-                    log.info(
-                        f"Switching the fixture context back to index: {original_idx}"
-                    )
-                    ocsci_config.switch_ctx(original_idx)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -568,7 +568,13 @@ def pytest_runtest_setup(item):
                 if item.callspec.params.get("cluster_index"):
                     context = item.callspec.params.get("cluster_index")
                     log.info(f"Switching the test context to index: {context}")
+                    original_idx = ocsci_config.cur_index
                     ocsci_config.switch_ctx(context)
+                    yield
+                    log.info(
+                        f"Switching the test context back to index: {original_idx}"
+                    )
+                    ocsci_config.switch_ctx(original_idx)
 
 
 def pytest_fixture_setup(fixturedef, request):
@@ -589,8 +595,14 @@ def pytest_fixture_setup(fixturedef, request):
             if mark.name == "parametrize":
                 if request.node.callspec.params.get("cluster_index"):
                     context = request.node.callspec.params.get("cluster_index")
-                    log.info(f"Switching the test context to index: {context}")
+                    log.info(f"Switching the fixture context to index: {context}")
+                    original_idx = ocsci_config.cur_index
                     ocsci_config.switch_ctx(context)
+                    yield
+                    log.info(
+                        f"Switching the fixture context back to index: {original_idx}"
+                    )
+                    ocsci_config.switch_ctx(original_idx)
 
 
 @pytest.fixture()

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -5,6 +5,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     red_squad,
+    run_on_all_clients,
     runs_on_provider,
     mcg,
     provider_client_ms_platform_required,
@@ -58,8 +59,8 @@ def test_verify_backingstore_uses_rgw(mcg_obj_session):
 @mcg
 @red_squad
 @tier1
-@runs_on_provider
 @provider_client_ms_platform_required
+@run_on_all_clients
 @pytest.mark.polarion_id("OCS-5214")
 def test_write_file_to_bucket_on_client(
     bucket_factory, mcg_obj, awscli_pod_client_session, return_to_original_context
@@ -70,11 +71,10 @@ def test_write_file_to_bucket_on_client(
     awscli_pod, client_cluster = awscli_pod_client_session
     # Retrieve a list of all objects on the test-objects bucket and
     # downloads them to the pod
-    bucketname = bucket_factory(1, interface="OC")[0].name
+    with config.RunWithProviderConfigContextIfAvailable():
+        bucketname = bucket_factory(1, interface="OC")[0].name
     full_object_path = f"s3://{bucketname}"
 
-    config.switch_ctx(client_cluster)
-    log.info(f"Switched to client cluster with index {client_cluster}")
     downloaded_files = awscli_pod.exec_cmd_on_pod(
         f"ls -A1 {constants.AWSCLI_TEST_OBJ_DIR}"
     ).split(" ")

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -63,7 +63,11 @@ def test_verify_backingstore_uses_rgw(mcg_obj_session):
 @run_on_all_clients
 @pytest.mark.polarion_id("OCS-5214")
 def test_write_file_to_bucket_on_client(
-    bucket_factory, mcg_obj, awscli_pod_client_session, return_to_original_context
+    bucket_factory,
+    mcg_obj,
+    awscli_pod_client_session,
+    return_to_original_context,
+    cluster_index,
 ):
     """
     Test object IO using the S3 SDK on bucket created on provider and used on client.

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -27,7 +27,7 @@ class TestEphemeralPod:
     @pytest.mark.parametrize(
         argnames=["interface"], argvalues=[[CEPHFS_INTERFACE], [RBD_INTERFACE]]
     )
-    def test_ephemeral_pod_creation(self, interface) -> None:
+    def test_ephemeral_pod_creation(self, interface, cluster_index) -> None:
         pod_name = None
         storage_type = interface
         ephemeral_pod = EphemeralPodFactory.create_ephemeral_pod(pod_name, storage_type)

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -21,12 +21,12 @@ log = getLogger(__name__)
 
 @tier1
 @brown_squad
-@run_on_all_clients
 @polarion_id("OCS-5792")
 class TestEphemeralPod:
     @pytest.mark.parametrize(
         argnames=["interface"], argvalues=[[CEPHFS_INTERFACE], [RBD_INTERFACE]]
     )
+    @run_on_all_clients
     def test_ephemeral_pod_creation(self, interface, cluster_index) -> None:
         pod_name = None
         storage_type = interface

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -9,13 +9,19 @@ from ocs_ci.ocs.constants import (
     RBD_INTERFACE,
 )
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, brown_squad, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    brown_squad,
+    polarion_id,
+    run_on_all_clients,
+)
 
 log = getLogger(__name__)
 
 
 @tier1
 @brown_squad
+@run_on_all_clients
 @polarion_id("OCS-5792")
 class TestEphemeralPod:
     @pytest.mark.parametrize(

--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -5,7 +5,10 @@ import time
 import yaml
 
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    run_on_all_clients_push_missing_configs,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     polarion_id,
@@ -57,7 +60,8 @@ class TestRwopPvc(ManageTest):
     @polarion_id("OCS-5911")
     @polarion_id("OCS-5912")
     @polarion_id("OCS-5924")
-    def test_pod_with_same_priority(self, pod_factory, interface):
+    @run_on_all_clients_push_missing_configs
+    def test_pod_with_same_priority(self, pod_factory, interface, cluster_index):
         """
         Test RBD Block volume mode RWOP PVC
 


### PR DESCRIPTION
Based on solution designed by @fbalak 

Adding marker "@run_on_all_clients_push_missing_configs" make:
1. Run test on single cluster without spending additional time, performing and reporting same way
2. Run test on multiple storage client cluster, gathering configurations and pushing them to MultiClusterConfig. Running only on clients