### PR TITLE
[RDR] Retrieve mirroring status from CBPR for ODF 4.19

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -353,6 +353,7 @@ def check_mirroring_status_ok(
         NotFoundError: If the configuration is provider mode and the name of the cephblockpoolradosnamespace
             is not obtained
     """
+    ocs_version = version.get_semantic_ocs_version_from_config()
     if is_hci_cluster():
         logger.info("Get the cephblockpoolradosnamespace associated with storageclient")
         cephbpradosns = (
@@ -370,11 +371,20 @@ def check_mirroring_status_ok(
             resource_name=cephbpradosns,
         )
     else:
-        cbp_obj = ocp.OCP(
-            kind=constants.CEPHBLOCKPOOL,
-            resource_name=constants.DEFAULT_CEPHBLOCKPOOL,
-            namespace=config.ENV_DATA["cluster_namespace"],
-        )
+        if ocs_version >= version.VERSION_4_19:
+            cephbpradosns = "ocs-storagecluster-cephblockpool-builtin-implicit"
+            cbp_obj = ocp.OCP(
+                kind=constants.CEPHBLOCKPOOLRADOSNS,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=cephbpradosns,
+            )
+        else:
+            cbp_obj = ocp.OCP(
+                kind=constants.CEPHBLOCKPOOL,
+                resource_name=constants.DEFAULT_CEPHBLOCKPOOL,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            )
+
     mirroring_status = cbp_obj.get().get("status").get("mirroringStatus").get("summary")
     logger.info(f"Mirroring status: {mirroring_status}")
     health_keys = ["daemon_health", "health", "image_health"]
@@ -391,7 +401,6 @@ def check_mirroring_status_ok(
         # Replaying images count can be higher due to presence of dummy images
         # This does not apply for clusters with ODF 4.12 and above.
         # See https://bugzilla.redhat.com/show_bug.cgi?id=2132359
-        ocs_version = version.get_semantic_ocs_version_from_config()
         if ocs_version >= version.VERSION_4_12:
             expected_value = [replaying_images]
         else:


### PR DESCRIPTION
Fetch mirroring status from the CBPR resource starting with ODF version 4.19