### PR TITLE
A few test cases for RHSTOR-6413 - ACM kubevirt DR integration

### DIFF
--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -855,9 +855,7 @@ def assign_drpolicy_for_discovered_vms_via_ui(
             )
             aria_disabled = shared_radio_btn.get_attribute("aria-disabled")
             if aria_disabled == "false":
-                log.info(
-                    "Shared protection type is disabled as expected"
-                )
+                log.info("Shared protection type is disabled as expected")
                 acm_obj.take_screenshot()
             else:
                 log.error("Shared protection type is enabled for the first VM")
@@ -878,7 +876,15 @@ def assign_drpolicy_for_discovered_vms_via_ui(
             log.info("View VMs")
             acm_obj.do_click(acm_loc["view-vms"], enable_screenshot=True)
             log.info("Look for existing VM name")
-
+            existing_vm_check = acm_obj.wait_until_expected_text_is_found(
+                acm_loc["vm-name"], expected_text="vm-workload-1"
+            )
+            if existing_vm_check:
+                log.info("Existing DR protected VM found")
+                acm_obj.take_screenshot()
+            else:
+                acm_obj.take_screenshot()
+                raise ResourceWrongStatusException
         log.info("Click next")
         acm_obj.do_click(acm_loc["vm-page-next-btn"], enable_screenshot=True)
         if standalone:

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1377,14 +1377,18 @@ acm_configuration_4_19 = {
     "select-drpc": ("input[name='radioGroup']", By.CSS_SELECTOR),
 }
 
-acm_configuration_420 = {
-    "view-vms": ("button[class='pf-v5-c-button pf-m-link pf-m-inline']", By.CSS_SELECTOR),
+acm_configuration_4_20 = {
     "admin-dropdown": (
         "(//h2[normalize-space()='Administrator'])[1]",
         By.XPATH,
     ),
     "submariner-custom-source": ("//input[@id='source']", By.XPATH),
     "submariner-custom-channel": ("//input[@id='channel']", By.XPATH),
+    "view-vms": (
+        "button[class='pf-v5-c-button pf-m-link pf-m-inline']",
+        By.CSS_SELECTOR,
+    ),
+    "vm-name": ("//td[contains(text(),'vm-workload-1')]", By.XPATH),
 }
 
 add_capacity = {


### PR DESCRIPTION
Test cases:

1. Deploy the discovered VM using the CLI and apply DRpolicy and select protection type as Standalone. If there is no drpc for that namespace then Shared protection type option should remain disabled for that given workload.
2. Deploy the discovered VM using the CLI and apply DRpolicy and select protection type as Shared. Click View VM in action column and all vm's in that group should be listed.
