### PR TITLE
A fix to test object integrity

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -226,7 +226,7 @@ class ObjectBucket(ABC):
             self.internal_delete()
         except NotFoundError:
             logger.warning(f"{self.name} was not found, or already deleted.")
-        except TimeoutError:
+        except (TimeoutError, TimeoutExpiredError):
             logger.warning(f"{self.name} deletion timed out. Verifying deletion.")
             verify = True
         if verify:


### PR DESCRIPTION
This PR is a fix to issue # https://github.com/red-hat-storage/ocs-ci/issues/11900 . 

When a bucket is deleted, TimeoutExpiredError may be thrown after 600 seconds. 

The fix is that this exception is handled now exactly the same way TimeoutError exception was handled in the existing code.