### PR TITLE
Skipping ocp-logging due to issue 11604 (#12699)

### DIFF
--- a/ocs_ci/utility/deployment_openshift_logging.py
+++ b/ocs_ci/utility/deployment_openshift_logging.py
@@ -375,6 +375,7 @@ def install_logging():
 
     # Gets OCP version to align logging version to OCP version
     ocp_version = version.get_semantic_ocp_version_from_config()
+
     logging_channel = "stable" if ocp_version >= version.VERSION_4_7 else ocp_version
 
     # Creates namespace openshift-operators-redhat

--- a/tests/functional/workloads/ocp/logging/test_openshift-logging.py
+++ b/tests/functional/workloads/ocp/logging/test_openshift-logging.py
@@ -39,6 +39,9 @@ def setup_fixture(install_logging):
     logger.info("Testcases execution post deployment of openshift-logging")
 
 
+@pytest.mark.skip(
+    reason="Skipped due to ocs-ci issue https://github.com/red-hat-storage/ocs-ci/issues/11604"
+)
 @magenta_squad
 @pytest.mark.usefixtures(setup_fixture.__name__)
 @ignore_leftovers


### PR DESCRIPTION
Logging tests on 4.18 and 4.17 too were failing on the issue https://github.com/red-hat-storage/ocs-ci/issues/11604

From the recent debuging session we found out that the logging version 5.8-6.1 is moved to maintenance support and full support is revoked.

https://access.redhat.com/product-life-cycles?product=Red%20Hat%20Enterprise%20Linux,Red%20Hat%20OpenShift%20Logging