### PR TITLE
`test_guaranteed_bucket_logs_management`: Increase the timeout of `wait_for_logs_pvc_mount_status` from 120 to the default 300

### DIFF
--- a/tests/functional/object/mcg/test_bucket_logs.py
+++ b/tests/functional/object/mcg/test_bucket_logs.py
@@ -119,7 +119,7 @@ class TestBucketLogs(MCGTest):
 
         # 3. Wait for the nb pods to have mounts to logs PVC
         assert logs_manager.wait_for_logs_pvc_mount_status(
-            mount_status_expected=True, timeout=120
+            mount_status_expected=True,
         ), "One of the noobaa pods failed to mount the logs PVC"
 
         # 4. Create two buckets: source bucket and logs bucket
@@ -157,7 +157,7 @@ class TestBucketLogs(MCGTest):
 
         # 11. Wait for the nb pods to restart without the mounts
         assert logs_manager.wait_for_logs_pvc_mount_status(
-            mount_status_expected=False, timeout=120
+            mount_status_expected=False,
         ), "One of the noobaa pods failed to unmount the logs PVC"
 
         # 12. Validate that the logs PVC hasn't been deleted


### PR DESCRIPTION
`wait_for_logs_pvc_mount_status` sometimes fails because one of the old noobaa-endpoint pods is still up and not mounting the needed volume:
```
15:27:21 - MainThread - ocs_ci.ocs.resources.bucket_logging_manager - WARNING  - One of the noobaa pods still doesn't mount the logs PVC: {'noobaa-core-0': True, 'noobaa-endpoint-5cf48746bb-d4kjk': False, 'noobaa-endpoint-6c68585f6b-92qmc': True, 'noobaa-endpoint-6c68585f6b-bqhg5': True}
```
This doesn't happen in `test_bucket_logs_integrity` where the same timeout is set to the default 300 seconds.