### PR TITLE
Add a new test for autoscaler behavior with OCS operator deletion and updates metadata for existing autoscaler-related tests

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6215,7 +6215,7 @@ def create_auto_scaler(
     namespace=None,
     sc_name=None,
     device_class=None,
-    capacity_limit="4Ti",
+    capacity_limit="8Ti",
     scaling_threshold=70,
     max_osd_size="8Ti",
     timeout=1800,

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3776,7 +3776,7 @@ def check_ceph_osd_df_tree():
             return False
         # If it's a regular OSD entry, check if the expected osd size
         # and the current size are equal ignoring a small diff
-        diff = size * 0.02
+        diff = size * 0.04
         if not osd_id.startswith("-") and not (
             size - diff <= storage_size <= size + diff
         ):


### PR DESCRIPTION
This PR introduces a new test to validate the behavior of the StorageAutoScaler when the OCS operator is deleted during scaling, alongside improvements to cluster fill-up logic and test class structure. 

In the PR, I implemented the following:
- Added new test: test_auto_scaling_with_ocs_operator_delete
- Refactored test class hierarchy to introduce TestStorageAutoscalerBase for shared utilities
- Improved fill_up_cluster method with fast_fill_up option to reduce runtime
- Moved verify_autoscaler_no_trigger_steps to base class for reuse
- Added Polarion IDs to multiple autoscaler tests
