### PR TITLE
`odf_cli.py::check_odf_cli_binary`: account for the case where the odf-cli binary doesn't have the version attribute

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -43,9 +43,13 @@ class ODFCLIRetriever:
             return False
 
         # Check if the binary's version matches the cluster's in upgrade runs
-        if not xattr.getxattr(path, self.version_attribute_name).decode() == str(
-            self.semantic_version
-        ):
+        try:
+            binary_version = xattr.getxattr(path, self.version_attribute_name).decode()
+        except OSError:
+            log.warning("ODF CLI binary is not tagged with a version attribute")
+            return False
+
+        if binary_version != str(self.semantic_version):
             log.warning(
                 f"ODF CLI binary is not tagged with the correct version {self.semantic_version}"
             )


### PR DESCRIPTION
[check_odf_cli_binary](https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/helpers/odf_cli.py/#L32-L57) currently fails if the odf-cli binary is available but doesn't have the `user.version` file attribute. 

This doesn't fail our regression runs because new downloads of the binary are getting tagged [after their download via OCS-CI](https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/helpers/odf_cli.py/#L74-L83), but it can fail local runs that use an untagged binary.

This PR fixes this issue by adding a check to `check_odf_cli_binary` so it also returns False in case the binary doesn't have the attribute.