### PR TITLE
Create new decorator to enable the recovery profile High in the Ceph rebalance

### DIFF
--- a/conf/ocsci/disable_high_recovery_during_rebalance.yaml
+++ b/conf/ocsci/disable_high_recovery_during_rebalance.yaml
@@ -1,0 +1,4 @@
+# Use this file to disable the ceph high recovery performance during the rebalance
+---
+ENV_DATA:
+  enable_high_recovery_during_rebalance: false

--- a/ocs_ci/deployment/helpers/odf_deployment_helpers.py
+++ b/ocs_ci/deployment/helpers/odf_deployment_helpers.py
@@ -6,8 +6,13 @@ ODF deployment.
 import logging
 
 from ocs_ci.ocs import defaults
-from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
 from ocs_ci.utility import version
+from ocs_ci.ocs.constants import (
+    MCLOCK_HIGH_CLIENT_OPS,
+    MCLOCK_BALANCED,
+    MCLOCK_HIGH_RECOVERY_OPS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +79,67 @@ def is_storage_system_needed():
     else:
         logger.debug("Storage system is needed")
     return storage_system_needed
+
+
+def set_ceph_mclock_config_profile(profile_name, osd_ids=None):
+    """
+    Set the Ceph mClock profile for the specified OSDs.
+
+    If no OSDs are specified, the profile is applied to all OSDs in the cluster.
+
+    Args:
+        profile_name (str): The mClock profile to set ('balanced', 'high_client_ops', 'high_recovery_ops').
+        osd_ids (list): List of OSD IDs. If None, it is applied to all OSDs.
+
+    Raises:
+        CommandFailed: If enabling override or setting the profile fails.
+
+    """
+    if not osd_ids:
+        osd_pods = get_osd_pods()
+        osd_ids = [get_osd_pod_id(p) for p in osd_pods]
+
+    toolbox = get_ceph_tools_pod()
+    enable_mclock_override_cmd = (
+        "ceph config set osd osd_mclock_override_recovery_settings true"
+    )
+    toolbox.exec_ceph_cmd(enable_mclock_override_cmd)
+
+    for osd_id in osd_ids:
+        set_profile_cmd = (
+            f"ceph config set osd.{osd_id} osd_mclock_profile {profile_name}"
+        )
+        toolbox.exec_ceph_cmd(set_profile_cmd)
+
+
+def set_ceph_mclock_high_client_recovery_profile(osd_ids=None):
+    """
+    Apply the 'high_client_ops' mClock profile to specified OSDs (or all OSDs if not provided).
+
+    Raises:
+        CommandFailed: If enabling override or setting the profile fails.
+
+    """
+    set_ceph_mclock_config_profile(MCLOCK_HIGH_CLIENT_OPS, osd_ids)
+
+
+def set_ceph_mclock_balanced_profile(osd_ids=None):
+    """
+    Apply the 'balanced' mClock profile to specified OSDs (or all OSDs if not provided).
+
+    Raises:
+        CommandFailed: If enabling override or setting the profile fails.
+
+    """
+    set_ceph_mclock_config_profile(MCLOCK_BALANCED, osd_ids)
+
+
+def set_ceph_mclock_high_recovery_profile(osd_ids=None):
+    """
+    Apply the 'high_recovery_ops' mClock profile to specified OSDs (or all OSDs if not provided).
+
+    Raises:
+        CommandFailed: If enabling override or setting the profile fails.
+
+    """
+    set_ceph_mclock_config_profile(MCLOCK_HIGH_RECOVERY_OPS, osd_ids)

--- a/ocs_ci/deployment/helpers/odf_deployment_helpers.py
+++ b/ocs_ci/deployment/helpers/odf_deployment_helpers.py
@@ -125,6 +125,9 @@ def set_ceph_mclock_high_client_recovery_profile(osd_ids=None):
     """
     Apply the 'high_client_ops' mClock profile to specified OSDs (or all OSDs if not provided).
 
+    Args:
+        osd_ids (list): List of OSD IDs. If None, the profile is applied to all OSDs.
+
     Raises:
         CommandFailed: If enabling override or setting the profile fails.
 
@@ -136,6 +139,9 @@ def set_ceph_mclock_balanced_profile(osd_ids=None):
     """
     Apply the 'balanced' mClock profile to specified OSDs (or all OSDs if not provided).
 
+    Args:
+        osd_ids (list): List of OSD IDs. If None, the profile is applied to all OSDs.
+
     Raises:
         CommandFailed: If enabling override or setting the profile fails.
 
@@ -146,6 +152,9 @@ def set_ceph_mclock_balanced_profile(osd_ids=None):
 def set_ceph_mclock_high_recovery_profile(osd_ids=None):
     """
     Apply the 'high_recovery_ops' mClock profile to specified OSDs (or all OSDs if not provided).
+
+    Args:
+        osd_ids (list): List of OSD IDs. If None, the profile is applied to all OSDs.
 
     Raises:
         CommandFailed: If enabling override or setting the profile fails.

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -293,6 +293,8 @@ ENV_DATA:
   # Label nodes with specific labels, used for example fot ODF deployment on ROSA HCP
   node_labels: ""
 
+  # Enabling the ceph high recovery performance during the rebalance
+  enable_high_recovery_during_rebalance: true
   # Assisted Installer related settings
 
 # This section is related to upgrade

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -378,6 +378,13 @@ def pytest_addoption(parser):
         default=False,
         help=("Skips the RPM and go version collection for every pod for session"),
     )
+    parser.addoption(
+        "--enable-high-recovery-during-rebalance",
+        dest="enable_high_recovery_during_rebalance",
+        choices=["true", "false"],
+        default="true",
+        help="Enable high recovery profile during Ceph rebalance",
+    )
 
 
 def pytest_configure(config):
@@ -747,6 +754,12 @@ def process_cluster_cli_params(config):
         config, "skip_rpm_go_version_collection"
     )
     ocsci_config.RUN["skip_rpm_go_version_collection"] = skip_rpm_go_version_collection
+    enable_high_recovery_during_rebalance = get_cli_param(
+        config, "enable_high_recovery_during_rebalance"
+    )
+    ocsci_config.RUN["enable_high_recovery_during_rebalance"] = (
+        enable_high_recovery_during_rebalance
+    )
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -378,13 +378,6 @@ def pytest_addoption(parser):
         default=False,
         help=("Skips the RPM and go version collection for every pod for session"),
     )
-    parser.addoption(
-        "--enable-high-recovery-during-rebalance",
-        dest="enable_high_recovery_during_rebalance",
-        choices=["true", "false"],
-        default="true",
-        help="Enable high recovery profile during Ceph rebalance",
-    )
 
 
 def pytest_configure(config):
@@ -754,12 +747,6 @@ def process_cluster_cli_params(config):
         config, "skip_rpm_go_version_collection"
     )
     ocsci_config.RUN["skip_rpm_go_version_collection"] = skip_rpm_go_version_collection
-    enable_high_recovery_during_rebalance = get_cli_param(
-        config, "enable_high_recovery_during_rebalance"
-    )
-    ocsci_config.RUN["enable_high_recovery_during_rebalance"] = (
-        enable_high_recovery_during_rebalance
-    )
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -8,7 +8,12 @@ from ocs_ci.utility.version import get_semantic_ocs_version_from_config, VERSION
 from ocs_ci.utility.utils import exec_cmd
 from ocs_ci.framework import config
 from ocs_ci.deployment.ocp import download_pull_secret
-from ocs_ci.ocs.constants import ODF_CLI_DEV_IMAGE
+from ocs_ci.ocs.constants import (
+    ODF_CLI_DEV_IMAGE,
+    LOW_RECOVERY_OPS,
+    BALANCED,
+    HIGH_RECOVERY_OPS,
+)
 
 
 log = getLogger(__name__)
@@ -163,3 +168,61 @@ class ODFCliRunner:
         return self.run_command(
             f" set ceph log-level {service} {subsystem} {log_level}"
         )
+
+    def get_recovery_profile(self):
+        output = self.run_get_recovery_profile()
+        str_output = output.stdout.decode().strip()
+        if not str_output:
+            log.warning(
+                f"ODF CLI returned no recovery profile; Fall back to the default value {BALANCED}"
+            )
+            return BALANCED
+        return str_output.split()[-1]
+
+    def run_set_recovery_profile(self, profile_name):
+        self.run_command(f" set recovery-profile {profile_name}")
+
+    def run_set_recovery_profile_low(self):
+        return self.run_set_recovery_profile(LOW_RECOVERY_OPS)
+
+    def run_set_recovery_profile_balanced(self):
+        return self.run_set_recovery_profile(BALANCED)
+
+    def run_set_recovery_profile_high(self):
+        return self.run_set_recovery_profile(HIGH_RECOVERY_OPS)
+
+
+def odf_cli_setup_helper():
+    """
+    Initializes and returns an instance of ODFCliRunner.
+    Downloads the ODF CLI binary if it does not exist.
+
+    Returns:
+        ODFCliRunner: The initialized runner, or None if initialization failed.
+    """
+    odf_cli_retriever = ODFCLIRetriever()
+
+    # Check and download ODF CLI binary if needed
+    if not odf_cli_retriever.check_odf_cli_binary():
+        log.warning("ODF CLI binary not found. Attempting to download...")
+        odf_cli_retriever.retrieve_odf_cli_binary()
+        if not odf_cli_retriever.check_odf_cli_binary():
+            log.warning("Failed to download ODF CLI binary")
+            return None
+
+    # Check and initialize ODFCliRunner
+    try:
+        odf_cli_runner = ODFCliRunner()
+        assert odf_cli_runner
+    except AssertionError:
+        log.warning("ODFCliRunner not initialized. Attempting to initialize again...")
+        odf_cli_runner = ODFCliRunner()
+        if not odf_cli_runner:
+            log.warning("Failed to initialize ODFCliRunner after retry")
+            return None
+    except Exception as e:
+        log.warning(f"Exception during ODFCliRunner initialization: {e}")
+        return None
+
+    log.info("ODF CLI binary downloaded and ODFCliRunner initialized successfully")
+    return odf_cli_runner

--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -211,18 +211,13 @@ def odf_cli_setup_helper():
             return None
 
     # Check and initialize ODFCliRunner
-    try:
-        odf_cli_runner = ODFCliRunner()
-        assert odf_cli_runner
-    except AssertionError:
+    odf_cli_runner = ODFCliRunner()
+    if not odf_cli_runner:
         log.warning("ODFCliRunner not initialized. Attempting to initialize again...")
         odf_cli_runner = ODFCliRunner()
         if not odf_cli_runner:
             log.warning("Failed to initialize ODFCliRunner after retry")
             return None
-    except Exception as e:
-        log.warning(f"Exception during ODFCliRunner initialization: {e}")
-        return None
 
     log.info("ODF CLI binary downloaded and ODFCliRunner initialized successfully")
     return odf_cli_runner

--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -170,6 +170,18 @@ class ODFCliRunner:
         )
 
     def get_recovery_profile(self):
+        """
+        Retrieve the current recovery profile using the ODF CLI.
+
+        Returns:
+            str: The name of the current recovery profile (e.g., 'low_recovery_ops',
+            'balanced', 'high_recovery_ops').
+
+        Notes:
+            If the CLI returns no output, the method logs a warning and returns the
+            default profile 'balanced' as a fallback.
+
+        """
         output = self.run_get_recovery_profile()
         str_output = output.stdout.decode().strip()
         if not str_output:
@@ -180,15 +192,38 @@ class ODFCliRunner:
         return str_output.split()[-1]
 
     def run_set_recovery_profile(self, profile_name):
+        """
+        Set the recovery profile using the ODF CLI.
+
+        Args:
+            profile_name (str): The name of the recovery profile to apply
+                (e.g., 'low_recovery_ops', 'balanced', 'high_recovery_ops').
+
+        Raises:
+            CommandFailed: If the CLI command fails.
+
+        """
         self.run_command(f" set recovery-profile {profile_name}")
 
     def run_set_recovery_profile_low(self):
+        """
+        Set the recovery profile to 'low_recovery_ops'.
+
+        """
         return self.run_set_recovery_profile(LOW_RECOVERY_OPS)
 
     def run_set_recovery_profile_balanced(self):
+        """
+        Set the recovery profile to 'balanced'.
+
+        """
         return self.run_set_recovery_profile(BALANCED)
 
     def run_set_recovery_profile_high(self):
+        """
+        Set the recovery profile to 'high_recovery_ops'.
+
+        """
         return self.run_set_recovery_profile(HIGH_RECOVERY_OPS)
 
 
@@ -198,7 +233,12 @@ def odf_cli_setup_helper():
     Downloads the ODF CLI binary if it does not exist.
 
     Returns:
-        ODFCliRunner: The initialized runner, or None if initialization failed.
+        ODFCliRunner: The initialized runner.
+
+    Raises:
+        NotSupportedException: If ODF CLI is not supported on the current version or deployment.
+        RuntimeError: If CLI binary download or ODFCliRunner initialization fails.
+
     """
     odf_cli_retriever = ODFCLIRetriever()
 
@@ -207,8 +247,7 @@ def odf_cli_setup_helper():
         log.warning("ODF CLI binary not found. Attempting to download...")
         odf_cli_retriever.retrieve_odf_cli_binary()
         if not odf_cli_retriever.check_odf_cli_binary():
-            log.warning("Failed to download ODF CLI binary")
-            return None
+            raise RuntimeError("Failed to download ODF CLI binary")
 
     # Check and initialize ODFCliRunner
     odf_cli_runner = ODFCliRunner()
@@ -216,8 +255,7 @@ def odf_cli_setup_helper():
         log.warning("ODFCliRunner not initialized. Attempting to initialize again...")
         odf_cli_runner = ODFCliRunner()
         if not odf_cli_runner:
-            log.warning("Failed to initialize ODFCliRunner after retry")
-            return None
+            raise RuntimeError("Failed to initialize ODFCliRunner after retry")
 
     log.info("ODF CLI binary downloaded and ODFCliRunner initialized successfully")
     return odf_cli_runner

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,6 +20,7 @@ import math
 
 from datetime import datetime
 from semantic_version import Version
+from ocs_ci.utility.decorators import enable_high_recovery_if_io_flag
 
 from ocs_ci.ocs.utils import thread_init_class
 
@@ -824,6 +825,7 @@ class CephCluster(object):
                 and states["count"] == total_pg_count
             )
 
