### PR TITLE
use separated lvs for disk and partitions in case of partitioned_disk_on_workers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -987,7 +987,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 587,
+        "line_number": 606,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -987,7 +987,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 606,
+        "line_number": 607,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/conf/README.md
+++ b/conf/README.md
@@ -188,6 +188,7 @@ version.
 * `submariner_cli_deployment` - Enforce Submariner CLI deployment.
 * `hub_cluster_name` - Name of the Management cluster. Applicable for Agent deployments, where the hub cluster is pre-created.
 * `hub_cluster_path` - Path to the Management cluster directory to store auth_path, credentials files or cluster related files.
+* `partitioned_disk_primary_affinity` - Configure primaryAffinity for OSDs on partitioned disks, https://access.redhat.com/solutions/5807201 (default: "0.0")
 
 #### REPORTING
 

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -188,6 +188,9 @@ def create_local_volume_set(storage_node_names, storageclass, device_types=None)
     logger.info("Pulling LocalVolumeSet CR data from yaml")
     lvs_data = templating.load_yaml(constants.LOCAL_VOLUME_SET_YAML)
 
+    # set LVS name
+    lvs_data["metadata"]["name"] = storageclass
+
     # Since we don't have datastore with SSD on our current VMware machines, localvolumeset doesn't detect
     # NonRotational disk. As a workaround we are setting Rotational to device MechanicalProperties to detect
     # HDD disk

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -130,12 +130,67 @@ def setup_local_storage(storageclass):
         if config.ENV_DATA["mcg_only_deployment"]:
             lvs_data["spec"]["volumeMode"] = constants.VOLUME_MODE_FILESYSTEM
 
+        # configure deviceTypes only to disk if partitioned_disk_on_workers (the part is configured in second LVS)
+        if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
+            lvs_data["spec"]["deviceInclusionSpec"]["deviceTypes"] = ["disk"]
+
         lvs_data_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="local_volume_set", delete=False
         )
         templating.dump_data_to_temp_yaml(lvs_data, lvs_data_yaml.name)
         logger.info("Creating LocalVolumeSet CR")
         run_cmd(f"oc create -f {lvs_data_yaml.name}")
+
+        # Create second LVS for partitions if partitioned_disk_on_workers
+        if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
+            # Pull local volume set yaml data
+            logger.info("Pulling LocalVolumeSet CR data from yaml for partitions")
+            lvs_data = templating.load_yaml(constants.LOCAL_VOLUME_SET_YAML)
+
+            # Since we don't have datastore with SSD on our current VMware machines, localvolumeset doesn't detect
+            # NonRotational disk. As a workaround we are setting Rotational to device MechanicalProperties to detect
+            # HDD disk
+            if config.ENV_DATA.get(
+                "local_storage_allow_rotational_disks"
+            ) or config.ENV_DATA.get("odf_provider_mode_deployment"):
+                logger.info(
+                    "Adding Rotational for deviceMechanicalProperties spec"
+                    " to detect HDD disk"
+                )
+                lvs_data["spec"]["deviceInclusionSpec"][
+                    "deviceMechanicalProperties"
+                ].append("Rotational")
+
+            # Update local volume set data with Worker node Names
+            logger.info(
+                "Updating LocalVolumeSet for partitions CR data with storage nodes Name: %s",
+                storage_node_names,
+            )
+            lvs_data["spec"]["nodeSelector"]["nodeSelectorTerms"][0][
+                "matchExpressions"
+            ][0]["values"] = storage_node_names
+
+            # Set storage class
+            logger.info(
+                "Updating LocalVolumeSet CR data with LSO storageclass-part: %s",
+                storageclass + "-part",
+            )
+            lvs_data["spec"]["storageClassName"] = storageclass + "-part"
+
+            # set volumeMode to Filesystem for MCG only deployment
+            if config.ENV_DATA["mcg_only_deployment"]:
+                lvs_data["spec"]["volumeMode"] = constants.VOLUME_MODE_FILESYSTEM
+
+            # configure deviceTypes only to disk if partitioned_disk_on_workers (the part is configured in second LVS)
+            if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
+                lvs_data["spec"]["deviceInclusionSpec"]["deviceTypes"] = ["part"]
+
+            lvs_data_yaml = tempfile.NamedTemporaryFile(
+                mode="w+", prefix="local_volume_set_part", delete=False
+            )
+            templating.dump_data_to_temp_yaml(lvs_data, lvs_data_yaml.name)
+            logger.info("Creating LocalVolumeSet for partitions CR")
+            run_cmd(f"oc create -f {lvs_data_yaml.name}")
     else:
         # Retrieve NVME device path ID for each worker node
         device_paths = get_device_paths(worker_names)
