### PR TITLE
generate kubeconfig with setup_multicluster_marker

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -28,7 +28,6 @@ from ocs_ci.utility.utils import (
 )
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.ocs.utils import get_namespce_name_by_pattern
-from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
 
 """
 This module contains the base class for HyperShift hosted cluster management.
@@ -379,7 +378,6 @@ class HyperShiftBase:
 
     def __init__(self):
         super().__init__()
-        BaseOCPDeployment(skip_download_installer=True).test_cluster()
 
         bin_dir_rel_path = os.path.expanduser(config.RUN["bin_dir"])
         self.bin_dir = os.path.abspath(bin_dir_rel_path)

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -9,6 +9,9 @@ import sys
 import pytest
 from funcy import compose
 
+from ocs_ci.framework.pytest_customization.ocscilib import (
+    generate_kubeconfig_using_creds,
+)
 from ocs_ci.ocs.exceptions import ClusterNotFoundException
 from ocs_ci.framework import config
 from ocs_ci.ocs.constants import (
@@ -459,6 +462,9 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
                 and config.default_cluster_ctx.ENV_DATA["platform"].lower()
                 in HCI_PROVIDER_CLIENT_PLATFORMS
             ) and test_stage:
+                generate_kubeconfig_using_creds(
+                    config.default_cluster_ctx.ENV_DATA["cluster_path"], config
+                )
                 hypershift_cluster_factory(
                     duty=DUTY_USE_EXISTING_HOSTED_CLUSTERS_PUSH_MISSING_CONFIG,
                 )

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -610,54 +610,7 @@ def process_cluster_cli_params(config):
             )
             set_cli_param(config, f"cluster_path{suffix}", cluster_path)
 
-    if not cluster_path:
-        raise ClusterPathNotProvidedError()
-    cluster_path = os.path.expanduser(cluster_path)
-    if not os.path.exists(cluster_path):
-        os.makedirs(cluster_path)
-
-    # create kubeconfig if doesn't exist and OCP url and kubeadmin password is provided
-    kubeconfig_path = os.path.join(
-        cluster_path, ocsci_config.RUN["kubeconfig_location"]
-    )
-    if not os.path.isfile(kubeconfig_path) and not (
-        get_cli_param(config, "deploy", default=False)
-        or get_cli_param(config, "teardown", default=False)
-        or get_cli_param(config, "kubeconfig")
-    ):
-        if ocsci_config.RUN.get("kubeadmin_password") and ocsci_config.RUN.get(
-            "ocp_url"
-        ):
-            log.info(
-                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
-            )
-            # check and correct OCP URL (change it to API url if console url provided and add port if needed
-            ocp_api_url = ocsci_config.RUN.get("ocp_url").replace(
-                "console-openshift-console.apps", "api"
-            )
-            if ":6443" not in ocp_api_url:
-                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
-
-            cmd = (
-                f"oc login --username {ocsci_config.RUN['username']} "
-                f"--password {ocsci_config.RUN['kubeadmin_password']} "
-                f"{ocp_api_url} "
-                f"--kubeconfig {kubeconfig_path} "
-                "--insecure-skip-tls-verify=true"
-            )
-            result = exec_cmd(cmd, secrets=(ocsci_config.RUN["kubeadmin_password"],))
-            if result.returncode:
-                log.warning(f"executed command: {cmd}")
-                log.warning(f"returncode: {result.returncode}")
-                log.warning(f"stdout: {result.stdout}")
-                log.warning(f"stderr: {result.stderr}")
-            else:
-                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
-        else:
-            raise ConfigurationError(
-                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
-                "environment variables were not provided."
-            )
+    cluster_path = generate_kubeconfig_using_creds(cluster_path, config)
 
     # Importing here cause once the function is invoked we have already config
     # loaded, so this is OK to import once you sure that config is loaded.
@@ -831,6 +784,75 @@ def process_cluster_cli_params(config):
         config, "skip_rpm_go_version_collection"
     )
     ocsci_config.RUN["skip_rpm_go_version_collection"] = skip_rpm_go_version_collection
+
+
+def generate_kubeconfig_using_creds(cluster_path, config):
+    """
+    Generate kubeconfig file from provided kubeadmin password and OCP URL
+
+    Args:
+        cluster_path (str): Path to cluster directory
+        config (pytest.config): Pytest config object
+
+    Raises:
+        ClusterPathNotProvidedError: If a cluster path is missing
+        ConfigurationError: If kubeconfig doesn't exist and RUN['kubeadmin_password'] and
+            RUN['ocp_url'] environment variables were not provided.
+
+    Returns:
+        str: Path to cluster directory
+
+    """
+
+    if not cluster_path:
+        raise ClusterPathNotProvidedError()
+    cluster_path = os.path.expanduser(cluster_path)
+    if not os.path.exists(cluster_path):
+        os.makedirs(cluster_path)
+
+    # create kubeconfig if doesn't exist and OCP url and kubeadmin password is provided
+    kubeconfig_path = os.path.join(
+        cluster_path, ocsci_config.RUN["kubeconfig_location"]
+    )
+    if not os.path.isfile(kubeconfig_path) and not (
+        get_cli_param(config, "deploy", default=False)
+        or get_cli_param(config, "teardown", default=False)
+        or get_cli_param(config, "kubeconfig")
+    ):
+        if ocsci_config.RUN.get("kubeadmin_password") and ocsci_config.RUN.get(
+            "ocp_url"
+        ):
+            log.info(
+                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
+            )
+            # check and correct OCP URL (change it to API url if console url provided and add port if needed
+            ocp_api_url = ocsci_config.RUN.get("ocp_url").replace(
+                "console-openshift-console.apps", "api"
+            )
+            if ":6443" not in ocp_api_url:
+                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
+
+            cmd = (
+                f"oc login --username {ocsci_config.RUN['username']} "
+                f"--password {ocsci_config.RUN['kubeadmin_password']} "
+                f"{ocp_api_url} "
+                f"--kubeconfig {kubeconfig_path} "
+                "--insecure-skip-tls-verify=true"
+            )
+            result = exec_cmd(cmd, secrets=[ocsci_config.RUN["kubeadmin_password"]])
+            if result.returncode:
+                log.warning(f"executed command: {cmd}")
+                log.warning(f"returncode: {result.returncode}")
+                log.warning(f"stdout: {result.stdout}")
+                log.warning(f"stderr: {result.stderr}")
+            else:
+                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
+        else:
+            raise ConfigurationError(
+                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
+                "environment variables were not provided."
+            )
+    return cluster_path
 
 
 def pytest_collection_modifyitems(session, config, items):


### PR DESCRIPTION
pr to resolve issue:

```
The kubeconfig file ../clusters/dahorak-test/auth/kubeconfig doesn't exist!
/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py:318: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: helpconfig, Hook: pytest_cmdline_parse
Failed: Cluster is not available!
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config = pluginmanager.hook.pytest_cmdline_parse(
Traceback (most recent call last):
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/bin/run-ci", line 8, in <module>
    sys.exit(main())
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/main.py", line 30, in main
    return pytest.main(arguments)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 143, in main
    config = _prepareconfig(args, plugins)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 318, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 156, in _multicall
    teardown[0].send(outcome)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
    config: Config = outcome.get_result()
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1003, in pytest_cmdline_parse
    self.parse(args)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1283, in parse
    self._preparse(args, addopts=addopts)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1168, in _preparse
    self.pluginmanager.consider_preparse(args, exclude_only=False)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 635, in consider_preparse
    self.consider_pluginarg(parg)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 660, in consider_pluginarg
    self.import_plugin(arg, consider_entry_points=True)
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 703, in import_plugin
    __import__(importspec)
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/assertion/rewrite.py", line 170, in exec_module
    exec(co, module.__dict__)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/pytest_customization/marks.py", line 474, in <module>
    run_on_all_clients_push_missing_configs = setup_multicluster_marker(
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/framework/pytest_customization/marks.py", line 457, in setup_multicluster_marker
    hypershift_cluster_factory(
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 196, in wrapper
    return func(*args, **kwargs)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 2066, in hypershift_cluster_factory
    hosted_clients_obj = HostedClients()
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/deployment/hosted_cluster.py", line 239, in __init__
    HyperShiftBase.__init__(self)
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/deployment/helpers/hypershift_base.py", line 378, in __init__
    BaseOCPDeployment(skip_download_installer=True).test_cluster()
  File "/home/dahorak/RedHat/OCS/ocs-ci/ocs_ci/deployment/ocp.py", line 226, in test_cluster
    pytest.fail("Cluster is not available!")
  File "/home/dahorak/RedHat/OCS/ocs-ci/venv/lib64/python3.9/site-packages/_pytest/outcomes.py", line 153, in fail
    raise Failed(msg=msg, pytrace=pytrace)
Failed: Cluster is not available!
```