### PR TITLE
Fix the DB query in test_unidirectional_bucketclass_replication

### DIFF
--- a/tests/functional/object/mcg/test_bucket_replication.py
+++ b/tests/functional/object/mcg/test_bucket_replication.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import gc
 
@@ -504,12 +505,13 @@ class TestReplication(MCGTest):
             logger.info(f"Deleted source bucket {source_bucket_name}")
 
             # check in db that the replication config was deleted
-            replication_conf_count = exec_nb_db_query(
-                f"SELECT COUNT (*) FROM replicationconfigs WHERE _id='{replication_id}'"
+            replication_conf_data_str = exec_nb_db_query(
+                f"SELECT data FROM replicationconfigs WHERE _id='{replication_id}'"
             )[0].strip()
+            replication_conf_data_dict = json.loads(replication_conf_data_str)
 
             assert (
-                int(replication_conf_count) == 0
+                "deleted" in replication_conf_data_dict
             ), f"Replication config for {source_bucket_name} is not deleted!"
 
             # check in noobaa core logs


### PR DESCRIPTION
Fixes #12919

### What
Update the way we check whether the replication configuration was deleted after deleting the OBC it was set on.

### Why
In the past we were expecting the replication configuration to get deleted immediately from the DB, but now it's initially only soft-deleted by setting a `deleted` timestamp in its data. After enough time or deleted configurations have accumulated, they're supposed to get hard-deleted. More context here: https://issues.redhat.com/browse/DFBUGS-2353?focusedId=27211791&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27211791

### How
Update the `exec_nb_db_query` to fetch the JSON string of the relevant configuration, and then check whether it has the "deleted" key as expected.
