### PR TITLE
odf-cli: from 4.20 use odf-cli for noobaa commands

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4681,10 +4681,13 @@ def retrieve_cli_binary(cli_type="mcg"):
 
     remote_path = get_architecture_path(cli_type)
     remote_cli_basename = os.path.basename(remote_path)
-    if cli_type == "mcg":
+    if cli_type == "mcg" and semantic_version < version.VERSION_4_20:
         local_cli_path = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
     elif cli_type == "odf":
         local_cli_path = os.path.join(config.RUN["bin_dir"], "odf-cli")
+    elif cli_type == "mcg" and semantic_version >= version.VERSION_4_20:
+        local_cli_path = os.path.join(config.RUN["bin_dir"], "odf-cli noobaa")
+
     local_cli_dir = os.path.dirname(local_cli_path)
     live_deployment = config.DEPLOYMENT["live_deployment"]
     if live_deployment and semantic_version >= version.VERSION_4_13:

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -959,20 +959,24 @@ class MCG:
 
         namespace = f"-n {namespace}" if namespace else f"-n {self.namespace}"
 
+        local_cli_path = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
+        if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_20:
+            local_cli_path = os.path.join(config.RUN["bin_dir"], "odf-cli noobaa")
+
         # Mask sensitive data
         if self.data_to_mask:
             kwargs.setdefault("secrets", []).extend(self.data_to_mask)
 
         if use_yes:
             result = exec_cmd(
-                [f"yes | {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH} {cmd} {namespace}"],
+                [f"yes | {local_cli_path} {cmd} {namespace}"],
                 ignore_error=ignore_error,
                 shell=True,
                 **kwargs,
             )
         else:
             result = exec_cmd(
-                f"{constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH} {cmd} {namespace}",
+                f"{local_cli_path} {cmd} {namespace}",
                 ignore_error=ignore_error,
                 **kwargs,
             )

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -68,6 +68,7 @@ VERSION_4_16 = get_semantic_version("4.16", True)
 VERSION_4_17 = get_semantic_version("4.17", True)
 VERSION_4_18 = get_semantic_version("4.18", True)
 VERSION_4_19 = get_semantic_version("4.19", True)
+VERSION_4_20 = get_semantic_version("4.20", True)
 
 
 def get_semantic_ocs_version_from_config(cluster_config=None):


### PR DESCRIPTION
this commits replace noobaa root command as odf-cli noobaa as a root command from odf 4.20. The noobaa cli will embedded with odf-cli.