### PR TITLE
add time to deploy mce on cluster 4.18

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -188,7 +188,7 @@ class MCEInstaller(object):
 
         if not configmaps_obj.check_resource_existence(
             should_exist=True,
-            timeout=60,
+            timeout=600,
             resource_name=constants.SUPPORTED_VERSIONS_CONFIGMAP,
         ):
             raise UnavailableResourceException(


### PR DESCRIPTION
Similar increase in time for checking supported-version cm we already have on master branch. 
Because of more robust module in master I could not cherry-pick `ocs_ci/deployment/mce.p`y from master to 4.18 
Please review this PR same way as a cherry-pick.

PR should fix this error
`https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/50765/consoleFull` 