### PR TITLE
increase-timeout-hypershift-installation

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -188,9 +188,11 @@ class MCEInstaller(object):
             namespace=constants.HYPERSHIFT_NAMESPACE,
         )
 
+        # configMap is created during hypershift installation in around 5 min.
+        # Increasing this timeout to 10 min for safer deployment.
         if not configmaps_obj.check_resource_existence(
             should_exist=True,
-            timeout=300,
+            timeout=600,
             resource_name=constants.SUPPORTED_VERSIONS_CONFIGMAP,
         ):
             raise UnavailableResourceException(


### PR DESCRIPTION
Creation timestamps
2025-06-10T16:10:28Z - ns
2025-06-10T16:10:30Z - subscription 
2025-06-10T16:11:02Z - mce
2025-06-10T16:16:05Z - cm 
--- 
that means configMap was created 3 sec after timeout

FIXES: #12354