### PR TITLE
Run on all clients push missing configs

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -38,7 +38,6 @@ Main tasks include:
 
 
 logger = logging.getLogger(__name__)
-BaseOCPDeployment(skip_download_installer=True).test_cluster()
 
 
 @retry((CommandFailed, TimeoutError), tries=3, delay=5, backoff=1)
@@ -373,6 +372,8 @@ class HyperShiftBase:
 
     def __init__(self):
         super().__init__()
+        BaseOCPDeployment(skip_download_installer=True).test_cluster()
+
         bin_dir_rel_path = os.path.expanduser(config.RUN["bin_dir"])
         self.bin_dir = os.path.abspath(bin_dir_rel_path)
         self.hcp_binary_path = os.path.join(self.bin_dir, "hcp")

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -50,19 +50,10 @@ def get_hosted_cluster_names():
     """
 
     logger.info("Getting HyperShift hosted cluster names")
-    cmd = "get --namespace clusters hostedclusters -o custom-columns=NAME:.metadata.name --no-headers"
-
-    with config.RunWithProviderConfigContextIfAvailable():
-        out = OCP().exec_oc_cmd(
-            command=cmd,
-            cluster_config=config,
-            shell=True,
-            out_yaml_format=False,
-            silent=True,
-        )
-        if not out:
-            return []
-    return out.strip().split()
+    hosted_clusters_obj = OCP(
+        kind=constants.HOSTED_CLUSTERS, namespace=constants.CLUSTERS_NAMESPACE
+    ).get()
+    return [cluster.get("metadata").get("name") for cluster in hosted_clusters_obj]
 
 
 @catch_exceptions((CommandFailed, TimeoutExpiredError))
@@ -307,13 +298,13 @@ def worker_nodes_deployed(name: str):
     return get_current_nodepool_size(name) == get_desired_nodepool_size(name)
 
 
-def wait_for_worker_nodes_to_be_ready(name: str, timeout=2400):
+def wait_for_worker_nodes_to_be_ready(name: str, timeout: int = 2400):
     """
     Wait for worker nodes to be ready for HyperShift hosted cluster
 
     Args:
         name (str): name of the cluster
-        timeout: timeout in seconds
+        timeout (int): timeout in seconds
 
     Returns:
         bool: True if worker nodes are ready, False otherwise

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -175,7 +175,7 @@ def apply_cluster_roles_wa(cluster_names):
 
 def skip_if_not_hcp_provider(func):
     """
-    Decorator to skip the test if deployment is not Hosted Control Plane provider
+    Decorator to skip the function execution if deployment is not Hosted Control Plane provider
 
     Returns:
         function: wrapped function
@@ -2023,7 +2023,7 @@ def hypershift_cluster_factory(
     hosted_clients_obj = HostedClients()
     logger.info(f"hypershift_cluster_factory duty is '{duty}'")
 
-    # this section 1. is to gather and remove if configurations and execute deployment due to the duty
+    # this section 1. is to gather and remove configurations and execute deployment due to the duty
     if duty == "create_hosted_cluster_push_config":
         hosted_cluster_conf_on_provider = {"ENV_DATA": {"clusters": {}}}
         for cluster_name in cluster_names:

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -2063,7 +2063,7 @@ def hypershift_cluster_factory(
             return
         deployed_clusters = list(cl_name_ver_dict.keys())
 
-        if constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG in duty:
+        if constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_FORCE_PUSH_CONFIG in duty:
             existing_clusters = {
                 conf.ENV_DATA.get("cluster_name") for conf in config.clusters
             }

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -2174,7 +2174,7 @@ def hypershift_cluster_factory(
                         ClusterKubeconfigNotFoundError,
                     )
 
-                    ClusterKubeconfigNotFoundError(
+                    raise ClusterKubeconfigNotFoundError(
                         f"Failed to download kubeconfig for cluster {cluster_name}"
                     )
                 else:

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -2154,8 +2154,10 @@ def hypershift_cluster_factory(
                     "installer_version"
                 ] = running_ocp_version
 
+            print("Cluster version: %s", running_ocp_version)
+            print("Cluster name: %s", cluster_name)
             cluster_path = create_cluster_dir(cluster_name)
-            logger.info("Cluster path: %s", cluster_path)
+            print("Cluster path: %s", cluster_path)
             def_client_config_dict["ENV_DATA"]["cluster_path"] = cluster_path
 
             kubeconf_paths = (
@@ -2173,9 +2175,9 @@ def hypershift_cluster_factory(
                 kubeconf_path = [
                     path for path in kubeconf_paths if cluster_name in path
                 ][0]
-            logger.debug(f"Kubeconfig path: {kubeconf_path}")
+            print(f"Kubeconfig path: {kubeconf_path}")
 
-            logger.debug(
+            print(
                 "Setting default context to config. Every config should have same default context"
             )
             # sync our configurations with the one in MultiClusterConfig to have the same default context index
@@ -2192,7 +2194,7 @@ def hypershift_cluster_factory(
             cluster_config = Config()
             cluster_config.update(def_client_config_dict)
 
-            logger.info(
+            print(
                 "Inserting new hosted cluster config to Multicluster Config "
                 f"\n{json.dumps(vars(cluster_config), indent=4, cls=SetToListJSONEncoder)}"
             )

--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -2024,7 +2024,7 @@ def hypershift_cluster_factory(
     logger.info(f"hypershift_cluster_factory duty is '{duty}'")
 
     # this section 1. is to gather and remove configurations and execute deployment due to the duty
-    if duty == "create_hosted_cluster_push_config":
+    if duty == constants.DUTY_CREATE_HOSTED_CLUSTER_PUSH_CONFIG:
         hosted_cluster_conf_on_provider = {"ENV_DATA": {"clusters": {}}}
         for cluster_name in cluster_names:
             # this configuration is necessary to deploy hosted cluster, but not for running tests with multicluster job
@@ -2052,8 +2052,8 @@ def hypershift_cluster_factory(
         deployed_clusters = [obj.name for obj in deployed_hosted_cluster_objects]
 
     elif duty in [
-        "use_existing_hosted_clusters_force_push_configs",
-        "use_existing_hosted_clusters_push_missing_configs",
+        constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_FORCE_PUSH_CONFIG,
+        constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
     ]:
         cl_name_ver_dict = get_available_hosted_clusters_to_ocp_ver_dict()
         if not cl_name_ver_dict:
@@ -2063,7 +2063,7 @@ def hypershift_cluster_factory(
             return
         deployed_clusters = list(cl_name_ver_dict.keys())
 
-        if "use_existing_hosted_clusters_force_push_configs" in duty:
+        if constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG in duty:
             existing_clusters = {
                 conf.ENV_DATA.get("cluster_name") for conf in config.clusters
             }
@@ -2079,7 +2079,7 @@ def hypershift_cluster_factory(
             deployed_clusters = {
                 conf.ENV_DATA.get("cluster_name") for conf in config.clusters
             }
-        if duty == "use_existing_hosted_clusters_push_missing_configs":
+        if duty == constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG:
             clusters_in_config = {
                 conf.ENV_DATA.get("cluster_name") for conf in config.clusters
             }
@@ -2162,8 +2162,12 @@ def hypershift_cluster_factory(
             logger.debug(
                 "Setting default context to config. Every config should have same default context"
             )
+            # sync our configurations with the one in MultiClusterConfig to have the same default context index
+            # we set provider's index to every client config
+
+            default_index = config.get_provider_index()
             def_client_config_dict["ENV_DATA"].setdefault(
-                "default_cluster_context_index", 0
+                "default_cluster_context_index", default_index
             )
 
             def_client_config_dict.setdefault("RUN", {}).update(

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -44,9 +44,13 @@ def download_pull_secret():
 
 
 class OCPDeployment:
-    def __init__(self):
+    def __init__(self, **kwargs):
         """
         Constructor for OCPDeployment class
