### PR TITLE
[RHSTOR-6624] - Missing MCG Lifecycle Configuration rules: advanced tests

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -18,6 +18,7 @@ import inspect
 import stat
 import platform
 import ipaddress
+from urllib.parse import urlparse, urlunparse
 from concurrent.futures import ThreadPoolExecutor
 from itertools import cycle
 from subprocess import PIPE, run
@@ -6001,3 +6002,19 @@ def find_cephfilesystemsubvolumegroup(storageclient_uid=None):
         cephbfssubvolumegroup = storage_consumer.get_cephfs_subvolumegroup()
 
     return cephbfssubvolumegroup
+
+
+def remove_port_from_url(url):
+    """
+    Remove the port from a URL while preserving the scheme, hostname, and path.
+
+    Args:
+        url (str): The URL to sanitize.
+
+    Returns:
+        str: The URL without any port information.
+    """
+    parsed = urlparse(url)
+    # hostname is netloc without the port suffix
+    # i.e parsed.netloc='example.com:80'; parsed.hostname='example.com'
+    return urlunparse(parsed._replace(netloc=parsed.hostname))

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -32,7 +32,7 @@ from ocs_ci.utility.utils import (
     exec_nb_db_query,
     exec_cmd,
 )
-from ocs_ci.helpers.helpers import create_resource
+from ocs_ci.helpers.helpers import create_resource, remove_port_from_url
 from ocs_ci.utility import version
 
 logger = logging.getLogger(__name__)
@@ -165,32 +165,34 @@ def craft_s3cmd_command(cmd, mcg_obj=None, signed_request_creds=None):
 
     """
     no_ssl = "--no-ssl"
+
     if mcg_obj:
-        if mcg_obj.region:
-            region = f"--region={mcg_obj.region} "
-        else:
-            region = ""
+        signed_request_creds = {
+            "access_key_id": mcg_obj.access_key_id,
+            "access_key": mcg_obj.access_key,
+            "endpoint": mcg_obj.s3_endpoint,
+            "region": mcg_obj.region,
+        }
+
+    if signed_request_creds:
+        access_key_id = signed_request_creds.get("access_key_id")
+        access_key = signed_request_creds.get("access_key")
+        endpoint = signed_request_creds.get("endpoint")
+        region = signed_request_creds.get("region")
+
+        # s3cmd doesn't support port suffix under host
+        endpoint = remove_port_from_url(endpoint)
+
         base_command = (
-            f"s3cmd --access_key={mcg_obj.access_key_id} "
-            f"--secret_key={mcg_obj.access_key} "
-            f"{region}"
-            f"--host={mcg_obj.s3_external_endpoint} "
-            f"--host-bucket={mcg_obj.s3_external_endpoint} "
+            "s3cmd "
+            f"--access_key={access_key_id} "
+            f"--secret_key={access_key} "
+            f"--host={endpoint} "
+            f"--host-bucket={endpoint} "
             f"{no_ssl} "
         )
-    elif signed_request_creds:
-        if signed_request_creds.get("region"):
-            region = f'--region={signed_request_creds.get("region")} '
-        else:
-            region = ""
-        base_command = (
-            f's3cmd --access_key={signed_request_creds.get("access_key_id")} '
-            f'--secret_key={signed_request_creds.get("access_key")} '
-            f"{region}"
-            f'--host={signed_request_creds.get("endpoint")} '
-            f'--host-bucket={signed_request_creds.get("endpoint")} '
-            f"{no_ssl} "
-        )
+        base_command += f"--region={region} " if region else ""
+
     else:
         base_command = f"s3cmd {no_ssl}"
 

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -331,3 +331,45 @@ class AbortIncompleteMultipartUploadRule(LifecycleRule):
             "DaysAfterInitiation": self.days_after_initiation
         }
         return rule_dict
+
+
+class NoncurrentVersionExpirationRule(LifecycleRule):
+    """
+    A class for handling the parsing of an MCG non-current version expiration rule
+    """
+
+    def __init__(
+        self,
+        non_current_days=None,
+        newer_non_current_versions=None,
+        filter=LifecycleFilter(),
+        is_enabled=True,
+    ):
+        """
+        Constructor method for the class
+
+        Args:
+            non_current_days (int): Number of days after which the non-current version will expire
+            newer_non_current_versions (int): Number of newer non-current versions to retain
+            filter (LifecycleFilter): Optional object filter
+            is_enabled (bool): Whether the rule is enabled or not
+        """
+        super().__init__(filter=filter, is_enabled=is_enabled)
+        self.non_current_days = non_current_days
+        self.newer_non_current_versions = newer_non_current_versions
+        if not self.non_current_days and not self.newer_non_current_versions:
+            raise ValueError(
+                "Either non_current_days or newer_non_current_versions must be set"
+            )
+
+    def as_dict(self):
+        rule_dict = super().as_dict()
+
+        d = {}
+        if self.non_current_days is not None:
+            d["NoncurrentDays"] = self.non_current_days
+        if self.newer_non_current_versions is not None:
+            d["NewerNoncurrentVersions"] = self.newer_non_current_versions
+        rule_dict["NoncurrentVersionExpiration"] = d
+
+        return rule_dict

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -302,3 +302,32 @@ class NoncurrentVersionExpirationRule(LifecycleRule):
         rule_dict["NoncurrentVersionExpiration"] = d
 
         return rule_dict
+
+
+class AbortIncompleteMultipartUploadRule(LifecycleRule):
+    """
+    A class for handling the parsing of an MCG object expiration rule
+    """
+
+    def __init__(
+        self,
+        days_after_initiation,
+        filter=LifecycleFilter(),
+        is_enabled=True,
+    ):
+        """
+        Constructor method for the class
+
+        Args:
+            days_after_initiation (int): Number of days after which the multipart upload will be aborted
+            filter (LifecycleFilter): Optional object filter
+        """
+        super().__init__(filter=filter, is_enabled=is_enabled)
+        self.days_after_initiation = days_after_initiation
+
+    def as_dict(self):
+        rule_dict = super().as_dict()
+        rule_dict["AbortIncompleteMultipartUpload"] = {
+            "DaysAfterInitiation": self.days_after_initiation
+        }
+        return rule_dict

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -210,7 +210,6 @@ class ExpirationRule(LifecycleRule):
         filter=LifecycleFilter(),
         use_date=False,
         is_enabled=True,
-        expired_object_delete_marker=False,
     ):
         """
         Constructor method for the class
