### PR TITLE
Add Ceph BlueStore Simulation Support During LSO Deployment

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -428,6 +428,7 @@ higher priority).
 * `use_config_file` - If set to true the external-cluster-details-exporter python script will use a config file to setup the external cluster.
 * `configure_acm_to_import_mce` - If set to true while installing ACM, the configuration to discover and import MCE clusters will be done
 * `skip_disks_cleanup` - If set to true, skips disks cleanup on BareMetal and LSO cluster deployments.
+* `simulate_bluestore_label` - If set to true, simulates Ceph OSD BlueStore metadata on OSD disks before deploying a new ODF cluster. Used to test whether Ceph correctly detects existing BlueStore metadata. Intended for use only with LSO deployments (Default: false)
 * `wipe_devices_from_other_clusters` - If set to true, automatically wipes devices with old Ceph metadata during ODF deployment. This prevents conflicts when reusing disks that were previously part of a different Ceph cluster.
 * `product_type` - Differentiate between ODF or FDF deployments. Set via --product-type CLI option. Default value is 'odf'
 * `enable_infrastructure_management_for_agent` - To enable central infrastructure management service while installing dependencies for hosted cluster. This is used to create agent based hosted cluster.

--- a/conf/ocsci/simulate_bluestore_label.yaml
+++ b/conf/ocsci/simulate_bluestore_label.yaml
@@ -1,0 +1,5 @@
+# This configuration file enables simulation of Ceph OSD BlueStore metadata on OSD disks.
+# It is used to test whether Ceph correctly detects existing BlueStore metadata when deploying a new cluster.
+# This simulation is intended to be used only with LSO (Local Storage Operator) deployments.
+ENV_DATA:
+  simulate_bluestore_label: true

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -7,8 +7,6 @@ import tempfile
 import time
 from datetime import datetime
 from time import sleep
-from pathlib import Path
-import base64
 
 import yaml
 import requests
