### PR TITLE
drop "hosted" from config names

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -157,7 +157,7 @@ version.
 * `sts_enabled` - Enable STS deployment functionality.
 * `metallb_operator` - Enable MetalLB operator installation during OCP deployment.
 * `multi_storagecluster` - Enable multi-storagecluster deployment when set to true.
-* `deploy_hosted_clusters` - Deploy hosted clusters.
+* `deploy_spoke_clusters` - Deploy spoke clusters.
 * `ssh_jump_host` - dict containing configuration for SSH jump host
     * `host` - hostname or IP address of the SSH Jump host
     * `user` - username for the ssh connection to the SSH jump host
@@ -354,13 +354,13 @@ higher priority).
 * `deploy_hyperconverged` - Deploy hyperconverged operator or not (Default: false).  Necessary for Converged clusters with hosted clients with unreleased OCP version
 * `clusters` - section for hosted clusters
     * `<cluster name>` - name of the cluster
-      * `hosted_cluster_path` - path to the cluster directory to store auth_path, credentials files or cluster related files
+      * `cluster_path` - path to the cluster directory to store auth_path, credentials files or cluster related files
       * `ocp_version` - OCP version of the hosted cluster in form x.y or x.y.z (e.g. "4.15.13" or "4.17")
       * `cpu_cores_per_hosted_cluster` - number of CPU cores per hosted cluster (default: 6)
       * `memory_per_hosted_cluster` - amount of memory per hosted cluster (default: 12Gi)
       * `nodepool_replicas` - number of replicas of nodepool for each cluster (default: 2)
-      * `hosted_odf_registry` - registry for hosted ODF (default: quay.io/rhceph-dev/ocs-registry)
-      * `hosted_odf_version` - version of ODF to be deployed on hosted clusters
+      * `odf_registry` - registry for ODF image (default: quay.io/rhceph-dev/ocs-registry)
+      * `odf_version` - version of ODF to be deployed on clusters, representation of a registry tag
       * `cp_availability_policy` - "HighlyAvailable" or "SingleReplica"; if not provided the default value is "SingleReplica"
       * `storage_quota` - storage quota for the hosted cluster
       * `provider_cluster_name` - Name of the provider cluster if storageclient is required/present in the hosted cluster. This is optional and useful when there are more than one provider cluster in the config, provider mode RDR for example

--- a/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
+++ b/conf/examples/provider_mode_ibm_cloud_baremetal_kubevirt_clients.yaml
@@ -23,23 +23,23 @@ ENV_DATA:
   deploy_mce: false # second option to enable multicluster setup; used instead of ACM
   clusters: # the list of the Hosted clusters and their configuration. If field does not exist HostedClsuter installation will be skipped
     hcp415-bm3-e: # the field name is the name of the Hosted cluster
-      hosted_cluster_path: "~/clusters/hcp416-bm3-e/openshift-cluster-dir" # path to store auth_path dir or cluster related files
+      cluster_path: "~/clusters/hcp416-bm3-e/openshift-cluster-dir" # path to store auth_path dir or cluster related files
       ocp_version:  "4.15.13" # this is an example, please provide the desired OCP version
       cpu_cores_per_hosted_cluster: 6 # minimal, tested value for the kubevirt cluster is 6
       memory_per_hosted_cluster: "12Gi" # minimal, tested value for the kubevirt cluster is 12Gi
-      hosted_odf_registry: "quay.io/rhceph-dev/ocs-registry" # this is an example, please provide the desired registry
-      hosted_odf_version: "4.16.0-99" # this is an example, please provide the desired version
+      odf_registry: "quay.io/rhceph-dev/ocs-registry" # this is an example, please provide the desired registry
+      odf_version: "4.16.0-99" # this is an example, please provide the desired version
       setup_storage_client: true # if true, the Storage Client will be created and verification will be performed
       nodepool_replicas: 3 # number of worker nodes created for Hosted cluster
       cp_availability_policy: "HighlyAvailable" # this field is optional, if not provided the default value is "HighlyAvailable"
       storage_quota: 100  # int. 100 means "100Gi". this field is optional, if not provided client will have unlimited storage quota
       infra_availability_policy: "HighlyAvailable" # this field is optional, if not provided the default value is "HighlyAvailable"
     hcp415-bm3-f:
