### PR TITLE
[release-4.18] Changes in tier1 tests to align with its purpose

### DIFF
--- a/tests/cross_functional/system_test/multicluster/test_post_installation_state.py
+++ b/tests/cross_functional/system_test/multicluster/test_post_installation_state.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     pc_or_ms_provider_required,
     tier1,
+    tier2,
     runs_on_provider,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -78,7 +79,7 @@ class TestPostInstallationState(ManageTest):
             )
 
     @provider_mode
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-3917")
     @runs_on_provider
     def test_provider_server_logs(self):
@@ -140,7 +141,7 @@ class TestPostInstallationState(ManageTest):
                     client in found_clients
                 ), f"Ceph client {client} for {consumer_name} not found"
 
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-2694")
     def test_deployer_logs_not_empty(self):
         """
@@ -159,7 +160,7 @@ class TestPostInstallationState(ManageTest):
         log.info(f"Deployer log has {len(log_lines)} lines.")
         assert len(log_lines) > 100
 
-    @tier1
+    @tier2
     @runs_on_provider
     @pytest.mark.polarion_id("OCS-2695")
     def test_connection_time_out(self):

--- a/tests/cross_functional/ui/test_create_pool_block_pool.py
+++ b/tests/cross_functional/ui/test_create_pool_block_pool.py
@@ -3,7 +3,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
+    tier2,
     skipif_ui_not_support,
     skipif_hci_provider_or_client,
     skipif_external_mode,
@@ -84,7 +84,7 @@ class TestPoolUserInterface(ManageTest):
         self.pod_obj = pod_factory(pvc=self.pvc_obj)
 
     @ui
-    @tier1
+    @tier2
     @skipif_ocs_version("<4.16")
     @green_squad
     def test_create_delete_pool(

--- a/tests/cross_functional/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
+++ b/tests/cross_functional/ui/test_creation_and_deletion_of_sc_and_rbdpool.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.ui.block_pool import BlockPoolUI
 from ocs_ci.ocs.ui.storageclass import StorageClassUI
 from ocs_ci.framework.pytest_customization.marks import (
@@ -25,7 +25,6 @@ log = logging.getLogger(__name__)
 
 @green_squad
 @ui
-@tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.9")
 @skipif_ibm_cloud_managed
@@ -46,7 +45,7 @@ class TestRbDPool(ManageTest):
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
                 ],
-                marks=pytest.mark.polarion_id("OCS-3886"),
+                marks=[tier1, pytest.mark.polarion_id("OCS-3886")],
             ),
             pytest.param(
                 *[
@@ -55,7 +54,7 @@ class TestRbDPool(ManageTest):
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
                 ],
-                marks=pytest.mark.polarion_id("OCS-3885"),
+                marks=[tier2, pytest.mark.polarion_id("OCS-3885")],
             ),
         ],
     )
@@ -152,6 +151,7 @@ class TestRbDPool(ManageTest):
         assert all(checks.values())
 
     @pytest.mark.polarion_id("OCS-3890")
+    @tier2
     def test_multiple_sc_one_pool(
         self,
         setup_ui_class,

--- a/tests/cross_functional/ui/test_validation_ui.py
+++ b/tests/cross_functional/ui/test_validation_ui.py
@@ -5,6 +5,7 @@ from ocs_ci.ocs.resources.pod import get_pod_logs
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.framework.testlib import (
     tier1,
+    tier2,
     skipif_ui_not_support,
     skipif_ocs_version,
     polarion_id,
@@ -148,7 +149,7 @@ class TestUserInterfaceValidation(object):
         )
 
     @ui
-    @tier1
+    @tier2
     @runs_on_provider
     def test_ocs_operator_is_not_present(self, setup_ui_class_factory):
         """

--- a/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
@@ -5,7 +5,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     stretchcluster_required,
     turquoise_squad,
     polarion_id,
-    tier1,
+    tier4a,
+    tier4,
     jira,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
@@ -18,7 +19,8 @@ from ocs_ci.ocs.resources.stretchcluster import StretchCluster
 logger = logging.getLogger(__name__)
 
 
-@tier1
+@tier4a
+@tier4
 @stretchcluster_required
 @turquoise_squad
 @jira("DFBUGS-1273")

--- a/tests/functional/lvmo/test_lvm_alerts.py
+++ b/tests/functional/lvmo/test_lvm_alerts.py
@@ -3,7 +3,6 @@ import time
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
@@ -80,10 +79,9 @@ class TestLvmCapacityAlerts(ManageTest):
         self.proj_obj = project_factory()
         self.proj = self.proj_obj.namespace
 
-    @tier1
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.11")
-    def test_thin_pool_capacity_alert(
+    def deprecated_test_thin_pool_capacity_alert(
         self,
         namespace,
         init_lvm,

--- a/tests/functional/lvmo/test_lvm_clone_base.py
+++ b/tests/functional/lvmo/test_lvm_clone_base.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
@@ -46,11 +45,10 @@ class TestLvmSnapshot(ManageTest):
     pvc_size = 100
     access_mode = constants.ACCESS_MODE_RWO
 
-    @tier1
     @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.11")
-    def test_create_clone_from_pvc(
+    def deprecated_test_create_clone_from_pvc(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvm_clone_bigger_than_disk.py
+++ b/tests/functional/lvmo/test_lvm_clone_bigger_than_disk.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier2,
     skipif_lvm_not_installed,
     aqua_squad,
 )
@@ -16,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 @aqua_squad
-@tier2
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.11")
 class TestLvmCloneBiggerThanDisk(ManageTest):
@@ -49,7 +47,7 @@ class TestLvmCloneBiggerThanDisk(ManageTest):
             ),
         ],
     )
-    def test_create_clone_from_pvc_bigger_than_disk(
+    def deprecated_test_create_clone_from_pvc_bigger_than_disk(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvm_manual_diskpath.py
+++ b/tests/functional/lvmo/test_lvm_manual_diskpath.py
@@ -13,7 +13,6 @@ from ocs_ci.utility.lvmo_utils import (
 )
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_lvm_not_installed,
-    tier1,
     aqua_squad,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version
@@ -55,7 +54,6 @@ def create_lvm_cluster_cr_with_device_selector(disks):
 
 
 @aqua_squad
-@tier1
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.12")
 @pytest.mark.parametrize(
@@ -75,7 +73,9 @@ def create_lvm_cluster_cr_with_device_selector(disks):
         ),
     ],
 )
