### PR TITLE
Reduce the number of pods in test_run_io_multiple_pods to lower memory consumption

### DIFF
--- a/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
+++ b/tests/functional/pv/pv_services/test_run_io_multiple_pods.py
@@ -27,7 +27,7 @@ class TestIOMultiplePods(ManageTest):
     Run IO on multiple pods in parallel
     """
 
-    num_of_pvcs = 6
+    num_of_pvcs = 4
     pvc_size = 5
 
     @pytest.fixture()


### PR DESCRIPTION
Reduce the number of pods in test_run_io_multiple_pods to lower memory consumption.

The test test_run_io_multiple_pods is failing in multiclient cluster due to memory constraints.

The failure from the log is:
```
failed on setup with "ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed Out: wait_for_resource_oc_wait: Timed out waiting for resource  to reach condition Running at column STATUS"
```
waiting for 3 pods running, but one was stuck in Pending state:
```
$ oc --kubeconfig /home/jenkins/clusters/j051-c2baie-pm/openshift-cluster-dir/auth/kubeconfig -n namespace-test-af366381d72446d69e4921070 get pod 
NAME                                                        READY   STATUS    RESTARTS   AGE
pod-test-cephfs-185efa79a683476495d9d551-7574684f8c-pt2d4   0/1     Pending   0          11m
pod-test-cephfs-21b1f74ca5a84520be7916c0-7ccb69798-bz5m2    1/1     Running   0          11m
pod-test-cephfs-aa8f8af13f4c4d9286192762-84c9f9dbc5-z88mq   1/1     Running   0          12m
```
And from the description of the Pending pod, the reason is:
```
  Warning  FailedScheduling  9m57s (x2 over 10m)  default-scheduler  0/3 nodes are available: 3 Insufficient memory. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.
  ```