### PR TITLE
Updated timeout time to fix issue#13606

### DIFF
--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -66,7 +66,7 @@ def nfs_enable(
         condition=constants.STATUS_RUNNING,
         selector="app=rook-ceph-nfs",
         dont_allow_other_resources=True,
-        timeout=60,
+        timeout=120,
     )
 
     provisioner_list = provisioner_selectors(nfs_plugins=True)
@@ -78,7 +78,7 @@ def nfs_enable(
             condition=constants.STATUS_RUNNING,
             selector=provisioner,
             dont_allow_other_resources=True,
-            timeout=60,
+            timeout=120,
         )
 
     # Fetch the nfs-ganesha pod name


### PR DESCRIPTION
In a few 4.20 runs, the NFS tests failed during the suite setup with the following error:

> def iter(self):
> if self.start_time is None:
> self.start_time = time.time()
> while True:
> self.last_sample_time = time.time()
> if self.timeout <= (self.last_sample_time - self.start_time):
> raise self.timeout_exc_cls(*self.timeout_exc_args)
> try:
> yield self.func(*self.func_args, **self.func_kwargs)
> except Exception as ex:
> msg = f"Exception raised during iteration: {ex}"
> log.exception(msg)
> if self.timeout <= (time.time() - self.start_time):
> raise self.timeout_exc_cls(*self.timeout_exc_args)
> 
> E ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed out after 60s running get("", True, "app=rook-ceph-nfs")
> ocs_ci/utility/utils.py:1530: TimeoutExpiredError

Although the pods eventually came up, the test failed due to the timeout.
To avoid this issue, the timeout duration has been increased from 60s to 120s.