-def test_create_lvm_cluster_w_manual_disk_selection(remove_lvm_cluster, by, select_all):
+def deprecated_test_create_lvm_cluster_w_manual_disk_selection(
+    remove_lvm_cluster, by, select_all
+):
     """
     Test creation of lvm cluster with manual disk selection,
     by disks name or by disks path

--- a/tests/functional/lvmo/test_lvm_multi_clone.py
+++ b/tests/functional/lvmo/test_lvm_multi_clone.py
@@ -5,11 +5,10 @@ import pytest
 import concurrent.futures
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
 from ocs_ci.ocs.resources.pod import cal_md5sum
@@ -50,11 +49,9 @@ class TestLvmMultiClone(ManageTest):
     access_mode = constants.ACCESS_MODE_RWO
     pvc_num = 5
 
-    @tier1
-    @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.11")
-    def test_create_multi_clone_from_pvc(
+    def deprecated_test_create_multi_clone_from_pvc(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvm_multi_snapshot.py
+++ b/tests/functional/lvmo/test_lvm_multi_snapshot.py
@@ -5,12 +5,11 @@ import pytest
 import concurrent.futures
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
 from ocs_ci.framework import config, config_safe_thread_pool_task
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
 from ocs_ci.ocs.resources.pod import cal_md5sum
@@ -51,11 +50,9 @@ class TestLvmMultiSnapshot(ManageTest):
     access_mode = constants.ACCESS_MODE_RWO
     pvc_num = 5
 
-    @tier1
-    @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.11")
-    def test_create_multi_snapshot_from_pvc(
+    def deprecated_test_create_multi_snapshot_from_pvc(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvm_snapshot_base.py
+++ b/tests/functional/lvmo/test_lvm_snapshot_base.py
@@ -2,11 +2,10 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
 from ocs_ci.ocs.resources.pod import cal_md5sum
@@ -46,11 +45,9 @@ class TestLvmSnapshot(ManageTest):
     pvc_size = 100
     access_mode = constants.ACCESS_MODE_RWO
 
-    @tier1
-    @acceptance
     @skipif_lvm_not_installed
     @skipif_ocs_version("<4.11")
-    def test_create_snapshot_from_pvc(
+    def deprecated_test_create_snapshot_from_pvc(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvm_snapshot_bigger_than_disk.py
+++ b/tests/functional/lvmo/test_lvm_snapshot_bigger_than_disk.py
@@ -3,11 +3,10 @@ import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
-from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, acceptance
+from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import LVM
 from ocs_ci.ocs.exceptions import LvSizeWrong
@@ -16,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 @aqua_squad
-@tier1
-@acceptance
 @skipif_lvm_not_installed
 @skipif_ocs_version("<4.11")
 class TestLvmSnapshotBiggerThanDisk(ManageTest):
@@ -50,7 +47,7 @@ class TestLvmSnapshotBiggerThanDisk(ManageTest):
             ),
         ],
     )
-    def test_create_snapshot_from_pvc_bigger_than_disk(
+    def deprecated_test_create_snapshot_from_pvc_bigger_than_disk(
         self,
         volume_mode,
         volume_binding_mode,

--- a/tests/functional/lvmo/test_lvmo_pvc_resize.py
+++ b/tests/functional/lvmo/test_lvmo_pvc_resize.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
     skipif_lvm_not_installed,
     aqua_squad,
 )
@@ -77,10 +76,9 @@ class TestLVMPVCResize(ManageTest):
         self.proj_obj = project_factory()
         self.proj = self.proj_obj.namespace
 
-    @tier1
     @skipif_ocs_version("<4.11")
     @skipif_lvm_not_installed
-    def test_pvc_resize(
+    def deprecated_test_pvc_resize(
         self,
         init_lvm,
         status,

--- a/tests/functional/monitoring/prometheus/metrics/test_ocs_utilization.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_ocs_utilization.py
@@ -9,7 +9,7 @@ from flaky import flaky
 import logging
 
 from ocs_ci.framework.pytest_customization import marks
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.testlib import tier2
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.utility.prometheus import check_query_range_result_limits
 from ocs_ci.utility.workloadfixture import ignore_next_measurement_file
@@ -34,7 +34,7 @@ CPU_USAGE_POD = (
 @provider_mode
 @mcg
 @blue_squad
-@tier1
+@tier2
 @flaky(rerun_filter=ignore_next_measurement_file)
 @marks.polarion_id("OCS-2364")
 @skipif_managed_service

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -34,7 +34,6 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     blue_squad,
-    tier1,
     tier2,
     pre_upgrade,
     post_upgrade,
@@ -183,7 +182,7 @@ def test_workload_with_checksum_verify(
 
 @blue_squad
 @skipif_mcg_only
-@tier1
+@tier2
 @pytest.mark.polarion_id("OCS-2125")
 @skipif_managed_service
 def test_workload_rbd_cephfs_10g(

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
+    tier2,
     tier4c,
     skipif_ocp_version,
     skipif_managed_service,
@@ -528,7 +529,7 @@ class TestNfsEnable(ManageTest):
         log.info("Check nfs pv is deleted")
         pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
-    @tier1
+    @tier2
     @aws_platform_required
     @polarion_id("OCS-4274")
     def test_multiple_nfs_based_PVs(
@@ -671,7 +672,7 @@ class TestNfsEnable(ManageTest):
             log.info("Check nfs pv is deleted")
             pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
-    @tier1
+    @tier2
     @aws_platform_required
     @polarion_id("OCS-4293")
     def test_multiple_mounts_of_same_nfs_volume(
@@ -809,7 +810,7 @@ class TestNfsEnable(ManageTest):
         log.info("Check nfs pv is deleted")
         pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
-    @tier1
+    @tier2
     @aws_platform_required
     @polarion_id("OCS-4312")
     def test_external_nfs_client_can_write_read_new_file(
@@ -1393,7 +1394,7 @@ class TestNfsEnable(ManageTest):
         log.info("Check nfs pv is deleted")
         pv_obj.ocp.wait_for_delete(resource_name=pv_obj.name, timeout=180)
 
-    @tier1
+    @tier2
     @polarion_id("OCS-6193")
     def test_nfs_pvc_subvolume_deletion(
         self,

--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -6,6 +6,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
+    tier2,
     tier3,
     acceptance,
     performance,
@@ -81,7 +82,7 @@ class TestBucketCreationAndDeletion(MCGTest):
             pytest.param(
                 *[3, "CLI", None],
                 marks=[
-                    tier1,
+                    tier2,
                     acceptance,
                     pytest.mark.polarion_id("OCS-1298"),
                 ],
@@ -110,7 +111,7 @@ class TestBucketCreationAndDeletion(MCGTest):
                         },
                     },
                 ],
-                marks=[tier1, skipif_mcg_only, pytest.mark.polarion_id("OCS-2331")],
+                marks=[tier2, skipif_mcg_only, pytest.mark.polarion_id("OCS-2331")],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_bucket_logs.py
+++ b/tests/functional/object/mcg/test_bucket_logs.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     red_squad,
     skipif_mcg_only,
     tier1,
+    tier2,
     polarion_id,
     skipif_external_mode,
 )
@@ -54,14 +55,13 @@ class TestBucketLogs(MCGTest):
             ]
         )
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=["use_provided_logs_pvc"],
         argvalues=[
-            pytest.param(False, marks=[polarion_id("OCS-6242")]),
+            pytest.param(False, marks=[tier1, polarion_id("OCS-6242")]),
             pytest.param(
                 True,
-                marks=[polarion_id("OCS-6243"), skipif_mcg_only],
+                marks=[tier2, polarion_id("OCS-6243"), skipif_mcg_only],
             ),
         ],
         ids=[
@@ -166,14 +166,13 @@ class TestBucketLogs(MCGTest):
             pvc.name == logs_manager.cur_logs_pvc for pvc in pvc_dicts
         ), f"The logs PVC {logs_manager.cur_logs_pvc} was deleted"
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=["use_provided_logs_pvc"],
         argvalues=[
-            pytest.param(False, marks=[polarion_id("OCS-6244")]),
+            pytest.param(False, marks=[tier1, polarion_id("OCS-6244")]),
             pytest.param(
                 True,
-                marks=[polarion_id("OCS-6245"), skipif_mcg_only],
+                marks=[tier2, polarion_id("OCS-6245"), skipif_mcg_only],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -68,14 +68,13 @@ class TestBucketNotifications(MCGTest):
         notif_manager.setup_kafka()
         return notif_manager
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=["use_provided_pvc"],
         argvalues=[
-            pytest.param(False, marks=[polarion_id("OCS-6329")]),
+            pytest.param(False, marks=[tier1, polarion_id("OCS-6329")]),
             pytest.param(
                 True,
-                marks=[polarion_id("OCS-6330"), skipif_mcg_only],
+                marks=[tier2, polarion_id("OCS-6330"), skipif_mcg_only],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -383,7 +383,7 @@ class TestS3BucketPolicy(MCGTest):
             assert False, "Delete object succeeded when it should have failed"
 
     @pytest.mark.polarion_id("OCS-2145")
-    @tier1
+    @tier2
     def test_anonymous_read_only(self, mcg_obj, bucket_factory):
         """
         Tests read only access by an anonymous user
