### PR TITLE
DR operation on discovered app for cephfs using custom storage class and pool of replica-2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2925,
+        "line_number": 3088,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -2,7 +2,7 @@ ENV_DATA:
   deploy_via_cli: True
   cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
-  dr_workload_repo_branch: "custom_sc_for_cephfs"
+  dr_workload_repo_branch: "master"
   dr_workload_subscription_rbd: [
     {name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placementrule/app-busybox-1",
      pod_count: 10, pvc_count: 10

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -217,24 +217,6 @@ ENV_DATA:
       multi_ns_dr_workload_app_pvc_selector_value: "simple_io_pvc",
     },
   ]
-  dr_workload_discovered_apps_cephfs_custom_pool_and_sc: [
-    { name: "busybox-dict-1-cephfs_custom_sc", workload_dir: "rdr/busybox/cephfs/custom_sc_resources/app-busybox-1",
-      pod_count: 10, pvc_count: 10,
-      dr_workload_app_pod_selector_key: "workloadpattern",
-      dr_workload_app_pod_selector_value: "simple_io",
-      dr_workload_app_pvc_selector_key: "appname",
-      dr_workload_app_pvc_selector_value: "busybox_app1_cephfs",
-      workload_namespace: "busybox-dict-1-cephfs",
-      dr_workload_app_placement_name: "busybox-dict-1-cephfs",
-      multi_ns_dr_workload_app_pvc_selector_key: "workloadpattern",
-      multi_ns_dr_workload_app_pvc_selector_value: "simple_io_pvc",
-      dr_workload_app_recipe_name_key: "name",
-      dr_workload_app_recipe_name_value: "busybox-dict-1",
-      dr_workload_app_recipe_namespace_key: "namespace",
-      dr_workload_app_recipe_namespace_value: "busybox-dict-1",
-      dr_workload_app_recipe_name_selector_value: "busybox-*",
-    },
-  ]
   dr_workload_subscription_placement_rbd: [
     { name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-1",
       pod_count: 10, pvc_count: 10, is_placement: True,
@@ -407,6 +389,39 @@ ENV_DATA:
       workload_namespace: "mongodb-dict-1-cephfs",
       dr_workload_app_placement_name: "mongodb-dict-1-cephfs",
     }
+  ]
+
+  dr_workload_appset_with_custom_pool_rbd: [
+    { name: "appset-busybox-1-with-custom-pool", workload_dir: "rdr/busybox/rbd/custom_sc_resources/app-busybox-1",
+      pod_count: 10, pvc_count: 10,
+      dr_workload_app_placement_name: "busybox-1-placement",
+      dr_workload_app_pvc_selector: {'appname': 'busybox_app1'},
+    },]
+
+  dr_workload_appset_with_custom_pool_cephfs: [
+    { name: "busybox-dict-1-cephfs_custom_sc", workload_dir: "rdr/busybox/cephfs/custom_sc_resources/app-busybox-1",
+      pod_count: 10, pvc_count: 10,
+      dr_workload_app_placement_name: "busybox-1-placement-cephfs",
+      dr_workload_app_pvc_selector: { 'appname': 'busybox_app1_cephfs'}
+    },]
+
+  dr_workload_discovered_apps_cephfs_custom_pool_and_sc: [
+    { name: "busybox-dict-1-cephfs_custom_sc", workload_dir: "rdr/busybox/cephfs/custom_sc_resources/app-busybox-1",
+      pod_count: 10, pvc_count: 10,
+      dr_workload_app_pod_selector_key: "workloadpattern",
+      dr_workload_app_pod_selector_value: "simple_io",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "busybox_app1_cephfs",
+      workload_namespace: "busybox-dict-1-cephfs",
+      dr_workload_app_placement_name: "busybox-dict-1-cephfs",
+      multi_ns_dr_workload_app_pvc_selector_key: "workloadpattern",
+      multi_ns_dr_workload_app_pvc_selector_value: "simple_io_pvc",
+      dr_workload_app_recipe_name_key: "name",
+      dr_workload_app_recipe_name_value: "busybox-dict-1",
+      dr_workload_app_recipe_namespace_key: "namespace",
+      dr_workload_app_recipe_namespace_value: "busybox-dict-1",
+      dr_workload_app_recipe_name_selector_value: "busybox-*",
+    },
   ]
 
   # dr_policy_name: PLACEHOLDER

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -217,6 +217,24 @@ ENV_DATA:
       multi_ns_dr_workload_app_pvc_selector_value: "simple_io_pvc",
     },
   ]
