### PR TITLE
Added marker to skip for hci-clients

### DIFF
--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     tier4c,
     skipif_external_mode,
+    skipif_hci_client,
 )
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
@@ -50,6 +51,7 @@ def verify_active_and_standby_mds_count(target_count):
 @brown_squad
 @tier4c
 @skipif_external_mode
+@skipif_hci_client
 class TestMultipleMds:
     """
     Tests for support multiple mds

--- a/tests/functional/z_cluster/test_storagesystem.py
+++ b/tests/functional/z_cluster/test_storagesystem.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     brown_squad,
     ManageTest,
     tier1,
+    skipif_hci_client,
 )
 from ocs_ci.framework.logger_helper import log_step
 
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@skipif_hci_client
 class TestStorageSystem(ManageTest):
     """
     Verify the ceph full thresholds storagecluster parameters move to cephcluster

--- a/tests/functional/z_cluster/test_storagesystem.py
+++ b/tests/functional/z_cluster/test_storagesystem.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     brown_squad,
     ManageTest,
     tier1,
+    skipif_ocs_version,
     skipif_hci_client,
 )
 from ocs_ci.framework.logger_helper import log_step
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@skipif_ocs_version("<4.19")
 @skipif_hci_client
 class TestStorageSystem(ManageTest):
     """


### PR DESCRIPTION
Added 'skipif_hci_client' marker to below test cases, 

> ocs-ci/tests/functional/z_cluster/test_multiple_mds.py 
> ocs-ci/tests/functional/z_cluster/test_storagesystem.py

And added 'storagesystem' unavailable error as part of the test case

validation of test_storagesystem.py: http://magna002.ceph.redhat.com/ocsci-jenkins/openshift-clusters/ammahapa-419-upi/ammahapa-419-upi_20250708T075206/logs/test_report_1752486428.html