### PR TITLE
Support RDR deployment on provider and client clusters

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -424,6 +424,9 @@ Scenarios that use this data include MDR and RDR deployments.
 * `acm_cluster` - True if the cluster is an ACM hub cluster, otherwise False.
 * `primary_cluster` - True if the cluster is the primary cluster, otherwise False.
 * `active_acm_cluster` - True if the cluster is the active ACM hub cluster, False if passive.
+* `dr_cluster_relations` - List specifying each pair of RDR clusters
+   - ["cluster1", "cluster2"]
+   - ["cluster3", "cluster4"]
 
 ##### ibmcloud
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3698,7 +3698,20 @@ class MultiClusterDROperatorsDeploy(object):
         # Fill in for the rest of the non-acm clusters
         # index 0 is filled by primary
         index = 1
-        for cluster in get_non_acm_cluster_config():
+        dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
+        # The dr_cluster_relations is expected to have only 1 pair for deployment, else,
+        # the first pair will be considered. This is mainly applicable for client cluster RDR pairs
+        # in multiclient configuration and provider cluster contexts will also be present.
+        if dr_cluster_relations:
+            dr_cluster_names = dr_cluster_relations[0]
+            cluster_configs = [
+                cluster
+                for cluster in config.clusters
+                if cluster.ENV_DATA["cluster_name"] in dr_cluster_names
+            ]
+        else:
+            cluster_configs = get_non_acm_cluster_config()
+        for cluster in cluster_configs:
             if (
                 cluster.ENV_DATA["cluster_name"]
                 == get_primary_cluster_config().ENV_DATA["cluster_name"]

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3298,7 +3298,7 @@ class RBDDRDeployOps(object):
             if out.stdout.decode() != expected_state:
                 # If there are more than one cephblockpoolradosnamespaces resource
                 if resource_name == constants.CEPHBLOCKPOOLRADOSNS:
-                    item_states = out.stdout.decode().strip.split()
+                    item_states = out.stdout.decode().strip().split()
                     if all(
                         rns_state.strip() == expected_state for rns_state in item_states
                     ):

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -354,7 +354,7 @@ class Deployment(object):
             templating.dump_data_to_temp_yaml(
                 managedclustersetbinding_obj, managedclustersetbinding.name
             )
-            run_cmd(f"oc create -f {managedclustersetbinding.name}")
+            run_cmd(f"oc apply -f {managedclustersetbinding.name}")
 
             gitops_obj = ocp.OCP(
                 resource_name=constants.GITOPS_CLUSTER_NAME,
@@ -372,7 +372,7 @@ class Deployment(object):
                 if cluster["metadata"]["name"] != constants.ACM_LOCAL_CLUSTER:
                     config.switch_to_cluster_by_name(cluster["metadata"]["name"])
                     exec_cmd(
-                        f"oc create -f {constants.CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}"
+                        f"oc apply -f {constants.CLUSTERROLEBINDING_APPSET_PULLMODEL_PATH}"
                     )
 
     def do_deploy_ocs(self):

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3279,10 +3279,7 @@ class RBDDRDeployOps(object):
     """
 
     def deploy(self):
-        # TODO: Skip this check for now in client clusters.
-        #  This should be enhanced to get details from the provider cluster
-        if config.hci_client_exist():
-            self.configure_rbd()
+        self.configure_rbd()
 
     @retry(ResourceWrongStatusException, tries=10, delay=5)
     def configure_rbd(self):

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -786,7 +786,6 @@ class Deployment(object):
         self.do_gitops_deploy()
         self.do_deploy_oadp()
         self.do_deploy_ocs()
-        self.do_deploy_odf_provider_mode()
         self.do_deploy_rdr()
         self.do_deploy_mce()
         self.do_deploy_cnv()

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -4163,7 +4163,8 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             )
             if orchestrator_controller.is_exist():
                 logger.info(
-                    f"{constants.DEPLOYMENT} {constants.ODF_MULTICLUSTER_ORCHESTRATOR_CONTROLLER_MANAGER} already exists"
+                    f"{constants.DEPLOYMENT} {constants.ODF_MULTICLUSTER_ORCHESTRATOR_CONTROLLER_MANAGER} "
+                    f"already exists"
                 )
                 orchestrator_controller.wait_for_resource(
                     condition="1", column="AVAILABLE", resource_count=1, timeout=300

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -573,7 +573,7 @@ class Deployment(object):
                     templating.dump_data_to_temp_yaml(
                         oadp_subscription_yaml_data, oadp_subscription_manifest.name
                     )
-                    run_cmd(f"oc create -f {oadp_subscription_manifest.name}")
+                    run_cmd(f"oc apply -f {oadp_subscription_manifest.name}")
                     self.wait_for_subscription(
                         constants.OADP_OPERATOR_NAME, namespace=constants.OADP_NAMESPACE
                     )

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -276,7 +276,11 @@ class Deployment(object):
         )
 
         logger.info("Creating Namespace for GitOps Operator ")
-        run_cmd(f"oc apply namespace {constants.GITOPS_NAMESPACE}")
+        gitops_namespace = OCP(
+            kind=constants.NAMESPACE, resource_name=constants.GITOPS_NAMESPACE
+        )
+        if not gitops_namespace.is_exist():
+            run_cmd(f"oc create namespace {constants.GITOPS_NAMESPACE}")
 
         logger.info("Creating OperatorGroup for GitOps Operator ")
         run_cmd(f"oc apply -f {constants.GITOPS_OPERATORGROUP_YAML}")

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -370,6 +370,19 @@ class Deployment(object):
                 "Create clusterrolebinding on both the managed clusters, needed "
                 "for appset pull model gitops deployment"
             )
+
+            # Find the DR clusters under test
+            dr_cluster_names = []
+            dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
+            for cluster_relation in dr_cluster_relations:
+                dr_cluster_names.extend(cluster_relation)
+            if dr_cluster_names:
+                managed_clusters = [
+                    cluster
+                    for cluster in managed_clusters
+                    if cluster["metadata"]["name"] in dr_cluster_names
+                ]
+            # TODO: Iterate over dr_cluster_names when dr_cluster_names becomes a mandatory config parameter
             for cluster in managed_clusters:
                 if cluster["metadata"]["name"] != constants.ACM_LOCAL_CLUSTER:
                     config.switch_to_cluster_by_name(cluster["metadata"]["name"])

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -573,7 +573,7 @@ class Deployment(object):
                     templating.dump_data_to_temp_yaml(
                         oadp_subscription_yaml_data, oadp_subscription_manifest.name
                     )
-                    run_cmd(f"oc apply -f {oadp_subscription_manifest.name}")
+                    run_cmd(f"oc create -f {oadp_subscription_manifest.name}")
                     self.wait_for_subscription(
                         constants.OADP_OPERATOR_NAME, namespace=constants.OADP_NAMESPACE
                     )
@@ -768,7 +768,7 @@ class Deployment(object):
 
         self.do_deploy_lvmo()
         self.do_deploy_submariner()
-        # self.do_gitops_deploy()
+        self.do_gitops_deploy()
         self.do_deploy_oadp()
         self.do_deploy_ocs()
         self.do_deploy_rdr()

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -768,7 +768,7 @@ class Deployment(object):
 
         self.do_deploy_lvmo()
         self.do_deploy_submariner()
-        self.do_gitops_deploy()
+        #self.do_gitops_deploy()
         self.do_deploy_oadp()
         self.do_deploy_ocs()
         self.do_deploy_rdr()

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -768,7 +768,7 @@ class Deployment(object):
 
         self.do_deploy_lvmo()
         self.do_deploy_submariner()
-        #self.do_gitops_deploy()
+        # self.do_gitops_deploy()
         self.do_deploy_oadp()
         self.do_deploy_ocs()
         self.do_deploy_rdr()
@@ -3288,7 +3288,7 @@ class RBDDRDeployOps(object):
         out_list = run_cmd_multicluster(
             cmd,
             skip_index=get_all_acm_and_recovery_indexes()
-            + config.get_consumer_indexes_list(),
+            + config.get_consumer_indexes_list(raise_exception=False),
         )
         index = 0
         for out in out_list:
@@ -3326,10 +3326,9 @@ class RBDDRDeployOps(object):
 
         for cluster in get_non_acm_and_non_recovery_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
-            if (
-                cluster.MULTICLUSTER["multicluster_index"]
-                not in config.get_consumer_indexes_list()
-            ):
+            if cluster.MULTICLUSTER[
+                "multicluster_index"
+            ] not in config.get_consumer_indexes_list(raise_exception=False):
                 _get_mirror_pod_count()
             self.validate_csi_sidecar()
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -771,6 +771,7 @@ class Deployment(object):
         self.do_gitops_deploy()
         self.do_deploy_oadp()
         self.do_deploy_ocs()
+        self.do_deploy_odf_provider_mode()
         self.do_deploy_rdr()
         self.do_deploy_mce()
         self.do_deploy_cnv()

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -338,7 +338,9 @@ class Deployment(object):
             run_cmd(f"oc apply -f {constants.GITOPS_PLACEMENT_YAML}")
 
             logger.info("Creating ManagedClusterSetBinding")
-            cluster_set = config.ENV_DATA.get("cluster_set") or get_cluster_set_name()
+            cluster_set = (
+                config.ENV_DATA.get("cluster_set") or get_cluster_set_name()[0]
+            )
 
             managed_clusters = (
                 ocp.OCP(kind=constants.ACM_MANAGEDCLUSTER).get().get("items", [])
@@ -346,8 +348,8 @@ class Deployment(object):
             managedclustersetbinding_obj = templating.load_yaml(
                 constants.GITOPS_MANAGEDCLUSTER_SETBINDING_YAML
             )
-            managedclustersetbinding_obj["metadata"]["name"] = cluster_set[0]
-            managedclustersetbinding_obj["spec"]["clusterSet"] = cluster_set[0]
+            managedclustersetbinding_obj["metadata"]["name"] = cluster_set
+            managedclustersetbinding_obj["spec"]["clusterSet"] = cluster_set
             managedclustersetbinding = tempfile.NamedTemporaryFile(
                 mode="w+", prefix="managedcluster_setbinding", delete=False
             )

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3608,7 +3608,11 @@ class MultiClusterDROperatorsDeploy(object):
         # on all participating clusters except HUB
         # We will switch config ctx to Participating clusters
         for cluster in config.clusters:
-            if is_acm_cluster(cluster) or is_recovery_cluster(cluster):
+            if (
+                is_acm_cluster(cluster)
+                or is_recovery_cluster(cluster)
+                or cluster.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT
+            ):
                 continue
             else:
                 config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3544,10 +3544,10 @@ class MultiClusterDROperatorsDeploy(object):
             index += 1
 
         # Use unique cluster name to easily identify the managed clusters
-        pirror_peer_name = "mirrorpeer"
+        mirror_peer_name = "mirrorpeer"
         for cluster_info in mirror_peer_data["spec"]["items"]:
-            pirror_peer_name = pirror_peer_name + "-" + cluster_info["clusterName"]
-        mirror_peer_data["metadata"]["name"] = pirror_peer_name
+            mirror_peer_name = mirror_peer_name + "-" + cluster_info["clusterName"]
+        mirror_peer_data["metadata"]["name"] = mirror_peer_name
 
         templating.dump_data_to_temp_yaml(mirror_peer_data, mirror_peer_yaml.name)
         # Current CTX: ACM

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -276,6 +276,8 @@ class MultiClusterConfig:
         provider_index = None
         if provider_name:
             provider_index = self.get_cluster_index_by_name(cluster_name=provider_name)
+        elif config.ENV_DATA.get("cluster_type") == "provider":
+            provider_index = config.cur_index
         else:
             for i, cluster in enumerate(self.clusters):
                 if cluster.ENV_DATA["cluster_type"] == "provider":

--- a/ocs_ci/framework/__init__.py
+++ b/ocs_ci/framework/__init__.py
@@ -298,7 +298,7 @@ class MultiClusterConfig:
                 provider_indexes_list.append(cluster_index)
         return provider_indexes_list
 
-    def get_consumer_indexes_list(self):
+    def get_consumer_indexes_list(self, raise_exception=True):
         """
         Get the consumer cluster indexes
 
@@ -318,7 +318,7 @@ class MultiClusterConfig:
             ]:
                 consumer_indexes_list.append(i)
 
-        if not consumer_indexes_list:
+        if (not consumer_indexes_list) and raise_exception:
             raise ClusterNotFoundException("Didn't find any consumer cluster")
 
         return consumer_indexes_list

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2354,7 +2354,7 @@ def create_service_exporter():
             config.ENV_DATA["platform"].lower()
             in constants.HCI_PROVIDER_CLIENT_PLATFORMS
         ):