@@ -224,7 +223,6 @@ class ExpirationRule(LifecycleRule):
         super().__init__(filter=filter, is_enabled=is_enabled)
         self.days = days
         self.use_date = use_date
-        self.expired_object_delete_marker = expired_object_delete_marker
 
     def as_dict(self):
         """
@@ -353,77 +351,6 @@ class NoncurrentVersionExpirationRule(LifecycleRule):
         Returns the rule as a dictionary that matches
         the expected S3 lifecycle policy JSON format
         """
-        rule_dict = super().as_dict()
-
-        d = {}
-        if self.non_current_days is not None:
-            d["NoncurrentDays"] = self.non_current_days
-        if self.newer_non_current_versions is not None:
-            d["NewerNoncurrentVersions"] = self.newer_non_current_versions
-        rule_dict["NoncurrentVersionExpiration"] = d
-
-        return rule_dict
-
-
-class AbortIncompleteMultipartUploadRule(LifecycleRule):
-    """
-    A class for handling the parsing of an MCG object expiration rule
-    """
-
-    def __init__(
-        self,
-        days_after_initiation,
-        filter=LifecycleFilter(),
-        is_enabled=True,
-    ):
-        """
-        Constructor method for the class
-
-        Args:
-            days_after_initiation (int): Number of days after which the multipart upload will be aborted
-            filter (LifecycleFilter): Optional object filter
-        """
-        super().__init__(filter=filter, is_enabled=is_enabled)
-        self.days_after_initiation = days_after_initiation
-
-    def as_dict(self):
-        rule_dict = super().as_dict()
-        rule_dict["AbortIncompleteMultipartUpload"] = {
-            "DaysAfterInitiation": self.days_after_initiation
-        }
-        return rule_dict
-
-
-class NoncurrentVersionExpirationRule(LifecycleRule):
-    """
-    A class for handling the parsing of an MCG non-current version expiration rule
-    """
-
-    def __init__(
-        self,
-        non_current_days=None,
-        newer_non_current_versions=None,
-        filter=LifecycleFilter(),
-        is_enabled=True,
-    ):
-        """
-        Constructor method for the class
-
-        Args:
-            non_current_days (int): Number of days after which the non-current version will expire
-            newer_non_current_versions (int): Number of newer non-current versions to retain
-            filter (LifecycleFilter): Optional object filter
-            is_enabled (bool): Whether the rule is enabled or not
-        """
-        super().__init__(filter=filter, is_enabled=is_enabled)
-        self.non_current_days = non_current_days
-        self.newer_non_current_versions = newer_non_current_versions
-        if not self.non_current_days and not self.newer_non_current_versions:
-            raise ValueError(
-                "Either non_current_days or newer_non_current_versions must be set"
-            )
-
-    def as_dict(self):
         rule_dict = super().as_dict()
 
         d = {}

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -179,17 +179,6 @@ class ExpirationRule(LifecycleRule):
             filter (LifecycleFilter): Optional object filter
             use_date (bool): Whether to set a a date instead of the number of days
             is_enabled (bool): Whether the rule is enabled or not
