### PR TITLE
Fixing Bugs for FDF Deployment on some SDS cluster

### DIFF
--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -49,24 +49,24 @@ class FusionDataFoundationDeployment:
         # self.setup_storage()
 
     def create_image_tag_mirror_set(self):
-    """
-    Create or update ImageTagMirrorSet.
-    """
-    logger.info("Creating or Updating FDF ImageTagMirrorSet")
+        """
+        Create or update ImageTagMirrorSet.
+        """
+        logger.info("Creating or Updating FDF ImageTagMirrorSet")
 
-    imagetag_file = constants.FDF_IMAGE_TAG_MIRROR_SET
-    resource_name = "isf-fdf" 
+        imagetag_file = constants.FDF_IMAGE_TAG_MIRROR_SET
+        resource_name = "isf-fdf" 
 
-    # Check if resource exists
-    cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
-    exists = run_cmd(cmd_check, ignore_error=True)
+        # Check if resource exists
+        cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
+        exists = run_cmd(cmd_check, ignore_error=True)
 
-    if exists:
-        logger.info("ImageTagMirrorSet exists applying changes")
-        run_cmd(f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}")
-    else:
-        logger.info("ImageTagMirrorSet not found creating with save-config")
-        run_cmd(f"oc --kubeconfig {self.kubeconfig} create --save-config -f {imagetag_file}")
+        if exists:
+            logger.info("ImageTagMirrorSet exists applying changes")
+            run_cmd(f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}")
+        else:
+            logger.info("ImageTagMirrorSet not found creating with save-config")
+            run_cmd(f"oc --kubeconfig {self.kubeconfig} create --save-config -f {imagetag_file}")
 
     def create_image_digest_mirror_set(self):
         """

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -19,7 +19,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import run_cmd
 
 logger = logging.getLogger(__name__)
-
+# 1
 
 class FusionDataFoundationDeployment:
     def __init__(self):
@@ -32,9 +32,10 @@ class FusionDataFoundationDeployment:
         """
         logger.info("Installing IBM Fusion Data Foundation")
         if self.pre_release:
-            self.create_image_tag_mirror_set()
+            # self.create_image_tag_mirror_set()
             self.create_image_digest_mirror_set()
             self.setup_fdf_pre_release_deployment()
+
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
         # self.setup_storage()

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -25,7 +25,6 @@ from ocs_ci.utility.utils import (
 ) 
 
 logger = logging.getLogger(__name__)
-# 1
 
 class FusionDataFoundationDeployment:
     def __init__(self):
@@ -48,7 +47,7 @@ class FusionDataFoundationDeployment:
 
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
-        # self.setup_storage()
+        self.setup_storage()
 
     def create_image_tag_mirror_set(self):
         """
@@ -59,7 +58,6 @@ class FusionDataFoundationDeployment:
         imagetag_file = constants.FDF_IMAGE_TAG_MIRROR_SET
         resource_name = "isf-fdf" 
 
-        # Check if resource exists
         cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
         exists = run_cmd(cmd_check, ignore_error=True)
 
@@ -88,14 +86,6 @@ class FusionDataFoundationDeployment:
             logger.info("ImageDigestMirrorSet not found creating with save-config")
             run_cmd(f"oc --kubeconfig {self.kubeconfig} create --save-config -f {image_digest_mirror_set}")
             
-        # update the metadata.name += tag
-        # connect boris
-        # run_cmd(
-        #     f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}"
-        
-        # )
-        #  sleep for 1 minute for mcp to be triggered
-        #  wait for mcp
         os.remove(image_digest_mirror_set)
 
     def create_fdf_service_cr(self):
@@ -283,7 +273,6 @@ def extract_image_digest_mirror_set():
         f"{pull_secret} {fdf_registry}/{fdf_catalog_name}:{fdf_image_tag} --confirm --path /{filename}:./"
     )
     run_cmd(cmd)
-    #  change the metdata 
     return filename
 
 

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -17,6 +17,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import run_cmd
+from ocs_ci.utility.utils import get_ocp_version
 
 logger = logging.getLogger(__name__)
 # 1
@@ -87,13 +88,15 @@ class FusionDataFoundationDeployment:
             logger.info(f"Retrieved image digest: {fdf_image_digest}")
             config.DEPLOYMENT["fdf_pre_release_image_digest"] = fdf_image_digest
 
+        ocp_version = f"ocp{get_ocp_version('')}-t"
+        logger.info("OCP version: {ocp_version}")
         logger.info("Updating FusionServiceDefinition")
         params_dict = {
             "spec": {
                 "onboarding": {
                     "serviceOperatorSubscription": {
                         "multiVersionCatSrcDetails": {
-                            "ocp418-t": {
+                            ocp_version: {
                                 "imageDigest": fdf_image_digest,
                                 "registryPath": fdf_registry,
                             }

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -20,7 +20,8 @@ from ocs_ci.utility.utils import run_cmd
 import time
 from ocs_ci.utility.utils import (
     get_ocp_version,
-    wait_for_machineconfigpool_status
+    wait_for_machineconfigpool_status,
+    get_running_ocp_version
 ) 
 
 logger = logging.getLogger(__name__)

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -125,8 +125,8 @@ class FusionDataFoundationDeployment:
             logger.info(f"Retrieved image digest: {fdf_image_digest}")
             config.DEPLOYMENT["fdf_pre_release_image_digest"] = fdf_image_digest
 
-        ocp_version = f"ocp{get_running_ocp_version(self.kubeconfig, '')}-t"
-        logger.info("OCP version: {ocp_version}")
+        ocp_version = f"ocp{get_running_ocp_version('')}-t"
+        logger.info(f"OCP version: {ocp_version}")
         logger.info("Updating FusionServiceDefinition")
         params_dict = {
             "spec": {

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -43,7 +43,7 @@ class FusionDataFoundationDeployment:
 
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
-        self.setup_storage()
+        # self.setup_storage()
 
     def create_image_tag_mirror_set(self):
         """

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -125,7 +125,7 @@ class FusionDataFoundationDeployment:
             logger.info(f"Retrieved image digest: {fdf_image_digest}")
             config.DEPLOYMENT["fdf_pre_release_image_digest"] = fdf_image_digest
 
