### PR TITLE
Add --fail-on-unaudited option to detect-secrets pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: 0.13.1+ibm.64.dss
     hooks:
       - id: detect-secrets
-        args: [--baseline, .secrets.baseline, --use-all-plugins]
+        args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]
   # Local wrapper to strip "generated_at" after detect-secrets runs
   - repo: local
     hooks:


### PR DESCRIPTION
This should prevent us from being able to accidentally commit and push unaudited secrets