### PR TITLE
fix test cases

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2212,6 +2212,7 @@ def wait_for_storage_pods(timeout=200):
         and all(
             label[4:] not in pod.get_labels().values() for label in labels_to_ignore
         )
+        and "storageclient" not in pod.name
     ]
 
     for pod_obj in all_pod_obj:

--- a/tests/cross_functional/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/cross_functional/kcs/test_noobaa_db_backup_and_recovery.py
@@ -43,7 +43,7 @@ class TestNoobaaBackupAndRecovery(E2ETest):
 
     @pytest.mark.polarion_id("OCS-2605")
     @skipif_ocs_version("<4.6")
-    def test_noobaa_db_backup_and_recovery(
+    def deprecated_test_noobaa_db_backup_and_recovery(
         self,
         pvc_factory,
         pod_factory,

--- a/tests/cross_functional/kcs/test_noobaadb_pw_reset.py
+++ b/tests/cross_functional/kcs/test_noobaadb_pw_reset.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.pod import get_noobaa_pods
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import get_primary_nb_db_pod
+from ocs_ci.utility.utils import exec_nb_db_query
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +85,4 @@ def run_db_reset_cmd():
 
     """
     alter_cmd = "ALTER USER noobaa WITH PASSWORD 'myNewPassword';"
-    primary_nb_db_pod = get_primary_nb_db_pod()
-    ocp.OCP().exec_oc_cmd(
-        f"exec -n {config.ENV_DATA['cluster_namespace']} {primary_nb_db_pod.name} "
-        f'-- psql -d nbcore -c "{alter_cmd}"'
-    )
+    exec_nb_db_query(alter_cmd)


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/12379 and https://github.com/red-hat-storage/ocs-ci/issues/12380 
and deprecate test_noobaa_db_backup_and_recovery[According to new changes introduced in 4.19 https://issues.redhat.com/browse/RHSTOR-6436, the existing backup-and-recovery procedure for the noobaa-db(https://access.redhat.com/solutions/6686081) is no more valid]