### PR TITLE
catch destroy applience cluster 404

### DIFF
--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -806,6 +806,8 @@ def get_rosa_cluster_service_id(cluster):
     return cluster_service_info
 
 
+# with 1.2.53 rosa list service or delete service command return 404, we catch this exception and later deprecate
+@catch_exceptions(CommandFailed)
 def destroy_appliance_mode_cluster(cluster):
     """
     Delete rosa cluster if appliance mode


### PR DESCRIPTION
Fixes: #13872

The function destroy_appliance_mode_cluster was a leftover on managed-service destroy job. We utilized that until 4.20 and this issue did not appear. The problem is that this api call is now either deprecated or broken. So the safer solution will be to preserve this function and try to call it and later remove it or adjust, by necessity.