### PR TITLE
Fix OCP deployment on vSphere via Assisted Installer

### DIFF
--- a/terraform/ai/vsphere/vm/main.tf
+++ b/terraform/ai/vsphere/vm/main.tf
@@ -11,6 +11,7 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
   storage_policy_id           = var.storage_policy_id
+  firmware                    = "efi"
 
   network_interface {
     network_id = var.network_id


### PR DESCRIPTION
Recently vSphere deployments via Assisted Installer are failing, because the installation seems to count with EFI boot mode, while the VMs are configured to legacy BIOS mode. Changing the boot mode to EFI explicitly.