### PR TITLE
bump catsrc of hcp clients on upgrade

### DIFF
--- a/ocs_ci/ocs/acm_upgrade.py
+++ b/ocs_ci/ocs/acm_upgrade.py
@@ -32,7 +32,7 @@ class ACMUpgrade(object):
         # Hence we can't rely on ENV_DATA['acm_version'] for the pre-upgrade version
         # we need to dynamically find it
         self.version_before_upgrade = self.get_acm_version_before_upgrade()
-        self.upgrade_version = config.UPGRADE["upgrade_acm_version"]
+        self.upgrade_version = config.UPGRADE.get(["upgrade_acm_version"], "")
         # In case if we are using registry image
         self.acm_registry_image = config.UPGRADE.get("upgrade_acm_registry_image", "")
         self.zstream_upgrade = False


### PR DESCRIPTION
following the discussion in slack thread: we need to manually bump image tag in catalog sources of client clusters before starting or during ODF upgrade: https://url.corp.redhat.com/c02f0d2 