@@ -1033,7 +1033,7 @@ class TestS3BucketPolicy(MCGTest):
         delete_bucket_policy_verify(obc_obj, obc_obj.bucket_name)
 
     @pytest.mark.polarion_id("OCS-5770")
-    @tier1
+    @tier2
     def test_bucket_policy_elements_NotResource(self, mcg_obj, bucket_factory):
         """
         Test bucket policy element of NotResource with Effect: Deny
@@ -1079,7 +1079,7 @@ class TestS3BucketPolicy(MCGTest):
 
     @pytest.mark.polarion_id("OCS-2451")
     @skipif_ocs_version("<4.6")
-    @tier1
+    @tier2
     def test_public_website(self, mcg_obj, bucket_factory):
         """
         Tests public bucket website access

--- a/tests/functional/object/mcg/test_bucket_replication.py
+++ b/tests/functional/object/mcg/test_bucket_replication.py
@@ -130,7 +130,7 @@ class TestReplication(MCGTest):
                     "interface": "CLI",
                     "backingstore_dict": {"gcp": [(1, None)]},
                 },
-                marks=[tier1],
+                marks=[tier2],
             ),
         ],
         ids=[
@@ -397,7 +397,7 @@ class TestReplication(MCGTest):
                     "interface": "OC",
                     "backingstore_dict": {"gcp": [(1, None)]},
                 },
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 {

--- a/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
+++ b/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
@@ -5,7 +5,7 @@ import random
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     MCGTest,
-    tier1,
+    tier2,
     red_squad,
     mcg,
 )
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 mcg_cli = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
 
 
-@tier1
 @red_squad
 @mcg
 class TestCustomCredsUsingMcgCli(MCGTest):
@@ -39,6 +38,7 @@ class TestCustomCredsUsingMcgCli(MCGTest):
         logger.info(output)
 
     @skipif_ocs_version("<4.17")
+    @tier2
     def test_account_update_with_custom_creds_using_cli(self, mcg_account_factory):
         """
         1. Create a new account using MCG CLI

--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -8,7 +8,6 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     polarion_id,
-    tier1,
     tier2,
     pre_upgrade,
     post_upgrade,
@@ -44,7 +43,7 @@ class TestDefaultBackingstoreOverride(MCGTest):
 
     """
 
-    @tier1
+    @tier2
     @polarion_id("OCS-5193")
     def test_default_buckets_backingstore(
         self,

--- a/tests/functional/object/mcg/test_endpoint_autoscale.py
+++ b/tests/functional/object/mcg/test_endpoint_autoscale.py
@@ -1,7 +1,7 @@
 import time
 import logging
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import MCGTest, tier1, skipif_ocs_version
+from ocs_ci.framework.testlib import MCGTest, tier2, skipif_ocs_version
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 @runs_on_provider
 @skipif_ocs_version(["<4.5", "<4.14"])
 @skipif_managed_service
-@tier1
+@tier2
 class TestEndpointAutoScale(MCGTest):
     """
     Test MCG endpoint auto-scaling

--- a/tests/functional/object/mcg/test_log_based_bucket_replication.py
+++ b/tests/functional/object/mcg/test_log_based_bucket_replication.py
@@ -251,7 +251,7 @@ class TestLogBasedBucketReplication(MCGTest):
         mockup_logger_b.delete_objs_and_log(bucket_b.name, objs, prefix=BUCKET_B_PREFIX)
         _assert_compare_bucket_object_list(DEL_SYNC_FAIL_MSG)
 
-    @tier1
+    @tier2
     @polarion_id("OCS-4937")
     def test_deletion_sync_opt_out(self, mcg_obj_session, log_based_replication_setup):
         """

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -140,7 +140,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-6339"),
                 ],
@@ -154,7 +154,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-6353"),
                 ],
             ),
@@ -167,7 +167,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-6354"),
                 ],
             ),
@@ -180,7 +180,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-6355"),
                 ],
             ),
@@ -193,7 +193,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-6356"),
                 ],
             ),
@@ -209,7 +209,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-6338"),
                 ],
@@ -225,7 +225,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     on_prem_platform_required,
                     pytest.mark.polarion_id("OCS-6351"),
                 ],
@@ -239,7 +239,7 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-5442"),
                     skipif_fips_enabled,
                 ],
@@ -470,7 +470,7 @@ class TestNamespace(MCGTest):
             amount=3,
         )
 
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-2258")
     @on_prem_platform_required
     def test_distribution_of_objects_in_ns_bucket_crd(
@@ -719,7 +719,7 @@ class TestNamespace(MCGTest):
         ):
             raise UnexpectedBehaviour("Cached object was not downloaded")
 
-    @tier1
+    @tier2
     @pytest.mark.parametrize(
         argnames=["bucketclass_dict"],
         argvalues=[

--- a/tests/functional/object/mcg/test_object_expiration.py
+++ b/tests/functional/object/mcg/test_object_expiration.py
@@ -371,7 +371,7 @@ class TestObjectExpiration(MCGTest):
             raise e
 
     @pytest.mark.polarion_id("OCS-5167")
-    @tier1
+    @tier2
     def test_disabled_object_expiration(
         self, mcg_obj, bucket_factory, awscli_pod_session, test_directory_setup
     ):
@@ -441,7 +441,7 @@ class TestObjectExpiration(MCGTest):
 
     @skipif_ocs_version("<4.10")
     @pytest.mark.polarion_id("OCS-3929")
-    @tier1
+    @tier2
     def test_object_expiration_in_minutes(self, mcg_obj, bucket_factory):
         """
         Test object is not deleted in minutes when object is set to expire in a day

--- a/tests/functional/object/mcg/test_object_integrity.py
+++ b/tests/functional/object/mcg/test_object_integrity.py
@@ -54,15 +54,15 @@ class TestObjectIntegrity(MCGTest):
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"azure": [(1, None)]}},
-                marks=[tier1, skipif_disconnected_cluster],
+                marks=[tier2, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
-                marks=[tier1, skipif_disconnected_cluster],
+                marks=[tier2, skipif_disconnected_cluster],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1, skipif_disconnected_cluster, skipif_fips_enabled],
+                marks=[tier2, skipif_disconnected_cluster, skipif_fips_enabled],
             ),
             pytest.param(
                 {

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
+    tier2,
     sts_deployment_required,
     red_squad,
     mcg,
@@ -35,7 +36,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 *[None],

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -128,7 +128,7 @@ class TestBucketIO(MCGTest):
                     "CLI",
                     {"interface": "CLI", "backingstore_dict": {"rgw": [(1, None)]}},
                 ],
-                marks=[tier1, on_prem_platform_required],
+                marks=[tier2, on_prem_platform_required],
             ),
             pytest.param(
                 *[
@@ -142,7 +142,7 @@ class TestBucketIO(MCGTest):
                     },
                 ],
                 marks=[
-                    tier1,
+                    tier2,
                     on_prem_platform_required,
                     jira("DFBUGS-1035", run=False),
                 ],
@@ -198,19 +198,19 @@ class TestBucketIO(MCGTest):
                     "interface": "OC",
                     "backingstore_dict": {"aws": [(1, "eu-central-1")]},
                 },
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"azure": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1, skipif_fips_enabled],
+                marks=[tier2, skipif_fips_enabled],
             ),
         ],
         ids=[
@@ -283,11 +283,11 @@ class TestBucketIO(MCGTest):
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier2],
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
+                marks=[tier2],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -24,6 +24,7 @@ from ocs_ci.framework.testlib import (
     tier2,
     skipif_ui_not_support,
     ui,
+    post_upgrade,
 )
 from ocs_ci.ocs.exceptions import IncorrectUiOptionRequested
 from ocs_ci.ocs.ocp import OCP, get_all_resource_names_of_a_kind
@@ -418,8 +419,9 @@ class TestObcUserInterface(object):
 
 @ui
 @black_squad
-@tier1
 class TestBucketCreate:
+    @tier1
+    @post_upgrade
     @pytest.mark.polarion_id("OCS-6334")
     def test_bucket_create(self, setup_ui_class_factory):
         """
@@ -442,6 +444,8 @@ class TestBucketCreate:
             bucket_ui.create_folder_in_bucket()
         ), "Failed to create and upload folder in bucket"
 
+    @post_upgrade
+    @tier2
     @pytest.mark.polarion_id("OCS-6397")
     def test_empty_bucket_delete(self, setup_ui_class_factory):
         """
@@ -493,6 +497,7 @@ class TestBucketCreate:
         logger.info(f"Successfully deleted bucket: {bucket_to_delete}")
 
     @pytest.mark.polarion_id("OCS-6398")
+    @tier2
     def test_bucket_list_comparison(self, setup_ui_class_factory, mcg_obj):
         """
         Test that the bucket list from UI matches the bucket list from CLI.

--- a/tests/functional/object/rgw/test_bucket_creation.py
+++ b/tests/functional/object/rgw/test_bucket_creation.py
@@ -37,7 +37,7 @@ class TestRGWBucketCreation:
             ),
         ],
     )
