### PR TITLE
Backlog item: add missing NSFS tests

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -473,6 +473,32 @@ def copy_random_individual_objects(
         logger.info(f"Copied {src_obj}")
 
 
+def sync_random_objects(
+    podobj, file_dir, target, amount, pattern="test-obj-", s3_obj=None, **kwargs
+):
+    """
+    Generates random objects and then syncs them to a bucket
+
+    Args:
+        podobj: Pod object used to perform the operation
+        file_dir: file directory name where the generated objects are placed
+        target: target bucket name
+        amount: number of objects to generate
+        pattern: pattern to follow for objects naming
+        s3_obj: MCG/OBC object
+
+    Returns:
+        list: A list of the generated objects' names
+    """
+    logger.info(f"Generating {amount} random objects in {file_dir}")
+    podobj.exec_cmd_on_pod(f"mkdir -p {file_dir}")
+    object_files = write_random_objects_in_pod(
+        podobj, pattern=pattern, file_dir=file_dir, amount=amount
+    )
+    sync_object_directory(podobj, file_dir, target, s3_obj, **kwargs)
+    return object_files
+
+
 def upload_objects_with_javasdk(javas3_pod, s3_obj, bucket_name, is_multipart=False):
     """
     Performs upload operation using java s3 pod
@@ -1814,7 +1840,9 @@ def compare_directory(
     return all(comparisons)
 
 
-def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=None):
+def s3_copy_object(
+    s3_obj, bucketname, source, object_key, metadata=None, metadata_directive=""
+):
     """
     Boto3 client based copy object
 
@@ -1824,6 +1852,7 @@ def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=None):
         source (str): Source object key. eg: '<bucket>/<key>
         object_key (str): Unique object Identifier for copied object
         metadata (dict): Metadata to be updated with the object
+        metadata_directive (str): Metadata directive to be used. Defaults to an empty string.
 
     Returns:
         dict : Copy object response
@@ -1833,7 +1862,11 @@ def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=None):
     metadata = {} if metadata is None else metadata
 
     return s3_obj.s3_client.copy_object(
-        Bucket=bucketname, CopySource=source, Key=object_key, Metadata=metadata
+        Bucket=bucketname,
+        CopySource=source,
+        Key=object_key,
+        Metadata=metadata,
+        MetadataDirective=metadata_directive,
     )
 
 

--- a/ocs_ci/ocs/resources/mcg_params.py
+++ b/ocs_ci/ocs/resources/mcg_params.py
@@ -49,3 +49,4 @@ class NSFS:
     mounted_bucket_path: str = None
     s3_creds: dict = None
     nss: NamespaceStore = None
