### PR TITLE
Fixes content check in boto response

### DIFF
--- a/tests/functional/object/mcg/test_write_to_bucket.py
+++ b/tests/functional/object/mcg/test_write_to_bucket.py
@@ -445,7 +445,7 @@ class TestBucketIO(MCGTest):
             s3_obj=mcg_obj_session, bucketname=bucket_name, object_key=f"{filename}"
         )
         assert (
-            head_obj["ContentEncoding"] == "zip"
+            "zip" in head_obj["ContentEncoding"]
         ), "Put object operation doesn't store ContentEncoding!!"
         logger.info(
             "Put object operation is preserving ContentEncoding as a object metadata"


### PR DESCRIPTION
Fixes content check in boto response

Latest boto response has `zip,aws-chunked` in content type where as previously script was checking only for `zip` using == operator

Fixes https://github.com/red-hat-storage/ocs-ci/issues/13458
