### PR TITLE
Re-enable Consistency Group feature for ODF 4.21+

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -1,5 +1,5 @@
 ENV_DATA:
-  cg_enabled: False
+  cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
   dr_workload_repo_branch: "master"
   dr_workload_subscription_rbd: [

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3306,7 +3306,7 @@ class MultiClusterDROperatorsDeploy(object):
         if not sample.wait_for_func_status(True):
             raise TimeoutExpiredError("DR Policy failed to reach Succeeded state")
 
-        # Validate DRPolicy grouping for ODF version >= 4.20 (only when CG is enabled)
+        # Validate DRPolicy grouping for ODF version >= 4.21
         if is_cg_enabled():
             logger.info("Validating DRPolicy grouping configuration")
             validate_drpolicy_grouping(drpolicy_name=self.dr_policy_name)

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -576,12 +576,19 @@ def is_cg_enabled():
     Returns:
         bool: True if CG is enabled, False otherwise
 
+    Note:
+        CG can be enabled/disabled via cg_enabled in dr_workload.yaml config.
+
     """
     # CG is applicable for Regional-DR mode only
     if config.MULTICLUSTER["multicluster_mode"] != constants.RDR_MODE:
         return False
 
-    return config.ENV_DATA.get("cg_enabled", False)
+    ocs_version = version.get_semantic_ocs_version_from_config()
+    if ocs_version >= version.VERSION_4_21:
+        return config.ENV_DATA.get("cg_enabled", True)
+    else:
+        return False
 
 
 def get_resource_count(kind, namespace=None):
@@ -1374,7 +1381,7 @@ def validate_drpolicy_grouping(drpolicy_name=None):
     Validate DRPolicy configuration for CG behavior.
 
     This function validates that DRPolicy has grouping=true for every storageClass
-    in status.async.peerClasses in ODF version >= 4.20.
+    in status.async.peerClasses in ODF version >= 4.21
 
     Args:
         drpolicy_name (str, optional): Name of specific DRPolicy to validate.
@@ -1388,12 +1395,12 @@ def validate_drpolicy_grouping(drpolicy_name=None):
 
     """
     ocs_version = version.get_semantic_ocs_version_from_config()
-    if ocs_version < version.VERSION_4_20:
-        logger.info("ODF version < 4.20, skipping DRPolicy grouping validation")
+    if ocs_version < version.VERSION_4_21:
+        logger.info("ODF version < 4.21, skipping DRPolicy grouping validation")
         return True
 
     logger.info(
-        "Validating DRPolicy grouping for ODF version >= 4.20 to ensure CG behavior is properly configured."
+        "Validating DRPolicy grouping for ODF version >= 4.21 to ensure CG behavior is properly configured."
     )
 
     # Get DRPolicy resources

--- a/tests/functional/disaster-recovery/regional-dr/test_cg_configuration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cg_configuration.py
@@ -1,24 +1,27 @@
 import logging
 
-import pytest
-
+from ocs_ci.framework.testlib import (
+    acceptance,
+    post_ocs_upgrade,
+    rdr,
+    skipif_ocs_version,
+    tier1,
+    turquoise_squad,
+)
 from ocs_ci.helpers import dr_helpers
 
 logger = logging.getLogger(__name__)
 
 
-# @rdr
-# @tier1
-# @acceptance
-# @post_ocs_upgrade
-# @turquoise_squad
-# Test disabled until CG support is added in a future release. Related bug: DFBUGS-4556
-@pytest.mark.skip(
-    reason="Test disabled until CG support is added in a future release. Related bug: DFBUGS-4556"
-)
+@rdr
+@tier1
+@acceptance
+@turquoise_squad
+@post_ocs_upgrade
+@skipif_ocs_version("<4.21")
 class TestCGConfiguration:
     """
-    Test for validating CG behavior for ODF version >= 4.20
+    Test for validating CG behavior for ODF version >= 4.21
 
     """
 


### PR DESCRIPTION
- Change default cg_enabled from False to True
- Update docstrings to reflect CG enabled by default from 4.21+
- Re-enable test_cg_configuration.py tests with @skipif_ocs_version("<4.21")