### PR TITLE
extend time for waiting for packagemanifest in set_upgrade_channel

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -475,7 +475,7 @@ class OCSUpgrade(object):
             resource_name=resource_name,
             selector=operator_selector,
         )
-        package_manifest.wait_for_resource()
+        package_manifest.wait_for_resource(timeout=120)
         channel = config.DEPLOYMENT.get("ocs_csv_channel")
         if not channel:
             channel = package_manifest.get_default_channel()


### PR DESCRIPTION
The disconnected upgrade seems to be failing there, becuase the packagemanifest is available a moment after the timeout expires.
I check some successful upgrades and the packagemanifest were available after about 45 seconds, so extending the timeout from 1 minute to 2 minutes to have some space for slower environments.

Example failed jobs:
* https://url.corp.redhat.com/80c7a87
* https://url.corp.redhat.com/cc13e5d