### PR TITLE
Skip add capacity tests for lean profile

### DIFF
--- a/tests/cross_functional/ui/test_add_capacity_ui.py
+++ b/tests/cross_functional/ui/test_add_capacity_ui.py
@@ -18,11 +18,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ui_not_support,
     brown_squad,
     skipif_hci_provider_or_client,
+    skipif_lean_deployment,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@skipif_lean_deployment
 class TestAddCapacityUI(object):
     """
     Test Add Capacity on via UI

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -25,6 +25,7 @@ from ocs_ci.framework.testlib import (
     tier1,
     acceptance,
     cloud_platform_required,
+    skipif_lean_deployment,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -130,6 +131,7 @@ def add_capacity_test(ui_flag=False):
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@skipif_lean_deployment
 class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
@@ -164,6 +166,7 @@ class TestAddCapacity(ManageTest):
 @skipif_hci_provider_and_client
 @skipif_no_lso
 @skipif_stretch_cluster
+@skipif_lean_deployment
 class TestAddCapacityLSO(ManageTest):
     """
     Add capacity on lso cluster
@@ -197,6 +200,7 @@ class TestAddCapacityLSO(ManageTest):
 @cloud_platform_required
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@skipif_lean_deployment
 class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade


### PR DESCRIPTION
Related discussion:
https://ibm-systems-storage.slack.com/archives/C06DWD30QTZ/p1762845959047449 and
https://ibm-systems-storage.slack.com/archives/C06DWD30QTZ/p1763454715570799?thread_ts=1763017123.697059&cid=C06DWD30QTZ Where Nikhil mentioned it actually Lean profile env support only 3 OSDs

Related bug:
https://issues.redhat.com/browse/DFBUGS-4071