### PR TITLE
test_bucket_create-locator-fix-4.20

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2379,7 +2379,7 @@ bucket_tab = {
         By.XPATH,
     ),
     "create_folder_button": (
-        "//div[contains(@class, 'u-w-50')]//div//button[contains(@class, 'c-button')]",
+        "//button[normalize-space()='Create folder']",
         By.XPATH,
     ),
     "folder_name_input": (


### PR DESCRIPTION
locator "create_folder_button" was not unique, leading to 2 webElements, which silently broke the test

_ 1 of 1 completed, 1 Pass, 0 Fail, 0 Skip, 0 XPass, 0 XFail, 0 Error, 0 ReRun _
14:14:02 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/functional/object/mcg/ui/test_mcg_ui.py::TestBucketCreate::test_bucket_create immediately after test execution: 13.67