### PR TITLE
consumer and configmap post-deploy verification internal and external

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -56,6 +56,7 @@ from ocs_ci.ocs.resources.storageconsumer import (
     check_consumer_rns,
     get_ready_consumers_names,
     check_consumer_svg,
+    verify_storage_consumer_resources,
 )
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.version import if_version
@@ -312,7 +313,7 @@ class HostedClients(HyperShiftBase):
                 else:
                     start_time = time.time()
                     client_installed = hosted_odf.setup_storage_client_converged(
-                        storage_consumer_name=f"consumer-{cluster_name}"
+                        storage_consumer_name=f"{constants.STORAGECONSUMER_NAME_PREFIX}{cluster_name}"
                     )
                     time_taken = time.time() - start_time
                     time_sec = int(time_taken % 60) + 1
@@ -355,6 +356,20 @@ class HostedClients(HyperShiftBase):
             for name in cluster_names
             if self.storage_installation_requested(name)
         )
+
+        log_step("storage consumers and configmaps for newly deployed clients")
+        storage_consumers_verified = []
+        for cluster_name in hosted_odf_clusters_installed:
+            try:
+                verify_storage_consumer_resources(
+                    f"{constants.STORAGECONSUMER_NAME_PREFIX}{cluster_name}"
+                )
+                storage_consumers_verified.append(True)
+            except Exception as e:
+                logger.error(
+                    f"Storage consumer resources verification failed for cluster {cluster_name}: {e}"
+                )
+                storage_consumers_verified.append(False)
 
         log_step("verify backing Ceph storage for newly deployed clients")
 
@@ -412,6 +427,9 @@ class HostedClients(HyperShiftBase):
         assert all(
             svg_for_consumer_verified
         ), "SVG for consumers of deployed clusters failed verification"
+        assert all(
+            storage_consumers_verified
+        ), "Storage consumer resources verification failed for some of the clusters"
 
         return hosted_odf_clusters_installed
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -229,6 +229,7 @@ STORAGECLASSCLAIM = "StorageClassClaim"
 # Deprecated and data moved to StorageClient starting from 4.19
 STORAGECLAIM = "StorageClaim"
 STORAGECONSUMER = "StorageConsumer"
+STORAGECONSUMER_NAME_PREFIX = "consumer-"
 MACHINEHEALTHCHECK = "machinehealthcheck"
 STORAGECLIENT = "StorageClient"
 STORAGECLIENTS = "storageclients.ocs.openshift.io"


### PR DESCRIPTION
Verified with multiple clusters to confirm fresh, postupgrade, single-client and multi-client

Internal consumer check on Converged 4.20 multi-client

```
verify_storage_consumer_resources("internal")
StorageConsumer config map data match:
 {
  "cephfs-subvolumegroup": true,
  "cephfs-subvolumegroup-rados-ns": true,
  "rbd-rados-ns": true,
  "csi-cephfs-node-ceph-user": true,
  "csi-cephfs-provisioner-ceph-user": true,
  "csi-rbd-node-ceph-user": true,
  "csi-rbd-provisioner-ceph-user": true,
  "csiop-cephfs-client-profile": true,
  "csiop-rbd-client-profile": true
}
```

---------

External consumer check on Converged 4.20 multi-client

```
verify_storage_consumer_resources("consumer-cl-419-b")
StorageConsumer config map data match:
 {
  "cephfs-subvolumegroup": true,
  "cephfs-subvolumegroup-rados-ns": true,
  "rbd-rados-ns": true,
  "csi-cephfs-node-ceph-user": true,
  "csi-cephfs-provisioner-ceph-user": true,
  "csi-rbd-node-ceph-user": true,
  "csi-rbd-provisioner-ceph-user": true,
  "csiop-cephfs-client-profile": true,
  "csiop-rbd-client-profile": true
```

---------

Internal consumer check on Upgraded 4.18 -> 4.19 Single-client

```
verify_storage_consumer_resources("internal")
StorageConsumer config map data match:
 {
  "cephfs-subvolumegroup": true,
  "cephfs-subvolumegroup-rados-ns": true,
  "rbd-rados-ns": true,
  "csi-cephfs-node-ceph-user": true,
  "csi-cephfs-provisioner-ceph-user": true,
  "csi-rbd-node-ceph-user": true,
  "csi-rbd-provisioner-ceph-user": true,
  "csiop-cephfs-client-profile": true,
  "csiop-rbd-client-profile": true
}
```

---------

Internal consumer on fresh 4.19 Single-client

```
StorageConsumer config map data match:
 {
  "cephfs-subvolumegroup": true,
  "cephfs-subvolumegroup-rados-ns": true,
  "rbd-rados-ns": true,
  "csi-cephfs-node-ceph-user": true,
  "csi-cephfs-provisioner-ceph-user": true,
  "csi-rbd-node-ceph-user": true,
  "csi-rbd-provisioner-ceph-user": true,
  "csiop-cephfs-client-profile": true,
  "csiop-rbd-client-profile": true
}
```