### PR TITLE
skipping test_crashcollector_pod_existence_on_ceph_pods_running_nodes if failure domain is host

### DIFF
--- a/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -68,7 +68,9 @@ class TestAddNodeCrashCollector(ManageTest):
         logger.info(f"The failure domain is {failure_domain}")
 
         if failure_domain == "host":
-            pytest.skip("Test requires zone or rack failure domain for topology validation")
+            pytest.skip(
+                "Test requires zone or rack failure domain for topology validation"
+            )
 
         if failure_domain in ("zone", "rack"):
             old_node_rack_zone_dict = get_node_rack_or_zone_dict(failure_domain)


### PR DESCRIPTION
When test_crashcollector_pod_existence_on_ceph_pods_running_nodes runs in LSO 1AZ deployments , the function is_node_rack_or_zone_exist times out as 'host' is the failure domain by default in such cases. Hence added skip statements to handle such scenarios.

https://github.com/red-hat-storage/ocs-ci/issues/13686