### PR TITLE
skip test_detach_attach_worker_volume for ROSA HCP

### DIFF
--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -142,6 +142,7 @@ class TestDiskFailures(ManageTest):
         """
         self.sanity_helpers = Sanity()
 
+    @skipif_rosa_hcp
     @skipif_managed_service
     @skipif_ibm_cloud
     @skipif_hci_provider_and_client


### PR DESCRIPTION
Resolution on a bug [[ROSA HCP] Fail re-attach worker volume automatically](https://issues.redhat.com/browse/DFBUGS-1038) was to skip testing detach/attach worker volume. User is not able to change ec2 instances via aws console. 