@@ -184,6 +239,8 @@ def setup_local_storage(storageclass):
     expected_pvs = len(worker_names) * storage_class_device_count
     if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
         verify_pvs_created(expected_pvs, storageclass, False)
+        if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
+            verify_pvs_created(expected_pvs, storageclass + "-part", False)
     else:
         verify_pvs_created(expected_pvs, storageclass)
 

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -308,6 +308,22 @@ class StorageClusterSetup(object):
             )["hostNetwork"] = False
 
         cluster_data["spec"]["storageDeviceSets"] = [deviceset_data]
+        if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
+            pv_size_list = helpers.get_pv_size(
+                storageclass=constants.DEFAULT_STORAGECLASS_LSO + "-part"
+            )
+            pv_size_list.sort()
+            deviceset_data_part = deepcopy(deviceset_data)
+            deviceset_data_part["name"] = (
+                constants.DEFAULT_DEVICESET_LSO_PVC_NAME + "-part"
+            )
+            deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (
+                self.deployment.storage_class + "-part"
+            )
+            deviceset_data_part["dataPVCTemplate"]["spec"]["resources"]["requests"][
+                "storage"
+            ] = f"{pv_size_list[0]}"
+            cluster_data["spec"]["storageDeviceSets"].append(deviceset_data_part)
 
         if self.managed_ibmcloud:
             mon_pvc_template = {

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -317,9 +317,9 @@ class StorageClusterSetup(object):
             deviceset_data_part["name"] = (
                 constants.DEFAULT_DEVICESET_LSO_PVC_NAME + "-part"
             )
-            if self.deployment.storage_class:
+            if config.ENV_DATA.get("storage_class"):
                 deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (
-                    self.deployment.storage_class + "-part"
+                    config.ENV_DATA["storage_class"] + "-part"
                 )
             elif deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"]:
                 deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -317,9 +317,15 @@ class StorageClusterSetup(object):
             deviceset_data_part["name"] = (
                 constants.DEFAULT_DEVICESET_LSO_PVC_NAME + "-part"
             )
-            deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (
-                self.deployment.storage_class + "-part"
-            )
+            if self.deployment.storage_class:
+                deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (
+                    self.deployment.storage_class + "-part"
+                )
+            elif deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"]:
+                deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"] = (
+                    deviceset_data_part["dataPVCTemplate"]["spec"]["storageClassName"]
+                    + "-part"
+                )
             deviceset_data_part["dataPVCTemplate"]["spec"]["resources"]["requests"][
                 "storage"
             ] = f"{pv_size_list[0]}"

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -329,6 +329,9 @@ class StorageClusterSetup(object):
             deviceset_data_part["dataPVCTemplate"]["spec"]["resources"]["requests"][
                 "storage"
             ] = f"{pv_size_list[0]}"
+            deviceset_data_part["primaryAffinity"] = config.DEPLOYMENT.get(
+                "partitioned_disk_primary_affinity", "0.0"
+            )
             cluster_data["spec"]["storageDeviceSets"].append(deviceset_data_part)
 
         if self.managed_ibmcloud:


### PR DESCRIPTION
This is required to be able to use two separated storageDeviceSets in StorageCluster CR to be able to configure primary affinitity for the OSDs on partitioned disks.