### PR TITLE
log improvements wait_for_resource_oc_wait

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -137,6 +137,9 @@ STATUS_POWERON = "ON"
 STATUS_POWEROFF = "OFF"
 STATUS_STOPPED = "stopped"
 STATUS_STOPPING = "stopping"
+STATUS_REPLACING = "Replacing"
+STATUS_SUCCEED = "Succeeded"
+STATUS_ACTIVE = "Active"
 
 # NooBaa statuses
 BS_AUTH_FAILED = "AUTH_FAILED"
@@ -151,7 +154,7 @@ HEALTHY_PV_BS = ["OPTIMAL", "LOW_CAPACITY"]
 # Storage-Auto-Scaler statuses
 NOT_STARTED = "NotStarted"
 IN_PROGRES = "InProgress"
-SUCCEEDED = "Succeeded"
+SUCCEEDED = STATUS_SUCCEED
 
 # noobaa-core config.js parameters
 CONFIG_JS_PREFIX = "CONFIG_JS_"

--- a/tests/libtest/test_log_improvements.py
+++ b/tests/libtest/test_log_improvements.py
@@ -1,0 +1,165 @@
+# Module for testing functions designed for log improvements
+import time
+
+import pytest
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import ignore_leftovers, libtest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
+from ocs_ci.ocs.ocp import OCP
+
+log = logging.getLogger(__name__)
+
+
+class TestWaitForResource:
+    pvc_size = 1
+
+    @pytest.fixture()
+    def pvc(self, pvc_factory_class):
+        self.pvc_obj = pvc_factory_class(
+            interface=constants.CEPHFILESYSTEM,
+            access_mode=constants.ACCESS_MODE_RWX,
+            size=self.pvc_size,
+        )
+
+    @pytest.fixture()
+    def pod(self, pod_factory_class):
+        self.pod_obj = pod_factory_class(
+            pvc=self.pvc_obj,
+            pod_dict_path=constants.PERF_POD_YAML,
+        )
+
+    @libtest
+    @ignore_leftovers
+    def test_wait_for_resource_oc_wait(self, pvc, pod):
+        """
+        Test the wait_for_resource_oc function to ensure it waits for a resource to be in different states
+        with different search strategies.
+
+        """
+        label = "wait_for_resource_oc_wait"
+
+        ocp_pod_obj = OCP(
+            kind=constants.POD,
+            namespace=self.pvc_obj.namespace,
+        )
+        ocp_pod_obj.get()
+        ocp_pod_obj.add_label(resource_name=self.pod_obj.name, label=f'{label}=""')
+
+        ocp_pvc_obj = OCP(
+            kind=constants.PVC,
+            namespace=self.pvc_obj.namespace,
+        )
+        ocp_pvc_obj.get()
+        ocp_pvc_obj.add_label(resource_name=self.pvc_obj.name, label=f'{label}=""')
+
+        # positive tests
+        start_time = time.time()
+        assert ocp_pod_obj.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            resource_name=self.pod_obj.name,
+            timeout=10,
+        )
+        log.info(
+            f"Time taken for pod {self.pod_obj.name} to be found in running state: "
+            f"{time.time() - start_time} seconds"
+        )
+
+        start_time = time.time()
+        assert ocp_pod_obj.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector=label,
+            timeout=10,
+        )
+        log.info(
+            f"Time taken for pod with label {label} to be found in running state: "
+            f"{time.time() - start_time} seconds"
+        )
+
+        start_time = time.time()
+        assert ocp_pvc_obj.wait_for_resource(
+            condition=constants.STATUS_BOUND,
+            resource_name=self.pvc_obj.name,
+            timeout=10,
+        )
+        log.info(
+            f"Time taken for pvc {self.pvc_obj.name} to be found in bound state: "
+            f"{time.time() - start_time} seconds"
+        )
+
+        start_time = time.time()
+        assert ocp_pvc_obj.wait_for_resource(
+            condition=constants.STATUS_BOUND,
+            selector=label,
+            timeout=10,
+        )
+        log.info(
+            f"Time taken for pvc with label {label} to be found in bound state: "
+            f"{time.time() - start_time} seconds"
+        )
+
+        # negative tests
+        with pytest.raises(TimeoutExpiredError, match=".*"):
+            ocp_pod_obj.wait_for_resource(
+                condition=constants.STATUS_FAILED,
+                resource_name=self.pod_obj.name,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. Pod {self.pod_obj.name} did not reach failed state within timeout"
+        )
+
+        with pytest.raises(TimeoutExpiredError, match=".*"):
+            ocp_pod_obj.wait_for_resource(
+                condition=constants.STATUS_FAILED,
+                selector=label,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. Pod with label {label} did not reach failed state within timeout"
+        )
+
+        with pytest.raises(TimeoutExpiredError, match=".*"):
+            ocp_pvc_obj.wait_for_resource(
+                condition=constants.STATUS_PENDING,
+                resource_name=self.pvc_obj.name,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. PVC {self.pvc_obj.name} did not reach released state within timeout"
+        )
+
+        with pytest.raises(TimeoutExpiredError, match=".*"):
+            ocp_pvc_obj.wait_for_resource(
+                condition=constants.STATUS_PENDING,
+                selector=label,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. PVC with label {label} did not reach released state within timeout"
+        )
+
+        # Clean up resources
+        ocp_pod_obj.delete(resource_name=self.pod_obj.name, wait=True, force=True)
+        ocp_pvc_obj.delete(resource_name=self.pvc_obj.name, wait=True, force=True)
+
+        with pytest.raises(CommandFailed, match=".*"):
+            ocp_pod_obj.wait_for_resource(
+                condition=constants.STATUS_RUNNING,
+                resource_name=self.pod_obj.name,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. Pod {self.pod_obj.name} does not exist after deletion"
+        )
+
+        with pytest.raises(CommandFailed, match=".*"):
+            ocp_pvc_obj.wait_for_resource(
+                condition=constants.STATUS_BOUND,
+                resource_name=self.pvc_obj.name,
+                timeout=5,
+            )
+        log.info(
+            f"Expected exception raised. PVC {self.pvc_obj.name} does not exist after deletion"
+        )


