### PR TITLE
Skip customstorageclass tests on provider mode

### DIFF
--- a/tests/functional/storageclass/test_custom_storageclass_names.py
+++ b/tests/functional/storageclass/test_custom_storageclass_names.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     tier3,
     skipif_external_mode,
+    skipif_ms_provider_and_consumer,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.framework import config
@@ -26,6 +27,7 @@ log = logging.getLogger(__name__)
 @green_squad
 @skipif_external_mode
 @skipif_ocs_version("<4.14")
+@skipif_ms_provider_and_consumer
 class TestCustomStorageClassNames:
     def setup(self):
         self.custom_sc_list = []


### PR DESCRIPTION
Creating a StorageClass as a Day 2 operation is not supported in provider mode; hence, skipping the custom StorageClass test cases.