### PR TITLE
Disable old BM locking mechanism (bm_status)

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -324,7 +324,7 @@ higher priority).
     * `bm_httpd_server_user` - user name used to ssh to the helper node
     * `bm_tftp_base_dir` - TFTP root dir where are placed files for PXE boot (usually `/tftpboot/`)
     * `bm_dnsmasq_dir` - _dnsmasq_ configuration files place
-    * `bm_status_check` - link to status service for BM environment (deprecated in favor of Resource Locker, but still used for one environment)
+    * `bm_status_check` - link to status service for BM environment (deprecated in favor of Resource Locker)
     * `bm_provisioning_network` - which network is used as provisioning (`public` or `private`)
     * `bm_httpd_provision_server` - IP or hostname of the helper/provisioning server (http server) accessible from the provisioning network
     * `root_disk_common_path` - path to root disk where an additional partition should be created common for all worker nodes (see `partitioned_disk_on_workers` option)

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -168,11 +168,12 @@ class BMBaseOCPDeployment(BaseOCPDeployment):
         """
         Destroy OCP cluster
         """
-        logger.info("Updating BM status")
-        result = self.update_bm_status(constants.BM_STATUS_ABSENT)
-        assert (
-            result == constants.BM_STATUS_RESPONSE_UPDATED
-        ), "Failed to update request"
+        if self.bm_config.get("bm_status_check"):
+            logger.info("Updating BM status")
+            result = self.update_bm_status(constants.BM_STATUS_ABSENT)
+            assert (
+                result == constants.BM_STATUS_RESPONSE_UPDATED
+            ), "Failed to update request"
 
     def configure_dnsmasq_on_helper_vm(self):
         """


### PR DESCRIPTION
One of the BM environment were still using some custom locking mechanism together with Resource Locker service. This causes occasional issues, when the locking fails for some reason even though the env. is correctly reserved in Resource locker.