### PR TITLE
odf-cli: Add support for odf-cli noobaa command

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4737,7 +4737,7 @@ def retrieve_cli_binary(cli_type="mcg"):
     if cli_type == "mcg":
         local_cli_path = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
     elif cli_type == "odf":
-        local_cli_path = os.path.join(config.RUN["bin_dir"], "odf-cli")
+        local_cli_path = constants.ODF_CLI_LOCAL_PATH
     local_cli_dir = os.path.dirname(local_cli_path)
     live_deployment = config.DEPLOYMENT["live_deployment"]
     if live_deployment and semantic_version >= version.VERSION_4_13:

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2238,6 +2238,8 @@ RGW_ROUTE_EXTERNAL_MODE = "ocs-external-storagecluster-cephobjectstore"
 NOOBAA_OPERATOR_POD_CLI_PATH = "/usr/local/bin/noobaa-operator"
 NOOBAA_OPERATOR_LOCAL_CLI_PATH = os.path.join(DATA_DIR, "mcg-cli")
 CLI_TOOL_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
+# New constant for unified CLI usage (same as CLI_TOOL_LOCAL_PATH but more explicit)
+ODF_CLI_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
 DEFAULT_INGRESS_CRT = "router-ca.crt"
 DEFAULT_INGRESS_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{DEFAULT_INGRESS_CRT}"
 SERVICE_CA_CRT = "service-ca.crt"
@@ -3462,3 +3464,43 @@ HIGH_RECOVERY_OPS = "high_recovery_ops"
 MCLOCK_HIGH_CLIENT_OPS = "high_client_ops"
 MCLOCK_BALANCED = "balanced"
 MCLOCK_HIGH_RECOVERY_OPS = "high_recovery_ops"
+
+
+def get_noobaa_cli_path():
+    """
+    Get the appropriate NooBaa CLI path based on OCS version.
+
+    For OCS version >= 4.20: Returns path to odf-cli
+    For OCS version < 4.20: Returns path to mcg-cli
+
+    Returns:
+        str: Path to the CLI binary to use for NooBaa operations
+    """
+    from ocs_ci.utility import version
+
+    ocs_version = version.get_semantic_ocs_version_from_config()
+
+    if ocs_version >= version.VERSION_4_20:
+        return ODF_CLI_LOCAL_PATH
+    else:
+        return NOOBAA_OPERATOR_LOCAL_CLI_PATH
+
+
+def get_noobaa_cli_command_prefix():
+    """
+    Get the appropriate command prefix for NooBaa CLI operations.
+
+    For OCS version >= 4.20: Returns 'noobaa' (for odf-cli noobaa <command>)
+    For OCS version < 4.20: Returns '' (for mcg-cli <command>)
+
+    Returns:
+        str: Command prefix to insert between CLI binary and actual command
+    """
+    from ocs_ci.utility import version
+
+    ocs_version = version.get_semantic_ocs_version_from_config()
+
+    if ocs_version >= version.VERSION_4_20:
+        return "noobaa"
+    else:
+        return ""

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -94,16 +94,22 @@ class MCG:
                 resource=self.operator_pod, state=constants.STATUS_RUNNING, timeout=300
             )
 
+            # Determine which CLI to use based on version
+            cli_path = constants.get_noobaa_cli_path()
+            ocs_version = version.get_semantic_ocs_version_from_config()
+
             if (
-                not os.path.isfile(constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH)
-                or self.get_mcg_cli_version().minor
-                != version.get_semantic_ocs_version_from_config().minor
+                not os.path.isfile(cli_path)
+                or self.get_mcg_cli_version().minor != ocs_version.minor
             ):
                 logger.info(
-                    "The expected MCG CLI binary could not be found,"
+                    "The expected NooBaa CLI binary could not be found,"
                     " downloading the expected version"
                 )
-                retrieve_cli_binary(cli_type="mcg")
+                if ocs_version >= version.VERSION_4_20:
+                    retrieve_cli_binary(cli_type="odf")
+                else:
+                    retrieve_cli_binary(cli_type="mcg")
 
             """
             The certificate will be copied on each mcg_obj instantiation since
@@ -944,7 +950,10 @@ class MCG:
         self, cmd, namespace=None, use_yes=False, ignore_error=False, **kwargs
     ):
         """
