### PR TITLE
Use prefix for the imported hosted clusters in ACM hub

### DIFF
--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -873,7 +873,7 @@ def discover_hosted_clusters():
         resource_name="hypershift-addon-deploy-config",
         params=(
             '{"spec":{"customizedVariables":[{"name":"disableMetrics","value": "true"},'
-            '{"name":"disableHOManagement","value": "true"},{"name":"discoveryPrefix","value": "dr-"}]}}'
+            '{"name":"disableHOManagement","value": "true"},{"name":"discoveryPrefix","value": "dr"}]}}'
         ),
         format_type="merge",
     )


### PR DESCRIPTION
Use prefix for the discovered hosted clusters that will be automatically imported to in ACM hub. Current prefix is empty.
This change is based on a new node added in https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/discovering_hostedclusters.md#configure-naming-convention
The note is
```
Important: Using an empty string as the custom prefix is not recommended as it can cause klusterlet naming collisions within the MCE cluster.
```



