### PR TITLE
use numeric priority in the pytest order for "last"

### DIFF
--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 @magenta_squad
 @system_test
 @ignore_leftovers
-@pytest.mark.order("last")
+@pytest.mark.order("last-1")
 @pytest.mark.polarion_id("OCS-3911")
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.10")

--- a/tests/functional/disaster-recovery/regional-dr/test_neutral_hub_failure_and_recovery.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_neutral_hub_failure_and_recovery.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 @tier2
 @turquoise_squad
 @dr_hub_recovery
-@pytest.mark.order("last")
+@pytest.mark.order("last-1")
 class TestNeutralHubFailureAndRecovery:
     """
     Perform hub failure where active hub is at a neutral site and then perform hub recovery

--- a/tests/functional/disaster-recovery/regional-dr/test_site_failure_recovery_and_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_site_failure_recovery_and_failover.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 @tier4a
 @turquoise_squad
 @dr_hub_recovery
-@pytest.mark.order("last")
+@pytest.mark.order("last-1")
 class TestSiteFailureRecoveryAndFailover:
     """
     Perform site-failure by bringing down the active hub and the primary managed cluster, then perform hub recovery

--- a/tests/functional/disaster-recovery/sc_arbiter/test_add_capacity.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_add_capacity.py
@@ -75,7 +75,7 @@ class TestAddCapacityStretchCluster:
         ), "OSD weights are not balanced"
         logger.info("OSD weights are balanced")
 
-    @pytest.mark.order("last")
+    @pytest.mark.order("last-1")
     @pytest.mark.parametrize(
         argnames=["iterations"],
         argvalues=[

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -324,7 +324,7 @@ class TestResizeOSD(ManageTest):
 
     @tier2
     @black_squad
-    @pytest.mark.order("last")
+    @pytest.mark.order("last-1")
     @polarion_id("OCS-5800")
     @ui
     @skipif_ibm_cloud_managed

--- a/tests/libtest/test_hci_pc_markers.py
+++ b/tests/libtest/test_hci_pc_markers.py
@@ -82,7 +82,7 @@ class TestHCIProviderClientMarkers(ManageTest):
         ), "The cluster is not a HCI provider cluster, even though we have the marker 'runs_on_provider'"
         logger.info("The cluster is a provider cluster as expected")
 
-    @pytest.mark.order("last")
+    @pytest.mark.order("last-1")
     def test_current_index_not_change_after_using_runs_on_provider(self):
         """
         Test that the current cluster index didn't change after using the 'runs_on_provider'


### PR DESCRIPTION
test_failure_propagator should be last test case to run and since we had many test cases with same order "last" which make different order which is not expected. use numeric priority in last order.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)