-            logger.info(f"Skipping ServiceExport creation")
+            logger.info("Skipping ServiceExport creation for multiclient cluster")
             continue
         logger.info("Creating Service exporter")
         run_cmd(f"oc create -f {constants.DR_SERVICE_EXPORTER}")

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2368,19 +2368,12 @@ def verify_volsync():
     restore_index = config.cur_index
     managed_clusters = get_non_acm_cluster_config()
     for cluster in managed_clusters:
-        if cluster.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
-            with config.RunWithConfigContext(
-                cluster.MULTICLUSTER["multicluster_index"]
-            ):
-                index = config.get_provider_index()
-        else:
-            index = cluster.MULTICLUSTER["multicluster_index"]
+        index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)
         logger.info(
             f"Verifying volsync pod in namespace {constants.VOLSYNC_SYSTEM_NAMESPACE}"
         )
         pod = ocp.OCP(kind=constants.POD, namespace=constants.VOLSYNC_SYSTEM_NAMESPACE)
-        # TODO: Check whether volsync pod is created for each RDR pair of client clusters
         assert pod.wait_for_resource(
             condition="Running",
             selector=constants.VOLSYNC_LABEL,

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2302,7 +2302,6 @@ def validate_storage_cluster_peer_state():
             index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)
         logger.info("Validating Storage Cluster Peer status")
