### PR TITLE
Fix test_csi_logs_rotation

### DIFF
--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 
 log = logging.getLogger(__name__)
 
-WAIT_FOR_ROTATION_TIME = 1200  # seconds
+WAIT_FOR_ROTATION_TIME = 1500  # seconds
 SLEEP_BETWEEN_TRIES = 300  # seconds
 
 


### PR DESCRIPTION
sometimes test fails due to timeout 1200 is not enough.

- [x] timeout is now 1500sec