### PR TITLE
Ensure lvm tests are skipped when skipif marker is applied and valid

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,8 +420,8 @@ def pytest_collection_modifyitems(session, config, items):
             skipif_lvm_not_installed_marker = item.get_closest_marker(
                 "skipif_lvm_not_installed"
             )
-            if skipif_lvm_not_installed_marker and "lvm" in ocsci_config.RUN:
-                if not ocsci_config.RUN["lvm"]:
+            if skipif_lvm_not_installed_marker:
+                if not ocsci_config.RUN.get("lvm", False):
                     log.info(f"Test {item} will be removed due to lvm not installed")
                     items.remove(item)
                     continue


### PR DESCRIPTION
This change fixes an issue where lvm tests are being executed against a cluster where lvmo is not installed because the skipif marker is only considered in cases where `lvm` is found in `config.RUN`.