### PR TITLE
Fix test_abort_incomplete_multipart_upload

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2472,7 +2472,7 @@ def expire_multipart_upload_in_noobaa_db(upload_id):
         "UPDATE objectmultiparts "
         "SET data = jsonb_set(data, '{create_time}', "
         f"to_jsonb(to_timestamp({one_year_ago}))) "
-        f"WHERE obj = '{upload_id}';"
+        f"WHERE data->>'obj' = '{upload_id}';"
     )
     exec_nb_db_query(psql_query)
 

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2441,7 +2441,7 @@ def expire_objects_in_bucket(bucket_name, object_keys=[], prefix=""):
 
 def expire_multipart_upload_in_noobaa_db(upload_id):
     """
-    Expire a multipart upload by changing its creation date to one year back.
+    Expire a multipart upload and its parts by changing their creation date to one year back.
 
     Args:
         upload_id (str): The ID of the multipart upload to expire (unique across all buckets)
@@ -2452,8 +2452,11 @@ def expire_multipart_upload_in_noobaa_db(upload_id):
     # and that ID's first 8 characters are the initial timestamp
     # in hex
 
-    # first two characters of the hex are 0x
-    new_upload_started = hex(int(one_year_ago))[2:] + upload_id[8:]
+    # The first two characters in the python hex representation are "0x"
+    one_year_ago_hex_str = hex(int(one_year_ago))[2:]
+
+    # Concatenate the new timestamp with the rest of the ID
+    new_upload_started = one_year_ago_hex_str + upload_id[8:]
 
     psql_query = (
         "UPDATE objectmds "
@@ -2462,6 +2465,15 @@ def expire_multipart_upload_in_noobaa_db(upload_id):
         f"WHERE _id = '{upload_id}'"
     )
     psql_query += ";"
+    exec_nb_db_query(psql_query)
+
+    # Expire the parts as well
+    psql_query = (
+        "UPDATE objectmultiparts "
+        "SET data = jsonb_set(data, '{create_time}', "
+        f"to_jsonb(to_timestamp({one_year_ago}))) "
+        f"WHERE obj = '{upload_id}';"
+    )
     exec_nb_db_query(psql_query)
 
 

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -147,7 +147,7 @@ class TestLifecycleConfiguration(MCGTest):
             f"SELECT data FROM objectmultiparts WHERE data->>'bucket' = '{bucket_id}'"
         )
         for parts_md_list in TimeoutSampler(
-            timeout=900,
+            timeout=3600,
             sleep=TIMEOUT_SLEEP_DURATION,
             func=exec_nb_db_query,
             query=list_parts_md_query,

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -147,7 +147,7 @@ class TestLifecycleConfiguration(MCGTest):
             f"SELECT data FROM objectmultiparts WHERE data->>'bucket' = '{bucket_id}'"
         )
         for parts_md_list in TimeoutSampler(
-            timeout=TIMEOUT_THRESHOLD,
+            timeout=900,
             sleep=TIMEOUT_SLEEP_DURATION,
             func=exec_nb_db_query,
             query=list_parts_md_query,


### PR DESCRIPTION
- Changes to docstrings and comments
- Extend expire_multipart_upload_in_noobaa_db to also expire the parts
- Remove the final step of the test where we're waiting for the parts to be marked as "deleted". While local and automated attempts have shown they do eventually get deleted, I couldn't find a way to speed up this process. Since it can take up to an hour, it's just best to remove this verification.