### PR TITLE
fix setup_multicluster_marker

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -429,7 +429,16 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
     """
     try:
         if push_missing_configs:
-            # run this only if cluster type is provider
+            # run this only if cluster type is provider and it is part of test execution stage (not deployment or
+            # teardown)
+            # FIXME: the usage of `sys.argv` here is not correct, but we can't use something like
+            # `config.RUN["cli_params"]["deploy"]`, because this setup_multicluster_marker(...) function is called on
+            # the module level (see the lines below this function definition) which means that it is actually called
+            # immediately when the module is imported and the config object is not fully initialized (especially some of
+            # the command line arguments are not processed)
+            # the solution will be to move following logic to some fixture (similarly as we have session scope autouse
+            # fixture `cluster`, which is responsible for deploying and teardown of the whole cluster (when particular
+            # parameters are passed)
             test_stage = not ("--deploy" in sys.argv or "--teardown" in sys.argv)
             if (
                 config.default_cluster_ctx.ENV_DATA["cluster_type"].lower()

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from funcy import compose
 
+from ocs_ci.framework.pytest_customization.ocscilib import get_cli_param
 from ocs_ci.ocs.exceptions import ClusterNotFoundException
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import (
@@ -428,10 +429,20 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
     """
     try:
         if push_missing_configs:
-
-            hypershift_cluster_factory(
-                duty=DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
+            # run this only if cluster type is provider
+            test_stage = not (
+                get_cli_param(config, "deploy", default=False)
+                or get_cli_param(config, "tearDown", default=False)
             )
+            if (
+                config.default_cluster_ctx.ENV_DATA["cluster_type"].lower()
+                == HCI_PROVIDER
+                and config.default_cluster_ctx.ENV_DATA["platform"].lower()
+                in HCI_PROVIDER_CLIENT_PLATFORMS
+            ) and test_stage:
+                hypershift_cluster_factory(
+                    duty=DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
+                )
         client_indexes = [
             pytest.param(*[idx]) for idx in config.get_consumer_indexes_list()
         ]

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -4,11 +4,11 @@ all related hooks/plugins to markers.
 """
 
 import os
+import sys
 
 import pytest
 from funcy import compose
 
-from ocs_ci.framework.pytest_customization.ocscilib import get_cli_param
 from ocs_ci.ocs.exceptions import ClusterNotFoundException
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import (
@@ -430,10 +430,7 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
     try:
         if push_missing_configs:
             # run this only if cluster type is provider
-            test_stage = not (
-                get_cli_param(config, "deploy", default=False)
-                or get_cli_param(config, "tearDown", default=False)
-            )
+            test_stage = not ("--deploy" in sys.argv or "--teardown" in sys.argv)
             if (
                 config.default_cluster_ctx.ENV_DATA["cluster_type"].lower()
                 == HCI_PROVIDER


### PR DESCRIPTION
fix issue after run-ci for OCP Deployment and single Deploy OCS without multiple clusters provided. 
traceback:
```
2025-08-14 15:21:21  Traceback (most recent call last):
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/bin/run-ci", line 33, in <module>
2025-08-14 15:21:21      sys.exit(load_entry_point('ocs-ci', 'console_scripts', 'run-ci')())
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/main.py", line 30, in main
2025-08-14 15:21:21      return pytest.main(arguments)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 143, in main
2025-08-14 15:21:21      config = _prepareconfig(args, plugins)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 318, in _prepareconfig
2025-08-14 15:21:21      config = pluginmanager.hook.pytest_cmdline_parse(
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_hooks.py", line 512, in __call__
2025-08-14 15:21:21      return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_manager.py", line 120, in _hookexec
2025-08-14 15:21:21      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 167, in _multicall
2025-08-14 15:21:21      raise exception
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 139, in _multicall
2025-08-14 15:21:21      teardown.throw(exception)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 43, in run_old_style_hookwrapper
2025-08-14 15:21:21      teardown.send(result)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
2025-08-14 15:21:21      config: Config = outcome.get_result()
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_result.py", line 103, in get_result
2025-08-14 15:21:21      raise exc.with_traceback(tb)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 38, in run_old_style_hookwrapper
2025-08-14 15:21:21      res = yield
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 121, in _multicall
2025-08-14 15:21:21      res = hook_impl.function(*args)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
2025-08-14 15:21:21      self.parse(args)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1283, in parse
2025-08-14 15:21:21      self._preparse(args, addopts=addopts)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1168, in _preparse
2025-08-14 15:21:21      self.pluginmanager.consider_preparse(args, exclude_only=False)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 635, in consider_preparse
2025-08-14 15:21:21      self.consider_pluginarg(parg)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 660, in consider_pluginarg
2025-08-14 15:21:21      self.import_plugin(arg, consider_entry_points=True)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 703, in import_plugin
2025-08-14 15:21:21      __import__(importspec)
2025-08-14 15:21:21    File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
2025-08-14 15:21:21    File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
2025-08-14 15:21:21    File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
2025-08-14 15:21:21      exec(co, module.__dict__)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/pytest_customization/marks.py", line 449, in <module>
2025-08-14 15:21:21      run_on_all_clients_push_missing_configs = setup_multicluster_marker(
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/framework/pytest_customization/marks.py", line 432, in setup_multicluster_marker
2025-08-14 15:21:21      hypershift_cluster_factory(
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 195, in wrapper
2025-08-14 15:21:21      return func(*args, **kwargs)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 2048, in hypershift_cluster_factory
2025-08-14 15:21:21      hosted_clients_obj = HostedClients()
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 221, in __init__
2025-08-14 15:21:21      HyperShiftBase.__init__(self)
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/deployment/helpers/hypershift_base.py", line 376, in __init__
2025-08-14 15:21:21      BaseOCPDeployment(skip_download_installer=True).test_cluster()
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/ocs_ci/deployment/ocp.py", line 226, in test_cluster
2025-08-14 15:21:21      pytest.fail("Cluster is not available!")
2025-08-14 15:21:21    File "/home/jenkins/workspace/qe-deploy-ocs-cluster/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/outcomes.py", line 153, in fail
2025-08-14 15:21:21      raise Failed(msg=msg, pytrace=pytrace)
2025-08-14 15:21:21  Failed: Cluster is not available!
2025-08-14 15:21:21  + run_ci_rc=1
```