### PR TITLE
configure proxy trustedCA in hosted clusters and provide custom CA certificate to AWS s3 cli pod

### DIFF
--- a/ocs_ci/utility/ssl_certs.py
+++ b/ocs_ci/utility/ssl_certs.py
@@ -528,6 +528,46 @@ def configure_ingress_and_api_certificates(skip_tls_verify=False):
     )
 
 
+def create_ocs_ca_bundle(
+    ca_cert_path,
+    ca_bundle_name="ocs-ca-bundle",
+    namespace=constants.OPENSHIFT_CONFIG_NAMESPACE,
+    skip_tls_verify=False,
+):
+    """
+    Create or update configmap object with ocs-ca-bundle
+
+    Args:
+        ca_cert_path (str): path to CA Certificate(s) bundle file
+        ca_bundle_name (str): name of the created or updated configmap object (default: ocs-ca-bundle)
+        namespace (str): namespace where to create the configmap (default: openshift-config)
+        skip_tls_verify (bool): True if allow skipping TLS verification
+
+    """
+    # check if ocs-ca-bundle configmap already exists, if yes, concatenate
+    # existing ca-bundle.crt with the new CA bundle (ca_cert_path) and delete
+    # the old configmap before the new one is created
+    configmap_obj = ocp.OCP(
+        kind=constants.CONFIGMAP,
+        namespace=namespace,
+        resource_name=ca_bundle_name,
+        skip_tls_verify=skip_tls_verify,
+    )
+    if configmap_obj.is_exist():
+        existing_ca_bundle = configmap_obj.get()["data"]["ca-bundle.crt"]
+        with open(ca_cert_path, "a") as fd:
+            fd.write(existing_ca_bundle)
+        configmap_obj.delete(resource_name=ca_bundle_name, wait=True)
+    ignore_tls = ""
+    if skip_tls_verify:
+        ignore_tls = "--insecure-skip-tls-verify "
+    cmd = (
+        f"oc create configmap {ca_bundle_name} -n {namespace} {ignore_tls}"
+        f"--from-file=ca-bundle.crt={ca_cert_path}"
+    )
+    exec_cmd(cmd)
+
+
 def configure_trusted_ca_bundle(ca_cert_path, skip_tls_verify=False):
     """
     Configure cluster-wide trusted CA bundle in Proxy object
@@ -538,28 +578,12 @@ def configure_trusted_ca_bundle(ca_cert_path, skip_tls_verify=False):
 
     """
     ocs_ca_bundle_name = "ocs-ca-bundle"
-    # check if ocs-ca-bundle configmap already exists, if yes, concatenate
-    # existing ca-bundle.crt with the new CA bundle (ca_cert_path) and delete
-    # the old configmap before the new one is created
-    configmap_obj = ocp.OCP(
-        kind=constants.CONFIGMAP,
-        namespace=constants.OPENSHIFT_CONFIG_NAMESPACE,
-        resource_name=ocs_ca_bundle_name,
-        skip_tls_verify=skip_tls_verify,
+    create_ocs_ca_bundle(
+        ca_cert_path, ocs_ca_bundle_name, skip_tls_verify=skip_tls_verify
     )
-    if configmap_obj.is_exist():
-        existing_ca_bundle = configmap_obj.get()["data"]["ca-bundle.crt"]
-        with open(ca_cert_path, "a") as fd:
-            fd.write(existing_ca_bundle)
-        configmap_obj.delete(resource_name=ocs_ca_bundle_name, wait=True)
     ignore_tls = ""
     if skip_tls_verify:
         ignore_tls = "--insecure-skip-tls-verify "
-    cmd = (
-        f"oc create configmap {ocs_ca_bundle_name} -n openshift-config {ignore_tls}"
-        f"--from-file=ca-bundle.crt={ca_cert_path}"
-    )
-    exec_cmd(cmd)
     cmd = (
         f"oc patch proxy/cluster --type=merge {ignore_tls}"
         f'--patch=\'{{"spec":{{"trustedCA":{{"name":"{ocs_ca_bundle_name}"}}}}}}\''


### PR DESCRIPTION
* Configure `trustedCA` in proxy object for hosted clusters (through `hostedclusters` object on the hosting cluster).
* provide custom CA certificate to AWS S3 cli pod, if required

The aim of this PR is to fix following failures of some tests on Provider - Client scenario:
```
ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/clusters/j015-pcbaie-pm/openshift-cluster-dir/auth/kubeconfig -n s3cli-w8vslw3wbjzz3 rsh s3cli-0 sh -c 'AWS_CA_BUNDLE=/tmp/ca-bundle.crt AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=.... AWS_DEFAULT_REGION=us-east aws s3 --endpoint=https://s3-openshift-storage.apps.cluster.example.com:443  cp /test_objects/airbus.jpg s3://oc-bucket-.../airbus.jpg'.
Error is upload failed: ../test_objects/airbus.jpg to s3://oc-bucket-.../airbus.jpg SSL validation failed for https://s3-openshift-storage.apps.cluster.example.com:443/oc-bucket-.../airbus.jpg?uploads [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)
command terminated with exit code 1
```