### PR TITLE
rename storageClient. address issue with distribution of sc

### DIFF
--- a/ocs_ci/templates/ocs-deployment/provider-mode/storage_client.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/storage_client.yaml
@@ -1,7 +1,7 @@
 apiVersion: ocs.openshift.io/v1alpha1
 kind: StorageClient
 metadata:
-  name: storage-client
+  name: ocs-storagecluster
 spec:
   storageProviderEndpoint: {}
   onboardingTicket: {}


### PR DESCRIPTION
minor issue that causes duplicates in storageClass distribution. 

> Rewant Soni
> Is 4.19.0-49k the latest version? There was a bug with a workaround does this build include that fix?
> For most of the backend related issue that you have I see that you have used a different name for the storage client name - "storage-client". This is an unsupported configuration. The only customers we have for Provider Mode are Fusion and they are using the name "ocs-storagecluster" for the external clients well and they will continue to do that. Using a different name means that the storageClass name will be different and things will break. Please fix the ci to use the right storage client name for external clients "ocs-storagecluster" and then run the upgrade test using the latest version.
> For 4.18 the name of storage class is dependent on the name of storageclients hence we should use the name "ocs-storagecluster" for external clients. For 4.19 onwards a we can use a different name since storageClass name will not depend on storageclient name.

https://ibm-systems-storage.slack.com/archives/C081L5H77H7/p1745779458010979?thread_ts=1745775468.623389&cid=C081L5H77H7