### PR TITLE
Fix missing resource_name fallback in wait_for_resource_oc_wait()

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -792,6 +792,7 @@ class OCP(object):
             )
 
         selector = selector or self.selector
+        resource_name = resource_name or self.resource_name
         command = f"wait {self.kind} {resource_name} --for=jsonpath='{{.status.phase}}'={condition}"
 
         # if selector is used, all resources of kind self.kind with that selector must match the condition, e.g.


### PR DESCRIPTION
Add resource_name = resource_name or self.resource_name fallback to match the existing pattern used for selector and the legacy path. Without this, in rare cases,  `oc wait` commands fail with "no name was specified" when resource_name is set on the OCP constructor but not passed to wait_for_resource().