### PR TITLE
Add polarion and jira marker in the test case test_subvolume_group_pinning

### DIFF
--- a/tests/functional/storageclass/test_csi_subvolume_group_property.py
+++ b/tests/functional/storageclass/test_csi_subvolume_group_property.py
@@ -2,7 +2,7 @@ import logging
 import yaml
 
 from ocs_ci.framework.testlib import ManageTest, tier3, skipif_external_mode
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id
 from ocs_ci.helpers.performance_lib import run_oc_command
 
 logger = logging.getLogger(__name__)
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @tier3
 class TestCSISubvolumeGroup(ManageTest):
+    @jira("DFBUGS-2759")
+    @polarion_id("OCS-5740")
     def test_subvolume_group_pinning(self):
         """
         Test that verifies that the pinning value of CephFilesystemSubVolumeGroup is 1

--- a/tests/functional/storageclass/test_csi_subvolume_group_property.py
+++ b/tests/functional/storageclass/test_csi_subvolume_group_property.py
@@ -1,7 +1,7 @@
 import logging
 import yaml
 
-from ocs_ci.framework.testlib import ManageTest, tier3, skipif_external_mode
+from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
 from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id
 from ocs_ci.helpers.performance_lib import run_oc_command
 
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 @green_squad
 @skipif_external_mode
-@tier3
+@tier2
 class TestCSISubvolumeGroup(ManageTest):
     @jira("DFBUGS-2759")
     @polarion_id("OCS-5740")


### PR DESCRIPTION
Add `polarion_id` and `jira` marker in the test case tests/functional/storageclass/test_csi_subvolume_group_property.py::TestCSISubvolumeGroup::test_subvolume_group_pinning

Changed from tier3 to tier2 because this is not a negative test case.

Fixes #12358 