### PR TITLE
Skip `TestDefaultBackingstoreOverride` in external deployments

### DIFF
--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
+    skipif_external_mode,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers  # needed for the upgrade TCs
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
+@skipif_external_mode
 class TestDefaultBackingstoreOverride(MCGTest):
     """
     Test overriding the default noobaa backingstore


### PR DESCRIPTION
This test suite attempts to clone the existing default backingstore and set the clone as the new default.

In external deployments, this process requires additional configuration steps that add complexity without meaningful benefit. This PR skips these scenarios to streamline the test flow and avoid spending time on a low-value edge case.