### PR TITLE
Use provider cluster namespace when checking mirroring status

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -386,7 +386,9 @@ def check_mirroring_status_ok(
 
         cbp_obj = ocp.OCP(
             kind=constants.CEPHBLOCKPOOLRADOSNS,
-            namespace=config.ENV_DATA["cluster_namespace"],
+            namespace=config.clusters[config.get_provider_index()].ENV_DATA[
+                "cluster_namespace"
+            ],
             resource_name=cephbpradosns,
         )
     else:


### PR DESCRIPTION
Use provider cluster's  cluster_namespace value when checking mirroring status for RBD.
Fixes #13450 