### PR TITLE
test_obj_owner_in_obc_buckets.py - increasing timeout for nss reaching healthy state

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -156,7 +156,7 @@ class NamespaceStore:
             == constants.STATUS_READY
         )
 
-    def verify_health(self, timeout=240, interval=5):
+    def verify_health(self, timeout=360, interval=5):
         """
         Health verification function that tries to verify
         a namespacestores's health until a given time limit is reached


### PR DESCRIPTION
This PR is a fix for  https://github.com/red-hat-storage/ocs-ci/issues/13286.