### PR TITLE
Make 'disable_default_sources' default True for hcp clusters

### DIFF
--- a/ocs_ci/deployment/hosted_cluster.py
+++ b/ocs_ci/deployment/hosted_cluster.py
@@ -869,7 +869,7 @@ class HypershiftHostedOCP(
         disable_default_sources = (
             config.ENV_DATA["clusters"]
             .get(self.name)
-            .get("disable_default_sources", False)
+            .get("disable_default_sources", True)
         )
         return self.create_kubevirt_ocp_cluster(
             name=self.name,


### PR DESCRIPTION
Set the default value of '`disable_default_sources`' True for hcp clusters.
This is needed because to enabled RDR on hcp clusters(used as client clusters) we need to have custom catalogsource redhat-operators created to install df operator automatically. If the default sources are not disabled, the custom catalogsource redhat-operators will be reconciled.