### PR TITLE
verify_last_heartbeat_timestamp-skip-if-no-odf

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1844,
+        "line_number": 2207,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -1058,7 +1058,8 @@ class HostedClients(HyperShiftBase):
 
         heartbeat_stable = []
         for cluster_name in cluster_names:
-            heartbeat_stable.append(verify_last_heartbeat_timestamp(cluster_name))
+            if storage_installation_requested(cluster_name):
+                heartbeat_stable.append(verify_last_heartbeat_timestamp(cluster_name))
 
         assert (
             hosted_ocp_verification_passed


### PR DESCRIPTION
remove heartbeat validation when ODF is not set on clients.\
By default we are passing same set of validations when ODF installed and not installed and originally we forgot to include skip logic for this validation.