### PR TITLE
added storage classes to storage consumer for distribution

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -288,7 +288,7 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                 ), "Storage classes ae not created as expected"
 
         else:
-            # Create ODF subscription for storage-client and native client
+            # Create ODF subscription for storage client operator and native client
             self.storage_clients.create_native_storage_client()
 
             # Verify native storageclient is created successfully

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -158,7 +158,7 @@ REPORTING:
 ENV_DATA:
   cluster_name: null  # will be changed in ocscilib plugin
   storage_cluster_name: 'ocs-storagecluster'
-  storage_client_name: "storage-client"
+  storage_client_name: "ocs-storagecluster"
   storage_device_sets_name: "storageDeviceSets"
   sno: false
   cluster_namespace: 'openshift-storage'

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -299,7 +299,6 @@ VOLSYNC_SYSTEM_NAMESPACE = "volsync-system"
 OPENSHIFT_NAMESPACE = "openshift"
 OPENSHIFT_STORAGE_CLIENT_NAMESPACE = "openshift-storage-client"
 OPENSHIFT_STORAGE_EXTENDED_NAMESPACE = "openshift-storage-extended"
-OPENSHIFT_STORAGE_CLIENT_NAMESPACE = "openshift-storage-client"
 OPENSHIFT_INGRESS_OPERATOR_NAMESPACE = "openshift-ingress-operator"
 MANAGED_FUSION_NAMESPACE = "managed-fusion"
 OPENSHIFT_MACHINE_API_NAMESPACE = "openshift-machine-api"
@@ -437,7 +436,7 @@ PROVIDER_SUBSCRIPTION = "subs"
 
 OCS_CLIENT_OPERATOR_CONTROLLER_MANAGER_PREFIX = "ocs-client-operator-controller-manager"
 OCS_CLIENT_OPERATOR_CONSOLE = "ocs-client-operator-console"
-STORAGE_CLIENT_NAME = "storage-client"
+STORAGE_CLIENT_NAME = "ocs-storagecluster"
 
 OCP_QE_MISC_REPO = "https://gitlab.cee.redhat.com/aosqe/flexy-templates.git"
 CRITICAL_ERRORS = ["core dumped", "oom_reaper"]
@@ -464,7 +463,6 @@ UPI_INSTALL_SCRIPT = "upi_on_aws-install.sh"
 
 DEFAULT_CLUSTERNAME = DEFAULT_STORAGE_CLUSTER = "ocs-storagecluster"
 DEFAULT_CLUSTERNAME_EXTERNAL_MODE = "ocs-external-storagecluster"
-DEFAULT_CLUSTERNAME_CLIENT = "storage-client"
 DEFAULT_BLOCKPOOL = f"{DEFAULT_CLUSTERNAME}-cephblockpool"
 METADATA_POOL = f"{DEFAULT_CLUSTERNAME}-cephfilesystem-metadata"
 DATA_POOL = f"{DEFAULT_CLUSTERNAME}-cephfilesystem-data0"
@@ -493,6 +491,7 @@ DEFAULT_CEPHBLOCKPOOL = "ocs-storagecluster-cephblockpool"
 DEFAULT_STORAGECLASS_CEPHFS = f"{DEFAULT_CLUSTERNAME}-cephfs"
 DEFAULT_STORAGECLASS_RBD = f"{DEFAULT_CLUSTERNAME}-ceph-rbd"
 DEFAULT_STORAGECLASS_RGW = f"{DEFAULT_CLUSTERNAME}-ceph-rgw"
+DEFAULT_STORAGECLASS_VIRTUALIZATION = f"{DEFAULT_CLUSTERNAME}-ceph-rbd-virtualization"
 DEFAULT_STORAGECLASS_RBD_THICK = f"{DEFAULT_CLUSTERNAME}-ceph-rbd-thick"
 DEFAULT_OCS_STORAGECLASS = "default-ocs-storage-class"
 # Default storage class for LSO deployments. While each platform specific
@@ -519,8 +518,8 @@ DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD_NAMESPACE_PREFIX = (
 )
 
 # Default StorageClass for Provider-mode
-DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{DEFAULT_CLUSTERNAME_CLIENT}-cephfs"
-DEFAULT_STORAGECLASS_CLIENT_RBD = f"{DEFAULT_CLUSTERNAME_CLIENT}-ceph-rbd"
+DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{STORAGE_CLIENT_NAME}-cephfs"
+DEFAULT_STORAGECLASS_CLIENT_RBD = f"{STORAGE_CLIENT_NAME}-ceph-rbd"
 
 # Default VolumeSnapshotClass
 DEFAULT_VOLUMESNAPSHOTCLASS_CEPHFS = f"{DEFAULT_CLUSTERNAME}-cephfsplugin-snapclass"

--- a/ocs_ci/ocs/resources/storage_client.py
+++ b/ocs_ci/ocs/resources/storage_client.py
@@ -397,7 +397,7 @@ class StorageClient:
         self, namespace_to_create_storage_client=None, resource_name=None
     ):
         """
-        This method creates network policy for the namespace where storage-client will be created
+        This method creates network policy for the namespace where Storage Client will be created
 
         Inputs:
         namespace_to_create_storage_client (str): Namespace where the storage client will be created

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -3046,14 +3046,14 @@ def get_client_storage_provider_endpoint():
 
 def wait_for_storage_client_connected(timeout=180, sleep=10):
     """
-    Wait for the storage-client to be in a connected phase
+    Wait for the Storage client to be in a connected phase
 
     Args:
-        timeout (int): Time to wait for the storage-client to be in a connected phase
+        timeout (int): Time to wait for the Storage Client to be in a connected phase
         sleep (int): Time in seconds to sleep between attempts
 
     Raises:
-        ResourceWrongStatusException: In case the storage-client didn't reach the desired connected phase
+        ResourceWrongStatusException: In case the Storage Client didn't reach the desired connected phase
 
     """
     sc_obj = OCP(

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -389,15 +389,17 @@ class StorageConsumer:
             storage_consumer_data["metadata"]["namespace"] = self.namespace
             if storage_classes:
                 storage_consumer_data["spec"].setdefault(
-                    "storageClasses", storage_classes
+                    "storageClasses", [{"name": sc} for sc in storage_classes]
                 )
             if volume_snapshot_classes:
                 storage_consumer_data["spec"].setdefault(
-                    "volumeSnapshotClasses", volume_snapshot_classes
+                    "volumeSnapshotClasses",
+                    [{"name": vsc} for vsc in volume_snapshot_classes],
                 )
             if volume_group_snapshot_classes:
                 storage_consumer_data["spec"].setdefault(
-                    "volumeGroupSnapshotClasses", volume_group_snapshot_classes
+                    "volumeGroupSnapshotClasses",
+                    [{"name": vgsc} for vgsc in volume_group_snapshot_classes],
                 )
             if storage_quota_in_gib:
                 storage_consumer_data["spec"].setdefault(

--- a/ocs_ci/templates/ocs-deployment/provider-mode/native_storage_client.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/native_storage_client.yaml
@@ -1,7 +1,7 @@
 apiVersion: ocs.openshift.io/v1alpha1
 kind: StorageClient
 metadata:
-  name: storage-client
+  name: ocs-storagecluster
   namespace: openshift-storage-client
 spec:
   storageProviderEndpoint: PLACEHOLDER1

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -301,7 +301,7 @@ class TestNodesRestartHCI(ManageTest):
         1. Get the client "storageProviderEndpoint" param in the storage-client resource
         2. Get the provider endpoint node by the client "storageProviderEndpoint" in the previous step,
         and stop the provider endpoint node.
-        3. Verify the client storage-client is connected to the provider.
+        3. Verify the Storage Client is connected to the provider.
         4. Try to create and delete resources from the client/s.
         5. Start the provider endpoint node
         6. Check the cluster health is ok for the provider and clients.
@@ -354,7 +354,7 @@ class TestNodesRestartHCI(ManageTest):
         The test will implement the following steps:
         1. Pick randomly one of the provider MGR nodes.
         2. Stop the MGR node.
-        3. Verify the client storage-client is connected to the provider.
+        3. Verify the Storage Client is connected to the provider.
         4. Try to create and delete resources from the client/s.
         5. Start the MGR node
         6. Check the cluster health is ok for the provider and clients.


### PR DESCRIPTION
following the set of rules:

1. UI distributes all default storage classes, that were provisioned by odf operator
2. virtualization storage is filtered out by automation script as this is a preferable behavior, and no use sace for having this storage class
3. automation logic will be that we'd want to have all storage classes that provider have to have the same on clients, to continue with that set in testing
4. automation allows tests to delete storage classes from distribution. For that purpose user must modify StorageConsumer cr on provider's side.