### PR TITLE
remove pf version number and refactor views.py

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -141,14 +141,12 @@ deployment_4_6 = {
         By.CSS_SELECTOR,
     ),
     "enable_encryption": (
-        '//span[@class="pf-v5-c-switch__toggle"] | '
-        '//span[@class="pf-c-switch__toggle"]',
+        '//span[contains(@class, "c-switch__toggle")]',
         By.XPATH,
     ),
     "click_install_lso_page": ("//button[text()='Install']", By.XPATH),
     "project_dropdown": (
-        'button[class="pf-v5-c-dropdown__toggle pf-m-plain"], '
-        'button[class="pf-c-dropdown__toggle pf-m-plain"]',
+        'button[class*="c-dropdown__toggle"][class*="pf-m-plain"]',
         By.CSS_SELECTOR,
     ),
     "OpenShift Container Storage": ('a[id="openshift-storage-link"]', By.CSS_SELECTOR),
@@ -173,13 +171,11 @@ deployment_4_7 = {
 
 deployment_4_9 = {
     "drop_down_projects": (
-        'button[class="pf-v5-c-menu-toggle co-namespace-dropdown__menu-toggle"], '
-        'button[class="pf-v6-c-menu-toggle co-namespace-dropdown__menu-toggle"], '
-        'button[class="pf-c-menu-toggle co-namespace-dropdown__menu-toggle"]',
+        'button[class*="c-menu-toggle"].co-namespace-dropdown__menu-toggle',
         By.CSS_SELECTOR,
     ),
     "enable_default_porjects": (
-        'span[class="pf-v5-c-switch__toggle"], span[class="pf-c-switch__toggle"]',
+        '[class*="c-switch__toggle"]',
         By.CSS_SELECTOR,
     ),
     "choose_openshift-storage_project": (
@@ -206,8 +202,7 @@ deployment_4_9 = {
     "refresh_popup": ("//button[text()='Refresh web console']", By.XPATH),
     "advanced_deployment": ("//span[text()='Advanced']", By.XPATH),
     "expand_advanced_mode": (
-        'button[class="pf-v5-c-select__toggle"], '
-        'button[class="pf-c-select__toggle"]',
+        'button[class*="c-select__toggle"]',
         By.CSS_SELECTOR,
     ),
     "mcg_only_option": ("//button[text()='MultiCloud Object Gateway']", By.XPATH),
@@ -240,60 +235,54 @@ deployment_4_12 = {
 
 deployment_4_15 = {
     "drop_down_projects": (
-        'button[class="pf-v5-c-menu-toggle co-namespace-dropdown__menu-toggle"], '
-        'button[class="pf-v6-c-menu-toggle co-namespace-dropdown__menu-toggle"]',
+        'button[class*="c-menu-toggle"].co-namespace-dropdown__menu-toggle',
         By.CSS_SELECTOR,
     ),
     "drop_down_performance": (
-        "//*[@class='pf-v5-c-select odf-configure-performance__selector pf-u-mb-md'] | "
-        "//*[@class='pf-c-select odf-configure-performance__selector pf-u-mb-md']",
+        "//*[contains(@class, 'c-select') and contains(@class, 'odf-configure-performance__selector')]",
         By.XPATH,
     ),
     "lean_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Lean mode')] |"
-        "//span[@class='pf-c-select__menu-item-main' and contains(text(), 'Lean mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Lean mode')]",
         By.XPATH,
     ),
     "balanced_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Balanced mode')] | "
-        "//span[@class='pf-c-select__menu-item-main' and contains(text(), 'Balanced mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Balanced mode')]",
         By.XPATH,
     ),
     "performance_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Performance mode')] | "
-        "//span[@class='pf-c-select__menu-item-main' and contains(text(), 'Performance mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Performance mode')]",
         By.XPATH,
     ),
 }
 
 deployment_4_16 = {
     "osd_size_dropdown": (
-        "//*[@class='pf-v5-c-select dropdown--full-width'] | "
-        "//*[@class='pf-c-select dropdown--full-width']",
+        "//*[@class='c-select dropdown--full-width'] | "
+        "//*[@class='c-select dropdown--full-width']",
         By.XPATH,
     ),
     "drop_down_performance": (
-        "//*[@class='pf-v5-c-select odf-configure-performance__selector pf-v5-u-mb-md']",
+        "//*[@class='c-select odf-configure-performance__selector pf-v5-u-mb-md']",
         By.XPATH,
     ),
     "lean_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Lean mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Lean mode')]",
         By.XPATH,
     ),
     "balanced_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Balanced mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Balanced mode')]",
         By.XPATH,
     ),
     "performance_mode": (
-        "//span[@class='pf-v5-c-select__menu-item-main' and contains(text(), 'Performance mode')]",
+        "//span[contains(@class, 'c-select__menu-item-main') and contains(text(), 'Performance mode')]",
         By.XPATH,
     ),
 }
 
 deployment_4_17 = {
     "osd_size_dropdown": (
-        "//*[@class='pf-v5-c-select dropdown--full-width'] | "
-        "//*[@class='pf-c-select dropdown--full-width']",
+        "//div[contains(@class, 'select') and contains(@class, 'dropdown--full-width')]",
         By.XPATH,
     ),
 }
