### PR TITLE
[release-4.17 backport] Red Squad - Remove obsolete and redundant tests

### DIFF
--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -49,22 +49,6 @@ class TestBucketCreationAndDeletion(MCGTest):
                 ],
             ),
             pytest.param(
-                *[100, "S3", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1823"),
-                ],
-            ),
-            pytest.param(
-                *[1000, "S3", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1824"),
-                ],
-            ),
-            pytest.param(
                 *[3, "OC", None],
                 marks=[
                     tier1,
@@ -105,22 +89,6 @@ class TestBucketCreationAndDeletion(MCGTest):
                 ],
             ),
             pytest.param(
-                *[100, "CLI", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1825"),
-                ],
-            ),
-            pytest.param(
-                *[1000, "CLI", None],
-                marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
-                    performance,
-                    pytest.mark.polarion_id("OCS-1828"),
-                ],
-            ),
-            pytest.param(
                 *[
                     1,
                     "OC",
@@ -149,15 +117,11 @@ class TestBucketCreationAndDeletion(MCGTest):
         ],
         ids=[
             "3-S3-DEFAULT-BACKINGSTORE",
-            "100-S3-DEFAULT-BACKINGSTORE",
-            "1000-S3-DEFAULT-BACKINGSTORE",
             "3-OC-DEFAULT-BACKINGSTORE",
             "10-OC-DEFAULT-BACKINGSTORE",
             "100-OC-DEFAULT-BACKINGSTORE",
             "1000-OC-DEFAULT-BACKINGSTORE",
             "3-CLI-DEFAULT-BACKINGSTORE",
-            "100-CLI-DEFAULT-BACKINGSTORE",
-            "1000-CLI-DEFAULT-BACKINGSTORE",
             "1-OC-PVPOOL",
             "1-CLI-PVPOOL",
         ],

--- a/tests/functional/object/mcg/test_bucket_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_deletion.py
@@ -77,13 +77,6 @@ class TestBucketDeletion(MCGTest):
             ),
             pytest.param(
                 *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
                     "CLI",
                     {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 ],
@@ -107,7 +100,6 @@ class TestBucketDeletion(MCGTest):
             "OC-AWS",
             "OC-AZURE",
             "OC-GCP",
-            "OC-IBMCOS",
             "CLI-IBMCOS",
             "CLI-AWS-STS",
         ],

--- a/tests/functional/object/mcg/test_multicloud.py
+++ b/tests/functional/object/mcg/test_multicloud.py
@@ -95,7 +95,7 @@ class TestMultiCloud(MCGTest):
             "IBMCOS-OC-1",
         ],
     )
