### PR TITLE
Skips executing IBM backed NSFS creation test if FIPS is enabled on cluster

### DIFF
--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -182,6 +182,7 @@ class TestNamespace(MCGTest):
                 marks=[
                     tier2,
                     pytest.mark.polarion_id("OCS-6355"),
+                    skipif_fips_enabled,
                 ],
             ),
             pytest.param(


### PR DESCRIPTION
Skips executing IBM backed NSFS creation test if FIPS is enabled on cluster

Fixes #12634 