### PR TITLE
Add runs_on_provider decorator in TestMonFailuresWithIntransitEncryption

### DIFF
--- a/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
+++ b/tests/functional/encryption/test_mon_failure_in_intransit_encryption.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     skipif_ocs_version,
     green_squad,
+    runs_on_provider,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -23,11 +24,11 @@ from ocs_ci.helpers.helpers import modify_deployment_replica_count
 log = logging.getLogger(__name__)
 
 
-@green_squad
 @tier4a
 @skipif_ocs_version("<4.13")
 @pytest.mark.polarion_id("OCS-4919")
 @green_squad
+@runs_on_provider
 class TestMonFailuresWithIntransitEncryption:
     @pytest.fixture(autouse=True)
     def teardown_fixture(self, request):


### PR DESCRIPTION
Add the marker `runs_on_provider` in the test tests/functional/encryption/test_mon_failure_in_intransit_encryption.py::TestMonFailuresWithIntransitEncryption::test_mon_failures_with_intransit_encryption

The test steps are designed to run on the provider cluster only.
Removed duplicate marker `green_squad`.
Fixes #12645 