### PR DESCRIPTION
This PR created under **ODF QE Logging Enhancement Initiative** 

During implementation, we discovered that oc wait --for is not always suitable for our wait_for_resource use cases. For example:

oc wait --for will fail if any of the matched resources do not meet the specified condition. However, in some scenarios, we want wait_for_resource to return True as long as some resources satisfy the condition.

oc wait --for does not support waiting until a specific number (<n>) of resources reach a condition.

Our wait_for_resource implementation includes additional logic in ocs-ci that parses YAML output and matches the condition using the STATUS column, which oc wait --for does not support out of the box.

As a partial solution, we propose using oc wait --for only for common resource types such as PVCs, Pods, and CSVs, where the condition mapping to the STATUS column is straightforward. For other resource types like Deployments and OBCs—where STATUS or PHASE values are not reliably mapped—we will continue using the original wait_for_resource logic.

********** test_wait_for_resource_oc_wait **********

wait for pod which is running before improvement - 3.631286859512329 seconds
number of lines printed out to debug log - 162

wait for pod which is running after improvement - 1.7074522972106934 seconds
number of lines printed out to debug log - 1 

````
start_time = time.time()
o.wait_for_resource(resource_name="busybox-test-1-8d76b7b98-j2jkx",condition="Running", timeout=5)
print(f"{time.time() - start_time} seconds")
1.7074522972106934 seconds

````
* wait_for_resource_oc_wait is running in most common and positive scenarios
* wait_for_resource_oc_wait will be running only if supported kind of resources and arguments passed to old wait_for_resource
* wait_for_resource_oc_wait is used for most common resources, when "oc wait --for allows"
* added exception-safe _process_oc_wait_cmd for safety and will check if resource kind and arguments passed to wait_for_resource are suitable for enhanced wait_for_resource_oc_wait
* if _process_oc_wait_cmd fails we do wait with legacy approach
* avoided to change exec_oc_cmd to catch timeout message but still print resource description by wrapping exec_oc_cmd 
* approach can be improved by adding more resources, conditions and jsonpath patters


