### PR TITLE
wait all storage PVCs are Bound on Deployment

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1404,7 +1404,7 @@ class OCP(object):
         log.info(f"Check if resource: {resource_name} exists.")
         self.check_name_is_specified(resource_name)
         try:
-            self.get(resource_name, selector=selector)
+            self.get(resource_name, selector=selector, silent=True)
             log.info(f"Resource: '{resource_name}', selector: '{selector}' was found.")
             return True
         except CommandFailed:


### PR DESCRIPTION
* add 'fetch' a dynamic name of the storageDeviceSets that becomes a prefix for the local storage PVC for the osd's 
* add timeout to wait until all PVCs are in bound state. This is necessary for the deployments with big number of disks (we had failed deployments before when we used 36 disks on the cluster)

This should fix: 
```
2025-11-14 20:45:55  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-11-14 20:45:55  ocs_ci/deployment/deployment.py:828: in deploy_cluster
2025-11-14 20:45:55      self.do_deploy_ocs()
2025-11-14 20:45:55  ocs_ci/deployment/deployment.py:411: in do_deploy_ocs
2025-11-14 20:45:55      self.deploy_ocs()
2025-11-14 20:45:55  ocs_ci/deployment/deployment.py:2423: in deploy_ocs
2025-11-14 20:45:55      validate_cluster_on_pvc()
2025-11-14 20:45:55  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-11-14 20:45:55  
2025-11-14 20:45:55      def validate_cluster_on_pvc():
2025-11-14 20:45:55          """
2025-11-14 20:45:55          Validate creation of PVCs for MON and OSD pods.
2025-11-14 20:45:55          Also validate that those PVCs are attached to the OCS pods
2025-11-14 20:45:55      
2025-11-14 20:45:55          Raises:
2025-11-14 20:45:55               AssertionError: If PVC is not mounted on one or more OCS pods
2025-11-14 20:45:55      
2025-11-14 20:45:55          """
2025-11-14 20:45:55          # Get the PVCs for selected label (MON/OSD)
2025-11-14 20:45:55          ns = config.ENV_DATA["cluster_namespace"]
2025-11-14 20:45:55          ocs_pvc_obj = get_all_pvc_objs(namespace=ns)
2025-11-14 20:45:55      
2025-11-14 20:45:55          # Check all pvc's are in bound state
2025-11-14 20:45:55      
2025-11-14 20:45:55          pvc_names = []
2025-11-14 20:45:55          for pvc_obj in ocs_pvc_obj:
2025-11-14 20:45:55              if pvc_obj.name.startswith(
2025-11-14 20:45:55                  constants.DEFAULT_DEVICESET_PVC_NAME
2025-11-14 20:45:55              ) or pvc_obj.name.startswith(constants.DEFAULT_MON_PVC_NAME):
2025-11-14 20:45:55                  assert (
2025-11-14 20:45:55  >                   pvc_obj.status == constants.STATUS_BOUND
2025-11-14 20:45:55                  ), f"PVC {pvc_obj.name} is not Bound"
2025-11-14 20:45:55  E               AssertionError: PVC ocs-deviceset-localblock-5-data-4lhw6f is not Bound
2025-11-14 20:45:55  
2025-11-14 20:45:55  ocs_ci/ocs/cluster.py:1237: AssertionError
```