### PR TITLE
change Arbiter node CPU's

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_arbiter.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_arbiter.yaml
@@ -26,7 +26,7 @@ ENV_DATA:
     - 'data-1'
     - 'data-2'
   worker_num_cpus: '16'
-  master_num_cpus: '4'
+  master_num_cpus: '8'
   master_memory: '16384'
   compute_memory: '65536'
   extra_disks: 2


### PR DESCRIPTION
Problem: OCP upgrade is failing on Arbiter mode ( VSPHERE UPI 2+arbiter AZ RHCOS LSO VMDK ARBITER 3M 6W Cluster ) because of low CPU resources on Arbiter node.

Fixes: #12957

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)