### PR TITLE
Skip crash test in stretch cluster until we have WA implemented or fix

### DIFF
--- a/tests/functional/disaster-recovery/sc_arbiter/test_zone_shutdown_and_crash.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_zone_shutdown_and_crash.py
@@ -31,6 +31,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     turquoise_squad,
     stretchcluster_required,
+    jira,
 )
 
 log = logging.getLogger(__name__)
@@ -366,6 +367,7 @@ class TestZoneShutdownsAndCrashes:
         ), "Data is corrupted for RBD workloads"
         log.info("No data corruption is seen in RBD workloads")
 
+    @jira("DFBUGS-3636")
     @pytest.mark.parametrize(
         argnames="iteration, delay",
         argvalues=[


### PR DESCRIPTION
There is https://issues.redhat.com/browse/DFBUGS-3636 issue with kubelet that is triggered after the node crash. This will impact other test as well. Hence we need to skip this test until we have fix or WA implemented