### PR TITLE
handle EndpointConnectionError when fetching ocs-ci-data bucket

### DIFF
--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -8,7 +8,12 @@ import traceback
 import re
 
 from datetime import datetime, timezone
-from botocore.exceptions import ClientError, NoCredentialsError, WaiterError
+from botocore.exceptions import (
+    ClientError,
+    NoCredentialsError,
+    WaiterError,
+    EndpointConnectionError,
+)
 
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import exec_cmd, get_infra_id
@@ -2562,6 +2567,9 @@ def update_config_from_s3(
         return None
     except ClientError:
         logger.warning(f"Permission denied to access bucket {bucket_name}")
+        return None
+    except EndpointConnectionError:
+        logger.warning("Failed to fetch auth.yaml from ocs-ci-data")
         return None
 
 


### PR DESCRIPTION
This fix should prevent following failure:
```
(venv) :~/ocs-ci$ run-ci tests/functional/storageclass/test_verify_all_fields_in_sc_yaml_with_oc_describe_sc.py --cluster-name CLUSTER_NAME --ocsci-conf /mnt/c/Users/USER/Desktop/ODF/secret/cloud_odf-qe.yaml --ocsci-conf conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml --cluster-path /mnt/c/Users/USER/Desktop/ODF/clusters --dev-mode
Unable to find the authentication configuration at /home/user/ocs-ci/data/auth.yaml, please refer to the getting started guide (https://ocs-ci.readthedocs.io/en/latest/docs/getting_started.html#authentication-config)
/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py:318: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: helpconfig, Hook: pytest_cmdline_parse
EndpointConnectionError: Could not connect to the endpoint URL: "https://ocs-ci-data.s3.SOMETHING.amazonaws.com/auth.yaml"
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config = pluginmanager.hook.pytest_cmdline_parse(
Traceback (most recent call last):
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/util/connection.py", line 72, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/socket.py", line 974, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/httpsession.py", line 455, in send
    urllib_response = conn.urlopen(
                      ^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 801, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/util/retry.py", line 527, in increment
    raise six.reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/packages/six.py", line 770, in reraise
    raise value
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 715, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 404, in _make_request
    self._validate_conn(conn)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 1060, in _validate_conn
    conn.connect()
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 363, in connect
    self.sock = conn = self._new_conn()
                       ^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPSConnection object at 0x71d53b965650>: Failed to establish a new connection: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/ocs-ci/venv/bin/run-ci", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/user/ocs-ci/ocs_ci/framework/main.py", line 30, in main
    return pytest.main(arguments)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 143, in main
    config = _prepareconfig(args, plugins)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 318, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 43, in run_old_style_hookwrapper
    teardown.send(result)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
    config: Config = outcome.get_result()
                     ^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_result.py", line 103, in get_result
    raise exc.with_traceback(tb)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
    res = yield
          ^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
    self.parse(args)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 1283, in parse
    self._preparse(args, addopts=addopts)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 1168, in _preparse
    self.pluginmanager.consider_preparse(args, exclude_only=False)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 635, in consider_preparse
    self.consider_pluginarg(parg)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 660, in consider_pluginarg
    self.import_plugin(arg, consider_entry_points=True)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/config/__init__.py", line 703, in import_plugin
    __import__(importspec)
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
    exec(co, module.__dict__)
  File "/home/user/ocs-ci/ocs_ci/framework/pytest_customization/marks.py", line 216, in <module>
    and update_config_from_s3() is None
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/ocs_ci/utility/aws.py", line 2556, in update_config_from_s3
    s3.meta.client.download_file(bucket_name, filename, auth.name)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/boto3/s3/inject.py", line 190, in download_file
    return transfer.download_file(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/boto3/s3/transfer.py", line 320, in download_file
    future.result()
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/s3transfer/futures.py", line 103, in result
    return self._coordinator.result()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/s3transfer/futures.py", line 266, in result
    raise self._exception
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/s3transfer/tasks.py", line 269, in _main
    self._submit(transfer_future=transfer_future, **kwargs)
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/s3transfer/download.py", line 354, in _submit
    response = client.head_object(
               ^^^^^^^^^^^^^^^^^^^
 File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/client.py", line 514, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/client.py", line 921, in _make_api_call
    http, parsed_response = self._make_request(
                            ^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/client.py", line 944, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/endpoint.py", line 119, in make_request
    return self._send_request(request_dict, operation_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/endpoint.py", line 202, in _send_request
    while self._needs_retry(
          ^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/endpoint.py", line 354, in _needs_retry
    responses = self._event_emitter.emit(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 207, in __call__
    if self._checker(**checker_kwargs):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 284, in __call__
    should_retry = self._should_retry(
                   ^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 320, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 363, in __call__
    checker_response = checker(
                       ^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 247, in __call__
    return self._check_caught_exception(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/retryhandler.py", line 416, in _check_caught_exception
    raise caught_exception
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/endpoint.py", line 281, in _do_get_response
    http_response = self._send(request)
                    ^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/endpoint.py", line 377, in _send
    return self.http_session.send(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ocs-ci/venv/lib64/python3.11/site-packages/botocore/httpsession.py", line 484, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://ocs-ci-data.s3.SOMETHING.amazonaws.com/auth.yaml"
```