### PR TITLE
removed import create_unique_resource_name from vm_snapshot_restore_f…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10082,7 +10082,6 @@ def vm_snapshot_restore_fixture(request):
         """
         from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
         from ocp_resources.virtual_machine_restore import VirtualMachineRestore
-        from ocs_ci.utility.utils import create_unique_resource_name
 
         snapshot_name = f"snapshot-{vm.name}"
         vm_snapshot = VirtualMachineSnapshot(


### PR DESCRIPTION
removed import create_unique_resource_name from vm_snapshot_restore_fixture

fixes- https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/852/33474/1638295/1638338/log 