### PR TITLE
update tox syntax (change {} to {:})

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,4 +73,4 @@ deps =
 skip_install = true
 skipsdist = true
 commands =
-    bash -c 'git grep --name-only retry | grep -E "\.py$" | xargs -I {} python scripts/python/checks/validate_retry_usage.py {}'
+    bash -c 'git grep --name-only retry | grep -E "\.py$" | xargs -I {:} python scripts/python/checks/validate_retry_usage.py {:}'


### PR DESCRIPTION
Newer version of tox requires `{:}` instead of `{}`, otherwise it fails with following traceback:
```
(clone) user@MacBook-Pro ocs-ci % tox                  
Traceback (most recent call last):
 File "/Users/user/Desktop/csi_tests/clone/clone/bin/tox", line 8, in <module>
  sys.exit(cmdline())
       ^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/session/__init__.py", line 44, in cmdline
  main(args)
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/session/__init__.py", line 65, in main
  config = load_config(args)
       ^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/session/__init__.py", line 81, in load_config
  config = parseconfig(args)
       ^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 282, in parseconfig
  ParseIni(config, config_file, content)
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1306, in __init__
  raise tox.exception.ConfigError(
tox.exception.ConfigError: ConfigError: retry-check failed with ConfigError: Malformed substitution; no substitution type provided. If you were using `{}` for `os.pathsep`, please use `{:}`. at Traceback (most recent call last):
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1282, in run
  results[name] = cur_self.make_envconfig(name, section, subs, config)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1458, in make_envconfig
  res = meth(env_attr.name, env_attr.default, replace=replace)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1755, in getargvlist
  return _ArgvlistReader.getargvlist(self, s, replace=replace, name=name)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 2019, in getargvlist
  commands.append(cls.processcommand(reader, current_command, replace, name=name))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 2045, in processcommand
  new_word = reader._replace(word, name=name)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1840, in _replace
  replaced = Replacer(self, crossonly=crossonly).do_replace(value)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1876, in do_replace
  expanded = substitute_once(value)
        ^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1874, in substitute_once
  return [self.RE](http://self.re/)_ITEM_REF.sub(self._replace_match, x)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/Users/user/Desktop/csi_tests/clone/clone/lib/python3.11/site-packages/tox/config/__init__.py", line 1927, in _replace_match
  raise tox.exception.ConfigError(
tox.exception.ConfigError: ConfigError: Malformed substitution; no substitution type provided. If you were using `{}` for `os.pathsep`, please use `{:}`.
```
