### PR TITLE
Bump python-ipmi to 0.5.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "numpy==1.23.2",
         "pandas==1.5.2",
         "tabulate==0.9.0",
-        "python-ipmi==0.4.2",
+        "python-ipmi==0.5.7",
         "scipy==1.12.0",
         "PrettyTable==0.7.2",
         "azure-common==1.1.28",


### PR DESCRIPTION
Avoiding issues like:
AttributeError: 'array.array' object has no attribute 'tostring'
In newer version of python , as this method was deprecated and dropped
already in python 3.9.