### PR TITLE
Parameterize rdr_ui tests with CLI and remove using global config

### DIFF
--- a/conf/ocsci/dr_ui.yaml
+++ b/conf/ocsci/dr_ui.yaml
@@ -3,7 +3,5 @@
 
 RUN:
   dr_action_via_ui: true
-  rdr_failover_via_ui: true
-  rdr_relocate_via_ui: true
   mdr_failover_via_ui: true
   mdr_relocate_via_ui: true

--- a/conf/ocsci/dr_ui.yaml
+++ b/conf/ocsci/dr_ui.yaml
@@ -2,6 +2,5 @@
 #Perform Failover/Relocate via ACM UI (Combination of ODF>=4.13 and ACM>=2.7 is supported, please look at the code)
 
 RUN:
-  dr_action_via_ui: true
   mdr_failover_via_ui: true
   mdr_relocate_via_ui: true

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -628,13 +628,6 @@ metrics_for_external_mode_required = pytest.mark.skipif(
     reason="Metrics is not enabled for external mode OCS <4.6",
 )
 
-rdr_ui_skipif = pytest.mark.skipif(
-    not config.RUN.get("rdr_failover_via_ui")
-    or not config.RUN.get("rdr_relocate_via_ui"),
-    reason="RDR UI failover or relocate config needed",
-)
-rdr_ui = compose(rdr_ui_skipif, pytest.mark.rdr_ui)
-
 dr_hub_recovery = pytest.mark.skipif(
     config.nclusters != 4,
     reason="DR hub recovery requires 4th OCP cluster to be available for Passive hub",

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2117,7 +2117,7 @@ def get_cluster_set_name():
         logger.info(f"Found the unique clusterset {cluster_set[0]}")
     else:
         raise UnexpectedDeploymentConfiguration(
-            "There are more then one clusterset added to multiple managedcluters"
+            "There are more then one clusterset added to the managed clusters"
         )
 
     return cluster_set

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -691,6 +691,7 @@ def check_apps_running_on_selected_cluster(
         else:
             log.error(f"App {app} not found on cluster {cluster_name} on DR dashboard")
             return False
+    return True
 
 
 def verify_application_present_in_ui(acm_obj, workloads_to_check=[], timeout=60):

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -11,6 +11,7 @@ from selenium.common.exceptions import (
     NoSuchElementException,
 )
 
+from ocs_ci.helpers.dr_helpers import get_cluster_set_name
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm_constants import (
@@ -160,6 +161,10 @@ class AcmAddClusters(AcmPageNavigator):
         Args:
             globalnet (bool): Globalnet is set to True by default for ODF versions greater than or equal to 4.13
 
+        Returns:
+            str: cluster set name created during the function to which managed clusters are tied for Submariner
+            installation
+
         """
         ocs_version = version.get_semantic_ocs_version_from_config()
 
@@ -301,6 +306,7 @@ class AcmAddClusters(AcmPageNavigator):
         self.take_screenshot()
         log.info("Click on 'Install'")
         self.do_click(self.page_nav["install-btn"])
+        return cluster_set_name
 
     def submariner_unreleased_downstream_info(self):
         log.info("Use custom Submariner subscription ")
@@ -342,6 +348,7 @@ class AcmAddClusters(AcmPageNavigator):
         else:
             log.error("Couldn't navigate to Cluster sets page")
             raise NoSuchElementException
+        cluster_set_name = get_cluster_set_name()[0]
         log.info("Click on the cluster set created")
         self.do_click(
             format_locator(self.page_nav["cluster-set-selection"], cluster_set_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,6 @@ from ocs_ci.ocs.exceptions import (
     StorageClassNotDeletedFromUI,
     ResourceNotDeleted,
     MissingDecoratorError,
-    MissingRequiredConfigKeyError,
     UnsupportedWorkloadError,
 )
 from ocs_ci.ocs.mcg_workload import mcg_job_factory as mcg_job_factory_implementation
@@ -5316,12 +5315,6 @@ def setup_acm_ui(request):
 
 
 def setup_acm_ui_fixture(request):
-    if not ocsci_config.RUN.get("dr_action_via_ui"):
-        log.error(
-            "'dr_action_via_ui' params are missing, please pass conf/ocsci/dr_ui.yaml config to "
-            "run UI tests on Regional DR setup"
-        )
-        return MissingRequiredConfigKeyError
     restore_ctx_index = ocsci_config.cur_index
     ocsci_config.switch_acm_ctx()
     driver = login_to_acm()

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -36,7 +36,7 @@ class TestFailover:
 
     """
 
-    params = (
+    params = [
         [
             pytest.param(
                 False,  # primary_cluster_down = False
@@ -95,7 +95,7 @@ class TestFailover:
                 id="primary_down-cephfs-ui",
             ),
         ],
-    )
+    ]
 
     @pytest.mark.parametrize(
         argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -25,12 +25,6 @@ from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
-polarion_id_primary_up = "OCS-4429"
-polarion_id_primary_down = "OCS-4426"
-if config.RUN.get("rdr_failover_via_ui"):
-    polarion_id_primary_up = "OCS-4741"
-    polarion_id_primary_down = "OCS-4742"
-
 
 @rdr
 @acceptance
@@ -42,35 +36,75 @@ class TestFailover:
 
     """
 
-    @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface"],
-        argvalues=[
+    params = (
+        [
             pytest.param(
-                *[False, constants.CEPHBLOCKPOOL],
-                marks=pytest.mark.polarion_id(polarion_id_primary_up),
-                id="primary_up-rbd",
+                False,  # primary_cluster_down = False
+                constants.CEPHBLOCKPOOL,
+                False,  # via_ui = False
+                id="primary_up-rbd-cli",
+                marks=pytest.mark.polarion_id("OCS-4429"),
             ),
             pytest.param(
-                *[True, constants.CEPHBLOCKPOOL],
-                marks=pytest.mark.polarion_id(polarion_id_primary_down),
-                id="primary_down-rbd",
+                False,  # primary_cluster_down = False
+                constants.CEPHBLOCKPOOL,
+                True,  # via_ui = True
+                id="primary_up-rbd-ui",
+                marks=pytest.mark.polarion_id("OCS-4741"),
             ),
             pytest.param(
-                *[False, constants.CEPHFILESYSTEM],
-                marks=pytest.mark.polarion_id("OCS-4729"),
-                id="primary_up-cephfs",
+                True,  # primary_cluster_down = True
+                constants.CEPHBLOCKPOOL,
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4426"),
+                id="primary_down-rbd-cli",
             ),
             pytest.param(
-                *[True, constants.CEPHFILESYSTEM],
+                True,  # primary_cluster_down = True
+                constants.CEPHBLOCKPOOL,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-4742"),
+                id="primary_down-rbd-ui",
+            ),
+            pytest.param(
+                False,  # primary_cluster_down = False
+                constants.CEPHFILESYSTEM,
+                False,  # via_ui = False
                 marks=pytest.mark.polarion_id("OCS-4726"),
-                id="primary_down-cephfs",
+                id="primary_up-cephfs-cli",
+            ),
+            pytest.param(
+                False,  # primary_cluster_down = False
+                constants.CEPHFILESYSTEM,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-6848"),
+                id="primary_down-cephfs-ui",
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHFILESYSTEM,
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4729"),
+                id="primary_up-cephfs-cli",
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHFILESYSTEM,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-6847"),
+                id="primary_down-cephfs-ui",
             ),
         ],
+    )
+
+    @pytest.mark.parametrize(
+        argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params
     )
     def test_failover(
         self,
         primary_cluster_down,
         pvc_interface,
+        via_ui,
         setup_acm_ui,
         dr_workload,
         nodes_multicluster,
@@ -79,11 +113,10 @@ class TestFailover:
         """
         Tests to verify application failover between managed clusters when the primary cluster is either UP or DOWN.
 
-        This test is also compatible to be run from ACM UI,
-        pass the yaml conf/ocsci/dr_ui.yaml to trigger it.
+        This test will run twice both via CLI and UI
 
         """
-        if config.RUN.get("rdr_failover_via_ui"):
+        if via_ui:
             acm_obj = AcmAddClusters()
 
         workloads = dr_workload(
@@ -115,7 +148,7 @@ class TestFailover:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        if config.RUN.get("rdr_failover_via_ui"):
+        if via_ui:
             logger.info("Start the process of Failover from ACM UI")
             config.switch_acm_ctx()
             dr_submariner_validation_from_ui(acm_obj)
@@ -127,18 +160,18 @@ class TestFailover:
             nodes_multicluster[primary_cluster_index].stop_nodes(primary_cluster_nodes)
 
             # Verify if cluster is marked unknown on ACM console
-            if config.RUN.get("rdr_failover_via_ui"):
+            if via_ui:
                 config.switch_acm_ctx()
                 check_cluster_status_on_acm_console(
                     acm_obj,
                     down_cluster_name=primary_cluster_name,
                     expected_text="Unknown",
                 )
-        elif config.RUN.get("rdr_failover_via_ui"):
+        elif via_ui:
             check_cluster_status_on_acm_console(acm_obj)
 
         for wl in workloads:
-            if config.RUN.get("rdr_failover_via_ui"):
+            if via_ui:
                 # Failover via ACM UI
                 failover_relocate_ui(
                     acm_obj,
@@ -210,6 +243,6 @@ class TestFailover:
                 replaying_images=sum([wl.workload_pvc_count for wl in workloads])
             )
 
-        if config.RUN.get("rdr_failover_via_ui"):
+        if via_ui:
             config.switch_acm_ctx()
             verify_failover_relocate_status_ui(acm_obj)

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -36,66 +36,64 @@ class TestFailover:
 
     """
 
-    params = (
-        [
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHBLOCKPOOL,
-                False,  # via_ui = False
-                id="primary_up-rbd-cli",
-                marks=pytest.mark.polarion_id("OCS-4429"),
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHBLOCKPOOL,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4426"),
-                id="primary_down-rbd-cli",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4726"),
-                id="primary_up-cephfs-cli",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4729"),
-                id="primary_up-cephfs-cli",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHBLOCKPOOL,
-                True,  # via_ui = True
-                id="primary_up-rbd-ui",
-                marks=pytest.mark.polarion_id("OCS-4741"),
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHBLOCKPOOL,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-4742"),
-                id="primary_down-rbd-ui",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHFILESYSTEM,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-6848"),
-                id="primary_down-cephfs-ui",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHFILESYSTEM,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-6847"),
-                id="primary_down-cephfs-ui",
-            ),
-        ],
-    )
+    params = [
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            id="primary_up-rbd-cli",
+            marks=pytest.mark.polarion_id("OCS-4429"),
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4426"),
+            id="primary_down-rbd-cli",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4726"),
+            id="primary_up-cephfs-cli",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4729"),
+            id="primary_up-cephfs-cli",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            True,  # via_ui = True
+            id="primary_up-rbd-ui",
+            marks=pytest.mark.polarion_id("OCS-4741"),
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-4742"),
+            id="primary_down-rbd-ui",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHFILESYSTEM,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6848"),
+            id="primary_down-cephfs-ui",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6847"),
+            id="primary_down-cephfs-ui",
+        ),
+    ]
 
     @pytest.mark.parametrize(
         argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -32,11 +32,11 @@ logger = logging.getLogger(__name__)
 @turquoise_squad
 class TestFailover:
     """
-    Test Failover action
+    Test Failover action via CLI and UI
 
     """
 
-    params = [
+    params = (
         [
             pytest.param(
                 False,  # primary_cluster_down = False
@@ -44,6 +44,27 @@ class TestFailover:
                 False,  # via_ui = False
                 id="primary_up-rbd-cli",
                 marks=pytest.mark.polarion_id("OCS-4429"),
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHBLOCKPOOL,
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4426"),
+                id="primary_down-rbd-cli",
+            ),
+            pytest.param(
+                False,  # primary_cluster_down = False
+                constants.CEPHFILESYSTEM,
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4726"),
+                id="primary_up-cephfs-cli",
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHFILESYSTEM,
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4729"),
+                id="primary_up-cephfs-cli",
             ),
             pytest.param(
                 False,  # primary_cluster_down = False
@@ -55,23 +76,9 @@ class TestFailover:
             pytest.param(
                 True,  # primary_cluster_down = True
                 constants.CEPHBLOCKPOOL,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4426"),
-                id="primary_down-rbd-cli",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHBLOCKPOOL,
                 True,  # via_ui = True
                 marks=pytest.mark.polarion_id("OCS-4742"),
                 id="primary_down-rbd-ui",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4726"),
-                id="primary_up-cephfs-cli",
             ),
             pytest.param(
                 False,  # primary_cluster_down = False
@@ -83,19 +90,12 @@ class TestFailover:
             pytest.param(
                 True,  # primary_cluster_down = True
                 constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4729"),
-                id="primary_up-cephfs-cli",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHFILESYSTEM,
                 True,  # via_ui = True
                 marks=pytest.mark.polarion_id("OCS-6847"),
                 id="primary_down-cephfs-ui",
             ),
         ],
-    ]
+    )
 
     @pytest.mark.parametrize(
         argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -63,7 +63,7 @@ class TestFailover:
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4729"),
-            id="primary_up-cephfs-cli",
+            id="primary_down-cephfs-cli",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
@@ -84,7 +84,7 @@ class TestFailover:
             constants.CEPHFILESYSTEM,
             True,  # via_ui = True
             marks=pytest.mark.polarion_id("OCS-6848"),
-            id="primary_down-cephfs-ui",
+            id="primary_up-cephfs-ui",
         ),
         pytest.param(
             True,  # primary_cluster_down = True

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -33,66 +33,64 @@ class TestFailoverAndRelocate:
 
     """
 
-    params = (
-        [
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHBLOCKPOOL,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4430"),
-                id="primary_up-rbd",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHBLOCKPOOL,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4427"),
-                id="primary_down-rbd",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4730"),
-                id="primary_up-cephfs",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHFILESYSTEM,
-                False,  # via_ui = False
-                marks=pytest.mark.polarion_id("OCS-4727"),
-                id="primary_down-cephfs",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHBLOCKPOOL,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-6861"),
-                id="primary_up-rbd",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHBLOCKPOOL,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-4743"),
-                id="primary_down-rbd",
-            ),
-            pytest.param(
-                False,  # primary_cluster_down = False
-                constants.CEPHFILESYSTEM,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-6860"),
-                id="primary_up-cephfs",
-            ),
-            pytest.param(
-                True,  # primary_cluster_down = True
-                constants.CEPHFILESYSTEM,
-                True,  # via_ui = True
-                marks=pytest.mark.polarion_id("OCS-6859"),
-                id="primary_down-cephfs",
-            ),
-        ],
-    )
+    params = [
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4430"),
+            id="primary_up-rbd",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4427"),
+            id="primary_down-rbd",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4730"),
+            id="primary_up-cephfs",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            marks=pytest.mark.polarion_id("OCS-4727"),
+            id="primary_down-cephfs",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6861"),
+            id="primary_up-rbd",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-4743"),
+            id="primary_down-rbd",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHFILESYSTEM,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6860"),
+            id="primary_up-cephfs",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6859"),
+            id="primary_down-cephfs",
+        ),
+    ]
 
     @pytest.mark.parametrize(
         argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -22,17 +22,6 @@ from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
-polarion_id_primary_up = "OCS-4430"
-polarion_id_primary_down = "OCS-4427"
-polarion_id_primary_down_cephfs = "OCS-4727"
-polarion_id_primary_up_cephfs = "OCS-4730"
-
-
-if config.RUN.get("rdr_failover_via_ui"):
-    polarion_id_primary_down = "OCS-4744"
-# TODO: Specify polarion id when available for test case where primary is up when failedover and relocate back.
-#  This test case is added in ODF 4.13 test plan.
-
 
 @rdr
 @turquoise_squad
@@ -40,43 +29,79 @@ if config.RUN.get("rdr_failover_via_ui"):
 @tier1
 class TestFailoverAndRelocate:
     """
-    Test Failover and Relocate actions
+    Test Failover and Relocate actions via CLI and UI
 
     """
 
-    @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface"],
-        argvalues=[
+    params = (
+        [
             pytest.param(
-                False,
+                False,  # primary_cluster_down = False
                 constants.CEPHBLOCKPOOL,
-                marks=pytest.mark.polarion_id(polarion_id_primary_up),
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4430"),
                 id="primary_up-rbd",
             ),
             pytest.param(
-                True,
+                True,  # primary_cluster_down = True
                 constants.CEPHBLOCKPOOL,
-                marks=pytest.mark.polarion_id(polarion_id_primary_down),
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4427"),
                 id="primary_down-rbd",
             ),
             pytest.param(
-                False,
+                False,  # primary_cluster_down = False
                 constants.CEPHFILESYSTEM,
-                marks=pytest.mark.polarion_id(polarion_id_primary_up_cephfs),
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4730"),
                 id="primary_up-cephfs",
             ),
             pytest.param(
-                True,
+                True,  # primary_cluster_down = True
                 constants.CEPHFILESYSTEM,
-                marks=pytest.mark.polarion_id(polarion_id_primary_down_cephfs),
+                False,  # via_ui = False
+                marks=pytest.mark.polarion_id("OCS-4727"),
+                id="primary_down-cephfs",
+            ),
+            pytest.param(
+                False,  # primary_cluster_down = False
+                constants.CEPHBLOCKPOOL,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-6861"),
+                id="primary_up-rbd",
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHBLOCKPOOL,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-4743"),
+                id="primary_down-rbd",
+            ),
+            pytest.param(
+                False,  # primary_cluster_down = False
+                constants.CEPHFILESYSTEM,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-6860"),
+                id="primary_up-cephfs",
+            ),
+            pytest.param(
+                True,  # primary_cluster_down = True
+                constants.CEPHFILESYSTEM,
+                True,  # via_ui = True
+                marks=pytest.mark.polarion_id("OCS-6859"),
                 id="primary_down-cephfs",
             ),
         ],
+    )
+
+    @pytest.mark.parametrize(
+        argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params
     )
     def test_failover_and_relocate(
         self,
         primary_cluster_down,
         pvc_interface,
+        via_ui,
         setup_acm_ui,
         dr_workload,
         nodes_multicluster,
@@ -85,11 +110,11 @@ class TestFailoverAndRelocate:
         """
         Tests to verify application failover when the primary cluster is either UP or DOWN and relocate between managed
         clusters.
-        This test is also compatible to be run from ACM UI,
-        pass the yaml conf/ocsci/dr_ui.yaml to trigger it.
+
+        This test will run twice both via CLI and UI
 
         """
-        if config.RUN.get("rdr_failover_via_ui"):
+        if via_ui:
             acm_obj = AcmAddClusters()
 
         workloads = dr_workload(
@@ -134,7 +159,7 @@ class TestFailoverAndRelocate:
             )
         logger.info("Verified lastGroupSyncTime before failover.")
 
-        if config.RUN.get("rdr_failover_via_ui"):
+        if via_ui:
             logger.info("Start the process of Failover from ACM UI")
             config.switch_acm_ctx()
             dr_submariner_validation_from_ui(acm_obj)
@@ -146,18 +171,18 @@ class TestFailoverAndRelocate:
             nodes_multicluster[primary_cluster_index].stop_nodes(primary_cluster_nodes)
 
             # Verify if cluster is marked unavailable on ACM console
-            if config.RUN.get("rdr_failover_via_ui"):
+            if via_ui:
                 config.switch_acm_ctx()
                 check_cluster_status_on_acm_console(
                     acm_obj,
                     down_cluster_name=primary_cluster_name,
                     expected_text="Unknown",
                 )
-        elif config.RUN.get("rdr_failover_via_ui"):
+        elif via_ui:
             check_cluster_status_on_acm_console(acm_obj)
 
         for wl in workloads:
-            if config.RUN.get("rdr_failover_via_ui"):
+            if via_ui:
                 # Failover via ACM UI
                 failover_relocate_ui(
                     acm_obj,
@@ -231,7 +256,7 @@ class TestFailoverAndRelocate:
                 replaying_images=sum([wl.workload_pvc_count for wl in workloads])
             )
 
-        if config.RUN.get("rdr_relocate_via_ui"):
+        if via_ui:
             config.switch_acm_ctx()
             verify_failover_relocate_status_ui(acm_obj)
 
@@ -251,7 +276,7 @@ class TestFailoverAndRelocate:
 
         # Relocate action
         for wl in workloads:
-            if config.RUN.get("rdr_relocate_via_ui"):
+            if via_ui:
                 logger.info("Start the process of Relocate from ACM UI")
                 check_cluster_status_on_acm_console(acm_obj)
                 dr_submariner_validation_from_ui(acm_obj)
@@ -309,7 +334,7 @@ class TestFailoverAndRelocate:
                 replaying_images=sum([wl.workload_pvc_count for wl in workloads])
             )
 
-        if config.RUN.get("rdr_relocate_via_ui"):
+        if via_ui:
             config.switch_acm_ctx()
             verify_failover_relocate_status_ui(
                 acm_obj, action=constants.ACTION_RELOCATE

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -39,56 +39,56 @@ class TestFailoverAndRelocate:
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4430"),
-            id="primary_up-rbd",
+            id="primary_up-rbd-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4427"),
-            id="primary_down-rbd",
+            id="primary_down-rbd-cli",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4730"),
-            id="primary_up-cephfs",
+            id="primary_up-cephfs-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4727"),
-            id="primary_down-cephfs",
+            id="primary_down-cephfs-cli",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHBLOCKPOOL,
             True,  # via_ui = True
             marks=pytest.mark.polarion_id("OCS-6861"),
-            id="primary_up-rbd",
+            id="primary_up-rbd-ui",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
             True,  # via_ui = True
             marks=pytest.mark.polarion_id("OCS-4743"),
-            id="primary_down-rbd",
+            id="primary_down-rbd-ui",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHFILESYSTEM,
             True,  # via_ui = True
             marks=pytest.mark.polarion_id("OCS-6860"),
-            id="primary_up-cephfs",
+            id="primary_up-cephfs-ui",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             True,  # via_ui = True
             marks=pytest.mark.polarion_id("OCS-6859"),
-            id="primary_down-cephfs",
+            id="primary_down-cephfs-ui",
         ),
     ]
 

--- a/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
@@ -6,7 +6,6 @@ from time import sleep
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     rdr,
-    rdr_ui,
     turquoise_squad,
 )
 from ocs_ci.framework.testlib import tier3, skipif_ocs_version
@@ -26,7 +25,6 @@ logger = logging.getLogger(__name__)
 @tier3
 @turquoise_squad
 @skipif_ocs_version("<4.13")
-@rdr_ui
 class TestNegativeFailoverRelocate:
     """
     Test Failover/Relocate action to same cluster where workloads are already  running

--- a/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
@@ -42,81 +42,75 @@ class TestNegativeFailoverRelocate:
     ):
         """
         Tests to verify if application failover to same cluster where it's running is blocked
-        Pass the yaml conf/ocsci/dr_ui.yaml to trigger UI actions.
 
         """
-        if config.RUN.get("rdr_failover_via_ui"):
-            acm_obj = AcmAddClusters()
-            rdr_workload = dr_workload(num_of_subscription=1)[0]
+        acm_obj = AcmAddClusters()
+        rdr_workload = dr_workload(num_of_subscription=1)[0]
 
-            dr_helpers.set_current_primary_cluster_context(
-                rdr_workload.workload_namespace
-            )
+        dr_helpers.set_current_primary_cluster_context(rdr_workload.workload_namespace)
 
-            scheduling_interval = dr_helpers.get_scheduling_interval(
-                rdr_workload.workload_namespace
-            )
-            wait_time = 2 * scheduling_interval  # Time in minutes
-            logger.info(f"Waiting for {wait_time} minutes to run IOs")
-            sleep(wait_time * 60)
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload.workload_namespace
+        )
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
 
-            primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
-                rdr_workload.workload_namespace
-            )
+        primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
+            rdr_workload.workload_namespace
+        )
 
-            logger.info("Start the process of Failover from ACM UI")
-            config.switch_acm_ctx()
-            dr_submariner_validation_from_ui(acm_obj)
-            check_cluster_status_on_acm_console(acm_obj)
+        logger.info("Start the process of Failover from ACM UI")
+        config.switch_acm_ctx()
+        dr_submariner_validation_from_ui(acm_obj)
+        check_cluster_status_on_acm_console(acm_obj)
 
-            # Failover via ACM UI
-            result = failover_relocate_ui(
-                acm_obj,
-                scheduling_interval=scheduling_interval,
-                workload_to_move=f"{rdr_workload.workload_name}-1",
-                policy_name=rdr_workload.dr_policy_name,
-                failover_or_preferred_cluster=primary_cluster_name,
-                move_workloads_to_same_cluster=True,
-            )
-            assert result, "Failover negative scenario test via ACM UI failed"
-            logger.info("Failover negative scenario test via ACM UI passed")
+        # Failover via ACM UI
+        result = failover_relocate_ui(
+            acm_obj,
+            scheduling_interval=scheduling_interval,
+            workload_to_move=f"{rdr_workload.workload_name}-1",
+            policy_name=rdr_workload.dr_policy_name,
+            failover_or_preferred_cluster=primary_cluster_name,
+            move_workloads_to_same_cluster=True,
+        )
+        assert result, "Failover negative scenario test via ACM UI failed"
+        logger.info("Failover negative scenario test via ACM UI passed")
 
     @pytest.mark.polarion_id("OCS-4747")
     def test_relocate_to_same_cluster(self, setup_acm_ui, dr_workload):
         """
         Tests to verify if application relocate to same cluster where it's running is blocked
-        Pass the yaml conf/ocsci/dr_ui.yaml to trigger UI actions.
 
         """
-        if config.RUN.get("rdr_relocate_via_ui"):
-            acm_obj = AcmAddClusters()
-            rdr_workload = dr_workload(num_of_subscription=1)[0]
+        acm_obj = AcmAddClusters()
+        rdr_workload = dr_workload(num_of_subscription=1)[0]
 
-            scheduling_interval = dr_helpers.get_scheduling_interval(
-                rdr_workload.workload_namespace
-            )
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            rdr_workload.workload_namespace
+        )
 
-            wait_time = 2 * scheduling_interval  # Time in minutes
-            logger.info(f"Waiting for {wait_time} minutes to run IOs")
-            sleep(wait_time * 60)
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
 
-            primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
-                rdr_workload.workload_namespace
-            )
+        primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
+            rdr_workload.workload_namespace
+        )
 