-        # TODO: Check whether storageclusterpeer is created for each RDR pair of client clusters
         sample = TimeoutSampler(
             timeout=300,
             sleep=5,

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2293,11 +2293,11 @@ def validate_storage_cluster_peer_state():
     restore_index = config.cur_index
     managed_clusters = get_non_acm_cluster_config()
     for cluster in managed_clusters:
-        if (
-            config.ENV_DATA["platform"].lower()
-            in constants.HCI_PROVIDER_CLIENT_PLATFORMS
-        ):
-            index = config.get_provider_index()
+        if cluster.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+            with config.RunWithConfigContext(
+                cluster.MULTICLUSTER["multicluster_index"]
+            ):
+                index = config.get_provider_index()
         else:
             index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)
@@ -2368,11 +2368,11 @@ def verify_volsync():
     restore_index = config.cur_index
     managed_clusters = get_non_acm_cluster_config()
     for cluster in managed_clusters:
-        if (
-            config.ENV_DATA["platform"].lower()
-            in constants.HCI_PROVIDER_CLIENT_PLATFORMS
-        ):
-            index = config.get_provider_index()
+        if cluster.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+            with config.RunWithConfigContext(
+                cluster.MULTICLUSTER["multicluster_index"]
+            ):
+                index = config.get_provider_index()
         else:
             index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -190,7 +190,9 @@ class AcmAddClusters(AcmPageNavigator):
         log.info("Click on Create cluster set")
         self.do_click(self.page_nav["create-cluster-set"])
         global cluster_set_name