+
+        Args:
+            **kwargs: keyword arguments;
+            skip_download_installer for skipping download OCP installer regardless of the configuration
         """
         self.pull_secret = {}
         self.metadata = {}
@@ -66,7 +70,9 @@ class OCPDeployment:
             and not ibmcloud_managed_deployment
             and not ai_deployment
         ):
-            self.installer = self.download_installer()
+            skip_download_installer = kwargs.get("skip_download_installer", False)
+            if not skip_download_installer:
+                self.installer = self.download_installer()
         self.cluster_path = config.ENV_DATA["cluster_path"]
         self.cluster_name = config.ENV_DATA["cluster_name"]
         if (

--- a/ocs_ci/framework/exceptions.py
+++ b/ocs_ci/framework/exceptions.py
@@ -38,3 +38,7 @@ class InvalidDeploymentType(Exception):
 
 class ClusterNotAccessibleError(Exception):
     pass
+
+
+class ClusterKubeconfigNotFoundError(Exception):
+    pass

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -414,7 +414,9 @@ hci_provider_and_client_required = pytest.mark.skipif(
 # parameter to the test to prevent any issues with the test parametrization
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
-    client_indexes = [pytest.param(idx) for idx in config.get_consumer_indexes_list()]
+    client_indexes = [
+        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
+    ]
     run_on_all_clients = pytest.mark.parametrize(
         argnames=["cluster_index"], argvalues=client_indexes, indirect=True
     )

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -414,9 +414,7 @@ hci_provider_and_client_required = pytest.mark.skipif(
 # parameter to the test to prevent any issues with the test parametrization
 run_on_all_clients = pytest.mark.run_on_all_clients
 try:
-    client_indexes = [
-        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
-    ]
+    client_indexes = [pytest.param(idx) for idx in config.get_consumer_indexes_list()]
     run_on_all_clients = pytest.mark.parametrize(
         argnames=["cluster_index"], argvalues=client_indexes, indirect=True
     )

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -44,7 +44,7 @@ from ocs_ci.ocs.constants import (
 from ocs_ci.utility import version
 from ocs_ci.utility.aws import update_config_from_s3
 from ocs_ci.utility.utils import load_auth_config
-
+from ocs_ci.deployment.hosted_cluster import hypershift_cluster_factory
 
 # tier marks
 
@@ -410,18 +410,45 @@ hci_provider_and_client_required = pytest.mark.skipif(
     ),
     reason="Test runs ONLY on Fusion HCI provider and client clusters",
 )
+
+
 # when run_on_all_clients marker is used, there needs to be added cluster_index
 # parameter to the test to prevent any issues with the test parametrization
-run_on_all_clients = pytest.mark.run_on_all_clients
-try:
-    client_indexes = [
-        pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
-    ]
-    run_on_all_clients = pytest.mark.parametrize(
-        argnames=["cluster_index"], argvalues=client_indexes, indirect=True
-    )
-except ClusterNotFoundException:
-    pass
+def setup_multicluster_marker(marker_base, push_missing_configs=False):
+    """
+    Set up multicluster marker with parametrization based on client indexes.
+
+    Args:
+        marker_base: Base pytest marker to be parametrized
+        push_missing_configs: Boolean flag to push missing configs
+
+    Returns:
+        Parametrized marker or original marker if setup fails
+    """
+    try:
+        if push_missing_configs:
+
+            hypershift_cluster_factory(
+                duty="use_existing_hosted_clusters_push_missing_configs",
+            )
+        client_indexes = [
+            pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
+        ]
+        if len(client_indexes):
+            config.multicluster = True
+            return pytest.mark.parametrize(
+                argnames=["cluster_index"], argvalues=client_indexes, indirect=True
+            )
+        return marker_base
+    except ClusterNotFoundException:
+        return marker_base
+
+
+run_on_all_clients = setup_multicluster_marker(pytest.mark.run_on_all_clients)
+run_on_all_clients_push_missing_configs = setup_multicluster_marker(
+    pytest.mark.run_on_all_clients, True
+)
+
 kms_config_required = pytest.mark.skipif(
     (
         config.ENV_DATA["KMS_PROVIDER"].lower() != HPCS_KMS_PROVIDER

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -39,8 +39,8 @@ from ocs_ci.ocs.constants import (
     AZURE_KV_PROVIDER_NAME,
     ROSA_HCP_PLATFORM,
     VAULT_KMS_PROVIDER,
-    DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
     NFS_OUTCLUSTER_TEST_PLATFORMS,
+    DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
 )
 from ocs_ci.utility import version
 from ocs_ci.utility.aws import update_config_from_s3

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -39,6 +39,7 @@ from ocs_ci.ocs.constants import (
     AZURE_KV_PROVIDER_NAME,
     ROSA_HCP_PLATFORM,
     VAULT_KMS_PROVIDER,
+    DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
     NFS_OUTCLUSTER_TEST_PLATFORMS,
 )
 from ocs_ci.utility import version
@@ -429,7 +430,7 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
         if push_missing_configs:
 
             hypershift_cluster_factory(
-                duty="use_existing_hosted_clusters_push_missing_configs",
+                duty=DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
             )
         client_indexes = [
             pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 from junitparser import JUnitXml
 import ocs_ci.utility.memory
+from ocs_ci.deployment.helpers.hypershift_base import create_cluster_dir
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework.logger_factory import set_log_record_factory
 from ocs_ci.framework.exceptions import (
@@ -544,14 +545,27 @@ def process_cluster_cli_params(config):
         ClusterNameLengthError: If a cluster name is too short or too long
     """
     suffix = ocsci_config.cur_index + 1 if ocsci_config.multicluster else ""
