### PR TITLE
Fix the benchmark operator deployment to use 'kustomize' in the setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8933,6 +8933,9 @@ def benchmark_workload_storageutilization(request):
         bs="4096KiB",
         storageclass=constants.DEFAULT_STORAGECLASS_RBD,
         timeout_completed=2400,
+        benchmark_name=None,
+        use_kustomize_build=True,
+        is_completed=True,
     ):
         """
         Setup of benchmark fio
@@ -8944,6 +8947,9 @@ def benchmark_workload_storageutilization(request):
             bs (str): the Block size that need to used for the prefill
             storageclass (str): StorageClass to use for PVC per server pod
             timeout_completed (int): timeout client pod move to completed state
+            benchmark_name (str): Optional. Name for the Benchmark resource.
+            use_kustomize_build (bool): True, if use kustomize build. False, otherwise.
+            is_completed (bool): if True, verify the benchmark operator moved to completed state.
 
         """
         nonlocal benchmark_obj
@@ -8957,8 +8963,10 @@ def benchmark_workload_storageutilization(request):
             bs=bs,
             storageclass=storageclass,
             timeout_completed=timeout_completed,
+            benchmark_name=benchmark_name,
+            use_kustomize_build=use_kustomize_build,
         )
-        benchmark_obj.run_fio_benchmark_operator(is_completed=True)
+        benchmark_obj.run_fio_benchmark_operator(is_completed=is_completed)
 
     def finalizer():
         if benchmark_obj is not None:

--- a/tests/libtest/test_benchmark_operator.py
+++ b/tests/libtest/test_benchmark_operator.py
@@ -1,0 +1,40 @@
+import logging
+from uuid import uuid4
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    ignore_leftovers,
+    libtest,
+)
+
+log = logging.getLogger(__name__)
+
+
+@libtest
+@ignore_leftovers
+class TestBenchmarkOperator(ManageTest):
+    """
+    Test the Benchmark Operator FIO Class functionalities
+    """
+
+    def test_benchmark_workload_storageutilization_default_values(
+        self, benchmark_workload_storageutilization
+    ):
+        """
+        Create a new benchmark operator with the default values
+        """
+        benchmark_workload_storageutilization(target_percentage=25, is_completed=True)
+
+    def test_benchmark_workload_storageutilization_picked_values(
+        self, benchmark_workload_storageutilization
+    ):
+        """
+        Create a new benchmark operator with picked values
+        """
+        benchmark_name = f"fio-benchmark{uuid4().hex[:4]}"
+        benchmark_workload_storageutilization(
+            target_percentage=20,
+            bs="2048KiB",
+            benchmark_name=benchmark_name,
+            is_completed=True,
+        )


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/12284.
The PR implements the following:
- Fix the benchmark operator deployment to have the option to use 'kustomize' in the setup and deployment. 
- Add option to have a benchmark name, 
- Create a new libtest to test the new benchmark changes