### PR TITLE
Move annotation in create_service_exporter function

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -897,7 +897,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 590,
+        "line_number": 576,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2554,9 +2554,13 @@ def check_storage_cluster_peer_state():
         return False
 
 
-def create_service_exporter():
+def create_service_exporter(annotate=True):
     """
     Create Service exporter
+
+    Args:
+        annotate (bool): If True - annotate the service exporter
+
     """
     restore_index = config.cur_index
     managed_clusters = get_non_acm_cluster_config()
@@ -2571,6 +2575,12 @@ def create_service_exporter():
             continue
         logger.info("Creating Service exporter")
         run_cmd(f"oc create -f {constants.DR_SERVICE_EXPORTER}")
+        if annotate:
+            run_cmd(
+                "oc annotate storagecluster ocs-storagecluster -n openshift-storage"
+                f" ocs.openshift.io/api-server-exported-address={cluster.ENV_DATA['cluster_name']}"
+                ".ocs-provider-server.openshift-storage.svc.clusterset.local:50051"
+            )
     config.switch_ctx(restore_index)
 
 

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -417,20 +417,6 @@ class StorageClusterSetup(object):
             merge_dict(
                 cluster_data, {"metadata": {"annotations": rdr_bluestore_annotation}}
             )
-        if (
-            version.get_semantic_ocs_version_from_config() >= version.VERSION_4_19
-            and config.MULTICLUSTER.get("multicluster_mode") == "regional-dr"
-        ):
-            api_server_exported_address_annotation = {
-                "ocs.openshift.io/api-server-exported-address": (
-                    f'{config.ENV_DATA["cluster_name"]}.'
-                    f"ocs-provider-server.openshift-storage.svc.clusterset.local:50051"
-                )
-            }
-            merge_dict(
-                cluster_data,
-                {"metadata": {"annotations": api_server_exported_address_annotation}},
-            )
         if config.ENV_DATA.get("noobaa_external_pgsql"):
             log_step(
                 "Creating external pgsql DB for NooBaa and correct StorageCluster data"


### PR DESCRIPTION
It's documented here:
https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#connecting-storage-clusters-with-the-ocs-provider-server-serviceexport_rdr And this is needed to be done also for ROKS deployment so it can be moved to create_service_exporter function to do at once for all cases, also for those when we install ODF via addon.