+    if (
+        ocsci_config.multicluster
+        and ocsci_config.ENV_DATA["cluster_type"] == "provider"
+    ):
+        suffix = ""
     cluster_path = get_cli_param(config, f"cluster_path{suffix}")
+
+    if not cluster_path and ocsci_config.multicluster:
+        if ocsci_config.ENV_DATA["cluster_type"] in ["consumer", "hci_client"]:
+            cluster_name = ocsci_config.ENV_DATA["cluster_name"]
+            cluster_path = ocsci_config.ENV_DATA["cluster_path"] or create_cluster_dir(
+                cluster_name
+            )
+
     if not cluster_path:
         raise ClusterPathNotProvidedError()
     cluster_path = os.path.expanduser(cluster_path)
     if not os.path.exists(cluster_path):
         os.makedirs(cluster_path)
 
-    # create kubeconfig if doesn't exists and OCP url and kubeadmin password is provided
+    # create kubeconfig if doesn't exist and OCP url and kubeadmin password is provided
     kubeconfig_path = os.path.join(
         cluster_path, ocsci_config.RUN["kubeconfig_location"]
     )
@@ -605,6 +619,12 @@ def process_cluster_cli_params(config):
 
     OCP.set_kubeconfig(os.path.join(cluster_path, kubeconfig_location))
     cluster_name = get_cli_param(config, f"cluster_name{suffix}")
+
+    if not cluster_name:
+        cluster_name = ocsci_config.ENV_DATA.get("cluster_name")
+        if not cluster_name:
+            raise ClusterNameNotProvidedError()
+
     ocsci_config.RUN["cli_params"]["teardown"] = get_cli_param(
         config, "teardown", default=False
     )

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -558,11 +558,12 @@ def process_cluster_cli_params(config):
         ClusterNameLengthError: If a cluster name is too short or too long
     """
     suffix = ocsci_config.cur_index + 1 if ocsci_config.multicluster else ""
-    if (
-        ocsci_config.multicluster
-        and ocsci_config.ENV_DATA["cluster_type"] == "provider"
-    ):
-        suffix = ""
+    # TODO: remove commented code
+    # if (
+    #     ocsci_config.multicluster
+    #     and ocsci_config.ENV_DATA["cluster_type"] == "provider"
+    # ):
+    #     suffix = ""
     cluster_path = get_cli_param(config, f"cluster_path{suffix}")
 
     if not cluster_path and ocsci_config.multicluster:

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -480,7 +480,20 @@ def gather_version_info_for_report(config):
 
         # add ceph version
         if not ocsci_config.ENV_DATA["mcg_only_deployment"]:
-            ceph_version = get_ceph_version()
+
+            managed_or_hcp_platform = (
+                ocsci_config.multicluster
+                and ocsci_config.ENV_DATA.get("platform", "").lower()
+                in constants.HCI_PC_OR_MS_PLATFORM
+                and ocsci_config.ENV_DATA.get("cluster_type", "").lower()
+                in [constants.MS_CONSUMER_TYPE, constants.HCI_CLIENT]
+            )
+            # provide ceph details of ceph cluster for client clusters. client clusters do not have ceph pods
+            if managed_or_hcp_platform:
+                with ocsci_config.RunWithProviderConfigContextIfAvailable():
+                    ceph_version = get_ceph_version()
+            else:
+                ceph_version = get_ceph_version()
             config._metadata["Ceph Version"] = ceph_version
 
             # add csi versions

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -9,11 +9,12 @@ pytest which proccess config and passes all params to pytest.
 
 import logging
 import os
+import shutil
+
 import pandas as pd
 import pytest
 from junitparser import JUnitXml
 import ocs_ci.utility.memory
-from ocs_ci.deployment.helpers.hypershift_base import create_cluster_dir
 from ocs_ci.framework import config as ocsci_config
 from ocs_ci.framework.logger_factory import set_log_record_factory
 from ocs_ci.framework.exceptions import (
@@ -545,6 +546,23 @@ def get_cli_param(config, name_of_param, default=None):
     return cli_param
 
 
+def set_cli_param(config, name_of_param, value):
+    """
+    This is helper function which set cli parameter in RUN section in
+    cli_params
+
+    Args:
+        config (pytest.config): Pytest config object
+        name_of_param (str): cli parameter name
+        value (any): value of parameter
+
+    Returns:
+        None
+    """
+    ocsci_config.RUN["cli_params"][name_of_param] = value
+    setattr(config.option, name_of_param, value)
+
+
 def process_cluster_cli_params(config):
     """
     Process cluster related cli parameters
