### PR TITLE
fix test_pods_csi_log_rotation 4.18,4.19

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -701,8 +701,8 @@ class Pod(OCS):
 
         all_logs = (
             self.exec_cmd_on_pod(
-                command=f"-- ls -l {logs_dir}",
-                container_name="log-collector",
+                command=f"ls -l {logs_dir}",
+                container_name="log-rotator",
                 out_yaml_format=False,
                 shell=True,
             )

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -78,8 +78,8 @@ class TestPodsCsiLogRotation(BaseTest):
 
         # pump current log file size
         pod_obj.exec_cmd_on_pod(
-            command=f"-- truncate -s 560M {logs_dir + log_file_name}",
-            container_name="log-collector",
+            command=f" truncate -s 560M {logs_dir + log_file_name}",
+            container_name="log-rotator",
             out_yaml_format=False,
             shell=True,
         )
@@ -156,7 +156,7 @@ class TestPodsCsiLogRotation(BaseTest):
             additional_log_file_name (str) Additional log file name; empty string if is not relevant
 
         """
-        base_dir = "/var/lib/rook/"
+        base_dir = "/csi-logs/"
         suffix_dir = ""
         if pod_selector == "csi-cephfsplugin":
             suffix_dir = "openshift-storage.cephfs.csi.ceph.com/log/node-plugin/"

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -5,13 +5,14 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import BaseTest
-from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs import constants
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     tier2,
     post_upgrade,
     skipif_ocs_version,
 )
+from ocs_ci.ocs.resources.pod import get_pods_having_label, Pod
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
@@ -115,28 +116,28 @@ class TestPodsCsiLogRotation(BaseTest):
         argvalues=[
             pytest.param(
                 *[
-                    "csi-cephfsplugin",
+                    constants.CSI_CEPHFSPLUGIN_LABEL_419,
                     "csi-cephfsplugin.log",
                     "",
                 ],
             ),
             pytest.param(
                 *[
-                    "csi-rbdplugin",
+                    constants.CSI_RBDPLUGIN_LABEL_419,
                     "csi-rbdplugin.log",
                     "",
                 ],
             ),
             pytest.param(
                 *[
-                    "csi-cephfsplugin-provisioner",
+                    constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL_419,
                     "csi-cephfsplugin.log",
                     "csi-addons.log",
                 ],
             ),
             pytest.param(
                 *[
-                    "csi-rbdplugin-provisioner",
+                    constants.CSI_RBDPLUGIN_PROVISIONER_LABEL_419,
                     "csi-rbdplugin.log",
                     "csi-addons.log",
                 ],
@@ -151,7 +152,6 @@ class TestPodsCsiLogRotation(BaseTest):
 
         Args:
             pod_selector (str): Pod selector according to the interface
-            logs_dir (str): Logs directory on this pod
             log_file_name (str) Current log file name
             additional_log_file_name (str) Additional log file name; empty string if is not relevant
 
@@ -169,9 +169,11 @@ class TestPodsCsiLogRotation(BaseTest):
 
         logs_dir = os.path.join(base_dir, suffix_dir)
         log.debug(f"logs dir: {logs_dir}")
-        csi_interface_plugin_pod_objs = pod.get_all_pods(
-            namespace=config.ENV_DATA["cluster_namespace"], selector=[pod_selector]
+
+        pod_list = get_pods_having_label(
+            namespace=config.ENV_DATA["cluster_namespace"], label=pod_selector
         )
+        csi_interface_plugin_pod_objs = [Pod(**pod) for pod in pod_list]
 
         # check on the first pod
         pod_obj = csi_interface_plugin_pod_objs[0]


### PR DESCRIPTION
this PR is fixing issue with indexError and incorrect plugin labels