### PR TITLE
Fixed keyerror in the test test_verify_rwo_using_replicated_pod

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -309,7 +309,7 @@ def create_pod(
         pod_dict = pod_dict_path if pod_dict_path else constants.CSI_CEPHFS_POD_YAML
         interface = constants.CEPHFS_INTERFACE
     if deployment:
-        pod_dict = pod_dict_path if pod_dict_path else constants.FEDORA_DC_YAML
+        pod_dict = pod_dict_path if pod_dict_path else constants.FEDORA_DEPLOY_YAML
     pod_data = templating.load_yaml(pod_dict)
     if not pod_name:
         pod_name = create_unique_resource_name(f"test-{interface}", "pod")

--- a/tests/functional/pv/pv_services/test_verify_rwo_using_dc_pod.py
+++ b/tests/functional/pv/pv_services/test_verify_rwo_using_dc_pod.py
@@ -67,7 +67,7 @@ class TestVerifyRwoUsingReplicatedPod(ManageTest):
         self.namespace = pod1.namespace
 
         dc_obj = OCP(
-            kind=constants.DEPLOYMENTCONFIG,
+            kind=constants.DEPLOYMENT,
             namespace=self.namespace,
             resource_name=self.name,
         )


### PR DESCRIPTION
This is Fix for the issue : https://github.com/red-hat-storage/ocs-ci/issues/12753 
Root Cause Identified

The test was failing with KeyError: 'selector' because the DeploymentConfig template  is being use and it doesn't has the "selector" key. So i have changed the yaml to use  Deployment instead of DeploymentConfig