### PR TITLE
consumer-verification-on-client-creation fix

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -375,9 +375,10 @@ class HostedClients(HyperShiftBase):
             if self.storage_installation_requested(name)
         )
 
-        log_step("storage consumers and configmaps for newly deployed clients")
+        log_step("Verify storage consumers and configmaps for newly deployed clients")
         storage_consumers_verified = []
-        for cluster_name in hosted_odf_clusters_installed:
+        for hosted_odf_obj in hosted_odf_clusters_installed:
+            cluster_name = hosted_odf_obj.name
             try:
                 verify_storage_consumer_resources(
                     f"{constants.STORAGECONSUMER_NAME_PREFIX}{cluster_name}"


### PR DESCRIPTION
syntax issue - fix

failure:
https://url.corp.redhat.com/1b33f35

```
2025-08-13 14:09:09  Error is Error from server (NotFound): storageconsumers.ocs.openshift.io "consumer-<ocs_ci.deployment.hosted_cluster.HostedODF" not found
```