### PR TITLE
install latest hypershift operator to support 4.19 guest OCP

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -346,6 +346,7 @@ higher priority).
 * `deploy_acm_hub_cluster` - Deploy ACM hub cluster or not (Default: false)
 * `cnv_deployment` - Deploy CNV or not (Default: false) necessary for Converged clusters with hosted clients
 * `deploy_hyperconverged` - Deploy hyperconverged operator or not (Default: false).  Necessary for Converged clusters with hosted clients with unreleased OCP version
+* `install_latest_hypershift_operator` - Install the latest hypershift operator (Default: false). Will also upgrade existing hypershift operator to latest version. Necessary to support unreleased guest OCP version
 * `clusters` - section for hosted clusters
     * `<cluster name>` - name of the cluster
       * `hosted_cluster_path` - path to the cluster directory to store auth_path, credentials files or cluster related files

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -18,6 +18,7 @@ import yaml
 
 from botocore.exceptions import EndpointConnectionError, BotoCoreError
 
+from ocs_ci.deployment.helpers.hypershift_base import update_hypershift_operator
 from ocs_ci.deployment.helpers import storage_class
 from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
 from ocs_ci.deployment.helpers.external_cluster_helpers import (
@@ -461,9 +462,13 @@ class Deployment(object):
 
         """
         if config.ENV_DATA["skip_ocs_deployment"]:
+            mce_installer = MCEInstaller()
             if config.ENV_DATA.get("deploy_mce"):
-                mce_installer = MCEInstaller()
                 mce_installer.deploy_mce()
+
+            if config.ENV_DATA.get("install_latest_hypershift_operator"):
+                if mce_installer.mce_installed():
+                    update_hypershift_operator()
 
     def do_deploy_oadp(self):
         """

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -211,6 +211,43 @@ def get_current_nodepool_size(name):
     return exec_cmd(cmd, shell=True).stdout.decode("utf-8").strip()
 
 
+def update_hypershift_operator(version="latest"):
+    """
+    Update the hypershift operator by extracting the latest image and installing it.
+    This function is also used to update the existing hypershift operator.
+    One of the suggested options to support unreleased guest OCP clusters
+
+    Args:
+        version (str): The version of the hypershift operator to install. Default is 'latest'.
+
+    """
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        try:
+            logger.info("Extracting hypershift operator binary from the latest image")
+            exec_cmd(
+                f"oc image extract {constants.HCP_REGISTRY}:{version} "
+                f"--path=/usr/bin/hypershift:{temp_dir}",
+                shell=True,
+            )
+            logger.info("Setting executable permissions for the hypershift binary")
+            hypershift_binary_path = os.path.join(temp_dir, "hypershift")
+            os.chmod(hypershift_binary_path, 0o755)
+            hypershift_abs_path = os.path.abspath(hypershift_binary_path)
+            logger.info(f"hypershift binary path: {hypershift_abs_path}")
+            logger.info("Installing the hypershift operator")
+            cmd = (
+                f"{hypershift_binary_path} install --hypershift-image {constants.HCP_REGISTRY}:{version}",
+            )
+            exec_cmd(
+                cmd,
+                shell=True,
+            )
+        except Exception as e:
+            logger.error(f"Failed to install/update hypershift operator: {e}")
+
+
 class HyperShiftBase:
     """
     Class to handle HyperShift hosted cluster management


### PR DESCRIPTION
To support unreleased versions of OCP we need follow one of three options

1. install MCE 2.9 from pre-release (need quay access for it)
2. use Latest hypershift operator [quay.io/hypershift/hypershift-operator:latest](http://quay.io/hypershift/hypershift-operator:latest)
3. put annotation on the HostedCluster to ignore this validation

Hypershift team recommended to follow the 2nd option as we can not access unreleased upstream MCE versions. 
This was implemented here.

New ENV_DATA config var introduced: `install_latest_hypershift_operator`, by default False/None