-        cluster_set_name = create_unique_resource_name("submariner", "clusterset")
+        cluster_set_name = config.ENV_DATA.get(
+            "cluster_set"
+        ) or create_unique_resource_name("submariner", "clusterset")
         log.info(f"Send Cluster set name '{cluster_set_name}'")
         self.do_send_keys(self.page_nav["cluster-set-name"], text=cluster_set_name)
         log.info("Click on Create")
@@ -319,7 +321,9 @@ class AcmAddClusters(AcmPageNavigator):
         else:
             log.error("Couldn't navigate to Cluster sets page")
             raise NoSuchElementException
-        cluster_set_name = get_cluster_set_name()[0]
+        cluster_set_name = (
+            config.ENV_DATA.get("cluster_set") or get_cluster_set_name()[0]
+        )
         log.info("Click on the cluster set created")
         self.do_click(
             format_locator(self.page_nav["cluster-set-selection"], cluster_set_name)

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -14,7 +14,7 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedPlatformVersionError,
 )
 from ocs_ci.ocs import constants
-
+from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -115,6 +115,7 @@ def get_semantic_ocp_running_version(separator=None):
     return get_semantic_version(get_running_ocp_version(separator), True)
 
 
+@switch_to_orig_index_at_last
 def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     """
     Returns semantic OCS Version from the CSV (ODF if version >= 4.9, OCS otherwise)

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -15,7 +15,6 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.ocs import constants
 
-# from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +115,6 @@ def get_semantic_ocp_running_version(separator=None):
     return get_semantic_version(get_running_ocp_version(separator), True)
 
 
-# @switch_to_orig_index_at_last
 def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     """
     Returns semantic OCS Version from the CSV (ODF if version >= 4.9, OCS otherwise)
@@ -132,9 +130,9 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     # Import ocp here to avoid circular dependency issue
     from ocs_ci.ocs import ocp
 
-    # if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
-    #     context_to_switch = config.get_provider_index()
-    #     config.switch_ctx(context_to_switch)
+    if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+        context_to_switch = config.get_provider_index()
+        config.switch_ctx(context_to_switch)
     csvs = ocp.OCP(
         namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
     )

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -134,6 +134,8 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     )
     if get_semantic_ocs_version_from_config() >= VERSION_4_9:
         operator_name = defaults.ODF_OPERATOR_NAME