@@ -558,20 +576,39 @@ def process_cluster_cli_params(config):
         ClusterNameLengthError: If a cluster name is too short or too long
     """
     suffix = ocsci_config.cur_index + 1 if ocsci_config.multicluster else ""
-    # TODO: remove commented code
-    # if (
-    #     ocsci_config.multicluster
-    #     and ocsci_config.ENV_DATA["cluster_type"] == "provider"
-    # ):
-    #     suffix = ""
     cluster_path = get_cli_param(config, f"cluster_path{suffix}")
 
+    # # # # # # # # # # # This block is an overwrite logic for dynamic configuration adjustments  # # # # # # # # # # #
     if not cluster_path and ocsci_config.multicluster:
-        if ocsci_config.ENV_DATA["cluster_type"] in ["consumer", "hci_client"]:
-            cluster_name = ocsci_config.ENV_DATA["cluster_name"]
-            cluster_path = ocsci_config.ENV_DATA["cluster_path"] or create_cluster_dir(
-                cluster_name
+
+        # Problem:
+        # In case of setting up multiple configuration files provided to run-ci, script expects path to have suffix + 1
+        # When running run-ci with single configuration, suffix is empty, but pytest script sets config.multicluster
+        # in time when loading marks.py module, if platform is 'hci_baremetal'
+        # When script dynamically adds configuration, makes ocsci_config.multicluster and adds suffix + 1 to config_path
+        # This leads to ClusterPathNotProvidedError
+        #
+        # Solution:
+        # to make script reach path in both scenarios we will copy content of cluster_path that does not have suffix to
+        # cluster_path that has suffix "1" or higher
+        if suffix:
+            if not os.path.exists(ocsci_config.ENV_DATA["cluster_path"]):
+                raise ClusterPathNotProvidedError(
+                    "Cluster path is not provided and cluster_path does not exist"
+                )
+            parent_path = os.path.dirname(ocsci_config.ENV_DATA["cluster_path"])
+            if suffix > 1:
+                # historically cluster_path for client clusters is set to
+                # '/ocs-ci/cluster_path/clusters/<cl-419-a>/openshift-cluster-dir', so we want to create path like
+                # '/ocs-ci/cluster_path/clusters/cluster_path2 for auth directory of a client cluster
+                parent_path = os.path.dirname(parent_path)
+            cluster_path = os.path.join(parent_path, f"cluster_path{suffix}")
+            # we do not want to move files from original folder and preserve original cluster folder because
+            # we don't want to bind cluster to some incremental number, because cluster may dynamically change
+            shutil.copytree(
+                ocsci_config.ENV_DATA["cluster_path"], cluster_path, dirs_exist_ok=True
             )
+            set_cli_param(config, f"cluster_path{suffix}", cluster_path)
 
     if not cluster_path:
         raise ClusterPathNotProvidedError()
@@ -634,10 +671,23 @@ def process_cluster_cli_params(config):
     OCP.set_kubeconfig(os.path.join(cluster_path, kubeconfig_location))
     cluster_name = get_cli_param(config, f"cluster_name{suffix}")
 
-    if not cluster_name:
-        cluster_name = ocsci_config.ENV_DATA.get("cluster_name")
-        if not cluster_name:
-            raise ClusterNameNotProvidedError()
+    # # # # # # # # # # # This block is an overwrite logic for dynamic configuration adjustments  # # # # # # # # # # #
+    if not cluster_name and ocsci_config.multicluster:
+        if ocsci_config.ENV_DATA["cluster_type"] == "provider":
+            # If cluster_name is not provided, and we are in multicluster mode
+            # we will create cluster_name with suffix
+            provider_name = get_cli_param(config, "cluster_name")
+            set_cli_param(config, f"cluster_name{suffix}", provider_name)
+            cluster_name = get_cli_param(config, f"cluster_name{suffix}")
+        elif ocsci_config.ENV_DATA["cluster_type"] in [
+            "consumer",
+            "hci_client",
+        ]:
+            # If cluster_name is not provided, and we are in multicluster mode
+            # we'll assign existing name to config.'cluster_name{suffix}' to have matching provided and dynamic config's
+            cluster_name = ocsci_config.ENV_DATA.get("cluster_name")
+            set_cli_param(config, f"cluster_name{suffix}", cluster_name)
+            cluster_name = get_cli_param(config, f"cluster_name{suffix}")
 
     ocsci_config.RUN["cli_params"]["teardown"] = get_cli_param(
         config, "teardown", default=False

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -459,6 +459,16 @@ PROVIDER_CLUSTER_RESOURCE_KINDS = [
 ]
 PROVIDER_SUBSCRIPTION = "subs"
 
+# duties for fixtures to create hosted clusters and manipulate configurations
+DUTY_USE_EXISTING_HOSTED_CLUSTERS_FORCE_PUSH_CONFIG = (
+    "use_existing_hosted_clusters_force_push_configs"
+)
+DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG = (
+    "use_existing_hosted_clusters_push_missing_configs"
+)
+DUTY_CREATE_HOSTED_CLUSTER_PUSH_CONFIG = "create_hosted_cluster_push_config"
+
+
 OCS_CLIENT_OPERATOR_CONTROLLER_MANAGER_PREFIX = "ocs-client-operator-controller-manager"
 OCS_CLIENT_OPERATOR_CONSOLE = "ocs-client-operator-console"
 STORAGE_CLIENT_NAME = "ocs-storagecluster"

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -221,8 +221,21 @@ def get_version_info(namespace=None):
 
     operator_selector = get_selector_for_ocs_operator()
     subscription_plan_approval = config.DEPLOYMENT.get("subscription_plan_approval")
+
+    managed_or_hcp_platform = (
+        config.multicluster
+        and config.ENV_DATA.get("platform", "").lower()
+        in constants.HCI_PC_OR_MS_PLATFORM
+        and config.ENV_DATA.get("cluster_type", "").lower()
+        in [constants.MS_CONSUMER_TYPE, constants.HCI_CLIENT]
+    )
+    if managed_or_hcp_platform:
+        ocs_operator_name = constants.OCS_CLIENT_OPERATOR
+    else:
+        ocs_operator_name = defaults.OCS_OPERATOR_NAME
+
     package_manifest = PackageManifest(
-        resource_name=defaults.OCS_OPERATOR_NAME,
+        resource_name=ocs_operator_name,
         selector=operator_selector,
         subscription_plan_approval=subscription_plan_approval,
     )

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -170,6 +170,16 @@ class PackageManifest(OCP):
             config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
             and config.ENV_DATA["deployment_type"] == "managed"
         )
+        managed_or_hcp_platform = (
+            config.multicluster
+            and config.ENV_DATA.get("platform", "").lower()
+            in constants.HCI_PC_OR_MS_PLATFORM
+            and config.ENV_DATA.get("cluster_type", "").lower()
+            in [constants.MS_CONSUMER_TYPE, constants.HCI_CLIENT]
+        )
+        if managed_or_hcp_platform:
+            csv_pattern = constants.OCS_CLIENT_OPERATOR
+
         if self.subscription_plan_approval == "Manual" or managed_ibmcloud:
             try:
                 return self.get_installed_csv_from_install_plans(
@@ -186,6 +196,7 @@ class PackageManifest(OCP):
                     "No CSV found from any installPlan, continue to get the CSV"
                     " name from the packageManifest"
                 )
+
         for _channel in channels:
             if _channel["name"] == channel:
                 return _channel["currentCSV"]

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -899,12 +899,12 @@ def get_ceph_tools_pod(
                 )
                 ct_pod_items = ocp_pod_obj.data["items"]
 
-            if not ct_pod_items:
-                raise CephToolBoxNotFoundException
+        if not ct_pod_items:
+            raise CephToolBoxNotFoundException
 
-            if not get_running_pods:
-                # Return the ceph tool pod objects even if they are not running
-                return ct_pod_items
+        if not get_running_pods:
+            # Return the ceph tool pod objects even if they are not running
+            return ct_pod_items
 
             # In the case of node failure, the CT pod will be recreated with the old
             # one in status Terminated. Therefore, need to filter out the Terminated pod

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -899,12 +899,12 @@ def get_ceph_tools_pod(
                 )
                 ct_pod_items = ocp_pod_obj.data["items"]
 
-        if not ct_pod_items:
-            raise CephToolBoxNotFoundException
+            if not ct_pod_items:
+                raise CephToolBoxNotFoundException
 
-        if not get_running_pods:
-            # Return the ceph tool pod objects even if they are not running
-            return ct_pod_items
+            if not get_running_pods:
+                # Return the ceph tool pod objects even if they are not running
+                return ct_pod_items
 
             # In the case of node failure, the CT pod will be recreated with the old
             # one in status Terminated. Therefore, need to filter out the Terminated pod

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -437,6 +437,24 @@ def get_running_odf_version():
     return odf_full_version
 
 
+def get_running_odf_client_version():
+    """
+    Get current running ODF Client version
+
+    Returns:
+        string: ODF Client version
+    """
+    from ocs_ci.ocs.resources import csv
+
+    namespace = config.ENV_DATA["cluster_namespace"]
+    odf_client_csv = csv.get_csvs_start_with_prefix(
+        defaults.ODF_CLIENT_OPERATOR, namespace=namespace
+    )
+    odf_client_full_version = odf_client_csv[0]["metadata"]["labels"]["full_version"]
+    log.info(f"ODF Client full version is {odf_client_full_version}")
+    return odf_client_full_version
+
+
 def get_semantic_running_odf_version():
     """
     Get current running ODF semantic version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -602,9 +602,7 @@ def pytest_runtest_setup(item):
                 log.info(f"Switching the test context to index: {mark.args[0]}")
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
-        log.warning(item.callspec.params)
         for mark in item.iter_markers():
