### PR TITLE
Update BucketNotificationsManager::get_events to filter out NooBaa's TestEvent

### DIFF
--- a/ocs_ci/ocs/resources/bucket_notifications_manager.py
+++ b/ocs_ci/ocs/resources/bucket_notifications_manager.py
@@ -401,6 +401,10 @@ class BucketNotificationsManager:
                     event_dict = parsed_event["Records"][0]
                     events.append(event_dict)
         logger.info(events)
+
+        # Filter out the irrelevant TestEvent which helps NooBaa check the connection
+        events = [event for event in events if "TestEvent" not in str(event)]
+
         return events
 
     def cleanup(self):

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -145,9 +145,7 @@ class TestBucketNotifications(MCGTest):
                 func=notif_manager.get_events,
                 topic=topic,
             ):
-                keys_in_notifs = set(
-                    event["s3"]["object"]["key"] for event in events[1:]
-                )
+                keys_in_notifs = set(event["s3"]["object"]["key"] for event in events)
                 delta = obj_keys_set.difference(keys_in_notifs)
                 if not delta:
                     logger.info("All expected events were received by Kafka")


### PR DESCRIPTION
Fixes #12811

[NooBaa's bucket notifications tests](https://github.com/red-hat-storage/ocs-ci/blob/master/tests/functional/object/mcg/test_bucket_notifications.py) have been failing due to a KeyError because of the TestEvent which doesn't match the expected schema of an actual bucket notification. 

This PR fixes that by filtering it out from the output of BucketNotificationsManager::get_events