+    @enable_high_recovery_if_io_flag
     def wait_for_rebalance(self, timeout=600, repeat=3):
         """
         Wait for re-balance to complete

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -20,7 +20,7 @@ import math
 
 from datetime import datetime
 from semantic_version import Version
-from ocs_ci.utility.decorators import enable_high_recovery_if_io_flag
+from ocs_ci.utility.decorators import enable_high_recovery_during_rebalance_flag
 
 from ocs_ci.ocs.utils import thread_init_class
 
@@ -825,7 +825,7 @@ class CephCluster(object):
                 and states["count"] == total_pg_count
             )
 
-    @enable_high_recovery_if_io_flag
+    @enable_high_recovery_during_rebalance_flag
     def wait_for_rebalance(self, timeout=600, repeat=3):
         """
         Wait for re-balance to complete

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3397,3 +3397,8 @@ LOWER_REQ_MDS_CACHE_MEMORY = 1073741824
 AUTO_SCALING_YAML = os.path.join(AUTO_SCALING_DIR, "storage-autoscaler.yaml")
 # StorageAutoScaler Values
 PROMETHEUS_RECONCILE_TIMEOUT = 660
+
+# ODF recovery profiles
+LOW_RECOVERY_OPS = "low_recovery_ops"
+BALANCED = "balanced"
+HIGH_RECOVERY_OPS = "high_recovery_ops"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3402,3 +3402,8 @@ PROMETHEUS_RECONCILE_TIMEOUT = 660
 LOW_RECOVERY_OPS = "low_recovery_ops"
 BALANCED = "balanced"
 HIGH_RECOVERY_OPS = "high_recovery_ops"
