### PR TITLE
Verify RBD Block PVC Monitoring Metrics (Happy Path)

### DIFF
--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -64,7 +64,9 @@ def test_block_pvc_kubelet_metrics_match_rbd_usage(
     dev_path = "/dev/rbdblock"
 
     # Write sample data using dd
-    dd_cmd_str = f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} oflag=direct"
+    dd_cmd_str = (
+        f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} oflag=direct"
+    )
     logger.info(
         f"Writing {write_size_mib} MiB to device {dev_path} inside pod {pod_obj.name}"
     )


### PR DESCRIPTION
As part of new testcase - test_block_pvc_kubelet_metrics_match_rbd_usage, we will be performing the below steps

1. Create a Block PVC and a Pod that consumes the block device.
2. Exec into the Pod and write sample data directly to the block device with dd.
3. Query kubelet metrics (kubelet_volume_stats_*) and capture used bytes.
4. Run `rbd du` from Ceph toolbox pod and compare the reported used bytes.

JIRA: https://issues.redhat.com/browse/OCSQE-4207