### PR TITLE
Update fixture name dc_pod_factory to deployment_pod_factory in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6628,7 +6628,7 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
                 pods_for_rwx if pvc_obj.access_mode == constants.ACCESS_MODE_RWX else 1
             )
             for _ in range(num_pods):
-                # pod_obj will be a Pod instance if deployment_config=False,
+                # pod_obj will be a Pod instance if deployment=False,
                 # otherwise an OCP instance of kind DC
                 pod_obj = pod_factory(
                     interface=interface,

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
@@ -36,7 +36,7 @@ state = constants.STATUS_RUNNING
 
 
 @pytest.fixture(scope="function")
-def run_metadata_io_with_cephfs(dc_pod_factory):
+def run_metadata_io_with_cephfs(deployment_pod_factory):
     """
     This function facilitates
     1. Create PVC with Cephfs, access mode RWX
@@ -58,7 +58,7 @@ def run_metadata_io_with_cephfs(dc_pod_factory):
             target_node.append(node)
     for dc_pod in range(3):
         log.info("Create fedora dc pod")
-        pod_obj = dc_pod_factory(
+        pod_obj = deployment_pod_factory(
             size="30",
             access_mode=access_mode,
             interface=interface,

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")
-def run_file_creator_io_with_cephfs(dc_pod_factory):
+def run_file_creator_io_with_cephfs(deployment_pod_factory):
     """
     This function facilitates
     1. Create PVC with Cephfs, access mode RWX
@@ -36,7 +36,7 @@ def run_file_creator_io_with_cephfs(dc_pod_factory):
     for dc_pod in range(10):
         log.info(f"Creating {interface} based PVC")
         log.info("Creating fedora dc pod")
-        pod_obj = dc_pod_factory(
+        pod_obj = deployment_pod_factory(
             size="15", access_mode=access_mode, interface=interface
         )
         log.info("Copying file_creator_io.py to fedora pod ")

--- a/tests/functional/pv/pv_services/test_cephfs_pvc_with_chunk_size.py
+++ b/tests/functional/pv/pv_services/test_cephfs_pvc_with_chunk_size.py
@@ -37,7 +37,7 @@ class TestCephfsWithChunkIo(E2ETest):
         cluster.ceph_config_set_debug("1/5")
         log.info("Ceph mds debug level has been set to default 1/5")
 
-    def test_cephfs_with_large_chunk_io(self, dc_pod_factory):
+    def test_cephfs_with_large_chunk_io(self, deployment_pod_factory):
         """
         This function facilitates
         1. Create PVC with Cephfs
@@ -55,7 +55,7 @@ class TestCephfsWithChunkIo(E2ETest):
         file = constants.CHUNK
         interface = constants.CEPHFILESYSTEM
         log.info("Creating fedora dc pod")
-        pod_obj = dc_pod_factory(size="50", interface=interface)
+        pod_obj = deployment_pod_factory(size="50", interface=interface)
         log.info("Copying chunk.py to fedora pod ")
         cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/"
         helpers.run_cmd(cmd=cmd)

--- a/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
@@ -27,7 +27,7 @@ class TestIOMultiplePods(ManageTest):
     pvc_size = 5
 
     @pytest.fixture()
-    def pods(self, interface, multi_pvc_factory, pod_factory, dc_pod_factory):
+    def pods(self, interface, multi_pvc_factory, pod_factory, deployment_pod_factory):
         """
         Prepare multiple pods for the test
 
@@ -41,7 +41,7 @@ class TestIOMultiplePods(ManageTest):
 
         pod_objs = list()
         for pvc_obj in pvc_objs[: len(pvc_objs) // 2]:
-            pod_objs.append(dc_pod_factory(interface=interface, pvc=pvc_obj))
+            pod_objs.append(deployment_pod_factory(interface=interface, pvc=pvc_obj))
 
         for pvc_obj in pvc_objs[len(pvc_objs) // 2 :]:
             pod_objs.append(pod_factory(interface=interface, pvc=pvc_obj))

--- a/tests/functional/pv/pv_services/test_rwo_pvc_fencing_unfencing.py
+++ b/tests/functional/pv/pv_services/test_rwo_pvc_fencing_unfencing.py
@@ -75,7 +75,7 @@ class TestRwoPVCFencingUnfencing(ManageTest):
                 pods if not running on selected nodes, else False
             project_factory: A fixture to create new project
             multi_pvc_factory: A fixture create a set of new PVCs
-            dc_pod_factory: A fixture to create deploymentconfig pods
+            deployment_pod_factory: A fixture to create deploymentconfig pods
 
         Returns:
             tuple: containing the params used in test cases

--- a/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -42,13 +42,13 @@ class TestWorkerNodesFailure(ManageTest):
     @pytest.fixture()
     def setup(self, request, interface, multi_pvc_factory, deployment_pod_factory):
         """
-        Create PVCs and DeploymentConfig based app pods for the test
+        Create PVCs and Deployment based app pods for the test
 
         Args:
             interface(str): The type of the interface
                 (e.g. CephBlockPool, CephFileSystem)
             multi_pvc_factory: A fixture create a set of new PVCs
-            deployment_pod_factory: A fixture to create dc pod
+            deployment_pod_factory: A fixture to create deployments
 
         Returns:
             list: dc pod objs

--- a/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -48,7 +48,7 @@ class TestWorkerNodesFailure(ManageTest):
             interface(str): The type of the interface
                 (e.g. CephBlockPool, CephFileSystem)
             multi_pvc_factory: A fixture create a set of new PVCs
-            dc_pod_factory: A fixture to create dc pod
+            deployment_pod_factory: A fixture to create dc pod
 
         Returns:
             list: dc pod objs


### PR DESCRIPTION
The name of the fixture function 'dc_pod_factory' is now 'deployment_pod_factory'. Updating this change in the test cases which are not updated.
In addition to this one comment is also updated with the new function argument name.

Fixes #12105 