### PR TITLE
WIP: Add support for simulating Ceph BlueStore label stamping on OSD disks

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1493,6 +1493,96 @@ def clean_disk(worker, namespace=constants.DEFAULT_NAMESPACE):
                 logger.info(out)
 
 
+def download_script_to_node(
+    worker,
+    script_url: str,
+    script_path: str,
+    namespace: str = "default",
+    timeout: int = 300,
+):
+    """
+    Download a shell script directly on a node (inside chroot /host)
+    using curl via oc debug.
+
+    Assumes the URL is valid and directly downloadable
+    (e.g., a raw GitHub or internal script URL).
+
+    Args:
+        worker (object): Worker node object.
+        script_url (str): Direct URL to the script.
+        script_path (str): Destination path on the node (default: /tmp/simulate_bluestore_label.sh).
+        namespace (str): Namespace for the debug pod.
+        timeout (int): Timeout for the oc debug command (in seconds).
+
+    Returns:
+        str: Output of the command execution.
+    """
+    ocp_obj = ocp.OCP()
+
+    # Single, atomic command string
+    download_cmd = [
+        (
+            f"set -euo pipefail; "
+            f'curl -fsSL "{script_url}" -o "{script_path}" && '
+            f'chmod 755 "{script_path}" && '
+            f'echo "Downloaded to {script_path}" && ls -l "{script_path}"'
+        )
+    ]
+
+    out = ocp_obj.exec_oc_debug_cmd(
+        node=worker.name,
+        cmd_list=download_cmd,
+        namespace=namespace,
+        use_root=True,
+        timeout=timeout,
+    )
+
+    return out
+
+
+def run_script_on_node(
+    worker,
+    script_path: str,
+    args: str = "",
+    namespace: str = "default",
+    timeout: int = 600,
+):
+    """
+    Execute a shell script directly on a node (inside chroot /host)
+    using oc debug.
+
+    Args:
+        worker (object): Worker node object.
+        script_path (str): Full path to the script on the node.
+        args (str): Optional arguments to pass to the script.
+        namespace (str): Namespace for the debug pod.
+        timeout (int): Timeout for the command execution (in seconds).
+
+    Returns:
+        str: Output of the script execution.
+    """
+    ocp_obj = ocp.OCP()
+
+    # Build the command — single element, no single quotes inside
+    run_cmd = [
+        (
+            f"set -euo pipefail; "
+            f'echo ">>> Running: {script_path} {args}"; '
+            f'bash "{script_path}" {args}'
+        )
+    ]
+
+    out = ocp_obj.exec_oc_debug_cmd(
+        node=worker.name,
+        cmd_list=run_cmd,
+        namespace=namespace,
+        use_root=True,
+        timeout=timeout,
+    )
+
+    return out
+
+
 class BaremetalPSIUPI(Deployment):
     """
     All the functionalities related to BaremetalPSI- UPI deployment

--- a/scripts/bash/simulate_bluestore_label.sh
+++ b/scripts/bash/simulate_bluestore_label.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEVICE="$1"
+VERIFY_DISK_EMPTY="${2:-true}"  # optional second argument (default: false)
+
+if [[ -z "$DEVICE" ]]; then
+    echo "Usage: $0 /dev/sdX [verify_disk_empty:true|false]"
+    exit 1
+fi
+
+echo ">>> Running BlueStore label simulation on $DEVICE"
+echo ">>> Verify disk empty: $VERIFY_DISK_EMPTY"
+
+# Stage 0 — Optional disk emptiness verification
+if [[ "$VERIFY_DISK_EMPTY" == "true" ]]; then
+    echo ">>> Precheck: Verifying device is empty (first 22 bytes)..."
+    if hexdump -C -s 0 -n 22 "$DEVICE" | grep -qv "00 "; then
+        echo "ERROR: $DEVICE contains non-zero data at LBA0 — refusing to overwrite."
+        echo ">>> Please wipe or use a clean test disk."
+        exit 1
+    fi
+fi
+
+# Stage 1 — Prechecks
+echo ">>> Precheck: Validating device..."
+
+[ -b "$DEVICE" ] || { echo "ERROR: $DEVICE is not a block device"; exit 1; }
+[ "$(lsblk -no TYPE "$DEVICE")" = "disk" ] || { echo "ERROR: $DEVICE is not a whole disk"; exit 1; }
+[ "$(blockdev --getro "$DEVICE")" -eq 0 ] || { echo "ERROR: $DEVICE is read-only"; exit 1; }
+
+# Stage 2 — Prepare disk
+echo ">>> Preparing disk (wiping signatures and partition table)..."
+sgdisk -Z "$DEVICE" || true
+wipefs -a "$DEVICE" || true
+blockdev --rereadpt "$DEVICE" || true
+udevadm settle || true
+
+# Stage 3 — Write BlueStore label
+echo ">>> Writing BlueStore label..."
+UUID=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
+LABEL=$(printf 'bluestore block device\n%.36s\n' "$UUID")
+LEN=$(echo -n "$LABEL" | wc -c)
+
+if [[ "$LEN" -ne 60 ]]; then
+    echo "ERROR: Label length=$LEN (expected 60)"
+    exit 1
+fi
+
+echo -n "$LABEL" | dd of="$DEVICE" bs=1 seek=0 conv=notrunc,fsync status=none
+blockdev --flushbufs "$DEVICE" || true
+udevadm settle || true
+
+echo ">>> Label stamped: $DEVICE:$UUID"
+
+# Stage 4 — Verify label
+echo ">>> Verifying label..."
+VERIFY_OK=1
+head -c 22 "$DEVICE" | grep -qx 'bluestore block device' || VERIFY_OK=0
+[ "$(dd if="$DEVICE" bs=1 count=60 status=none | wc -c)" -eq 60 ] || VERIFY_OK=0
+
+if [[ "$VERIFY_OK" -eq 1 ]]; then
+    echo ">>> Verification PASSED"
+    echo ">>> BlueStore UUID: $UUID"
+else
+    echo ">>> Verification FAILED"
+    echo ">>> Hexdump of first 60 bytes:"
+    hexdump -C -n 60 -s 0 "$DEVICE" || true
+    exit 1
+fi

--- a/tests/libtest/test_simulate_ceph_bluestore_label.py
+++ b/tests/libtest/test_simulate_ceph_bluestore_label.py
@@ -1,0 +1,54 @@
+import logging
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    ignore_leftovers,
+    libtest,
+    brown_squad,
+    runs_on_provider,
+)
+from ocs_ci.deployment.baremetal import download_script_to_node, run_script_on_node
+from ocs_ci.ocs.node import get_nodes
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@libtest
+@ignore_leftovers
+@runs_on_provider
+class TestSimulateCephBlueStoreLabel(ManageTest):
+    """
+    Test that simulate_bluestore_label correctly stamps and verifies a BlueStore label on a test disk.
+    """
+
+    def test_simulate_bluestore_label(self):
+        worker = get_nodes()[0]
+        # Destination path on node
+        script_path = "/tmp/simulate_bluestore_label.sh"
+        url_prefix = "https://raw.githubusercontent.com/red-hat-storage/ocs-ci/master/"
+        script_name = "scripts/bash/simulate_bluestore_label.sh"
+        script_url = url_prefix + script_name
+
+        # Step 1: Download the script directly on the node
+        download_script_to_node(
+            worker=worker,  # worker node object
+            script_url=script_url,
+            script_path=script_path,  # destination path on node
+            namespace="default",
+            timeout=300,
+        )
+
+        # Step 2: Run the script (optional verification stage)
+        out = run_script_on_node(
+            worker=worker,
+            script_path=script_path,
+            args="/dev/sda",
+            namespace="default",
+            timeout=600,
+        )
+
+        log.info(out)
+        assert (
+            "Verification PASSED" in out or ">>> BlueStore UUID:" in out
+        ), "BlueStore label simulation failed"


### PR DESCRIPTION
This change enables automated testing of BlueStore label simulation on test disks in a baremetal environment. It provides a safe and controlled way to mimic BlueStore disk preparation, useful for validating Ceph OSD detection logic without impacting real data.

This PR introduces a utility for simulating the stamping of a BlueStore label on a block device, primarily for testing and validation purposes. It includes:

**A new shell script `simulate_bluestore_label.sh` that:**

- Verifies the target device is empty (optional)
- Validates the device type and readiness
- Wipes existing signatures and partition tables
- Writes a mock BlueStore label with a generated UUID
- Verifies the label was written correctly 

**Two helper functions in baremetal.py:**

- `download_script_to_node`: Downloads a script to a worker node using oc debug
- `run_script_on_node`: Executes a script on a worker node using oc debug



**A new test case TestSimulateCephBlueStoreLabel in `test_simulate_ceph_bluestore_label.py` that:**

- Downloads the script to a worker node
- Executes the script on a specified device
- Asserts successful label verification



