### PR TITLE
increase rosa-hcp depl timeouts

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -87,6 +87,9 @@ class ROSAOCP(BaseOCPDeployment):
             log_level (str): openshift installer's log level
 
         """
+        # AWS does not guarantee machines provisioning time,
+        # we need to wait up to 3 hours (observed time)
+        wait_replicas_ready_timeout = 60 * 60 * 3
         if (
             config.ENV_DATA.get("appliance_mode", False)
             and config.ENV_DATA.get("cluster_type", "") == "provider"
@@ -99,7 +102,8 @@ class ROSAOCP(BaseOCPDeployment):
                 self.cluster_name, config.ENV_DATA["machine_pool"]
             )
             machinepool_details.wait_replicas_ready(
-                target_replicas=config.ENV_DATA["worker_replicas"], timeout=2400
+                target_replicas=config.ENV_DATA["worker_replicas"],
+                timeout=wait_replicas_ready_timeout,
             )
             if node_labels := config.ENV_DATA.get("node_labels"):
                 if machinepool_id := config.ENV_DATA.get("machine_pool"):

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -70,7 +70,9 @@ def create_cluster(cluster_name, version_str, region):
         region (str): Cluster region
 
     """
-    create_timeout = 2400
+    # AWS does not guarantee cluster creation time, and machinepool desired replicas.
+    # we need to wait cmd finish execution up to 3 hours (recorded time during observation)
+    create_timeout = 60 * 60 * 3
     aws = AWSUtil()
     rosa_ocp_version = config.DEPLOYMENT["installer_version"]
     # Validate ocp version with rosa ocp supported version
@@ -196,7 +198,7 @@ def create_cluster(cluster_name, version_str, region):
 
     logger.info("Waiting for installation of ROSA cluster")
     for cluster_info in utils.TimeoutSampler(
-        4500, 30, ocm.get_cluster_details, cluster_name
+        create_timeout, 30, ocm.get_cluster_details, cluster_name
     ):
         status = cluster_info["status"]["state"]
         logger.info(f"Current installation status: {status}")


### PR DESCRIPTION
recent failed job: https://url.corp.redhat.com/6f7164f

```
025-10-20 10:27:38  E           subprocess.TimeoutExpired: Command '['rosa', 'create', 'cluster', '--cluster-name', 'dosypenk-2010r1', '--region', 'us-west-2', '--machine-cidr', '10.0.0.0/16', '--replicas', '3', '--compute-machine-type', 'm5.12xlarge', '--version', '4.19.16', '--sts', '--yes', '--watch', '--oidc-config-id', '2m1op7nad8g4d5ct2kvkl53sc5cb55md', '--mode', 'auto', '--subnet-ids', 'subnet-06de2b94c676e2e1b,subnet-08d4ad834dec518c0', '--operator-roles-prefix', 'oproleshcp-dosypenk-2010r1', '--hosted-cp']' timed out after 2400 seconds
```
```
rosa describe cluster --cluster dosypenk-2010r1 | grep "Created"
Created:                    Oct 20 2025 06:47:45 UTC
```
```
oc get nodes -o custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp
NAME                                       CREATED
ip-10-0-0-108.us-west-2.compute.internal   2025-10-20T08:59:28Z
ip-10-0-0-129.us-west-2.compute.internal   2025-10-20T08:59:29Z
ip-10-0-0-20.us-west-2.compute.internal    2025-10-20T08:59:34Z
```
```
echo $(( $(date -d 2025-10-20T08:59:34Z +%s) - $(date -d "Oct 20 2025 06:47:45 UTC" +%s) )) seconds

**7909 seconds**
```
2 h 19 for nodes getting created