-        ocp_version = f"ocp{get_running_ocp_version('')}-t"
+        ocp_version = f"ocp{get_running_ocp_version().replace('.', '')}-t"
         logger.info(f"OCP version: {ocp_version}")
         logger.info("Updating FusionServiceDefinition")
         params_dict = {

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -38,8 +38,6 @@ class FusionDataFoundationDeployment:
         logger.info("Installing IBM Fusion Data Foundation")
         if self.pre_release:
             self.create_image_tag_mirror_set()
-            time.sleep(60)
-            wait_for_machineconfigpool_status(node_type="all")
             self.create_image_digest_mirror_set()
             time.sleep(60)
             wait_for_machineconfigpool_status(node_type="all")

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -37,7 +37,7 @@ class FusionDataFoundationDeployment:
             self.setup_fdf_pre_release_deployment()
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
-        self.setup_storage()
+        # self.setup_storage()
 
     def create_image_tag_mirror_set(self):
         """

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -17,6 +17,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import run_cmd
+import time
 from ocs_ci.utility.utils import (
     get_ocp_version,
     wait_for_machineconfigpool_status

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -52,21 +52,24 @@ class FusionDataFoundationDeployment:
         logger.info("Creating or Updating FDF ImageTagMirrorSet")
 
         imagetag_file = constants.FDF_IMAGE_TAG_MIRROR_SET
-        resource_name = "isf-fdf"
+        # resource_name = "isf-fdf"
 
-        cmd_check = (
-            f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
+        # cmd_check = (
+        #     f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
+        # )
+        # exists = run_cmd(cmd_check, ignore_error=True)
+
+        # if exists:
+        #     logger.info("ImageTagMirrorSet exists applying changes")
+        #     run_cmd(f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}")
+        # else:
+        #     logger.info("ImageTagMirrorSet not found creating with save-config")
+        #     run_cmd(
+        #         f"oc --kubeconfig {self.kubeconfig} create --save-config -f {imagetag_file}"
+        #     )
+        run_cmd(
+            f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}", silent=True
         )
-        exists = run_cmd(cmd_check, ignore_error=True)
-
-        if exists:
-            logger.info("ImageTagMirrorSet exists applying changes")
-            run_cmd(f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}")
-        else:
-            logger.info("ImageTagMirrorSet not found creating with save-config")
-            run_cmd(
-                f"oc --kubeconfig {self.kubeconfig} create --save-config -f {imagetag_file}"
-            )
 
     def create_image_digest_mirror_set(self):
         """
@@ -74,22 +77,25 @@ class FusionDataFoundationDeployment:
         """
         logger.info("Creating FDF ImageDigestMirrorSet")
         image_digest_mirror_set = extract_image_digest_mirror_set()
-        resource_name = "df-repo"
+        # resource_name = "df-repo"
 
-        cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagedigestmirrorset {resource_name}"
-        exists = run_cmd(cmd_check, ignore_error=True)
+        # cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagedigestmirrorset {resource_name}"
+        # exists = run_cmd(cmd_check, ignore_error=True)
 
-        if exists:
-            logger.info("ImageDigestMirrorSet exists applying changes")
-            run_cmd(
-                f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}"
-            )
-        else:
-            logger.info("ImageDigestMirrorSet not found creating with save-config")
-            run_cmd(
-                f"oc --kubeconfig {self.kubeconfig} create --save-config -f {image_digest_mirror_set}"
-            )
-
+        # if exists:
+        #     logger.info("ImageDigestMirrorSet exists applying changes")
+        #     run_cmd(
+        #         f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}"
+        #     )
+        # else:
+        #     logger.info("ImageDigestMirrorSet not found creating with save-config")
+        #     run_cmd(
+        #         f"oc --kubeconfig {self.kubeconfig} create --save-config -f {image_digest_mirror_set}"
+        #     )
+        run_cmd(
+            f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}",
+            silent=True,
+        )
         os.remove(image_digest_mirror_set)
 
     def create_fdf_service_cr(self):

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -43,7 +43,7 @@ class FusionDataFoundationDeployment:
 
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
-        # self.setup_storage()
+        self.setup_storage()
 
     def create_image_tag_mirror_set(self):
         """
@@ -52,21 +52,7 @@ class FusionDataFoundationDeployment:
         logger.info("Creating or Updating FDF ImageTagMirrorSet")
 
         imagetag_file = constants.FDF_IMAGE_TAG_MIRROR_SET
-        # resource_name = "isf-fdf"
 
-        # cmd_check = (
-        #     f"oc --kubeconfig {self.kubeconfig} get imagetagmirrorset {resource_name}"
-        # )
-        # exists = run_cmd(cmd_check, ignore_error=True)
-
-        # if exists:
-        #     logger.info("ImageTagMirrorSet exists applying changes")
-        #     run_cmd(f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}")
-        # else:
-        #     logger.info("ImageTagMirrorSet not found creating with save-config")
-        #     run_cmd(
-        #         f"oc --kubeconfig {self.kubeconfig} create --save-config -f {imagetag_file}"
-        #     )
         run_cmd(
             f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}", silent=True
         )