-    def test_bucket_creation(self, rgw_bucket_factory, amount, interface):
+    def test_rgw_bucket_creation(self, rgw_bucket_factory, amount, interface):
         """
         Test RGW OBC creation using the OC command.
         The factory checks the bucket's health by default.
@@ -52,7 +52,7 @@ class TestRGWBucketCreation:
             ),
         ],
     )
-    def test_duplicate_bucket_creation(
+    def test_rgw_duplicate_bucket_creation(
         self, rgw_obj, rgw_bucket_factory, amount, interface
     ):
         """

--- a/tests/functional/object/rgw/test_bucket_deletion.py
+++ b/tests/functional/object/rgw/test_bucket_deletion.py
@@ -7,12 +7,12 @@ from ocs_ci.ocs.bucket_utils import sync_object_directory
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    acceptance,
     red_squad,
     rgw,
     runs_on_provider,
     skipif_mcg_only,
     tier1,
+    acceptance,
     tier3,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -37,7 +37,7 @@ class TestBucketDeletion:
         argvalues=[
             pytest.param(
                 *[3, "RGW-OC"],
-                marks=[tier1, acceptance, pytest.mark.polarion_id("2248")],
+                marks=[acceptance, pytest.mark.polarion_id("2248")],
             ),
         ],
     )

--- a/tests/functional/object/rgw/test_multipart_upload.py
+++ b/tests/functional/object/rgw/test_multipart_upload.py
@@ -65,7 +65,7 @@ class TestS3MultipartUpload(ManageTest):
 
     @tier1
     @pytest.mark.polarion_id("OCS-2245")
-    def test_multipart_upload_operations(
+    def test_rgw_multipart_upload_operations(
         self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -47,7 +47,7 @@ class TestOBCQuota:
             ),
         ],
     )
