### PR TITLE
Add max_servers parameter to control FIO server pod count

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9331,6 +9331,7 @@ def benchmark_workload_storageutilization(request):
         is_completed=True,
         numjobs=1,
         iodepth=16,
+        max_servers=20,
     ):
         """
         Setup of benchmark fio
@@ -9347,6 +9348,7 @@ def benchmark_workload_storageutilization(request):
             is_completed (bool): if True, verify the benchmark operator moved to completed state.
             numjobs (int): Number of threads per job
             iodepth (int): I/O queue depth
+            max_servers (int): Maximum number of fio server pods to deploy.
 
         Returns:
             BenchmarkOperatorFIO: The Benchmark operator FIO object
@@ -9357,6 +9359,7 @@ def benchmark_workload_storageutilization(request):
         size = retry(CommandFailed, tries=6, delay=20, backoff=1)(get_file_size)(
             target_percentage
         )
+        log.info(f"Total size = {size}")
         benchmark_obj = BenchmarkOperatorFIO()
         benchmark_obj.setup_benchmark_fio(
             total_size=size,
@@ -9369,6 +9372,7 @@ def benchmark_workload_storageutilization(request):
             use_kustomize_build=use_kustomize_build,
             numjobs=numjobs,
             iodepth=iodepth,
+            max_servers=max_servers,
         )
         benchmark_obj.run_fio_benchmark_operator(is_completed=is_completed)
 

--- a/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
@@ -198,12 +198,14 @@ class TestStorageAutoscalerBase(ManageTest):
             f"(fast_fill_up={fast_fill_up})"
         )
 
-        numjobs = None
-        iodepth = None
+        numjobs = 1
+        iodepth = 16
+        max_servers = 20
 
         if fast_fill_up:
             numjobs = 4
             iodepth = 64
+            max_servers = 60
             # Reduce the target to compensate for likely overshoot
             target_percentage = int(target_percentage - target_percentage / 4)
             logger.info(
@@ -216,6 +218,7 @@ class TestStorageAutoscalerBase(ManageTest):
             is_completed=is_completed,
             numjobs=numjobs,
             iodepth=iodepth,
+            max_servers=max_servers,
         )
 
     def cleanup_cluster(self):

--- a/tests/libtest/test_benchmark_operator.py
+++ b/tests/libtest/test_benchmark_operator.py
@@ -68,7 +68,6 @@ class TestBenchmarkOperator(ManageTest):
         """
         benchmark_name = f"fio-benchmark{uuid4().hex[:4]}"
         log.info(f"Starting benchmark {benchmark_name} with fast fill settings")
-        numjobs = 4
         start = time.time()
 
         benchmark_workload_storageutilization(
@@ -76,8 +75,9 @@ class TestBenchmarkOperator(ManageTest):
             bs="4096KiB",
             benchmark_name=benchmark_name,
             is_completed=True,
-            numjobs=numjobs,
+            numjobs=4,
             iodepth=64,
+            max_servers=60,
         )
         end = time.time()
         fill_up_time = end - start


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/12997
This PR introduces a new parameter `max_servers` to the BenchmarkOperatorFIO class and related test fixtures, allowing users to control the maximum number of FIO server pods deployed during benchmark execution. This enhances scalability and flexibility in benchmarking scenarios.

This update adds support for a new max_servers parameter in the FIO benchmark setup, allowing users to define the upper limit of server pods used. Key changes include:

- setup_benchmark_fio: Added max_servers argument with default value of 20.
- calc_number_servers_file_size: Updated logic to dynamically calculate the number of servers and file size per server based on total_size and max_servers, ensuring better parallelism and balanced workload distribution.
- factory fixture: Propagated max_servers to benchmark setup.
- fill_up_cluster and test_benchmark_workload_storageutilization_fill_up_quickly: Integrated max_servers into fast fill-up scenarios, allowing up to 60 servers for high-throughput tests.
- Logging: Added detailed log output for server count, file size, and total written data to aid in debugging and performance analysis.

This change improves benchmark configurability and helps optimize resource usage in various cluster environments.