### PR TITLE
Remove the node param from the deployment_pod_factory

### DIFF
--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -235,20 +235,14 @@ class TestNodeReplacementWithIO(ManageTest):
         osd_node_name = select_osd_node_name()
 
         log.info("Creating dc pod backed with rbd pvc and running io in bg")
-        for worker_node in worker_node_list:
-            if worker_node != osd_node_name:
-                rbd_dc_pod = deployment_pod_factory(
-                    interface=constants.CEPHBLOCKPOOL, node_name=worker_node, size=20
-                )
-                pod.run_io_in_bg(rbd_dc_pod, expect_to_fail=False, fedora_dc=True)
+        rbd_dc_pod = deployment_pod_factory(interface=constants.CEPHBLOCKPOOL, size=20)
+        pod.run_io_in_bg(rbd_dc_pod, expect_to_fail=False, fedora_dc=True)
 
         log.info("Creating dc pod backed with cephfs pvc and running io in bg")
-        for worker_node in worker_node_list:
-            if worker_node != osd_node_name:
-                cephfs_dc_pod = deployment_pod_factory(
-                    interface=constants.CEPHFILESYSTEM, node_name=worker_node, size=20
-                )
-                pod.run_io_in_bg(cephfs_dc_pod, expect_to_fail=False, fedora_dc=True)
+        cephfs_dc_pod = deployment_pod_factory(
+            interface=constants.CEPHFILESYSTEM, size=20
+        )
+        pod.run_io_in_bg(cephfs_dc_pod, expect_to_fail=False, fedora_dc=True)
 
         delete_and_create_osd_node(osd_node_name)
 


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/13071.
The fixture "deployment_pod_factory" failed to create the pod.
See the error here https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/852/31785/1557903/1557933/log, for example.

The solution proposed is to remove the `node_name` param.