### PR TITLE
[release-4.18] [RDR] Update MirrorPeer template to remove deprecated field

### DIFF
--- a/ocs_ci/templates/ocs-deployment/multicluster/mirror_peer_rdr.yaml
+++ b/ocs_ci/templates/ocs-deployment/multicluster/mirror_peer_rdr.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mirrorpeer-sample
   labels:
     cluster.open-cluster-management.io/backup: resource
-    control-plane: odfmo-controller-manager
 spec:
   items:
   - clusterName: PLACE_HOLDER
@@ -16,6 +15,4 @@ spec:
       name: ocs-storagecluster
       namespace: openshift-storage
   manageS3: true
-  schedulingIntervals:
-  - 5m
-  - 15m
+  type: async


### PR DESCRIPTION
This PR updates the MirrorPeer template to remove deprecated fields

 - Removed schedulingIntervals field: Deprecated and no longer needed.
 - Also updated labels and type field