### PR TITLE
fix existing yaml configs with nodepool replicas

### DIFF
--- a/conf/deployment/fusion_hci_pc/client_bm_upi_1az_rhcos_nvme_2w.yaml
+++ b/conf/deployment/fusion_hci_pc/client_bm_upi_1az_rhcos_nvme_2w.yaml
@@ -4,7 +4,7 @@ ENV_DATA:
   cluster_type: 'hci_client'
   cluster_namespace: "openshift-storage-client"
   deployment_type: 'upi'
-  worker_replicas: 2
+  nodepool_replicas: 2
   mon_type: 'hostpath'
   osd_type: 'nvme'
 REPORTING:

--- a/conf/deployment/fusion_hci_pc/client_bm_upi_1az_rhcos_nvme_3w.yaml
+++ b/conf/deployment/fusion_hci_pc/client_bm_upi_1az_rhcos_nvme_3w.yaml
@@ -4,7 +4,7 @@ ENV_DATA:
   cluster_type: 'hci_client'
   cluster_namespace: "openshift-storage-client"
   deployment_type: 'upi'
-  worker_replicas: 3
+  nodepool_replicas: 3
   mon_type: 'hostpath'
   osd_type: 'nvme'
 REPORTING:


### PR DESCRIPTION
`nodepool_replicas` were not used and `worker_replicas` used instead, when deployment job expected to get  `nodepool_replicas`, hence default value '2' always takes place