### PR TITLE
A fix to test_multi_region.py 

### DIFF
--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -63,7 +63,7 @@ class BackingStore:
         self.vol_num = vol_num
         self.vol_size = vol_size
 
-    def delete(self, retry=True, timeout=120):
+    def delete(self, retry=True, timeout=240):
         """
         Deletes the current backingstore by using OC/CLI commands
 

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -120,7 +120,7 @@ class TestMultiRegion(MCGTest):
             awscli_pod_session, local_testobjs_dir_path, mcg_bucket_path, mcg_obj
         )
 
-        mcg_obj.check_if_mirroring_is_done(bucket_name)
+        mcg_obj.check_if_mirroring_is_done(bucket_name, timeout=420)
 
         # Bring bucket A down
         aws_client.toggle_aws_bucket_readwrite(backingstore1.uls_name)


### PR DESCRIPTION
This PR contains increasing of the following timeouts: 

* backingstore deletion timeout ( There is a timeout sampler so if the deletion will be faster - the test will not wait without a reason)
* check if mirroring is done timeout 

This is a fix for https://github.com/red-hat-storage/ocs-ci/issues/13510