### PR TITLE
[release-4.14] Restore RGW client data prefix and refactor cloud manager + Cloud Manager init: account for the case where AWS credentials are not provided 

### DIFF
--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -37,12 +37,16 @@ class CloudManager(ABC):
     """
 
     def __init__(self):
+        """
+        Constructor for the CloudManager class
+
+        """
         cloud_map = {
-            "AWS": S3Client,
+            "AWS": AwsClient,
             "GCP": GoogleClient,
             "AZURE": AzureClient,
-            "IBMCOS": S3Client,
-            "RGW": S3Client,
+            "IBMCOS": IbmCosClient,
+            "RGW": RgwClient,
         }
         try:
             logger.info(
@@ -77,23 +81,20 @@ class CloudManager(ABC):
                     if not any(
                         value is None for value in cred_dict[cloud_name].values()
                     ):
-                        setattr(
-                            self,
-                            f"{cloud_name.lower()}_client",
-                            cloud_map[cloud_name](auth_dict=cred_dict[cloud_name]),
-                        )
+                        try:
+                            setattr(
+                                self,
+                                f"{cloud_name.lower()}_client",
+                                cloud_map[cloud_name](auth_dict=cred_dict[cloud_name]),
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to instantiate {cloud_name} client: {e}"
+                            )
+                            setattr(self, f"{cloud_name.lower()}_client", None)
 
         try:
-            rgw_conn = RGW()
-            endpoint, access_key, secret_key = rgw_conn.get_credentials()
-            cred_dict["RGW"] = {
-                "SECRET_PREFIX": "RGW",
-                "DATA_PREFIX": "RGW",
-                "ENDPOINT": endpoint,
-                "RGW_ACCESS_KEY_ID": access_key,
-                "RGW_SECRET_ACCESS_KEY": secret_key,
-            }
-            setattr(self, "rgw_client", cloud_map["RGW"](auth_dict=cred_dict["RGW"]))
+            setattr(self, "rgw_client", cloud_map["RGW"]())
         except CommandFailed:
             setattr(self, "rgw_client", None)
 
@@ -207,33 +208,16 @@ class S3Client(CloudClient):
         self.access_key = key_id
         self.secret_key = access_key
 
-        boto3_kwargs = {
-            "verify": verify,
-            "endpoint_url": self.endpoint,
-            "aws_access_key_id": self.access_key,
-            "aws_secret_access_key": self.secret_key,
-        }
-        if self.data_prefix == "AWS":
-            boto3_kwargs.update(
-                {
-                    "endpoint_url": None,  # lets boto3 pick the endpoint dynamically
-                    "region_name": "us-east-1",  # the only region that allows cross-region bucket operations
-                    "config": Config(
-                        s3={"addressing_style": "virtual"}
-                    ),  # supports cross-region bucket operation
-                }
-            )
-            self.region = "us-east-1"
-
-        self.client = boto3.resource("s3", **boto3_kwargs)
         self.secret = self.create_s3_secret(self.secret_prefix, self.data_prefix)
 
-        self.nss_creds = {
-            "access_key_id": self.access_key,
-            "access_key": self.secret_key,
-            "endpoint": endpoint,
-            "region": self.region,
-        }
+        self.client = boto3.resource(
+            "s3",
+            verify=verify,
+            endpoint_url=self.endpoint,
+            region_name=config.ENV_DATA["region"],
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+        )
 
     def internal_create_uls(self, name, region=None):
         """
@@ -312,6 +296,66 @@ class S3Client(CloudClient):
             logger.info(f"{uls_name} does not exist")
             return False
 
