### PR TITLE
Use active ACM cluster context for the test test_acm_import

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -489,9 +489,7 @@ class MultiClusterConfig:
 
     class RunWithAcmConfigContext(RunWithConfigContext):
         def __init__(self):
-            from ocs_ci.ocs.utils import get_all_acm_indexes
-
-            acm_index = get_all_acm_indexes()[0]
+            acm_index = config.get_active_acm_index()
             super().__init__(acm_index)
 
     class RunWithPrimaryConfigContext(RunWithConfigContext):

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -516,7 +516,7 @@ def validate_cluster_import(cluster_name, switch_ctx=None):
 def get_clusters_env():
     """
     Stores cluster's kubeconfig location and clusters name, in case of multi-cluster setup.
-    Function will switch to context index zero before returning
+
     Returns:
         dict: with clusters names, clusters kubeconfig locations
 
@@ -529,8 +529,6 @@ def get_clusters_env():
             config.ENV_DATA["cluster_path"], config.RUN["kubeconfig_location"]
         )
         clusters_env[f"cluster_name_{index}"] = config.ENV_DATA["cluster_name"]
-
-    config.switch_ctx(index=0)
 
     return clusters_env
 

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -50,6 +50,7 @@ from ocs_ci.ocs.exceptions import (
 from ocs_ci.utility import templating
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.helpers.helpers import create_project
+from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -511,6 +512,7 @@ def validate_cluster_import(cluster_name, switch_ctx=None):
     return True
 
 
+@switch_to_orig_index_at_last
 def get_clusters_env():
     """
     Stores cluster's kubeconfig location and clusters name, in case of multi-cluster setup.

--- a/tests/functional/deployment/test_acm.py
+++ b/tests/functional/deployment/test_acm.py
@@ -1,6 +1,8 @@
 from ocs_ci.ocs.acm.acm import import_clusters_with_acm
 from ocs_ci.framework.pytest_customization.marks import purple_squad
 from ocs_ci.framework.testlib import acm_import
+from ocs_ci.framework import config
+
 
 ####################################################################################################
 # This file is placeholder for calling import ACM as test, until full solution will be implimented #
@@ -10,4 +12,5 @@ from ocs_ci.framework.testlib import acm_import
 @purple_squad
 @acm_import
 def test_acm_import():
-    import_clusters_with_acm()
+    with config.RunWithAcmConfigContext():
+        import_clusters_with_acm()


### PR DESCRIPTION
Use active ACM cluster context for running the test case tests/functional/deployment/test_acm.py::test_acm_import.
Update the class RunWithAcmConfigContext to identify the active ACM index instead of expecting the first ACM cluster in the config as the active ACM cluster.

Added the decorator `switch_to_orig_index_at_last` in the function `get_clusters_env` to change back the cluster context to the initial value instead of just changing the cluster context to the first cluster in the configuration.

Fixes #12154 