-    def test_obc_quota(
+    def test_rgw_obc_quota(
         self,
         awscli_pod_session,
         rgw_bucket_factory,

--- a/tests/functional/object/rgw/test_object_bucket_size.py
+++ b/tests/functional/object/rgw/test_object_bucket_size.py
@@ -67,7 +67,7 @@ def compare_sizes(mcg_obj, ceph_obj, bucket_name):
 @pytest.mark.polarion_id("OCS-2476")
 @skipif_mcg_only
 @tier1
-def deprecated_test_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
+def deprecated_test_rgw_object_bucket_size(mcg_obj, bucket_factory, rgw_deployments):
     """
     Test to verify object bucket(backed by RGW) available size
 

--- a/tests/functional/object/rgw/test_object_integrity.py
+++ b/tests/functional/object/rgw/test_object_integrity.py
@@ -33,7 +33,7 @@ class TestObjectIntegrity(ManageTest):
     @tier1
     @flaky
     @pytest.mark.polarion_id("OCS-2246")
-    def test_check_object_integrity(
+    def test_check_rgw_object_integrity(
         self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """
@@ -65,7 +65,7 @@ class TestObjectIntegrity(ManageTest):
 
     @pytest.mark.polarion_id("OCS-2243")
     @tier2
-    def test_empty_file_integrity(
+    def test_rgw_empty_file_integrity(
         self, awscli_pod_session, rgw_bucket_factory, test_directory_setup
     ):
         """

--- a/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
+++ b/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
@@ -4,13 +4,15 @@ import logging
 from ocs_ci.helpers.helpers import get_ceph_log_level
 from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.testlib import tier2, skipif_kms_deployment, skipif_external_mode
 
 log = logging.getLogger(__name__)
 
 
 @brown_squad
-@tier1
+@tier2
+@skipif_kms_deployment
+@skipif_external_mode
 class TestDebugVerbosityOfCephComponents:
     @pytest.fixture(autouse=True)
     def setup(self, odf_cli_setup):

--- a/tests/functional/odf-cli/test_operator_restart.py
+++ b/tests/functional/odf-cli/test_operator_restart.py
@@ -6,12 +6,12 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.odf_cli import ODFCLIRetriever, ODFCliRunner
-from ocs_ci.framework.testlib import tier1, brown_squad, polarion_id
+from ocs_ci.framework.testlib import tier3, brown_squad, polarion_id
 
 logger = logging.getLogger(__name__)
 
 
-@tier1
+@tier3
 @brown_squad
 @polarion_id("OCS-6235")
 class TestOperatorRestart:

--- a/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
+++ b/tests/functional/odf-cli/test_pvc_stale_volume_cleanup_cli.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
+    tier2,
     green_squad,
 )
 from ocs_ci.ocs import constants
@@ -17,7 +18,6 @@ from ocs_ci.framework.testlib import ignore_leftovers
 logger = logging.getLogger(__name__)
 
 
-@tier1
 @ignore_leftovers
 @green_squad
 class TestSubvolumesCommand(ManageTest):
@@ -28,6 +28,7 @@ class TestSubvolumesCommand(ManageTest):
 
     @skipif_ocs_version("<4.15")
     @pytest.mark.polarion_id("OCS-5794")
+    @tier1
     def test_pvc_stale_volume_cleanup_cli(self, storageclass_factory, pvc_factory):
         """
         1. Create a new PVC with Retain strategy.
@@ -86,6 +87,7 @@ class TestSubvolumesCommand(ManageTest):
             subvolumes.append((fs, sv, svg, status))
         return subvolumes
 
+    @tier2
     @skipif_ocs_version("<4.17")
     @pytest.mark.polarion_id("OCS-6194")
     def test_rox_pvc_stale_volume_cleanup_cli(
@@ -169,6 +171,7 @@ class TestSubvolumesCommand(ManageTest):
 
     @skipif_ocs_version("<4.17")
     @pytest.mark.polarion_id("OCS-6195")
+    @tier2
     def test_stale_volume_snapshot_cleanup_cli(
         self,
         storageclass_factory,

--- a/tests/functional/pod_and_daemons/test_ephemeral_pod.py
+++ b/tests/functional/pod_and_daemons/test_ephemeral_pod.py
@@ -9,12 +9,16 @@ from ocs_ci.ocs.constants import (
     RBD_INTERFACE,
 )
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import tier1, brown_squad, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    brown_squad,
+    polarion_id,
+)
 
 log = getLogger(__name__)
 
 
-@tier1
+@tier2
 @brown_squad
 @polarion_id("OCS-5792")
 class TestEphemeralPod:

--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
+    tier2,
     tier3,
     skipif_ocp_version,
     skipif_managed_service,
@@ -50,7 +51,7 @@ class TestMetadataUnavailable(ManageTest):
         ],
     )
     @polarion_id("OCS-4669")
-    def test_metadata_feature_unavailable_for_previous_versions(
+    def deprecated_test_metadata_feature_unavailable_for_previous_versions(
         self, project_factory_class, sc_name, fs
     ):
         """
@@ -281,19 +282,19 @@ class TestMetadata(ManageTest):
             self.pod_obj,
         )
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=["fs", "sc_name"],
         argvalues=[
             pytest.param(
                 "ocs-storagecluster-cephfilesystem",
                 constants.DEFAULT_STORAGECLASS_CEPHFS,
-                marks=pytest.mark.polarion_id("OCS-4676"),
+                marks=[tier1, pytest.mark.polarion_id("OCS-4676")],
             ),
             pytest.param(
                 "ocs-storagecluster-cephblockpool",
                 constants.DEFAULT_STORAGECLASS_RBD,
                 marks=[
+                    tier2,
                     pytest.mark.polarion_id("OCS-4679"),
                 ],
             ),
@@ -419,7 +420,7 @@ class TestMetadata(ManageTest):
             resource_name=clone_pvc_obj.name, timeout=300
         ), f"PVC {clone_pvc_obj.name} is not deleted"
 
-    @tier1
+    @tier2
     @pytest.mark.parametrize(
         argnames=["fs", "sc_name"],
         argvalues=[
@@ -515,7 +516,7 @@ class TestMetadata(ManageTest):
             resource_name=pvc_obj.name, timeout=300
         ), f"PVC {pvc_obj.name} is not deleted"
 
-    @tier1
+    @tier2
     @pytest.mark.parametrize(
         argnames=["fs", "sc_name"],
         argvalues=[
@@ -782,7 +783,6 @@ class TestMetadata(ManageTest):
             resource_name=pvc_obj_with_metadata_disabled.name, timeout=300
         ), f"PVC {pvc_obj_with_metadata_disabled.name} is not deleted"
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=["fs", "sc_name"],
         argvalues=[
@@ -793,6 +793,7 @@ class TestMetadata(ManageTest):
     )
     @polarion_id("OCS-4680")
     @polarion_id("OCS-4681")
+    @tier2
     def test_metadata_update_for_PV_Retain(self, fs, sc_name, project_factory_class):
         """
         This test is to validate metadata is updated after a PVC is deleted by setting ReclaimPloicy: Retain on PV

--- a/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.testlib import config, tier1
+from ocs_ci.framework.testlib import config, tier2
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.keyrotation_helper import PVKeyrotation
 from ocs_ci.helpers.helpers import create_pods
@@ -107,7 +107,7 @@ class PVKeyrotationTestBase:
         self.pv_keyrotation_obj = PVKeyrotation(self.sc_obj)
 
 
-@tier1
+@tier2
 @green_squad
 @pytest.mark.parametrize(
     argnames=argnames,

--- a/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
@@ -4,7 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
-    tier1,
+    tier2,
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
@@ -77,7 +77,7 @@ class TestEncryptedPVCNOExpansionOption(ManageTest):
         self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
         log.info("csi-kms-connection-details setup successful")
 
-    @tier1
+    @tier2
     @pytest.mark.parametrize(
         argnames=argnames,
         argvalues=argvalues,

--- a/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_clone.py
@@ -156,7 +156,7 @@ class TestEncryptedRbdClone(ManageTest):
                         f"Vault: Key not found for {pvc_obj.name}"
                     )
 
-    def test_pvc_to_pvc_clone(self, kv_version, kms_provider, pod_factory):
+    def test_encrypted_pvc_to_pvc_clone(self, kv_version, kms_provider, pod_factory):
         """
         Test to create a clone from an existing encrypted RBD PVC.
         Verify that the cloned PVC is encrypted and all the data is preserved.

--- a/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_rbd_pvc_snapshot.py
@@ -66,7 +66,6 @@ else:
     argnames=argnames,
     argvalues=argvalues,
 )
-@tier1
 @skipif_ocs_version("<4.8")
 @skipif_ocp_version("<4.8")
 @kms_config_required
@@ -156,6 +155,7 @@ class TestEncryptedRbdBlockPvcSnapshot(ManageTest):
                         f"Vault: Key not found for {pvc_obj.name}"
                     )
 
+    @tier1
     def test_encrypted_rbd_block_pvc_snapshot(
         self,
         kms_provider,

--- a/tests/functional/pv/pv_encryption/test_encrypted_rbd_volume_expansion.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_rbd_volume_expansion.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
@@ -32,19 +33,31 @@ else:
     if config.ENV_DATA.get("vault_hcp"):
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-5389")
+                "v1",
+                kmsprovider,
+                True,
+                marks=[tier2, pytest.mark.polarion_id("OCS-5389")],
             ),
             pytest.param(
-                "v2", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-5390")
+                "v2",
+                kmsprovider,
+                True,
+                marks=[tier1, pytest.mark.polarion_id("OCS-5390")],
             ),
         ]
     else:
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-5387")
+                "v1",
+                kmsprovider,
+                False,
+                marks=[tier2, pytest.mark.polarion_id("OCS-5387")],
             ),
             pytest.param(
-                "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-5388")
+                "v2",
+                kmsprovider,
+                False,
+                marks=[tier1, pytest.mark.polarion_id("OCS-5388")],
             ),
         ]
 
@@ -77,7 +90,6 @@ class TestEncryptedVolumeExpansion(ManageTest):
         self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
         log.info("csi-kms-connection-details setup successful")
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=argnames,
         argvalues=argvalues,

--- a/tests/functional/pv/pv_encryption/test_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_pv_keyrotation.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
@@ -33,19 +34,31 @@ else:
     if config.ENV_DATA.get("vault_hcp"):
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-6179")
+                "v1",
+                kmsprovider,
+                True,
+                marks=[tier2, pytest.mark.polarion_id("OCS-6179")],
             ),
             pytest.param(
-                "v2", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-6180")
+                "v2",
+                kmsprovider,
+                True,
+                marks=[tier1, pytest.mark.polarion_id("OCS-6180")],
             ),
         ]
     else:
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-6181")
+                "v1",
+                kmsprovider,
+                False,
+                marks=[tier2, pytest.mark.polarion_id("OCS-6181")],
             ),
             pytest.param(
-                "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-6182")
+                "v2",
+                kmsprovider,
+                False,
+                marks=[tier1, pytest.mark.polarion_id("OCS-6182")],
             ),
         ]
 
@@ -79,7 +92,6 @@ class TestPVKeyRotationWithVaultKMS(ManageTest):
         self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
         log.info("csi-kms-connection-details setup successful")
 
-    @tier1
     @pytest.mark.parametrize(
         argnames=argnames,
         argvalues=argvalues,

--- a/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
+++ b/tests/functional/pv/pv_encryption/test_rbd_pv_encryption.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_ocs_version,
     kms_config_required,
     skipif_managed_service,
@@ -41,19 +42,31 @@ else:
     if config.ENV_DATA.get("vault_hcp"):
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-3973")
+                "v1",
+                kmsprovider,
+                True,
+                marks=[tier1, pytest.mark.polarion_id("OCS-3973")],
             ),
             pytest.param(
-                "v2", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-3974")
+                "v2",
+                kmsprovider,
+                True,
+                marks=[tier2, pytest.mark.polarion_id("OCS-3974")],
             ),
         ]
     else:
         argvalues = [
             pytest.param(
-                "v1", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2585")
+                "v1",
+                kmsprovider,
+                False,
+                marks=[tier1, pytest.mark.polarion_id("OCS-2585")],
             ),
             pytest.param(
-                "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-2592")
+                "v2",
+                kmsprovider,
+                False,
+                marks=[tier2, pytest.mark.polarion_id("OCS-2592")],
             ),
         ]
 
@@ -90,7 +103,6 @@ class TestRbdPvEncryption(ManageTest):
         self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
         log.info("csi-kms-connection-details setup successful")
 
-    @tier1
     def test_rbd_pv_encryption(
         self,
         kms_provider,

--- a/tests/functional/pv/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
+++ b/tests/functional/pv/pv_encryption/test_vault_namespace_override_using_tenant_configmap.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_proxy_cluster,
     ManageTest,
     tier1,
+    tier2,
     config,
 )
 from ocs_ci.helpers.helpers import create_unique_resource_name, create_pods
@@ -25,20 +26,20 @@ argnames = ["kv_version", "kms_provider", "use_vault_namespace"]
 if config.ENV_DATA.get("vault_hcp"):
     argvalues = [
         pytest.param(
-            "v1", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-4639")
+            "v1", kmsprovider, True, marks=[tier2, pytest.mark.polarion_id("OCS-4639")]
         ),
         pytest.param(
-            "v2", kmsprovider, True, marks=pytest.mark.polarion_id("OCS-4641")
+            "v2", kmsprovider, True, marks=[tier1, pytest.mark.polarion_id("OCS-4641")]
         ),
     ]
 
 else:
     argvalues = [
         pytest.param(
-            "v1", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-4638")
+            "v1", kmsprovider, False, marks=[tier2, pytest.mark.polarion_id("OCS-4638")]
         ),
         pytest.param(
-            "v2", kmsprovider, False, marks=pytest.mark.polarion_id("OCS-4640")
+            "v2", kmsprovider, False, marks=[tier1, pytest.mark.polarion_id("OCS-4640")]
         ),
     ]
 
@@ -48,7 +49,6 @@ else:
     argnames=argnames,
     argvalues=argvalues,
 )
-@tier1
 @skipif_ocs_version("<4.10")
 @kms_config_required
 @skipif_managed_service

--- a/tests/functional/pv/pv_services/test_cephfs_pvc_with_necessary_scc_permissions.py
+++ b/tests/functional/pv/pv_services/test_cephfs_pvc_with_necessary_scc_permissions.py
@@ -5,7 +5,7 @@ from ocs_ci.helpers.helpers import create_pod
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
-    tier1,
+    tier2,
     polarion_id,
 )
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -26,7 +26,7 @@ def validate_permissions(pod_obj):
 
 
 @green_squad
-@tier1
+@tier2
 @polarion_id("OCS-4931")
 class TestToVerifyfsgroupSetOnSubpathVolumeForCephfsPVC(ManageTest):
     """

--- a/tests/functional/pv/pv_services/test_change_reclaim_policy_of_pv.py
+++ b/tests/functional/pv/pv_services/test_change_reclaim_policy_of_pv.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_managed_service,
     skipif_hci_provider_and_client,
 )
@@ -27,17 +28,17 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @pytest.mark.parametrize(
     argnames=["interface", "reclaim_policy"],
     argvalues=[
         pytest.param(
             *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_DELETE],
-            marks=[pytest.mark.polarion_id("OCS-939"), provider_mode],
+            marks=[tier1, pytest.mark.polarion_id("OCS-939"), provider_mode],
         ),
         pytest.param(
             *[constants.CEPHBLOCKPOOL, RECLAIM_POLICY_RETAIN],
             marks=[
+                tier2,
                 pytest.mark.polarion_id("OCS-962"),
                 skipif_managed_service,
                 skipif_hci_provider_and_client,
@@ -45,11 +46,12 @@ log = logging.getLogger(__name__)
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_DELETE],
-            marks=[pytest.mark.polarion_id("OCS-963"), provider_mode],
+            marks=[tier2, pytest.mark.polarion_id("OCS-963"), provider_mode],
         ),
         pytest.param(
             *[constants.CEPHFILESYSTEM, RECLAIM_POLICY_RETAIN],
             marks=[
+                tier2,
                 pytest.mark.polarion_id("OCS-964"),
                 skipif_managed_service,
                 skipif_hci_provider_and_client,

--- a/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
+++ b/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_ocs_version,
     skipif_managed_service,
     skipif_hci_provider_and_client,
@@ -76,15 +77,19 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
     @pytest.mark.parametrize(
         argnames=["sc_name", "sc_type"],
         argvalues=[
-            pytest.param(*[constants.CEPHBLOCKPOOL_SC, constants.CEPHBLOCKPOOL]),
-            pytest.param(*[constants.CEPHFILESYSTEM_SC, constants.CEPHFILESYSTEM]),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL_SC, constants.CEPHBLOCKPOOL], marks=[tier1]
+            ),
+            pytest.param(
+                *[constants.CEPHFILESYSTEM_SC, constants.CEPHFILESYSTEM], marks=[tier2]
+            ),
             pytest.param(
                 *["sc-test-blk", constants.CEPHBLOCKPOOL],
-                marks=[skipif_ocs_version("<4.10")],
+                marks=[tier2, skipif_ocs_version("<4.10")],
             ),
             pytest.param(
                 *["sc-test-fs", constants.CEPHFILESYSTEM],
-                marks=[skipif_ocs_version("<4.10")],
+                marks=[tier2, skipif_ocs_version("<4.10")],
             ),
         ],
     )

--- a/tests/functional/pv/pv_services/test_rwop_pvc.py
+++ b/tests/functional/pv/pv_services/test_rwop_pvc.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     polarion_id,
-    tier1,
+    tier2,
     post_upgrade,
     skipif_ocs_version,
 )
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
     ],
 )
 @green_squad
-@tier1
+@tier2
 @post_upgrade
 @skipif_ocs_version("<4.15")
 class TestRwopPvc(ManageTest):

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
+    tier2,
     acceptance,
     skipif_ocp_version,
     config,
@@ -23,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_ocs_version("<4.9")
 @skipif_ocp_version("<4.9")
 class TestClone(ManageTest):
@@ -75,6 +75,7 @@ class TestClone(ManageTest):
             ),
         ],
     )
