### PR TITLE
Ypersky pv based bs data distribution

### DIFF
--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import time
+
 import pytest
 
 from ocs_ci.framework import config
@@ -426,3 +428,32 @@ class TestPvPool:
             amount=5,
             mcg_obj=mcg_obj,
         )
+
+
+    @tier2
+    @ignore_leftovers
+    @polarion_id("OCS-6552")
+    def test_pv_data_dist(
+        self, setup_nfs, bucket_factory, awscli_pod, test_directory_setup, mcg_obj
+    ):
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {
+                "pv": [
+                    (
+                        3,
+                        MIN_PV_BACKINGSTORE_SIZE_IN_GB,
+                        constants.NFS_SC_NAME,
+                    ),
+                    (
+                        3,
+                        MIN_PV_BACKINGSTORE_SIZE_IN_GB,
+                        constants.NFS_SC_NAME,
+                    )
+                ]
+            },
+        }
+        bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
+        logger.info(f"********** The bucket with name {bucket.name} was created")
+        time.sleep(600)

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -437,29 +437,65 @@ class TestPvPool:
             pytest.param(
                 *[
                     1,
+                    "5K",
+                    1,
+                    50000,  # dataset contains 50000 small files of 5K each, 1 pv per backingstore
+                ],
+                marks=pytest.mark.polarion_id("OCS-6852"),
+            ),
+            pytest.param(
+                *[
+                    1,
+                    "5K",
+                    1,
+                    5000,  # dataset contains 5000 small files of 5K each, 1 pv per backingstore
+                ],
+                marks=pytest.mark.polarion_id("OCS-6853"),
+            ),
+            pytest.param(
+                *[
+                    1,
                     "1M",
                     10,
-                    20,
+                    20,  # dataset contains 20 medium files of 10MB each, 1 pv per backingstore
                 ],
-                marks=pytest.mark.polarion_id("OCS-4587"),
+                marks=pytest.mark.polarion_id("OCS-6854"),
             ),
             pytest.param(
                 *[
                     5,
                     "1M",
                     10,
-                    20,
+                    20,  # dataset contains 20 medium files of 10MB each, 5 pvs per backingstore
                 ],
-                marks=pytest.mark.polarion_id("OCS-4587"),
+                marks=pytest.mark.polarion_id("OCS-6855"),
             ),
             pytest.param(
                 *[
                     10,
                     "1M",
                     10,
-                    20,
+                    20,  # dataset contains 20 medium files of 10MB each, 10 pvs per backingstore
                 ],
-                marks=pytest.mark.polarion_id("OCS-4587"),
+                marks=pytest.mark.polarion_id("OCS-6856"),
+            ),
+            pytest.param(
+                *[
+                    1,
+                    "10M",
+                    20,
+                    10,  # dataset contains 10 big files of 200MB each, 1 pv per backingstore
+                ],
+                marks=pytest.mark.polarion_id("OCS-6857"),
+            ),
+            pytest.param(
+                *[
+                    1,
+                    "10M",
+                    10,
+                    255,  # 255 files of 100 MB each are 25.5 GB which is 75% of 17GB*2=34GB
+                ],
+                marks=pytest.mark.polarion_id("OCS-6858"),
             ),
         ],
     )

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -405,7 +405,7 @@ class TestPvPool:
             dfbug: https://issues.redhat.com/browse/DFBUGS-1114
 
         """
-        # Create bucket based of pv-pool backingstore
+        # Create bucket based of pv-pool backingstores
         bucketclass_dict = {
             "interface": "OC",
             "backingstore_dict": {

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -498,6 +498,15 @@ class TestPvPool:
                 marks=pytest.mark.polarion_id("OCS-6858"),
             ),
         ],
+        ids=[
+            "OnePV_ManySmall_Files",
+            "OnePV_Small_Files",
+            "OnePV_MediumFiles",
+            "FivePV_Medium_Files",
+            "TenPV_Medium_Files",
+            "OnePV_Big_Files",
+            "OnePV_Medium_Files_High_Usage",
+        ],
     )
     def test_pv_data_dist(
         self,

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -430,7 +430,6 @@ class TestPvPool:
         )
 
     @tier2
-    @if_version(">4.19")
     @pytest.mark.parametrize(
         argnames=["pv_in_bs", "block_size", "block_count", "file_count"],
         argvalues=[

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import statistics
-import time
 
 import pytest
 

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import statistics
 import time
 
 import pytest
@@ -16,7 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     fips_required,
     ignore_leftovers,
 )
-
+from ocs_ci.ocs.version import if_version
 from ocs_ci.ocs.bucket_utils import (
     wait_for_pv_backingstore,
     check_pv_backingstore_status,
@@ -429,31 +430,114 @@ class TestPvPool:
             mcg_obj=mcg_obj,
         )
 
-
     @tier2
-    @ignore_leftovers
-    @polarion_id("OCS-6552")
+    @if_version(">4.19")
+    @pytest.mark.parametrize(
+        argnames=["pv_in_bs", "block_size", "block_count", "file_count"],
+        argvalues=[
+            pytest.param(
+                *[
+                    1,
+                    "1M",
+                    10,
+                    20,
+                ],
+                marks=pytest.mark.polarion_id("OCS-4587"),
+            ),
+            pytest.param(
+                *[
+                    5,
+                    "1M",
+                    10,
+                    20,
+                ],
+                marks=pytest.mark.polarion_id("OCS-4587"),
+            ),
+            pytest.param(
+                *[
+                    10,
+                    "1M",
+                    10,
+                    20,
+                ],
+                marks=pytest.mark.polarion_id("OCS-4587"),
+            ),
+        ],
+    )
     def test_pv_data_dist(
-        self, setup_nfs, bucket_factory, awscli_pod, test_directory_setup, mcg_obj
+        self,
+        pv_in_bs,
+        block_size,
+        block_count,
+        file_count,
+        bucket_factory,
+        awscli_pod_session,
+        mcg_obj_session,
     ):
+        """
+        The test checks even distribution of the data written on bucket with 2 pv-backed backingstores,several pvs each.
+            1) Create bucket with 2 pv-based backingstores, several pvs on each
+            2) Write data to the bucket
+            3) Verify that the data is distributed evenly among all the pvs.
+
+        Args:
+            pv_in_bs (int): Number of pvs on each backing store
+            block_size (str): Size of each file block
+            block_count (int): Number of blocks in each file. Product of 'block_size' and this parameter gives the
+                size of each file to be written
+            file_count (int): Number of files to write
+
+
+        """
 
         bucketclass_dict = {
             "interface": "OC",
             "backingstore_dict": {
                 "pv": [
+                    (pv_in_bs, MIN_PV_BACKINGSTORE_SIZE_IN_GB, CEPHBLOCKPOOL_SC),
                     (
-                        3,
+                        pv_in_bs,
                         MIN_PV_BACKINGSTORE_SIZE_IN_GB,
-                        constants.NFS_SC_NAME,
+                        CEPHBLOCKPOOL_SC,
                     ),
-                    (
-                        3,
-                        MIN_PV_BACKINGSTORE_SIZE_IN_GB,
-                        constants.NFS_SC_NAME,
-                    )
                 ]
             },
         }
         bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
-        logger.info(f"********** The bucket with name {bucket.name} was created")
-        time.sleep(600)
+        logger.info(
+            f"The bucket with name {bucket.name} was successfully created on {pv_in_bs*2} pvs."
+        )
+
+        for i in range(file_count):
+            logger.info(f"Writing file number {i}")
+            awscli_pod_session.exec_cmd_on_pod(
+                f"dd if=/dev/urandom of=/tmp/testfile bs={block_size} count={block_count}"
+            )
+
+            awscli_pod_session.exec_s3_cmd_on_pod(
+                f"cp /tmp/testfile s3://{bucket.name}/testfile_{i}",
+                mcg_obj_session,
+            )
+
+        pv_pods_usage_list = list()
+        for backing_store in bucket.bucketclass.backingstores:
+            for pod in get_pods_having_label(
+                label=f"pool={backing_store.name}",
+                namespace=config.ENV_DATA["cluster_namespace"],
+            ):
+                pod_obj = Pod(**pod)
+                df_res = pod_obj.exec_cmd_on_pod(command="df -kh /noobaa_storage/")
+                logger.info(df_res)
+                usage_str = df_res.split()[9]
+                usage = int(usage_str[:-1])
+                pv_pods_usage_list.append(usage)
+
+        std_dev_st = statistics.stdev(pv_pods_usage_list)
+        mean_st = statistics.mean(pv_pods_usage_list)
+        st_dev_percent = (std_dev_st / mean_st) * 100
+        logger.info(f"Standard deviation in percents is = {st_dev_percent}%")
+
+        st_dev_percent_limit = 20
+        assert (
+            st_dev_percent < st_dev_percent_limit
+        ), "The data distribution is not even among the pvs"

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -16,7 +16,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     fips_required,
     ignore_leftovers,
 )
-from ocs_ci.ocs.version import if_version
 from ocs_ci.ocs.bucket_utils import (
     wait_for_pv_backingstore,
     check_pv_backingstore_status,


### PR DESCRIPTION
This PR contains 3 test cases for happy path testing of [RHSTOR-6635](https://issues.redhat.com//browse/RHSTOR-6635) - Qualify "NooBaa Backing Store Data Distribution and Rebalancing". 

The dataset is 20 files, 10MB each.
In each test cases the test verifies data distribution of the dataset on 2 pv-backed backinstores, each one has 1/5/10 backed pvs. 

The data should be distributed evenly between all the pvs, while the accepted standard deviation of the average data written to the PVs is 20%. 