### PR TITLE
Ignore failures in rpm collector which causes test_change_cluster_resource_profile to fail

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4961,8 +4961,16 @@ def collect_logs_fixture(request):
                 if not skip_rpm_go_version_collection:
                     utils.collect_pod_container_rpm_package("testcases")
             except Exception as ex:
-                failure_in_mg.append(("rpm_package_info", ex))
-                log.error(f"Failure in collecting RPM package info! Exception: {ex}")
+                # At times the pod might be killed/restarted during this operation, hence skipping if pod not found error is shown
+                if "Error is Error from server (NotFound)" in str(ex):
+                    log.info(
+                        f"One of the pod was not found, assuming it was already deleted. refer {ex}"
+                    )
+                else:
+                    failure_in_mg.append(("rpm_package_info", ex))
+                    log.error(
+                        f"Failure in collecting RPM package info! Exception: {ex}"
+                    )
             if failure_in_mg:
                 if config.REPORTING.get("dont_fail_on_collect_logs"):
                     exception_errors = [str(ex) for ex in failure_in_mg]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2153,6 +2153,7 @@ def environment_checker(request):
     node = request.node
     # List of marks for which we will ignore the leftover checker
     marks_to_ignore = [m.mark for m in [deployment, ignore_leftovers]]
+    log.info(marks_to_ignore)
     # app labels of resources to be excluded for leftover check
     exclude_labels = [
         constants.must_gather_pod_label,
@@ -4961,7 +4962,7 @@ def collect_logs_fixture(request):
                 if not skip_rpm_go_version_collection:
                     utils.collect_pod_container_rpm_package("testcases")
             except Exception as ex:
-                # At times the pod might be killed/restarted during this operation, hence skipping if pod not found error is shown
+                # If pod is killed/restarted during this operation, skip if pod not found error is shown
                 if "Error is Error from server (NotFound)" in str(ex):
                     log.info(
                         f"One of the pod was not found, assuming it was already deleted. refer {ex}"

--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -37,6 +37,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-5646")
 @pytest.mark.polarion_id("OCS-5656")
 @pytest.mark.polarion_id("OCS-5657")
+@ignore_leftovers
 class TestProfileDefaultValuesCheck(ManageTest):
     @pytest.mark.parametrize(
         argnames=["perf_profile"],
@@ -46,7 +47,6 @@ class TestProfileDefaultValuesCheck(ManageTest):
             pytest.param(*["balanced"]),
         ],
     )
-    @ignore_leftovers
     def test_validate_cluster_resource_profile(self, perf_profile):
         """
         Testcase to validate osd, mgr, mon, mds and rgw pod memory and cpu values
@@ -165,7 +165,6 @@ class TestProfileDefaultValuesCheck(ManageTest):
             pytest.param(*["balanced"], marks=pytest.mark.polarion_id("OCS-5644")),
         ],
     )
-    @ignore_leftovers
     def test_change_cluster_resource_profile(self, perf_profile):
         """
         Testcase to validate osd, mgr, mon, mds and rgw pod memory and cpu values


### PR DESCRIPTION
This fixes https://github.com/red-hat-storage/ocs-ci/issues/12565