### PR TITLE
Add fio parameter direct=1 in the test case test_snapshot_restore_with_different_access_mode for block volume mode pvc

### DIFF
--- a/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
@@ -70,20 +70,20 @@ class TestSnapshotRestoreWithDifferentAccessMode(ManageTest):
 
         # Start IO
         log.info("Starting IO on all pods")
+
         for pod_obj in self.pods:
-            if pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK:
-                storage_type = "block"
-                io_direct = 1
-            else:
-                storage_type = "filesystem"
-                io_direct = 0
+            storage_type = (
+                "block"
+                if pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK
+                else "fs"
+            )
             pod_obj.run_io(
                 storage_type=storage_type,
                 size="1G",
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
-                direct=io_direct,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on all pods")


### PR DESCRIPTION
Update the test case tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py::TestSnapshotRestoreWithDifferentAccessMode::test_snapshot_restore_with_different_access_mode with fio parameter direct=1 when the volume mode of the PVC is block
Fixes #13635 