### PR TITLE
Disable Consistency Group by default

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -1,5 +1,5 @@
 ENV_DATA:
-  cg_enabled: True
+  cg_enabled: False
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
   dr_workload_repo_branch: "master"
   dr_workload_subscription_rbd: [

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -581,11 +581,7 @@ def is_cg_enabled():
     if config.MULTICLUSTER["multicluster_mode"] != constants.RDR_MODE:
         return False
 
-    ocs_version = version.get_semantic_ocs_version_from_config()
-    if ocs_version >= version.VERSION_4_20:
-        return config.ENV_DATA.get("cg_enabled", True)
-    else:
-        return False
+    return config.ENV_DATA.get("cg_enabled", False)
 
 
 def get_resource_count(kind, namespace=None):

--- a/tests/functional/disaster-recovery/regional-dr/test_cg_configuration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cg_configuration.py
@@ -1,24 +1,21 @@
 import logging
 
-from ocs_ci.framework.testlib import (
-    acceptance,
-    post_ocs_upgrade,
-    rdr,
-    skipif_ocs_version,
-    tier1,
-    turquoise_squad,
-)
+import pytest
+
 from ocs_ci.helpers import dr_helpers
 
 logger = logging.getLogger(__name__)
 
 
-@rdr
-@tier1
-@acceptance
-@turquoise_squad
-@post_ocs_upgrade
-@skipif_ocs_version("<4.20")
+# @rdr
+# @tier1
+# @acceptance
+# @post_ocs_upgrade
+# @turquoise_squad
+# Test disabled until CG support is added in a future release. Related bug: DFBUGS-4556
+@pytest.mark.skip(
+    reason="Test disabled until CG support is added in a future release. Related bug: DFBUGS-4556"
+)
 class TestCGConfiguration:
     """
     Test for validating CG behavior for ODF version >= 4.20


### PR DESCRIPTION
This PR disables the Consistency Group (CG) feature by default
 - Change default value from True to False in config
 - Remove version-specific handling from is_cg_enabled() function
 - Disable test_cg_configuration.py tests until CG is enabled by default

Related bug: [DFBUGS-4556](https://issues.redhat.com//browse/DFBUGS-4556)
CG feature is now disabled by default and can be explicitly enabled via configuration when needed. The version check is removed as it's no longer necessary with the default disabled state.