### PR TITLE
FDF import fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__
 rerun
 ven*
+.venv
 *egg*
 .idea
 *.iml

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -11,8 +11,7 @@ import yaml
 
 from ocs_ci.deployment.helpers.storage_class import get_storageclass
 from ocs_ci.framework import config
-from ocs_ci.ocs import constants, defaults
-from ocs_ci.helpers.helpers import get_worker_nodes
+from ocs_ci.ocs import constants, defaults, node
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
@@ -167,7 +166,7 @@ class FusionDataFoundationDeployment:
 
         logger.info("Creating OdfCluster CR")
         storageclass = get_storageclass()
-        worker_nodes = get_worker_nodes()
+        worker_nodes = node.get_worker_nodes()
         with open(constants.FDF_ODFCLUSTER_CR, "r") as f:
             odfcluster_data = yaml.safe_load(f.read())
 

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -39,8 +39,6 @@ from ocs_ci.ocs.utils import (
     get_nb_db_psql_version_from_image,
     query_nb_db_psql_version,
 )
-
-from ocs_ci.ocs.node import get_worker_nodes, wait_for_nodes_status
 from ocs_ci.ocs import constants, defaults, node, ocp, exceptions
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -4975,11 +4973,10 @@ def configure_node_network_configuration_policy_on_all_worker_nodes():
     Configure NodeNetworkConfigurationPolicy CR on each worker node in cluster
 
     """
-    from ocs_ci.ocs.node import get_worker_nodes
 
     # This function require changes for compact mode
     logger.info("Configure NodeNetworkConfigurationPolicy on all worker nodes")
-    worker_node_names = get_worker_nodes()
+    worker_node_names = node.get_worker_nodes()
     ip_version = "ipv4"
     if (
         config.DEPLOYMENT.get("ipv6")
@@ -5082,7 +5079,7 @@ def restart_node_if_debug_doesnt_work(worker_node_name):
         factory = platform_nodes.PlatformNodesFactory()
         nodes = factory.get_nodes_platform()
         nodes.restart_nodes_by_stop_and_start(node_to_restart)
-        wait_for_nodes_status([worker_node_name], constants.NODE_READY)
+        node.wait_for_nodes_status([worker_node_name], constants.NODE_READY)
         oc_cmd.exec_oc_debug_cmd(node=worker_node_name, cmd_list=[cmd])
 
 
@@ -6112,7 +6109,7 @@ def create_network_fence_class():
         )
 
     logger.info("Verifying CsiAddonsNode object for CSI RBD daemonset")
-    all_nodes = get_worker_nodes()
+    all_nodes = node.get_worker_nodes()
 
     @retry(KeyError, tries=3, delay=5)
     def _verify_csi_addons_objects():


### PR DESCRIPTION
These changes address some circular import issues I hit when trying to use `get_worker_nodes`.  This is also to help backporting the FDF changes to release-4.18.