### PR TITLE
[RDR] Update MirrorPeer template to remove deprecated fields for ODF 4.19+

### DIFF
--- a/ocs_ci/templates/ocs-deployment/multicluster/mirror_peer_rdr.yaml
+++ b/ocs_ci/templates/ocs-deployment/multicluster/mirror_peer_rdr.yaml
@@ -4,18 +4,13 @@ metadata:
   name: mirrorpeer-sample
   labels:
     cluster.open-cluster-management.io/backup: resource
-    control-plane: odfmo-controller-manager
 spec:
   items:
   - clusterName: PLACE_HOLDER
     storageClusterRef:
       name: ocs-storagecluster
-      namespace: openshift-storage
   - clusterName: PLACE_HOLDER
     storageClusterRef:
       name: ocs-storagecluster
-      namespace: openshift-storage
   manageS3: true
-  schedulingIntervals:
-  - 5m
-  - 15m
+  type: async


### PR DESCRIPTION
This PR updates the MirrorPeer template to remove deprecated fields 

- Removed schedulingIntervals field: Deprecated and no longer needed.
- Removed namespace field under storageClusterRef: This field is no longer used starting from ODF 4.19.
- Also updated labels and type field