### PR TITLE
Updated mark_masters_schedulable: true by default for provider deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2355,7 +2355,7 @@ class Deployment(object):
             OCP().exec_oc_cmd(command=patch_cmd)
 
             # Mark master nodes schedulable if mark_masters_schedulable: True
-            if config.ENV_DATA.get("mark_masters_schedulable", False):
+            if config.ENV_DATA.get("mark_masters_schedulable", True):
                 path = "/spec/mastersSchedulable"
                 params = f"""[{{"op": "replace", "path": "{path}", "value": true}}]"""
                 scheduler_obj = ocp.OCP(


### PR DESCRIPTION
Updated master nodes schedulable parameter, mark_masters_schedulable: true by default
 to avoid https://github.com/red-hat-storage/ocs-ci/issues/13504