### PR TITLE
fix test_scale_obc_pre_upgrade, test_scale_obc_post_upgrade

### DIFF
--- a/tests/cross_functional/scale/conftest.py
+++ b/tests/cross_functional/scale/conftest.py
@@ -1,6 +1,9 @@
+import pytest
 import logging
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
+
+from ocs_ci.ocs.scale_noobaa_lib import fetch_noobaa_storage_class_name
 
 log = logging.getLogger(__name__)
 
@@ -32,3 +35,8 @@ def pytest_collection_modifyitems(items):
                     )
                     items.remove(item)
                     break
+
+
+@pytest.fixture(scope="session")
+def noobaa_storage_class_name():
+    return fetch_noobaa_storage_class_name()

--- a/tests/cross_functional/scale/noobaa/conftest.py
+++ b/tests/cross_functional/scale/noobaa/conftest.py
@@ -1,8 +1,0 @@
-import pytest
-
-from ocs_ci.ocs.scale_noobaa_lib import fetch_noobaa_storage_class_name
-
-
-@pytest.fixture(scope="session")
-def noobaa_storage_class_name():
-    return fetch_noobaa_storage_class_name()


### PR DESCRIPTION
Address problem on missing fixture. This also reflects on test_scale_obc_post_upgrade later not able to verify content.
RP link - https://url.corp.redhat.com/527c86c

```
file /home/jenkins/workspace/qe-deploy-ocs-cluster-prod/ocs-ci/tests/cross_functional/scale/upgrade/test_upgrade_with_scaled_obc.py, line 34
  @mcg
  @orange_squad
  @pre_upgrade
  @skipif_external_mode
  @skipif_bm
  @skipif_managed_service
  @pytest.mark.polarion_id("OCS-3987")
  def test_scale_obc_pre_upgrade(tmp_path, noobaa_storage_class_name, timeout=60):
E       fixture 'noobaa_storage_class_name' not found

  available fixtures: __pytest_repeat_step_number, add_env_vars_to_noobaa_core, add_env_vars_to_noobaa_core_class, add_env_vars_to_noobaa_core_session, add_env_vars_to_noobaa_endpoint_
  ```
  
