### PR TITLE
fix prometheus tests teardown

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -679,15 +679,19 @@ class OCP(object):
             update_kubeconfig_with_proxy_url_for_client(kubeconfig)
         return status
 
-    def login_as_sa(self):
+    def login_as_user(self, user="system:admin"):
         """
-        Logs in as system:admin
+        Logs in as specified user (by default 'system:admin'). This user should have valid token in kubeconfig file.
+
+        Args:
+            user (str): Name of user to be logged in (by default 'system:admin')
 
         Returns:
             str: output of login command
+
         """
         kubeconfig = config.RUN.get("kubeconfig")
-        command = "oc login -u system:admin "
+        command = f"oc login -u {user} "
         if kubeconfig:
             command += f"--kubeconfig {kubeconfig}"
         status = run_cmd(command, threading_lock=self.threading_lock)

--- a/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
@@ -52,6 +52,11 @@ def test_prometheus_rule_failures(threading_lock):
     ]
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_capacity.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_capacity.py
@@ -149,6 +149,11 @@ def test_cephfs_capacity_workload_alerts(
         )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -279,6 +279,11 @@ class TestCephOSDSlowOps(object):
             )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
@@ -178,6 +178,11 @@ def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
         )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_encryption.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_encryption.py
@@ -49,6 +49,11 @@ def test_kms_unavailable(measure_rewrite_kms_endpoint, threading_lock):
     )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa.py
@@ -164,6 +164,11 @@ def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted, threading_loc
         )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -89,6 +89,11 @@ def test_change_client_ocs_version_and_stop_heartbeat(
         )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_rgw.py
@@ -57,6 +57,11 @@ def test_rgw_unavailable(measure_stop_rgw, threading_lock):
     )
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/sendgrid/alerts/test_capacity.py
+++ b/tests/functional/monitoring/sendgrid/alerts/test_capacity.py
@@ -32,6 +32,11 @@ def deprecated_test_capacity_workload_alerts(
     # TODO(fbalak): automate checking of email content
 
 
-def teardown_module():
+def setup_module(module):
     ocs_obj = OCP()
-    ocs_obj.login_as_sa()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)


### PR DESCRIPTION
get the actual logged in user in the setup phase of the test and login back to this user in teardown, instead of to hardcoded system:admin user

fixes: https://github.com/red-hat-storage/ocs-ci/issues/12229