### PR TITLE
Soft-force specific <resource> when create OCP object [Reduce Logs]

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -198,6 +198,9 @@ STORAGECLUSTER = "storagecluster"
 CLUSTER_OPERATOR = "ClusterOperator"
 CRONJOB = "CronJob"
 MONITORING = "monitoring"
+
+# Resource types that can produce massive output when queried without selectors
+HIGH_VOLUME_RESOURCES = {POD, NODE, PVC, SERVICE, DEPLOYMENT, DAEMONSET, CONFIGMAP}
 CLUSTER_SERVICE_VERSION = "csv"
 JOB = "job"
 OAUTH = "OAuth"

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -102,7 +102,7 @@ def test_ceph_mgr_dashboard_not_deployed():
         kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
     )
     # if there is no "items" in the reply, OCS is very broken
-    ocs_pods = ocp_pod.get()["items"]
+    ocs_pods = ocp_pod.get(selector="ALL")["items"]
     for pod_item in ocs_pods:
         # just making the assumptions explicit
         assert pod_item["kind"] == constants.POD


### PR DESCRIPTION
- [ ] OCP Resource Query Validation System
- [ ] HIGH_VOLUME_RESOURCES Protection (constant)
- [ ] selector="ALL" Explicit Bypass

This PR should prevent creation of resource without specify selector or name, in order to prevent cases like getting all pods in yaml format when it is not required
With the merge if this PR, in such cases `Warning` will be raised, and test owner should decide how to proceed:
1. if needed-> add `selector=ALL`
2. if not -> modify test to only print necessary data