+  dr_workload_discovered_apps_cephfs_custom_pool_and_sc: [
+    { name: "busybox-dict-1-cephfs_custom_sc", workload_dir: "rdr/busybox/cephfs/custom_sc_resources/app-busybox-1",
+      pod_count: 10, pvc_count: 10,
+      dr_workload_app_pod_selector_key: "workloadpattern",
+      dr_workload_app_pod_selector_value: "simple_io",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "busybox_app1_cephfs",
+      workload_namespace: "busybox-dict-1-cephfs",
+      dr_workload_app_placement_name: "busybox-dict-1-cephfs",
+      multi_ns_dr_workload_app_pvc_selector_key: "workloadpattern",
+      multi_ns_dr_workload_app_pvc_selector_value: "simple_io_pvc",
+      dr_workload_app_recipe_name_key: "name",
+      dr_workload_app_recipe_name_value: "busybox-dict-1",
+      dr_workload_app_recipe_namespace_key: "namespace",
+      dr_workload_app_recipe_namespace_value: "busybox-dict-1",
+      dr_workload_app_recipe_name_selector_value: "busybox-*",
+    },
+  ]
   dr_workload_subscription_placement_rbd: [
     { name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-1",
       pod_count: 10, pvc_count: 10, is_placement: True,

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -2,7 +2,7 @@ ENV_DATA:
   deploy_via_cli: True
   cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
-  dr_workload_repo_branch: "master"
+  dr_workload_repo_branch: "custom_sc_for_cephfs"
   dr_workload_subscription_rbd: [
     {name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placementrule/app-busybox-1",
      pod_count: 10, pvc_count: 10

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1399,6 +1399,43 @@ def create_cephfs_data_pool(
         logger.error(f"Failed to create data pool '{pool_name}': {e}")
         return None
 
+def check_additional_cephfs_data_pool_exists(
+    pool_name,
+    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+):
+    """
+    Check if a CephFS additional data pool exists
+
+    Args:
+        pool_name (str): Name of the data pool to check
+        namespace (str): Namespace where the StorageCluster exists
+
+    Returns:
+        bool: True if data pool exists, False otherwise
+
+    """
+    if not pool_name:
+        return False
+    try:
+        storage_cluster_obj = ocp.OCP(
+            kind=constants.STORAGECLUSTER, namespace=namespace,resource_name=constants.DEFAULT_CLUSTERNAME
+        )
+
+        additional_pools = (
+            storage_cluster_obj.data
+            .get("spec", {})
+            .get("managedResources", {})
+            .get("cephFilesystems", {})
+            .get("additionalDataPools", [])
+        )
+        return any(
+            pool.get("name") == pool_name
+            for pool in additional_pools
+        )
+    except Exception as e:
+        logger(f"Failed to check if data pool exists: {e}")
+        return False
+
 
 def delete_cephfs_data_pool(
     pool_name,

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1317,30 +1317,27 @@ def create_cephfs_data_pool(
     replica=2,
     compression="none",
     namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
- ):
+):
     """
-    Create a new CephFS data pool or return the existing one.
-    Includes all mandatory fields required by OCS.
-    
+    Create a new CephFS additional data pool or return the existing one.
+
     Args:
-        cephfs_name (str): Name of the CephFilesystem
-        pool_name (str): Name of the pool to create
-        replica_size (int): Number of replicas
-        compression_mode (str): Compression mode
-        device_class (str): Device class for pool
-        failure_domain (str): Failure domain (e.g., zone)
-        namespace (str): Namespace of the CephFilesystem
+        pool_name (str): Name of the data pool to create
+        replica (int): Number of replicas for the pool
+        compression (str): Compression mode (none, passive, aggressive, force)
+        namespace (str): Namespace where the StorageCluster exists
 
     Returns:
-        str: New datapool if created or existing, None on failure
+        str: Pool name if created or already existing, None on failure
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
 
     storage_cluster_obj = ocp.OCP(
-            kind=constants.STORAGECLUSTER, namespace=namespace, resource_name=constants.DEFAULT_CLUSTERNAME
+        kind=constants.STORAGECLUSTER,
+        namespace=namespace,
+        resource_name=constants.DEFAULT_CLUSTERNAME,
     )
 
-    # Normalize + default compression
     compression = (compression or "none").lower()
     allowed = {"none", "passive", "aggressive", "force", ""}
     if compression not in allowed:
@@ -1348,92 +1345,85 @@ def create_cephfs_data_pool(
             f"Invalid compressionMode '{compression}'. Supported values: {allowed}"
         )
 
-    # Check if additionalDataPools exists
-    if "additionalDataPools" in storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]:
-        data_pools_available = storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]["additionalDataPools"]
+    cephfs_spec = storage_cluster_obj.data["spec"]["managedResources"][
+        "cephFilesystems"
+    ]
+    if "additionalDataPools" in cephfs_spec:
+        data_pools_available = cephfs_spec["additionalDataPools"]
         pool_names = {p.get("name") for p in data_pools_available}
         if pool_name in pool_names:
-            logger.info(f"data pool '{pool_name}' already exists to CephFilesystem")
+            logger.info(f"Data pool '{pool_name}' already exists in CephFilesystem")
             return pool_name
-        else:
-            # Field exists → append to the list
-            data_pool_patch = [
-        {
-            "op": "add",
-            "path": "/spec/managedResources/cephFilesystems/additionalDataPools/-",
-            "value": {
-                "name": pool_name,
-                "compressionMode": compression,
-                "replicated": {
-                    "size": replica,
-                },
-            },
-        }
-    ]
-
-    # Construct JSON Patch
-    else:
-        # Field does not exist → create it as a list
+        # Field exists — append to the list
         data_pool_patch = [
-        {
-            "op": "add",
-            "path": "/spec/managedResources/cephFilesystems/additionalDataPools",
-            "value": [
-                {
+            {
+                "op": "add",
+                "path": (
+                    "/spec/managedResources/cephFilesystems/additionalDataPools/-"
+                ),
+                "value": {
                     "name": pool_name,
                     "compressionMode": compression,
-                    "replicated": {
-                        "size": replica,
-                    },
-                }
-            ],
-        }
-    ]
-
+                    "replicated": {"size": replica},
+                },
+            }
+        ]
+    else:
+        # Field does not exist — create it as a list
+        data_pool_patch = [
+            {
+                "op": "add",
+                "path": ("/spec/managedResources/cephFilesystems/additionalDataPools"),
+                "value": [
+                    {
+                        "name": pool_name,
+                        "compressionMode": compression,
+                        "replicated": {"size": replica},
+                    }
+                ],
+            }
+        ]
 
     try:
         storage_cluster_obj.patch(params=data_pool_patch, format_type="json")
-        logger.info(f"additional data pool '{pool_name}' added to CephFilesystem")
+        logger.info(f"Additional data pool '{pool_name}' added to CephFilesystem")
         return pool_name
     except Exception as e:
         logger.error(f"Failed to create data pool '{pool_name}': {e}")
         return None
+
 
 def check_additional_cephfs_data_pool_exists(
     pool_name,
     namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
 ):
     """
-    Check if a CephFS additional data pool exists
+    Check if a CephFS additional data pool exists in the StorageCluster.
 
     Args:
         pool_name (str): Name of the data pool to check
         namespace (str): Namespace where the StorageCluster exists
 
     Returns:
-        bool: True if data pool exists, False otherwise
-
+        bool: True if the data pool exists, False otherwise
     """
     if not pool_name:
         return False
     try:
         storage_cluster_obj = ocp.OCP(
-            kind=constants.STORAGECLUSTER, namespace=namespace,resource_name=constants.DEFAULT_CLUSTERNAME
+            kind=constants.STORAGECLUSTER,
+            namespace=namespace,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
         )
-
         additional_pools = (
-            storage_cluster_obj.data
-            .get("spec", {})
+            storage_cluster_obj.data.get("spec", {})
             .get("managedResources", {})
             .get("cephFilesystems", {})
             .get("additionalDataPools", [])
         )
-        return any(
-            pool.get("name") == pool_name
-            for pool in additional_pools
-        )
+        return any(pool.get("name") == pool_name for pool in additional_pools)
     except Exception as e:
-        logger(f"Failed to check if data pool exists: {e}")
+        logger.error(f"Failed to check if data pool exists: {e}")
         return False
 
 
@@ -1442,7 +1432,7 @@ def delete_cephfs_data_pool(
     namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
 ):
     """
-    Delete a CephFS additional data pool by patching StorageCluster
+    Delete a CephFS additional data pool by patching the StorageCluster.
 
     Args:
         pool_name (str): Name of the CephFS additional data pool to delete
@@ -1450,16 +1440,17 @@ def delete_cephfs_data_pool(
 
     Returns:
         bool: True if the pool was found and removed, False if the pool
-        does not exist in the StorageCluster
+            does not exist in the StorageCluster
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
     storage_cluster_obj = ocp.OCP(
-            kind=constants.STORAGECLUSTER, namespace=namespace, resource_name=constants.DEFAULT_CLUSTERNAME
+        kind=constants.STORAGECLUSTER,
+        namespace=namespace,
+        resource_name=constants.DEFAULT_CLUSTERNAME,
     )
 
     pools = (
-        storage_cluster_obj.data
-        .get("spec", {})
+        storage_cluster_obj.data.get("spec", {})
         .get("managedResources", {})
         .get("cephFilesystems", {})
         .get("additionalDataPools", [])
@@ -1470,7 +1461,10 @@ def delete_cephfs_data_pool(
             patch = [
                 {
                     "op": "remove",
-                    "path": f"/spec/managedResources/cephFilesystems/additionalDataPools/{idx}",
+                    "path": (
+                        "/spec/managedResources/cephFilesystems"
+                        f"/additionalDataPools/{idx}"
+                    ),
                 }
             ]
             storage_cluster_obj.patch(params=patch, format_type="json")
@@ -1480,7 +1474,7 @@ def delete_cephfs_data_pool(
     logger.info(f"CephFS data pool '{pool_name}' not found")
     return False
 
-    
+
 def validate_cephfilesystem(fs_name, namespace=None):
     """
     Verify CephFileSystem exists at Ceph and OCP

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1311,6 +1311,7 @@ def get_cephfs_data_pool_name():
     out = ct_pod.exec_ceph_cmd("ceph fs ls")
     return out[0]["data_pools"][0]
 
+
 def create_cephfs_data_pool(
     pool_name,
     replica=2,
@@ -1336,7 +1337,7 @@ def create_cephfs_data_pool(
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
 
     storage_cluster_obj = ocp.OCP(
-            kind=constants.STORAGECLUSTER, namespace=namespace,resource_name=constants.DEFAULT_CLUSTERNAME
+            kind=constants.STORAGECLUSTER, namespace=namespace, resource_name=constants.DEFAULT_CLUSTERNAME
     )
 
     # Normalize + default compression
@@ -1399,6 +1400,50 @@ def create_cephfs_data_pool(
         return None
 
 
+def delete_cephfs_data_pool(
+    pool_name,
+    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+):
+    """
+    Delete a CephFS additional data pool by patching StorageCluster
+
+    Args:
+        pool_name (str): Name of the CephFS additional data pool to delete
+        namespace (str): Namespace where the StorageCluster exists
+
+    Returns:
+        bool: True if the pool was found and removed, False if the pool
+        does not exist in the StorageCluster
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    storage_cluster_obj = ocp.OCP(
+            kind=constants.STORAGECLUSTER, namespace=namespace, resource_name=constants.DEFAULT_CLUSTERNAME
+    )
+
+    pools = (
+        storage_cluster_obj.data
+        .get("spec", {})
+        .get("managedResources", {})
+        .get("cephFilesystems", {})
+        .get("additionalDataPools", [])
+    )
+
+    for idx, pool in enumerate(pools):
+        if pool.get("name") == pool_name:
+            patch = [
+                {
+                    "op": "remove",
+                    "path": f"/spec/managedResources/cephFilesystems/additionalDataPools/{idx}",
+                }
+            ]
+            storage_cluster_obj.patch(params=patch, format_type="json")
+            logger.info(f"CephFS data pool '{pool_name}' deleted")
+            return True
+
+    logger.info(f"CephFS data pool '{pool_name}' not found")
+    return False
+
+    
 def validate_cephfilesystem(fs_name, namespace=None):
     """
     Verify CephFileSystem exists at Ceph and OCP

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1316,7 +1316,7 @@ def create_cephfs_data_pool(
     replica=2,
     compression="none",
     namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
-):
+ ):
     """
     Create a new CephFS data pool or return the existing one.
     Includes all mandatory fields required by OCS.
@@ -1339,52 +1339,56 @@ def create_cephfs_data_pool(
             kind=constants.STORAGECLUSTER, namespace=namespace,resource_name=constants.DEFAULT_CLUSTERNAME
     )
 
+    # Normalize + default compression
+    compression = (compression or "none").lower()
+    allowed = {"none", "passive", "aggressive", "force", ""}
+    if compression not in allowed:
+        raise ValueError(
+            f"Invalid compressionMode '{compression}'. Supported values: {allowed}"
+        )
+
     # Check if additionalDataPools exists
-    data_pools_available = storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]["additionalDataPools"]
-    pool_names = {p.get("name") for p in data_pools_available}
-    if data_pools_available:
-        # Check if the pool name already exists
+    if "additionalDataPools" in storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]:
+        data_pools_available = storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]["additionalDataPools"]
+        pool_names = {p.get("name") for p in data_pools_available}
         if pool_name in pool_names:
             logger.info(f"data pool '{pool_name}' already exists to CephFilesystem")
             return pool_name
         else:
             # Field exists → append to the list
-            data_pool_patch = f"""
-            [
-                {{
-                    "op": "add",
-                    "path": "/spec/managedResources/cephFilesystems/additionalDataPools/-",
-                    "value": {{
-                        "name": "{pool_name}",
-                        "compressionMode": "{compression}",
-                        "replicated": {{
-                            "size": {replica}
-                        }}
-                    }}
-                }}
-            ]
-            """
+            data_pool_patch = [
+        {
+            "op": "add",
+            "path": "/spec/managedResources/cephFilesystems/additionalDataPools/-",
+            "value": {
+                "name": pool_name,
+                "compressionMode": compression,
+                "replicated": {
+                    "size": replica,
+                },
+            },
+        }
+    ]
 
     # Construct JSON Patch
-    if not data_pools_available or data_pools_available in ["", "null", "[]"]:
+    else:
         # Field does not exist → create it as a list
-        data_pool_patch = f"""
-        [
-            {{
-                "op": "add",
-                "path": "/spec/managedResources/cephFilesystems/additionalDataPools",
-                "value": [
-                    {{
-                        "name": "{pool_name}",
-                        "compressionMode": "{compression}",
-                        "replicated": {{
-                            "size": {replica}
-                        }}
-                    }}
-                ]
-            }}
-        ]
-        """
+        data_pool_patch = [
+        {
+            "op": "add",
+            "path": "/spec/managedResources/cephFilesystems/additionalDataPools",
+            "value": [
+                {
+                    "name": pool_name,
+                    "compressionMode": compression,
+                    "replicated": {
+                        "size": replica,
+                    },
+                }
+            ],
+        }
+    ]
+
 
     try:
         storage_cluster_obj.patch(params=data_pool_patch, format_type="json")

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1311,6 +1311,89 @@ def get_cephfs_data_pool_name():
     out = ct_pod.exec_ceph_cmd("ceph fs ls")
     return out[0]["data_pools"][0]
 
+def create_cephfs_data_pool(
+    pool_name,
+    replica=2,
+    compression="none",
+    namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+):
+    """
+    Create a new CephFS data pool or return the existing one.
+    Includes all mandatory fields required by OCS.
+    
+    Args:
+        cephfs_name (str): Name of the CephFilesystem
+        pool_name (str): Name of the pool to create
+        replica_size (int): Number of replicas
+        compression_mode (str): Compression mode
+        device_class (str): Device class for pool
+        failure_domain (str): Failure domain (e.g., zone)
+        namespace (str): Namespace of the CephFilesystem
+
+    Returns:
+        str: New datapool if created or existing, None on failure
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+
+    storage_cluster_obj = ocp.OCP(
+            kind=constants.STORAGECLUSTER, namespace=namespace,resource_name=constants.DEFAULT_CLUSTERNAME
+    )
+
+    # Check if additionalDataPools exists
+    data_pools_available = storage_cluster_obj.data["spec"]["managedResources"]["cephFilesystems"]["additionalDataPools"]
+    pool_names = {p.get("name") for p in data_pools_available}
+    if data_pools_available:
+        # Check if the pool name already exists
+        if pool_name in pool_names:
+            logger.info(f"data pool '{pool_name}' already exists to CephFilesystem")
+            return pool_name
+        else:
+            # Field exists → append to the list
+            data_pool_patch = f"""
+            [
+                {{
+                    "op": "add",
+                    "path": "/spec/managedResources/cephFilesystems/additionalDataPools/-",
+                    "value": {{
+                        "name": "{pool_name}",
+                        "compressionMode": "{compression}",
+                        "replicated": {{
+                            "size": {replica}
+                        }}
+                    }}
+                }}
+            ]
+            """
+
+    # Construct JSON Patch
+    if not data_pools_available or data_pools_available in ["", "null", "[]"]:
+        # Field does not exist → create it as a list
+        data_pool_patch = f"""
+        [
+            {{
+                "op": "add",
+                "path": "/spec/managedResources/cephFilesystems/additionalDataPools",
+                "value": [
+                    {{
+                        "name": "{pool_name}",
+                        "compressionMode": "{compression}",
+                        "replicated": {{
+                            "size": {replica}
+                        }}
+                    }}
+                ]
+            }}
+        ]
+        """
+
+    try:
+        storage_cluster_obj.patch(params=data_pool_patch, format_type="json")
+        logger.info(f"additional data pool '{pool_name}' added to CephFilesystem")
+        return pool_name
+    except Exception as e:
+        logger.error(f"Failed to create data pool '{pool_name}': {e}")
+        return None
+
 
 def validate_cephfilesystem(fs_name, namespace=None):
     """

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1549,7 +1549,9 @@ RDR_OSD_MODE_GREENFIELD = "greenfield"
 RDR_OSD_MODE_BROWNFIELD = "brownfield"
 RDR_VOLSYNC_CEPHFILESYSTEM_SC = "ocs-storagecluster-cephfs-vrg"
 RDR_CUSTOM_RBD_POOL = "rdr-test-storage-pool"
+RDR_CUSTOM_CEPHFS_POOL = "rdr-test-cephfs-storage-pool"
 RDR_CUSTOM_RBD_STORAGECLASS = "rbd-cnv-custom-sc"
+RDR_CUSTOM_CEPHFS_STORAGECLASS = "cephfs-custom-sc"
 RDR_CUSTOM_RBD_DR_POLICY = "custom-pool-dr-policy"
 
 # Ramen DR labels on StorageClass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1257,6 +1257,7 @@ def storageclass_factory_fixture(
 
     """
     instances = []
+    additional_cephfs_data_pools = []
 
     def factory(
         interface=constants.CEPHBLOCKPOOL,
@@ -1367,10 +1368,15 @@ def storageclass_factory_fixture(
                 if ocsci_config.ENV_DATA.get("new_cephfs_pool") or new_cephfs_pool:
                     new_data_pool_name = helpers.create_cephfs_data_pool(
                         pool_name=constants.RDR_CUSTOM_CEPHFS_POOL,
-                        compression=ocsci_config.ENV_DATA.get("compression") or compression,
+                        compression=ocsci_config.ENV_DATA.get("compression")
+                        or compression,
                         replica=ocsci_config.ENV_DATA.get("replica") or replica,
                     )
-                    interface_name = f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
+                    if new_data_pool_name:
+                        additional_cephfs_data_pools.append(new_data_pool_name)
+                    interface_name = (
+                        f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
+                    )
                 else:
                     if pool_name is None:
                         interface_name = helpers.get_cephfs_data_pool_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1257,7 +1257,6 @@ def storageclass_factory_fixture(
 
     """
     instances = []
-    additional_cephfs_data_pools = []
 
     def factory(
         interface=constants.CEPHBLOCKPOOL,
@@ -1372,7 +1371,6 @@ def storageclass_factory_fixture(
                         replica=ocsci_config.ENV_DATA.get("replica") or replica,
                     )
                     interface_name = f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
-                    additional_cephfs_data_pools.append(new_data_pool_name)
                 else:
                     if pool_name is None:
                         interface_name = helpers.get_cephfs_data_pool_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1371,6 +1371,7 @@ def storageclass_factory_fixture(
                         replica=ocsci_config.ENV_DATA.get("replica") or replica,
                     )
                     interface_name = f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
+                    instances.append(new_data_pool_name)
                 else:
                     if pool_name is None:
                         interface_name = helpers.get_cephfs_data_pool_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1370,7 +1370,7 @@ def storageclass_factory_fixture(
                         compression=ocsci_config.ENV_DATA.get("compression") or compression,
                         replica=ocsci_config.ENV_DATA.get("replica") or replica,
                     )
-                    interface_name = new_data_pool_name
+                    interface_name = f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
                 else:
                     if pool_name is None:
                         interface_name = helpers.get_cephfs_data_pool_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1279,6 +1279,7 @@ def storageclass_factory_fixture(
         mounter=None,
         erasure_coded=False,
         data_pool_name=None,
+        new_cephfs_pool=False,
     ):
         """
         Args:
@@ -1312,6 +1313,7 @@ def storageclass_factory_fixture(
                 metadata pool and dataPool set to the new EC data pool.
             data_pool_name (str): Explicit EC data pool name to set as dataPool in the StorageClass.
                 Use when sharing an existing EC pool across multiple SCs without creating a new one.
+            new_cephfs_pool (bool): True if user wants to create new cephfs pool for SC
 
         Returns:
             object: helpers.create_storage_class instance with links to
@@ -1362,7 +1364,18 @@ def storageclass_factory_fixture(
                     else:
                         interface_name = pool_name
             elif interface == constants.CEPHFILESYSTEM:
-                interface_name = helpers.get_cephfs_data_pool_name()
+                if ocsci_config.ENV_DATA.get("new_cephfs_pool") or new_cephfs_pool:
+                    new_data_pool_name = helpers.create_cephfs_data_pool(
+                        pool_name=constants.RDR_CUSTOM_CEPHFS_POOL,
+                        compression=ocsci_config.ENV_DATA.get("compression") or compression,
+                        replica=ocsci_config.ENV_DATA.get("replica") or replica,
+                    )
+                    interface_name = new_data_pool_name
+                else:
+                    if pool_name is None:
+                        interface_name = helpers.get_cephfs_data_pool_name()
+                    else:
+                        interface_name = pool_name
 
             sc_obj = helpers.create_storage_class(
                 interface_type=interface,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1257,6 +1257,7 @@ def storageclass_factory_fixture(
 
     """
     instances = []
+    additional_cephfs_data_pools = []
 
     def factory(
         interface=constants.CEPHBLOCKPOOL,
@@ -1371,7 +1372,7 @@ def storageclass_factory_fixture(
                         replica=ocsci_config.ENV_DATA.get("replica") or replica,
                     )
                     interface_name = f"ocs-storagecluster-cephfilesystem-{new_data_pool_name}"
-                    instances.append(new_data_pool_name)
+                    additional_cephfs_data_pools.append(new_data_pool_name)
                 else:
                     if pool_name is None:
                         interface_name = helpers.get_cephfs_data_pool_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8226,14 +8226,17 @@ def discovered_apps_dr_workload(request):
         pvc_interface=constants.CEPHBLOCKPOOL,
         multi_ns=False,
         workloads=None,
+        custom_sc=False,
     ):
         """
         Args:
-            kubeobject (int): Number if Discovered Apps workload with kube object protection to be created
-            recipe (int): Number if Discovered Apps workload with recipe protection to be created
+            kubeobject (int): Number of Discovered Apps workload with kube object protection to be created
+            recipe (int): Number of Discovered Apps workload with recipe protection to be created
             pvc_interface (str): 'CephBlockPool' or 'CephFileSystem'.
                 This decides whether a RBD based or CephFS based resource is created. RBD is default.
             multi_ns (bool): True for Multi Namespace
+            custom_sc (bool): False by default, will create and use custom Pool and Storage Class
+                            when set to True for discovered apps workload
 
         Raises:
             ResourceNotDeleted: In case workload resources not deleted properly
@@ -8249,7 +8252,10 @@ def discovered_apps_dr_workload(request):
         if multi_ns and kubeobject <= 1:
             raise UnsupportedWorkloadError("kubeobject count should be more than 2")
         if pvc_interface == constants.CEPHFILESYSTEM:
-            workload_key = "dr_workload_discovered_apps_cephfs"
+            if custom_sc:
+                workload_key = "dr_workload_discovered_apps_cephfs_custom_pool_and_sc"
+            else:
+                workload_key = "dr_workload_discovered_apps_cephfs"
         if workloads == "filebrowser":
             if pvc_interface == constants.CEPHFILESYSTEM:
                 workload_key = "dr_workload_discovered_apps_filebrowser_cephfs"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1405,7 +1405,8 @@ def storageclass_factory_fixture(
 
     def finalizer():
         """
-        Delete the storageclass by deregistering from StorageConsumer first
+        Delete the storageclass by deregistering from StorageConsumer first.
+        Removes any CephFS additional data pools if available.
         """
         from ocs_ci.ocs.resources.storage_cluster import (
             delete_storageclass_and_deregister,
@@ -1421,6 +1422,8 @@ def storageclass_factory_fixture(
             except Exception as e:
                 log.error(f"Failed to delete storageclass {instance.name}: {e}")
                 teardown_errors.append((instance.name, e))
+        for cfs_data_pool in additional_cephfs_data_pools:
+            assert helpers.delete_cephfs_data_pool(cfs_data_pool)
         if teardown_errors:
             parts = [f"{name}: {exc}" for name, exc in teardown_errors]
             raise RuntimeError(

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -449,6 +449,59 @@ def cnv_custom_storage_class(
     return factory
 
 
+@pytest.fixture()
+def cephfs_custom_storage_class(request, storageclass_factory):
+    """
+    Uses storage class factory fixture to create a custom CephFS storage class and a custom
+    cephfs pool with replica-2 to be used by discovered applications
+
+    Raises Exception if the custom SC creation fails on any of the managed clusters
+    """
+
+    def factory(replica, compression):
+        """
+        Args:
+            replica (int):  Replica count used in Pool creation
+            compression (str): Type of compression to be used in the Pool, defaults to None
+
+        """
+
+        cephfs_pool_name = constants.RDR_CUSTOM_CEPHFS_POOL
+        cephfs_sc_name = constants.RDR_CUSTOM_CEPHFS_STORAGECLASS
+
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            # Create or verify existing SC in all clusters
+            existing_sc_list = get_all_storageclass()
+            if cephfs_sc_name in existing_sc_list:
+                log.info(f"Storage class {cephfs_sc_name} already exists")
+            else:
+                try:
+                    sc_obj = storageclass_factory(
+                        sc_name=cephfs_sc_name,
+                        replica=replica,
+                        compression=compression,
+                        pool_name=cephfs_pool_name,
+                    )
+                    if sc_obj is None or sc_obj.name != cephfs_sc_name:
+                        log.error(
+                            f"Failed to create SC '{cephfs_sc_name}' or name mismatch: "
+                            f"Created '{sc_obj.name if sc_obj else 'None'}'"
+                        )
+                    else:
+                        log.info(
+                            f"Successfully created custom CephFS SC: {cephfs_sc_name}"
+                        )
+                        time.sleep(60)
+
+                except Exception as e:
+                    log.error(f"Error creating SC '{cephfs_sc_name}': {e}")
+                    raise
+        config.reset_ctx()
+
+    return factory
+
+
 @pytest.fixture
 def scale_deployments(request):
     """

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -482,6 +482,7 @@ def cephfs_custom_storage_class(request, storageclass_factory):
                         sc_name=cephfs_sc_name,
                         replica=replica,
                         compression=compression,
+                        new_cephfs_pool=True,
                         pool_name=cephfs_pool_name,
                     )
                     if sc_obj is None or sc_obj.name != cephfs_sc_name:

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -483,7 +483,7 @@ def cephfs_custom_storage_class(request, storageclass_factory):
                         replica=replica,
                         compression=compression,
                         new_cephfs_pool=True,
-                        pool_name=cephfs_pool_name,
+                        pool_name=f"ocs-storagecluster-cephfilesystem-{cephfs_pool_name}",
                     )
                     if sc_obj is None or sc_obj.name != cephfs_sc_name:
                         log.error(

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -2,6 +2,7 @@ import logging
 import platform
 import os
 import tempfile
+import time
 from ocs_ci.utility import templating
 import pytest
 
@@ -452,18 +453,27 @@ def cnv_custom_storage_class(
 @pytest.fixture()
 def cephfs_custom_storage_class(request, storageclass_factory):
     """
-    Uses storage class factory fixture to create a custom CephFS storage class and a custom
-    cephfs pool with replica-2 to be used by discovered applications
+    Fixture that returns a factory for creating a custom CephFS storage class
+    with a custom data pool on all non-ACM managed clusters.
 
-    Raises Exception if the custom SC creation fails on any of the managed clusters
+    The factory creates the storage class and pool on each cluster if they do
+    not already exist, then resets the cluster context.
+
+    Raises:
+        Exception: If storage class creation fails on any of the managed clusters
+
+    Returns:
+        callable: factory(replica, compression) that creates the custom SC
     """
 
     def factory(replica, compression):
         """
-        Args:
-            replica (int):  Replica count used in Pool creation
-            compression (str): Type of compression to be used in the Pool, defaults to None
+        Create the custom CephFS storage class and data pool on all clusters.
 
+        Args:
+            replica (int): Replica count for the CephFS data pool
+            compression (str): Compression mode for the pool
+                (e.g. None, 'aggressive', 'passive', 'force')
         """
 
         cephfs_pool_name = constants.RDR_CUSTOM_CEPHFS_POOL

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -478,6 +478,7 @@ def cephfs_custom_storage_class(request, storageclass_factory):
             else:
                 try:
                     sc_obj = storageclass_factory(
+                        interface=constants.CEPHFILESYSTEM,
                         sc_name=cephfs_sc_name,
                         replica=replica,
                         compression=compression,

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -89,7 +89,7 @@ class TestFailoverAndRelocate:
             True,
             2,
             None,
-           # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
             id="primary_down-rbd-custom_pool_replica2_without_compression",
         ),
         pytest.param(
@@ -106,6 +106,9 @@ class TestFailoverAndRelocate:
             False,  # primary_cluster_down = False
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
+            False,
+            None,
+            None,
             marks=[acceptance, pytest.mark.polarion_id("OCS-4730")],
             id="primary_up-cephfs-cli",
         ),
@@ -123,6 +126,9 @@ class TestFailoverAndRelocate:
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
+            False,
+            None,
+            None,
             marks=[acceptance, pytest.mark.polarion_id("OCS-4727")],
             id="primary_down-cephfs-cli",
         ),
@@ -170,6 +176,9 @@ class TestFailoverAndRelocate:
             False,  # primary_cluster_down = False
             constants.CEPHBLOCKPOOL,
             True,  # via_ui = True
+            False,
+            None,
+            None,
             marks=pytest.mark.polarion_id("OCS-6861"),
             id="primary_up-rbd-ui",
         ),
@@ -177,6 +186,9 @@ class TestFailoverAndRelocate:
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
             True,  # via_ui = True
+            False,
+            None,
+            None,
             marks=pytest.mark.polarion_id("OCS-4743"),
             id="primary_down-rbd-ui",
         ),
@@ -184,13 +196,24 @@ class TestFailoverAndRelocate:
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             True,  # via_ui = True
+            False,
+            None,
+            None,
             marks=pytest.mark.polarion_id("OCS-6859"),
             id="primary_down-cephfs-ui",
         ),
     ]
 
     @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface", "via_ui", "custom_sc", "replica", "compression"], argvalues=params
+        argnames=[
+            "primary_cluster_down",
+            "pvc_interface",
+            "via_ui",
+            "custom_sc",
+            "replica",
+            "compression",
+        ],
+        argvalues=params,
     )
     def test_failover_and_relocate(
         self,
@@ -216,7 +239,7 @@ class TestFailoverAndRelocate:
         """
         if via_ui:
             acm_obj = AcmAddClusters()
-        
+
         if custom_sc:
             if pvc_interface == constants.CEPHBLOCKPOOL:
                 logger.info("Calling fixture to create Custom rbd Pool/SC..")
@@ -225,10 +248,12 @@ class TestFailoverAndRelocate:
             elif pvc_interface == constants.CEPHFILESYSTEM:
                 logger.info("Calling fixture to create Custom Pool/SC..")
                 cephfs_custom_storage_class(replica=replica, compression=compression)
-            
 
         workloads = dr_workload(
-            num_of_subscription=1, num_of_appset=1, pvc_interface=pvc_interface, custom_sc=custom_sc
+            num_of_subscription=1,
+            num_of_appset=1,
+            pvc_interface=pvc_interface,
+            custom_sc=custom_sc,
         )
         drpc_subscription = DRPC(namespace=workloads[0].workload_namespace)
         drpc_appset = DRPC(

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -36,15 +36,71 @@ class TestFailoverAndRelocate:
             False,  # primary_cluster_down = False
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
+            False,
+            3,
+            None,
             marks=[acceptance, pytest.mark.polarion_id("OCS-4430")],
             id="primary_up-rbd-cli",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            True,
+            2,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_up-rbd-custom_pool_replica2_with_compression",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHBLOCKPOOL,
             False,  # via_ui = False
+            False,
+            3,
+            None,
             marks=[acceptance, pytest.mark.polarion_id("OCS-4427")],
             id="primary_down-rbd-cli",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            True,
+            3,
+            None,
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-rbd-custom_pool_replica3_without_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            True,
+            3,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-rbd-custom_pool_replica3_with_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            True,
+            2,
+            None,
+           # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-rbd-custom_pool_replica2_without_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHBLOCKPOOL,
+            False,  # via_ui = False
+            True,
+            2,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-rbd-custom_pool_replica2_with_compression",
         ),
         pytest.param(
             False,  # primary_cluster_down = False
@@ -54,11 +110,68 @@ class TestFailoverAndRelocate:
             id="primary_up-cephfs-cli",
         ),
         pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            True,
+            2,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_up-cephfs-custom_pool_replica2_with_compression",
+        ),
+        pytest.param(
             True,  # primary_cluster_down = True
             constants.CEPHFILESYSTEM,
             False,  # via_ui = False
             marks=[acceptance, pytest.mark.polarion_id("OCS-4727")],
             id="primary_down-cephfs-cli",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            True,
+            3,
+            None,
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-cephfs-custom_pool_replica3_without_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            True,
+            3,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-cephfs-custom_pool_replica3_with_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            True,
+            2,
+            None,
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-cephfs-custom_pool_replica2_without_compression",
+        ),
+        pytest.param(
+            True,  # primary_cluster_down = True
+            constants.CEPHFILESYSTEM,
+            False,  # via_ui = False
+            True,
+            2,
+            "aggressive",
+            # marks=pytest.mark.polarion_id("OCS-XXXX"),
+            id="primary_down-cephfs-custom_pool_replica2_with_compression",
+        ),
+        pytest.param(
+            False,  # primary_cluster_down = False
+            constants.CEPHBLOCKPOOL,
+            True,  # via_ui = True
+            marks=pytest.mark.polarion_id("OCS-6861"),
+            id="primary_up-rbd-ui",
         ),
         pytest.param(
             True,  # primary_cluster_down = True
@@ -77,16 +190,21 @@ class TestFailoverAndRelocate:
     ]
 
     @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface", "via_ui"], argvalues=params
+        argnames=["primary_cluster_down", "pvc_interface", "via_ui", "custom_sc", "replica", "compression"], argvalues=params
     )
     def test_failover_and_relocate(
         self,
         primary_cluster_down,
         pvc_interface,
         via_ui,
+        custom_sc,
+        replica,
+        compression,
         setup_acm_ui,
         dr_workload,
         nodes_multicluster,
+        cnv_custom_storage_class,
+        cephfs_custom_storage_class,
         node_restart_teardown,
     ):
         """
@@ -98,9 +216,19 @@ class TestFailoverAndRelocate:
         """
         if via_ui:
             acm_obj = AcmAddClusters()
+        
+        if custom_sc:
+            if pvc_interface == constants.CEPHBLOCKPOOL:
+                logger.info("Calling fixture to create Custom rbd Pool/SC..")
+                cnv_custom_storage_class(replica=replica, compression=compression)
+
+            elif pvc_interface == constants.CEPHFILESYSTEM:
+                logger.info("Calling fixture to create Custom Pool/SC..")
+                cephfs_custom_storage_class(replica=replica, compression=compression)
+            
 
         workloads = dr_workload(
-            num_of_subscription=1, num_of_appset=1, pvc_interface=pvc_interface
+            num_of_subscription=1, num_of_appset=1, pvc_interface=pvc_interface, custom_sc=custom_sc
         )
         drpc_subscription = DRPC(namespace=workloads[0].workload_namespace)
         drpc_appset = DRPC(

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -4,7 +4,7 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.testlib import acceptance, tier1, skipif_ocs_version
+from ocs_ci.framework.testlib import acceptance, tier1, tier4, skipif_ocs_version
 from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.dr_helpers import (
@@ -27,35 +27,154 @@ logger = logging.getLogger(__name__)
 @skipif_ocs_version("<4.16")
 class TestFailoverAndRelocateWithDiscoveredApps:
     """
-    Test Failover and Relocate with Discovered Apps
+    Test Failover and Relocate with Discovered Apps and
+    custom CephFS SC and Pool
 
     """
 
     @pytest.mark.parametrize(
-        argnames=["primary_cluster_down", "pvc_interface"],
+        argnames=[
+            "primary_cluster_down",
+            "pvc_interface",
+            "kubeobject",
+            "recipe",
+            "iterations",
+            "custom_sc",
+            "replica",
+            "compression",
+        ],
         argvalues=[
             pytest.param(
                 False,
                 constants.CEPHBLOCKPOOL,
-                marks=acceptance,
+                1,
+                1,
+                1,
+                False,
+                None,
+                None,
+                marks=[tier1, acceptance],
                 id="primary_up-rbd",
             ),
             pytest.param(
                 True,
                 constants.CEPHBLOCKPOOL,
+                1,
+                1,
+                1,
+                False,
+                None,
+                None,
+                marks=tier4,
                 id="primary_down-rbd",
             ),
             pytest.param(
                 False,
+                constants.CEPHBLOCKPOOL,
+                1,
+                1,
+                3,
+                False,
+                None,
+                None,
+                marks=tier4,
+                id="primary_up-rbd-multiple-iterations",
+            ),
+            pytest.param(
+                True,
+                constants.CEPHBLOCKPOOL,
+                1,
+                1,
+                3,
+                False,
+                None,
+                None,
+                marks=tier4,
+                id="primary_down-rbd-multiple-iterations",
+            ),
+            pytest.param(
+                False,
                 constants.CEPHFILESYSTEM,
-                marks=[skipif_ocs_version("<4.19"), acceptance],
+                1,
+                1,
+                1,
+                False,
+                None,
+                None,
+                marks=[skipif_ocs_version("<4.19"), tier1, acceptance],
                 id="primary_up-cephfs",
             ),
             pytest.param(
                 True,
                 constants.CEPHFILESYSTEM,
-                marks=skipif_ocs_version("<4.19"),
+                1,
+                1,
+                1,
+                False,
+                None,
+                None,
+                marks=[skipif_ocs_version("<4.19"), tier4],
                 id="primary_down-cephfs",
+            ),
+            pytest.param(
+                False,
+                constants.CEPHFILESYSTEM,
+                1,
+                1,
+                3,
+                False,
+                None,
+                None,
+                marks=[skipif_ocs_version("<4.19"), tier4],
+                id="primary_up-cephfs-multiple-iterations",
+            ),
+            pytest.param(
+                True,
+                constants.CEPHFILESYSTEM,
+                1,
+                1,
+                3,
+                False,
+                None,
+                None,
+                marks=[skipif_ocs_version("<4.19"), tier4],
+                id="primary_down-cephfs-multiple-iterations",
+            ),
+            pytest.param(
+                True,
+                constants.CEPHFILESYSTEM,
+                1,
+                0,
+                1,
+                True,
+                2,
+                None,
+                marks=[skipif_ocs_version("<4.21")],
+                id="custom_pool_replica2_without_compression_with_primary-down",
+            ),
+            pytest.param(
+                True,
+                constants.CEPHFILESYSTEM,
+                1,
+                0,
+                1,
+                True,
+                3,
+                "aggressive",
+                marks=[skipif_ocs_version("<4.21")],
+                id="custom_pool_replica3_with_compression_with_primary-down",
+            ),
+            pytest.param(
+                True,
+                constants.CEPHFILESYSTEM,
+                1,
+                0,
+                1,
+                True,
+                2,
+                "aggressive",
+                marks=[skipif_ocs_version("<4.21")],
+                id="custom_pool_replica2_with_compression_with_primary-down",
             ),
         ],
     )
@@ -66,14 +185,29 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         discovered_apps_dr_workload,
         nodes_multicluster,
         node_restart_teardown,
+        kubeobject,
+        recipe,
+        iterations,
+        custom_sc,
+        replica,
+        compression,
+        cephfs_custom_storage_class,
     ):
         """
         Tests to verify application failover and relocate with discovered applications
         Covers primary cluster up or down scenarios.
 
+        Test is parametrized to run with Custom CephFS Storage Class and Pool of Replica-2.
         """
+        if custom_sc:
+            logger.info("Calling fixture to create Custom Pool/SC..")
+            cephfs_custom_storage_class(replica=replica, compression=compression)
+
         rdr_workloads = discovered_apps_dr_workload(
-            pvc_interface=pvc_interface, kubeobject=1, recipe=1
+            pvc_interface=pvc_interface,
+            kubeobject=kubeobject,
+            recipe=recipe,
+            custom_sc=custom_sc,
         )
         first_workload = rdr_workloads[0]
         drpc_objs = [

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -38,7 +38,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             "pvc_interface",
             "kubeobject",
             "recipe",
-            "iterations",
             "custom_sc",
             "replica",
             "compression",
@@ -47,7 +46,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             pytest.param(
                 False,
                 constants.CEPHBLOCKPOOL,
-                1,
                 1,
                 1,
                 False,
@@ -61,7 +59,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 constants.CEPHBLOCKPOOL,
                 1,
                 1,
-                1,
                 False,
                 None,
                 None,
@@ -70,32 +67,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             ),
             pytest.param(
                 False,
-                constants.CEPHBLOCKPOOL,
-                1,
-                1,
-                3,
-                False,
-                None,
-                None,
-                marks=tier4,
-                id="primary_up-rbd-multiple-iterations",
-            ),
-            pytest.param(
-                True,
-                constants.CEPHBLOCKPOOL,
-                1,
-                1,
-                3,
-                False,
-                None,
-                None,
-                marks=tier4,
-                id="primary_down-rbd-multiple-iterations",
-            ),
-            pytest.param(
-                False,
                 constants.CEPHFILESYSTEM,
-                1,
                 1,
                 1,
                 False,
@@ -109,7 +81,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 constants.CEPHFILESYSTEM,
                 1,
                 1,
-                1,
                 False,
                 None,
                 None,
@@ -117,35 +88,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 id="primary_down-cephfs",
             ),
             pytest.param(
-                False,
-                constants.CEPHFILESYSTEM,
-                1,
-                1,
-                3,
-                False,
-                None,
-                None,
-                marks=[skipif_ocs_version("<4.19"), tier4],
-                id="primary_up-cephfs-multiple-iterations",
-            ),
-            pytest.param(
-                True,
-                constants.CEPHFILESYSTEM,
-                1,
-                1,
-                3,
-                False,
-                None,
-                None,
-                marks=[skipif_ocs_version("<4.19"), tier4],
-                id="primary_down-cephfs-multiple-iterations",
-            ),
-            pytest.param(
                 True,
                 constants.CEPHFILESYSTEM,
                 1,
                 0,
-                1,
                 True,
                 2,
                 None,
@@ -157,7 +103,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 constants.CEPHFILESYSTEM,
                 1,
                 0,
-                1,
                 True,
                 3,
                 "aggressive",
@@ -169,7 +114,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 constants.CEPHFILESYSTEM,
                 1,
                 0,
-                1,
                 True,
                 2,
                 "aggressive",
@@ -187,7 +131,6 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         node_restart_teardown,
         kubeobject,
         recipe,
-        iterations,
         custom_sc,
         replica,
         compression,
@@ -200,9 +143,17 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         Test is parametrized to run with Custom CephFS Storage Class and Pool of Replica-2.
         """
         if custom_sc:
-            logger.info("Calling fixture to create Custom Pool/SC..")
+            logger.test_step(
+                f"Creating custom CephFS pool and storage class "
+                f"(replica={replica}, compression={compression})"
+            )
             cephfs_custom_storage_class(replica=replica, compression=compression)
 
+        logger.test_step(
+            f"Deploying discovered apps DR workload "
+            f"(interface={pvc_interface}, kubeobject={kubeobject}, "
+            f"recipe={recipe}, custom_sc={custom_sc})"
+        )
         rdr_workloads = discovered_apps_dr_workload(
             pvc_interface=pvc_interface,
             kubeobject=kubeobject,
@@ -240,6 +191,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             resource_name=first_workload.discovered_apps_placement_name,
         )
 
+        logger.test_step(
+            f"Verifying initial replication state on secondary "
+            f"cluster '{secondary_cluster_name}'"
+        )
         if pvc_interface == constants.CEPHFILESYSTEM:
             cg_cephfs_enabled = is_cg_cephfs_enabled()
             # Verify the creation of ReplicationDestination resources on secondary cluster
@@ -261,9 +216,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 )
 
         wait_time = 2 * scheduling_interval  # Time in minutes
-        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        logger.test_step(f"Waiting {wait_time} minutes for IOs to run before failover")
         sleep(wait_time * 60)
 
+        logger.test_step("Verifying lastKubeObjectProtectionTime before failover")
         for drpc_obj, rdr_workload in zip(drpc_objs, rdr_workloads):
             logger.info(
                 "Checking for lastKubeObjectProtectionTime before Failover Operation"
@@ -272,6 +228,9 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 drpc_obj, rdr_workload.kubeobject_capture_interval_int
             )
 
+        logger.test_step(
+            f"Initiating failover to secondary cluster '{secondary_cluster_name}'"
+        )
         if primary_cluster_down:
             config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
             logger.info(
@@ -321,6 +280,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 vrg_name=rdr_workload.discovered_apps_placement_name,
             )
 
+        logger.test_step(
+            f"Verifying resources on secondary (failover) cluster "
+            f"'{secondary_cluster_name}'"
+        )
         # Verify resources creation on secondary cluster (failoverCluster)
         config.switch_to_cluster_by_name(secondary_cluster_name)
         for rdr_workload in rdr_workloads:
@@ -371,9 +334,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
 
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
 
-        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        logger.test_step(f"Waiting {wait_time} minutes for IOs to run after failover")
         sleep(wait_time * 60)
 
+        logger.test_step("Verifying lastKubeObjectProtectionTime after failover")
         for drpc_obj, rdr_workload in zip(drpc_objs, rdr_workloads):
             logger.info(
                 "Checking for lastKubeObjectProtectionTime after Failover Operation"
@@ -382,7 +346,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 drpc_obj, rdr_workload.kubeobject_capture_interval_int
             )
 
-        logger.info("Running Relocate Steps")
+        logger.test_step(
+            f"Running relocate back to primary cluster "
+            f"'{primary_cluster_name_before_failover}'"
+        )
         for rdr_workload in rdr_workloads:
             dr_helpers.relocate(
                 preferred_cluster=primary_cluster_name_before_failover,
@@ -393,6 +360,10 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 workload_instance=rdr_workload,
             )
 
+        logger.test_step(
+            f"Verifying resources on primary (preferred) cluster "
+            f"'{primary_cluster_name_before_failover}' after relocate"
+        )
         # Verify resources creation on primary cluster (preferredCluster)
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         for rdr_workload in rdr_workloads:
@@ -441,6 +412,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                         expected_count=rdr_workload.workload_pvc_count,
                     )
 
+        logger.test_step("Verifying lastKubeObjectProtectionTime post relocate")
         for drpc_obj, rdr_workload in zip(drpc_objs, rdr_workloads):
             logger.info(
                 "Checking for lastKubeObjectProtectionTime post Relocate Operation"


### PR DESCRIPTION
Updated test TestFailoverAndRelocateWithDiscoveredApps to include test cases for failover and relocate of custom storage class and pool of replica-2.

Ref: https://issues.redhat.com/browse/OCSQE-3767
Epic: https://issues.redhat.com/browse/RHSTOR-7331
Workload PR: https://github.com/red-hat-storage/ocs-workloads/pull/130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disaster recovery workloads using custom CephFS storage pools and storage classes.
  * Added configurable replication and compression settings for custom storage.
  * Added custom-storage options for discovered-application DR workflows.

* **Tests**
  * Expanded failover and relocation coverage across custom RBD and CephFS configurations.
  * Improved validation of workload protection, failover, cleanup, and relocation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->