### PR TITLE
Make sure run_id is unique by using miliseconds instead of only seconds

### DIFF
--- a/ocs_ci/utility/framework/fusion_fdf_init.py
+++ b/ocs_ci/utility/framework/fusion_fdf_init.py
@@ -201,7 +201,7 @@ def generate_run_id() -> int:
 
     """
     logger.debug("Generating run_id from timestamp")
-    run_id = int(time.time())
+    run_id = int(time.time() * 1000)
     config.RUN["run_id"] = run_id
     return run_id
 

--- a/ocs_ci/utility/framework/initialization.py
+++ b/ocs_ci/utility/framework/initialization.py
@@ -209,7 +209,7 @@ def process_ocsci_conf(arguments):
     if args.flexy_env_file:
         framework.config.ENV_DATA["flexy_env_file"] = args.flexy_env_file
 
-    framework.config.RUN["run_id"] = int(time.time())
+    framework.config.RUN["run_id"] = int(time.time() * 1000)
     bin_dir = framework.config.RUN.get("bin_dir")
     if bin_dir:
         framework.config.RUN["bin_dir"] = os.path.abspath(


### PR DESCRIPTION
When the `run_id` is taken just from seconds timestamp, there is a possibility that two runs will get the same `run_id`:
* https://url.corp.redhat.com/209791b
* https://url.corp.redhat.com/6cc73a3

This situation breaks the reporting to Report Portal and might cause another issues.
To minimize this risk, we can use miliseconds as run_id.