### PR TITLE
Address edge case in MCG.wait_for_ready_status()

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -1021,7 +1021,14 @@ class MCG:
             timeout=timeout,
             sleep=10,
         )
-        timeout = int(timeout - (time.time() - starttime))
+
+        # The timeout is reduced by the time already spent waiting for the pods
+        # time spent might get longer than the timeout due to overheads,
+        # so we set a minimum timeout of 60 seconds
+        time_spent = time.time() - starttime
+        time_remaining = timeout - time_spent
+        timeout = max(int(time_remaining), 60)
+
         try:
             for mcg_status_ready in TimeoutSampler(
                 timeout=timeout, sleep=30, func=MCG._status


### PR DESCRIPTION
Sometimes MCG.wait_for_ready_status() fails with the following error:
```
ValueError: timeout should be larger than sleep time
```

This PR fixes this edge case by making sure that the timeout is at least 60 seconds, regardless of how much time was spent in the first part of the method.

RP reference: https://url.corp.redhat.com/ad29a7d