+    @tier1
     def test_pvc_to_pvc_clone(self, interface_type, setup, teardown_factory):
         """
         Create a clone from an existing pvc,
@@ -171,6 +172,7 @@ class TestClone(ManageTest):
             ),
         ],
     )
+    @tier2
     def test_pvc_to_pvc_rox_clone(
         self,
         interface_type,
@@ -269,6 +271,7 @@ class TestClone(ManageTest):
             ),
         ],
     )
+    @tier2
     def test_pvc_to_pvc_rox_shallow_vol_clone(
         self,
         interface_type,
@@ -397,6 +400,7 @@ class TestClone(ManageTest):
             ),
         ],
     )
+    @tier2
     def test_pvc_to_pvc_rox_shallow_vol_post_clone(
         self,
         interface_type,

--- a/tests/functional/pv/pvc_resize/test_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_pvc_expansion.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
+    tier2,
     acceptance,
     skipif_upgraded_from,
 )
@@ -19,7 +20,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_ocs_version("<4.5")
 @skipif_upgraded_from(["4.4"])
 class TestPvcExpand(ManageTest):
@@ -177,6 +177,7 @@ class TestPvcExpand(ManageTest):
 
     @provider_mode
     @acceptance
+    @tier1
     @pytest.mark.polarion_id("OCS-2219")
     def test_pvc_expansion(self):
         """
@@ -194,6 +195,7 @@ class TestPvcExpand(ManageTest):
         log.info(f"Expanding PVCs to {pvc_size_new}G")
         self.expand_and_verify(pvc_size_new)
 
+    @tier2
     @pytest.mark.polarion_id("OCS-302")
     def test_pvc_expand_expanded_pvc(self):
         """

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -6,7 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
-    tier1,
+    tier2,
     skipif_ocp_version,
     skipif_managed_service,
     skipif_hci_provider_and_client,
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @skipif_ocs_version("<4.6")
@@ -54,6 +53,7 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
             access_modes_cephfs=[constants.ACCESS_MODE_RWO],
         )
 
+    @tier2
     def test_snapshot_restore_using_different_sc(
         self,
         storageclass_factory,

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
@@ -6,7 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
-    tier1,
+    tier2,
     polarion_id,
     skipif_ocp_version,
 )
@@ -17,7 +17,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_ocs_version("<4.16")
 @skipif_ocp_version("<4.16")
 @polarion_id("OCS-6176")
@@ -42,6 +41,7 @@ class TestRestoreSnapshotWhenParentPVCDeleted(ManageTest):
         """
         self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
 