-            log.warning(mark)
             if mark.name == "parametrize":
                 if item.callspec.params.get("cluster_index"):
                     context = item.callspec.params.get("cluster_index")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -616,7 +616,7 @@ def pytest_runtest_setup(item):
                     ocsci_config.switch_ctx(original_idx)
 
 
-def pytest_fixture_setup(fixturedef, request):
+def pytest_fixture_setup(fixturedef, request, item):
     """
     In case of multicluster scenarios, we want to make sure that before running
     any fixture related to the testcase we need to switch the cluster context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9516,7 +9516,7 @@ def create_config_of_existing_hosted_clusters():
 
         """
         hypershift_cluster_factory(
-            duty="use_existing_hosted_clusters_push_missing_configs",
+            duty=constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
         )
 
     return factory
@@ -9536,7 +9536,7 @@ def refresh_hosted_config():
 
         """
         hypershift_cluster_factory(
-            duty="use_existing_hosted_clusters_force_push_configs",
+            duty=constants.DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
         )
 
     return factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from ocs_ci.deployment.helpers.hypershift_base import HyperShiftBase
 from ocs_ci.deployment.hosted_cluster import (
     hypershift_cluster_factory,
     get_autodistributed_storage_classes,
+    skip_if_not_hcp_provider
 )
 from ocs_ci.framework import config as ocsci_config, config
 import ocs_ci.framework.pytest_customization.marks
@@ -616,7 +617,7 @@ def pytest_runtest_setup(item):
                     ocsci_config.switch_ctx(original_idx)
 
 
-def pytest_fixture_setup(fixturedef, request, item):
+def pytest_fixture_setup(fixturedef, request):
     """
     In case of multicluster scenarios, we want to make sure that before running
     any fixture related to the testcase we need to switch the cluster context
