### PR TITLE
fix retry code for StorageCluster creation

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -257,7 +257,9 @@ class ODFAndNativeStorageClientDeploymentOnProvider(object):
                 CommandFailed,
                 tries=12,
                 delay=15,
-            )(self.ocp_obj.exec_oc_cmd(f"apply -f {storage_cluster_path}"))
+            )(
+                self.ocp_obj.exec_oc_cmd
+            )(f"apply -f {storage_cluster_path}")
 
         # Creating toolbox pod
         setup_ceph_toolbox()


### PR DESCRIPTION
in provider_client/storage_client_deployment.py module

The original `retry` logic didn't work properly, because for example in this job: https://url.corp.redhat.com/edcdcb0 the StorageCluster creation command was executed only once and wasn't re-tried:
```
2025-07-15 18:11:04  12:11:01 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig apply -f /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml
2025-07-15 18:11:04  12:11:01 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: resource mapping not found for name: "ocs-storagecluster" namespace: "openshift-storage" from "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml": no matches for kind "StorageCluster" in version "ocs.openshift.io/v1"
2025-07-15 18:11:04  ensure CRDs are installed first
...
2025-07-15 18:11:04  >           deployer.deploy_cluster(log_cli_level)
2025-07-15 18:11:04  
2025-07-15 18:11:04  tests/conftest.py:2090: 
2025-07-15 18:11:04  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-07-15 18:11:04  ocs_ci/deployment/deployment.py:770: in deploy_cluster
2025-07-15 18:11:04      self.do_deploy_odf_provider_mode()
2025-07-15 18:11:04  ocs_ci/deployment/deployment.py:642: in do_deploy_odf_provider_mode
2025-07-15 18:11:04      storage_client_deployment_obj.provider_and_native_client_installation()
2025-07-15 18:11:04  ocs_ci/deployment/provider_client/storage_client_deployment.py:260: in provider_and_native_client_installation
2025-07-15 18:11:04      )(self.ocp_obj.exec_oc_cmd(f"apply -f {storage_cluster_path}"))
2025-07-15 18:11:04  ocs_ci/ocs/ocp.py:216: in exec_oc_cmd
2025-07-15 18:11:04      out = run_cmd(
2025-07-15 18:11:04  ocs_ci/utility/utils.py:492: in run_cmd
2025-07-15 18:11:04      completed_process = exec_cmd(
...
2025-07-15 18:11:04  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig apply -f /home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml.
2025-07-15 18:11:04  E               Error is error: resource mapping not found for name: "ocs-storagecluster" namespace: "openshift-storage" from "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/templates/ocs-deployment/provider-mode/ocs_storagecluster_converged.yaml": no matches for kind "StorageCluster" in version "ocs.openshift.io/v1"
2025-07-15 18:11:04  E               ensure CRDs are installed first
2025-07-15 18:11:04  
2025-07-15 18:11:04  ocs_ci/utility/utils.py:732: CommandFailed
```

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/12666