### PR TITLE
Added S3 and OBC bucket creation via UI before comparison

### DIFF
--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -523,6 +523,7 @@ class TestBucketCreate:
         bucket_ui.create_bucket_ui("s3")
         bucket_ui.nav_object_storage_page()
         bucket_ui.create_bucket_ui("obc")
+        bucket_ui.nav_object_storage_page()
 
         bucket_ui.nav_buckets_page()
 


### PR DESCRIPTION
test_bucket_list_comparison required test_bucket_create as prerequisite, but tests are in different tiers

- [x] Added S3 and OBC bucket creation via UI before comparison 