### PR TITLE
Increase NooBaa's logging level for flaky tests 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8356,8 +8356,23 @@ def ceph_monstore_tool_fixture(request):
     return mot_obj
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
+def change_the_noobaa_log_level_class(request):
+    """
+    Class-scoped fixture for changing the noobaa log level
+    """
+    return change_the_noobaa_log_level_fixture(request)
+
+
+@pytest.fixture(scope="function")
 def change_the_noobaa_log_level(request):
+    """
+    Function-scoped fixture for changing the noobaa log level
+    """
+    return change_the_noobaa_log_level_fixture(request)
+
+
+def change_the_noobaa_log_level_fixture(request):
     """
     This fixture helps you set the noobaa log level to any of these ["all", "nsfs", "default_level"]
     """

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -51,11 +51,11 @@ class TestBucketNotifications(MCGTest):
 
     # TODO: Remove when https://github.com/red-hat-storage/ocs-ci/issues/13893 is closed
     @pytest.fixture(scope="class", autouse=True)
-    def increase_noobaa_logging_level(self, change_the_noobaa_log_level):
+    def increase_noobaa_logging_level(self, change_the_noobaa_log_level_class):
         """
         A fixture to set the noobaa log level to all.
         """
-        change_the_noobaa_log_level(level="all")
+        change_the_noobaa_log_level_class(level="all")
 
     @pytest.fixture(autouse=True, scope="class")
     def notif_manager(self, request, pvc_factory_class):

--- a/tests/functional/object/mcg/test_log_based_bucket_replication.py
+++ b/tests/functional/object/mcg/test_log_based_bucket_replication.py
@@ -51,11 +51,11 @@ class TestLogBasedBucketReplication(MCGTest):
 
     # TODO: Remove when https://github.com/red-hat-storage/ocs-ci/issues/13893 is closed
     @pytest.fixture(scope="class", autouse=True)
-    def increase_noobaa_logging_level(self, change_the_noobaa_log_level):
+    def increase_noobaa_logging_level(self, change_the_noobaa_log_level_class):
         """
         A fixture to set the noobaa log level to all.
         """
-        change_the_noobaa_log_level(level="all")
+        change_the_noobaa_log_level_class(level="all")
 
     @pytest.fixture(scope="class", autouse=True)
     def reduce_replication_delay_setup(self, add_env_vars_to_noobaa_core_class):


### PR DESCRIPTION
To fix https://github.com/red-hat-storage/ocs-ci/issues/13823, we higher-level logs to appear in the must-gather logs of when the issue occurs: https://github.com/noobaa/noobaa-core/blob/master/src/endpoint/s3/s3_bucket_logging.js/#L11-L52

The same applies for: https://github.com/red-hat-storage/ocs-ci/issues/13893, where we could get a better understanding if we see the following logs in the must-gather:
https://github.com/noobaa/noobaa-core/blob/master/src/server/bg_services/log_replication_scanner.js/#L144-L145