@@ -629,6 +630,17 @@ def pytest_fixture_setup(fixturedef, request, item):
             for mark in request.node.iter_markers():
                 if mark.name == "config_index":
                     ocsci_config.switch_ctx(mark.args[0])
+    _switch_context_helper(request)
+
+
+def _switch_context_helper(request):
+    """
+    Helper function to switch context of the cluster
+
+    Args:
+        request: pytest request object
+    """
+
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
             if mark.name == "parametrize":
@@ -647,11 +659,13 @@ def pytest_fixture_post_finalizer(fixturedef, request):
     """
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
+            # if we have multiple parametrize markers, we need to reset only one time, hence breaking from first match
             if mark.name == "parametrize":
                 if isinstance(
                     request.node, pytest.Function
                 ) and request.node.callspec.params.get("cluster_index"):
                     ocsci_config.reset_ctx()
+                    break
 
 
 @pytest.fixture()
@@ -1255,6 +1269,8 @@ def project_factory_fixture(request):
         return proj_obj
 
     def finalizer():
+        _switch_context_helper(request)
+
         delete_projects(instances)
 
     request.addfinalizer(finalizer)
@@ -1443,6 +1459,8 @@ def pvc_factory_fixture(request, project_factory):
         """
         Delete the PVC
         """
+        _switch_context_helper(request)
+
         pv_objs = []
 
         # Get PV form PVC instances and delete PVCs
@@ -1594,6 +1612,8 @@ def pod_factory_fixture(request, pvc_factory):
         """
         Delete the Pod or the DeploymentConfig
         """
+        _switch_context_helper(request)
+
         for instance in instances:
             instance.delete()
             instance.ocp.wait_for_delete(instance.name)
@@ -9452,6 +9472,7 @@ def scale_noobaa_db_pv(request):
 
 
 @pytest.fixture()
+@skip_if_not_hcp_provider
 def create_hypershift_clusters_push_config():
     """
     Create hosted HyperShift clusters using the hypershift_cluster_factory function.
@@ -9483,30 +9504,18 @@ def create_hypershift_clusters_push_config():
 
 
 @pytest.fixture()
+@skip_if_not_hcp_provider
 def create_config_of_existing_hosted_clusters():
     """
     Get the list of available hosted clusters. Push config to Multicluster Config for configs that do not exist only.
     """
 
-    def factory(
-        cluster_names, ocp_version, odf_version, setup_storage_client, nodepool_replicas
-    ):
+    def factory():
         """
         Wrapper to call hypershift_cluster_factory with a predefined duty.
 
-        Args:
-            cluster_names (list): List of cluster names
-            ocp_version (str): OCP version
-            odf_version (str): ODF version
-            setup_storage_client (bool): Setup storage client
-            nodepool_replicas (int): Nodepool replicas; supported values are 2,3
         """
         hypershift_cluster_factory(
-            cluster_names=cluster_names,
-            ocp_version=ocp_version,
-            odf_version=odf_version,
-            setup_storage_client=setup_storage_client,
-            nodepool_replicas=nodepool_replicas,
             duty="use_existing_hosted_clusters_push_missing_configs",
         )
 
@@ -9514,31 +9523,19 @@ def create_config_of_existing_hosted_clusters():
 
 
 @pytest.fixture()
+@skip_if_not_hcp_provider
 def refresh_hosted_config():
     """
     Get the list of available hosted clusters. Push new config to Multicluster Config,
     replacing already existing if found.
     """
 