libtest: 
```
/Users/danielosypenko/Work/automation_4/venv3.11/bin/python -X pycache_prefix=/Users/danielosypenko/Library/Caches/JetBrains/PyCharmCE2023.3/cpython-cache /Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pydev/pydevd.py --qt-support=auto --client 127.0.0.1 --port 65387 --file /Users/danielosypenko/Work/automation_4/venv3.9/bin/run-ci --cluster-path ${CLUSTER_PATH} --ocp-version 4.18 --ocs-version 4.18 --cluster-name $CLUSTER_NAME tests/libtest/test_log_improvements.py::TestWaitForResource::test_wait_for_resource_oc_wait -k  --dev-mode --ocsci-conf /Users/danielosypenko/Work/automation_4/ocs-ci/conf/deployment/fusion_hci_pc/provider_bm_upi_1az_rhcos_nvme_3m_3w.yaml 
/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pydev/pydevd_plugins/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  __import__('pkg_resources').declare_namespace(__name__)
Connected to pydev debugger (build 233.15619.17)
============================================================================================================================= test session starts =============================================================================================================================
platform darwin -- Python 3.11.13, pytest-6.2.5, py-1.11.0, pluggy-1.6.0
rootdir: /Users/danielosypenko/Work/automation_4/ocs-ci, configfile: pytest.ini
plugins: jira-0.3.22, order-1.2.0, repeat-0.9.3, flaky-3.7.0, html-3.1.1, metadata-1.11.0, progress-1.2.5, logger-0.5.1, typeguard-4.3.0
collected 1 item                                                                                                                                                                                                                                                              

tests/libtest/test_log_improvements.py::TestWaitForResource::test_wait_for_resource_oc_wait 
------------------------------------------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------------------------------------------
18:49:16 - MainThread - ocs_ci.utility.utils - INFO  - testrun_name: OCS4-18-Downstream-OCP4-18-LSO-MON-HOSTPATH-OSD-NVME-HCI_BAREMETAL-UPI-1AZ-RHCOS-3M-3W
18:49:16 - MainThread - ocs_ci.utility.utils - INFO  - testrun_name: OCS4-18-Downstream-OCP4-18-LSO-MON-HOSTPATH-OSD-NVME-HCI_BAREMETAL-UPI-1AZ-RHCOS-3M-3W
18:49:16 - MainThread - ocs_ci.utility.utils - INFO  - Retrieving the authentication config dictionary
18:49:16 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n openshift-storage get lvmcluster -n openshift-storage -o yaml
18:49:17 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n openshift-storage get cephcluster -n openshift-storage -o yaml
18:49:19 - MainThread - ocs_ci.ocs.cluster - INFO  - Detected CephCluster is installed
18:49:19 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n openshift-storage get pods -o name
18:49:21 - MainThread - ocs_ci.ocs.utils - INFO  - pod name match found appending rook-ceph-tools-85897f55c8-s8mxz
18:49:21 - MainThread - ocs_ci.ocs.utils - INFO  - Ceph toolbox already exists, skipping
18:49:21 - MainThread - tests.conftest - INFO  - All logs located at /tmp/ocs-ci-logs-1753717752077
18:49:22 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: /Users/danielosypenko/Work/automation_4/ocs-ci/bin/oc version --client -o json
18:49:22 - MainThread - ocs_ci.utility.utils - INFO  - OpenShift Client version: None
18:49:22 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n openshift-storage get csv -n openshift-storage -o yaml
18:49:27 - MainThread - tests.conftest - INFO  - Skipping RPM collection for development mode.
18:49:27 - MainThread - tests.conftest - INFO  - Skipping version reporting for development mode.
18:49:27 - MainThread - tests.conftest - INFO  - PagerDuty service is not created because platform from ['openshiftdedicated', 'rosa', 'fusion_aas'] is not used
18:49:27 - MainThread - ocs_ci.utility.utils - INFO  - testrun_name: OCS4-18-Downstream-OCP4-18-LSO-MON-HOSTPATH-OSD-NVME-HCI_BAREMETAL-UPI-1AZ-RHCOS-3M-3W
18:49:27 - MainThread - ocs_ci.utility.utils - INFO  - testrun_name: OCS4-18-Downstream-OCP4-18-LSO-MON-HOSTPATH-OSD-NVME-HCI_BAREMETAL-UPI-1AZ-RHCOS-3M-3W
18:49:27 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n openshift-storage get csv -n openshift-storage -o yaml
18:49:31 - MainThread - tests.conftest - INFO  - Skipping health checks for development mode
18:49:31 - MainThread - tests.conftest - INFO  - Skipping alert check for development mode
18:49:31 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig new-project namespace-test-31f41ef847ab4f8f989475145
18:49:32 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get clusterversion -n openshift-storage -o yaml
18:49:34 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig label namespace namespace-test-31f41ef847ab4f8f989475145 security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=baseline pod-security.kubernetes.io/warn=baseline --overwrite
18:49:35 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get storageclass -o yaml
18:49:36 - MainThread - ocs_ci.ocs.ocp - INFO  - Waiting for a resource(s) of kind storageclass identified by name '' using selector None at column name NAME to reach desired condition ocs-storagecluster-cephfs
18:49:36 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get storageclass ocs-storagecluster-cephfs -o yaml
18:49:37 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get storageclass ocs-storagecluster-cephfs
18:49:38 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get storageclass ocs-storagecluster-cephfs -o yaml
18:49:39 - MainThread - ocs_ci.ocs.ocp - INFO  - status of ocs-storagecluster-cephfs at NAME reached condition!
18:49:39 - MainThread - ocs_ci.ocs.resources.ocs - INFO  - Adding PersistentVolumeClaim with name pvc-test-46b2c23974ed40aeb807df24738d3fd
18:49:39 - MainThread - ocs_ci.utility.templating - INFO  - apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc-test-46b2c23974ed40aeb807df24738d3fd
  namespace: namespace-test-31f41ef847ab4f8f989475145
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  storageClassName: ocs-storagecluster-cephfs

18:49:39 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 create -f /var/folders/s3/k_k_0dbn7zx6vg7f1dhpcsr00000gn/T/PersistentVolumeClaimls29r55o -o yaml
18:49:41 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node -o yaml
18:49:43 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/worker -o yaml
18:49:45 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/master -o yaml
18:49:47 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/master -o yaml
18:49:50 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd '--for=jsonpath={.status.phase}=Bound' --timeout=90s
18:49:51 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource pvc-test-46b2c23974ed40aeb807df24738d3fd reached condition Bound
18:49:51 - MainThread - ocs_ci.helpers.helpers - INFO  - PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd reached state Bound
18:49:51 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Proxy cluster -o yaml
18:49:53 - MainThread - ocs_ci.helpers.helpers - INFO  - Creating new Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 for test
18:49:53 - MainThread - ocs_ci.ocs.resources.ocs - INFO  - Adding Pod with name pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
18:49:53 - MainThread - ocs_ci.utility.templating - INFO  - apiVersion: v1
kind: Pod
metadata:
  name: pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
  namespace: namespace-test-31f41ef847ab4f8f989475145
spec:
  containers:
  - command:
    - /bin/sh
    image: quay.io/ocsci/perf:latest
    imagePullPolicy: IfNotPresent
    name: performance
    stdin: true
    tty: true
    volumeMounts:
    - mountPath: /mnt
      name: mypvc
  volumes:
  - name: mypvc
    persistentVolumeClaim:
      claimName: pvc-test-46b2c23974ed40aeb807df24738d3fd
      readOnly: false

18:49:53 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 create -f /var/folders/s3/k_k_0dbn7zx6vg7f1dhpcsr00000gn/T/POD_1d4jqsyh -o yaml
18:49:54 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:49:55 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node -o yaml
18:49:57 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/worker -o yaml
18:49:59 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/master -o yaml
18:50:01 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig get Node --selector=node-role.kubernetes.io/master -o yaml
18:50:02 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 '--for=jsonpath={.status.phase}=Running' --timeout=300s
18:50:04 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 reached condition Running
18:50:04 - MainThread - ocs_ci.helpers.helpers - INFO  - Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 reached state Running
18:50:04 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:50:05 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/libtest/test_log_improvements.py::TestWaitForResource::test_wait_for_resource_oc_wait immediately after test execution: 49.37
-------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------
18:50:05 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Pod -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:50:06 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 label Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 wait_for_resource_oc_wait=
18:50:08 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get PersistentVolumeClaim -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:50:09 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 label PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd wait_for_resource_oc_wait=
18:50:10 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 '--for=jsonpath={.status.phase}=Running' --timeout=10s
18:50:12 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 reached condition Running
18:50:12 - MainThread - test_log_improvements - INFO  - Time taken for pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 to be found in running state: 1.609581708908081 seconds
18:50:12 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod '--for=jsonpath={.status.phase}=Running' --selector=wait_for_resource_oc_wait --timeout=10s
18:50:13 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource  reached condition Running
18:50:13 - MainThread - test_log_improvements - INFO  - Time taken for pod with label wait_for_resource_oc_wait to be found in running state: 1.7071621417999268 seconds
18:50:14 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd '--for=jsonpath={.status.phase}=Bound' --timeout=10s
18:50:15 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource pvc-test-46b2c23974ed40aeb807df24738d3fd reached condition Bound
18:50:15 - MainThread - test_log_improvements - INFO  - Time taken for pvc pvc-test-46b2c23974ed40aeb807df24738d3fd to be found in bound state: 1.5909810066223145 seconds
18:50:15 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim '--for=jsonpath={.status.phase}=Bound' --selector=wait_for_resource_oc_wait --timeout=10s
18:50:17 - MainThread - ocs_ci.ocs.ocp - INFO  - wait_for_resource_oc_wait: Resource  reached condition Bound
18:50:17 - MainThread - test_log_improvements - INFO  - Time taken for pvc with label wait_for_resource_oc_wait to be found in bound state: 1.615231990814209 seconds
18:50:17 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 '--for=jsonpath={.status.phase}=Failed' --timeout=5s
18:50:23 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: timed out waiting for the condition on pods/pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2

18:50:58 - MainThread - ocs_ci.ocs.ocp - ERROR  - Timeout expired
18:50:59 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 describe Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
18:51:04 - MainThread - ocs_ci.ocs.ocp - WARNING  - wait_for_resource_oc_wait: Description of the resource(s) we were waiting for:
Name:             pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
Namespace:        namespace-test-31f41ef847ab4f8f989475145
Priority:         0
Service Account:  default
Node:             baremetal4-04/52.118.40.230
Start Time:       Mon, 28 Jul 2025 18:49:54 +0300
Labels:           wait_for_resource_oc_wait=
Annotations:      k8s.ovn.org/pod-networks:
                    {"default":{"ip_addresses":["10.129.2.113/23"],"mac_address":"0a:58:0a:81:02:71","gateway_ips":["10.129.2.1"],"routes":[{"dest":"10.128.0....
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "ovn-kubernetes",
                        "interface": "eth0",
                        "ips": [
                            "10.129.2.113"
                        ],
                        "mac": "0a:58:0a:81:02:71",
                        "default": true,
                        "dns": {}
                    }]
                  openshift.io/scc: anyuid
Status:           Running
IP:               10.129.2.113
IPs:
  IP:  10.129.2.113
Containers:
  performance:
    Container ID:  cri-o://852fab0bce87a27212f40a639c75f34c562d2c2f6c45f0d1d96ee9c44fb13847
    Image:         quay.io/ocsci/perf:latest
    Image ID:      quay.io/ocsci/perf@sha256:0a2d28c92688f1811d7ea9608175a6511884344e410e933340f98e0c32081126
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
    State:          Running
      Started:      Mon, 28 Jul 2025 18:49:58 +0300
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt from mypvc (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hrbzh (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
Volumes:
  mypvc:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  pvc-test-46b2c23974ed40aeb807df24738d3fd
    ReadOnly:   false
  kube-api-access-hrbzh:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
    ConfigMapName:           openshift-service-ca.crt
    ConfigMapOptional:       <nil>
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason                  Age   From                     Message
  ----    ------                  ----  ----                     -------
  Normal  Scheduled               66s   default-scheduler        Successfully assigned namespace-test-31f41ef847ab4f8f989475145/pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 to baremetal4-04
  Normal  SuccessfulAttachVolume  66s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb"
  Normal  AddedInterface          62s   multus                   Add eth0 [10.129.2.113/23] from ovn-kubernetes
  Normal  Pulled                  62s   kubelet                  Container image "quay.io/ocsci/perf:latest" already present on machine
  Normal  Created                 62s   kubelet                  Created container: performance
  Normal  Started                 62s   kubelet                  Started container performance

18:51:31 - MainThread - test_log_improvements - INFO  - Expected exception raised. Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 did not reach failed state within timeout
18:51:31 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod '--for=jsonpath={.status.phase}=Failed' --selector=wait_for_resource_oc_wait --timeout=5s
18:51:37 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: timed out waiting for the condition on pods/pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2

18:51:53 - MainThread - ocs_ci.ocs.ocp - ERROR  - Timeout expired
18:51:53 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 describe Pod --selector=wait_for_resource_oc_wait
18:51:55 - MainThread - ocs_ci.ocs.ocp - WARNING  - wait_for_resource_oc_wait: Description of the resource(s) we were waiting for:
Name:             pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
Namespace:        namespace-test-31f41ef847ab4f8f989475145
Priority:         0
Service Account:  default
Node:             baremetal4-04/52.118.40.230
Start Time:       Mon, 28 Jul 2025 18:49:54 +0300
Labels:           wait_for_resource_oc_wait=
Annotations:      k8s.ovn.org/pod-networks:
                    {"default":{"ip_addresses":["10.129.2.113/23"],"mac_address":"0a:58:0a:81:02:71","gateway_ips":["10.129.2.1"],"routes":[{"dest":"10.128.0....
                  k8s.v1.cni.cncf.io/network-status:
                    [{
                        "name": "ovn-kubernetes",
                        "interface": "eth0",
                        "ips": [
                            "10.129.2.113"
                        ],
                        "mac": "0a:58:0a:81:02:71",
                        "default": true,
                        "dns": {}
                    }]
                  openshift.io/scc: anyuid
Status:           Running
IP:               10.129.2.113
IPs:
  IP:  10.129.2.113
Containers:
  performance:
    Container ID:  cri-o://852fab0bce87a27212f40a639c75f34c562d2c2f6c45f0d1d96ee9c44fb13847
    Image:         quay.io/ocsci/perf:latest
    Image ID:      quay.io/ocsci/perf@sha256:0a2d28c92688f1811d7ea9608175a6511884344e410e933340f98e0c32081126
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/sh
    State:          Running
      Started:      Mon, 28 Jul 2025 18:49:58 +0300
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /mnt from mypvc (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hrbzh (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
Volumes:
  mypvc:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  pvc-test-46b2c23974ed40aeb807df24738d3fd
    ReadOnly:   false
  kube-api-access-hrbzh:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
    ConfigMapName:           openshift-service-ca.crt
    ConfigMapOptional:       <nil>
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason                  Age   From                     Message
  ----    ------                  ----  ----                     -------
  Normal  Scheduled               2m    default-scheduler        Successfully assigned namespace-test-31f41ef847ab4f8f989475145/pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 to baremetal4-04
  Normal  SuccessfulAttachVolume  2m1s  attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb"
  Normal  AddedInterface          117s  multus                   Add eth0 [10.129.2.113/23] from ovn-kubernetes
  Normal  Pulled                  117s  kubelet                  Container image "quay.io/ocsci/perf:latest" already present on machine
  Normal  Created                 117s  kubelet                  Created container: performance
  Normal  Started                 117s  kubelet                  Started container performance

18:51:55 - MainThread - test_log_improvements - INFO  - Expected exception raised. Pod with label wait_for_resource_oc_wait did not reach failed state within timeout
18:51:55 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd '--for=jsonpath={.status.phase}=Pending' --timeout=5s
18:52:01 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: timed out waiting for the condition on persistentvolumeclaims/pvc-test-46b2c23974ed40aeb807df24738d3fd

18:52:01 - MainThread - ocs_ci.ocs.ocp - ERROR  - Timeout expired
18:52:01 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 describe PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd
18:52:03 - MainThread - ocs_ci.ocs.ocp - WARNING  - wait_for_resource_oc_wait: Description of the resource(s) we were waiting for:
Name:          pvc-test-46b2c23974ed40aeb807df24738d3fd
Namespace:     namespace-test-31f41ef847ab4f8f989475145
StorageClass:  ocs-storagecluster-cephfs
Status:        Bound
Volume:        pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb
Labels:        wait_for_resource_oc_wait=
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
               volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWX
VolumeMode:    Filesystem
Used By:       pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
Events:
  Type    Reason                 Age    From                                                                                                                                        Message
  ----    ------                 ----   ----                                                                                                                                        -------
  Normal  Provisioning           2m22s  openshift-storage.cephfs.csi.ceph.com_openshift-storage.cephfs.csi.ceph.com-ctrlplugin-5ffcc5c66tzmch_0f12efc2-9be6-49ff-9e6d-8d47e615f37a  External provisioner is provisioning volume for claim "namespace-test-31f41ef847ab4f8f989475145/pvc-test-46b2c23974ed40aeb807df24738d3fd"
  Normal  ExternalProvisioning   2m22s  persistentvolume-controller                                                                                                                 Waiting for a volume to be created either by the external provisioner 'openshift-storage.cephfs.csi.ceph.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  2m22s  openshift-storage.cephfs.csi.ceph.com_openshift-storage.cephfs.csi.ceph.com-ctrlplugin-5ffcc5c66tzmch_0f12efc2-9be6-49ff-9e6d-8d47e615f37a  Successfully provisioned volume pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb

18:52:03 - MainThread - test_log_improvements - INFO  - Expected exception raised. PVC pvc-test-46b2c23974ed40aeb807df24738d3fd did not reach released state within timeout
18:52:03 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim '--for=jsonpath={.status.phase}=Pending' --selector=wait_for_resource_oc_wait --timeout=5s
18:52:09 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: timed out waiting for the condition on persistentvolumeclaims/pvc-test-46b2c23974ed40aeb807df24738d3fd

18:52:09 - MainThread - ocs_ci.ocs.ocp - ERROR  - Timeout expired
18:52:09 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 describe PersistentVolumeClaim --selector=wait_for_resource_oc_wait
18:52:10 - MainThread - ocs_ci.ocs.ocp - WARNING  - wait_for_resource_oc_wait: Description of the resource(s) we were waiting for:
Name:          pvc-test-46b2c23974ed40aeb807df24738d3fd
Namespace:     namespace-test-31f41ef847ab4f8f989475145
StorageClass:  ocs-storagecluster-cephfs
Status:        Bound
Volume:        pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb
Labels:        wait_for_resource_oc_wait=
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
               volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      1Gi
Access Modes:  RWX
VolumeMode:    Filesystem
Used By:       pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
Events:
  Type    Reason                 Age    From                                                                                                                                        Message
  ----    ------                 ----   ----                                                                                                                                        -------
  Normal  Provisioning           2m29s  openshift-storage.cephfs.csi.ceph.com_openshift-storage.cephfs.csi.ceph.com-ctrlplugin-5ffcc5c66tzmch_0f12efc2-9be6-49ff-9e6d-8d47e615f37a  External provisioner is provisioning volume for claim "namespace-test-31f41ef847ab4f8f989475145/pvc-test-46b2c23974ed40aeb807df24738d3fd"
  Normal  ExternalProvisioning   2m29s  persistentvolume-controller                                                                                                                 Waiting for a volume to be created either by the external provisioner 'openshift-storage.cephfs.csi.ceph.com' or manually by the system administrator. If volume creation is delayed, please verify that the provisioner is running and correctly registered.
  Normal  ProvisioningSucceeded  2m29s  openshift-storage.cephfs.csi.ceph.com_openshift-storage.cephfs.csi.ceph.com-ctrlplugin-5ffcc5c66tzmch_0f12efc2-9be6-49ff-9e6d-8d47e615f37a  Successfully provisioned volume pvc-02f252d9-9504-430d-a5bc-fe4086afe8fb

18:52:10 - MainThread - test_log_improvements - INFO  - Expected exception raised. PVC with label wait_for_resource_oc_wait did not reach released state within timeout
18:52:10 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 delete Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 --grace-period=0 --force
18:52:12 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.

18:52:12 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 delete PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd --grace-period=0 --force
18:52:13 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.

18:52:13 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 '--for=jsonpath={.status.phase}=Running' --timeout=5s
18:52:15 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): pods "pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2" not found

18:52:15 - MainThread - test_log_improvements - INFO  - Expected exception raised. Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2 does not exist after deletion
18:52:15 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 wait PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd '--for=jsonpath={.status.phase}=Bound' --timeout=5s
18:52:16 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): persistentvolumeclaims "pvc-test-46b2c23974ed40aeb807df24738d3fd" not found

18:52:16 - MainThread - test_log_improvements - INFO  - Expected exception raised. PVC pvc-test-46b2c23974ed40aeb807df24738d3fd does not exist after deletion
18:52:16 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/libtest/test_log_improvements.py::TestWaitForResource::test_wait_for_resource_oc_wait immediately after test execution: 131.03
PASSED
------------------------------------------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------------------------------------------
18:52:16 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 delete Pod pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2
18:52:17 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): pods "pod-test-rbd-b8ac7bffbda84478b5b63fbe4a2" not found

18:52:17 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:52:19 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): persistentvolumeclaims "pvc-test-46b2c23974ed40aeb807df24738d3fd" not found

18:52:19 - MainThread - ocs_ci.ocs.ocp - WARNING  - Failed to get resource: pvc-test-46b2c23974ed40aeb807df24738d3fd of kind: PersistentVolumeClaim, selector: None, Error: Error during execution of command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get PersistentVolumeClaim pvc-test-46b2c23974ed40aeb807df24738d3fd -n namespace-test-31f41ef847ab4f8f989475145 -o yaml.
Error is Error from server (NotFound): persistentvolumeclaims "pvc-test-46b2c23974ed40aeb807df24738d3fd" not found

18:52:19 - MainThread - ocs_ci.ocs.ocp - WARNING  - Number of attempts to get resource reached!
18:52:19 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Event -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:52:21 - MainThread - tests.conftest - INFO  - There were 10 events in namespace-test-31f41ef847ab4f8f989475145 namespace before it's removal (out of which 0 were of type Warning). For a full dump of this event list, see DEBUG logs.
18:52:21 - MainThread - ocs_ci.ocs.ocp - INFO  - Switching to project openshift-storage
18:52:21 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig project openshift-storage
18:52:22 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 delete Project namespace-test-31f41ef847ab4f8f989475145
18:52:31 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Warning: deleting cluster-scoped resources, not scoped to the provided namespace

18:52:31 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Project namespace-test-31f41ef847ab4f8f989475145 -n namespace-test-31f41ef847ab4f8f989475145 -o yaml
18:52:32 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (NotFound): namespaces "namespace-test-31f41ef847ab4f8f989475145" not found

18:52:32 - MainThread - ocs_ci.ocs.ocp - WARNING  - Failed to get resource: namespace-test-31f41ef847ab4f8f989475145 of kind: Project, selector: None, Error: Error during execution of command: oc --kubeconfig /Users/danielosypenko/Work/automation_4/ocs-ci/cluster_path/auth/kubeconfig -n namespace-test-31f41ef847ab4f8f989475145 get Project namespace-test-31f41ef847ab4f8f989475145 -n namespace-test-31f41ef847ab4f8f989475145 -o yaml.
Error is Error from server (NotFound): namespaces "namespace-test-31f41ef847ab4f8f989475145" not found

18:52:32 - MainThread - ocs_ci.ocs.ocp - WARNING  - Number of attempts to get resource reached!
18:52:32 - MainThread - ocs_ci.ocs.ocp - INFO  - Project namespace-test-31f41ef847ab4f8f989475145 got deleted successfully

________________________________________________________________________________________________ 1 of 1 completed, 1 Pass, 0 Fail, 0 Skip, 0 XPass, 0 XFail, 0 Error, 0 ReRun _________________________________________________________________________________________________

```