+    @tier2
     def test_restore_snapshot_when_parent_pvc_deleted(
         self, snapshot_factory, snapshot_restore_factory, pvc_clone_factory
     ):

--- a/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
+++ b/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
@@ -3,7 +3,7 @@ import pytest
 import math
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.testlib import tier2
 from ocs_ci.helpers.helpers import (
     change_reclaimspacecronjob_state_for_pvc,
     get_rbd_image_info,
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 class TestDisableReclaimSpaceOperation:
     @pytest.fixture(autouse=True)
     def setup(self, storageclass_factory, multi_pvc_factory):
@@ -100,6 +99,7 @@ class TestDisableReclaimSpaceOperation:
             self.wait_till_expected_image_size(pvc_obj, expected_volume_size)
 
     @pytest.mark.polarion_id("OCS-6279")
+    @tier2
     def test_disable_reclaimspace_operation(self, pod_factory):
         """Test to verify disabling and enabling reclaim space operation.
 

--- a/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -8,7 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
-    tier1,
+    tier2,
     polarion_id,
     skipif_external_mode,
     skipif_hci_provider_and_client,
@@ -56,7 +56,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
     @polarion_id("OCS-2759")
     @skipif_hci_provider_and_client
-    @tier1
+    @tier2
     def test_rbd_space_reclaim_cronjob(self, pause_and_resume_cluster_load):
         """
         Test to verify RBD space reclamation
@@ -148,7 +148,7 @@ class TestRbdSpaceReclaim(ManageTest):
         if check_file_existence(pod_obj=pod_obj, file_path=file_path):
             log.info(f"{fio_filename4} is intact")
 
-    @tier1
+    @tier2
     @skipif_hci_provider_and_client
     @skipif_external_mode
     @pytest.mark.parametrize(

--- a/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
@@ -149,7 +149,7 @@ class TestRbdSpaceReclaim(ManageTest):
             log.info(f"{fio_filename2} is intact")
 
     @polarion_id("OCS-2774")
-    @tier1
+    @tier2
     @skipif_managed_service
     @skipif_external_mode
     def test_rbd_space_reclaim_no_space(self):

--- a/tests/functional/storageclass/test_create_storageclass_with_same_name.py
+++ b/tests/functional/storageclass/test_create_storageclass_with_same_name.py
@@ -4,7 +4,7 @@ import pytest
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import tier1, ManageTest
+from ocs_ci.framework.testlib import tier3, ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility import templating
@@ -74,7 +74,7 @@ def create_storageclass(sc_name, expect_fail=False):
 
 
 @green_squad
-@tier1
+@tier3
 @pytest.mark.usefixtures(
     test_fixture.__name__,
 )

--- a/tests/functional/storageclass/test_custom_storageclass_names.py
+++ b/tests/functional/storageclass/test_custom_storageclass_names.py
@@ -4,6 +4,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     tier1,
+    tier3,
     skipif_external_mode,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version
@@ -23,7 +24,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.14")
 class TestCustomStorageClassNames:
@@ -72,6 +72,7 @@ class TestCustomStorageClassNames:
             ),
         ],
     )
+    @tier1
     def test_custom_storageclass_post_deployment(self, interface):
         """
         Test custom storage class creation post deployment.
@@ -107,6 +108,7 @@ class TestCustomStorageClassNames:
             ("special", 10, False),
         ],
     )
+    @tier3
     def test_custom_storageclass_names_character_limit(
         self, sc_name, str_length, expect_to_pass
     ):

--- a/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
+++ b/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
@@ -8,7 +8,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     ignore_resource_not_found_error_label,
-    tier1,
+    tier3,
     green_squad,
     skipif_ibm_cloud_managed,
 )
@@ -89,7 +89,6 @@ def preconditions_rbd_pool_created_associated_to_sc(
 @green_squad
 @ignore_resource_not_found_error_label
 class TestDeleteRbdPool(ManageTest):
-    @tier1
     @skipif_external_mode
     @pytest.mark.parametrize(
         argnames=["replica", "compression", "volume_binding_mode", "pvc_status"],
@@ -101,7 +100,7 @@ class TestDeleteRbdPool(ManageTest):
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
                 ],
-                marks=pytest.mark.polarion_id("OCS-5134"),
+                marks=[tier3, pytest.mark.polarion_id("OCS-5134")],
             ),
             pytest.param(
                 *[
@@ -110,7 +109,7 @@ class TestDeleteRbdPool(ManageTest):
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
                 ],
-                marks=pytest.mark.polarion_id("OCS-5135"),
+                marks=[tier3, pytest.mark.polarion_id("OCS-5135")],
             ),
             pytest.param(
                 *[
@@ -119,7 +118,7 @@ class TestDeleteRbdPool(ManageTest):
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
                 ],
-                marks=pytest.mark.polarion_id("OCS-5136"),
+                marks=[tier3, pytest.mark.polarion_id("OCS-5136")],
             ),
             pytest.param(
                 *[
@@ -128,7 +127,7 @@ class TestDeleteRbdPool(ManageTest):
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
                 ],
-                marks=pytest.mark.polarion_id("OCS-5137"),
+                marks=[tier3, pytest.mark.polarion_id("OCS-5137")],
             ),
         ],
     )
@@ -180,7 +179,7 @@ class TestDeleteRbdPool(ManageTest):
                 "cephblockpool deletion should fail if referenced by storageclass"
             )
 
-    @tier1
+    @tier3
     @skipif_external_mode
     @skipif_ibm_cloud_managed
     @pytest.mark.parametrize(

--- a/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
+++ b/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
-@tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.6")
 class TestCreateNewScWithNeWRbDPool(ManageTest):
@@ -37,7 +36,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2400"),
+                marks=[tier1, pytest.mark.polarion_id("OCS-2400")],
             ),
             pytest.param(
                 *[
@@ -46,7 +45,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2397"),
+                marks=[tier2, pytest.mark.polarion_id("OCS-2397")],
             ),
             pytest.param(
                 *[
@@ -55,7 +54,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2401"),
+                marks=[tier2, pytest.mark.polarion_id("OCS-2401")],
             ),
             pytest.param(
                 *[
@@ -64,7 +63,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
                 ],
-                marks=pytest.mark.polarion_id("OCS-2406"),
+                marks=[tier2, pytest.mark.polarion_id("OCS-2406")],
             ),
         ],
     )

--- a/tests/functional/storageclass/test_rbd_default_storageclass.py
+++ b/tests/functional/storageclass/test_rbd_default_storageclass.py
@@ -5,7 +5,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import templating
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.framework.pytest_customization.marks import (
-    tier1,
+    tier3,
     green_squad,
     polarion_id,
     baremetal_deployment_required,
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 @baremetal_deployment_required
 @ui_deployment_required
 class TestRBDStorageClassAsDefaultStorageClass:
-    @tier1
+    @tier3
     @polarion_id("OCS-5459")
     def test_pvc_creation_without_storageclass_name(self, pvc_factory, pod_factory):
         """

--- a/tests/functional/storageclass/test_storageclass_reclaim_space.py
+++ b/tests/functional/storageclass/test_storageclass_reclaim_space.py
@@ -7,7 +7,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     polarion_id,
-    tier1,
+    tier2,
 )
 
 log = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class TestStorageClassReclamespace:
         log.info(f" RBD Image { rbd_image_name} is size of {image_size}GiB")
         return True
 
-    @tier1
+    @tier2
     def test_storageclass_reclaimspace(
         self, storageclass_factory, multi_pvc_factory, pod_factory
     ):

--- a/tests/functional/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
+++ b/tests/functional/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility import templating
 from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import ManageTest, tier1, skipif_external_mode
