### PR TITLE
create metallb instance doubled retries

### DIFF
--- a/ocs_ci/deployment/metallb.py
+++ b/ocs_ci/deployment/metallb.py
@@ -323,7 +323,7 @@ class MetalLBInstaller:
         )
         templating.dump_data_to_temp_yaml(metallb_inst_data, metallb_inst_file.name)
 
-        retry(CommandFailed, tries=3, delay=15)(exec_cmd)(
+        retry(CommandFailed, tries=6, delay=30)(exec_cmd)(
             f"oc apply -f {metallb_inst_file.name}", timeout=240
         )
 


### PR DESCRIPTION
prevent failure on MetalLb instance installation 
```
2025-06-17 16:21:50  09:21:47 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (InternalError): error when creating "/tmp/metallb_instance_do35b1_m": Internal error occurred: failed calling webhook "metallbvalidationwebhook.metallb.io": failed to call webhook: Post "[https://metallb-operator-controller-manager-service.metallb-system.svc:443/validate-metallb-io-v1beta1-metallb?timeout=10s](https://metallb-operator-controller-manager-service.metallb-system.svc/validate-metallb-io-v1beta1-metallb?timeout=10s)": no endpoints available for service "metallb-operator-controller-manager-service"
```
console log ---> https://url.corp.redhat.com/c1e103a
