### PR TITLE
Skip KeyRotation precedence test on disconnected deployments

### DIFF
--- a/tests/functional/storageclass/test_enforce_storageclass_precedance_for_KRRS.py
+++ b/tests/functional/storageclass/test_enforce_storageclass_precedance_for_KRRS.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     tier1,
     kms_config_required,
+    skipif_disconnected_cluster,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,7 @@ class TestEnforceStorageclassPrecedenceForReclaimSpace:
 
 
 @green_squad
+@skipif_disconnected_cluster
 @kms_config_required
 class TestEnforceStorageclassPrecedenceForKeyRotation:
     """


### PR DESCRIPTION
This PR skips the KeyRotation precedence test on disconnected clusters by applying the existing pytest marker  to the  class in .

Rationale:
- The KeyRotation test requires KMS and network access to external services; on disconnected deployments it cannot run reliably.

