### PR TITLE
Add test for MON healthCheck passthrough from StorageCluster to CephCluster

### DIFF
--- a/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
+++ b/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
@@ -84,7 +84,7 @@ def _healthcheck_matches(actual, desired):
 @tier2
 @brown_squad
 @skipif_external_mode
-@pytest.mark.polarion_id("OCS-XXXX")
+@pytest.mark.polarion_id("OCS-7403")
 class TestMonHealthcheckPassthrough(ManageTest):
     """
     Verify StorageCluster.spec.managedResources.cephCluster.healthCheck.daemonHealth.mon


### PR DESCRIPTION
**Description**
This PR introduces an **ocs-ci** test that verifies the new MON healthCheck configuration (`disabled`, `interval`, `timeout`) exposed in the **StorageCluster** CR is correctly mirrored to the **CephCluster** CR.

**Test flow**

1. Patch `StorageCluster.spec.managedResources.cephCluster.healthCheck.daemonHealth.mon`.
2. Wait until the **CephCluster** reflects the same values.
3. Confirm the **StorageCluster** CR holds the updated configuration.
4. Teardown restores defaults by removing the `healthCheck` block.

Covers validation for *Enable Mon Timeout Configuration \[2292442] - GA*. https://issues.redhat.com/browse/RHSTOR-7337