+    nsfs_only: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6475,6 +6475,7 @@ def nsfs_bucket_factory_fixture(
             name=f"nsfs-integrity-test-{random.randrange(100)}",
             default_resource=nsfs_obj.nss.name,
             nsfs_account_config=True,
+            nsfs_only=nsfs_obj.nsfs_only,
             gid=nsfs_obj.gid,
             uid=nsfs_obj.uid,
             ssl=False,

--- a/tests/functional/object/mcg/test_nsfs.py
+++ b/tests/functional/object/mcg/test_nsfs.py
@@ -1,17 +1,30 @@
 import logging
+import types
 import pytest
 
 from ocs_ci.framework.testlib import MCGTest, tier1, tier3
 from ocs_ci.framework.pytest_customization.marks import (
+    skipif_disconnected_cluster,
     skipif_mcg_only,
     skipif_ocs_version,
     red_squad,
     runs_on_provider,
     mcg,
     jira,
+    skipif_proxy_cluster,
+    tier2,
 )
-from ocs_ci.ocs.bucket_utils import random_object_round_trip_verification
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import (
+    list_objects_from_bucket,
+    random_object_round_trip_verification,
+    s3_copy_object,
+    s3_head_object,
+    s3_list_buckets,
+    s3_put_object,
+    sync_random_objects,
+)
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 
 
 from ocs_ci.ocs.resources.mcg_params import NSFS
@@ -129,3 +142,190 @@ class TestNSFSObjectIntegrity(MCGTest):
             assert "AccessDenied" in str(
                 e
             ), f"Test failed unexpectedly; Exception data: {str(e)}"
+
+    @skipif_disconnected_cluster  # Test requires DNF
+    @skipif_proxy_cluster  # Test requires DNF
+    @pytest.mark.polarion_id("OCS-4513")
+    @pytest.mark.polarion_id("OCS-4512")
+    @tier2
+    def test_nsfs_metadata(
+        self,
+        nsfs_bucket_factory,
+    ):
+        """o
+        Test NSFS metadata handling:
+
+        1. Create an NSFS bucket
+        2. Using S3, write an object with some metadata
+        3. Using the FS interface, verify that the metadata shows in the file's extended attributes
+        4. Set a new extended attribute via the FS interface
+        5. Using S3, verify that the new extended attribute shows in the object's metadata
+        """
+        # 1. Create an NSFS bucket
+        nsfs_obj = NSFS(
+            method="CLI",
+            pvc_size=20,
+        )
+        nsfs_bucket_factory(nsfs_obj)
+
+        # 2. Using S3, write an object with some metadata
+        obj_key = "test-obj"
+        s3_md_key, s3_md_val = "s3md", "s3md-val"
+
+        # Existing implementation of s3_copy_object requires a source object
+
+        # First write to the bucket might fail due to AccessDenied
+        # because allow policy is still being processed
+        s3_put_object(
+            s3_obj=nsfs_obj,
+            bucketname=nsfs_obj.bucket_name,
+            object_key=f"{obj_key}-source",
+            data="test-data",
+        )
+        s3_copy_object(
+            s3_obj=nsfs_obj,
+            bucketname=nsfs_obj.bucket_name,
+            source=f"/{nsfs_obj.bucket_name}/{obj_key}-source",
+            object_key=obj_key,
+            metadata={s3_md_key: s3_md_val},
+            metadata_directive="REPLACE",  # Otherwise the original empty md is kept
+        )
+
+        # 3. Using the FS interface, verify that the metadata shows in the file's extended attributes
+        fs_interface_pod = nsfs_obj.interface_pod
+        # Use DNF to install the attr package
+        fs_interface_pod.exec_cmd_on_pod("dnf install -y attr", out_yaml_format=False)
+        # Verify that the metadata shows in the file's extended attributes
+        try:
+            response = fs_interface_pod.exec_cmd_on_pod(
+                f"attr -g {s3_md_key} {nsfs_obj.mounted_bucket_path}/{obj_key}",
+                out_yaml_format=False,
+            )
+        except CommandFailed as e:
+            if "No such file or directory" in str(e):
+                raise UnexpectedBehaviour("File matching the object key does not exist")
+            elif "No data available" in str(e):
+                raise UnexpectedBehaviour(
+                    "Metadata {s3_md_key} not found in file's extended attributes"
+                )
+            else:
+                raise e
+        assert (
+            s3_md_val in response
+        ), "Metadata added via S3 not found in file's extended attributes"
+
+        # 4. Set a new extended attribute via the FS interface
+        fs_md_key, fs_md_val = "fsmd", "fsmd-val"
+        fs_interface_pod.exec_cmd_on_pod(
+            f"attr -s {fs_md_key} -V {fs_md_val} {nsfs_obj.mounted_bucket_path}/{obj_key}",
+            out_yaml_format=False,
+        )
+        # 5. Using S3, verify that the new extended attribute shows in the object's metadata
+        response = s3_head_object(
+            s3_obj=nsfs_obj,
+            bucketname=nsfs_obj.bucket_name,
+            object_key=obj_key,
+        )
+        assert (
+            response["Metadata"][fs_md_key] == fs_md_val
+        ), "Extended attribute added via FS not found in object's metadata"
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-4511")
+    def test_nsfs_list_objects(
+        self, nsfs_bucket_factory, awscli_pod_session, test_directory_setup
+    ):
+        """
+        Test NSFS object listing:
+
+        1. Create an NSFS bucket
+        2. Upload some objects
+        3. List the objects and verify that the original objects are listed
+        """
+        # 1. Create an NSFS bucket
+        nsfs_obj = NSFS(
+            method="CLI",
+            pvc_size=20,
+        )
+        nsfs_bucket_factory(nsfs_obj)
+
+        # 2. Upload some objects
+
+        # Convert nsfs_obj.s3_creds to an S3 object with the expected attributes
+        nsfs_s3_obj = types.SimpleNamespace(
+            access_key_id=nsfs_obj.s3_creds["access_key_id"],
+            access_key=nsfs_obj.s3_creds["access_key"],
+            s3_internal_endpoint=nsfs_obj.s3_creds["endpoint"],
+            region=constants.DEFAULT_AWS_REGION,  # any region will do, we don't use it
+        )
+        objs_amount = 200
+        uploaded_objs = sync_random_objects(
+            podobj=awscli_pod_session,
+            file_dir=test_directory_setup.origin_dir,
+            target=f"s3://{nsfs_obj.bucket_name}",
+            s3_obj=nsfs_s3_obj,
+            amount=objs_amount,
+            pattern="nsfs-test-obj-",
+        )
+
+        # 3. List the objects and verify that the original objects are listed
+        listed_objs = list_objects_from_bucket(
+            pod_obj=awscli_pod_session,
+            target=f"s3://{nsfs_obj.bucket_name}",
+            s3_obj=nsfs_s3_obj,
+        )
+        assert set(uploaded_objs).issubset(listed_objs), "Objects are not listed"
+
+    @pytest.mark.polarion_id("OCS-4510")
+    @pytest.mark.polarion_id("OCS-4509")
+    @tier2
+    def test_nsfs_list_buckets(
+        self,
+        nsfs_bucket_factory,
+    ):
+        """
+        Test NSFS bucket listing:
+
+        1. Create two NSFS accounts - one with NSFS_ONLY=True and one with NSFS_ONLY=False
+        2. Create two NSFS buckets - one from each account
+        3. Verify that the NSFS_ONLY=True account can only see the NSFS buckets
+        4. Verify that the NSFS_ONLY=False account can also see first.bucket
+        """
+        # 1. Create two NSFS accounts - one with NSFS_ONLY=True and one with NSFS_ONLY=False
+        # 2. Create two NSFS buckets - one from each account
+        nsfs_obj_1 = NSFS(
+            method="CLI",
+            pvc_size=20,
+            nsfs_only=True,
+        )
+        nsfs_obj_2 = NSFS(
+            method="CLI",
+            pvc_size=20,
+            nsfs_only=False,
+        )
+        nsfs_bucket_factory(nsfs_obj_1)
+        nsfs_bucket_factory(nsfs_obj_2)
+
+        nsfs_buckets = {nsfs_obj_1.bucket_name, nsfs_obj_2.bucket_name}
+        non_nsfs_bucket = "first.bucket"
+
+        # 3. Verify that the NSFS_ONLY=True account can only see the NSFS buckets
+        nsfs_only_acc_list = set(
+            s3_list_buckets(
+                s3_obj=nsfs_obj_1,
+            )
+        )
+        assert (
+            nsfs_buckets.issubset(nsfs_only_acc_list)
+            and non_nsfs_bucket not in nsfs_only_acc_list
+        ), "NSFS_ONLY=True account can see non-NSFS buckets"
+
+        # 4. Verify that the NSFS_ONLY=False account can also see first.bucket
+        nsfs_only_acc_list = set(
+            s3_list_buckets(
+                s3_obj=nsfs_obj_2,
+            )
+        )
+        assert nsfs_buckets.union({non_nsfs_bucket}).issubset(
+            nsfs_only_acc_list
+        ), "NSFS_ONLY=False account can't see some of expected buckets"


### PR DESCRIPTION
This PR adds missing NSFS (NooBaa File System) test coverage:

**New Tests Added:**
- `test_nsfs_metadata`: Validates bidirectional metadata sync between S3 API and filesystem extended attributes
- `test_nsfs_list_objects`: Tests object listing functionality for NSFS buckets  
- `test_nsfs_account_bucket_visibility`: Verifies NSFS_ONLY account isolation behavior

**Related additions:**
- Enhanced s3_copy_object function with configurable metadata_directive parameter for flexible metadata handling
- Extended NSFS data class with additional configuration options
- Added sync_random_objects utility function, allowing uploading many  random files in batches