### PR TITLE
[RDR] Remove redundant UI tests and reorganize acceptance marker

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -11,14 +11,7 @@ from ocs_ci.helpers.dr_helpers import (
     wait_for_replication_destinations_creation,
     wait_for_replication_destinations_deletion,
 )
-from ocs_ci.helpers.dr_helpers_ui import (
-    dr_submariner_validation_from_ui,
-    check_cluster_status_on_acm_console,
-    failover_relocate_ui,
-    verify_failover_relocate_status_ui,
-)
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility.utils import ceph_health_check
@@ -32,7 +25,7 @@ logger = logging.getLogger(__name__)
 @turquoise_squad
 class TestFailover:
     """
-    Test Failover action via CLI and UI
+    Test Failover action via CLI
 
     """
 
@@ -40,70 +33,36 @@ class TestFailover:
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHBLOCKPOOL,
-            False,  # via_ui = False
-            id="primary_up-rbd-cli",
             marks=pytest.mark.polarion_id("OCS-4429"),
+            id="primary_up-rbd-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
-            False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4426"),
             id="primary_down-rbd-cli",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHFILESYSTEM,
-            False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4726"),
             id="primary_up-cephfs-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
-            False,  # via_ui = False
             marks=pytest.mark.polarion_id("OCS-4729"),
             id="primary_down-cephfs-cli",
-        ),
-        pytest.param(
-            False,  # primary_cluster_down = False
-            constants.CEPHBLOCKPOOL,
-            True,  # via_ui = True
-            id="primary_up-rbd-ui",
-            marks=pytest.mark.polarion_id("OCS-4741"),
-        ),
-        pytest.param(
-            True,  # primary_cluster_down = True
-            constants.CEPHBLOCKPOOL,
-            True,  # via_ui = True
-            marks=pytest.mark.polarion_id("OCS-4742"),
-            id="primary_down-rbd-ui",
-        ),
-        pytest.param(
-            False,  # primary_cluster_down = False
-            constants.CEPHFILESYSTEM,
-            True,  # via_ui = True
-            marks=pytest.mark.polarion_id("OCS-6848"),
-            id="primary_up-cephfs-ui",
-        ),
-        pytest.param(
-            True,  # primary_cluster_down = True
-            constants.CEPHFILESYSTEM,
-            True,  # via_ui = True
-            marks=pytest.mark.polarion_id("OCS-6847"),
-            id="primary_down-cephfs-ui",
         ),
     ]
 
     @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params
