### PR TITLE
<GSS Closed Loop BZ: 2231860> : Add a test to verify no CLBO seen on force deletion of noobaa-db pod repeatedly

### DIFF
--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -1080,15 +1080,27 @@ class TestNamespace(MCGTest):
 
     @tier4c
     @pytest.mark.parametrize(
-        argnames=["mcg_pod"],
+        argnames=["mcg_pod", "respin_count"],
         argvalues=[
             pytest.param(
                 *["noobaa-db"],
+                respin_count=0,
                 marks=[pytest.mark.polarion_id("OCS-2291")],
             ),
-            pytest.param(*["noobaa-core"], marks=pytest.mark.polarion_id("OCS-2319")),
             pytest.param(
-                *["noobaa-operator"], marks=pytest.mark.polarion_id("OCS-2320")
+                *["noobaa-db"],
+                respin_count=10,
+                marks=[pytest.mark.polarion_id("OCS-6907")],
+            ),
+            pytest.param(
+                *["noobaa-core"],
+                respin_count=0,
+                marks=pytest.mark.polarion_id("OCS-2319"),
+            ),
+            pytest.param(
+                *["noobaa-operator"],
+                respin_count=0,
+                marks=pytest.mark.polarion_id("OCS-2320"),
             ),
         ],
     )
@@ -1101,6 +1113,7 @@ class TestNamespace(MCGTest):
         bucket_factory,
         test_directory_setup,
         mcg_pod,
+        respin_count,
     ):
         """
         Test Write to ns bucket using CRDs and read directly from AWS.
@@ -1148,17 +1161,33 @@ class TestNamespace(MCGTest):
         if not obj_ls:
             raise UnexpectedBehaviour("Failed to sync objects")
 
-        logger.info(f"Respin mcg resource {mcg_pod}")
-        noobaa_pods = pod.get_noobaa_pods()
-        pod_obj = [pod for pod in noobaa_pods if pod.name.startswith(mcg_pod)][0]
-        pod_obj.delete(force=True)
-        logger.info("Wait for noobaa pods to come up")
-        assert pod_obj.ocp.wait_for_resource(
-            condition="Running",
-            selector="app=noobaa",
-            resource_count=len(noobaa_pods),
-            timeout=1000,
-        )
+        if respin_count:
+            for _ in range(respin_count):
+                logger.info(f"Respin mcg resource {mcg_pod}")
+                noobaa_pods = pod.get_noobaa_pods()
+                pod_obj = [pod for pod in noobaa_pods if pod.name.startswith(mcg_pod)][
+                    0
+                ]
+                pod_obj.delete(force=True)
+                logger.info("Wait for noobaa pods to come up")
+                assert pod_obj.ocp.wait_for_resource(
+                    condition="Running",
+                    selector="app=noobaa",
+                    resource_count=len(noobaa_pods),
+                    timeout=1000,
+                )
+        else:
+            logger.info(f"Respin mcg resource {mcg_pod}")
+            noobaa_pods = pod.get_noobaa_pods()
+            pod_obj = [pod for pod in noobaa_pods if pod.name.startswith(mcg_pod)][0]
+            pod_obj.delete(force=True)
+            logger.info("Wait for noobaa pods to come up")
+            assert pod_obj.ocp.wait_for_resource(
+                condition="Running",
+                selector="app=noobaa",
+                resource_count=len(noobaa_pods),
+                timeout=1000,
+            )
         logger.info("Wait for noobaa health to be OK")
         ceph_cluster_obj = CephCluster()
         ceph_cluster_obj.wait_for_noobaa_health_ok()


### PR DESCRIPTION
This PR covers and test the scenarios mentioned in the BZ 2231860.

- The PR attached to this bug is also solving the bug 2165907#c35 so used these steps instead of bug 2231860#c15

- Test to verify no CLBO seen on force deletion of noobaa-db pod repeatedly and check data availability for MCG Namespace bucket