### PR TITLE
storagesystem-drop-from-status-card-419

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1838,7 +1838,7 @@ validation_4_9 = {
         By.XPATH,
     ),
     "storage-system-external-status-card-hyperlink": (
-        "//div[@role='dialog']//a[contains(text(),'ocs-external-storagecluster-storagesystem')]",
+        "//div[@role='dialog']//a[contains(text(),'ocs-external-storagecluster')]",
         By.XPATH,
     ),
     "storagesystem-details": (


### PR DESCRIPTION
Following storage system deprecation in 4.19-4.20, cr names and their texts in 4.19 got updated, such as Storage System status card text causing failures in 4.19 test_dashboard_validation_ui.

```
_locator = ("//div[@role='dialog']//a[contains(text(),'ocs-external-storagecluster-storagesystem')]", 'xpath')
_timeout = 30, _enable_screenshot = True, _copy_dom = False


def _do_click(_locator, _timeout=30, _enable_screenshot=False, _copy_dom=False):
    # wait for page fully loaded only if an element was not located
    # prevents needless waiting and frequent crushes on ODF Overview page,
    # when metrics and alerts frequently updated
    if not self.get_elements(_locator):
        self.page_has_loaded()
    screenshot = (
        ocsci_config.UI_SELENIUM.get("screenshot") and enable_screenshot
    )
    if screenshot:
        self.take_screenshot()
    if _copy_dom:
        self.copy_dom()

    wait = WebDriverWait(self.driver, timeout)
    try:
        if (
            version.get_semantic_version(get_ocp_version(), True)
            <= version.VERSION_4_11
        ):
            element = wait.until(
                ec.element_to_be_clickable((locator[1], locator[0]))
            )
        else:
            element = wait.until(
                ec.visibility_of_element_located((locator[1], locator[0]))
            )
        element.click()
    except TimeoutException as e:
        self.take_screenshot()
        self.copy_dom()
        logger.error(e)

      raise TimeoutException(
            f"Failed to find the element ({locator[1]},{locator[0]})"
        )
E           selenium.common.exceptions.TimeoutException: Message: Failed to find the element (xpath,//div[@role='dialog']//a[contains(text(),'ocs-external-storagecluster-storagesystem')])
```


<img width="3840" height="2661" alt="image" src="https://github.com/user-attachments/assets/d46d2293-b1ba-468a-b5fc-e4eb005eeca1" />
