### PR TITLE
BM OCP deployment via Assisted Installer: handle pending user action

### DIFF
--- a/ocs_ci/deployment/assisted_installer.py
+++ b/ocs_ci/deployment/assisted_installer.py
@@ -392,15 +392,20 @@ class AssistedInstallerCluster(object):
                 # them is used to the name and role mapping
                 pass
 
-    def install_cluster(self):
+    def install_cluster(self, pending_user_action_handler=None):
         """
         Trigger cluster installation
+
+        Args:
+            pending_user_action_handler (function): function handling pending user action for particular host (host
+                details as dict provided as first parameter)
+
         """
         self.api.install_cluster(self.id)
         logger.info("Started cluster installation")
         # wait for cluster installation success
         for sample in TimeoutSampler(
-            timeout=7200, sleep=300, func=self.api.get_cluster, cluster_id=self.id
+            timeout=10800, sleep=300, func=self.api.get_cluster, cluster_id=self.id
         ):
             status_per_hosts = [
                 h.get("progress", {}).get("installation_percentage", 0)
@@ -423,6 +428,19 @@ class AssistedInstallerCluster(object):
                     )
                 except KeyError:
                     pass
+
+            if sample["status"] == "installing-pending-user-action":
+                for host in sample["hosts"]:
+                    try:
+                        if host["status"] == "installing-pending-user-action":
+                            msg = f"{host['requested_hostname']}: {host['status']} ({host['status_info']})"
+                            if pending_user_action_handler:
+                                logger.info(msg)
+                                pending_user_action_handler(host)
+                            else:
+                                logger.error(msg)
+                    except KeyError:
+                        pass
 
             if sample["status"] == "installed":
                 logger.info(

--- a/ocs_ci/deployment/assisted_installer.py
+++ b/ocs_ci/deployment/assisted_installer.py
@@ -174,6 +174,7 @@ class AssistedInstallerCluster(object):
 
         Args:
             original_pull_secret (str or dict): content of pull secret
+
         """
         if isinstance(original_pull_secret, dict):
             # prepare copy of the original pull-secret (to not modify it)
@@ -291,6 +292,7 @@ class AssistedInstallerCluster(object):
 
         Args:
             expected_nodes (int): number of expected nodes
+
         """
 
         # wait for discovered nodes in cluster definition
@@ -324,6 +326,7 @@ class AssistedInstallerCluster(object):
         """
         Return:
             list: list of discovered hosts in the Infrastructure Environment
+
         """
         return self.api.get_infra_env_hosts(infra_env_id=self.infra_id)
 
@@ -331,7 +334,6 @@ class AssistedInstallerCluster(object):
     def verify_validations_info_for_discovered_nodes(self):
         """
         Check and verify validations info for the discovered nodes.
-
         """
         failed_validations = []
         for host in self.api.get_cluster_hosts(self.id):
@@ -357,6 +359,7 @@ class AssistedInstallerCluster(object):
 
         Return:
             list of lists: host id to mac mapping ([[host1_id, mac1], [host1_id, mac2], [host2_id, mac3],...])
+
         """
         hosts = self.api.get_infra_env_hosts(self.infra_id)
         mapping = []
@@ -373,6 +376,7 @@ class AssistedInstallerCluster(object):
         Args:
             mac_name_mapping (dict): host mac address to host name mapping
             mac_role_mapping (dict): host mac address to host role mapping
+
         """
         host_id_mac_mapping = self.get_host_id_mac_mapping()
         for host_id, mac in host_id_mac_mapping:

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -830,6 +830,7 @@ class BAREMETALAI(BAREMETALBASE):
     class OCPDeployment(BMBaseOCPDeployment):
         def __init__(self):
             super(BAREMETALAI.OCPDeployment, self).__init__()
+            self.handled_pending_user_actions = {}
 
         def deploy_prereq(self):
             """
@@ -1096,7 +1097,9 @@ class BAREMETALAI(BAREMETALBASE):
             )
 
             # install the OCP cluster
-            self.ai_cluster.install_cluster()
+            self.ai_cluster.install_cluster(
+                pending_user_action_handler=self.pending_user_action_handler
+            )
 
             # workaround for UEFI boot order issue (make sure that PXE boot is on first place)
             for machine in master_nodes + worker_nodes:
@@ -1108,6 +1111,63 @@ class BAREMETALAI(BAREMETALBASE):
                         ocp_node=machine,
                         ignore_error=True,
                     )
+
+        def pending_user_action_handler(self, host):
+            """
+            Method for handling pending user action during deployment (this usually means that the server didn't boot
+            properly from the disk.)
+
+            Args:
+                host (dict): details about host with pending user action (from Assisted Installer api)
+
+            """
+            machine = host["requested_hostname"]
+            # do not run the handler for particular machine more often than once in 20 minutes
+            # to make sure the server have time to reboot and connect to the cluster
+            if (
+                time.time() - self.handled_pending_user_actions.get(machine, 0)
+                < 20 * 60
+            ):
+                logger.info(
+                    f"Skipping handling pending user action for {machine}. "
+                    "It was already handled less than 20 minutes ago."
+                )
+                return
+
+            if self.srv_details[machine].get("mgmt_provider", "ipmitool") == "ipmitool":
+                secrets = [
+                    self.srv_details[machine]["mgmt_username"],
+                    self.srv_details[machine]["mgmt_password"],
+                ]
+                # reboot machine
+                cmd = (
+                    f"ipmitool -I lanplus -U {self.srv_details[machine]['mgmt_username']} "
+                    f"-P {self.srv_details[machine]['mgmt_password']} "
+                    f"-H {self.srv_details[machine]['mgmt_console']} chassis power cycle || "
+                    f"ipmitool -I lanplus -U {self.srv_details[machine]['mgmt_username']} "
+                    f"-P {self.srv_details[machine]['mgmt_password']} "
+                    f"-H {self.srv_details[machine]['mgmt_console']} chassis power on"
+                )
+                rc, stdout, stderr = self.helper_node_handler.exec_cmd(
+                    cmd=cmd, secrets=secrets
+                )
+                assert (
+                    rc == 0
+                ), f"Command execution failed - rc: {rc}, stdout: '{stdout}', stderr: '{stderr}'"
+
+            elif (
+                self.srv_details[machine].get("mgmt_provider", "ipmitool") == "ibmcloud"
+            ):
+                ibmcloud = ibmcloud_bm.IBMCloudBM()
+                m = ibmcloud.get_machines_by_names([machine])
+                ibmcloud.stop_machines(m)
+                time.sleep(5)
+                ibmcloud.start_machines(m)
+                # run the power-on command second time to make sure the host is powered on
+                time.sleep(5)
+                ibmcloud.start_machines(m)
+
+            self.handled_pending_user_actions[machine] = time.time()
 
         def create_dns_records(self):
             """


### PR DESCRIPTION
Handle pending user action during OCP deployment on baremetal servers via Assisted Installer. This usually means, that the server didn't properly boot from the disk when rebooted during the deployment. It seems to be usually just temporary issue and another reboot fixes the issue.

Fixes: [OCSQE-3815](https://issues.redhat.com//browse/OCSQE-3815)
