### PR TITLE
Pin oslo.utils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "msrestazure==0.6.3",
         "python-novaclient==17.1.0",
         "python-cinderclient==7.1.0",
+        "oslo.utils==8.2.0",  # Dependency of python-novaclient and python-cinderclient
         "keystoneauth1==4.2.0",
         "range-key-dict==1.1.0",
         "GitPython==3.1.41",


### PR DESCRIPTION
We are seeing issues with our destroy jobs due to this dependency. I suspect something weird happening with the version that was released today so I am pinning this to the last version we were using successfully.

Example failure: https://url.corp.redhat.com/8858210