-    def factory(
-        cluster_names, ocp_version, odf_version, setup_storage_client, nodepool_replicas
-    ):
+    def factory():
         """
         Wrapper to call hypershift_cluster_factory with a predefined duty.
 
-        Args:
-            cluster_names (list): List of cluster names
-            ocp_version (str): OCP version
-            odf_version (str): ODF version
-            setup_storage_client (bool): Setup storage client
-            nodepool_replicas (int): Nodepool replicas; supported values are 2,3
         """
         hypershift_cluster_factory(
-            cluster_names=cluster_names,
-            ocp_version=ocp_version,
-            odf_version=odf_version,
-            setup_storage_client=setup_storage_client,
-            nodepool_replicas=nodepool_replicas,
             duty="use_existing_hosted_clusters_force_push_configs",
         )
 
@@ -9546,6 +9543,7 @@ def refresh_hosted_config():
 
 
 @pytest.fixture()
+@skip_if_not_hcp_provider
 def destroy_hosted_cluster():
     """
     Destroy hosted HyperShift clusters using the hosted_cluster_remove_factory function.
@@ -9561,6 +9559,7 @@ def destroy_hosted_cluster():
 
 
 @pytest.fixture()
+@skip_if_not_hcp_provider
 def hosted_cluster_remove_config():
     """
     Remove hosted HyperShift clusters from Multicluster Config using the hosted_cluster_remove_factory function.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -602,7 +602,9 @@ def pytest_runtest_setup(item):
                 log.info(f"Switching the test context to index: {mark.args[0]}")
                 ocsci_config.switch_ctx(mark.args[0])
     if ocsci_config.multicluster:
+        log.warning(item.callspec.params)
         for mark in item.iter_markers():
+            log.warning(mark)
             if mark.name == "parametrize":
                 if item.callspec.params.get("cluster_index"):
                     context = item.callspec.params.get("cluster_index")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from ocs_ci.deployment.helpers.hypershift_base import HyperShiftBase
 from ocs_ci.deployment.hosted_cluster import (
     hypershift_cluster_factory,
     get_autodistributed_storage_classes,
-    skip_if_not_hcp_provider
+    skip_if_not_hcp_provider,
 )
 from ocs_ci.framework import config as ocsci_config, config
 import ocs_ci.framework.pytest_customization.marks

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -5,7 +5,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     red_squad,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
     runs_on_provider,
     mcg,
     provider_client_ms_platform_required,
@@ -60,7 +60,7 @@ def test_verify_backingstore_uses_rgw(mcg_obj_session):
 @red_squad
 @tier1
 @provider_client_ms_platform_required
-@run_on_all_clients
+@run_on_all_clients_push_missing_configs
 @pytest.mark.polarion_id("OCS-5214")
 def test_write_file_to_bucket_on_client(
     bucket_factory,

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -13,7 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     brown_squad,
     polarion_id,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 
 log = getLogger(__name__)
@@ -31,7 +31,7 @@ class TestEphemeralPod:
     @pytest.mark.parametrize(
         argnames=["interface"], argvalues=[[CEPHFS_INTERFACE], [RBD_INTERFACE]]
     )
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_ephemeral_pod_creation(self, interface, cluster_index) -> None:
         pod_name = None
         storage_type = interface

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -21,7 +21,6 @@ log = getLogger(__name__)
 
 @tier2
 @brown_squad
-@run_on_all_clients
 @polarion_id("OCS-5792")
 class TestEphemeralPod:
     # This a workaround for any cluster other than multiclent provider mode

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -21,6 +21,7 @@ log = getLogger(__name__)
 
 @tier2
 @brown_squad
+@run_on_all_clients
 @polarion_id("OCS-5792")
 class TestEphemeralPod:
     # This a workaround for any cluster other than multiclent provider mode

--- a/tests/functional/pv/pv_services/test_create_large_sized_pvc_while_io_in_progress.py
+++ b/tests/functional/pv/pv_services/test_create_large_sized_pvc_while_io_in_progress.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import ManageTest, tier2
 
@@ -34,7 +34,7 @@ class TestCreateLargeSizedPVCWhileIOInProgress(ManageTest):
             ),
         ],
     )
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_create_large_sized_pvc_while_io_in_progress(
         self, interface, pvc_factory, pod_factory, cluster_index
     ):

--- a/tests/functional/pv/pv_services/test_pvc_concurrent_deletion_creation.py
+++ b/tests/functional/pv/pv_services/test_pvc_concurrent_deletion_creation.py
@@ -12,7 +12,7 @@ from ocs_ci.ocs.resources.pvc import delete_pvcs
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import tier2, ManageTest
 from ocs_ci.helpers.helpers import (
@@ -65,7 +65,7 @@ class TestMultiplePvcConcurrentDeletionCreation(ManageTest):
             wait_each=False,
         )
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_multiple_pvc_concurrent_creation_deletion(
         self, interface, multi_pvc_factory, cluster_index
     ):

--- a/tests/functional/pv/pv_services/test_pvc_deletion_during_io.py
+++ b/tests/functional/pv/pv_services/test_pvc_deletion_during_io.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import ManageTest, tier2
 
