### PR TITLE
Fixing cluster context switch issue for multi ns test

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
@@ -167,6 +167,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                             expected_count=wl.workload_pvc_count,
                         )
 
+        config.switch_to_cluster_by_name(secondary_cluster_name)
         wait_for_vrg_state(
             vrg_state="primary",
             vrg_namespace=constants.DR_OPS_NAMESAPCE,
@@ -265,7 +266,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                             namespace=wl.workload_namespace,
                             expected_count=wl.workload_pvc_count,
                         )
-
+        config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         wait_for_vrg_state(
             vrg_state="primary",
             vrg_namespace=constants.DR_OPS_NAMESAPCE,


### PR DESCRIPTION
There is an issue with context switching of clusters between iterations. Fixed it in this PR