### PR TITLE
add more time for wait node: multi-client upgrade

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5666,7 +5666,7 @@ def wait_custom_resource_defenition_available(crd_name, timeout=600):
     )
 
 
-def clean_up_pods_for_provider(node_type, max_retries=30, retry_delay_seconds=30):
+def clean_up_pods_for_provider(node_type, max_retries=45, retry_delay_seconds=30):
     """
     Manually clean up pods if nodes get stuck in Ready,SchedulingDisabled during OCP upgrade.
     Checks machine-config-controller logs for eviction errors or completion messages.


### PR DESCRIPTION
Resolve timing issue:

```
ests/functional/upgrade/test_upgrade_ocp.py::TestUpgradeOCP::test_upgrade_ocp immediately after test execution: 6602.12
2025-06-21 18:47:02  FAILED
2025-06-21 18:47:02  _______________________ TestUpgradeOCP.test_upgrade_ocp ________________________
2025-06-21 18:47:02  
2025-06-21 18:47:02  node_names = ['baremetal1-04'], status = 'Ready', timeout = 360, sleep = 30
2025-06-21 18:47:02  
2025-06-21 18:47:02      def wait_for_nodes_status(
2025-06-21 18:47:02          node_names=None, status=constants.NODE_READY, timeout=180, sleep=3
2025-06-21 18:47:02      ):
2025-06-21 18:47:02          """
2025-06-21 18:47:02          Wait until all nodes are in the given status
2025-06-21 18:47:02      
2025-06-21 18:47:02          Args:
2025-06-21 18:47:02              node_names (list): The node names to wait for to reached the desired state
2025-06-21 18:47:02                  If None, will wait for all cluster nodes
2025-06-21 18:47:02              status (str): The node status to wait for
2025-06-21 18:47:02                  (e.g. 'Ready', 'NotReady', 'SchedulingDisabled')
2025-06-21 18:47:02              timeout (int): The number in seconds to wait for the nodes to reach
2025-06-21 18:47:02                  the status
2025-06-21 18:47:02              sleep (int): Time in seconds to sleep between attempts
2025-06-21 18:47:02      
2025-06-21 18:47:02          Raises:
2025-06-21 18:47:02              ResourceWrongStatusException: In case one or more nodes haven't
2025-06-21 18:47:02                  reached the desired state
2025-06-21 18:47:02      
2025-06-21 18:47:02          """
2025-06-21 18:47:02          try:
2025-06-21 18:47:02              if not node_names:
2025-06-21 18:47:02                  for sample in TimeoutSampler(60, 3, get_node_objs):
2025-06-21 18:47:02                      if sample:
2025-06-21 18:47:02                          node_names = [node.name for node in sample]
2025-06-21 18:47:02                          break
2025-06-21 18:47:02              nodes_not_in_state = copy.deepcopy(node_names)
2025-06-21 18:47:02              log.info(f"Waiting for nodes {node_names} to reach status {status}")
2025-06-21 18:47:02  >           for sample in TimeoutSampler(timeout, sleep, get_node_objs, nodes_not_in_state):
2025-06-21 18:47:02  
2025-06-21 18:47:02  ocs_ci/ocs/node.py:186: 
2025-06-21 18:47:02  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-06-21 18:47:02  
2025-06-21 18:47:02  self = <ocs_ci.utility.utils.TimeoutSampler object at 0x7f0fd3d8d610>
2025-06-21 18:47:02  
2025-06-21 18:47:02      def __iter__(self):
2025-06-21 18:47:02          if self.start_time is None:
2025-06-21 18:47:02              self.start_time = time.time()
2025-06-21 18:47:02          while True:
2025-06-21 18:47:02              self.last_sample_time = time.time()
2025-06-21 18:47:02              if self.timeout <= (self.last_sample_time - self.start_time):
2025-06-21 18:47:02  >               raise self.timeout_exc_cls(*self.timeout_exc_args)
2025-06-21 18:47:02  E               ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed out after 360s running get_node_objs(['baremetal1-04'])
2025-06-21 18:47:02  
2025-06-21 18:47:02  ocs_ci/utility/utils.py:1515: TimeoutExpiredError
2025-06-21 18:47:02  
2025-06-21 18:47:02  During handling of the above exception, another exception occurred:
2025-06-21 18:47:02  
2025-06-21 18:47:02  self = <tests.functional.upgrade.test_upgrade_ocp.TestUpgradeOCP object at 0x7f0fdcf455e0>
2025-06-21 18:47:02  zone_rank = None, role_rank = None, config_index = None
2025-06-21 18:47:02  reduce_and_resume_cluster_load = None
2025-06-21 18:47:02  
2025-06-21 18:47:02      def test_upgrade_ocp(
2025-06-21 18:47:02          self, zone_rank, role_rank, config_index, reduce_and_resume_cluster_load
2025-06-21 18:47:02      ):
2025-06-21 18:47:02          """
2025-06-21 18:47:02          Tests OCS stability when upgrading OCP
2025-06-21 18:47:02      
2025-06-21 18:47:02          """
2025-06-21 18:47:02      
2025-06-21 18:47:02          cluster_ver = ocp.run_cmd("oc get clusterversions/version -o yaml")
2025-06-21 18:47:02          logger.debug(f"Cluster versions before upgrade:\n{cluster_ver}")
2025-06-21 18:47:02          if (
2025-06-21 18:47:02              config.multicluster
2025-06-21 18:47:02              and config.MULTICLUSTER["multicluster_mode"] == "metro-dr"
2025-06-21 18:47:02              and is_acm_cluster(config)
2025-06-21 18:47:02          ):
2025-06-21 18:47:02              # Find the ODF cluster in current zone
2025-06-21 18:47:02              mdr_upgrade = MDRClusterUpgradeParametrize()
2025-06-21 18:47:02              mdr_upgrade.config_init()
2025-06-21 18:47:02              local_zone_odf = None
2025-06-21 18:47:02              for cluster in get_non_acm_cluster_config():
2025-06-21 18:47:02                  if config.ENV_DATA["zone"] == cluster.ENV_DATA["zone"]:
2025-06-21 18:47:02                      local_zone_odf = cluster
2025-06-21 18:47:02              ceph_cluster = CephClusterMultiCluster(local_zone_odf)
2025-06-21 18:47:02              health_monitor = MulticlusterCephHealthMonitor
2025-06-21 18:47:02          else:
2025-06-21 18:47:02              ceph_cluster = CephCluster()
2025-06-21 18:47:02              health_monitor = CephHealthMonitor
2025-06-21 18:47:02      
2025-06-21 18:47:02          with health_monitor(ceph_cluster):
2025-06-21 18:47:02              ocp_channel = config.UPGRADE.get(
2025-06-21 18:47:02                  "ocp_channel", ocp.get_ocp_upgrade_channel()
2025-06-21 18:47:02              )
2025-06-21 18:47:02              logger.info(f"OCP Channel: {ocp_channel}")
2025-06-21 18:47:02      
2025-06-21 18:47:02              ocp_upgrade_version = config.UPGRADE.get("ocp_upgrade_version")
2025-06-21 18:47:02              logger.info(f"OCP upgrade version: {ocp_upgrade_version}")
2025-06-21 18:47:02      
2025-06-21 18:47:02              provider_cluster = (
2025-06-21 18:47:02                  config.ENV_DATA.get("cluster_type").lower() == constants.HCI_PROVIDER
2025-06-21 18:47:02              )
2025-06-21 18:47:02      
2025-06-21 18:47:02              rosa_platform = (
2025-06-21 18:47:02                  config.ENV_DATA["platform"].lower() in constants.ROSA_PLATFORMS
2025-06-21 18:47:02              )
2025-06-21 18:47:02      
2025-06-21 18:47:02              if rosa_platform:
2025-06-21 18:47:02                  # Handle ROSA-specific upgrade logic
2025-06-21 18:47:02                  # On ROSA environment, Nightly builds are not supported.
2025-06-21 18:47:02                  # rosa cli uses only "X.Y.Z" format for the version (builds and images are not supported)
2025-06-21 18:47:02                  # If not provided ocp_upgrade_version - get the latest released version of the channel.
2025-06-21 18:47:02                  # If provided - check availability and use the provided version in format "X.Y.Z"
2025-06-21 18:47:02                  if ocp_upgrade_version and ocp_version_available_on_rosa(
2025-06-21 18:47:02                      ocp_upgrade_version
2025-06-21 18:47:02                  ):
2025-06-21 18:47:02                      target_image = ocp_upgrade_version
2025-06-21 18:47:02                  else:
2025-06-21 18:47:02                      latest_ocp_ver = get_latest_ocp_version(channel=ocp_channel)
2025-06-21 18:47:02                      # check, if ver is not available on rosa then get the latest version available on ROSA
2025-06-21 18:47:02                      if not ocp_version_available_on_rosa(latest_ocp_ver):
2025-06-21 18:47:02                          version_major_minor = drop_z_version(latest_ocp_ver)
2025-06-21 18:47:02                          latest_ocp_ver = get_latest_rosa_ocp_version(
2025-06-21 18:47:02                              version_major_minor
2025-06-21 18:47:02                          )
2025-06-21 18:47:02                      target_image = latest_ocp_ver
2025-06-21 18:47:02              else:
2025-06-21 18:47:02                  # Handle non-ROSA upgrade logic
2025-06-21 18:47:02                  if ocp_upgrade_version:
2025-06-21 18:47:02                      target_image = (
2025-06-21 18:47:02                          expose_ocp_version(ocp_upgrade_version)
2025-06-21 18:47:02                          if ocp_upgrade_version.endswith(".nightly")
2025-06-21 18:47:02                          else ocp_upgrade_version
2025-06-21 18:47:02                      )
2025-06-21 18:47:02                  else:
2025-06-21 18:47:02                      ocp_upgrade_version = get_latest_ocp_version(channel=ocp_channel)
2025-06-21 18:47:02                      ocp_arch = config.UPGRADE["ocp_arch"]
2025-06-21 18:47:02                      target_image = f"{ocp_upgrade_version}-{ocp_arch}"
2025-06-21 18:47:02              logger.info(f"Target image: {target_image}")
2025-06-21 18:47:02      
2025-06-21 18:47:02              image_path = config.UPGRADE["ocp_upgrade_path"]
2025-06-21 18:47:02              cluster_operators = ocp.get_all_cluster_operators()
2025-06-21 18:47:02              logger.info(f" oc version: {ocp.get_current_oc_version()}")
2025-06-21 18:47:02              # disconnected environment prerequisites
2025-06-21 18:47:02              if config.DEPLOYMENT.get("disconnected"):
2025-06-21 18:47:02                  # mirror OCP release images to mirror registry
2025-06-21 18:47:02                  image_path, target_image, _, _ = mirror_ocp_release_images(
2025-06-21 18:47:02                      image_path, target_image
2025-06-21 18:47:02                  )
2025-06-21 18:47:02      
2025-06-21 18:47:02              # Verify Upgrade subscription channel:
2025-06-21 18:47:02              if not rosa_platform:
2025-06-21 18:47:02                  ocp.patch_ocp_upgrade_channel(ocp_channel)
2025-06-21 18:47:02                  for sampler in TimeoutSampler(
2025-06-21 18:47:02                      timeout=250,
2025-06-21 18:47:02                      sleep=15,
2025-06-21 18:47:02                      func=ocp.verify_ocp_upgrade_channel,
2025-06-21 18:47:02                      channel_variable=ocp_channel,
2025-06-21 18:47:02                  ):
2025-06-21 18:47:02                      if sampler:
2025-06-21 18:47:02                          logger.info(f"OCP Channel:{ocp_channel}")
2025-06-21 18:47:02                          break
2025-06-21 18:47:02      
2025-06-21 18:47:02                  # pause a MachineHealthCheck resource
2025-06-21 18:47:02                  # no machinehealthcheck on ROSA
2025-06-21 18:47:02                  if get_semantic_ocp_running_version() > VERSION_4_8:
2025-06-21 18:47:02                      pause_machinehealthcheck()
2025-06-21 18:47:02      
2025-06-21 18:47:02                  logger.info(f"full upgrade path: {image_path}:{target_image}")
2025-06-21 18:47:02                  ocp.upgrade_ocp(image=target_image, image_path=image_path)
2025-06-21 18:47:02              else:
2025-06-21 18:47:02                  logger.info(f"upgrade rosa cluster to target version: '{target_image}'")
2025-06-21 18:47:02                  upgrade_rosa_cluster(config.ENV_DATA["cluster_name"], target_image)
2025-06-21 18:47:02      
2025-06-21 18:47:02              # Wait for upgrade
2025-06-21 18:47:02              # ROSA Upgrades Are Controlled by the Hive Operator
2025-06-21 18:47:02              # HCP Clusters use a Control Plane Queue to manage the upgrade process
2025-06-21 18:47:02              # upgrades on ROSA clusters does not start immediately after the upgrade command but scheduled
2025-06-21 18:47:02              num_nodes = (
2025-06-21 18:47:02                  config.ENV_DATA["worker_replicas"]
2025-06-21 18:47:02                  + config.ENV_DATA["master_replicas"]
2025-06-21 18:47:02                  + config.ENV_DATA.get("infra_replicas", 0)
2025-06-21 18:47:02              )
2025-06-21 18:47:02              operator_upgrade_timeout = 4000
2025-06-21 18:47:02              if rosa_platform or num_nodes >= 6:
2025-06-21 18:47:02                  operator_upgrade_timeout = 8000
2025-06-21 18:47:02              for ocp_operator in cluster_operators:
2025-06-21 18:47:02                  logger.info(f"Checking upgrade status of {ocp_operator}:")
2025-06-21 18:47:02                  # ############ Workaround for issue 2624 #######
2025-06-21 18:47:02                  name_changed_between_versions = (
2025-06-21 18:47:02                      "service-catalog-apiserver",
2025-06-21 18:47:02                      "service-catalog-controller-manager",
2025-06-21 18:47:02                  )
2025-06-21 18:47:02                  if ocp_operator in name_changed_between_versions:
2025-06-21 18:47:02                      logger.info(f"{ocp_operator} upgrade will not be verified")
2025-06-21 18:47:02                      continue
2025-06-21 18:47:02                  # ############ End of Workaround ###############
2025-06-21 18:47:02                  if ocp_operator == "aro":
2025-06-21 18:47:02                      logger.debug(
2025-06-21 18:47:02                          f"{ocp_operator} do not match with OCP upgrade, check will be ignored!"
2025-06-21 18:47:02                      )
2025-06-21 18:47:02                      continue
2025-06-21 18:47:02                  ver = ocp.get_cluster_operator_version(ocp_operator)
2025-06-21 18:47:02                  logger.info(f"current {ocp_operator} version: {ver}")
2025-06-21 18:47:02                  check_cluster_operator_versions(target_image, operator_upgrade_timeout)
2025-06-21 18:47:02      
2025-06-21 18:47:02              # resume a MachineHealthCheck resource
2025-06-21 18:47:02              if get_semantic_ocp_running_version() > VERSION_4_8 and not rosa_platform:
2025-06-21 18:47:02                  if provider_cluster:
2025-06-21 18:47:02                      resume_machinehealthcheck(
2025-06-21 18:47:02                          wait_for_mcp_complete=True, force_delete_pods=True
2025-06-21 18:47:02                      )
2025-06-21 18:47:02                  else:
2025-06-21 18:47:02                      resume_machinehealthcheck()
2025-06-21 18:47:02      
2025-06-21 18:47:02              # post upgrade validation: check cluster operator status
2025-06-21 18:47:02              operator_ready_timeout = 2700 if not rosa_platform else 5400
2025-06-21 18:47:02              cluster_operators = ocp.get_all_cluster_operators()
2025-06-21 18:47:02              for ocp_operator in cluster_operators:
2025-06-21 18:47:02                  logger.info(f"Checking cluster status of {ocp_operator}")
2025-06-21 18:47:02                  for sampler in TimeoutSampler(
2025-06-21 18:47:02                      timeout=operator_ready_timeout,
2025-06-21 18:47:02                      sleep=60,
2025-06-21 18:47:02                      func=ocp.verify_cluster_operator_status,
2025-06-21 18:47:02                      cluster_operator=ocp_operator,
2025-06-21 18:47:02                  ):
2025-06-21 18:47:02                      if sampler:
2025-06-21 18:47:02                          break
2025-06-21 18:47:02                      else:
2025-06-21 18:47:02                          logger.info(f"{ocp_operator} status is not valid")
2025-06-21 18:47:02              # Post upgrade validation: check cluster version status
2025-06-21 18:47:02              logger.info("Checking clusterversion status")
2025-06-21 18:47:02              cluster_version_timeout = 900 if not rosa_platform else 1800
2025-06-21 18:47:02              for sampler in TimeoutSampler(
2025-06-21 18:47:02                  timeout=cluster_version_timeout,
2025-06-21 18:47:02                  sleep=15,
2025-06-21 18:47:02                  func=ocp.validate_cluster_version_status,
2025-06-21 18:47:02              ):
2025-06-21 18:47:02                  if sampler:
2025-06-21 18:47:02                      logger.info("Upgrade Completed Successfully!")
2025-06-21 18:47:02  >                   break
2025-06-21 18:47:02  
2025-06-21 18:47:02  tests/functional/upgrade/test_upgrade_ocp.py:280: 
2025-06-21 18:47:02  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-06-21 18:47:02  ocs_ci/ocs/cluster.py:1128: in __exit__
2025-06-21 18:47:02      raise exception_type.with_traceback(value, traceback)
2025-06-21 18:47:02  tests/functional/upgrade/test_upgrade_ocp.py:249: in test_upgrade_ocp
2025-06-21 18:47:02      resume_machinehealthcheck(
2025-06-21 18:47:02  ocs_ci/utility/ocp_upgrade.py:42: in resume_machinehealthcheck
2025-06-21 18:47:02      wait_for_machineconfigpool_status(node_type="all", force_delete_pods=True)
2025-06-21 18:47:02  ocs_ci/utility/utils.py:4392: in wait_for_machineconfigpool_status
2025-06-21 18:47:02      clean_up_pods_for_provider(node_type=role)
2025-06-21 18:47:02  ocs_ci/utility/utils.py:5765: in clean_up_pods_for_provider
2025-06-21 18:47:02      wait_for_nodes_status(
2025-06-21 18:47:02  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-06-21 18:47:02  
2025-06-21 18:47:02  node_names = ['baremetal1-04'], status = 'Ready', timeout = 360, sleep = 30
2025-06-21 18:47:02  
2025-06-21 18:47:02      def wait_for_nodes_status(
2025-06-21 18:47:02          node_names=None, status=constants.NODE_READY, timeout=180, sleep=3
2025-06-21 18:47:02      ):
2025-06-21 18:47:02          """
2025-06-21 18:47:02          Wait until all nodes are in the given status
2025-06-21 18:47:02      
2025-06-21 18:47:02          Args:
2025-06-21 18:47:02              node_names (list): The node names to wait for to reached the desired state
2025-06-21 18:47:02                  If None, will wait for all cluster nodes
2025-06-21 18:47:02              status (str): The node status to wait for
2025-06-21 18:47:02                  (e.g. 'Ready', 'NotReady', 'SchedulingDisabled')
2025-06-21 18:47:02              timeout (int): The number in seconds to wait for the nodes to reach
2025-06-21 18:47:02                  the status
2025-06-21 18:47:02              sleep (int): Time in seconds to sleep between attempts
2025-06-21 18:47:02      
2025-06-21 18:47:02          Raises:
2025-06-21 18:47:02              ResourceWrongStatusException: In case one or more nodes haven't
2025-06-21 18:47:02                  reached the desired state
2025-06-21 18:47:02      
2025-06-21 18:47:02          """
2025-06-21 18:47:02          try:
2025-06-21 18:47:02              if not node_names:
2025-06-21 18:47:02                  for sample in TimeoutSampler(60, 3, get_node_objs):
2025-06-21 18:47:02                      if sample:
2025-06-21 18:47:02                          node_names = [node.name for node in sample]
2025-06-21 18:47:02                          break
2025-06-21 18:47:02              nodes_not_in_state = copy.deepcopy(node_names)
2025-06-21 18:47:02              log.info(f"Waiting for nodes {node_names} to reach status {status}")
2025-06-21 18:47:02              for sample in TimeoutSampler(timeout, sleep, get_node_objs, nodes_not_in_state):
2025-06-21 18:47:02                  for node in sample:
2025-06-21 18:47:02                      try:
2025-06-21 18:47:02                          if node.ocp.get_resource_status(node.name) == status:
2025-06-21 18:47:02                              log.info(f"Node {node.name} reached status {status}")
2025-06-21 18:47:02                              nodes_not_in_state.remove(node.name)
2025-06-21 18:47:02                      except CommandFailed as ex:
2025-06-21 18:47:02                          log.info(f"failed to get the node status by error {ex}")
2025-06-21 18:47:02                          continue
2025-06-21 18:47:02                  if not nodes_not_in_state:
2025-06-21 18:47:02                      break
2025-06-21 18:47:02              log.info(f"The following nodes reached status {status}: {node_names}")
2025-06-21 18:47:02          except TimeoutExpiredError:
2025-06-21 18:47:02              log.error(
2025-06-21 18:47:02                  f"The following nodes haven't reached status {status}: "
2025-06-21 18:47:02                  f"{nodes_not_in_state}"
2025-06-21 18:47:02              )
2025-06-21 18:47:02              error_message = (
2025-06-21 18:47:02                  f"{node_names}, {[n.describe() for n in get_node_objs(node_names)]}"
2025-06-21 18:47:02              )
2025-06-21 18:47:02  >           raise exceptions.ResourceWrongStatusException(error_message)
2025-06-21 18:47:03  E           ocs_ci.ocs.exceptions.ResourceWrongStatusException: Resource ['baremetal1-04'], ['Name:               baremetal1-04\nRoles:              worker\nLabels:             beta.kubernetes.io/arch=amd64\n                    beta.kubernetes.io/os=linux\n                    cluster.ocs.openshift.io/openshift-storage=\n  
```