+    def create_s3_secret(self, secret_prefix, data_prefix):
+        """
+        Create a Kubernetes secret to allow NooBaa to create AWS-based backingstores
+
+        """
+        bs_secret_data = templating.load_yaml(constants.MCG_BACKINGSTORE_SECRET_YAML)
+        secret_name_prefix = secret_prefix.lower()
+        secret_name_prefix = secret_name_prefix.replace("_", "-")
+        bs_secret_data["metadata"]["name"] = create_unique_resource_name(
+            f"cldmgr-{secret_name_prefix}", "secret"
+        )
+        bs_secret_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+        bs_secret_data["data"][
+            f"{data_prefix}_ACCESS_KEY_ID"
+        ] = base64.urlsafe_b64encode(self.access_key.encode("UTF-8")).decode("ascii")
+        bs_secret_data["data"][
+            f"{data_prefix}_SECRET_ACCESS_KEY"
+        ] = base64.urlsafe_b64encode(self.secret_key.encode("UTF-8")).decode("ascii")
+
+        return create_resource(**bs_secret_data)
+
+
+class AwsClient(S3Client):
+    """
+    Implementation of a S3 Client using the S3 API for AWS buckets
+
+    """
+
+    def __init__(
+        self,
+        auth_dict,
+        verify=True,
+        endpoint="https://s3.amazonaws.com",
+        *args,
+        **kwargs,
+    ):
+        super().__init__(auth_dict, verify, endpoint, *args, **kwargs)
+        self.region = (
+            "us-east-1"  # the only region that allows cross-region bucket operations
+        )
+        self.endpoint = None  # lets AWS pick the endpoint dynamically
+
+        self.client = boto3.resource(
+            "s3",
+            verify=verify,
+            endpoint_url=self.endpoint,
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+            region_name=self.region,
+            config=Config(
+                s3={"addressing_style": "virtual"}
+            ),  # supports cross-region bucket operation
+        )
+        self.nss_creds = {
+            "access_key_id": self.access_key,
+            "access_key": self.secret_key,
+            "endpoint": endpoint,
+            "region": self.region,
+        }
+
     def toggle_aws_bucket_readwrite(self, aws_bucket_name, block=True):
         """
         Toggles a bucket's IO using a bucket policy
@@ -344,26 +388,38 @@ class S3Client(CloudClient):
         else:
             self.client.meta.client.delete_bucket_policy(Bucket=aws_bucket_name)
 
-    def create_s3_secret(self, secret_prefix, data_prefix):
-        """
-        Create a Kubernetes secret to allow NooBaa to create AWS-based backingstores
 
-        """
-        bs_secret_data = templating.load_yaml(constants.MCG_BACKINGSTORE_SECRET_YAML)
-        secret_name_prefix = secret_prefix.lower()
-        secret_name_prefix = secret_name_prefix.replace("_", "-")
-        bs_secret_data["metadata"]["name"] = create_unique_resource_name(
-            f"cldmgr-{secret_name_prefix}", "secret"
-        )
-        bs_secret_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
-        bs_secret_data["data"][
-            f"{data_prefix}_ACCESS_KEY_ID"
-        ] = base64.urlsafe_b64encode(self.access_key.encode("UTF-8")).decode("ascii")
-        bs_secret_data["data"][
-            f"{data_prefix}_SECRET_ACCESS_KEY"
-        ] = base64.urlsafe_b64encode(self.secret_key.encode("UTF-8")).decode("ascii")
+class RgwClient(S3Client):
+    """
+    Implementation of a S3 Client using the S3 API for RGW buckets
+    """
 
-        return create_resource(**bs_secret_data)
+    def __init__(
+        self,
+        auth_dict=None,
+        verify=True,
+        *args,
+        **kwargs,
+    ):
+        rgw_conn = RGW()
+        endpoint, access_key, secret_key = rgw_conn.get_credentials()
+        rgw_creds_dict = {
+            "SECRET_PREFIX": "RGW",
+            "DATA_PREFIX": "AWS",
+            "ENDPOINT": endpoint,
+            "S3_INTERNAL_ENDPOINT": rgw_conn.s3_internal_endpoint,
+            "RGW_ACCESS_KEY_ID": access_key,
+            "RGW_SECRET_ACCESS_KEY": secret_key,
+        }
+        super().__init__(rgw_creds_dict, verify, endpoint, *args, **kwargs)
+
+
+class IbmCosClient(S3Client):
+    """
+    Implementation of a S3 Client using the S3 API for IBM COS buckets
+    """
+
+    pass
 
 
 class GoogleClient(CloudClient):


### PR DESCRIPTION
This is a manual backport of #13842

The only difference between this and the 4.15 backport is the removal of the `AZURE_WITH_LOGS` key from the `cloud_map`, since the associated feature was only introduced in 4.15.