+
+# mclock_recovery_profiles
+MCLOCK_HIGH_CLIENT_OPS = "high_client_ops"
+MCLOCK_BALANCED = "balanced"
+MCLOCK_HIGH_RECOVERY_OPS = "high_recovery_ops"

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -164,15 +164,19 @@ def safe_exec(exception_type=Exception):
 
 def enable_high_recovery(func):
     """
-    Decorator to temporarily switch the Ceph recovery profile to 'high_recovery_ops'
-    during the execution of the wrapped function, and revert it back afterward.
+    Decorator to temporarily boost Ceph recovery performance during the execution
+    of the wrapped function by applying both Ceph and mClock high-recovery profiles.
 
-    This is useful when performing operations like OSD replacement or data rebalancing
-    that benefit from faster Ceph recovery performance.
+    This is useful for operations such as OSD replacement or data rebalancing
+    where faster recovery is desired at the cost of reduced client I/O bandwidth.
 
-    If the ODF CLI runner or current profile cannot be determined, the function executes without change.
+    Behavior:
+    - Sets the Ceph recovery profile to 'high_recovery_ops'
+    - Sets the mClock profile to 'high_client_ops'
+    - Restores both profiles to their original or default state after function execution
 
-    The switch is always reverted, even if the function raises an exception.
+    If the ODF CLI runner is not available or the current profile cannot be determined,
+    the wrapped function is executed without making any changes.
 
     Returns:
         The result of the wrapped function.

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -185,7 +185,7 @@ def enable_high_recovery_during_rebalance_flag(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        if not config.RUN.get("enable_high_recovery_during_rebalance"):
+        if not config.ENV_DATA.get("enable_high_recovery_during_rebalance"):
             logger.info(
                 "The 'enable_high_recovery_during_rebalance' flag is not set. "
                 "Proceeding with the original function..."

--- a/ocs_ci/utility/decorators.py
+++ b/ocs_ci/utility/decorators.py
@@ -111,7 +111,7 @@ def switch_to_provider_for_function(func):
 def safe_exec(exception_type=Exception):
     """
     A decorator factory that wraps a function in a try-except block to catch and suppress