@@ -315,9 +304,7 @@ deployment_4_19 = {
 
 generic_locators = {
     "project_selector": (
-        "//span[@class='pf-c-menu-toggle__text' and contains(text(), 'Project:')] | "
-        "//span[@class='pf-v5-c-menu-toggle__text' and contains(text(), 'Project:')] |"
-        "//span[@class='pf-v6-c-menu-toggle__text' and contains(text(), 'Project:')]",
+        "//span[contains(@class, 'c-menu-toggle__text') and contains(text(), 'Project:')]",
         By.XPATH,
     ),
     "select_openshift-storage_project": (
@@ -367,11 +354,10 @@ generic_locators = {
     "remove_search_filter": ('button[aria-label="close"]', By.CSS_SELECTOR),
     "delete_resource_kebab_button": ('//*[contains(text(), "Delete")]', By.XPATH),
     "text_input_popup_rules": (
-        "//*[@class='pf-c-helper-text__item-text'] | "
-        "//div[@data-test='field-requirements-popover']"
-        "//*[@class='pf-v5-c-helper-text__item-text'] | "
-        "//ul//span[@class='pf-v5-c-helper-text__item-text'] | "
-        "//ul[@class='pf-v5-c-helper-text']",
+        "//div[contains(@class, 'helper-text__item-text')] | "
+        "//div[@data-test='field-requirements-popover']//div[contains(@class, 'helper-text__item-text')] | "
+        "//ul//span[contains(@class, 'helper-text__item-text')] | "
+        "//ul[contains(@class, 'helper-text')]",
         By.XPATH,
     ),
     "ocp-overview-status-storage-popup-btn": (
@@ -379,14 +365,12 @@ generic_locators = {
         By.XPATH,
     ),
     "ocp-overview-status-storage-popup-content": (
-        "//div[@class='pf-v5-c-popover__content']//div[contains(.,'Storage')] | "
-        "//div[@class='pf-c-popover__content']//div[contains(.,'Storage')]",
+        "//div[contains(@class, 'popover__content')]//div[contains(.,'Storage')]",
         By.XPATH,
     ),
     "searchbar-dropdown": (
-        "//div[@class='pf-c-toolbar__item']//span[@class='pf-c-dropdown__toggle-text'] | "
-        "//div[@class='pf-v5-c-toolbar__item']//span[@class='pf-v5-c-dropdown__toggle-text'] | "
-        "//div[@class='pf-v6-c-input-group co-filter-group']//button/span",
+        "//div[contains(@class, 'toolbar__item')]//span[contains(@class, 'dropdown__toggle-text')] | "
+        "//div[contains(@class, 'input-group') and contains(@class, 'co-filter-group')]//button/span",
         By.XPATH,
     ),
     "searchbar_drop_down": ("//button[@data-test-id='dropdown-button']", By.XPATH),
@@ -423,8 +407,7 @@ generic_locators = {
         By.XPATH,
     ),
     "show_default_projects_toggle": (
-        "input[class='pf-c-switch__input'], input[class='pf-v5-c-switch__input'], "
-        "input[class='pf-v6-c-switch__input']",
+        "input[class*='c-switch__input']",
         By.CSS_SELECTOR,
     ),
     "developer_selected": ("//h2[.='Developer']", By.XPATH),
@@ -519,7 +502,7 @@ obc = {
     "select_administrator": (
         "//a[contains(@class,'c-dropdown__menu-item')]"
         "//h2[contains(@class, 'c-title pf-m-md')][normalize-space()='Administrator'] | "
-        "//h2[.='Administrator']/ancestor::button[@class='pf-v5-c-menu__item']",
+        "//h2[.='Administrator']/ancestor::button[contains(@class, 'c-menu__item')]",
         By.XPATH,
     ),
     "obc_menu_name": (
@@ -715,7 +698,7 @@ pvc_4_12 = {
 pvc_4_14 = {
     # tested on both for 4.14 and 4.15
     "create_pvc_dropdown_item": (
-        "//button[(@class='pf-c-dropdown__menu-item' or @class='pf-v5-c-dropdown__menu-item') "
+        "//button[contains(@class, 'c-dropdown__menu-item') "
         "and contains(text(), 'With Form')]",
         By.XPATH,
     ),
@@ -795,14 +778,13 @@ page_nav = {
     ),
     "odf_tab": ("OpenShift Data Foundation", By.LINK_TEXT),
     "drop_down_projects": (
-        'button[class="pf-v5-c-menu-toggle co-namespace-dropdown__menu-toggle"], '
-        'button[class="pf-v6-c-menu-toggle co-namespace-dropdown__menu-toggle"]',
+        'button[class*="c-menu-toggle co-namespace-dropdown__menu-toggle"]',
         By.CSS_SELECTOR,
     ),
     "choose_all_projects": ("//span[text()='All Projects']", By.XPATH),
     # show-default-projects works both for OCP 4.14 and 4.15
     "show-default-projects": (
-        ".pf-c-switch__toggle, .pf-v5-c-switch__toggle, .pf-v6-c-switch__toggle",
+        "[class*='c-switch__toggle']",
         By.CSS_SELECTOR,
     ),
     "storage_cluster": ("Storage cluster", By.LINK_TEXT),
@@ -832,7 +814,7 @@ acm_page_nav = {
     "Welcome_page": ("Welcome", By.LINK_TEXT),
     "Overview_page": ("Overview", By.LINK_TEXT),
     "Infrastructure": (
-        "//button[normalize-space()='Infrastructure' and @class='pf-v5-c-nav__link']",
+        "//button[normalize-space()='Infrastructure' and contains(@class, 'c-nav__link')]",
         By.XPATH,
     ),
     "Clusters_page": ("Clusters", By.LINK_TEXT),
@@ -854,7 +836,7 @@ acm_page_nav = {
 }
 acm_page_nav_419 = {
     "Infrastructure": (
-        "//button[normalize-space()='Infrastructure' and @class='pf-v6-c-nav__link']",
+        "//button[normalize-space()='Infrastructure' and contains(@class, 'c-nav__link')]",
         By.XPATH,
     ),
     "click-local-cluster": (
@@ -1103,30 +1085,25 @@ acm_configuration_4_12 = {
     # works for OCP 4.12 to 4.15
     "all-clusters_dropdown": (
         "//a[normalize-space()='All Clusters'] | "
-        "//span[(@class='pf-c-menu-toggle__text' or @class='pf-v5-c-menu-toggle__text'"
-        " or @class='pf-v6-c-menu-toggle__text') "
+        "//span[contains(@class, 'c-menu-toggle__text') "
         "and normalize-space()='All Clusters']/..",
         By.XPATH,
     ),
     # works for OCP 4.12 to 4.15
     "all-clusters_dropdown_item": (
-        "//span[(@class='pf-c-menu__item-text' or @class='pf-v5-c-menu__item-text'"
-        " or @class='pf-v6-c-menu__item-text') "
-        "and text()='All Clusters']/..",
+        "//span[contains(@class, 'c-menu__item-text') and text()='All Clusters']/..",
         By.XPATH,
     ),
     # works for OCP 4.12 to 4.15
     "local-cluster_dropdown": (
         "//h2[text()='local-cluster'] | "
-        "//span[(@class='pf-c-menu-toggle__text' or @class='pf-v5-c-menu-toggle__text'"
-        " or @class='pf-v6-c-menu-toggle__text') "
+        "//span[contains(@class, 'c-menu-toggle__text') "
         "and text()='local-cluster']/..",
         By.XPATH,
     ),
     # works for OCP 4.12 to 4.15
     "local-cluster_dropdown_item": (
-        "//span[(@class='pf-c-menu__item-text' or @class='pf-v5-c-menu__item-text'"
-        " or @class='pf-v6-c-menu__item-text') "
+        "//span[contains(@class, 'c-menu__item-text') "
         "and text()='local-cluster']/..",
         By.XPATH,
     ),
@@ -1147,7 +1124,7 @@ acm_configuration_4_12 = {
         "//input[contains(@class, 'c-text-input-group__text-input')]",
         By.XPATH,
     ),
-    "apply-filter": ("//div[@class='pf-c-select']", By.XPATH),
+    "apply-filter": ("//div[@class='c-select']", By.XPATH),
     "clear-filter": (
         "(//button[@type='button'][normalize-space()='Clear all filters'])[2]",
         By.XPATH,
@@ -1162,7 +1139,7 @@ acm_configuration_4_12 = {
     "relocate-app": ("//button[normalize-space()='Relocate application']", By.XPATH),
     "delete-app": ("//button[normalize-space()='Delete application']", By.XPATH),
     "remove-app-resources": (".//*[@id='remove-app-resources']", By.XPATH),
-    "delete": ("//button[@type='button'][@class='pf-c-button pf-m-danger']", By.XPATH),
+    "delete": ("//button[@type='button'][@class='c-button pf-m-danger']", By.XPATH),
     "no-results-found": ("//*[text()='No results found']", By.XPATH),
     "policy-dropdown": ("#drPolicy-selection", By.CSS_SELECTOR),
     "select-policy": ('//*[text()="{}"]', By.XPATH),
@@ -1172,15 +1149,11 @@ acm_configuration_4_12 = {
     ),
     "failover-preferred-cluster-name": ("//button[text()='{}']", By.XPATH),
     "operation-readiness": ("//*[contains(text(), 'Ready')]", By.XPATH),
-    "subscription-dropdown": (
-        "(//div[@class='pf-v5-c-select__toggle pf-m-typeahead'])[1]",
-        By.XPATH,
-    ),
     "peer-ready": ("//i[normalize-space()='Peer ready']", By.XPATH),
     "initiate-action": ("#modal-intiate-action", By.CSS_SELECTOR),
     "close-action-modal": ("//button[normalize-space()='Close']", By.XPATH),
     "close-action-modal-page": ("//*[text()='Close']", By.XPATH),
-    "title-alert-after-action": ("//h4[@class='pf-c-alert__title']", By.XPATH),
+    "title-alert-after-action": ("//h4[contains(@class, 'alert__title')]", By.XPATH),
     "clear-filters": (
         "(//button[@type='button'][normalize-space()='Clear all filters'])[2]"
     ),
@@ -1264,11 +1237,11 @@ acm_configuration_4_16 = {
         By.XPATH,
     ),
     "app-name-1": (
-        "(//span[@class='pf-v5-c-menu__item-text'][normalize-space()='busybox-1'])[1]",
+        "(//span[contains(@class, 'c-menu__item-text')][normalize-space()='busybox-1'])[1]",
         By.XPATH,
     ),
     "app-name-2": (
-        "(//span[@class='pf-v5-c-menu__item-text'][normalize-space()='busybox-1'])[2]",
+        "(//span[contains(@class, 'c-menu__item-text')][normalize-space()='busybox-1'])[2]",
         By.XPATH,
     ),
 }
@@ -1284,18 +1257,18 @@ acm_configuration_4_18 = {
         By.CSS_SELECTOR,
     ),
     "inconsistent-warning-alert": (
-        "//h4[@class='pf-v5-c-alert__title']",
+        "//h4[contains(@class, 'alert__title')]",
         By.XPATH,
     ),
     "cancel-action-modal": ("#modal-cancel-action", By.CSS_SELECTOR),
     "clear-filter": (
-        "div[class='pf-v5-c-toolbar__content pf-m-chip-container'] "
-        "div[class='pf-v5-c-toolbar__item'] button[type='button']",
-        By.CSS_SELECTOR,
+        "//div[contains(@class, 'toolbar__content') and contains(@class, 'm-chip-container')]"
+        "//div[contains(@class, 'toolbar__item')]//button[@type='button']",
+        By.XPATH,
     ),
-    "apply-filter": ("//div[@class='pf-v5-c-select']", By.XPATH),
+    "apply-filter": ("//div[contains(@class, 'c-select')]", By.XPATH),
     "kebab-action": (
-        "(//td[@class='pf-v5-c-table__td pf-v5-c-table__action']//button)[1]",
+        "(//td[contains(@class, 'c-table__td pf-v5-c-table__action']//button)[1]",
         By.XPATH,
     ),
     "failover-app": (
@@ -1345,7 +1318,7 @@ acm_configuration_4_19 = {
     ),
     "filter-vms": ("input[placeholder='Filter VirtualMachines']", By.CSS_SELECTOR),
     "filter-with-name": (
-        "(//span[@class='pf-v5-c-menu__item-text'][normalize-space()='name'])[1]",
+        "(//span[contains(@class, 'c-menu__item-text')][normalize-space()='name'])[1]",
         By.XPATH,
     ),
     "filter-vms-2": ("input[aria-label='Search input']", By.CSS_SELECTOR),
@@ -1366,10 +1339,13 @@ acm_configuration_4_19 = {
     "name-input-btn": ("#name-input", By.CSS_SELECTOR),
     "vm-page-next-btn": ("button[type='submit']", By.CSS_SELECTOR),
     "dr-policy": ("#pf-select-toggle-id-0", By.CSS_SELECTOR),
-    "select-policy": ("(//span[@class='pf-v5-c-select__menu-item-main'])[1]", By.XPATH),
+    "select-policy": (
+        "(//span[contains(@class, 'c-select__menu-item-main')])[1]",
+        By.XPATH,
+    ),
     "selected-protection-type": ("//div[normalize-space()='{}']", By.XPATH),
     "assign": ("button[type='submit']", By.CSS_SELECTOR),
-    "conf-msg": ("(//h4[@class='pf-v5-c-alert__title'])[1]", By.XPATH),
+    "conf-msg": ("(//h4[@class='c-alert__title'])[1]", By.XPATH),
     "close-page": ("button[aria-label='Close']", By.CSS_SELECTOR),
     "select-shared": ("#shared-vm-protection", By.CSS_SELECTOR),
     "select-drpc": ("input[name='radioGroup']", By.CSS_SELECTOR),
@@ -1594,19 +1570,18 @@ storageclass = {
     ),
     "encryption": ("#storage-class-encryption", By.CSS_SELECTOR),
     "connections-details": (
-        ".pf-c-button.pf-m-link[data-test='edit-kms-link'], .pf-v5-c-button.pf-m-link[data-test='edit-kms-link']",
+        "[class*='c-button'][class*='pf-m-link'][data-test='edit-kms-link']",
         By.CSS_SELECTOR,
     ),
     "service-name": ("#kms-service-name", By.CSS_SELECTOR),
     "kms-address": ("#kms-address", By.CSS_SELECTOR),
     "kms-port": ("#kms-address-port", By.CSS_SELECTOR),
     "save-btn": (
-        ".pf-c-button.pf-m-secondary[data-test='save-action'], .pf-v5-c-button.pf-m-secondary[data-test='save-action']",
+        "[class*='c-button'][class*='m-secondary'][data-test='save-action']",
         By.CSS_SELECTOR,
     ),
     "advanced-settings": (
-        ".pf-c-button.pf-m-link.ocs-storage-class-encryption__form-body, "
-        ".pf-v5-c-button.pf-m-link.ocs-storage-class-encryption__form-body",
+        "[class*='c-button'][class*='pf-m-link'].ocs-storage-class-encryption__form-body",
         By.CSS_SELECTOR,
     ),
     "backend-path": ("#kms-service-backend-path", By.CSS_SELECTOR),
@@ -1621,7 +1596,7 @@ storageclass = {
     ),
     "save-advanced-settings": ("#confirm-action", By.CSS_SELECTOR),
     "save-service-details": (
-        ".pf-c-button.pf-m-secondary[data-test='save-action'], .pf-v5-c-button.pf-m-secondary[data-test='save-action']",
+        "[class*='c-button'][class*='pf-m-secondary'][data-test='save-action']",
         By.CSS_SELECTOR,
     ),
     "create": ("#save-changes", By.CSS_SELECTOR),
@@ -1731,19 +1706,17 @@ validation = {
         By.XPATH,
     ),
     "req_capacity_dropdown_selected": (
-        "//div[@id='breakdown-card-title']/following-sibling::*//*[@class = 'pf-c-select__toggle-text'] | "
-        "//div[@class='pf-v5-c-select ceph-capacity-breakdown-card-header__dropdown']"
-        "//*[@class='pf-v5-c-select__toggle-text']",
+        "//div[@id='breakdown-card-title']/following-sibling::*//*[contains(@class, 'c-select__toggle-text')] | "
+        "//div[contains(@class, 'c-select ceph-capacity-breakdown-card-header__dropdown')]"
+        "//*[contains(@class, 'c-select__toggle-text')]",
         By.XPATH,
     ),
     "req_capacity_dropdown_btn_one": (
-        "//div[@class='pf-c-select ceph-capacity-breakdown-card-header__dropdown'] | "
-        "//div[@class='pf-v5-c-select ceph-capacity-breakdown-card-header__dropdown']",
+        "//div[contains(@class, 'select') and contains(@class, 'ceph-capacity-breakdown-card-header__dropdown')]",
         By.XPATH,
     ),
     "req_capacity_dropdown_btn_two": (
-        "(//span[@class='pf-c-select__toggle-arrow'])[2] | "
-        "(//span[@class='pf-v5-c-select__toggle-arrow'])[2]",
+        "(//span[contains(@class, 'c-select__toggle-arrow')])[2]",
         By.XPATH,
     ),
     "req_capacity_dropdown_list_option": (
@@ -1764,7 +1737,7 @@ validation = {
     # Header of the dropdown element by attributes is very similar to the dropdown item itself.
     "select_administrator": (
         "//h2[@data-test-id='perspective-switcher-menu-option' and normalize-space()='Administrator']/ancestor"
-        "::button[@role='option'] | //h2[.='Administrator']/ancestor::button[@class='pf-v5-c-menu__item']",
+        "::button[@role='option'] | //h2[.='Administrator']/ancestor::button[contains(@class, 'c-menu__item')]",
         By.XPATH,
     ),
     "storage-pools-tab": (
@@ -1809,7 +1782,6 @@ validation_4_8 = {
 }
 
 validation_4_9 = {
-    # Storage Systems page was renamed to Storage Cluster in 4.20
     "storage_systems": (
         "//a[@data-test-id='horizontal-link-Storage Systems'] | //a[text()='Storage cluster'] ",
         By.XPATH,
@@ -1861,13 +1833,13 @@ validation_4_9 = {
         By.CSS_SELECTOR,
     ),
     "storagesystems": (
-        ".pf-c-breadcrumb__link, .pf-v5-c-breadcrumb__link",
+        "[class*='c-breadcrumb__link']",
         By.CSS_SELECTOR,
     ),
     "console_plugin_option": (
-        ".pf-c-button.pf-m-link.pf-m-inline[data-test='edit-console-plugin'], "
-        "button[data-test='edit-console-plugin']",
-        By.CSS_SELECTOR,
+        "//button[contains(@class, 'button') and contains(@class, 'm-link') and contains(@class, 'm-inline') and "
+        "@data-test='edit-console-plugin'] | //button[@data-test='edit-console-plugin']",
+        By.XPATH,
     ),
     "save_console_plugin_settings": ("#confirm-action", By.CSS_SELECTOR),
     "warning-alert": ("//div[contains(@class, 'c-alert pf-m-warning')]", By.XPATH),
@@ -1890,7 +1862,7 @@ validation_4_9 = {
     ),
     # show-default-projects works both on OCP 4.14 and 4.15
     "show-default-projects": (
-        ".pf-c-switch__toggle, .pf-v5-c-switch__toggle, .pf-v6-c-switch__toggle",
+        "[class*='c-switch__toggle']",
         By.CSS_SELECTOR,
     ),
     "ocs-storagecluster-storgesystem": (
@@ -1901,9 +1873,9 @@ validation_4_9 = {
     "system-capacity": ("//h2[normalize-space()='System Capacity']", By.XPATH),
     "ocs-storagecluster": ("//a[normalize-space()='ocs-storagecluster']", By.XPATH),
     "storagesystem-status-card": (
-        ".pf-c-button.pf-m-link.pf-m-inline.co-dashboard-card__button-link.co-status-card__popup, "
-        "button[data-test='health-popover-link']",
-        By.CSS_SELECTOR,
+        "//button[contains(@class, 'button') and contains(@class, 'm-link') and contains(@class, 'm-inline') and "
+        "contains(@class, 'co-status-card__popup')] | //button[@data-test='health-popover-link']",
+        By.XPATH,
     ),
     "block-and-file-health-message": ("div[class='text-muted']", By.CSS_SELECTOR),
     "storage-system-status-card-hyperlink": (
@@ -1942,8 +1914,7 @@ validation_4_9 = {
     ),
     "backingstore-status": ("span[data-test='status-text']", By.CSS_SELECTOR),
     "backingstorage-breadcrumb": (
-        ".pf-v5-c-breadcrumb__link[data-test-id='breadcrumb-link-1'], "
-        ".pf-c-breadcrumb__link[data-test-id='breadcrumb-link-1']",
+        "[class*='c-breadcrumb__link'][data-test-id='breadcrumb-link-1']",
         By.CSS_SELECTOR,
     ),
     "bucketclass": ("a[data-test-id='horizontal-link-Bucket Class']", By.CSS_SELECTOR),
@@ -1953,8 +1924,7 @@ validation_4_9 = {
     ),
     "bucketclass-status": ("//span[@data-test='status-text']", By.XPATH),
     "bucketclass-breadcrumb": (
-        ".pf-v5-c-breadcrumb__link[data-test-id='breadcrumb-link-1'], "
-        ".pf-c-breadcrumb__link[data-test-id='breadcrumb-link-1']",
+        "[class*='c-breadcrumb__link'][data-test-id='breadcrumb-link-1']",
         By.CSS_SELECTOR,
     ),
     "namespace-store": ("//a[normalize-space()='Namespace Store']", By.XPATH),
@@ -2026,15 +1996,15 @@ validation_4_13 = {
         By.XPATH,
     ),
     "status-storage-popup-content": (
-        "//div[@class='pf-v5-c-popover pf-m-top']//*[contains(text(), 'Storage System')] | "
-        "//div[@class='pf-c-popover pf-m-top']//*[contains(text(), 'Storage System')] |"
+        "//div[contains(@class, 'popover') and contains(@class, 'm-top')]//*[contains(text(), 'Storage System')] | "
+        "//div[contains(@class, 'popover') and contains(@class, 'm-top')]//*[contains(text(), 'Storage System')] |"
         "//div[@class='odf-status-card__popup--margin']//a[contains(text(),'ocs-storagecluster')]",
         By.XPATH,
     ),
     "namespace-store-tab-active": (
-        "//button[@class='pf-c-tabs__link' and @aria-selected='true']"
+        "//button[contains(@class, 'c-tabs__link') and @aria-selected='true']"
         "//span[normalize-space()='Namespace Store'] | "
-        "//button[@class='pf-v5-c-tabs__link' and @aria-selected='true']"
+        "//button[contains(@class, 'c-tabs__link') and @aria-selected='true']"
         "//span[normalize-space()='Namespace Store']",
         By.XPATH,
     ),
@@ -2071,7 +2041,7 @@ validation_4_17 = {
     "select_administrator": (
         "//a[@class='pf-c-dropdown__menu-item']//h2[@class='pf-c-title pf-m-md'][normalize-space()='Administrator'] | "
         "//a[@class='pf-m-icon pf-v5-c-dropdown__menu-item']//h2[normalize-space()='Administrator'] | "
-        "//h2[.='Administrator']/ancestor::button[@class='pf-v5-c-menu__item']",
+        "//h2[.='Administrator']/ancestor::button[contains(@class, 'c-menu__item')]",
         By.XPATH,
     ),
 }
@@ -2080,31 +2050,31 @@ validation_4_18 = {
     "encryption_summary": {
         "file_and_block": {
             "enabled": (
-                "//button[@class='pf-v5-c-button pf-m-link pf-m-inline' and "
-                "(text()='Enabled' or text()='Not enabled')]",
+                "//button[contains(@class, 'c-button') and contains(@class, 'm-link') and contains(@class, 'm-inline') "
+                "and (text()='Enabled' or text()='Not enabled')]",
                 By.XPATH,
             ),
             "close": (
-                "//button[@class='pf-v5-c-button pf-m-plain' and @aria-label='Close']",
+                "//button[contains(@class, 'c-button') and contains(@class, 'm-plain') and @aria-label='Close']",
                 By.XPATH,
             ),
             "encryption_content_data": (
-                "//div[@class='pf-v5-c-popover__body']",
+                "//div[contains(@class, 'c-popover__body')]",
                 By.XPATH,
             ),
         },
         "object_storage": {
             "enabled": (
-                "//button[@class='pf-v5-c-button pf-m-link pf-m-inline' and "
-                "(text()='Enabled' or text()='Not enabled')]",
+                "//button[contains(@class, 'c-button') and contains(@class, 'm-link') and contains(@class, 'm-inline') "
+                "and (text()='Enabled' or text()='Not enabled')]",
                 By.XPATH,
             ),
             "close": (
-                "//button[@class='pf-v5-c-button pf-m-plain' and @aria-label='Close']",
+                "//button[contains(@class, 'c-button') and contains(@class, 'm-plain') and @aria-label='Close']",
                 By.XPATH,
             ),
             "encryption_content_data": (
-                "//div[@class='pf-v5-c-popover__content']",
+                "//div[contains(@class, 'c-popover__content')]",
                 By.XPATH,
             ),
         },
@@ -2388,16 +2358,16 @@ bucket_tab = {
         By.XPATH,
     ),
     "create_folder_button": (
-        "div.pf-v5-u-w-50 > div > button.pf-v5-c-button",
-        By.CSS_SELECTOR,
+        "//div[contains(@class, 'u-w-50')]//div//button[contains(@class, 'c-button')]",
+        By.XPATH,
     ),
     "folder_name_input": (
         "#folder-name",
         By.CSS_SELECTOR,
     ),
     "submit_button_folder": (
-        "button.pf-m-primary",
-        By.CSS_SELECTOR,
+        "//button[contains(@class, 'm-primary')]",
+        By.XPATH,
     ),
     "upload_button": (
         "//button[contains(text(), 'Upload')]",


### PR DESCRIPTION
We need to drop using patternfly version number. In most cases it is replaceable with contains xpath func or 'class*=' from syntax from css.
This will improve maintainability and stability of ui framework in future.
---------- TESTING ----------

PR has been tested with ODF 4.20.0-113 OCP 4.20 on AWS, all **black_squad** labeled tests - https://url.corp.redhat.com/ce99b55
<img width="1082" height="873" alt="image" src="https://github.com/user-attachments/assets/6a14206d-8773-4c7b-8b8a-a5a33dd3fcf4" />
https://url.corp.redhat.com/3aa7966

All 8 failures analyzed. No failures related to current changes

