### PR TITLE
Add decorator to wrap functions with RunWithProviderConfigContextIfAvailable

### DIFF
--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -9,6 +9,7 @@ under section PYTEST_DONT_REWRITE
 
 # Use the new python 3.7 dataclass decorator, which provides an object similar
 # to a namedtuple, but allows type enforcement and defining methods.
+import functools
 import os
 import yaml
 import logging
@@ -544,6 +545,26 @@ class MultiClusterConfig:
                 logger.debug("No provider was found - using current cluster")
                 switch_index = config.cur_index
             super().__init__(switch_index)
+
+    @staticmethod
+    def run_with_provider_context_if_available(func):
+        """
+        Decorator that runs the function using the Provider config if it exists.
+        If no Provider config is found, the function runs with the current config.
+
+        Args:
+            func (callable): Function to decorate.
+
+        Returns:
+            callable: Wrapped function.
+        """
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with config.RunWithProviderConfigContextIfAvailable():
+                return func(*args, **kwargs)
+
+        return wrapper
 
     class RunWithFirstConsumerConfigContextIfAvailable(RunWithConfigContext):
         """

--- a/tests/libtest/test_multicluster.py
+++ b/tests/libtest/test_multicluster.py
@@ -1,11 +1,14 @@
 import pytest
 import logging
 
+from ocs_ci.framework import config
+
 from ocs_ci.framework.pytest_customization.marks import (
     libtest,
     run_on_all_clients,
     run_on_all_clients_push_missing_configs,
 )
+from ocs_ci.utility.utils import get_primary_nb_db_pod
 
 logger = logging.getLogger(name=__file__)
 
@@ -35,3 +38,29 @@ def test_run_on_all_clients_marker_with_additional_parameters(
 @pytest.mark.parametrize("cluster_index", [1, 2], indirect=True)
 def test_cluster_index_fixture(cluster_index):
     logger.info(f"param: {cluster_index}")
+
+
+@libtest
+def test_run_with_provider_decorator():
+    """
+    Test context switching between provider and consumer configurations.
+    """
+    # Choose any function that will succeed on provider and fail on clients
+    provider_only_func = get_primary_nb_db_pod
+
+    # Wrap the provider_only_func with the decorator
+    @config.run_with_provider_context_if_available
+    def _run_provider_only_func_using_decorator():
+        return provider_only_func()
+
+    # Force switch to client
+    with config.RunWithFirstConsumerConfigContextIfAvailable():
+
+        # Use the wrapped function to switch back to provider
+        # and perform the action
+        _run_provider_only_func_using_decorator()
+
+        # Expect to switch back to client and try again
+        # expect to fail
+        with pytest.raises(Exception):
+            provider_only_func()


### PR DESCRIPTION
### What
Introduce a new decorator to wrap functions or methods, as if their content were ran inside a `with config.RunWithProviderConfigContextIfAvailable():` block. The purpose of which is to make sure certain code runs only on the provider cluster and not on the clients.

### Why
We need to modify many functions and methods (especially on MCG relalted tests) so they run only on provider. The current solution works, but it results in messy code and big PRs where we'll indent hundreds if not thousands of rows to fit inside `with config.RunWithProviderConfigContextIfAvailable()` blocks.

This decorator would simplify this process.

### How
- Added @staticmethod MultiClusterConfig.run_with_provider_context_if_available
- Added a new libtest to verify its functionality