### PR TITLE
fix(test_csiaddon_pod_security.py): adapt CSI addon pod security test for ODF 4.20 version

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6359,6 +6359,61 @@ def create_network_fence_class():
     _verify_csi_addons_objects()
 
 
+def get_csi_addon_pod():
+    """
+    Find a CSI addon pod that contains the 'csi-addons' container.
+
+    In ODF 4.20, CSI addon functionality is in dedicated pods with the label
+    'app=openshift-storage.rbd.csi.ceph.com-nodeplugin-csi-addons'.
+
+    Returns:
+        Pod: A Pod object that contains the 'csi-addons' container
+
+    Raises:
+        AssertionError: If no CSI addon pod with 'csi-addons' container is found
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label, get_all_pods, Pod
+    from ocs_ci.ocs.constants import CSI_RBD_ADDON_NODEPLUGIN_LABEL_420
+
+    namespace = config.ENV_DATA["cluster_namespace"]
+
+    try:
+        addon_pods = get_pods_having_label(
+            CSI_RBD_ADDON_NODEPLUGIN_LABEL_420, namespace
+        )
+        if not addon_pods:
+            raise AssertionError(
+                f"No CSI addon pods found with label '{CSI_RBD_ADDON_NODEPLUGIN_LABEL_420}' "
+                f"in namespace {namespace}"
+            )
+
+        pod_obj = Pod(**addon_pods[0])
+
+        # Verify the pod actually has the 'csi-addons' container
+        csi_addon_container = pod_obj.get_container_data("csi-addons")
+        if not csi_addon_container:
+            raise AssertionError(
+                f"CSI addon pod '{pod_obj.name}' exists but does not contain 'csi-addons' container"
+            )
+
+        logger.info(f"Found CSI addon pod: {pod_obj.name}")
+        return pod_obj
+
+    except Exception as e:
+        # Provide helpful diagnostic information
+        try:
+            all_pods = get_all_pods(namespace=namespace)
+            csi_pod_names = [pod.name for pod in all_pods if "csi" in pod.name.lower()]
+            error_msg = (
+                f"Failed to find CSI addon pod in namespace {namespace}. "
+                f"Error: {str(e)}. Available CSI-related pods: {csi_pod_names}"
+            )
+        except Exception:
+            error_msg = f"Failed to find CSI addon pod in namespace {namespace}. Error: {str(e)}"
+
+        raise AssertionError(error_msg)
+
+
 def create_network_fence(node_name, cidr):
     """
     Create NetworkFence for the node

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -681,6 +681,13 @@ CSI_RBDPLUGIN_PROVISIONER_LABEL_419 = (
 )
 CSI_CEPHFSPLUGIN_LABEL_419 = "app=openshift-storage.cephfs.csi.ceph.com-nodeplugin"
 CSI_RBDPLUGIN_LABEL_419 = "app=openshift-storage.rbd.csi.ceph.com-nodeplugin"
+# ODF 4.20+ CSI Addon pod labels - these pods contain the csi-addons containers
+CSI_RBD_ADDON_NODEPLUGIN_LABEL_420 = (
+    "app=openshift-storage.rbd.csi.ceph.com-nodeplugin-csi-addons"
+)
+CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420 = (
+    "app=openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"
+)
 OCS_OPERATOR_LABEL = "name=ocs-operator"
 ODF_OPERATOR_CONTROL_MANAGER_LABEL = "app.kubernetes.io/name=odf-operator"
 ROOK_CEPH_DRAIN_CANARY = "rook-ceph-drain-canary"

--- a/tests/functional/pod_and_daemons/test_csiaddon_pod_security.py
+++ b/tests/functional/pod_and_daemons/test_csiaddon_pod_security.py
@@ -1,23 +1,20 @@
 import pytest
 import logging
 
-from ocs_ci.ocs.resources.pod import get_pods_having_label
-from ocs_ci.ocs.resources.pod import Pod
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.ocs.constants import CSI_RBDPLUGIN_LABEL_419
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     green_squad,
 )
-from ocs_ci.framework.pytest_customization.marks import polarion_id, skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import polarion_id
+from ocs_ci.helpers.helpers import get_csi_addon_pod
 
-log = logging
+log = logging.getLogger(__name__)
 
 
 @tier1
 @green_squad
 @polarion_id("OCS-6807")
-@skipif_ocs_version("<4.19")
 class TestCSIAddonPodSecurity:
     """This class contains tests to Validate if CSI Addon pod enforces security
     by allowing HTTPS and rejecting HTTP connections.
@@ -28,7 +25,7 @@ class TestCSIAddonPodSecurity:
         Validate that the CSI Addon pods are compliant with the Pod Security Standards.
 
         Test Steps:
-        1. Fetch a pod with label 'app=openshift-storage.rbd.csi.ceph.com-nodeplugin' (CSI RBD Nodeplugin).
+        1. Find a CSI addon pod that contains the 'csi-addons' container using ODF 4.20 labels.
         2. Retrieve container information for the container named 'csi-addons'.
         3. Assert that the 'csi-addons' container exists in the pod.
         4. Extract the port used by the 'csi-addons' container.
@@ -45,11 +42,15 @@ class TestCSIAddonPodSecurity:
 
         log.info("Validating CSI Addon pod security standards")
 
-        pod_obj = Pod(**get_pods_having_label(CSI_RBDPLUGIN_LABEL_419)[0])
+        # Find a pod with the 'csi-addons' container (handles both old and new pod structures)
+        pod_obj = get_csi_addon_pod()
+        log.info(f"Using CSI addon pod: {pod_obj.name}")
 
         csi_addon_container = pod_obj.get_container_data("csi-addons")
 
-        assert csi_addon_container, "No CSI Addon container found in the pod"
+        assert (
+            csi_addon_container
+        ), f"No CSI Addon container found in pod {pod_obj.name}"
 
         port_used_by_csi_addon = csi_addon_container[0]["ports"][0]["containerPort"]
 


### PR DESCRIPTION
This is a Fix for the issue: https://github.com/red-hat-storage/ocs-ci/issues/13144

### Problem Statement
The issue was that in ODF 4.20, the CSI addon functionality has been restructured:
Before ODF 4.20: CSI RBD nodeplugin pods contained csi-addons containers directly
ODF 4.20+: CSI addon functionality is in separate dedicated pods with names like:
openshift-storage.rbd.csi.ceph.com-nodeplugin-csi-addons-*
The test was using the old approach (looking for csi-addons containers in traditional RBD nodeplugin pods), which no longer works in ODF 4.20.
### Solution Overview
New constants for ODF 4.20 CSI addon pod labels
Simplified, efficient pod discovery logic
Removed unnecessary version constraints