### PR TITLE
Skipping logging deployment/tests on 4.19 and above using old stack(EFK)

### DIFF
--- a/tests/functional/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/functional/workloads/ocp/logging/test_openshift-logging.py
@@ -25,6 +25,7 @@ from ocs_ci.utility import deployment_openshift_logging as ocp_logging_obj
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_ms_provider_and_consumer,
+    skipif_ocs_version,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ def setup_fixture(install_logging):
     logger.info("Testcases execution post deployment of openshift-logging")
 
 
+@skipif_ocs_version(">=4.19")
 @magenta_squad
 @pytest.mark.usefixtures(setup_fixture.__name__)
 @ignore_leftovers

--- a/tests/functional/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/functional/workloads/ocp/logging/test_openshift-logging.py
@@ -26,6 +26,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_ms_provider_and_consumer,
     skipif_ocs_version,
+    skipif_ocp_version,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ def setup_fixture(install_logging):
 
 
 @skipif_ocs_version(">=4.19")
+@skipif_ocp_version(">=4.19")
 @magenta_squad
 @pytest.mark.usefixtures(setup_fixture.__name__)
 @ignore_leftovers


### PR DESCRIPTION
Logging stack is different from logging 6.0 (lokistack) and logging 5.8(EFK) is no more supported from OCP 4.19. Hence the cluster operator fails to deploy using the old stack, The existing deployment and few tests are not relevant anymore in >= 4.19. 

https://github.com/red-hat-storage/ocs-ci/issues/11604