### PR TITLE
Add osd_maintenance_timeout parameter in provider mode storagecluster

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -248,6 +248,14 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                 "cluster_namespace"
             ]
 
+            if config.ENV_DATA.get("osd_maintenance_timeout"):
+                storage_cluster_data.setdefault("spec", {}).setdefault(
+                    "managedResources", {}
+                ).setdefault("cephCluster", {})
+                storage_cluster_data["spec"]["managedResources"]["cephCluster"][
+                    "osdMaintenanceTimeout"
+                ] = config.ENV_DATA.get("osd_maintenance_timeout")
+
             templating.dump_data_to_temp_yaml(
                 storage_cluster_data, storage_cluster_path
             )


### PR DESCRIPTION
Add `osd_maintenance_timeout` parameter in provider mode storagecluster if present in `ENV_DATA`.