### PR TITLE
Moving test_create_scale_pods_and_pvcs_using_kube_job to orange squad

### DIFF
--- a/tests/functional/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
+++ b/tests/functional/workloads/test_create_scale_pods_and_pvcs_using_kube_job.py
@@ -17,7 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ms_provider_and_consumer,
     ms_consumer_required,
     skipif_bm,
-    magenta_squad,
+    orange_squad,
     hci_provider_and_client_required,
 )
 from ocs_ci.ocs.ocp import OCP
@@ -29,7 +29,7 @@ from ocs_ci.ocs.resources.pod import get_all_pods
 log = logging.getLogger(__name__)
 
 
-@magenta_squad
+@orange_squad
 @ignore_leftovers
 class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
     """
@@ -49,6 +49,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
 
     @tier2
     @skipif_bm
+    @orange_squad
     @skipif_external_mode
     @ipi_deployment_required
     def test_create_scale_pods_and_pvcs_using_kube_job(
@@ -121,8 +122,8 @@ class TestCreateScalePodsAndPvcsUsingKubeJob(ManageTest):
         )
 
 
-@magenta_squad
 @tier1
+@orange_squad
 @ignore_leftovers
 @ms_provider_and_consumer_required
 class TestCreateScalePodsAndPvcsUsingKubeJobWithMSConsumers(ManageTest):
@@ -256,7 +257,7 @@ class TestCreateScalePodsAndPvcsUsingKubeJobWithMSConsumers(ManageTest):
         )
 
 
-@magenta_squad
+@orange_squad
 @tier1
 @hci_provider_and_client_required
 class TestCreateScalePodsAndPvcsUsingKubeJobWithHCIClients(ManageTest):


### PR DESCRIPTION
Description:

From the discussions https://ibm-systems-storage.slack.com/archives/C06GGES4810/p1755105146062679, we are moving the tests to orange squad