### PR TITLE
Use `expanduser` for `log_dir` config for deploy-fusion/fdf endpoint

### DIFF
--- a/ocs_ci/utility/framework/fusion_fdf_init.py
+++ b/ocs_ci/utility/framework/fusion_fdf_init.py
@@ -112,7 +112,7 @@ class Initializer(object):
         """
         Initialize the logging config.
         """
-        log_dir = config.RUN["log_dir"]
+        log_dir = os.path.expanduser(config.RUN.get("log_dir"))
         log_level = config.RUN.get("log_level", "INFO")
         log_name = f"{self.log_basename}_{self.run_id}"
         log_formatter = logging.Formatter(constants.LOG_FORMAT)
@@ -284,7 +284,7 @@ def create_junit_report(
             xml = JUnitXml()
             xml.add_testsuite(test_suite)
 
-            log_dir = config.RUN["log_dir"]
+            log_dir = os.path.expanduser(config.RUN["log_dir"])
             run_id = config.RUN["run_id"]
             filepath = os.path.join(log_dir, f"{case_name}_{run_id}.xml")
 


### PR DESCRIPTION
This is to avoid creating a directory `~` in  the current working directory (instead of considering `~` as user's home directory)

![obrazek](https://github.com/user-attachments/assets/10891786-e008-47b7-9cef-b09f74f8ad8f)
