### PR TITLE
skip capacity_breakdown test if disconnected. Container not found problem. Cluster cant download image

### DIFF
--- a/tests/functional/ui/test_capacity_breakdown_ui.py
+++ b/tests/functional/ui/test_capacity_breakdown_ui.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     runs_on_provider,
     skipif_ibm_cloud_managed,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
@@ -131,6 +132,7 @@ class TestCapacityBreakdownUI(ManageTest):
     @tier3
     @skipif_ibm_cloud_managed
     @polarion_id("OCS-5122")
+    @skipif_disconnected_cluster
     def test_requested_capacity_breakdown(
         self, setup_ui_class, teardown_project_factory
     ):

--- a/tests/functional/ui/test_odf_storage_consumption_trend.py
+++ b/tests/functional/ui/test_odf_storage_consumption_trend.py
@@ -280,6 +280,7 @@ class TestConsumptionTrendUI(ManageTest):
         average = block_and_file_page.get_avg_consumption_from_ui()
         logger.info(f"From the UI, Estimated Days: {est_days} and Average: {average}")
         days_avg_tpl = validation_ui_obj.calculate_est_days_and_average_manually()
+
         first_validation = est_days == days_avg_tpl[0]
         # rel_tol 0.1 means upto 10% tolerance, which means that difference between  manual and UI est days is up to 10%
         second_validation = math.isclose(est_days, days_avg_tpl[0], rel_tol=0.1)


### PR DESCRIPTION
We need to skip execution of the test on disconnected environment to avoid failure noise. This is cluster env limitation.