### PR TITLE
OCSQECL-5384 corrective measures. test_prometheus_rule_failures

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
@@ -69,13 +69,6 @@ def test_prometheus_rule_failures(threading_lock):
         pod_logs.reverse()
         for log_line in pod_logs:
             if "many-to-many matching not allowed" in log_line.lower():
-                log.error(
-                    f"Found 'warn' msg in logs of pod {pod_name}:"
-                    f"\n\n****************** Log message: ******************\n{log_line}"
-                    f"\n****************** End of logs ******************"
-                    f"\n\nThis is a known issue. Follow OCSQECL-5384 and knowledge base article "
-                    f"solutions/7103336 for more details."
-                )
                 test_results[f"many-to-many-error-present-{pod_name}-check"] = False
                 break
         else:


### PR DESCRIPTION
With this PR we expanded `test_prometheus_rule_failures` to check wether warning appears on failed 'many-to-many matching not allowed'. PrometheusRuleFailures can fire with this warn message or not, and in next case we are failing test
a) PrometheusRuleFailures query return message.Ok != True 
c) PrometheusRuleFailures query is fired and 'many-to-many matching not allowed'  error log is found in primetheus-k8s pod
d) PrometheusRuleFailures query is NOT fired, but 'many-to-many matching not allowed'  error log is found in primetheus-k8s pod 
* this may happen when custom query via Prometheus http req or via UI has violated 'many-to-many matching not allowed' requirement
 e) PrometheusRuleFailures query is fired, but 'many-to-many matching not allowed'  error log is NOT found in primetheus-k8s pod