### PR TITLE
correct storage client name to customer used one

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -1145,7 +1145,7 @@ class HostedODF(HypershiftHostedOCP):
             str: status of the storage client
         """
         cmd = (
-            f"get {constants.STORAGECLIENTS} storage-client -n {self.namespace_client} | "
+            f"get {constants.STORAGECLIENTS} {constants.DEFAULT_CLUSTERNAME} -n {self.namespace_client} | "
             "awk '/storage-client/{{print $2}}'"
         )
         return self.exec_oc_cmd(cmd, shell=True).stdout.decode("utf-8").strip()


### PR DESCRIPTION
Recently we changed name of the storage-client. The Convergence changes forced us to rename storage-client to specific name that our  customer uses (Fusion HCI). Doing this prevents duplication of storage classes upon distribution to clients after upgrade.  

It fixes the failure that we see in logs:
```
2025-05-15 20:30:13  >       assert all(
2025-05-15 20:30:13              client_setup_res
2025-05-15 20:30:13          ), "Storage client was not set up on all hosted ODF clusters"
2025-05-15 20:30:13  E       AssertionError: Storage client was not set up on all hosted ODF clusters
```