### PR TITLE
Discovered apps recipe workload dr ops

### DIFF
--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -1541,7 +1541,7 @@ class BusyboxDiscoveredApps(DRWorkload):
             )
             log.info(f"Deleting recipe from {cluster.ENV_DATA['cluster_name']}")
             run_cmd(
-                cmd=f"oc delete recipe {self.discovered_apps_recipe_name_value} -n {self.workload_namespace}",
+                cmd=f"oc delete recipe --all -n {self.workload_namespace}",
                 ignore_error=True,
             )
             log.info(f"Deleting secret from {cluster.ENV_DATA['cluster_name']}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7609,9 +7609,11 @@ def discovered_apps_dr_workload(request):
                         "dr_workload_app_recipe_name_selector_value"
                     ],
                 )
-            instances.append(workload)
-            total_pvc_count += workload_details["pvc_count"]
-            workload.deploy_workload(recipe=True)
+
+                instances.append(workload)
+                total_pvc_count += workload_details["pvc_count"]
+                workload.deploy_workload(recipe=True)
+
         return instances
 
     def teardown():

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -125,180 +125,192 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             2) Relocate back to primary
 
         """
-        rdr_workload = discovered_apps_dr_workload(
+        rdr_workloads = discovered_apps_dr_workload(
             pvc_interface=pvc_interface, kubeobject=kubeobject, recipe=recipe
-        )[0]
+        )
         iteration = 1
         while iteration <= iterations:
-            primary_cluster_name_before_failover = (
-                dr_helpers.get_current_primary_cluster_name(
+            for rdr_workload in rdr_workloads:
+                primary_cluster_name_before_failover = (
+                    dr_helpers.get_current_primary_cluster_name(
+                        rdr_workload.workload_namespace,
+                        discovered_apps=True,
+                        resource_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                )
+                config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
+                primary_cluster_name_before_failover_index = config.cur_index
+                primary_cluster_name_before_failover_nodes = get_node_objs()
+                secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
                     rdr_workload.workload_namespace,
                     discovered_apps=True,
                     resource_name=rdr_workload.discovered_apps_placement_name,
                 )
-            )
-            config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-            primary_cluster_name_before_failover_index = config.cur_index
-            primary_cluster_name_before_failover_nodes = get_node_objs()
-            secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
-                rdr_workload.workload_namespace,
-                discovered_apps=True,
-                resource_name=rdr_workload.discovered_apps_placement_name,
-            )
 
-            scheduling_interval = dr_helpers.get_scheduling_interval(
-                rdr_workload.workload_namespace,
-                discovered_apps=True,
-                resource_name=rdr_workload.discovered_apps_placement_name,
-            )
-            drpc_obj = DRPC(
-                namespace=constants.DR_OPS_NAMESAPCE,
-                resource_name=rdr_workload.discovered_apps_placement_name,
-            )
-
-            wait_time = 2 * scheduling_interval  # Time in minutes
-            logger.info(f"Waiting for {wait_time} minutes to run IOs")
-            sleep(wait_time * 60)
-            if pvc_interface == constants.CEPHFILESYSTEM:
-                # Verify the creation of ReplicationDestination resources on secondary cluster
-                config.switch_to_cluster_by_name(secondary_cluster_name)
-                dr_helpers.wait_for_replication_destinations_creation(
-                    rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
+                scheduling_interval = dr_helpers.get_scheduling_interval(
+                    rdr_workload.workload_namespace,
+                    discovered_apps=True,
+                    resource_name=rdr_workload.discovered_apps_placement_name,
+                )
+                drpc_obj = DRPC(
+                    namespace=constants.DR_OPS_NAMESAPCE,
+                    resource_name=rdr_workload.discovered_apps_placement_name,
                 )
 
-            logger.info("Checking for lastKubeObjectProtectionTime")
-            dr_helpers.verify_last_kubeobject_protection_time(
-                drpc_obj, rdr_workload.kubeobject_capture_interval_int
-            )
-
-            if primary_cluster_down:
-                config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-                logger.info(
-                    f"Stopping nodes of primary cluster: {primary_cluster_name_before_failover}"
-                )
-                nodes_multicluster[
-                    primary_cluster_name_before_failover_index
-                ].stop_nodes(primary_cluster_name_before_failover_nodes)
-
-            dr_helpers.failover(
-                failover_cluster=secondary_cluster_name,
-                namespace=rdr_workload.workload_namespace,
-                discovered_apps=True,
-                workload_placement_name=rdr_workload.discovered_apps_placement_name,
-                old_primary=primary_cluster_name_before_failover,
-            )
-
-            if primary_cluster_down:
-                logger.info(
-                    f"Waiting for {wait_time} minutes before starting nodes "
-                    f"of primary cluster: {primary_cluster_name_before_failover}"
-                )
+                wait_time = 2 * scheduling_interval  # Time in minutes
+                logger.info(f"Waiting for {wait_time} minutes to run IOs")
                 sleep(wait_time * 60)
-                nodes_multicluster[
-                    primary_cluster_name_before_failover_index
-                ].start_nodes(primary_cluster_name_before_failover_nodes)
-                wait_for_nodes_status(
-                    [node.name for node in primary_cluster_name_before_failover_nodes]
+                if pvc_interface == constants.CEPHFILESYSTEM:
+                    # Verify the creation of ReplicationDestination resources on secondary cluster
+                    config.switch_to_cluster_by_name(secondary_cluster_name)
+                    dr_helpers.wait_for_replication_destinations_creation(
+                        rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
+                    )
+
+                logger.info("Checking for lastKubeObjectProtectionTime")
+                dr_helpers.verify_last_kubeobject_protection_time(
+                    drpc_obj, rdr_workload.kubeobject_capture_interval_int
                 )
-                logger.info(
-                    "Wait for all the pods in openshift-storage to be in running state"
+
+                if primary_cluster_down:
+                    config.switch_to_cluster_by_name(
+                        primary_cluster_name_before_failover
+                    )
+                    logger.info(
+                        f"Stopping nodes of primary cluster: {primary_cluster_name_before_failover}"
+                    )
+                    nodes_multicluster[
+                        primary_cluster_name_before_failover_index
+                    ].stop_nodes(primary_cluster_name_before_failover_nodes)
+
+                dr_helpers.failover(
+                    failover_cluster=secondary_cluster_name,
+                    namespace=rdr_workload.workload_namespace,
+                    discovered_apps=True,
+                    workload_placement_name=rdr_workload.discovered_apps_placement_name,
+                    old_primary=primary_cluster_name_before_failover,
                 )
-                assert wait_for_pods_to_be_running(
-                    timeout=720
-                ), "Not all the pods reached running state"
-                logger.info("Checking for Ceph Health OK")
-                ceph_health_check()
 
-            logger.info("Doing Cleanup Operations")
-            dr_helpers.do_discovered_apps_cleanup(
-                drpc_name=rdr_workload.discovered_apps_placement_name,
-                old_primary=primary_cluster_name_before_failover,
-                workload_namespace=rdr_workload.workload_namespace,
-                workload_dir=rdr_workload.workload_dir,
-                vrg_name=rdr_workload.discovered_apps_placement_name,
-            )
+                if primary_cluster_down:
+                    logger.info(
+                        f"Waiting for {wait_time} minutes before starting nodes "
+                        f"of primary cluster: {primary_cluster_name_before_failover}"
+                    )
+                    sleep(wait_time * 60)
+                    nodes_multicluster[
+                        primary_cluster_name_before_failover_index
+                    ].start_nodes(primary_cluster_name_before_failover_nodes)
+                    wait_for_nodes_status(
+                        [
+                            node.name
+                            for node in primary_cluster_name_before_failover_nodes
+                        ]
+                    )
+                    logger.info(
+                        "Wait for all the pods in openshift-storage to be in running state"
+                    )
+                    assert wait_for_pods_to_be_running(
+                        timeout=720
+                    ), "Not all the pods reached running state"
+                    logger.info("Checking for Ceph Health OK")
+                    ceph_health_check()
 
-            # Verify resources creation on secondary cluster (failoverCluster)
-            config.switch_to_cluster_by_name(secondary_cluster_name)
-            dr_helpers.wait_for_all_resources_creation(
-                rdr_workload.workload_pvc_count,
-                rdr_workload.workload_pod_count,
-                rdr_workload.workload_namespace,
-                timeout=1200,
-                discovered_apps=True,
-                vrg_name=rdr_workload.discovered_apps_placement_name,
-            )
+                logger.info("Doing Cleanup Operations")
+                dr_helpers.do_discovered_apps_cleanup(
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                    old_primary=primary_cluster_name_before_failover,
+                    workload_namespace=rdr_workload.workload_namespace,
+                    workload_dir=rdr_workload.workload_dir,
+                    vrg_name=rdr_workload.discovered_apps_placement_name,
+                )
 
-            if pvc_interface == constants.CEPHFILESYSTEM:
+                # Verify resources creation on secondary cluster (failoverCluster)
                 config.switch_to_cluster_by_name(secondary_cluster_name)
-                dr_helpers.wait_for_replication_destinations_deletion(
-                    rdr_workload.workload_namespace
+                dr_helpers.wait_for_all_resources_creation(
+                    rdr_workload.workload_pvc_count,
+                    rdr_workload.workload_pod_count,
+                    rdr_workload.workload_namespace,
+                    timeout=1200,
+                    discovered_apps=True,
+                    vrg_name=rdr_workload.discovered_apps_placement_name,
                 )
-                # Verify the creation of ReplicationDestination resources on primary cluster
+
+                if pvc_interface == constants.CEPHFILESYSTEM:
+                    config.switch_to_cluster_by_name(secondary_cluster_name)
+                    dr_helpers.wait_for_replication_destinations_deletion(
+                        rdr_workload.workload_namespace
+                    )
+                    # Verify the creation of ReplicationDestination resources on primary cluster
+                    config.switch_to_cluster_by_name(
+                        primary_cluster_name_before_failover
+                    )
+                    dr_helpers.wait_for_replication_destinations_creation(
+                        rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
+                    )
+                # Doing Relocate
+                primary_cluster_name_after_failover = (
+                    dr_helpers.get_current_primary_cluster_name(
+                        rdr_workload.workload_namespace,
+                        discovered_apps=True,
+                        resource_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                )
                 config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-                dr_helpers.wait_for_replication_destinations_creation(
-                    rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
-                )
-            # Doing Relocate
-            primary_cluster_name_after_failover = (
-                dr_helpers.get_current_primary_cluster_name(
+                secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
                     rdr_workload.workload_namespace,
                     discovered_apps=True,
                     resource_name=rdr_workload.discovered_apps_placement_name,
                 )
-            )
-            config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-            secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
-                rdr_workload.workload_namespace,
-                discovered_apps=True,
-                resource_name=rdr_workload.discovered_apps_placement_name,
-            )
 
-            logger.info("Running Relocate Steps")
-            logger.info(f"Waiting for {wait_time} minutes to run IOs")
-            sleep(wait_time * 60)
+                logger.info("Running Relocate Steps")
+                logger.info(f"Waiting for {wait_time} minutes to run IOs")
+                sleep(wait_time * 60)
 
-            logger.info("Checking for lastKubeObjectProtectionTime")
-            dr_helpers.verify_last_kubeobject_protection_time(
-                drpc_obj, rdr_workload.kubeobject_capture_interval_int
-            )
+                logger.info("Checking for lastKubeObjectProtectionTime")
+                dr_helpers.verify_last_kubeobject_protection_time(
+                    drpc_obj, rdr_workload.kubeobject_capture_interval_int
+                )
 
-            dr_helpers.relocate(
-                preferred_cluster=secondary_cluster_name,
-                namespace=rdr_workload.workload_namespace,
-                workload_placement_name=rdr_workload.discovered_apps_placement_name,
-                discovered_apps=True,
-                old_primary=primary_cluster_name_after_failover,
-                workload_instance=rdr_workload,
-            )
+                dr_helpers.relocate(
+                    preferred_cluster=secondary_cluster_name,
+                    namespace=rdr_workload.workload_namespace,
+                    workload_placement_name=rdr_workload.discovered_apps_placement_name,
+                    discovered_apps=True,
+                    old_primary=primary_cluster_name_after_failover,
+                    workload_instance=rdr_workload,
+                )
 
-            logger.info(
-                "Checking for lastKubeObjectProtectionTime post Relocate Operation"
-            )
-            dr_helpers.verify_last_kubeobject_protection_time(
-                drpc_obj, rdr_workload.kubeobject_capture_interval_int
-            )
+                logger.info(
+                    "Checking for lastKubeObjectProtectionTime post Relocate Operation"
+                )
+                dr_helpers.verify_last_kubeobject_protection_time(
+                    drpc_obj, rdr_workload.kubeobject_capture_interval_int
+                )
 
-            # Verify resources creation on secondary cluster (failoverCluster)
-            config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-            dr_helpers.wait_for_all_resources_creation(
-                rdr_workload.workload_pvc_count,
-                rdr_workload.workload_pod_count,
-                rdr_workload.workload_namespace,
-                timeout=1200,
-                discovered_apps=True,
-                vrg_name=rdr_workload.discovered_apps_placement_name,
-            )
-
-            if pvc_interface == constants.CEPHFILESYSTEM:
+                # Verify resources creation on secondary cluster (failoverCluster)
                 config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-                dr_helpers.wait_for_replication_destinations_deletion(
-                    rdr_workload.workload_namespace
+                dr_helpers.wait_for_all_resources_creation(
+                    rdr_workload.workload_pvc_count,
+                    rdr_workload.workload_pod_count,
+                    rdr_workload.workload_namespace,
+                    timeout=1200,
+                    discovered_apps=True,
+                    vrg_name=rdr_workload.discovered_apps_placement_name,
                 )
-                # Verify the creation of ReplicationDestination resources on primary cluster
-                config.switch_to_cluster_by_name(primary_cluster_name_after_failover)
-                dr_helpers.wait_for_replication_destinations_creation(
-                    rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
-                )
+
+                if pvc_interface == constants.CEPHFILESYSTEM:
+                    config.switch_to_cluster_by_name(
+                        primary_cluster_name_before_failover
+                    )
+                    dr_helpers.wait_for_replication_destinations_deletion(
+                        rdr_workload.workload_namespace
+                    )
+                    # Verify the creation of ReplicationDestination resources on primary cluster
+                    config.switch_to_cluster_by_name(
+                        primary_cluster_name_after_failover
+                    )
+                    dr_helpers.wait_for_replication_destinations_creation(
+                        rdr_workload.workload_pvc_count, rdr_workload.workload_namespace
+                    )
             logger.info(f"Iteration {iteration} completed !!!!!!!")
             iteration += 1


### PR DESCRIPTION
 Fixes an earlier gap in the RDR recipe — previously, the discovered apps were only deployed but not actually failed over or relocated. This issue is now resolved in the update.