### PR TITLE
get_onboarding_ticket_secret add retry

### DIFF
--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.version import if_version
 from ocs_ci.utility import templating
+from ocs_ci.utility.retry import retry
 from ocs_ci.utility.templating import dump_data_to_temp_yaml
 from ocs_ci.utility.utils import exec_cmd
 
@@ -341,6 +342,7 @@ class StorageConsumer:
                 self.ocp.patch(resource_name=self.name, params=patch_param)
 
     @if_version(">4.18")
+    @retry((AttributeError, KeyError), tries=10, delay=5)
     def get_onboarding_ticket_secret(self):
         """
         Get OnboardingTicketSecret from storageconsumer resource status. Optional field.


### PR DESCRIPTION
avoid failure seen in this run: https://url.corp.redhat.com/086b8af 
```
    @if_version(">4.18")
    def get_onboarding_ticket_secret(self):
        """
        Get OnboardingTicketSecret from storageconsumer resource status. Optional field.
        Reference to name of an onboarding secret cr.
    
        Returns:
            string: OnboardingTicketSecret
    
        """
        with config.RunWithConfigContext(self.consumer_context):
            return (
>               self.ocp.get(resource_name=self.name)
                .get("status")
                .get("onboardingTicketSecret")
                .get("name")
            )
E           AttributeError: 'NoneType' object has no attribute 'get'
```