### PR TITLE
fix broken download hcp kubeconfig 420

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -453,7 +453,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1838,
+        "line_number": 1844,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -401,37 +401,6 @@ ms_provider_and_consumer_required = pytest.mark.skipif(
     reason="Test runs ONLY on Managed service with provider and consumer clusters",
 )
 
-hci_client_required = pytest.mark.skipif(
-    not (
-        config.default_cluster_ctx.ENV_DATA["platform"].lower()
-        in HCI_PROVIDER_CLIENT_PLATFORMS
-        and config.default_cluster_ctx.ENV_DATA["cluster_type"].lower() == HCI_CLIENT
-    ),
-    reason="Test runs ONLY on Fusion HCI Client cluster",
-)
-
-hci_provider_required = pytest.mark.skipif(
-    not (
-        config.default_cluster_ctx.ENV_DATA["platform"].lower()
-        in HCI_PROVIDER_CLIENT_PLATFORMS
-        and config.default_cluster_ctx.ENV_DATA["cluster_type"].lower() == HCI_PROVIDER
-    ),
-    reason="Test runs ONLY on Fusion HCI Provider cluster",
-)
-hci_provider_and_client_required = pytest.mark.skipif(
-    not (
-        config.ENV_DATA["platform"].lower() in HCI_PROVIDER_CLIENT_PLATFORMS
-        and config.hci_provider_exist()
-        and config.hci_client_exist()
-    ),
-    reason="Test runs ONLY on Fusion HCI provider and client clusters",
-)
-
-data_replication_separation_required = pytest.mark.skipif(
-    config.DEPLOYMENT.get("enable_data_replication_separation") is False,
-    reason="Test runs only on deployments with enabled data replication separation",
-)
-
 
 # when run_on_all_clients marker is used, there needs to be added cluster_index
 # parameter to the test to prevent any issues with the test parametrization
@@ -484,6 +453,38 @@ def setup_multicluster_marker(marker_base, push_missing_configs=False):
 run_on_all_clients = setup_multicluster_marker(pytest.mark.run_on_all_clients)
 run_on_all_clients_push_missing_configs = setup_multicluster_marker(
     pytest.mark.run_on_all_clients, True
+)
+
+
+hci_client_required = pytest.mark.skipif(
+    not (
+        config.default_cluster_ctx.ENV_DATA["platform"].lower()
+        in HCI_PROVIDER_CLIENT_PLATFORMS
+        and config.default_cluster_ctx.ENV_DATA["cluster_type"].lower() == HCI_CLIENT
+    ),
+    reason="Test runs ONLY on Fusion HCI Client cluster",
+)
+
+hci_provider_required = pytest.mark.skipif(
+    not (
+        config.default_cluster_ctx.ENV_DATA["platform"].lower()
+        in HCI_PROVIDER_CLIENT_PLATFORMS
+        and config.default_cluster_ctx.ENV_DATA["cluster_type"].lower() == HCI_PROVIDER
+    ),
+    reason="Test runs ONLY on Fusion HCI Provider cluster",
+)
+hci_provider_and_client_required = pytest.mark.skipif(
+    not (
+        config.ENV_DATA["platform"].lower() in HCI_PROVIDER_CLIENT_PLATFORMS
+        and config.hci_provider_exist()
+        and config.hci_client_exist()
+    ),
+    reason="Test runs ONLY on Fusion HCI provider and client clusters",
+)
+
+data_replication_separation_required = pytest.mark.skipif(
+    config.DEPLOYMENT.get("enable_data_replication_separation") is False,
+    reason="Test runs only on deployments with enabled data replication separation",
 )
 
 kms_config_required = pytest.mark.skipif(


### PR DESCRIPTION
This pr fixes the issue for running a job on provider with hosted clusters, when we do not provide client configurations.
This approach we use in local setups, but do not use on Multicluster Provider mode job.  