@@ -44,7 +44,7 @@ class TestDeletePVCWhileRunningIO(ManageTest):
         self.pvc_obj = pvc_factory(interface=interface)
         self.pod_obj = pod_factory(pvc=self.pvc_obj)
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_run_io_and_delete_pvc(self, cluster_index):
         """
         Delete PVC while IO is in progress

--- a/tests/functional/pv/pv_services/test_pvc_rwx_writeable_after_pod_deletions.py
+++ b/tests/functional/pv/pv_services/test_pvc_rwx_writeable_after_pod_deletions.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.ocs import constants, node
@@ -26,7 +26,7 @@ class TestRWXMountPoint(ManageTest):
 
     @pytest.mark.polarion_id("OCS-965")
     @tier1
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_pvc_rwx_writeable_after_pod_deletions(
         self, pvc_factory, teardown_factory, cluster_index
     ):

--- a/tests/functional/pv/pv_services/test_raw_block_pv.py
+++ b/tests/functional/pv/pv_services/test_raw_block_pv.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.resources.pod import get_fio_rw_iops
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import (
     tier1,
@@ -160,7 +160,7 @@ class TestRawBlockPV(ManageTest):
             get_fio_rw_iops(pod)
         return pods, pvcs, pvs
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_raw_block_pv(
         self, storageclass, namespace, teardown_factory, cluster_index
     ):

--- a/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import ManageTest, tier2
 
@@ -52,7 +52,7 @@ class TestIOMultiplePods(ManageTest):
 
         return pod_objs
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_run_io_multiple_pods(self, pods, cluster_index):
         """
         Run IO on multiple pods in parallel

--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -5,7 +5,10 @@ import time
 import yaml
 
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    run_on_all_clients_push_missing_configs,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     polarion_id,
@@ -50,7 +53,8 @@ class TestRwopPvc(ManageTest):
         )
 
     @polarion_id("OCS-5924")
-    def test_pod_with_same_priority(self, pod_factory, interface):
+    @run_on_all_clients_push_missing_configs
+    def test_pod_with_same_priority(self, pod_factory, interface, cluster_index):
         """
         Test RBD Block volume mode RWOP PVC
 

--- a/tests/functional/pv/pv_services/test_verify_rwo_using_multiple_pods.py
+++ b/tests/functional/pv/pv_services/test_verify_rwo_using_multiple_pods.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
             *[constants.CEPHBLOCKPOOL],
             marks=[
                 pytest.mark.polarion_id("OCS-1177"),
-                run_on_all_clients,
+                run_on_all_clients_push_missing_configs,
             ],
         ),
     ],

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.pytest_customization.marks import skipif_hci_provider_and_client
 from ocs_ci.framework.testlib import (
@@ -59,7 +59,7 @@ class TestClone(ManageTest):
 
     @provider_mode
     @acceptance
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     @pytest.mark.parametrize(
         argnames=["interface_type", "pod_dict_path", "access"],
         argvalues=[

--- a/tests/functional/pv/pvc_resize/test_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_pvc_expansion.py
@@ -7,7 +7,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -151,7 +151,7 @@ class TestPvcExpand(ManageTest):
 
             # Split file size and write from two pods if access mode is RWX
             size = (
-                f"{int(file_size/2)}G"
+                f"{int(file_size / 2)}G"
                 if (pod_obj.pvc.access_mode == constants.ACCESS_MODE_RWX)
                 else f"{file_size}G"
             )
@@ -181,7 +181,7 @@ class TestPvcExpand(ManageTest):
 
     @provider_mode
     @acceptance
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     @tier1
     @pytest.mark.polarion_id("OCS-2219")
     def test_pvc_expansion(self, cluster_index):

--- a/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -59,7 +59,7 @@ class TestPvcSnapshot(ManageTest):
             interface=interface, pvc=self.pvc_obj, status=constants.STATUS_RUNNING
         )
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_pvc_snapshot(self, interface, teardown_factory, cluster_index):
         """
         1. Run I/O on a pod file.

--- a/tests/functional/pv/pvc_snapshot/test_rbd_block_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_rbd_block_pvc_snapshot.py
@@ -6,7 +6,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -62,7 +62,7 @@ class TestRbdBlockPvcSnapshot(ManageTest):
             status=constants.STATUS_RUNNING,
         )
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_rbd_block_pvc_snapshot(
         self, snapshot_factory, snapshot_restore_factory, pod_factory, cluster_index
     ):

--- a/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs import constants, node
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
-    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -42,7 +42,7 @@ class TestSnapshotRestoreWithDifferentAccessMode(ManageTest):
         """
         self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
 
-    @run_on_all_clients
+    @run_on_all_clients_push_missing_configs
     def test_snapshot_restore_with_different_access_mode(
         self, pod_factory, snapshot_factory, snapshot_restore_factory, cluster_index
     ):

--- a/tests/libtest/test_multicluster.py
+++ b/tests/libtest/test_multicluster.py
@@ -1,7 +1,11 @@
 import pytest
 import logging
 
-from ocs_ci.framework.pytest_customization.marks import libtest, run_on_all_clients
+from ocs_ci.framework.pytest_customization.marks import (
+    libtest,
+    run_on_all_clients,
+    run_on_all_clients_push_missing_configs,
+)
 
 logger = logging.getLogger(name=__file__)
 
@@ -9,6 +13,12 @@ logger = logging.getLogger(name=__file__)
 @libtest
 @run_on_all_clients
 def test_run_on_all_clients_marker(cluster_index):
+    pass
+
+
+@libtest
+@run_on_all_clients_push_missing_configs
+def test_run_on_all_clients_push_missing_config_marker(cluster_index):
     pass
 
 


### PR DESCRIPTION
This PR is a clean rebase of #12007 Draft. Draft 12007 was initially done for demonstration purpose. 
Due to complexity of the changes and fact of #12007 heavy relying on already merged #11864 decided to push another PR

----
Additionally, to make test_pod_with_same_priority Pass without errors on health check and pre-run hooks issues were addressed: 
1) Collect ceph version and versions of images from provisioning plugins
2) Get tool pod for multi-client scenarios (executed on ceph cluster even when running test on client)
3) Ceph health checks for multi-client scenarios (executed on ceph cluster even when running test on client)