-    def test_multicloud_backingstore_deletion(
+    def deprecated_test_multicloud_backingstore_deletion(
         self, backingstore_factory, backingstore_tup
     ):
         """

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -87,7 +87,9 @@ class TestNamespace(MCGTest):
         ],
     )
     @pytest.mark.polarion_id("OCS-2255")
-    def test_namespace_store_creation_crd(self, namespace_store_factory, nss_tup):
+    def deprecated_test_namespace_store_creation_crd(
+        self, namespace_store_factory, nss_tup
+    ):
         """
         Test namespace store creation using the MCG CRDs.
         """

--- a/tests/functional/object/mcg/test_object_integrity.py
+++ b/tests/functional/object/mcg/test_object_integrity.py
@@ -65,10 +65,6 @@ class TestObjectIntegrity(MCGTest):
                 marks=[tier2, skipif_disconnected_cluster, skipif_fips_enabled],
             ),
             pytest.param(
-                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier2, skipif_disconnected_cluster],
-            ),
-            pytest.param(
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -93,7 +89,6 @@ class TestObjectIntegrity(MCGTest):
             "AZURE-OC-1",
             "GCP-OC-1",
             "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
             "AWS-OC-Cache",
         ],
     )
@@ -131,7 +126,7 @@ class TestObjectIntegrity(MCGTest):
 
     @pytest.mark.polarion_id("OCS-1945")
     @tier2
-    def test_empty_file_integrity(
+    def deprecated_test_empty_file_integrity(
         self, mcg_obj, awscli_pod, bucket_factory, test_directory_setup
     ):
         """

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -20,7 +20,6 @@ from ocs_ci.framework.testlib import (
     MCGTest,
     tier1,
     tier2,
-    acceptance,
     performance,
 )
 from ocs_ci.utility.utils import exec_nb_db_query
@@ -118,45 +117,6 @@ class TestBucketIO(MCGTest):
         argnames="interface,bucketclass_dict",
         argvalues=[
             pytest.param(
-                *["S3", None],
-                marks=[tier1, acceptance],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {
-                        "interface": "OC",
-                        "backingstore_dict": {"aws": [(1, "eu-central-1")]},
-                    },
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"azure": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *["OC", {"interface": "OC", "backingstore_dict": {"gcp": [(1, None)]}}],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "OC",
-                    {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
-                *[
-                    "CLI",
-                    {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                ],
-                marks=[tier1],
-            ),
-            pytest.param(
                 *[
                     "OC",
                     {"interface": "OC", "backingstore_dict": {"rgw": [(1, None)]}},
@@ -172,12 +132,6 @@ class TestBucketIO(MCGTest):
             ),
         ],
         ids=[
-            "DEFAULT-BACKINGSTORE",
-            "AWS-OC-1",
-            "AZURE-OC-1",
-            "GCP-OC-1",
-            "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
             "RGW-OC-1",
             "RGW-CLI-1",
         ],
@@ -237,10 +191,6 @@ class TestBucketIO(MCGTest):
                 marks=[tier2],
             ),
             pytest.param(
-                {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
-            ),
-            pytest.param(
                 {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 marks=[tier2, skipif_fips_enabled],
             ),
@@ -250,7 +200,6 @@ class TestBucketIO(MCGTest):
             "AWS-OC-1",
             "AZURE-OC-1",
             "GCP-OC-1",
-            "IBMCOS-OC-1",
             "IBMCOS-CLI-1",
         ],
     )
@@ -322,10 +271,6 @@ class TestBucketIO(MCGTest):
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
                 marks=[tier2],
             ),
-            pytest.param(
-                {"interface": "CLI", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier1],
-            ),
         ],
         ids=[
             "DEFAULT-BACKINGSTORE",
@@ -333,7 +278,6 @@ class TestBucketIO(MCGTest):
             "AZURE-OC-1",
             "GCP-OC-1",
             "IBMCOS-OC-1",
-            "IBMCOS-CLI-1",
         ],
     )
     def test_mcg_data_compression(
@@ -376,7 +320,9 @@ class TestBucketIO(MCGTest):
     @tier2
     @performance
     @skip_inconsistent
-    def test_data_reduction_performance(self, mcg_obj, awscli_pod, bucket_factory):
+    def deprecated_test_data_reduction_performance(
+        self, mcg_obj, awscli_pod, bucket_factory
+    ):
         """
         Test data reduction performance
         """

--- a/tests/functional/upgrade/test_noobaa.py
+++ b/tests/functional/upgrade/test_noobaa.py
@@ -183,7 +183,7 @@ def test_start_upgrade_mcg_io(mcg_workload_job):
 @bugzilla("1874243")
 @mcg
 @red_squad
-def test_upgrade_mcg_io(mcg_workload_job):
+def deprecated_test_upgrade_mcg_io(mcg_workload_job):
     """
     Confirm that there is MCG workload job running after upgrade.
     """

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -136,7 +136,7 @@ def test_pod_log_after_upgrade():
 @pytest.mark.polarion_id("OCS-2666")
 @mcg
 @red_squad
-def test_noobaa_service_mon_after_ocs_upgrade():
+def deprecated_test_noobaa_service_mon_after_ocs_upgrade():
     """
     Verify 'noobaa-service-monitor' does not exist after OCS upgrade.
 


### PR DESCRIPTION
This is a manual backport of https://github.com/red-hat-storage/ocs-ci/pull/10852 to the release-4.17 branch