### PR TITLE
use latest oc-mirror version for images mirroring

### DIFF
--- a/ocs_ci/helpers/disconnected.py
+++ b/ocs_ci/helpers/disconnected.py
@@ -11,7 +11,6 @@ from ocs_ci.ocs.exceptions import (
 from ocs_ci.utility.utils import (
     clone_repo,
     exec_cmd,
-    get_ocp_version,
     prepare_bin_dir,
 )
 
@@ -54,7 +53,7 @@ def get_oc_mirror_tool():
         # https://github.com/openshift/oc-mirror
         oc_mirror_repo = "https://github.com/openshift/oc-mirror.git"
         oc_mirror_dir = os.path.join(constants.EXTERNAL_DIR, "oc-mirror")
-        oc_mirror_branch = f"release-{get_ocp_version()}"
+        oc_mirror_branch = "main"
         clone_repo(url=oc_mirror_repo, location=oc_mirror_dir, branch=oc_mirror_branch)
         # build oc-mirror tool
         exec_cmd("make build", cwd=oc_mirror_dir)


### PR DESCRIPTION
Recently mirroring images for 4.17 failed with following error:

$ oc mirror --config imageset-config-1753355846917.yaml docker://mirror-registry.example.com:5000 --dest-skip-tls --ignore-history
...

error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: the manifest type *ocischema.DeserializedImageIndex is not supported
error: an error occurred during planning

This seems to be some limitation of older oc-mirror version, changing it to the latest one (main) where it seems to be fixed.