### PR TITLE
Add missing key when importing MCE cluster to ACM

### DIFF
--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -720,7 +720,7 @@ def import_clusters_via_cli(clusters):
                     klusterletconfig_name = klusterletconfig.get("metadata").get("name")
                     break
             if klusterletconfig_name:
-                managed_cluster["annotations"] = {
+                managed_cluster["metadata"]["annotations"] = {
                     "agent.open-cluster-management.io/klusterlet-config": klusterletconfig_name
                 }
             else:


### PR DESCRIPTION
Fixes #13142 