-            expired_object_delete_marker (bool): Only relevant for versioned buckets.
-                                               If set to True, a delete marker of an object
-                                               will expire if no other versions of the object
-                                               exist. This also means that an expired object
-                                               without any other versions will be deleted
-                                               along with its delete marker.
-
-        NOTE: - due to https://github.com/aws/aws-cli/issues/8239 setting expire_solo_delete_markers=True
-        while also using a filter that includes a file size criteria will result in an error
-        while attempting to set the lifecycle policy.
-
         """
         super().__init__(filter=filter, is_enabled=is_enabled)
         self.days = days
@@ -216,11 +205,33 @@ class ExpirationRule(LifecycleRule):
             )
             d[key] = value
 
-        # Add delete marker expiration (even if time-based expiration exists — for negative testing)
-        if self.expired_object_delete_marker:
-            d["ExpiredObjectDeleteMarker"] = True
-
         rule_dict["Expiration"] = d
+        return rule_dict
+
+
+class ExpiredObjectDeleteMarkerRule(LifecycleRule):
+    """
+    A class for handling the parsing of an MCG expired object delete marker rule
+
+    Note the separation from ExpirationRule is due to the fact that
+    Expiration.ExpiredObjectDeleteMarker cannot be specified with
+    Days or Date in a Lifecycle Expiration Policy:
+    https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleExpiration.html
+    """
+
+    def __init__(self, filter=LifecycleFilter(), is_enabled=True):
+        """
+        Constructor method for the class
+
+        Args:
+            filter (LifecycleFilter): Optional object filter
+            is_enabled (bool): Whether the rule is enabled or not
+        """
+        super().__init__(filter=filter, is_enabled=is_enabled)
+
+    def as_dict(self):
+        rule_dict = super().as_dict()
+        rule_dict["Expiration"] = {"ExpiredObjectDeleteMarker": True}
         return rule_dict
 
 

--- a/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
+++ b/ocs_ci/ocs/resources/mcg_lifecycle_policies.py
@@ -219,19 +219,28 @@ class ExpiredObjectDeleteMarkerRule(LifecycleRule):
     https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleExpiration.html
     """
 
-    def __init__(self, filter=LifecycleFilter(), is_enabled=True):
+    def __init__(
+        self,
+        filter=LifecycleFilter(),
+        is_enabled=True,
+        expire_object_delete_marker=True,
+    ):
         """
         Constructor method for the class
 
         Args:
             filter (LifecycleFilter): Optional object filter
             is_enabled (bool): Whether the rule is enabled or not
+            expire_object_delete_marker (bool): Whether to expire the object delete marker
         """
         super().__init__(filter=filter, is_enabled=is_enabled)
+        self.expire_object_delete_marker = expire_object_delete_marker
 
     def as_dict(self):
         rule_dict = super().as_dict()
-        rule_dict["Expiration"] = {"ExpiredObjectDeleteMarker": True}
+        rule_dict["Expiration"] = {
+            "ExpiredObjectDeleteMarker": self.expire_object_delete_marker
+        }
         return rule_dict
 
 

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -380,6 +380,7 @@ class TestLifecycleConfiguration(MCGTest):
         logger.info("Object was deleted as expected")
 
     @tier2
+    @pytest.mark.polarion_id("OCS-6804")
     def test_lifecycle_rules_combined(
         self,
         mcg_obj,

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     change_versions_creation_date_in_noobaa_db,
+    change_versions_creation_date_in_noobaa_db,
     create_multipart_upload,
     expire_multipart_upload_in_noobaa_db,
     get_obj_versions,
@@ -95,6 +96,16 @@ class TestLifecycleConfiguration(MCGTest):
         bucket = bucket_factory(interface="OC")[0].name
 
         # 2. Set lifecycle configuration
+        lifecycle_policy = LifecyclePolicy(
+            AbortIncompleteMultipartUploadRule(days_after_initiation=1)
+        )
+        mcg_obj.s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket, LifecycleConfiguration=lifecycle_policy.as_dict()
+        )
+        logger.info(
+            f"Sleeping for {PROP_SLEEP_TIME} seconds to let the policy propagate"
+        )
+        sleep(PROP_SLEEP_TIME)
         lifecycle_policy = LifecyclePolicy(
             AbortIncompleteMultipartUploadRule(days_after_initiation=1)
         )


### PR DESCRIPTION
Add the following tests to cover the new lifecycle configuration rules for MCG buckets:
- `test_lifecycle_rules_combined`: verify that each of the new rules is respected when set in a combined lifecycle configuration
- `test_lifecycle_rules_invalid_values`: verify that PutBucketLifecycleConfiguration attempts fail as expected when using an invalid configuration
- `test_lifecycle_config_ops_s3_clients_compatibility`: verify that the Put/Get/Delete BucketLifecycleConfiguration ops work as expected on various S3 clients: AWS CLI, boto3 and s3cmd 