### PR TITLE
BucketNotificationsManager: Increase the sleep time after put_bucket_notification

### DIFF
--- a/ocs_ci/ocs/resources/bucket_notifications_manager.py
+++ b/ocs_ci/ocs/resources/bucket_notifications_manager.py
@@ -332,7 +332,7 @@ class BucketNotificationsManager:
         )
         if wait:
             logger.info("Waiting for put-bucket-notification to propagate")
-            sleep(60)
+            sleep(90)
 
     def get_bucket_notification_configuration(self, awscli_pod, mcg_obj, bucket):
         """


### PR DESCRIPTION
MCG bucket notifications tests have been sometimes failing with exactly one notification missing. For example in https://url.corp.redhat.com/2d45338:
```
E           ocs_ci.ocs.exceptions.TimeoutExpiredError: Some PutObject events were not received by Kafka: {'ObjKey-0'}
```
When we check the noobaa-endpoint logs in these runs, we can see that the missing notification is always of the first object who's put-operation was processed first. Fore example, in the above run:
```
$ ls -1
noobaa-endpoint-6699d86596-hjxd8.log
noobaa-endpoint-6699d86596-z9wfg.log

$ grep -e "s3_put_object.*ObjKey-" -R | head -n 3
./noobaa-endpoint-6699d86596-hjxd8.log:Dec-2 19:16:10.334 [Endpoint/8]    [L0] core.endpoint.s3.ops.s3_put_object:: PUT OBJECT s3-bucket-c05f4bb3801a4810a6b9775fd43dca ObjKey-0
./noobaa-endpoint-6699d86596-hjxd8.log:Dec-2 19:16:10.380 [Endpoint/8]    [L0] core.endpoint.s3.ops.s3_put_object:: PUT OBJECT s3-bucket-c05f4bb3801a4810a6b9775fd43dca ObjKey-11
./noobaa-endpoint-6699d86596-hjxd8.log:Dec-2 19:16:10.384 [Endpoint/8]    [L0] core.endpoint.s3.ops.s3_put_object:: PUT OBJECT s3-bucket-c05f4bb3801a4810a6b9775fd43dca ObjKey-12
```
Operations are logged only if the endpoint pods have the needed notifications config, but it looks like sometimes we're hitting their cache that still have the old state without this configuration.

By default, this cache's TTL (time-to-live) is 60 seconds: https://github.com/noobaa/noobaa-core/blob/master/config.js/#L669

By waiting a bit longer, we'll at least see if this was because of race-condition with this TTL.