### PR TITLE
Update tests test_subvolume_group_pinning to get pinning value from CephFilesystemSubVolumeGroup status

### DIFF
--- a/tests/functional/storageclass/test_csi_subvolume_group_property.py
+++ b/tests/functional/storageclass/test_csi_subvolume_group_property.py
@@ -1,9 +1,10 @@
 import logging
-import yaml
 
+from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
 from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id
-from ocs_ci.helpers.performance_lib import run_oc_command
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
 
 logger = logging.getLogger(__name__)
 
@@ -19,21 +20,27 @@ class TestCSISubvolumeGroup(ManageTest):
         Test that verifies that the pinning value of CephFilesystemSubVolumeGroup is 1
         """
 
-        result = run_oc_command("get CephFilesystemSubVolumeGroup -o yaml")
-        yaml_dict = yaml.safe_load("\n".join(result))
-        try:
-            pinning = yaml_dict["items"][0]["status"]["pinning"]
-            pinning_key, pinning_val = pinning.strip().split("=")
-            assert pinning_key == "distributed", "Pinning must be 'distributed'"
-            pinning_val = int(pinning_val)
-        except KeyError as e:
-            err_msg = 'Pinning property not found, missing key "%s"' % str(e)
-            logger.error(err_msg)
-            raise Exception(err_msg)
+        subvolumegroup = OCP(
+            kind=constants.CEPHFILESYSTEMSUBVOLUMEGROUP,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        ).get()
+        for subvolumegroup_info in subvolumegroup["items"]:
+            logger.info(
+                f"Checking {constants.CEPHFILESYSTEMSUBVOLUMEGROUP} {subvolumegroup_info['metadata']['name']}"
+            )
+            try:
+                pinning = subvolumegroup_info["status"]["info"]["pinning"]
+                pinning_key, pinning_val = pinning.strip().split("=")
+                assert pinning_key == "distributed", "Pinning must be 'distributed'"
+                pinning_val = int(pinning_val)
+            except KeyError as e:
+                err_msg = 'Pinning property not found, missing key "%s"' % str(e)
+                logger.error(err_msg)
+                raise Exception(err_msg)
 
-        if pinning_val != 1:
-            err_msg = f"Expected pinning value 1, got {pinning_val} instead"
-            logger.error(err_msg)
-            raise Exception(err_msg)
+            if pinning_val != 1:
+                err_msg = f"Expected pinning value 1, got {pinning_val} instead"
+                logger.error(err_msg)
+                raise Exception(err_msg)
 
-        logger.info("Pinning value found and it is 1, as expected")
+            logger.info("Pinning value found and it is 1, as expected")


### PR DESCRIPTION
The test case tests/functional/storageclass/test_csi_subvolume_group_property.py::TestCSISubvolumeGroup::test_subvolume_group_pinning is updated to get the pinning value from status instead of spec because the value is no longer available in the spec of the CephFilesystemSubVolumeGroup  CR. 

Spec and status of CephFilesystemSubVolumeGroup CR
```
  spec:
    dataPoolName: ""
    filesystemName: ocs-storagecluster-cephfilesystem
    name: internal
    pinning: {}
  status:
    info:
      clusterID: 5b79839b5480dd2ec940ebb2f4581f3c
      pinning: distributed=1
    observedGeneration: 1
    phase: Ready
```
Fixes #12878 