+    elif config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+        operator_name = defaults.ODF_CLIENT_OPERATOR
     else:
         operator_name = defaults.OCS_OPERATOR_NAME
     for item in csvs.get()["items"]:

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -14,7 +14,6 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedPlatformVersionError,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +114,6 @@ def get_semantic_ocp_running_version(separator=None):
     return get_semantic_version(get_running_ocp_version(separator), True)
 
 
-@switch_to_orig_index_at_last
 def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     """
     Returns semantic OCS Version from the CSV (ODF if version >= 4.9, OCS otherwise)
@@ -131,6 +129,7 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     # Import ocp here to avoid circular dependency issue
     from ocs_ci.ocs import ocp
 
+    initial_index = config.cluster_ctx.MULTICLUSTER["multicluster_index"]
     if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
         context_to_switch = config.get_provider_index()
         config.switch_ctx(context_to_switch)
@@ -143,6 +142,7 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
         operator_name = defaults.OCS_OPERATOR_NAME
     for item in csvs.get()["items"]:
         if item["metadata"]["name"].startswith(operator_name):
+            config.switch_ctx(initial_index)
             return get_semantic_version(
                 item["spec"]["version"], only_major_minor, ignore_pre_release
             )

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -14,7 +14,8 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedPlatformVersionError,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.utility.decorators import switch_to_orig_index_at_last
+
+# from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ def get_semantic_ocp_running_version(separator=None):
     return get_semantic_version(get_running_ocp_version(separator), True)
 
 
-@switch_to_orig_index_at_last
+# @switch_to_orig_index_at_last
 def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     """
     Returns semantic OCS Version from the CSV (ODF if version >= 4.9, OCS otherwise)

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -131,9 +131,9 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     # Import ocp here to avoid circular dependency issue
     from ocs_ci.ocs import ocp
 
-    if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
-        context_to_switch = config.get_provider_index()
-        config.switch_ctx(context_to_switch)
+    # if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+    #     context_to_switch = config.get_provider_index()
+    #     config.switch_ctx(context_to_switch)
     csvs = ocp.OCP(
         namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
     )

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -132,10 +132,10 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
     csvs = ocp.OCP(
         namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
     )
-    if get_semantic_ocs_version_from_config() >= VERSION_4_9:
-        operator_name = defaults.ODF_OPERATOR_NAME
-    elif config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
+    if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
         operator_name = defaults.ODF_CLIENT_OPERATOR
+    elif get_semantic_ocs_version_from_config() >= VERSION_4_9:
+        operator_name = defaults.ODF_OPERATOR_NAME
     else:
         operator_name = defaults.OCS_OPERATOR_NAME
     for item in csvs.get()["items"]:

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -133,17 +133,14 @@ def get_ocs_version_from_csv(only_major_minor=False, ignore_pre_release=False):
 
     if config.ENV_DATA["cluster_type"].lower() == constants.HCI_CLIENT:
         context_to_switch = config.get_provider_index()
-    else:
-        context_to_switch = config.MULTICLUSTER["multicluster_index"]
+        config.switch_ctx(context_to_switch)
+    csvs = ocp.OCP(
+        namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
+    )
     if get_semantic_ocs_version_from_config() >= VERSION_4_9:
         operator_name = defaults.ODF_OPERATOR_NAME
     else:
         operator_name = defaults.OCS_OPERATOR_NAME
-
-    config.switch_ctx(context_to_switch)
-    csvs = ocp.OCP(
-        namespace=config.ENV_DATA["cluster_namespace"], kind="", resource_name="csv"
-    )
     for item in csvs.get()["items"]:
         if item["metadata"]["name"].startswith(operator_name):
             return get_semantic_version(


### PR DESCRIPTION
Support RDR deployment on provider and client clusters.

* Added support to configure everything related to RDR for client clusters except submariner and backup.
* Use provider cluster for verification required, eg: verifying mirrorpeer, verify mirror pods.
* Use unique name for mirrorpeer and drpolicy.
* Updated the functions get_provider_index and get_consumer_indexes_list to avoid error if provider or client cluster is not available in config.
* Added a new parameter MULTICLUSTER.dr_cluster_relations to identify the pair of RDR clusters. There will be 1 pair for deployment and multiple pair for test execution. Updated README.md to add new parameter 'dr_cluster_relations'.
* Skip creating serviceexport for multiclient mode(provider mode) because hostNetwork is True.