@@ -77,21 +63,7 @@ class FusionDataFoundationDeployment:
         """
         logger.info("Creating FDF ImageDigestMirrorSet")
         image_digest_mirror_set = extract_image_digest_mirror_set()
-        # resource_name = "df-repo"
 
-        # cmd_check = f"oc --kubeconfig {self.kubeconfig} get imagedigestmirrorset {resource_name}"
-        # exists = run_cmd(cmd_check, ignore_error=True)
-
-        # if exists:
-        #     logger.info("ImageDigestMirrorSet exists applying changes")
-        #     run_cmd(
-        #         f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}"
-        #     )
-        # else:
-        #     logger.info("ImageDigestMirrorSet not found creating with save-config")
-        #     run_cmd(
-        #         f"oc --kubeconfig {self.kubeconfig} create --save-config -f {image_digest_mirror_set}"
-        #     )
         run_cmd(
             f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}",
             silent=True,

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
   fdf_pre_release: true
-  fdf_image_tag: v4.18
+  fdf_image_tag: v4.19
   fdf_pre_release_registry: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df
   fdf_pre_release_image_digest: null

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
   fdf_pre_release: true
-  fdf_image_tag: 4.20.0-83
+  fdf_image_tag: 4.18
   fdf_pre_release_registry: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df
   fdf_pre_release_image_digest: null

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
   fdf_pre_release: true
-  fdf_image_tag: v4.19
+  fdf_image_tag: 4.20.0-83
   fdf_pre_release_registry: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df
   fdf_pre_release_image_digest: null

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
   fdf_pre_release: true
-  fdf_image_tag: v4.18
+  fdf_image_tag: 4.20.0-83
   fdf_pre_release_registry: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df
   fdf_pre_release_image_digest: null

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -1,6 +1,6 @@
 ---
 DEPLOYMENT:
   fdf_pre_release: true
-  fdf_image_tag: 4.20.0-83
+  fdf_image_tag: v4.18
   fdf_pre_release_registry: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df
   fdf_pre_release_image_digest: null

--- a/ocs_ci/templates/fusion-data-foundation/data-foundation-instance.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/data-foundation-instance.yaml
@@ -15,7 +15,7 @@ spec:
     value: Fusion
   - name: backingStorageType
     provided: true
-    value: Dynamic
+    value: Local
   - name: autoUpgrade
     provided: false
     value: "false"


### PR DESCRIPTION
Following things are being fixed with these changes 

 **Not able to create a idms**
 If IDMS is with the same name is there on the cluster script will and stop the pipeline there itself. for that we are checking if the df-repo is already there we are applying the latest changes.
 
 **Not able to change FSD**
 In fusion Service Definition while patching we are hardcoding the ocp version that i am getting runtime and patching the FSD correctly in this branch.
 
 **Not able to install correct and mentioned version of the FDF**
 Its always installing the gaed version, its not installing the dev version always failing the reason was simple it was not able to edit the FSD correctly.
 
 **Backing Storage**
 By default we are going for local rather dynamic because mostly Z-stream as test on Local mode.
 
 
 **How Do I tested?**
 I tested by running the `Deploy-fdf-cluster` pipeline.