-    specified exceptions, logging a warning instead of raising.
+    specified exceptions, logging the full traceback.
 
     This is useful for non-critical operations where failure should not interrupt
     the main flow of the program.
@@ -155,7 +155,8 @@ def safe_exec(exception_type=Exception):
             try:
                 return func(*args, **kwargs)
             except exception_type as ex:
-                logger.warning(ex)
+                func_name = getattr(func, "__name__", "unknown")
+                logger.exception(f"Exception in {func_name}: {ex}")
                 return None
 
         return wrapper
@@ -218,7 +219,7 @@ def enable_high_recovery_if_io_flag(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        if config.RUN.get("io_in_bg") is not True:
+        if not config.RUN.get("io_in_bg"):
             logger.info(
                 "The 'io_in_bg' param is not set. Proceeding with the original function..."
             )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,32 +1,15 @@
 import pytest
 import logging
-from ocs_ci.helpers.odf_cli import ODFCLIRetriever, ODFCliRunner
+from ocs_ci.helpers.odf_cli import odf_cli_setup_helper
 
 log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")
 def odf_cli_setup():
-    odf_cli_retriever = ODFCLIRetriever()
-
-    # Check and download ODF CLI binary if needed
     try:
-        assert odf_cli_retriever.check_odf_cli_binary()
-    except AssertionError:
-        log.warning("ODF CLI binary not found. Attempting to download...")
-        odf_cli_retriever.retrieve_odf_cli_binary()
-        if not odf_cli_retriever.check_odf_cli_binary():
-            pytest.fail("Failed to download ODF CLI binary")
+        odf_cli_runner = odf_cli_setup_helper()
+    except RuntimeError as ex:
+        pytest.fail(str(ex))
 
-    # Check and initialize ODFCliRunner if needed
-    try:
-        odf_cli_runner = ODFCliRunner()
-        assert odf_cli_runner
-    except AssertionError:
-        log.warning("ODFCliRunner not initialized. Attempting to initialize...")
-        odf_cli_runner = ODFCliRunner()
-        if not odf_cli_runner:
-            pytest.fail("Failed to initialize ODFCliRunner")
-
-    log.info("ODF CLI binary downloaded and ODFCliRunner initialized successfully")
     return odf_cli_runner

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -87,7 +87,8 @@ def add_capacity_test(ui_flag=False):
     else:
         replica_count = 3
     pod.wait_for_resource(
-        timeout=300,
+        timeout=600,
+        sleep=5,
         condition=constants.STATUS_RUNNING,
         selector="app=rook-ceph-osd",
         resource_count=result * replica_count,

--- a/tests/libtest/test_wait_for_ceph_rebalance.py
+++ b/tests/libtest/test_wait_for_ceph_rebalance.py
@@ -19,12 +19,12 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 class TestWaitForCephRebalance(ManageTest):
     """
-    Test Wait for Ceph rebalance
+    Test Wait for Ceph rebalance without having the IO in the background
     """
 
     @pytest.fixture(autouse=True)
     def setup(self):
-        # Simulate the run when we have IO in the background
+        # Simulate the run when we don't have IO in the background
         self.original_io_in_bg = config.RUN.get("io_in_bg", False)
         config.RUN["io_in_bg"] = False
 

--- a/tests/libtest/test_wait_for_ceph_rebalance.py
+++ b/tests/libtest/test_wait_for_ceph_rebalance.py
@@ -1,0 +1,70 @@
+import logging
+import pytest
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    ignore_leftovers,
+    libtest,
+    brown_squad,
+)
+from ocs_ci.framework import config
+from ocs_ci.helpers.osd_resize import CephCluster
+
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@libtest
+@ignore_leftovers
+class TestWaitForCephRebalance(ManageTest):
+    """
+    Test Wait for Ceph rebalance
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        # Simulate the run when we have IO in the background
+        self.original_io_in_bg = config.RUN.get("io_in_bg", False)
+        config.RUN["io_in_bg"] = False
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        def finalizer():
+            config.RUN["io_in_bg"] = self.original_io_in_bg
+
+        request.addfinalizer(finalizer)
+
+    def test_wait_for_ceph_rebalance(self):
+        ceph_cluster_obj = CephCluster()
+        assert ceph_cluster_obj.wait_for_rebalance(
+            timeout=180
+        ), "Data re-balance failed to complete"
+
+
+@brown_squad
+@libtest
+@ignore_leftovers
+class TestWaitForCephRebalanceWithIO(ManageTest):
+    """
+    Test wait for Ceph rebalance when we run IO in the background
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        # Simulate the run when we have IO in the background
+        self.original_io_in_bg = config.RUN.get("io_in_bg", False)
+        config.RUN["io_in_bg"] = True
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        def finalizer():
+            config.RUN["io_in_bg"] = self.original_io_in_bg
+
+        request.addfinalizer(finalizer)
+
+    def test_wait_for_ceph_rebalance_with_io(self):
+        ceph_cluster_obj = CephCluster()
+        assert ceph_cluster_obj.wait_for_rebalance(
+            timeout=180
+        ), "Data re-balance failed to complete"

--- a/tests/libtest/test_wait_for_ceph_rebalance.py
+++ b/tests/libtest/test_wait_for_ceph_rebalance.py
@@ -77,7 +77,7 @@ class TestWaitForCephRebalanceWithIO(ManageTest):
 @libtest
 @ignore_leftovers
 @runs_on_provider
-class TestWaitForCephRebalanceWithoutRebalanceFlag(ManageTest):
+class TestWaitForCephRebalanceHighRecoveryDisabled(ManageTest):
     """
     Test Ceph rebalance wait behavior when the high recovery profile is disabled
     """
@@ -85,19 +85,21 @@ class TestWaitForCephRebalanceWithoutRebalanceFlag(ManageTest):
     @pytest.fixture(autouse=True)
     def setup(self):
         # Simulate the run when the high recovery profile is disabled
-        self.original_flag = config.RUN.get(
+        self.original_flag = config.ENV_DATA.get(
             "enable_high_recovery_during_rebalance", False
         )
-        config.RUN["enable_high_recovery_during_rebalance"] = False
+        config.ENV_DATA["enable_high_recovery_during_rebalance"] = False
 
     @pytest.fixture(autouse=True)
     def teardown(self, request):
         def finalizer():
-            config.RUN["enable_high_recovery_during_rebalance"] = self.original_flag
+            config.ENV_DATA["enable_high_recovery_during_rebalance"] = (
+                self.original_flag
+            )
 
         request.addfinalizer(finalizer)
 
-    def test_wait_for_ceph_rebalance_with_io(self):
+    def test_wait_for_ceph_rebalance_high_recovery_disabled(self):
         ceph_cluster_obj = CephCluster()
         assert ceph_cluster_obj.wait_for_rebalance(
             timeout=180


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/11290.
The PR implements the following:

- Extend the `ODFCliRunner` to include methods for setting the recovery profile using the CLI tool and add a new helper function `odf_cli_setup_helper` to easily get the `ODFCliRunner` instance.
- Add two new decorators: 
  - `enable_high_recovery` - to temporarily switch the Ceph recovery profile to 'high_recovery_ops' during the execution of the wrapped function, and revert it afterward. 
  - `enable_high_recovery_if_io_flag` - to temporarily switch the Ceph recovery profile to 'high_recovery_ops' during the execution of the wrapped function, and revert it afterward only if the IO flag is marked(and we run IO in the background). 
- Use the decorator `enable_high_recovery_if_io_flag` for the method `wait_for_rebalance` in the Ceph class. The decorator will be very useful since, when running IO in the background, switching to the profile 'high_recovery_ops' will make the Ceph rebalance go faster.