### PR TITLE
Switch to original cluster context at the end of exec_oc_cmd

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -231,7 +231,7 @@ class OCP(object):
         except ValueError:
             pass
 
-        if original_context:
+        if original_context is not None:
             config.switch_ctx(original_context)
 
         if out_yaml_format:


### PR DESCRIPTION
Switch to original cluster context at the end of exec_oc_cmd from ocs_ci.ocs.ocp.OCP. Switch back the context before any return statement.

Check for 'original_context' not None because the index can be 0.
Fixes #13453 