### PR TITLE
Inscreasing timeouts for nss creation and nss deletion

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -90,7 +90,7 @@ class NamespaceStore:
         }
         if retry:
             sample = TimeoutSampler(
-                timeout=120,
+                timeout=240,
                 sleep=20,
                 func=cmdMap[self.method],
             )
@@ -156,7 +156,7 @@ class NamespaceStore:
             == constants.STATUS_READY
         )
 
-    def verify_health(self, timeout=180, interval=5):
+    def verify_health(self, timeout=240, interval=5):
         """
         Health verification function that tries to verify
         a namespacestores's health until a given time limit is reached


### PR DESCRIPTION
This PR resolves issue https://github.com/red-hat-storage/ocs-ci/issues/12132 and https://github.com/red-hat-storage/ocs-ci/issues/12112 .

The upper limit of the timeouts was increased, while the timeout sampler will make sure that in case the operation takes less than timeout - the test will proceed and will not wait for 240 sec. 