### PR TITLE
Increase timeout for snapshot restore in test test_pvc_snapshot

### DIFF
--- a/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
@@ -136,7 +136,9 @@ class TestPvcSnapshot(ManageTest):
             pvc_name=restore_pvc_name,
             restore_pvc_yaml=restore_pvc_yaml,
         )
-        helpers.wait_for_resource_state(restore_pvc_obj, constants.STATUS_BOUND)
+        helpers.wait_for_resource_state(
+            restore_pvc_obj, constants.STATUS_BOUND, timeout=180
+        )
         restore_pvc_obj.reload()
         teardown_factory(restore_pvc_obj)
 


### PR DESCRIPTION
Increase timeout for snapshot restore in test the test tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py::TestPvcSnapshot::test_pvc_snapshot[CephFileSystem]

Fixes #11824 