### PR TITLE
To skip system_test.test_mcg_replication_with_disruptions on aws

### DIFF
--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -15,7 +15,6 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    tier2,
     system_test,
     skipif_vsphere_ipi,
     magenta_squad,
@@ -100,13 +99,13 @@ class TestMCGReplicationWithDisruptions(E2ETest):
                         "namespacestore_dict": {"rgw": [(1, None)]},
                     },
                 },
-                marks=[tier2, pytest.mark.polarion_id("OCS-3906")],
             ),
         ],
         ids=[
             "AZUREtoAWS-NS-CLI",
         ],
     )
+    @polarion_id("OCS-3906")
     def test_replication_with_disruptions(
         self,
         awscli_pod_session,

--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -68,6 +68,7 @@ logger = logging.getLogger(__name__)
 @skipif_ocs_version("<4.9")
 @skipif_vsphere_ipi
 @skipif_external_mode
+@skipif_aws_creds_are_missing
 @skipif_mcg_only
 class TestMCGReplicationWithDisruptions(E2ETest):
     """


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/ocs-ci/issues/10736