### PR TITLE
fix pytest_fixture_* functions for multicluster executions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -632,7 +632,9 @@ def pytest_fixture_setup(fixturedef, request):
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
             if mark.name == "parametrize":
-                if request.node.callspec.params.get("cluster_index"):
+                if isinstance(
+                    request.node, pytest.Function
+                ) and request.node.callspec.params.get("cluster_index"):
                     context = request.node.callspec.params.get("cluster_index")
                     log.info(f"Switching the fixture context to index: {context}")
                     ocsci_config.switch_ctx(context)
@@ -646,7 +648,9 @@ def pytest_fixture_post_finalizer(fixturedef, request):
     if ocsci_config.multicluster:
         for mark in request.node.iter_markers():
             if mark.name == "parametrize":
-                if request.node.callspec.params.get("cluster_index"):
+                if isinstance(
+                    request.node, pytest.Function
+                ) and request.node.callspec.params.get("cluster_index"):
                     ocsci_config.reset_ctx()
 
 


### PR DESCRIPTION
- check if request.node is type Function to avoid `AttributeError: 'Class' object has no attribute 'callspec'` failures

fixes: https://github.com/red-hat-storage/ocs-ci/issues/12712