### PR TITLE
Use provider cluster_namespace if provider kubeconfig is used for tools pod

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -840,16 +840,21 @@ def get_ceph_tools_pod(
         and config.ENV_DATA.get("cluster_type", "").lower()
         in [constants.MS_CONSUMER_TYPE, constants.HCI_CLIENT]
     ):
+        provider_cluster_index = config.get_provider_index()
         provider_kubeconfig = os.path.join(
-            config.clusters[config.get_provider_index()].ENV_DATA["cluster_path"],
-            config.clusters[config.get_provider_index()].RUN.get("kubeconfig_location"),
+            config.clusters[provider_cluster_index].ENV_DATA["cluster_path"],
+            config.clusters[provider_cluster_index].RUN.get("kubeconfig_location"),
         )
         cluster_kubeconfig = provider_kubeconfig
+        cluster_namespace = config.clusters[provider_cluster_index].ENV_DATA[
+            "cluster_namespace"
+        ]
     else:
         cluster_kubeconfig = config.ENV_DATA.get("provider_kubeconfig", "")
+        cluster_namespace = ""
 
     if cluster_kubeconfig:
-        namespace = config.ENV_DATA["cluster_namespace"]
+        namespace = cluster_namespace or config.ENV_DATA["cluster_namespace"]
     else:
         namespace = namespace or config.ENV_DATA["cluster_namespace"]
 


### PR DESCRIPTION
Use provider cluster's `cluster_namespace` parameter if provider kubeconfig is used for tools pod in provider-client configuration.

Fixes #12184 