### PR TITLE
Cloud Manager init: account for the case where AWS credentials are not provided

### DIFF
--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -114,7 +114,7 @@ class CloudManager(ABC):
         # set the client for STS enabled cluster
         try:
             setattr(
-                self, "aws_sts_client", cloud_map["AWS_STS"](auth_dict=cred_dict["AWS"])
+                self, "aws_sts_client", cloud_map["AWS_STS"](full_auth_dict=cred_dict)
             )
         except ClusterNotInSTSModeException:
             setattr(self, "aws_sts_client", None)
@@ -733,16 +733,26 @@ class AwsSTSClient(S3Client):
     @config.run_with_provider_context_if_available
     def __init__(
         self,
-        auth_dict,
+        full_auth_dict,
         verify=True,
         endpoint="https://s3.amazonaws.com",
         *args,
         **kwargs,
     ):
         role_arn = get_role_arn_from_sub()
-        auth_dict["ROLE_ARN"] = role_arn
+        aws_auth_dict = full_auth_dict.get("AWS")
+        if not aws_auth_dict:
+            logger.error(
+                "Cluster is supposed to be in STS mode, but no AWS credentials found"
+            )
+            raise ClusterNotInSTSModeException
+        aws_auth_dict["ROLE_ARN"] = role_arn
         self.role_arn = role_arn
 
         super().__init__(
-            auth_dict=auth_dict, verify=verify, endpoint=endpoint, *args, **kwargs
+            auth_dict=aws_auth_dict,
+            verify=verify,
+            endpoint=endpoint,
+            *args,
+            **kwargs,
         )


### PR DESCRIPTION
Running OCS-CI without AWS credentials in the auth.yaml results in the following key error:
```
        # set the client for STS enabled cluster
        try:
            setattr(
>               self, "aws_sts_client", cloud_map["AWS_STS"](auth_dict=cred_dict["AWS"])
            )
E           KeyError: 'AWS'
```
This PR moves the check to the `AwsSTSClient` subclass, so it will raise the expected `ClusterNotInSTSModeException` in such cases.