### PR TITLE
Workaround: lock zope.event==5.0 as workaround for issue with 5.1 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         # new version of marshmallow 4.0.0 seems to be broken, failing with error:
         # TypeError: __init__() got an unexpected keyword argument 'default'
         "marshmallow==3.26.1",
+        "zope.event==5.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/12483