-            logger.info("Start the process of Relocate from ACM UI")
-            config.switch_acm_ctx()
-            dr_submariner_validation_from_ui(acm_obj)
-            check_cluster_status_on_acm_console(acm_obj)
-            # Relocate via ACM UI
-            result = failover_relocate_ui(
-                acm_obj,
-                scheduling_interval=scheduling_interval,
-                workload_to_move=f"{rdr_workload.workload_name}-1",
-                policy_name=rdr_workload.dr_policy_name,
-                failover_or_preferred_cluster=primary_cluster_name,
-                action=constants.ACTION_RELOCATE,
-                move_workloads_to_same_cluster=True,
-            )
-            assert result, "Relocate negative scenario test via ACM UI failed"
-            logger.info("Relocate negative scenario test via ACM UI passed")
+        logger.info("Start the process of Relocate from ACM UI")
+        config.switch_acm_ctx()
+        dr_submariner_validation_from_ui(acm_obj)
+        check_cluster_status_on_acm_console(acm_obj)
+        # Relocate via ACM UI
+        result = failover_relocate_ui(
+            acm_obj,
+            scheduling_interval=scheduling_interval,
+            workload_to_move=f"{rdr_workload.workload_name}-1",
+            policy_name=rdr_workload.dr_policy_name,
+            failover_or_preferred_cluster=primary_cluster_name,
+            action=constants.ACTION_RELOCATE,
+            move_workloads_to_same_cluster=True,
+        )
+        assert result, "Relocate negative scenario test via ACM UI failed"
+        logger.info("Relocate negative scenario test via ACM UI passed")

--- a/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
@@ -8,7 +8,6 @@ from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     turquoise_squad,
-    rdr_ui,
 )
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
@@ -37,7 +36,6 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
-@rdr_ui
 @skipif_ocs_version("<4.16")
 class TestRDRMonitoringDashboardUI:
     """

--- a/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_warning_and_alerting.py
@@ -13,7 +13,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     turquoise_squad,
     polarion_id,
-    rdr_ui,
 )
 from ocs_ci.helpers import dr_helpers, helpers
 from ocs_ci.ocs import constants
@@ -90,7 +89,6 @@ def scale_up_deployment(request):
 @rdr
 @tier1
 @turquoise_squad
-@rdr_ui
 class TestRDRWarningAndAlerting:
     """
     Test class for RDR Warning and Alerting


### PR DESCRIPTION
As discussed in RDR-QE syncup meeting, we want to parameterize rdr_ui tests with CLI and remove using global config so that we have coverage from both sides in a single pipeline job, be it acceptance or regression runs.

Also fixes issue #12067 