### PR TITLE
Fixing test_overprovision_level_policy_control_with_capacity

### DIFF
--- a/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
+++ b/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
@@ -6,7 +6,12 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
-from ocs_ci.helpers.helpers import verify_quota_resource_exist
+from ocs_ci.helpers.helpers import (
+    verify_quota_resource_exist,
+    create_unique_resource_name,
+    wait_for_quota_usage_update,
+    verify_substrings_in_string,
+)
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.framework.testlib import (
@@ -24,11 +29,14 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(autouse=True, scope="class")
 def setup_sc(storageclass_factory_class):
+    sc_blk_name = create_unique_resource_name("test-blk", "sc")
+    sc_fs_name = create_unique_resource_name("test-fs", "sc")
+
     sc_fs_obj = storageclass_factory_class(
-        interface=constants.CEPHFILESYSTEM, sc_name="sc-test-fs"
+        interface=constants.CEPHFILESYSTEM, sc_name=sc_fs_name
     )
     sc_blk_obj = storageclass_factory_class(
-        interface=constants.CEPHBLOCKPOOL, sc_name="sc-test-blk"
+        interface=constants.CEPHBLOCKPOOL, sc_name=sc_blk_name
     )
     return {
         constants.CEPHBLOCKPOOL_SC: None,
@@ -116,14 +124,12 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             9.Create New PVC with 1G capacity and verify it is working [8Gi > 1Gi + 6Gi]
 
         """
+        # Quota names for default storage classes (these have fixed names)
         quota_names = {
             constants.CEPHBLOCKPOOL_SC: "ocs-storagecluster-ceph-rbd-quota-sc-test",
             constants.CEPHFILESYSTEM_SC: "ocs-storagecluster-cephfs-quota-sc-test",
-            "sc-test-blk": "sc-test-blk-quota-sc-test",
-            "sc-test-fs": "sc-test-fs-quota-sc-test",
         }
-        self.quota_name = quota_names[sc_name]
-        log.info("Create project with “openshift-quota” label")
+        log.info('Create project with "openshift-quota" label')
         project_name = "ocs-quota-sc-test"
         ocp_project_label = OCP(kind=constants.NAMESPACE)
         ocp_project_label.new_project(project_name=project_name)
@@ -135,13 +141,28 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
 
         sc_obj = setup_sc.get(sc_name)
 
+        # Get the actual storage class name (may have random suffix for sc-test-blk/sc-test-fs)
+        actual_sc_name = sc_obj.name if sc_obj else sc_name
+
+        # Construct quota name based on actual storage class name
+        if sc_name in [constants.CEPHBLOCKPOOL_SC, constants.CEPHFILESYSTEM_SC]:
+            self.quota_name = quota_names[sc_name]
+        else:
+            # For sc-test-blk and sc-test-fs, construct quota name from actual SC name
+            self.quota_name = f"{actual_sc_name}-quota-sc-test"
+
+        # Store the quota key format which includes the storage class name
+        self.quota_key = (
+            f"{actual_sc_name}.storageclass.storage.k8s.io/requests.storage"
+        )
+
         log.info("Add 'overprovisionControl' section to storagecluster yaml file")
         storagecluster_obj = OCP(
             resource_name=constants.DEFAULT_CLUSTERNAME,
             namespace=config.ENV_DATA["cluster_namespace"],
             kind=constants.STORAGECLUSTER,
         )
-        sc_name_str = f'"{sc_name}"'
+        sc_name_str = f'"{actual_sc_name}"'
         params = (
             '{"spec": {"overprovisionControl": [{"capacity": "8Gi","storageClassName":'
             + sc_name_str
@@ -161,24 +182,56 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             timeout=60,
             sleep=4,
             func=verify_quota_resource_exist,
-            quota_name=quota_names[sc_name],
+            quota_name=self.quota_name,
         )
         if not sample.wait_for_func_status(result=True):
             err_str = (
-                f"Quota resource {quota_names[sc_name]} does not exist "
-                f"after 60 seconds {clusterresourcequota_obj.describe()}"
+                f"Quota resource {self.quota_name} does not exist after 60 seconds"
             )
             log.error(err_str)
             raise TimeoutExpiredError(err_str)
 
-        log.info("Check clusterresourcequota output")
-        output_clusterresourcequota = clusterresourcequota_obj.describe(
-            resource_name=quota_names[sc_name]
+        log.info("Waiting for clusterresourcequota hard limit to be set")
+        # Wait for the hard limit to be properly configured
+        sample = TimeoutSampler(
+            timeout=120,
+            sleep=5,
+            func=clusterresourcequota_obj.get,
+            resource_name=self.quota_name,
         )
-        log.info(f"Output Cluster Resource Quota: {output_clusterresourcequota}")
-        assert self.verify_substrings_in_string(
-            output_string=output_clusterresourcequota, expected_strings=["8Gi", "0"]
-        ), f"{output_clusterresourcequota}\n expected string does not exist."
+        quota_resource = None
+        for quota_resource in sample:
+            try:
+                hard = quota_resource.get("spec", {}).get("quota", {}).get("hard", {})
+                hard_storage = hard.get(self.quota_key, "0")
+                log.info(
+                    f"Checking quota {self.quota_name}, hard limit: {hard_storage}"
+                )
+                if hard_storage == "8Gi":
+                    log.info("Hard limit is correctly set to 8Gi")
+                    break
+            except (KeyError, AttributeError) as e:
+                log.warning(f"Failed to parse quota resource: {e}")
+                continue
+        else:
+            err_str = f"Quota resource {self.quota_name} hard limit was not set to 8Gi after 120 seconds"
+            log.error(err_str)
+            raise TimeoutExpiredError(err_str)
+
+        # Extract quota values for final verification
+        used = quota_resource.get("status", {}).get("total", {}).get("used", {})
+        hard = quota_resource.get("spec", {}).get("quota", {}).get("hard", {})
+        used_storage = used.get(self.quota_key, "0")
+        hard_storage = hard.get(self.quota_key, "0")
+
+        log.info(
+            f"Cluster Resource Quota {self.quota_name}: "
+            f"used={used_storage}, hard={hard_storage}"
+        )
+        assert verify_substrings_in_string(
+            output_string=f"{used_storage} {hard_storage}",
+            expected_strings=["8Gi", "0"],
+        ), f"Expected strings not found. Used: {used_storage}, Hard: {hard_storage}"
 
         log.info("Create 5Gi pvc on project ocs-quota-sc-test")
         pvc_obj = pvc_factory(
@@ -188,14 +241,13 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             size=5,
             status=constants.STATUS_BOUND,
         )
-        output_clusterresourcequota = clusterresourcequota_obj.describe(
-            resource_name=quota_names[sc_name]
+        wait_for_quota_usage_update(
+            clusterresourcequota_obj,
+            self.quota_name,
+            self.quota_key,
+            ["5Gi", "8Gi"],
+            "PVC creation",
         )
-        log.info(f"Output Cluster Resource Quota: {output_clusterresourcequota}")
-        assert self.verify_substrings_in_string(
-            output_string=output_clusterresourcequota,
-            expected_strings=["5Gi", "8Gi"],
-        ), f"{output_clusterresourcequota}\n expected string does not exist."
         pod_factory(
             interface=sc_type,
             pvc=pvc_obj,
@@ -214,7 +266,7 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             )
         except Exception as e:
             log.info(e)
-            assert self.verify_substrings_in_string(
+            assert verify_substrings_in_string(
                 output_string=str(e), expected_strings=["5Gi", "6Gi", "8Gi"]
             ), f"The error does not contain strings:{str(e)}"
 
@@ -223,19 +275,19 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             pvc_obj.resize_pvc(new_size=20, verify=True)
         except Exception as e:
             log.info(e)
-            assert self.verify_substrings_in_string(
+            assert verify_substrings_in_string(
                 output_string=str(e), expected_strings=["15Gi", "5Gi", "8Gi"]
             ), f"The error does not contain strings:{str(e)}"
 
         log.info("Resize the PVC to 6Gi and verify it is working [8Gi > 6Gi]")
         pvc_obj.resize_pvc(new_size=6, verify=True)
-        output_clusterresourcequota = clusterresourcequota_obj.describe(
-            resource_name=quota_names[sc_name]
+        wait_for_quota_usage_update(
+            clusterresourcequota_obj,
+            self.quota_name,
+            self.quota_key,
+            ["8Gi", "6Gi"],
+            "PVC resize",
         )
-        log.info(f"Output Cluster Resource Quota: {output_clusterresourcequota}")
-        assert self.verify_substrings_in_string(
-            output_string=output_clusterresourcequota, expected_strings=["8Gi", "6Gi"]
-        ), f"{output_clusterresourcequota}\n expected string does not exist."
 
         log.info(
             "Create New PVC with 1G capacity and verify it is working [8Gi > 1Gi + 6Gi]"
@@ -246,29 +298,10 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             storageclass=sc_obj,
             size=1,
         )
-        output_clusterresourcequota = clusterresourcequota_obj.describe(
-            resource_name=quota_names[sc_name]
+        wait_for_quota_usage_update(
+            clusterresourcequota_obj,
+            self.quota_name,
+            self.quota_key,
+            ["8Gi", "7Gi"],
+            "new PVC creation",
         )
-
-        log.info(f"Output Cluster Resource Quota: {output_clusterresourcequota}")
-        assert self.verify_substrings_in_string(
-            output_string=output_clusterresourcequota, expected_strings=["8Gi", "7Gi"]
-        ), f"{output_clusterresourcequota}\n expected string does not exist."
-
-    def verify_substrings_in_string(self, output_string, expected_strings):
-        """
-        Verify substrings in string
-
-        Args:
-           output_string (str): the output of cmd
-           expected_strings (list) : list of strings
-
-        Returns:
-            bool: return True if all expected_strings in output_string, otherwise False
-
-        """
-        for expected_string in expected_strings:
-            if expected_string not in output_string:
-                log.error(f"expected string:{expected_string} not in {output_string}")
-                return False
-        return True


### PR DESCRIPTION
This is FIx for the issue : https://github.com/red-hat-storage/ocs-ci/issues/13803

A test that creates a StorageClass (sc-test-blk) fails with AlreadyExists when an older test run left the same StorageClass behind. The automation does not check for pre-existing resources before calling oc create, causing CI failures and test instability.