### PR TITLE
Inject cluster name into the compute name to avoid OCPBUGS-64930

### DIFF
--- a/ocs_ci/cleanup/vsphere/cleanup.py
+++ b/ocs_ci/cleanup/vsphere/cleanup.py
@@ -157,7 +157,11 @@ class IPAM(object):
         # IPAM server. In that we have to delete the IP's in IPAM server
         # even though resource pool is not created in Datacenter
         if not nodes:
-            node_type = ["compute", "control-plane", "lb"]
+            node_type = [
+                f"compute-{cluster_name}",
+                f"control-plane-{cluster_name}",
+                "lb",
+            ]
             for each_type in node_type:
                 if each_type == "lb":
                     nodes.append(f"{each_type}-0")

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -69,6 +69,7 @@ from ocs_ci.utility.utils import (
     create_directory_path,
     read_file_as_str,
     replace_content_in_file,
+    replace_regexp_in_file,
     run_cmd,
     upload_file,
     wait_for_co,
@@ -1054,6 +1055,7 @@ class VSPHEREUPI(VSPHEREBASE):
             logger.info("Deploying OCP cluster for vSphere platform")
             logger.info(f"Openshift-installer will be using loglevel:{log_cli_level}")
             os.chdir(self.terraform_data_dir)
+            adujst_node_names()
             self.terraform.initialize()
             self.terraform.apply(self.terraform_var)
             if config.ENV_DATA["sno"]:
@@ -2495,6 +2497,31 @@ def comment_bootstrap_in_lb_module():
     logger.debug(f"Commenting bootstrap module in {constants.VSPHERE_MAIN}")
     replace_str = "module.ipam_bootstrap.ip_addresses[0]"
     replace_content_in_file(constants.VSPHERE_MAIN, replace_str, f"//{replace_str}")
+
+
+def adujst_node_names():
+    """
+    Adjust node namesi in main.tf
+    """
+    logger.debug("Adjusting node names in main.tf file to contain the cluster name")
+    compute_nodes_regexp = r"^  compute_fqdns\s*=.*$"
+    compute_nodes_replacement = (
+        "  compute_fqdns       = [for idx in range(var.compute_count) : "
+        '"compute-${element(split(".", var.cluster_domain), 0)}-${idx}.${var.cluster_domain}"]'
+    )
+    control_plane_nodes_regexp = r"^  control_plane_fqdns\s*=.*$"
+    control_plane_nodes_replacement = (
+        "  control_plane_fqdns = [for idx in range(var.control_plane_count) : "
+        '"control-plane-${element(split(".", var.cluster_domain), 0)}-${idx}.${var.cluster_domain}"]'
+    )
+    replace_regexp_in_file(
+        constants.VSPHERE_MAIN, compute_nodes_regexp, compute_nodes_replacement
+    )
+    replace_regexp_in_file(
+        constants.VSPHERE_MAIN,
+        control_plane_nodes_regexp,
+        control_plane_nodes_replacement,
+    )
 
 
 def modify_haproxyservice():

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -2066,7 +2066,7 @@ class VSPHEREUPINode(VMWareNodes):
 
         current_compute_suffix = int(compute_node_names[-1].split("-")[-1])
         return [
-            f"{prefix}{current_compute_suffix + node_count}"
+            f"{prefix}{self.cluster_name}-{current_compute_suffix + node_count}"
             for node_count in range(1, count + 1)
         ]
 
@@ -2105,7 +2105,7 @@ class VSPHEREUPINode(VMWareNodes):
             search_str = "control-plane-"
 
         # get the VM index
-        pattern = rf"{search_str}(\d+)"
+        pattern = rf"{search_str}(?:{self.cluster_name}-)?(\d+)"
         match = re.search(pattern, vm_name)
         if match:
             vm_index = match.group(1)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3499,6 +3499,24 @@ def replace_content_in_file(file, old, new, match_and_replace_line=False):
         fd.writelines(file_data)
 
 
+def replace_regexp_in_file(filepath, pattern, new_line):
+    """
+    Replace the first line in filepath matching pattern with new_line.
+    The match is based on a regular expression (re.MULTILINE).
+    """
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+    new_content, count = re.subn(
+        pattern, new_line, content, count=1, flags=re.MULTILINE
+    )
+    if count == 0:
+        print(f"No match found for pattern: {pattern}")
+    else:
+        print(f"Replaced {count} line(s) matching pattern: {pattern}")
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+
 @retry((CommandFailed), tries=100, delay=10, backoff=1)
 def wait_for_co(operator):
     """


### PR DESCRIPTION
There is an issue when we have a tainted node because of bug: https://issues.redhat.com/browse/OCPBUGS-64930

Slack discussion:
https://ibm-systems-storage.slack.com/archives/C06DWD30QTZ/p1762789361407019