-        Executes an MCG CLI command through the noobaa-operator pod's CLI binary
+        Executes a NooBaa CLI command through the appropriate CLI binary
+
+        For OCS >= 4.20: Uses odf-cli noobaa <command>
+        For OCS < 4.20: Uses mcg-cli <command>
 
         Args:
             cmd (str): The command to run
@@ -961,20 +970,32 @@ class MCG:
 
         namespace = f"-n {namespace}" if namespace else f"-n {self.namespace}"
 
+        # Get version-appropriate CLI path and command prefix
+        cli_path = constants.get_noobaa_cli_path()
+        command_prefix = constants.get_noobaa_cli_command_prefix()
+
+        # Build the full command
+        if command_prefix:
+            # For odf-cli: odf-cli noobaa <command>
+            full_cmd = f"{cli_path} {command_prefix} {cmd} {namespace}"
+        else:
+            # For mcg-cli: mcg-cli <command>
+            full_cmd = f"{cli_path} {cmd} {namespace}"
+
         # Mask sensitive data
         if self.data_to_mask:
             kwargs.setdefault("secrets", []).extend(self.data_to_mask)
 
         if use_yes:
             result = exec_cmd(
-                [f"yes | {constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH} {cmd} {namespace}"],
+                [f"yes | {full_cmd}"],
                 ignore_error=ignore_error,
                 shell=True,
                 **kwargs,
             )
         else:
             result = exec_cmd(
-                f"{constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH} {cmd} {namespace}",
+                full_cmd,
                 ignore_error=ignore_error,
                 **kwargs,
             )
@@ -1062,30 +1083,45 @@ class MCG:
 
     def get_mcg_cli_version(self):
         """
-        Get the MCG CLI version by parsing the output of the `mcg-cli version` command.
+        Get the NooBaa CLI version by parsing the output of the version command.
 
         Example output of the mcg-cli version command:
-
             INFO[0000] CLI version: 5.12.0
             INFO[0000] noobaa-image: noobaa/noobaa-core:master-20220913
             INFO[0000] operator-image: noobaa/noobaa-operator:5.12.0
+
+        Example output of the odf-cli noobaa version command:
+            CLI version: 5.20.0
+            noobaa-image: noobaa/noobaa-core:master-20240101
+            operator-image: noobaa/noobaa-operator:5.20.0
 
         Returns:
             semantic_version.base.Version: Object of semantic version.
 
         """
 
-        # mcg-cli sends the output to stderr in this case
-        cmd_output = self.exec_mcg_cmd("version").stderr
+        # Execute version command using appropriate CLI
+        cmd_result = self.exec_mcg_cmd("version")
+
+        # Try stderr first (mcg-cli sends output to stderr)
+        # Then try stdout (odf-cli might send to stdout)
+        cmd_output = (
+            cmd_result.stderr if cmd_result.stderr.strip() else cmd_result.stdout
+        )
 
         # \s* captures any number of spaces
         # \S+ captures any number of non-space characters
         regular_expression = r"CLI version:\s*(\S+)"
 
         # group(1) is the first capturing group, which is the version string
-        mcg_cli_version_str = re.search(
-            regular_expression, cmd_output, re.IGNORECASE
-        ).group(1)
+        match = re.search(regular_expression, cmd_output, re.IGNORECASE)
+
+        if not match:
+            logger.warning(f"Could not parse CLI version from output: {cmd_output}")
+            # Fallback to current OCS version if parsing fails
+            return version.get_semantic_ocs_version_from_config()
+
+        mcg_cli_version_str = match.group(1)
 
         return version.get_semantic_version(mcg_cli_version_str, only_major_minor=True)
 

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -68,6 +68,7 @@ VERSION_4_16 = get_semantic_version("4.16", True)
 VERSION_4_17 = get_semantic_version("4.17", True)
 VERSION_4_18 = get_semantic_version("4.18", True)
 VERSION_4_19 = get_semantic_version("4.19", True)
+VERSION_4_20 = get_semantic_version("4.20", True)
 
 
 def get_semantic_ocs_version_from_config(cluster_config=None):


### PR DESCRIPTION
Add support for odf-cli noobaa command transition in OCS 4.20+ with version-based CLI selection, proper binary retrieval, and formatting fixes