### PR TITLE
Fix KeyError 'selector' in test_verify_rwo_using_dc_pod.py and related DC issues

### DIFF
--- a/ocs_ci/templates/app-pods/fedora_dc.yaml
+++ b/ocs_ci/templates/app-pods/fedora_dc.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: fedorapod
 spec:
+  selector:
+    matchLabels:
+      name: fedorapod
   template:
     metadata:
       labels:

--- a/ocs_ci/templates/app-pods/golang.yaml
+++ b/ocs_ci/templates/app-pods/golang.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: hsbenchpod
 spec:
+  selector:
+    matchLabels:
+      app: hsbenchpod
   template:
     metadata:
       labels:

--- a/ocs_ci/templates/app-pods/performance_dc.yaml
+++ b/ocs_ci/templates/app-pods/performance_dc.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: perfpod
 spec:
+  selector:
+    matchLabels:
+      name: perfpod
   template:
     metadata:
       labels:

--- a/ocs_ci/templates/workloads/amq/kafkadrop.yaml
+++ b/ocs_ci/templates/workloads/amq/kafkadrop.yaml
@@ -2,9 +2,12 @@ apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: kafdrop
+  labels:
+    app: kafdrop
 spec:
   selector:
-    app: kafdrop
+    matchLabels:
+      app: kafdrop
   replicas: 1
   template:
     metadata:

--- a/ocs_ci/templates/workloads/fio/fio_dc.yaml
+++ b/ocs_ci/templates/workloads/fio/fio_dc.yaml
@@ -6,6 +6,9 @@ metadata:
     app: fio-benchmark
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fio-benchmark
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is Fix for the issue : https://github.com/red-hat-storage/ocs-ci/issues/12753

## Summary
I've successfully analyzed and fixed the KeyError 'selector' bug in test_verify_rwo_using_dc_pod.py and other potential DeploymentConfig-related issues. Here's what I accomplished:
### ✅ Root Cause Identified
The issue was in the create_pod() function in ocs_ci/helpers/helpers.py at line 321, where it tries to access `pod_data["spec"]["selector"]["matchLabels"]["name"]` when deployment=True. However, several DeploymentConfig YAML templates were missing the required spec.selector.matchLabels field.