### PR TITLE
allow login to cluster via url and password for provider clusters

### DIFF
--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -223,7 +223,13 @@ class OCPDeployment:
                 config.RUN.get("kubeconfig_location"),
             )
         ):
-            pytest.fail("Cluster is not available!")
+            if config.RUN.get("kubeadmin_password") and config.RUN.get("ocp_url"):
+                logger.warning(
+                    "OCP url and kubeadmin password for cluster were provided,"
+                    "kubeconfig will be generated"
+                )
+            else:
+                pytest.fail("Cluster is not available!")
 
     def destroy(self, log_level="DEBUG"):
         """


### PR DESCRIPTION
This fix is required for tests execution on clusters which are identified by OCP URL and `kubeadmin` user password (not by `kubeconfig` file) and are HCP provider clusters. It didn't change the behaviour for standard execution in RH jenkins (where we are always providing the `kubeconfig` file for each cluster).

This code is hit before the actual `kubeconfig` generation in the [`process_cluster_cli_params`](https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/framework/pytest_customization/ocscilib.py#L628-L653) function, when _HCP_ platform is used and cluster is set as provider (it is related to `@run_on_all_clients_push_missing_configs`).