+from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
 from tests.fixtures import (
     create_ceph_block_pool,
     create_rbd_secret,
@@ -20,7 +20,7 @@ SC_OBJ = None
 
 @green_squad
 @skipif_external_mode
-@tier1
+@tier2
 @pytest.mark.usefixtures(
     create_rbd_secret.__name__,
     create_cephfs_secret.__name__,

--- a/tests/functional/ui/test_non_admin_user.py
+++ b/tests/functional/ui/test_non_admin_user.py
@@ -17,7 +17,6 @@ from ocs_ci.framework.testlib import (
     ui,
     polarion_id,
     tier2,
-    tier1,
     E2ETest,
 )
 from ocs_ci.utility.utils import ceph_health_check
@@ -77,7 +76,7 @@ class TestUnprivilegedUserODFAccess(E2ETest):
     """
 
     @ui
-    @tier1
+    @tier2
     @runs_on_provider
     @skipif_ibm_cloud_managed
     @polarion_id("OCS-4667")

--- a/tests/functional/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
+++ b/tests/functional/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
@@ -6,6 +6,7 @@ from ocs_ci.ocs.cluster import ceph_health_check
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     tier1,
+    tier2,
     ManageTest,
     ignore_leftovers,
 )
@@ -29,7 +30,6 @@ log = logging.getLogger(__name__)
 
 
 @magenta_squad
-@tier1
 @ignore_leftovers
 class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
     """
@@ -47,6 +47,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
 
         request.addfinalizer(finalizer)
 
+    @tier2
     @skipif_bm
     @skipif_external_mode
     @ipi_deployment_required
@@ -67,6 +68,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         ceph_health_check()
         log.info("The resources created successfully using the kube job")
 
+    @tier2
     @ms_provider_and_consumer_required
     def test_create_scale_pods_and_pvcs_using_kube_job_ms(
         self, create_scale_pods_and_pvcs_using_kube_job
@@ -96,6 +98,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         log.info("The resources created successfully using the kube job")
 
     @skipif_ms_provider_and_consumer
+    @tier1
     @ms_consumer_required
     def test_create_scale_pods_and_pvcs_with_ms_consumer(
         self, create_scale_pods_and_pvcs_using_kube_job
@@ -171,6 +174,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJobWithMSConsumers(ManageTest):
 
         log.info("All the pods and PVCs were deleted successfully on the consumers")
 
+    @tier1
     def test_create_scale_pods_and_pvcs_with_ms_consumers(
         self, create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
     ):
@@ -206,6 +210,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJobWithMSConsumers(ManageTest):
             "The scale pods and PVCs using a kube job with MS consumers created successfully"
         )
 
+    @tier1
     def test_create_and_delete_scale_pods_and_pvcs_with_ms_consumers(
         self, create_scale_pods_and_pvcs_using_kube_job_on_ms_consumers
     ):
@@ -303,6 +308,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJobWithHCIClients(ManageTest):
 
         log.info("All the pods and PVCs were deleted successfully on the clients")
 
+    @tier2
     @pytest.mark.polarion_id("OCS-5428")
     def test_create_scale_pods_and_pvcs_with_hci_clients(
         self, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients
@@ -340,6 +346,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJobWithHCIClients(ManageTest):
         )
 
     @pytest.mark.polarion_id("OCS-5429")
+    @tier2
     def test_create_and_delete_scale_pods_and_pvcs_with_hci_clients(
         self, create_scale_pods_and_pvcs_using_kube_job_on_hci_clients
     ):

--- a/tests/functional/workloads/test_data_consistency.py
+++ b/tests/functional/workloads/test_data_consistency.py
@@ -9,7 +9,7 @@ import yaml
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import magenta_squad
-from ocs_ci.framework.testlib import tier1
+from ocs_ci.framework.testlib import tier2
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import exceptions
 from ocs_ci.ocs import ocp
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 @magenta_squad
-@tier1
+@tier2
 @pytest.mark.polarion_id("OCS-2735")
 def test_log_reader_writer_parallel(project, tmp_path):
     """

--- a/tests/functional/z_cluster/cluster_expansion/test_create_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_create_multiple_device_classes.py
@@ -4,7 +4,7 @@ import pytest
 from ocs_ci.framework.testlib import (
     ManageTest,
     ignore_leftovers,
-    tier1,
+    tier2,
     brown_squad,
     skipif_no_lso,
     skipif_bm,
@@ -33,7 +33,6 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
-@tier1
 @ignore_leftovers
 @skipif_no_lso
 @skipif_bm
@@ -61,6 +60,7 @@ class TestMultipleDeviceClasses(ManageTest):
         log.info("Wait for the ceph health to be OK")
         ceph_health_check(tries=20)
 
+    @tier2
     def test_add_new_ssd_device_class(
         self, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
     ):

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -21,6 +21,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
     tier1,
+    tier2,
     tier4b,
     tier4c,
     tier4a,
@@ -302,10 +303,7 @@ class TestResizeOSD(ManageTest):
         resize_osd(self.new_storage_size)
         self.verification_steps_post_resize_osd()
 
-    @tier1
-    @tier4a
-    @tier4b
-    @tier4c
+    @tier2
     @black_squad
     @pytest.mark.order("last")
     @polarion_id("OCS-5800")

--- a/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
+++ b/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
@@ -5,7 +5,7 @@ import pytest
 from time import sleep
 from ocs_ci.ocs import constants, node
 from ocs_ci.framework.pytest_customization.marks import brown_squad
-from ocs_ci.framework.testlib import E2ETest, tier1
+from ocs_ci.framework.testlib import E2ETest, tier4, tier4b
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.node import get_worker_nodes
 from concurrent.futures import ThreadPoolExecutor
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
-@tier1
 class TestKernelCrash(E2ETest):
     """
     Tests to verify kernel crash
@@ -62,6 +61,8 @@ class TestKernelCrash(E2ETest):
             ),
         ],
     )
+    @tier4
+    @tier4b
     def test_node_kernel_crash_ceph_fsync(
         self, pvc_factory, teardown_factory, deployment_pod_factory, interface_type
     ):

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_external_mode,
     skipif_mcg_only,
     post_ocs_upgrade,
@@ -188,6 +189,7 @@ class TestCephDefaultValuesCheck(ManageTest):
     @pytest.mark.polarion_id("OCS-2739")
     @skipif_managed_service
     @skipif_ocs_version("<4.9")
+    @tier2
     def test_noobaa_postgres_cm_post_ocs_upgrade(self):
         """
         Validate noobaa postgres configmap post OCS upgrade

--- a/tests/functional/z_cluster/test_must_gather.py
+++ b/tests/functional/z_cluster/test_must_gather.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
+    tier2,
     skipif_external_mode,
     skipif_ms_consumer,
     skipif_hci_client,
@@ -38,6 +39,7 @@ class TestMustGather(ManageTest):
             pytest.param(
                 *["CEPH"],
                 marks=[
+                    tier2,
                     pytest.mark.polarion_id("OCS-1583"),
                     skipif_external_mode,
                     skipif_ms_consumer,
@@ -47,13 +49,16 @@ class TestMustGather(ManageTest):
             pytest.param(
                 *["JSON"],
                 marks=[
+                    tier1,
                     pytest.mark.polarion_id("OCS-1583"),
                     skipif_external_mode,
                     skipif_ms_consumer,
                     skipif_hci_client,
                 ]
             ),
-            pytest.param(*["OTHERS"], marks=pytest.mark.polarion_id("OCS-1583")),
+            pytest.param(
+                *["OTHERS"], marks=[tier2, pytest.mark.polarion_id("OCS-1583")]
+            ),
         ],
     )
     @pytest.mark.skipif(


### PR DESCRIPTION
Backport of https://github.com/red-hat-storage/ocs-ci/pull/12413 to release-4.18