+        argnames=["primary_cluster_down", "pvc_interface"], argvalues=params
     )
     def test_failover(
         self,
         primary_cluster_down,
         pvc_interface,
-        via_ui,
-        setup_acm_ui,
         dr_workload,
         nodes_multicluster,
         node_restart_teardown,
@@ -111,11 +70,7 @@ class TestFailover:
         """
         Tests to verify application failover between managed clusters when the primary cluster is either UP or DOWN.
 
-        This test will run twice both via CLI and UI
-
         """
-        if via_ui:
-            acm_obj = AcmAddClusters()
 
         workloads = dr_workload(
             num_of_subscription=1, num_of_appset=1, pvc_interface=pvc_interface
@@ -146,50 +101,24 @@ class TestFailover:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        if via_ui:
-            logger.info("Start the process of Failover from ACM UI")
-            config.switch_acm_ctx()
-            dr_submariner_validation_from_ui(acm_obj)
-
         # Stop primary cluster nodes
         if primary_cluster_down:
             config.switch_to_cluster_by_name(primary_cluster_name)
             logger.info(f"Stopping nodes of primary cluster: {primary_cluster_name}")
             nodes_multicluster[primary_cluster_index].stop_nodes(primary_cluster_nodes)
 
-            # Verify if cluster is marked unknown on ACM console
-            if via_ui:
-                config.switch_acm_ctx()
-                check_cluster_status_on_acm_console(
-                    acm_obj,
-                    down_cluster_name=primary_cluster_name,
-                    expected_text="Unknown",
-                )
-        elif via_ui:
-            check_cluster_status_on_acm_console(acm_obj)
-
         for wl in workloads:
-            if via_ui:
-                # Failover via ACM UI
-                failover_relocate_ui(
-                    acm_obj,
-                    scheduling_interval=scheduling_interval,
-                    workload_to_move=f"{wl.workload_name}-1",
-                    policy_name=wl.dr_policy_name,
-                    failover_or_preferred_cluster=secondary_cluster_name,
-                )
-            else:
-                # Failover action via CLI
-                dr_helpers.failover(
-                    secondary_cluster_name,
-                    wl.workload_namespace,
-                    wl.workload_type,
-                    (
-                        wl.appset_placement_name
-                        if wl.workload_type == constants.APPLICATION_SET
-                        else None
-                    ),
-                )
+            # Failover action via CLI
+            dr_helpers.failover(
+                secondary_cluster_name,
+                wl.workload_namespace,
+                wl.workload_type,
+                (
+                    wl.appset_placement_name
+                    if wl.workload_type == constants.APPLICATION_SET
+                    else None
+                ),
+            )
 
         # Verify resources creation on secondary cluster (failoverCluster)
         config.switch_to_cluster_by_name(secondary_cluster_name)
@@ -240,7 +169,3 @@ class TestFailover:
             dr_helpers.wait_for_mirroring_status_ok(
                 replaying_images=sum([wl.workload_pvc_count for wl in workloads])
             )
-
-        if via_ui:
-            config.switch_acm_ctx()
-            verify_failover_relocate_status_ui(acm_obj)

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -24,9 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 @rdr
-@turquoise_squad
-@acceptance
 @tier1
+@turquoise_squad
 class TestFailoverAndRelocate:
     """
     Test Failover and Relocate actions via CLI and UI
@@ -38,28 +37,28 @@ class TestFailoverAndRelocate:
             False,  # primary_cluster_down = False
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
-            marks=pytest.mark.polarion_id("OCS-4430"),
+            marks=[acceptance, pytest.mark.polarion_id("OCS-4430")],
             id="primary_up-rbd-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
-            marks=pytest.mark.polarion_id("OCS-4427"),
+            marks=[acceptance, pytest.mark.polarion_id("OCS-4427")],
             id="primary_down-rbd-cli",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
-            marks=pytest.mark.polarion_id("OCS-4730"),
+            marks=[acceptance, pytest.mark.polarion_id("OCS-4730")],
             id="primary_up-cephfs-cli",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
-            marks=pytest.mark.polarion_id("OCS-4727"),
+            marks=[acceptance, pytest.mark.polarion_id("OCS-4727")],
             id="primary_down-cephfs-cli",
         ),
         pytest.param(

--- a/tests/functional/disaster-recovery/regional-dr/test_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_relocate.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 @rdr
-@acceptance
 @tier1
 @turquoise_squad
 class TestRelocate:
@@ -35,22 +34,26 @@ class TestRelocate:
             pytest.param(
                 *[constants.CEPHBLOCKPOOL],
                 False,
-                marks=pytest.mark.polarion_id("OCS-4425"),
+                marks=[acceptance, pytest.mark.polarion_id("OCS-4425")],
+                id="rbd-cli",
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM],
                 False,
-                marks=pytest.mark.polarion_id("OCS-4725"),
+                marks=[acceptance, pytest.mark.polarion_id("OCS-4725")],
+                id="cephfs-cli",
             ),
             pytest.param(
                 *[constants.CEPHBLOCKPOOL],
                 True,
                 marks=pytest.mark.polarion_id("OCS-4744"),
+                id="rbd-ui",
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM],
                 True,
                 marks=pytest.mark.polarion_id("OCS-6862"),
+                id="cephfs-ui",
             ),
         ],
     )


### PR DESCRIPTION
  - Remove redundant UI test variants from test_failover.py (4 test cases)
  - Move acceptance marker from test class level to individual parameter level for cli tests
  - Add explicit test IDs to test_relocate.py for better identification