### PR TITLE
fix(test_disable_pv_keyrotation_globally): resolve timing issue in PV key rotation disable/enable test

### DIFF
--- a/ocs_ci/helpers/keyrotation_helper.py
+++ b/ocs_ci/helpers/keyrotation_helper.py
@@ -590,7 +590,7 @@ class PVKeyrotation(KeyRotation):
             for pvc in pvc_objs
         }
 
-    @retry(UnexpectedBehaviour, tries=5, delay=20)
+    @retry(UnexpectedBehaviour, tries=10, delay=20)
     def wait_till_all_pv_keyrotation_on_vault_kms(self, pvc_objs):
         """
         Waits for all PVC keys to be rotated in the Vault KMS.
@@ -663,6 +663,53 @@ class PVKeyrotation(KeyRotation):
             pvc.reload()
 
         log.info("Completed key rotation state changes for all specified PVCs.")
+        return True
+
+    @retry(UnexpectedBehaviour, tries=10, delay=10)
+    def wait_for_keyrotation_cronjobs_recreation(self, pvc_objs):
+        """
+        Wait for key rotation cronjobs to be recreated for all PVCs after re-enabling.
+
+        Args:
+            pvc_objs (list): List of PVC objects to check.
+
+        Returns:
+            bool: True if all cronjobs are recreated and active.
+
+        Raises:
+            UnexpectedBehaviour: If cronjobs are not recreated within timeout.
+        """
+        missing_cronjobs = []
+
+        for pvc_obj in pvc_objs:
+            # Reload PVC to get latest annotations
+            pvc_obj.reload()
+
+            try:
+                cronjob = self.get_keyrotation_cronjob_for_pvc(pvc_obj)
+                # Check if cronjob exists and is not suspended
+                if not cronjob.is_exist():
+                    missing_cronjobs.append(pvc_obj.name)
+                    continue
+
+                # Check if cronjob is not suspended
+                cronjob_data = cronjob.get()
+                if cronjob_data.get("spec", {}).get("suspend", False):
+                    missing_cronjobs.append(f"{pvc_obj.name} (suspended)")
+                    continue
+
+                log.info(f"Key rotation cronjob for PVC '{pvc_obj.name}' is active.")
+
+            except ValueError:
+                # Cronjob annotation not found or cronjob doesn't exist
+                missing_cronjobs.append(pvc_obj.name)
+
+        if missing_cronjobs:
+            raise UnexpectedBehaviour(
+                f"Key rotation cronjobs not ready for PVCs: {', '.join(missing_cronjobs)}"
+            )
+
+        log.info("All key rotation cronjobs are recreated and active.")
         return True
 
 

--- a/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
@@ -144,7 +144,13 @@ class TestDisablePVKeyrotationOperation(PVKeyrotationTestBase):
         self.pv_keyrotation_obj.set_keyrotation_state_by_annotation(True)
         log.info("Key rotation re-enabled globally via storage class annotation.")
 
-        # Verify key rotation cronjobs are recreated
+        # Wait for key rotation cronjobs to be recreated and active
+        assert self.pv_keyrotation_obj.wait_for_keyrotation_cronjobs_recreation(
+            self.pvc_objs
+        ), "Failed to recreate key rotation cronjobs after re-enabling."
+        log.info("Key rotation cronjobs successfully recreated and active.")
+
+        # Verify key rotation cronjobs are recreated and keys are rotated
         assert self.pv_keyrotation_obj.wait_till_all_pv_keyrotation_on_vault_kms(
             self.pvc_objs
         ), "Failed to re-enable PV key rotation."


### PR DESCRIPTION
This is a fix for the issue :[ test_disable_pv_keyrotation_globally](https://github.com/red-hat-storage/ocs-ci/issues/13226)

- Increase timeout in wait_till_all_pv_keyrotation_on_vault_kms from 5 to 10 retries to allow adequate time for key rotation after cronjob recreation (100s -> 200s)

- Add wait_for_keyrotation_cronjobs_recreation() method to validate cronjobs are properly recreated and active before checking key rotation

- Enhance test_disable_pv_keyrotation_globally to include intermediate validation step that ensures cronjobs are recreated after re-enabling key rotation
