### PR TITLE
test_ceph_metrics_presence_when_osd_down replace deprecated metric

### DIFF
--- a/ocs_ci/ocs/metrics.py
+++ b/ocs_ci/ocs/metrics.py
@@ -153,7 +153,12 @@ ceph_metrics_healthy = (
     "ceph_bluefs_slow_used_bytes",
     "ceph_osd_op_r_latency_sum",
     "ceph_bluestore_kv_flush_lat_count",
-    "ceph_rocksdb_compact_range",
+    # "ceph_rocksdb_compact_range" replaced with compact_running, compact_lasted, compact_completed
+    # more info in https://issues.redhat.com/browse/DFBUGS-2760,
+    # https://tracker.ceph.com/issues/67040 and https://github.com/ceph/ceph/pull/57107
+    "compact_running",
+    "compact_lasted",
+    "compact_completed",
     "ceph_osd_op_latency_sum",
     "ceph_mon_session_add",
     "ceph_paxos_share_state_keys_count",


### PR DESCRIPTION
"ceph_rocksdb_compact_range" replaced with compact_running, compact_lasted, compact_completed
more info in https://issues.redhat.com/browse/DFBUGS-2760,
https://tracker.ceph.com/issues/67040 and https://github.com/ceph/ceph/pull/57107 