### PR TITLE
A fix to test_nonexist_bucket_delete test case

### DIFF
--- a/tests/functional/object/mcg/test_bucket_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_deletion.py
@@ -164,7 +164,7 @@ class TestBucketDeletion(MCGTest):
                 cli_del = mcg_obj.exec_mcg_cmd(f"obc delete {name}")
                 assert cli_del, "Unexpected cli delete non-exist OBC succeed"
             except CommandFailed as err:
-                assert "Could not delete OBC" in str(
+                assert "Could not delete. OBC" in str(
                     err
                 ), "Couldn't verify delete non-exist OBC with cli"
         logger.info(f"Delete non-exist OBC {name} failed as expected")


### PR DESCRIPTION
This PR fixes : https://github.com/red-hat-storage/ocs-ci/issues/11411.

The error message was updated, therefore we needed to catch the correct message in the test code.