### PR TITLE
Fix the argument name in AZURE.compute_client and the methods to poweroff, start and restart Azure machines

### DIFF
--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -345,7 +345,7 @@ class AZURE:
 
         """
         for vm_name in vm_names:
-            result = self.compute_client.virtual_machines.restart(
+            result = self.compute_client.virtual_machines.begin_restart(
                 self.cluster_resource_group, vm_name
             )
             result.wait()
@@ -394,7 +394,7 @@ class AZURE:
 
         """
         for vm_name in vm_names:
-            result = self.compute_client.virtual_machines.start(
+            result = self.compute_client.virtual_machines.begin_start(
                 self.cluster_resource_group, vm_name
             )
             result.wait()
@@ -410,7 +410,7 @@ class AZURE:
 
         """
         for vm_name in vm_names:
-            result = self.compute_client.virtual_machines.power_off(
+            result = self.compute_client.virtual_machines.begin_power_off(
                 self.cluster_resource_group, vm_name, skip_shutdown=force
             )
             result.wait()


### PR DESCRIPTION
Fix the argument name "credential" in the method azure_utils.AZURE.compute_client.
Fix the method name to power off, start and restart Azure VMs. 
Fixes #13909 
Fixes #13913