### PR TITLE
[RDR][Mulitclient]Get provider index based on config value if present

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -355,6 +355,7 @@ higher priority).
       * `hosted_odf_version` - version of ODF to be deployed on hosted clusters
       * `cp_availability_policy` - "HighlyAvailable" or "SingleReplica"; if not provided the default value is "SingleReplica"
       * `storage_quota` - storage quota for the hosted cluster
+      * `provider_cluster_name` - Name of the provider cluster if storageclient is required/present in the hosted cluster. This is optional and useful when there are more than one provider cluster in the config, provider mode RDR for example
 * `wait_timeout_for_healthy_osd_in_minutes` - timeout waiting for healthy OSDs before continuing upgrade (see https://bugzilla.redhat.com/show_bug.cgi?id=2276694 for more details)
 * `osd_maintenance_timeout` - is a duration in minutes that determines how long an entire failureDomain like region/zone/host will be held in noout
 * `odf_provider_mode_deployment` - True if you would like to enable provider mode deployment.

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -271,11 +271,18 @@ class MultiClusterConfig:
             ClusterNotFoundException: In case it didn't find the provider cluster
 
         """
-        for i, cluster in enumerate(self.clusters):
-            if cluster.ENV_DATA["cluster_type"] == "provider":
-                return i
-
-        raise ClusterNotFoundException("Didn't find the provider cluster")
+        provider_name = config.ENV_DATA.get("provider_cluster_name")
+        provider_index = None
+        if provider_name:
+            provider_index = self.get_cluster_index_by_name(cluster_name=provider_name)
+        else:
+            for i, cluster in enumerate(self.clusters):
+                if cluster.ENV_DATA["cluster_type"] == "provider":
+                    provider_index = i
+                    break
+        if provider_index is None:
+            raise ClusterNotFoundException("Didn't find the provider cluster")
+        return provider_index
 
     def get_provider_cluster_indexes(self):
         """


### PR DESCRIPTION
When there are more more than one provider cluster in the config (RDR test , for example), the current implementation will fetch the lower index among the provider mode cluster indexes. This PR add an additional step in the function to get the provider index based on ENV_DATA parameter `provider_cluster_name`. The client cluster config can have this value to easily identify the associated provider cluster. If the parameter is not present, current implementation will execute.