@@ -1563,9 +1561,9 @@ def clean_disk(
         logger.info(out)
 
 
-def detect_simulation_disk_on_node(wnode, namespace="default", timeout=300):
+def detect_simulation_disk_on_node(wnode, namespace=None, timeout=300):
     """
-    Detects the last available /dev/sd* disk on a given worker node.
+    Detects the last available /dev/sd*, /dev/nvme*n0* disk on a given worker node.
 
     Args:
         wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object.
@@ -1573,13 +1571,38 @@ def detect_simulation_disk_on_node(wnode, namespace="default", timeout=300):
         timeout (int): Timeout for the command execution.
 
     Returns:
-        str or None: The detected disk path (e.g., "/dev/sdb") or None if not found.
+        str or None: The detected disk path (e.g., "/dev/sdb", "/dev/nvme*n0*") or None if not found.
 
     """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+
     logger.info(
-        f"Attempting to auto-detect a suitable /dev/sd* disk on worker node: {wnode.name}."
+        f"Attempting to auto-detect a suitable /dev/sd*, /dev/nvme*n0* "
+        f"disk on worker node: {wnode.name}."
     )
-    cmd = ['lsblk -dn -o NAME | grep -E "^sd[a-z]$" | sed "s#^#/dev/#" | tail -1']
+    # Determine disk naming pattern based on platform type
+    platform = config.ENV_DATA["platform"].lower()
+    if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
+        # NVMe disks typically used in baremetal environments
+        disk_names_available = disks_available_to_cleanup(wnode)
+        nvme_disks = [
+            disk_name
+            for disk_name in disk_names_available
+            if disk_name.startswith("nvme")
+        ]
+        if not nvme_disks:
+            raise ValueError(
+                f"Didnt find any nvme disks available on the node {wnode.name}"
+            )
+        disk_name_pattern = nvme_disks[0]
+    else:
+        # SATA/SCSI disks typically used in virtualized environments
+        disk_name_pattern = "^sd[a-z]$"
+
+    # Construct command to find the last matching disk device
+    cmd = [
+        f'lsblk -dn -o NAME | grep -E "{disk_name_pattern}" | sed "s#^#/dev/#" | tail -1'
+    ]
     ocp_obj = ocp.OCP()
 
     out = ocp_obj.exec_oc_debug_cmd(
@@ -1601,179 +1624,6 @@ def detect_simulation_disk_on_node(wnode, namespace="default", timeout=300):
 
     logger.info(f"Detected disk for simulation: {disk_name}")
     return disk_name
-
-
-def upload_script_to_node(
-    wnode,
-    script_src_path: str,
-    script_dest_path: str,
-    namespace: str = "default",
-    timeout: int = 300,
-):
-    """
-    Upload a shell script to a node using base64 encoding via `oc debug`.
-
-    The script is read locally, base64-encoded, and decoded on the node
-    using `echo | base64 -d`.
-
-    Args:
-        wnode (ocs_ci.ocs.resources.ocs.OCS): Worker node object.
-        script_src_path (str): Local path to the script.
-        script_dest_path (str): Destination path on the node.
-        namespace (str): Namespace for the debug pod.
-        timeout (int): Timeout for the oc debug command (in seconds).
-
-    Returns:
-        str: Output of the command execution.
-
-    Raises:
-        FileNotFoundError: If the local script file does not exist.
-
-    """
-    ocp_obj = ocp.OCP()
-
-    if not os.path.exists(script_src_path):
-        raise FileNotFoundError(f"Script not found at {script_src_path}")
-
-    # Read and encode the script
-    with open(script_src_path, "rb") as f:
-        script_content = f.read()
-    script_b64 = base64.b64encode(script_content).decode("utf-8").replace("\n", "")
-
-    logger.info(
-        f"Uploading script from '{script_src_path}' to node '{wnode.name}' at '{script_dest_path}'"
-    )
-
-    # Build the shell command
-    upload_cmd = [
-        (
-            f"set -euo pipefail; "
-            f'echo "{script_b64}" | base64 -d > {script_dest_path} && '
-            f"chmod 755 {script_dest_path} && "
-            f'echo "Script written to {script_dest_path}" && ls -l {script_dest_path}'
-        )
-    ]
-
-    # Execute the command on the node
-    out = ocp_obj.exec_oc_debug_cmd(
-        node=wnode.name,
-        cmd_list=upload_cmd,
-        namespace=namespace,
-        use_root=True,
-        timeout=timeout,
-    )
-
-    return out
-
-
-def run_script_on_node(
-    wnode,
-    script_path: str,
-    args: str = "",
-    namespace: str = "default",
-    timeout: int = 600,
-):
-    """
-    Execute a shell script directly on a node (inside chroot /host)
-    using oc debug.
-
-    Args:
-        wnode (ocs_ci.ocs.resources.ocs.OCS): Worker node object.
-        script_path (str): Full path to the script on the node.
-        args (str): Optional arguments to pass to the script.
-        namespace (str): Namespace for the debug pod.
-        timeout (int): Timeout for the command execution (in seconds).
-
-    Returns:
-        str: Output of the script execution.
-    """
-    ocp_obj = ocp.OCP()
-
-    logger.info(
-        f"Running the script {script_path} with the args '{args}' "
-        f"on the worker node {wnode.name}"
-    )
-    # Build the command — single element, no single quotes inside
-    cmd = [f"set -euo pipefail; " f"bash {script_path} {args} "]
-
-    out = ocp_obj.exec_oc_debug_cmd(
-        node=wnode.name,
-        cmd_list=cmd,
-        namespace=namespace,
-        use_root=True,
-        timeout=timeout,
-    )
-
-    return out
-
-
-def simulate_ceph_bluestore_on_node_disk(wnode, disk_name=None, namespace="default"):
-    """
-    Simulates a Ceph BlueStore label on a specified disk of a given worker node.
-
-
-    This function uploads a local shell script to the node using base64 encoding,
-    verifies its integrity via SHA256 checksum, and executes it to simulate a
-    BlueStore label on the specified disk. If no disk is specified, the function
-    attempts to auto-detect a suitable disk. The output is parsed to determine
-    whether the simulation was successful.
-
-    Args:
-        wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object where the simulation
-            should be performed.
-        disk_name (str, optional): The disk device name to simulate the label on.
-            If not provided, the function auto-detects the last /dev/sd* disk on the node.
-        namespace (str): Namespace for the debug pod.
-
-    Returns:
-        bool: True if the simulation succeeded (BlueStore label detected), False otherwise.
-
-    """
-    if not disk_name:
-        disk_name = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
-
-    if not disk_name:
-        logger.error("Disk detection failed. Aborting BlueStore simulation.")
-        return False
-
-    script_name = "simulate_bluestore_label.sh"
-    current_dir = Path(__file__).parent.parent.parent
-    script_src_path = os.path.join(current_dir, "scripts", "bash", script_name)
-    script_dest_path = f"/tmp/{script_name}"
-
-    # Step 3: Download the script directly on the node
-    logger.info(
-        f"Uploading BlueStore simulation script to the worker node {wnode.name}"
-    )
-    upload_script_to_node(
-        wnode=wnode,
-        script_src_path=script_src_path,
-        script_dest_path=script_dest_path,
-        namespace=namespace,
-        timeout=300,
-    )
-
-    # Step 5: Run the script on the node
-    logger.info(f"Running BlueStore simulation script on disk: {disk_name}")
-    out = run_script_on_node(
-        wnode=wnode,
-        script_path=script_dest_path,
-        args=disk_name,
-        namespace=namespace,
-        timeout=300,
-    )
-
-    logger.info("Script output:\n" + out)
-    result = "Verification PASSED" in out or ">>> BlueStore UUID:" in out
-    if result:
-        logger.info(
-            f"BlueStore label simulation succeeded on the worker node {wnode.name}"
-        )
-    else:
-        logger.warning(
-            f"BlueStore label simulation failed.on the worker node {wnode.name}"
-        )
-    return result
 
 
 class BaremetalPSIUPI(Deployment):

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1583,18 +1583,19 @@ def detect_simulation_disk_on_node(wnode, namespace=None, timeout=300):
     # Determine disk naming pattern based on platform type
     platform = config.ENV_DATA["platform"].lower()
     if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
-        # NVMe disks typically used in baremetal environments
-        disk_names_available = disks_available_to_cleanup(wnode)
-        nvme_disks = [
+        disk_names_available = disks_available_to_cleanup(wnode, namespace=namespace)
+        candidate_disks = [
             disk_name
             for disk_name in disk_names_available
-            if disk_name.startswith("nvme")
+            if disk_name.startswith(("nvme", "sd"))
         ]
-        if not nvme_disks:
+        if not candidate_disks:
             raise ValueError(
-                f"Didnt find any nvme disks available on the node {wnode.name}"
+                f"Didn't find any sd*/nvme* disks available on node {wnode.name}"
             )
-        disk_name_pattern = nvme_disks[0]
+        disk_name_pattern = "|".join(
+            f"^{re.escape(disk_name)}$" for disk_name in candidate_disks
+        )
     else:
         # SATA/SCSI disks typically used in virtualized environments
         disk_name_pattern = "^sd[a-z]$"

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1379,6 +1379,19 @@ class Deployment(object):
                     timeout=2100,
                 )
 
+        add_new_disks_for_lso = True
+        # Simulate bluestore label on Baremetal or vSphere LSO worker nodes before deploying OCS
+        simulate_bluestore_label = config.ENV_DATA.get(
+            "simulate_bluestore_label", False
+        )
+        if simulate_bluestore_label:
+            from ocs_ci.deployment.helpers.ceph_cluster import (
+                simulate_full_ceph_bluestore_process_on_wnodes,
+            )
+
+            simulate_full_ceph_bluestore_process_on_wnodes()
+            add_new_disks_for_lso = False
+
         # with Hub/Spoke deployments LSO on IBM BareMetal is a mandatory requirement, it is installed on Dependency
         # stage when config["DEPLOYMENT"]["lso_standalone_deployment"] is set to True
         # hence perform_lso_standalone_deployment must be False if we want to deploy LSO with ODF operator and do not
@@ -1390,7 +1403,10 @@ class Deployment(object):
             )
             if not lso_deployed:
                 log_step("Deploy and setup Local Storage Operator")
-                setup_local_storage(storageclass=constants.DEFAULT_STORAGECLASS_LSO)
+                setup_local_storage(
+                    storageclass=constants.DEFAULT_STORAGECLASS_LSO,
+                    add_new_disks=add_new_disks_for_lso,
+                )
 
         log_step("Creating namespace and operator group")
         # patch OLM YAML with the namespace

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -1,0 +1,450 @@
+import os
+import logging
+from pathlib import Path
+
+from ocs_ci.deployment.baremetal import (
+    detect_simulation_disk_on_node,
+    disks_available_to_cleanup,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.node import get_nodes, get_node_internal_ip, Node
+from ocs_ci.framework import config
+from ocs_ci.deployment.helpers.lso_helpers import add_disk_for_vsphere_platform
+
+logger = logging.getLogger(__name__)
+
+
+def get_ceph_admin_key(host_node, namespace=None):
+    """
+    Retrieves the Ceph admin key from the specified host node.
+
+    Args:
+        host_node (ocs_ci.ocs.resources.ocs.OCS): The host node object from
+            which to retrieve the Ceph admin key.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        str: The Ceph admin key.
+
+    Raises:
+        RuntimeError: If the key cannot be parsed from the output.
+
+    """
+    node_obj = Node(host_node.name, namespace, use_root=True)
+
+    cmd = "cephadm shell -- ceph auth get-key client.bootstrap-osd"
+    out = node_obj.run_cmd(cmd, timeout=300)
+    # Get the key from the last line of the output
+    if out:
+        key = str(out).strip().splitlines()[-1]
+        return key
+
+    raise RuntimeError("Failed to parse Ceph admin key from output")
+
+
+def get_ceph_fsid(host_node, namespace=None):
+    """
+    Retrieves the Ceph FSID from the specified host node.
+
+    Args:
+        host_node (ocs_ci.ocs.resources.ocs.OCS): The host node object from which to retrieve the FSID.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        str: The Ceph FSID.
+
+    Raises:
+        RuntimeError: If the FSID cannot be parsed from the output.
+
+    """
+    node_obj = Node(host_node.name, namespace, use_root=True)
+
+    cmd = "cephadm shell -- ceph fsid"
+    out = node_obj.run_cmd(cmd, timeout=300)
+    # Get the FSID from the last line of the output
+    if out:
+        fsid = str(out).strip().splitlines()[-1]
+        return fsid
+
+    raise RuntimeError("Failed to parse Ceph FSID from output")
+
+
+def remove_minimal_ceph_cluster(host_node, namespace=None):
+    """
+    Removes a minimal Ceph cluster from the specified host node.
+
+    Args:
+        host_node (ocs_ci.ocs.resources.ocs.OCS): The host node object from
+            which to remove the Ceph cluster.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the removal succeeded, False otherwise.
+
+    """
+    node_obj = Node(host_node.name, namespace, use_root=True)
+
+    fsid = get_ceph_fsid(host_node, namespace)
+    logger.info(f"Removing minimal Ceph cluster with FSID: {fsid}")
+    cmd = f"cephadm rm-cluster --fsid {fsid} --force"
+    out = node_obj.run_cmd(cmd, timeout=300)
+
+    logger.info(f"Removal command output:\n{out}")
+    success_msg = "Deleting cluster"
+    return success_msg in out
+
+
+def clear_ceph_bluestore_signature_on_wnodes(wnodes, disk_name=None, namespace=None):
+    """
+    Clears Ceph BlueStore signatures on the specified worker nodes.
+
+    Args:
+        wnodes (list): List of worker node objects where the Ceph BlueStore
+            signatures will be cleared.
+        disk_name (str): Specific disk name to clear the signature from.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the clearing succeeded on all nodes, False otherwise.
+
+    """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+
+    for wnode in wnodes:
+        logger.info(f"Clearing Ceph BlueStore signature on worker node: {wnode.name}")
+        node_disk = disk_name or detect_simulation_disk_on_node(wnode, namespace)
+        if not node_disk:
+            logger.warning(
+                f"Skipping Ceph BlueStore signature clearing on node {wnode.name} "
+                f"as no suitable disk was detected."
+            )
+            return False
+
+        node_obj = Node(wnode.name, namespace, use_root=True)
+        cmd = f"wipefs -a -f {node_disk}"
+        out = node_obj.run_cmd(cmd, timeout=300)
+
+        logger.info(f"Command output:\n{out}")
+
+    logger.info("Ceph BlueStore signatures cleared successfully on all worker nodes.")
+    return True
+
+
+def install_minimal_ceph_cluster(wnode, namespace=None):
+    """
+    Installs a minimal Ceph cluster on the specified worker node.
+
+    Args:
+        wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object where
+            the Ceph cluster will be installed.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the installation succeeded, False otherwise.
+
+    """
+    node_obj = Node(wnode.name, namespace, use_root=True)
+
+    script_name = "install_minimal_ceph_cluster.sh"
+    top_dir = Path(constants.TOP_DIR)
+    script_src_path = os.path.join(top_dir, "scripts", "bash", script_name)
+    script_dest_path = f"/tmp/{script_name}"
+
+    # Upload the script directly on the node
+    logger.info(
+        f"Uploading install minimal ceph cluster script to the worker node {wnode.name}"
+    )
+    node_obj.upload_script(
+        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+    )
+    # Run the script on the node
+    logger.info(
+        f"Running install minimal ceph cluster script on the worker node {wnode.name}. "
+        f"This may take a few minutes..."
+    )
+    out = node_obj.run_script(script_path=script_dest_path, timeout=600)
+    logger.info(f"result = {out}")
+    success_msg = "completed successfully"
+    return success_msg in out
+
+
+def install_minimal_ceph_conf(wnode, host_node, namespace=None):
+    """
+    Installs a minimal Ceph configuration on the specified worker node.
+
+    Args:
+        wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object where
+            the Ceph configuration will be installed.
+        host_node (ocs_ci.ocs.resources.ocs.OCS): The host node object from
+            which to copy the Ceph configuration.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the installation succeeded, False otherwise.
+
+    """
+    node_obj = Node(wnode.name, namespace, use_root=True)
+
+    ceph_key = get_ceph_admin_key(host_node, namespace)
+    ceph_fsid = get_ceph_fsid(host_node, namespace)
+    host_node_ip = get_node_internal_ip(host_node)
+    logger.info(
+        f"Ceph FSID: {ceph_fsid}, Ceph Key: {ceph_key}, Host Node IP: {host_node_ip}"
+    )
+
+    script_name = "install_minimal_ceph_conf.sh"
+    top_dir = Path(constants.TOP_DIR)
+    script_src_path = os.path.join(top_dir, "scripts", "bash", script_name)
+    script_dest_path = f"/tmp/{script_name}"
+
+    # Upload the script directly on the node
+    logger.info(
+        f"Uploading install minimal ceph conf script to the worker node {wnode.name}"
+    )
+    node_obj.upload_script(
+        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+    )
+
+    # Run the script on the node
+    args = f"{ceph_fsid} {ceph_key} {host_node_ip}"
+    logger.info(
+        f"Running install minimal ceph conf script on the worker node {wnode.name} "
+        f"with the args: {args}"
+    )
+    out = node_obj.run_script(script_path=script_dest_path, args=args, timeout=300)
+    logger.info("Script output:\n" + out)
+    success_msg = "created successfully"
+    return success_msg in out
+
+
+def install_minimal_ceph_cluster_and_conf_on_wnodes(
+    wnodes, host_node=None, namespace=None
+):
+    """
+    Installs a minimal Ceph cluster and configuration on the specified worker nodes.
+
+    Args:
+        wnodes (list): List of worker node objects where the Ceph cluster and configuration
+            will be installed.
+        host_node (ocs_ci.ocs.resources.ocs.OCS): The host node object where the Ceph cluster
+            will be installed. If None, the first worker node in the list will be used as the host node.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the installation succeeded on all nodes, False otherwise.
+
+    Raises:
+        RuntimeError: If the Ceph cluster or configuration installation fails on any node.
+
+    """
+    host_node = host_node or wnodes[0]
+    logger.info(f"Installing minimal Ceph cluster on host node: {host_node.name}")
+    result = install_minimal_ceph_cluster(host_node, namespace)
+    if not result:
+        logger.warning(
+            f"Failed to install minimal Ceph cluster on host node: {host_node.name}"
+        )
+        return False
+    logger.info("Minimal Ceph cluster installed successfully on host node.")
+
+    for wnode in wnodes[1:]:
+        logger.info(
+            f"Installing minimal Ceph configuration on worker node: {wnode.name}"
+        )
+        result = install_minimal_ceph_conf(wnode, host_node, namespace)
+        if not result:
+            logger.warning(
+                f"Failed to install minimal Ceph configuration on worker node: {wnode.name}"
+            )
+            return False
+
+    logger.info(
+        "Minimal Ceph cluster and ceph configuration installed successfully "
+        "on all worker nodes."
+    )
+    return True
+
+
+def simulate_ceph_bluestore_on_node_disk(wnode, disk_name=None, namespace=None):
+    """
+    Simulates a Ceph BlueStore label on a specified disk of a given worker node.
+
+
+    This function uploads a local shell script to the node using base64 encoding,
+    and executes it to simulate a BlueStore label on the specified disk. If no disk is specified,
+    the function attempts to auto-detect a suitable disk. The output is parsed to determine
+    whether the simulation was successful.
+
+    Args:
+        wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object where the simulation
+            should be performed.
+        disk_name (str, optional): The disk device name to simulate the label on.
+            If not provided, the function auto-detects the last /dev/sd* or the nvme disk on the node.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the simulation succeeded (BlueStore label detected), False otherwise.
+
+    """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+
+    if not disk_name:
+        disk_name = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+
+    if not disk_name:
+        logger.error("Disk detection failed. Aborting BlueStore simulation.")
+        return False
+
+    node_obj = Node(wnode.name, namespace, use_root=True)
+
+    script_name = "simulate_bluestore_label.sh"
+    top_dir = Path(constants.TOP_DIR)
+    script_src_path = os.path.join(top_dir, "scripts", "bash", script_name)
+    script_dest_path = f"/tmp/{script_name}"
+
+    # Upload the script directly on the node
+    logger.info(
+        f"Uploading BlueStore simulation script to the worker node {wnode.name}"
+    )
+    node_obj.upload_script(
+        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+    )
+    # Run the script on the node
+    logger.info(
+        f"Running BlueStore simulation script on disk: {disk_name}. "
+        f"This may take 1-2 minutes..."
+    )
+    args = f"{disk_name}"
+    out = node_obj.run_script(script_path=script_dest_path, args=args, timeout=300)
+
+    logger.info("Script output:\n" + out)
+    result = "BlueStore simulation complete" in out or (
+        "bluestore" in out and "osd_uuid" in out
+    )
+    if result:
+        logger.info(
+            f"BlueStore label simulation succeeded on the worker node {wnode.name}"
+        )
+    else:
+        logger.warning(
+            f"BlueStore label simulation failed on the worker node {wnode.name}"
+        )
+    return result
+
+
+def simulate_ceph_bluestore_on_wnodes(wnodes, namespace=None):
+    """
+    Simulates Ceph BlueStore labels on the specified worker nodes.
+
+    This function iterates over a list of worker nodes and simulates a BlueStore label
+    on each node's disk. It uses the `simulate_ceph_bluestore_on_node_disk` function
+    to perform the simulation on each node.
+
+    Args:
+        wnodes (list): List of worker node objects where the BlueStore simulation
+            should be performed.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the simulation succeeded on all nodes, False otherwise.
+
+    """
+    for wnode in wnodes:
+        logger.info(f"Simulating Ceph BlueStore on worker node: {wnode.name}")
+        result = simulate_ceph_bluestore_on_node_disk(wnode, namespace=namespace)
+        if not result:
+            logger.warning(
+                f"Failed to simulate Ceph BlueStore on worker node: {wnode.name}"
+            )
+            return False
+
+    logger.info("Ceph BlueStore simulation succeeded on all worker nodes.")
+    return True
+
+
+def simulate_full_ceph_bluestore_process_on_wnodes(
+    wnodes=None,
+    namespace=None,
+    add_disks=True,
+    remove_ceph_cluster=True,
+    clear_signatures=True,
+):
+    """
+    Simulates the full Ceph BlueStore process on the specified worker nodes.
+
+    This function performs the following steps on each worker node:
+    1. Adds disks to the nodes if specified.
+    2. Installs a minimal Ceph cluster and configuration.
+    3. Simulates a BlueStore label on the node's disk.
+    4. Removes the minimal Ceph cluster if specified.
+
+    Args:
+        wnodes (list): List of worker node objects where the full BlueStore simulation
+            should be performed.
+        namespace (str): Namespace for the debug pod.
+        add_disks (bool): Whether to add disks to the nodes before simulation.
+        remove_ceph_cluster (bool): Whether to remove the minimal Ceph cluster after simulation.
+        clear_signatures (bool): Whether to clear BlueStore signatures from disks after simulation.
+
+    Returns:
+        bool: True if all steps succeeded on all nodes, False otherwise.
+
+    """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+    wnodes = wnodes or get_nodes()
+    wnode_names = [wnode.name for wnode in wnodes]
+    logger.info(
+        f"Starting full Ceph BlueStore simulation process on worker nodes : {wnode_names}"
+    )
+
+    # Step 1: Optionally add disks to worker nodes
+    platform = config.ENV_DATA["platform"].lower()
+    if add_disks and platform == constants.VSPHERE_PLATFORM:
+        logger.info("Adding disks to worker nodes before simulation.")
+        # Check if disks are already added
+        disks_already_added = all(
+            disks_available_to_cleanup(wnode, namespace) for wnode in wnodes
+        )
+        if disks_already_added:
+            logger.info(
+                "Disks are already added to all worker nodes. Skipping addition."
+            )
+        else:
+            add_disk_for_vsphere_platform()
+
+    # Step 2: Install minimal Ceph cluster and configuration
+    host_node = wnodes[0]
+    result = install_minimal_ceph_cluster_and_conf_on_wnodes(
+        wnodes, host_node, namespace
+    )
+    if not result:
+        logger.warning("Failed to install minimal Ceph cluster and configuration.")
+        return False
+
+    # Step 3: Simulate BlueStore labels on all worker nodes
+    result = simulate_ceph_bluestore_on_wnodes(wnodes, namespace)
+    if not result:
+        logger.warning("Failed to simulate Ceph BlueStore on worker nodes.")
+        return False
+
+    # Step 4: Optionally remove the minimal Ceph cluster
+    if remove_ceph_cluster:
+        logger.info("Removing minimal Ceph cluster from host node.")
+        host_node = wnodes[0]
+        result = remove_minimal_ceph_cluster(host_node, namespace)
+        if not result:
+            logger.warning("Failed to remove minimal Ceph cluster from host node.")
+            return False
+
+    # Step 5: Optionally clear BlueStore signatures from disks
+    if clear_signatures:
+        logger.info("Clearing Ceph BlueStore signatures from worker node disks.")
+        result = clear_ceph_bluestore_signature_on_wnodes(wnodes, namespace=namespace)
+        if not result:
+            logger.warning(
+                "Failed to clear Ceph BlueStore signatures from worker nodes."
+            )
+            return False
+
+    logger.info("Full Ceph BlueStore simulation process completed successfully.")
+    return True

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -209,7 +209,12 @@ def install_minimal_ceph_conf(wnode, host_node, namespace=None):
         f"Running install minimal ceph conf script on the worker node {wnode.name} "
         f"with fsid={ceph_fsid}, host_node_ip={host_node_ip}"
     )
-    out = node_obj.run_script(script_path=script_dest_path, args=args, timeout=300)
+    out = node_obj.run_script(
+        script_path=script_dest_path,
+        args=args,
+        timeout=300,
+        secrets=[ceph_key],
+    )
     logger.info("Script output:\n" + out)
     success_msg = "created successfully"
     return success_msg in out

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -188,9 +188,7 @@ def install_minimal_ceph_conf(wnode, host_node, namespace=None):
     ceph_key = get_ceph_admin_key(host_node, namespace)
     ceph_fsid = get_ceph_fsid(host_node, namespace)
     host_node_ip = get_node_internal_ip(host_node)
-    logger.info(
-        f"Ceph FSID: {ceph_fsid}, Ceph Key: {ceph_key}, Host Node IP: {host_node_ip}"
-    )
+    logger.info(f"Ceph FSID: {ceph_fsid}, Host Node IP: {host_node_ip}")
 
     script_name = "install_minimal_ceph_conf.sh"
     top_dir = Path(constants.TOP_DIR)
@@ -209,7 +207,7 @@ def install_minimal_ceph_conf(wnode, host_node, namespace=None):
     args = f"{ceph_fsid} {ceph_key} {host_node_ip}"
     logger.info(
         f"Running install minimal ceph conf script on the worker node {wnode.name} "
-        f"with the args: {args}"
+        f"with fsid={ceph_fsid}, host_node_ip={host_node_ip}"
     )
     out = node_obj.run_script(script_path=script_dest_path, args=args, timeout=300)
     logger.info("Script output:\n" + out)

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -94,14 +94,15 @@ def remove_minimal_ceph_cluster(host_node, namespace=None):
     return success_msg in out
 
 
-def clear_ceph_bluestore_signature_on_wnodes(wnodes, disk_name=None, namespace=None):
+def clear_ceph_bluestore_signature_on_wnodes(wnodes, disk_names=None, namespace=None):
     """
     Clears Ceph BlueStore signatures on the specified worker nodes.
 
     Args:
         wnodes (list): List of worker node objects where the Ceph BlueStore
             signatures will be cleared.
-        disk_name (str): Specific disk name to clear the signature from.
+        disk_names (dict): Map of node name to disk name to clear. When
+            absent, the disk is auto-detected per node.
         namespace (str): Namespace for the debug pod.
 
     Returns:
@@ -112,7 +113,9 @@ def clear_ceph_bluestore_signature_on_wnodes(wnodes, disk_name=None, namespace=N
 
     for wnode in wnodes:
         logger.info(f"Clearing Ceph BlueStore signature on worker node: {wnode.name}")
-        node_disk = disk_name or detect_simulation_disk_on_node(wnode, namespace)
+        node_disk = (disk_names or {}).get(
+            wnode.name
+        ) or detect_simulation_disk_on_node(wnode, namespace)
         if not node_disk:
             logger.warning(
                 f"Skipping Ceph BlueStore signature clearing on node {wnode.name} "
@@ -155,7 +158,9 @@ def install_minimal_ceph_cluster(wnode, namespace=None):
         f"Uploading install minimal ceph cluster script to the worker node {wnode.name}"
     )
     node_obj.upload_script(
-        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+        script_src_path=script_src_path,
+        script_dest_path=script_dest_path,
+        timeout=300,
     )
     # Run the script on the node
     logger.info(
@@ -200,11 +205,13 @@ def install_minimal_ceph_conf(wnode, host_node, namespace=None):
         f"Uploading install minimal ceph conf script to the worker node {wnode.name}"
     )
     node_obj.upload_script(
-        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+        script_src_path=script_src_path,
+        script_dest_path=script_dest_path,
+        timeout=300,
     )
 
     # Run the script on the node
-    args = f"{ceph_fsid} {ceph_key} {host_node_ip}"
+    args = [ceph_fsid, ceph_key, host_node_ip]
     logger.info(
         f"Running install minimal ceph conf script on the worker node {wnode.name} "
         f"with fsid={ceph_fsid}, host_node_ip={host_node_ip}"
@@ -250,7 +257,7 @@ def install_minimal_ceph_cluster_and_conf_on_wnodes(
         return False
     logger.info("Minimal Ceph cluster installed successfully on host node.")
 
-    for wnode in wnodes[1:]:
+    for wnode in [wn for wn in wnodes if wn.name != host_node.name]:
         logger.info(
             f"Installing minimal Ceph configuration on worker node: {wnode.name}"
         )
@@ -310,15 +317,18 @@ def simulate_ceph_bluestore_on_node_disk(wnode, disk_name=None, namespace=None):
         f"Uploading BlueStore simulation script to the worker node {wnode.name}"
     )
     node_obj.upload_script(
-        script_src_path=script_src_path, script_dest_path=script_dest_path, timeout=300
+        script_src_path=script_src_path,
+        script_dest_path=script_dest_path,
+        timeout=300,
     )
     # Run the script on the node
     logger.info(
         f"Running BlueStore simulation script on disk: {disk_name}. "
         f"This may take 1-2 minutes..."
     )
-    args = f"{disk_name}"
-    out = node_obj.run_script(script_path=script_dest_path, args=args, timeout=300)
+    out = node_obj.run_script(
+        script_path=script_dest_path, args=[disk_name], timeout=300
+    )
 
     logger.info("Script output:\n" + out)
     result = "BlueStore simulation complete" in out or (
@@ -335,7 +345,7 @@ def simulate_ceph_bluestore_on_node_disk(wnode, disk_name=None, namespace=None):
     return result
 
 
-def simulate_ceph_bluestore_on_wnodes(wnodes, namespace=None):
+def simulate_ceph_bluestore_on_wnodes(wnodes, namespace=None, disk_map=None):
     """
     Simulates Ceph BlueStore labels on the specified worker nodes.
 
@@ -347,6 +357,8 @@ def simulate_ceph_bluestore_on_wnodes(wnodes, namespace=None):
         wnodes (list): List of worker node objects where the BlueStore simulation
             should be performed.
         namespace (str): Namespace for the debug pod.
+        disk_map (dict): Map of node name to pre-detected disk name. When
+            provided, skips per-node disk detection.
 
     Returns:
         bool: True if the simulation succeeded on all nodes, False otherwise.
@@ -354,7 +366,10 @@ def simulate_ceph_bluestore_on_wnodes(wnodes, namespace=None):
     """
     for wnode in wnodes:
         logger.info(f"Simulating Ceph BlueStore on worker node: {wnode.name}")
-        result = simulate_ceph_bluestore_on_node_disk(wnode, namespace=namespace)
+        disk_name = (disk_map or {}).get(wnode.name)
+        result = simulate_ceph_bluestore_on_node_disk(
+            wnode, disk_name=disk_name, namespace=namespace
+        )
         if not result:
             logger.warning(
                 f"Failed to simulate Ceph BlueStore on worker node: {wnode.name}"
@@ -415,7 +430,16 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
         else:
             add_disk_for_vsphere_platform()
 
-    # Step 2: Install minimal Ceph cluster and configuration
+    # Step 2: Detect disks once so the same device is used for simulation and cleanup
+    disk_map = {}
+    for wnode in wnodes:
+        disk = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        if not disk:
+            logger.error(f"Disk detection failed on node {wnode.name}. Aborting.")
+            return False
+        disk_map[wnode.name] = disk
+
+    # Step 3: Install minimal Ceph cluster and configuration
     host_node = wnodes[0]
     result = install_minimal_ceph_cluster_and_conf_on_wnodes(
         wnodes, host_node, namespace
@@ -424,30 +448,37 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
         logger.warning("Failed to install minimal Ceph cluster and configuration.")
         return False
 
-    # Step 3: Simulate BlueStore labels on all worker nodes
-    result = simulate_ceph_bluestore_on_wnodes(wnodes, namespace)
-    if not result:
-        logger.warning("Failed to simulate Ceph BlueStore on worker nodes.")
+    # Steps 4-6: simulation + cleanup (cleanup always runs when flags are set)
+    simulation_result = False
+    cleanup_ok = True
+    try:
+        # Step 4: Simulate BlueStore labels on all worker nodes
+        simulation_result = simulate_ceph_bluestore_on_wnodes(
+            wnodes, namespace, disk_map
+        )
+        if not simulation_result:
+            logger.warning("Failed to simulate Ceph BlueStore on worker nodes.")
+    finally:
+        # Step 5: Optionally remove the minimal Ceph cluster
+        if remove_ceph_cluster:
+            logger.info("Removing minimal Ceph cluster from host node.")
+            if not remove_minimal_ceph_cluster(host_node, namespace):
+                logger.warning("Failed to remove minimal Ceph cluster from host node.")
+                cleanup_ok = False
+
+        # Step 6: Optionally clear BlueStore signatures from disks
+        if clear_signatures:
+            logger.info("Clearing Ceph BlueStore signatures from worker node disks.")
+            if not clear_ceph_bluestore_signature_on_wnodes(
+                wnodes, disk_names=disk_map, namespace=namespace
+            ):
+                logger.warning(
+                    "Failed to clear Ceph BlueStore signatures from worker nodes."
+                )
+                cleanup_ok = False
+
+    if not simulation_result or not cleanup_ok:
         return False
-
-    # Step 4: Optionally remove the minimal Ceph cluster
-    if remove_ceph_cluster:
-        logger.info("Removing minimal Ceph cluster from host node.")
-        host_node = wnodes[0]
-        result = remove_minimal_ceph_cluster(host_node, namespace)
-        if not result:
-            logger.warning("Failed to remove minimal Ceph cluster from host node.")
-            return False
-
-    # Step 5: Optionally clear BlueStore signatures from disks
-    if clear_signatures:
-        logger.info("Clearing Ceph BlueStore signatures from worker node disks.")
-        result = clear_ceph_bluestore_signature_on_wnodes(wnodes, namespace=namespace)
-        if not result:
-            logger.warning(
-                "Failed to clear Ceph BlueStore signatures from worker nodes."
-            )
-            return False
 
     logger.info("Full Ceph BlueStore simulation process completed successfully.")
     return True

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -38,13 +38,14 @@ from ocs_ci.ocs.resources.catalog_source import CatalogSource, disable_specific_
 logger = logging.getLogger(__name__)
 
 
-def setup_local_storage(storageclass):
+def setup_local_storage(storageclass, add_new_disks=True):
     """
     Setup the necessary resources for enabling local storage.
 
     Args:
         storageclass (string): storageClassName value to be used in
             LocalVolume CR based on LOCAL_VOLUME_YAML
+        add_new_disks (bool): whether to add new disks to nodes after LSO installation
 
     """
     # Get the worker nodes
@@ -61,7 +62,8 @@ def setup_local_storage(storageclass):
     platform = config.ENV_DATA.get("platform").lower()
     lso_type = config.DEPLOYMENT.get("type")
 
-    add_disks_lso()
+    if add_new_disks:
+        add_disks_lso()
 
     if (ocp_version >= version.VERSION_4_6) and (ocs_version >= version.VERSION_4_6):
         # Pull local volume discovery yaml data

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -9,6 +9,8 @@ import random
 import json
 import unicodedata
 from ocs_ci.ocs.ocp import exec_cmd
+import base64
+import os
 import yaml
 
 from subprocess import TimeoutExpired
@@ -53,6 +55,145 @@ from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.utility.vsphere import VSPHERE
 
 log = logging.getLogger(__name__)
+
+
+class Node(OCP):
+    """
+    Node class inherits OCP class and contains all the methods related to
+    node operations
+    """
+
+    def __init__(self, resource_name=None, namespace=None, use_root=True, **kwargs):
+        """
+        Initializer for Node class
+
+        Args:
+            resource_name (str): Name of the node
+            namespace (str): Namespace of the node
+            use_root (bool): Whether to use root user or not for running commands
+
+        """
+        super(Node, self).__init__(
+            kind=constants.NODE, resource_name=resource_name, **kwargs
+        )
+
+        self._namespace = namespace or constants.DEFAULT_NAMESPACE
+        self.use_root = use_root
+
+    def run_cmd(self, cmd, namespace=None, use_root=None, timeout=300):
+        """
+        Run command on the node
+
+        Args:
+            cmd (str): Command to run.
+            namespace (str): Namespace of the node. If None, default namespace will be used.
+            use_root (bool): Whether to use root user or not for running the command.
+            timeout (int): Timeout for the command execution (in seconds)
+
+        Returns:
+            str: Output of the command execution
+
+        Raises:
+            CommandFailed: In case the command execution fails
+
+        """
+        namespace = namespace or self.namespace
+        use_root = use_root if use_root is not None else self.use_root
+
+        log.info(f"Running command '{cmd}' on node '{self.resource_name}'")
+        return self.exec_oc_debug_cmd(
+            node=self.resource_name,
+            cmd_list=[cmd],
+            namespace=namespace,
+            use_root=use_root,
+            timeout=timeout,
+        )
+
+    def run_script(
+        self,
+        script_path: str,
+        args: str = "",
+        namespace: str = None,
+        use_root: bool = None,
+        timeout: int = 600,
+    ):
+        """
+        Execute a shell script directly on a node (inside chroot /host)
+        using oc debug.
+
+        Args:
+            script_path (str): Full path to the script on the node.
+            args (str): Optional arguments to pass to the script.
+            namespace (str): Namespace for the debug pod.
+            use_root (bool): Whether to use root user or not for running the command.
+            timeout (int): Timeout for the command execution (in seconds).
+
+        Returns:
+            str: Output of the script execution.
+
+        Raises:
+            CommandFailed: In case the script execution fails.
+
+        """
+        log.info(
+            f"Running the script {script_path} with the args '{args}' "
+            f"on the worker node {self.resource_name}"
+        )
+        # Build the command — single element, no single quotes inside
+        cmd = f"set -euo pipefail; " f"bash {script_path} {args} "
+        return self.run_cmd(cmd, namespace, use_root, timeout)
+
+    def upload_script(
+        self,
+        script_src_path: str,
+        script_dest_path: str,
+        namespace: str = None,
+        use_root: bool = None,
+        timeout: int = 300,
+    ):
+        """
+        Upload a shell script to a node using base64 encoding via `oc debug`.
+
+        The script is read locally, base64-encoded, and decoded on the node
+        using `echo | base64 -d`.
+
+        Args:
+            script_src_path (str): Local path to the script.
+            script_dest_path (str): Destination path on the node.
+            namespace (str): Namespace for the debug pod.
+            use_root (bool): Whether to use root user or not for running the command.
+            timeout (int): Timeout for the oc debug command (in seconds).
+
+        Returns:
+            str: Output of the command execution.
+
+        Raises:
+            FileNotFoundError: If the local script file does not exist.
+            CommandFailed: In case the command execution fails.
+
+        """
+        if not os.path.exists(script_src_path):
+            raise FileNotFoundError(f"Script not found at {script_src_path}")
+
+        # Read and encode the script
+        with open(script_src_path, "rb") as f:
+            script_content = f.read()
+        script_b64 = base64.b64encode(script_content).decode("utf-8").replace("\n", "")
+
+        log.info(
+            f"Uploading script from '{script_src_path}' to node '{self.resource_name}' "
+            f"at '{script_dest_path}'"
+        )
+        # Build the shell command
+        upload_cmd = (
+            f"set -euo pipefail; "
+            f'echo "{script_b64}" | base64 -d > {script_dest_path} && '
+            f"chmod 755 {script_dest_path} && "
+            f'echo "Script written to {script_dest_path}" && ls -l {script_dest_path}'
+        )
+
+        # Execute the command on the node
+        return self.run_cmd(upload_cmd, namespace, use_root, timeout)
 
 
 def get_node_objs(node_names=None):

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -202,11 +202,12 @@ class Node(OCP):
             f"at '{script_dest_path}'"
         )
         # Build the shell command
+        quoted_dest = shlex.quote(script_dest_path)
         upload_cmd = (
             f"set -euo pipefail; "
-            f'echo "{script_b64}" | base64 -d > {script_dest_path} && '
-            f"chmod 755 {script_dest_path} && "
-            f'echo "Script written to {script_dest_path}" && ls -l {script_dest_path}'
+            f'echo "{script_b64}" | base64 -d > {quoted_dest} && '
+            f"chmod 755 {quoted_dest} && "
+            f"echo Script written to {quoted_dest} && ls -l {quoted_dest}"
         )
 
         # Execute the command on the node

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import re
+import shlex
 import time
 from prettytable import PrettyTable
 from collections import defaultdict
@@ -34,10 +35,19 @@ from ocs_ci.ocs import constants, exceptions, ocp, defaults
 from ocs_ci.ocs.resources.pvc import get_pvc_size
 from ocs_ci.utility import version
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import TimeoutSampler, convert_device_size, get_az_count
+from ocs_ci.utility.utils import (
+    TimeoutSampler,
+    convert_device_size,
+    get_az_count,
+    mask_secrets,
+)
 from ocs_ci.ocs import machine
 from ocs_ci.ocs.resources import pod
-from ocs_ci.utility.utils import set_selinux_permissions, get_ocp_version, run_cmd
+from ocs_ci.utility.utils import (
+    set_selinux_permissions,
+    get_ocp_version,
+    run_cmd,
+)
 from ocs_ci.ocs.resources.pv import (
     get_pv_objs_in_sc,
     get_pv_size,
@@ -101,7 +111,8 @@ class Node(OCP):
         namespace = namespace or self.namespace
         use_root = use_root if use_root is not None else self.use_root
 
-        log.info(f"Running command '{cmd}' on node '{self.resource_name}'")
+        cmd_to_log = mask_secrets(cmd, secrets) if secrets else cmd
+        log.info(f"Running command '{cmd_to_log}' on node '{self.resource_name}'")
         return self.exec_oc_debug_cmd(
             node=self.resource_name,
             cmd_list=[cmd],
@@ -114,7 +125,7 @@ class Node(OCP):
     def run_script(
         self,
         script_path: str,
-        args: str = "",
+        args: list = None,
         namespace: str = None,
         use_root: bool = None,
         timeout: int = 600,
@@ -126,7 +137,7 @@ class Node(OCP):
 
         Args:
             script_path (str): Full path to the script on the node.
-            args (str): Optional arguments to pass to the script.
+            args (list): Optional arguments to pass to the script.
             namespace (str): Namespace for the debug pod.
             use_root (bool): Whether to use root user or not for running the command.
             timeout (int): Timeout for the command execution (in seconds).
@@ -139,12 +150,14 @@ class Node(OCP):
             CommandFailed: In case the script execution fails.
 
         """
+        safe_args = mask_secrets(list(args or []), secrets)
         log.info(
-            f"Running the script {script_path} with the args '{args}' "
+            f"Running the script {script_path} with the args '{safe_args}' "
             f"on the worker node {self.resource_name}"
         )
-        # Build the command — single element, no single quotes inside
-        cmd = f"set -euo pipefail; " f"bash {script_path} {args} "
+        cmd = (
+            f"set -euo pipefail; " f"{shlex.join(['bash', script_path, *(args or [])])}"
+        )
         return self.run_cmd(cmd, namespace, use_root, timeout, secrets)
 
     def upload_script(
@@ -610,7 +623,8 @@ def add_new_node_and_label_it(machineset_name, num_nodes=1, mark_for_ocs_label=T
                 )
             else:
                 node_obj.add_label(
-                    resource_name=new_spun_node, label=constants.OPERATOR_NODE_LABEL
+                    resource_name=new_spun_node,
+                    label=constants.OPERATOR_NODE_LABEL,
                 )
                 log.info(f"Successfully labeled {new_spun_node} with OCS storage label")
 
@@ -661,7 +675,8 @@ def add_new_node_and_label_upi(
         node_obj = ocp.OCP(kind="node")
         for new_spun_node in new_spun_nodes:
             node_obj.add_label(
-                resource_name=new_spun_node, label=constants.OPERATOR_NODE_LABEL
+                resource_name=new_spun_node,
+                label=constants.OPERATOR_NODE_LABEL,
             )
             log.info(f"Successfully labeled {new_spun_node} with OCS storage label")
     return new_spun_nodes
@@ -706,7 +721,8 @@ def add_new_nodes_and_label_them_rosa_hcp(
         node_obj = ocp.OCP(kind="node")
         for new_spun_node in new_spun_nodes:
             node_obj.add_label(
-                resource_name=new_spun_node, label=constants.OPERATOR_NODE_LABEL
+                resource_name=new_spun_node,
+                label=constants.OPERATOR_NODE_LABEL,
             )
             log.info(f"Successfully labeled {new_spun_node} with OCS storage label")
     return new_spun_nodes
@@ -777,7 +793,11 @@ def get_node_resource_utilization_from_adm_top(
     if print_table:
         print_table_node_resource_utilization(
             utilization_dict=utilization_dict,
-            field_names=["Node Name", "CPU USAGE adm_top", "Memory USAGE adm_top"],
+            field_names=[
+                "Node Name",
+                "CPU USAGE adm_top",
+                "Memory USAGE adm_top",
+            ],
         )
     return utilization_dict
 
@@ -1397,7 +1417,9 @@ def delete_and_create_osd_node_vsphere_upi_lso(osd_node_name, use_existing_node=
 
     """
     from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
-    from ocs_ci.ocs.resources.storage_cluster import get_deviceset_sc_name_per_count
+    from ocs_ci.ocs.resources.storage_cluster import (
+        get_deviceset_sc_name_per_count,
+    )
 
     plt = PlatformNodesFactory()
     node_util = plt.get_nodes_platform()
@@ -1964,7 +1986,8 @@ def replace_old_node_in_lvd_and_lvs(old_node_name, new_node_name):
     )
 
     lvs_obj = OCP(
-        kind=constants.LOCAL_VOLUME_SET, namespace=defaults.LOCAL_STORAGE_NAMESPACE
+        kind=constants.LOCAL_VOLUME_SET,
+        namespace=defaults.LOCAL_STORAGE_NAMESPACE,
     )
     lvs_items = lvs_obj.data["items"]
     lvs_names = [lvs_data["metadata"]["name"] for lvs_data in lvs_items]
@@ -2010,7 +2033,8 @@ def wait_for_new_osd_node(old_osd_node_names, timeout=600):
 
     """
     pod.wait_for_pods_to_be_running(
-        pod_names=[osd_pod.name for osd_pod in pod.get_osd_pods()], timeout=timeout
+        pod_names=[osd_pod.name for osd_pod in pod.get_osd_pods()],
+        timeout=timeout,
     )
     try:
         for current_osd_node_names in TimeoutSampler(
@@ -3519,7 +3543,10 @@ def apply_node_affinity_for_noobaa_pod():
                     "nodeSelectorTerms": [
                         {
                             "matchExpressions": [
-                                {"key": "kubernetes.io/hostname", "operator": "Exists"}
+                                {
+                                    "key": "kubernetes.io/hostname",
+                                    "operator": "Exists",
+                                }
                             ]
                         }
                     ]
@@ -3656,7 +3683,15 @@ def get_worker_node_allocatable():
         dict: A dictionary where keys are worker node names and values are another
             dictionary containing 'cpu' (int, in millicores) and 'mem' (float, in GB).
     """
-    cmd = ["oc", "get", "nodes", "-l", "node-role.kubernetes.io/worker", "-o", "yaml"]
+    cmd = [
+        "oc",
+        "get",
+        "nodes",
+        "-l",
+        "node-role.kubernetes.io/worker",
+        "-o",
+        "yaml",
+    ]
     result = run_cmd(cmd)
     nodes = yaml.safe_load(result)
     alloc = {}
@@ -3839,7 +3874,9 @@ def check_cluster_resources(ram_gb=65, cpu_cores=6):
 
         # Sort namespaces by RAM usage
         sorted_ns = sorted(
-            breakdown["ram"].keys(), key=lambda x: breakdown["ram"][x], reverse=True
+            breakdown["ram"].keys(),
+            key=lambda x: breakdown["ram"][x],
+            reverse=True,
         )
         for ns in sorted_ns:
             ram_gb_used = breakdown["ram"][ns] / (1024 * 1024)

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -80,7 +80,7 @@ class Node(OCP):
         self._namespace = namespace or constants.DEFAULT_NAMESPACE
         self.use_root = use_root
 
-    def run_cmd(self, cmd, namespace=None, use_root=None, timeout=300):
+    def run_cmd(self, cmd, namespace=None, use_root=None, timeout=300, secrets=None):
         """
         Run command on the node
 
@@ -89,6 +89,7 @@ class Node(OCP):
             namespace (str): Namespace of the node. If None, default namespace will be used.
             use_root (bool): Whether to use root user or not for running the command.
             timeout (int): Timeout for the command execution (in seconds)
+            secrets (list): A list of secrets to be masked with asterisks in logs.
 
         Returns:
             str: Output of the command execution
@@ -107,6 +108,7 @@ class Node(OCP):
             namespace=namespace,
             use_root=use_root,
             timeout=timeout,
+            secrets=secrets,
         )
 
     def run_script(
@@ -116,6 +118,7 @@ class Node(OCP):
         namespace: str = None,
         use_root: bool = None,
         timeout: int = 600,
+        secrets: list = None,
     ):
         """
         Execute a shell script directly on a node (inside chroot /host)
@@ -127,6 +130,7 @@ class Node(OCP):
             namespace (str): Namespace for the debug pod.
             use_root (bool): Whether to use root user or not for running the command.
             timeout (int): Timeout for the command execution (in seconds).
+            secrets (list): A list of secrets to be masked with asterisks in logs.
 
         Returns:
             str: Output of the script execution.
@@ -141,7 +145,7 @@ class Node(OCP):
         )
         # Build the command — single element, no single quotes inside
         cmd = f"set -euo pipefail; " f"bash {script_path} {args} "
-        return self.run_cmd(cmd, namespace, use_root, timeout)
+        return self.run_cmd(cmd, namespace, use_root, timeout, secrets)
 
     def upload_script(
         self,

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -240,7 +240,13 @@ class OCP(object):
 
     @retry(CommandFailed, tries=3, delay=30, backoff=1)
     def exec_oc_debug_cmd(
-        self, node, cmd_list, timeout=300, namespace="default", use_root=True
+        self,
+        node,
+        cmd_list,
+        timeout=300,
+        namespace="default",
+        use_root=True,
+        secrets=None,
     ):
         """
         Function to execute "oc debug" command on OCP node
@@ -252,6 +258,8 @@ class OCP(object):
             namespace (str): Namespace name which will be used to create debug pods
                 It will use default namespace if not specified. openshift-stroage
                 namespace cannot be used from 4.19 because we are hitting: violates PodSecurity
+            use_root (bool): Whether to use root user or not for running the command.
+            secrets (list): A list of secrets to be masked with asterisks in logs.
 
         Returns:
             out (str): Returns output of the executed command/commands
@@ -273,7 +281,12 @@ class OCP(object):
             f' -- {root_option} "{cmd}"'
         )
         out = str(
-            self.exec_oc_cmd(command=debug_cmd, out_yaml_format=False, timeout=timeout)
+            self.exec_oc_cmd(
+                command=debug_cmd,
+                out_yaml_format=False,
+                timeout=timeout,
+                secrets=secrets,
+            )
         )
         if err_msg in out:
             raise CommandFailed

--- a/scripts/bash/install_minimal_ceph_cluster.sh
+++ b/scripts/bash/install_minimal_ceph_cluster.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+# Download cephadm
+curl -fsSL "https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm" -o /tmp/cephadm
+# Make it executable and move to PATH
+chmod +x /tmp/cephadm
+mv /tmp/cephadm /usr/local/bin/
+
+# Verify cephadm version
+cephadm version
+# Check that cephadm version starts with 'cephadm version 20.'
+if ! cephadm version | grep -q '^cephadm version 20\.'; then
+  echo "Error: cephadm version is not 20.x"
+  exit 1
+fi
+
+# Get the node IP address
+NODE_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
+echo "Node IP address: ${NODE_IP}"
+
+# Check if Bootstrap is already done
+if cephadm shell -- ceph health &> /dev/null; then
+    echo "Ceph cluster is already bootstrapped."
+else
+    echo "Ceph cluster is not bootstrapped yet. Proceeding with bootstrap."
+    # Bootstrap the Ceph cluster (skip monitoring stack)
+    cephadm bootstrap --mon-ip ${NODE_IP} --skip-monitoring-stack
+fi
+
+if cephadm shell -- ceph health | grep -qE 'HEALTH_OK|HEALTH_WARN'; then
+    echo "Cluster is operational (OK or WARN)."
+else
+    echo "Cluster is in a critical state (HEALTH_ERR)."
+    exit 1
+fi
+
+# Get the ceph keyring
+KEY=$(cephadm shell -- ceph auth get-key client.bootstrap-osd)
+
+# Create bootstrap keyring
+mkdir -p /var/lib/ceph/bootstrap-osd
+cat <<EOF > /var/lib/ceph/bootstrap-osd/ceph.keyring
+[client.bootstrap-osd]
+    key = $KEY
+    caps mon = "allow profile bootstrap-osd"
+EOF
+
+# Set permissions
+chown root:root /var/lib/ceph/bootstrap-osd/ceph.keyring
+chmod 644 /var/lib/ceph/bootstrap-osd/ceph.keyring
+
+echo "Bootstrap the Ceph cluster (skip monitoring stack) completed successfully."

--- a/scripts/bash/install_minimal_ceph_cluster.sh
+++ b/scripts/bash/install_minimal_ceph_cluster.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
+CEPHADM_URL="https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm"
+CEPHADM_VERSION_MAJOR="20"
+
 # Download cephadm
-curl -fsSL "https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm" -o /tmp/cephadm
+curl -fsSL "$CEPHADM_URL" -o /tmp/cephadm
 # Make it executable and move to PATH
 chmod +x /tmp/cephadm
 mv /tmp/cephadm /usr/local/bin/
 
 # Verify cephadm version
 cephadm version
-# Check that cephadm version starts with 'cephadm version 20.'
-if ! cephadm version | grep -q '^cephadm version 20\.'; then
-  echo "Error: cephadm version is not 20.x"
+# Check that cephadm version starts with the expected major version
+if ! cephadm version | grep -q "^cephadm version ${CEPHADM_VERSION_MAJOR}\."; then
+  echo "Error: cephadm version is not ${CEPHADM_VERSION_MAJOR}.x"
   exit 1
 fi
 

--- a/scripts/bash/install_minimal_ceph_conf.sh
+++ b/scripts/bash/install_minimal_ceph_conf.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+ if [ "$#" -ne 3 ]; then
+   echo "Usage: $0 <fsid> <bootstrap-osd-key> <mon_host>"
+   exit 1
+ fi
+
+ fsid="$1"
+ key="$2"
+ host_node_ip="$3"
+
+ if [ -z "$fsid" ] || [ -z "$key" ] || [ -z "$host_node_ip" ]; then
+   echo "None of the arguments can be empty."
+   exit 1
+ fi
+
+# Download cephadm
+curl -fsSL "https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm" -o /tmp/cephadm
+# Make it executable and move to PATH
+chmod +x /tmp/cephadm
+mv /tmp/cephadm /usr/local/bin/
+
+# Verify cephadm version
+cephadm version
+# Check that cephadm version starts with 'cephadm version 20.'
+if ! cephadm version | grep -q '^cephadm version 20\.'; then
+  echo "Error: cephadm version is not 20.x"
+  exit 1
+fi
+
+# Create ceph.conf
+mkdir -p /etc/ceph
+cat <<EOF > /etc/ceph/ceph.conf
+[global]
+fsid = $fsid
+mon_host = $host_node_ip
+EOF
+
+# Create bootstrap keyring
+mkdir -p /var/lib/ceph/bootstrap-osd
+cat <<EOF > /var/lib/ceph/bootstrap-osd/ceph.keyring
+[client.bootstrap-osd]
+    key = $key
+    caps mon = "allow profile bootstrap-osd"
+EOF
+
+# Set permissions
+chown root:root /var/lib/ceph/bootstrap-osd/ceph.keyring
+chmod 644 /var/lib/ceph/bootstrap-osd/ceph.keyring
+
+echo "Minimal Ceph configuration and bootstrap keyring created successfully."

--- a/scripts/bash/install_minimal_ceph_conf.sh
+++ b/scripts/bash/install_minimal_ceph_conf.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+CEPHADM_URL="https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm"
+CEPHADM_VERSION_MAJOR="20"
+
  if [ "$#" -ne 3 ]; then
    echo "Usage: $0 <fsid> <bootstrap-osd-key> <mon_host>"
    exit 1
@@ -16,16 +19,16 @@ set -euo pipefail
  fi
 
 # Download cephadm
-curl -fsSL "https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm" -o /tmp/cephadm
+curl -fsSL "$CEPHADM_URL" -o /tmp/cephadm
 # Make it executable and move to PATH
 chmod +x /tmp/cephadm
 mv /tmp/cephadm /usr/local/bin/
 
 # Verify cephadm version
 cephadm version
-# Check that cephadm version starts with 'cephadm version 20.'
-if ! cephadm version | grep -q '^cephadm version 20\.'; then
-  echo "Error: cephadm version is not 20.x"
+# Check that cephadm version starts with the expected major version
+if ! cephadm version | grep -q "^cephadm version ${CEPHADM_VERSION_MAJOR}\."; then
+  echo "Error: cephadm version is not ${CEPHADM_VERSION_MAJOR}.x"
   exit 1
 fi
 

--- a/scripts/bash/simulate_bluestore_label.sh
+++ b/scripts/bash/simulate_bluestore_label.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
-
 set -euo pipefail
 
-DEVICE="$1"
-VERIFY_DISK_EMPTY="${2:-true}"  # optional second argument (default: true)
+DEVICE="${1:-}"
+TAG="${2:-}"                     # Optional: Ceph container tag
+VERIFY_DISK_EMPTY="${3:-true}"   # Optional: verify disk is empty
 
+# Stage 0 — Argument validation
 if [[ -z "$DEVICE" ]]; then
-    echo "Usage: $0 /dev/sdX [verify_disk_empty:true|false]"
+    echo "Usage: $0 /dev/sdX <ceph_tag> [verify_disk_empty:true|false]"
     exit 1
 fi
-echo ">>> Running BlueStore label simulation on $DEVICE"
+
+# If TAG not provided, auto-detect from cephadm
+if [[ -z "$TAG" ]]; then
+    detected_tag="v$(cephadm version | awk '/cephadm version/ {print $3}')"
+    echo ">>> No TAG specified, using detected version: $detected_tag"
+    TAG="$detected_tag"
+fi
+
+echo ">>> Simulating BlueStore label on $DEVICE"
+echo ">>> Ceph image tag: $TAG"
 echo ">>> Verify disk empty: $VERIFY_DISK_EMPTY"
 
-# Stage 0 — Optional disk emptiness verification
+# Stage 1 — Optional disk emptiness check
 if [[ "$VERIFY_DISK_EMPTY" == "true" ]]; then
     echo ">>> Precheck: Verifying device is empty (first 22 bytes)..."
     if dd if="$DEVICE" bs=1 count=22 status=none | tr -d '\000' | grep -q .; then
@@ -22,54 +32,40 @@ if [[ "$VERIFY_DISK_EMPTY" == "true" ]]; then
     fi
 fi
 
-# Stage 1 — Prechecks
-echo ">>> Precheck: Validating device..."
-
+# Stage 2 — Device validation
 [ -b "$DEVICE" ] || { echo "ERROR: $DEVICE is not a block device"; exit 1; }
 [ "$(lsblk -no TYPE "$DEVICE")" = "disk" ] || { echo "ERROR: $DEVICE is not a whole disk"; exit 1; }
 [ "$(blockdev --getro "$DEVICE")" -eq 0 ] || { echo "ERROR: $DEVICE is read-only"; exit 1; }
 
-# Stage 2 — Prepare disk
-echo ">>> Preparing disk (wiping signatures and partition table)..."
+# Stage 3 — Disk cleanup
+echo ">>> Cleaning disk signatures and partition table..."
 sgdisk -Z "$DEVICE" || true
 wipefs -a "$DEVICE" || true
 blockdev --rereadpt "$DEVICE" || true
 udevadm settle || true
 
-# Stage 3 — Write BlueStore label
-echo ">>> Writing BlueStore label..."
-UUID=$(cat /proc/sys/kernel/random/uuid)
 
-# Build the label reliably with trailing newline preserved
-LC_ALL=C printf -v LABEL 'bluestore block device\n%.36s\n' "$UUID"
-LEN=$(printf '%s' "$LABEL" | wc -c)
+## Stage 4 — Simulate BlueStore label using ceph-volume
+echo ">>> Simulating BlueStore label using ceph-volume..."
+podman run --rm --privileged --net=host \
+  -v /dev:/dev \
+  -v /sys:/sys \
+  -v /run/udev:/run/udev:ro \
+  -v /etc/ceph:/etc/ceph:ro \
+  -v /var/lib/ceph/bootstrap-osd:/var/lib/ceph/bootstrap-osd:ro \
+  quay.io/ceph/ceph:$TAG \
+  ceph-volume --log-path /tmp/ceph-log \
+    raw prepare --bluestore --data "$DEVICE" --crush-device-class ssd
 
-echo "Label length: $LEN"
-if [[ "$LEN" -ne 60 ]]; then
-    echo "ERROR: Label length=$LEN (expected 60)"
-    echo "LABEL content (hex):"
-    printf '%s' "$LABEL" | hexdump -C
-    exit 1
-fi
+## Stage 5 — Verification
+echo ">>> Verifying with ceph-volume..."
+podman run --rm --privileged --net=host \
+  -v /dev:/dev \
+  -v /sys:/sys \
+  -v /run/udev:/run/udev:ro \
+  -v /etc/ceph:/etc/ceph:ro \
+  -v /var/lib/ceph:/var/lib/ceph:ro \
+  quay.io/ceph/ceph:$TAG \
+  ceph-volume raw list "$DEVICE" --format json
 
-printf '%s' "$LABEL" | dd of="$DEVICE" bs=1 seek=0 conv=notrunc,fsync status=none
-blockdev --flushbufs "$DEVICE" || true
-udevadm settle || true
-
-echo ">>> Label stamped: $DEVICE:$UUID"
-
-# Stage 4 — Verify label
-echo ">>> Verifying label..."
-VERIFY_OK=1
-head -c 22 "$DEVICE" | grep -qx 'bluestore block device' || VERIFY_OK=0
-[ "$(dd if="$DEVICE" bs=1 count=60 status=none | wc -c)" -eq 60 ] || VERIFY_OK=0
-
-if [[ "$VERIFY_OK" -eq 1 ]]; then
-    echo ">>> Verification PASSED"
-    echo ">>> BlueStore UUID: $UUID"
-else
-    echo ">>> Verification FAILED"
-    echo ">>> Hexdump of first 60 bytes:"
-    hexdump -C -n 60 -s 0 "$DEVICE" || true
-    exit 1
-fi
+echo ">>> BlueStore simulation complete."

--- a/scripts/bash/simulate_bluestore_label.sh
+++ b/scripts/bash/simulate_bluestore_label.sh
@@ -53,7 +53,7 @@ podman run --rm --privileged --net=host \
   -v /run/udev:/run/udev:ro \
   -v /etc/ceph:/etc/ceph:ro \
   -v /var/lib/ceph/bootstrap-osd:/var/lib/ceph/bootstrap-osd:ro \
-  quay.io/ceph/ceph:$TAG \
+  quay.io/ceph/ceph:"$TAG" \
   ceph-volume --log-path /tmp/ceph-log \
     raw prepare --bluestore --data "$DEVICE" --crush-device-class ssd
 
@@ -65,7 +65,7 @@ podman run --rm --privileged --net=host \
   -v /run/udev:/run/udev:ro \
   -v /etc/ceph:/etc/ceph:ro \
   -v /var/lib/ceph:/var/lib/ceph:ro \
-  quay.io/ceph/ceph:$TAG \
+  quay.io/ceph/ceph:"$TAG" \
   ceph-volume raw list "$DEVICE" --format json
 
 echo ">>> BlueStore simulation complete."

--- a/scripts/python/checks/validate_retry_usage.py
+++ b/scripts/python/checks/validate_retry_usage.py
@@ -75,8 +75,6 @@ class RetryValidator(ast.NodeVisitor):
         """Evaluate a constant value from an AST node."""
         if isinstance(node, ast.Constant):
             return node.value
-        if isinstance(node, ast.Num):
-            return node.n
         return default
 
 

--- a/tests/libtest/test_simulate_ceph_bluestore_label.py
+++ b/tests/libtest/test_simulate_ceph_bluestore_label.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 from ocs_ci.framework.testlib import (
     ManageTest,
     ignore_leftovers,
@@ -7,8 +9,11 @@ from ocs_ci.framework.testlib import (
     brown_squad,
     skipif_no_lso,
 )
-from ocs_ci.deployment.baremetal import simulate_ceph_bluestore_on_node_disk
-from ocs_ci.ocs.node import get_nodes
+
+from ocs_ci.framework import config
+from ocs_ci.deployment.helpers.ceph_cluster import (
+    simulate_full_ceph_bluestore_process_on_wnodes,
+)
 
 log = logging.getLogger(__name__)
 
@@ -27,11 +32,7 @@ class TestSimulateCephBlueStoreLabel(ManageTest):
         Test simulates a Ceph BlueStore label on the worker node disks.
 
         """
-        results = []
-        wnodes = get_nodes()
-        for wnode in wnodes:
-            result = simulate_ceph_bluestore_on_node_disk(wnode)
-            results.append(result)
-
-        assert all(results), "BlueStore label simulation failed"
-        log.info("BlueStore label simulation succeeded ")
+        if not config.ENV_DATA.get("simulate_bluestore_label", False):
+            pytest.skip("simulate_bluestore_label not set in config")
+        simulate_full_ceph_bluestore_process_on_wnodes()
+        log.info("BlueStore label simulation succeeded on all worker nodes disks")

--- a/tests/libtest/test_simulate_ceph_bluestore_label.py
+++ b/tests/libtest/test_simulate_ceph_bluestore_label.py
@@ -34,5 +34,6 @@ class TestSimulateCephBlueStoreLabel(ManageTest):
         """
         if not config.ENV_DATA.get("simulate_bluestore_label", False):
             pytest.skip("simulate_bluestore_label not set in config")
-        simulate_full_ceph_bluestore_process_on_wnodes()
+        result = simulate_full_ceph_bluestore_process_on_wnodes()
+        assert result, "BlueStore label simulation failed on worker nodes"
         log.info("BlueStore label simulation succeeded on all worker nodes disks")


### PR DESCRIPTION
This PR introduces functionality to simulate Ceph BlueStore labels on disks during Local Storage Operator (LSO) deployment. It adds new helper methods and scripts to enable testing scenarios where disks appear as Ceph OSD devices, ensuring that LSO correctly handles such cases.
Key Changes:

Deployment Enhancements:

- Added `simulate_bluestore_label` flag in `ENV_DATA` to trigger BlueStore simulation during LSO setup.
- Integrated `simulate_ceph_bluestore_on_node_disk` into the deployment workflow.


Baremetal Utilities:

- Implemented disk detection improvements to support both /dev/sd* and NVMe devices.
- Added functions for installing and removing minimal Ceph clusters and configurations on worker nodes.
- Added utilities to clear BlueStore signatures and manage Ceph bootstrap keys.


Scripts:

- `install_minimal_ceph_cluster.sh`: Bootstraps a minimal Ceph cluster using cephadm.
- `install_minimal_ceph_conf.sh`: Creates minimal Ceph configuration and bootstrap keyring.
- Enhanced `simulate_bluestore_label.sh` to use ceph-volume for realistic BlueStore label simulation.


Tests:

Updated `test_simulate_ceph_bluestore_label.py` to validate new simulation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional pre-deploy simulation of Ceph OSD BlueStore metadata across worker nodes, including an orchestrated end-to-end simulation and node-level helpers to run/upload scripts.
  * Local Storage setup can now skip adding new disks when simulation is enabled.

* **Documentation**
  * README option added to enable simulation (simulate_bluestore_label, default: false).

* **Tests**
  * End-to-end test updated to run and assert the full simulation flow when enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/13799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->