### PR TITLE
Fixed keyrotation test failure

### DIFF
--- a/ocs_ci/helpers/keyrotation_helper.py
+++ b/ocs_ci/helpers/keyrotation_helper.py
@@ -665,6 +665,17 @@ class PVKeyrotation(KeyRotation):
         log.info("Completed key rotation state changes for all specified PVCs.")
         return True
 
+    def reset_keyrotation_baseline(self):
+        """
+        Resets the baseline key data for key rotation verification.
+        This should be called after re-enabling key rotation to ensure
+        the baseline is captured after re-enabling, not before.
+        """
+        self.all_pvc_key_data = None
+        log.info(
+            "Reset key rotation baseline - will capture new baseline on next verification."
+        )
+
     @retry(UnexpectedBehaviour, tries=10, delay=10)
     def wait_for_keyrotation_cronjobs_recreation(self, pvc_objs):
         """

--- a/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py
@@ -150,6 +150,9 @@ class TestDisablePVKeyrotationOperation(PVKeyrotationTestBase):
         ), "Failed to recreate key rotation cronjobs after re-enabling."
         log.info("Key rotation cronjobs successfully recreated and active.")
 
+        # Reset baseline to capture keys after re-enabling, before waiting for rotation
+        self.pv_keyrotation_obj.reset_keyrotation_baseline()
+
         # Verify key rotation cronjobs are recreated and keys are rotated
         assert self.pv_keyrotation_obj.wait_till_all_pv_keyrotation_on_vault_kms(
             self.pvc_objs
@@ -189,6 +192,9 @@ class TestDisablePVKeyrotationOperation(PVKeyrotationTestBase):
             self.pvc_objs, disable=False
         )
         log.info("Key rotation re-enabled for specific PVCs.")
+
+        # Reset baseline to capture keys after re-enabling, before waiting for rotation
+        self.pv_keyrotation_obj.reset_keyrotation_baseline()
 
         # Verify key rotation cronjobs are recreated
         assert self.pv_keyrotation_obj.wait_till_all_pv_keyrotation_on_vault_kms(


### PR DESCRIPTION
Fix for the issue : https://github.com/red-hat-storage/ocs-ci/issues/13808
When re-enabling PV key rotation via storage class annotation in tests, wait_till_all_pv_keyrotation_on_vault_kms immediately initializes its baseline with the current keys and then compares the new keys to that same baseline that causing an UnexpectedBehaviour: PVC keys have not rotated yet. exception and a false test failure.