### PR TITLE
A fix to test_pv_data_dist - increasing backingstore deletion timeout

### DIFF
--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -425,7 +425,7 @@ def backingstore_factory(
         with cluster_context():
             for backingstore in created_backingstores:
                 try:
-                    backingstore.delete(timeout=240)
+                    backingstore.delete()
                 except CommandFailed as e:
                     if "not found" in str(e).lower():
                         log.warning(

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -425,7 +425,7 @@ def backingstore_factory(
         with cluster_context():
             for backingstore in created_backingstores:
                 try:
-                    backingstore.delete()
+                    backingstore.delete(timeout=240)
                 except CommandFailed as e:
                     if "not found" in str(e).lower():
                         log.warning(

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -579,7 +579,7 @@ class TestPvPool:
         else:
             # Upload smaller files with grouped dd and s3 sync calls,
             # but limit the batch size to support many small files
-            batch_size = 1000
+            batch_size = 750
             full_batches_num = file_count // batch_size
             remainder = file_count % batch_size
             total_batches_num = full_batches_num + (1 if remainder else 0)


### PR DESCRIPTION
This PR is a fix to https://github.com/red-hat-storage/ocs-ci/issues/13273 which is increasing backingstore deletion timeout. 