### PR TITLE
add retry on backingstore readiness

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1106,6 +1106,7 @@ def check_pv_backingstore_status(
     return True if res in desired_status else False
 
 
+@retry((AssertionError), tries=10, delay=10)
 def check_pv_backingstore_type(
     backingstore_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
     namespace=config.ENV_DATA["cluster_namespace"],
@@ -2696,7 +2697,7 @@ def wait_for_bucket_count_stability(
         current_count = len(cli_buckets)
 
         logger.info(
-            f"Bucket count from CLI (attempt {attempt+1}/{max_retries}): {current_count}"
+            f"Bucket count from CLI (attempt {attempt + 1}/{max_retries}): {current_count}"
         )
 
         previous_counts.append(current_count)


### PR DESCRIPTION
Fix issue seen here: https://url.corp.redhat.com/d5642c9

```
tests/functional/deployment/test_deployment.py::test_deployment immediately after test execution: 17.05
2025-06-24 15:35:42  FAILED
2025-06-24 15:35:42  _______________________________ test_deployment ________________________________
2025-06-24 15:35:42  
2025-06-24 15:35:42  pvc_factory = <function pvc_factory_fixture.<locals>.factory at 0x7f72da0def70>
2025-06-24 15:35:42  pod_factory = <function pod_factory_fixture.<locals>.factory at 0x7f72da0de8b0>
2025-06-24 15:35:42  
2025-06-24 15:35:42      @purple_squad
2025-06-24 15:35:42      @deployment
2025-06-24 15:35:42      @polarion_id(get_polarion_id())
2025-06-24 15:35:42      def test_deployment(pvc_factory, pod_factory):
2025-06-24 15:35:42          deploy = config.RUN["cli_params"].get("deploy")
2025-06-24 15:35:42          teardown = config.RUN["cli_params"].get("teardown")
2025-06-24 15:35:42          if not teardown or deploy:
2025-06-24 15:35:42              log.info("Verifying OCP cluster is running")
2025-06-24 15:35:42              assert is_cluster_running(config.ENV_DATA["cluster_path"])
2025-06-24 15:35:42              if not config.ENV_DATA["skip_ocs_deployment"]:
2025-06-24 15:35:42                  if config.multicluster:
2025-06-24 15:35:42                      restore_ctx_index = config.cur_index
2025-06-24 15:35:42                      for cluster in get_non_acm_cluster_config():
2025-06-24 15:35:42                          config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
2025-06-24 15:35:42                          log.info(
2025-06-24 15:35:42                              f"Sanity check for cluster: {cluster.ENV_DATA['cluster_name']}"
2025-06-24 15:35:42                          )
2025-06-24 15:35:42                          if config.DEPLOYMENT.get("external_mode") and (
2025-06-24 15:35:42                              config.MULTICLUSTER["multicluster_mode"] == "metro-dr"
2025-06-24 15:35:42                          ):
2025-06-24 15:35:42                              log.info("Sanity check for external mode")
2025-06-24 15:35:42                              sanity_helpers = SanityExternalCluster()
2025-06-24 15:35:42                          else:
2025-06-24 15:35:42                              sanity_helpers = Sanity()
2025-06-24 15:35:42                          sanity_helpers.health_check()
2025-06-24 15:35:42                          sanity_helpers.delete_resources()
2025-06-24 15:35:42                      config.switch_ctx(restore_ctx_index)
2025-06-24 15:35:42                      if (
2025-06-24 15:35:42                          config.ENV_DATA["platform"].lower()
2025-06-24 15:35:42                          in constants.HCI_PC_OR_MS_PLATFORM
2025-06-24 15:35:42                      ):
2025-06-24 15:35:42                          post_onboarding_verification()
2025-06-24 15:35:42                  else:
2025-06-24 15:35:42                      ocs_registry_image = config.DEPLOYMENT.get("ocs_registry_image")
2025-06-24 15:35:42                      if config.ENV_DATA["mcg_only_deployment"]:
2025-06-24 15:35:42                          mcg_only_install_verification(ocs_registry_image=ocs_registry_image)
2025-06-24 15:35:42                          return
2025-06-24 15:35:42                      elif config.ENV_DATA.get("odf_provider_mode_deployment", False):
2025-06-24 15:35:42                          storage_client_deployment_obj = (
2025-06-24 15:35:42                              ODFAndNativeStorageClientDeploymentOnProvider()
2025-06-24 15:35:42                          )
2025-06-24 15:35:42  >                       storage_client_deployment_obj.verify_provider_mode_deployment()
2025-06-24 15:35:42  
2025-06-24 15:35:42  tests/functional/deployment/test_deployment.py:66: 
2025-06-24 15:35:42  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-06-24 15:35:42  ocs_ci/deployment/provider_client/storage_client_deployment.py:373: in verify_provider_mode_deployment
2025-06-24 15:35:42      backingstore_type = check_pv_backingstore_type()
2025-06-24 15:35:42  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-06-24 15:35:42  
2025-06-24 15:35:42  backingstore_name = 'noobaa-default-backing-store'
2025-06-24 15:35:42  namespace = 'openshift-storage'
2025-06-24 15:35:42  
2025-06-24 15:35:42      def check_pv_backingstore_type(
2025-06-24 15:35:42          backingstore_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
2025-06-24 15:35:42          namespace=config.ENV_DATA["cluster_namespace"],
2025-06-24 15:35:42      ):
2025-06-24 15:35:42          """
2025-06-24 15:35:42          check if existing pv backing store is in READY state
2025-06-24 15:35:42      
2025-06-24 15:35:42          Args:
2025-06-24 15:35:42              backingstore_name (str): backingstore name
2025-06-24 15:35:42              namespace (str): backing store's namespace
2025-06-24 15:35:42      
2025-06-24 15:35:42          Returns:
2025-06-24 15:35:42              backingstore_type: type of the backing store
2025-06-24 15:35:42      
2025-06-24 15:35:42          """
2025-06-24 15:35:42          kubeconfig = config.RUN.get("kubeconfig")
2025-06-24 15:35:42          kubeconfig = f"--kubeconfig {kubeconfig}" if kubeconfig else ""
2025-06-24 15:35:42          namespace = namespace or config.ENV_DATA["cluster_namespace"]
2025-06-24 15:35:42      
2025-06-24 15:35:42          cmd = (
2025-06-24 15:35:42              f"oc get backingstore -n {namespace} {kubeconfig} {backingstore_name} "
2025-06-24 15:35:42              "-o=jsonpath='{.status.phase}'"
2025-06-24 15:35:42          )
2025-06-24 15:35:42          res = exec_cmd(cmd=cmd, use_shell=True)
2025-06-24 15:35:42          if res.returncode != 0:
2025-06-24 15:35:42              logger.error(f"Failed to fetch backingstore details\n{res.stderr}")
2025-06-24 15:35:42      
2025-06-24 15:35:42  >       assert (
2025-06-24 15:35:42              res.stdout.decode() == constants.STATUS_READY
2025-06-24 15:35:42          ), f"output is {res.stdout.decode()}, it is not as expected"
2025-06-24 15:35:42  E       AssertionError: output is Creating, it is not as expected
2025-06-24 15:35:42  
2025-06-24 15:35:42  ocs_ci/ocs/bucket_utils.py:1136: AssertionError
```