-      hosted_cluster_path: "~/clusters/hcp416-bm3-f/openshift-cluster-dir" # path to store auth_path dir or cluster related files
+      cluster_path: "~/clusters/hcp416-bm3-f/openshift-cluster-dir" # path to store auth_path dir or cluster related files
       ocp_version:  "4.15.10" # this is an example, please provide the desired OCP version
       cpu_cores_per_hosted_cluster: 8 # minimal, tested value for the kubevirt cluster is 6
       memory_per_hosted_cluster: "12Gi" # minimal, tested value for the kubevirt cluster is 12Gi
-      hosted_odf_registry: "quay.io/rhceph-dev/ocs-registry" # this is an example, please provide the desired registry
-      hosted_odf_version: "4.16.0-106" # this is an example, please provide the desired version
+      odf_registry: "quay.io/rhceph-dev/ocs-registry" # this is an example, please provide the desired registry
+      odf_version: "4.16.0-106" # this is an example, please provide the desired version
       setup_storage_client: true # if true, the Storage Client will be created and verification will be performed
       nodepool_replicas: 2 # number of worker nodes created for Hosted cluster

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -682,7 +682,7 @@ class Deployment(object):
         """
         if config.ENV_DATA.get("clusters", False) and (
             not config.ENV_DATA["skip_ocs_deployment"]
-            or config.DEPLOYMENT.get("deploy_hosted_clusters")
+            or config.DEPLOYMENT.get("deploy_spoke_clusters")
         ):
             # imported locally due to a circular dependency
             from ocs_ci.deployment.hosted_cluster import HostedClients

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -740,21 +740,21 @@ class HyperShiftBase:
                 return True
 
     def download_hosted_cluster_kubeconfig(
-        self, name: str, hosted_cluster_path: str, from_hcp: bool = True
+        self, name: str, cluster_path: str, from_hcp: bool = True
     ):
         """
         Download HyperShift hosted cluster kubeconfig
 
         Args:
             name (str): name of the cluster
-            hosted_cluster_path (str): path to create auth_path folder and download kubeconfig there
+            cluster_path (str): path to create auth_path folder and download kubeconfig there
             from_hcp (bool): if True, use hcp binary to download kubeconfig, otherwise use ocp secret
 
         Returns:
             str: path to the downloaded kubeconfig, None if failed
 
         """
-        path_abs = os.path.expanduser(hosted_cluster_path)
+        path_abs = os.path.expanduser(cluster_path)
         auth_path = os.path.join(path_abs, "auth")
         os.makedirs(auth_path, exist_ok=True)
         kubeconfig_path = os.path.join(auth_path, "kubeconfig")

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -182,7 +182,7 @@ IBM_CLOUD_REGIONS = {"us-south", "us-east"}
 HYPERSHIFT_NODEPOOL_REPLICAS_DEFAULT = 2
 HYPERSHIFT_MEMORY_DEFAULT = "12Gi"
 HYPERSHIFT_CPU_CORES_DEFAULT = 6
-HOSTED_ODF_REGISTRY_DEFAULT = "quay.io/rhceph-dev/ocs-registry"
+ODF_REGISTRY_DEFAULT = "quay.io/rhceph-dev/ocs-registry"
 
 # Custom Ingress SSL certificate, key and CA certificate related defaults
 INGRESS_SSL_CERT = os.path.join(constants.DATA_DIR, "ingress-cert.crt")


### PR DESCRIPTION
Drop "hosted" from config names allows to move away from "hosted"-only deployments for Hub/Spoke storage design and deploy External spoke as well as other in future.