### PR TITLE
cephObjectStores hostnetwork check

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -924,11 +924,19 @@ def ocs_install_verification(
     log.info("Verified the ownerReferences CSI plugin daemonsets")
     log.info("Verifying the providerAPIServerServiceType setting in StorageCluster")
     sc_obj = get_storage_cluster()
-    if sc_obj.get().get("items")[0].get("spec").get("hostNetwork"):
+    sc_ob_spec = sc_obj.get().get("items")[0].get("spec")
+    if sc_ob_spec.get("hostNetwork") is True:
         assert (
-            sc_obj.get().get("items")[0].get("spec").get("providerAPIServerServiceType")
+            sc_ob_spec.get("providerAPIServerServiceType")
             == constants.SERVICE_TYPE_NODEPORT
         ), f"Provider API server service type is not {constants.SERVICE_TYPE_NODEPORT}"
+        # check the rule in bz DFBUGS-2324 is followed:
+        assert (
+            sc_ob_spec.get("managedResources", {})
+            .get("cephObjectStores", {})
+            .get("hostNetwork", True)
+            is False
+        ), "Host network is not set to False for cephObjectStores when spec.hostNetwork is True"
     log.info("Verified the providerAPIServerServiceType setting in StorageCluster")
     log.info("Verifying the csi driver ownership")
     csi_driver_list = [constants.RBD_PROVISIONER, constants.CEPHFS_PROVISIONER]

--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
@@ -18,6 +18,7 @@ spec:
     cephFilesystems: {}
     cephNonResilientPools: {}
     cephObjectStoreUsers: {}
+    # cephObjectStores.hostNetwork setting follows the bz DFBUGS-2324
     cephObjectStores:
       hostNetwork: false
     cephRBDMirror: {}


### PR DESCRIPTION
Following the comment [DFBUGS-2324 rook-ceph-rgw-ocs-storagecluster-cephobjectstore pod crashes with ODF v4.19.0-75 deployment with host networking enabled](https://issues.redhat.com/browse/DFBUGS-2324?focusedId=27132195&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27132195 ) we need to ensure there is no competition between hostNetwork settings on cluster and on cephObjectStores in managed resources of StorageCluster. 
Added post-deployment check