### PR TITLE
Skipping ibmcloud testcase for machine not found error: v4.17

### DIFF
--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -327,6 +327,7 @@ class TestNodeReplacementTwice(ManageTest):
       2. ceph side host still on the old rack
     """
 
+    @skipif_ibm_cloud_managed
     def test_nodereplacement_twice(self):
         for i in range(2):
             # Get random node name for replacement


### PR DESCRIPTION
Skipping ibmcloud testcase for machine not found error: v4.17