### PR TITLE
Fixes skipping test on fips enabled IBM cluster

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -238,6 +238,14 @@ skipif_fips_enabled = pytest.mark.skipif(
     reason="This test cannot run on FIPS enabled cluster",
 )
 
+skipif_fips_enabled_on_ibm_cloud = pytest.mark.skipif(
+    (
+        config.ENV_DATA.get("fips") == "true"
+        and config.ENV_DATA["platform"].lower() == "ibm_cloud"
+    ),
+    reason="This test cannot run on FIPS enabled IBM cluster",
+)
+
 fips_required = pytest.mark.skipif(
     config.ENV_DATA.get("fips") != "true",
     reason="Test runs only on FIPS enabled cluster",

--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     skipif_fips_enabled,
+    skipif_fips_enabled_on_ibm_cloud,
 )
 from ocs_ci.framework.testlib import (
     MCGTest,
@@ -191,7 +192,7 @@ class TestBucketIO(MCGTest):
         argvalues=[
             pytest.param(
                 None,
-                marks=[tier1],
+                marks=[tier1, skipif_fips_enabled_on_ibm_cloud],
             ),
             pytest.param(
                 {
@@ -232,19 +233,6 @@ class TestBucketIO(MCGTest):
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
 
-        if (
-            config.ENV_DATA.get("fips") == "true"
-            and "ibmcos" in bucketclass_dict["backingstore_dict"]
-        ):
-            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
-
-        if (
-            config.ENV_DATA.get("fips") == "true"
-            and bucketclass_dict is None
-            and config.ENV_DATA["platform"].lower() == "ibm_cloud"
-        ):
-            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
-
         download_dir = AWSCLI_TEST_OBJ_DIR
         file_size = int(
             awscli_pod_session.exec_cmd_on_pod(
@@ -268,7 +256,7 @@ class TestBucketIO(MCGTest):
         argvalues=[
             pytest.param(
                 None,
-                marks=[tier1],
+                marks=[tier1, skipif_fips_enabled_on_ibm_cloud],
             ),
             pytest.param(
                 {
@@ -287,7 +275,7 @@ class TestBucketIO(MCGTest):
             ),
             pytest.param(
                 {"interface": "OC", "backingstore_dict": {"ibmcos": [(1, None)]}},
-                marks=[tier2],
+                marks=[tier2, skipif_fips_enabled],
             ),
         ],
         ids=[
@@ -308,18 +296,6 @@ class TestBucketIO(MCGTest):
             awscli_pod_session (pod): A pod running the AWSCLI tools
             bucket_factory: Calling this fixture creates a new bucket(s)
         """
-        if (
-            config.ENV_DATA.get("fips") == "true"
-            and "ibmcos" in bucketclass_dict["backingstore_dict"]
-        ):
-            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
-
-        if (
-            config.ENV_DATA.get("fips") == "true"
-            and bucketclass_dict is None
-            and config.ENV_DATA["platform"].lower() == "ibm_cloud"
-        ):
-            pytest.skip("Skipping test for IBM Cloud on FIPS enabled cluster")
 
         download_dir = AWSCLI_TEST_OBJ_DIR
         bucketname = bucket_factory(1, bucketclass=bucketclass_dict)[0].name


### PR DESCRIPTION
Fixes skipping test on fips enabled IBM cluster

fixes https://github.com/red-hat-storage/ocs-ci/issues/12203
