### PR TITLE
Added Krkn Node Scenarios

### DIFF
--- a/conf/ocsci/krkn_chaos_config.yaml
+++ b/conf/ocsci/krkn_chaos_config.yaml
@@ -25,6 +25,11 @@ ENV_DATA:
       num_pvcs_per_interface: 5  # Number of PVCs to create per storage interface (CephFS, CephBlockPool)
       pvc_size: 50  # PVC size in GiB
 
+      # Encryption configuration (requires KMS to be configured)
+      # NOTE: Only RBD (Ceph Block) PVCs support encryption via storage class
+      #       CephFS PVCs do NOT support per-PVC encryption (cluster-wide only)
+      use_encrypted_pvc: false  # Set to true to use encrypted RBD PVCs with encrypted storage class
+
       # Common workload parameters
       threads: 16
       elapsed: 600

--- a/conf/ocsci/resiliency_tests_config.yaml
+++ b/conf/ocsci/resiliency_tests_config.yaml
@@ -25,6 +25,11 @@ ENV_DATA:
       num_pvcs_per_interface: 5  # Number of PVCs to create per storage interface (CephFS, CephBlockPool)
       pvc_size: 50  # PVC size in GiB
 
+      # Encryption configuration (requires KMS to be configured)
+      # NOTE: Only RBD (Ceph Block) PVCs support encryption via storage class
+      #       CephFS PVCs do NOT support per-PVC encryption (cluster-wide only)
+      use_encrypted_pvc: false  # Set to true to use encrypted RBD PVCs with encrypted storage class
+
       # Common workload parameters
       threads: 16
       elapsed: 1200

--- a/ocs_ci/krkn_chaos/config/chaos_scenarios_list.yaml
+++ b/ocs_ci/krkn_chaos/config/chaos_scenarios_list.yaml
@@ -45,6 +45,22 @@ chaos_scenarios:
           jinja_template: scenarios/openshift/regex_openshift_pod_kill.yml.j2
           description: "Kills random pods in openshift-storage namespace using regex patterns"
 
+  - node_scenarios:
+      - node-scenarios:
+          jinja_template: scenarios/openshift/node_scenarios.yml.j2
+          description: "Simulates node failures (stop/start, reboot, terminate) on various cloud platforms"
+      # Supported cloud_types: aws, azure, openstack, ibm, alibaba, bm (baremetal), vmware
+      # Supported actions:
+      #   - node_start_scenario: Start a stopped/powered-off node
+      #   - node_stop_scenario: Stop/power-off a node (without start)
+      #   - node_stop_start_scenario: Stop and start a node (not supported on vmware)
+      #   - node_termination_scenario: Terminate/delete the node instance
+      #   - node_reboot_scenario: Reboot a node
+      #   - stop_kubelet_scenario: Stop the kubelet service on the node
+      #   - stop_start_kubelet_scenario: Stop and start the kubelet service
+      #   - restart_kubelet_scenario: Restart the kubelet service
+      #   - node_crash_scenario: Crash the node using kernel panic (requires SYS_BOOT capability)
+
   # - pod_disruption_scenarios:
   #     - etcd:
   #         jinja_template: scenarios/openshift/etcd.yml

--- a/ocs_ci/krkn_chaos/krkn_workload_config.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_config.py
@@ -219,6 +219,23 @@ class KrknWorkloadConfig:
         vdbench_config = self.get_vdbench_config()
         return vdbench_config.get("pvc_size", 50)
 
+    def use_encrypted_pvc(self) -> bool:
+        """
+        Check if encrypted PVCs should be used for VDBENCH workloads.
+
+        NOTE: Only RBD (Ceph Block Pool) PVCs support encryption via storage class.
+              CephFS PVCs do NOT support per-PVC encryption (cluster-wide only).
+
+        When enabled:
+        - RBD PVCs will use encrypted storage class with KMS
+        - CephFS PVCs will use default storage class (no encryption)
+
+        Returns:
+            bool: True if encrypted RBD PVCs should be used (default: False)
+        """
+        vdbench_config = self.get_vdbench_config()
+        return vdbench_config.get("use_encrypted_pvc", False)
+
     def get_block_workload_config(self) -> Dict[str, Any]:
         """
         Get block workload configuration.

--- a/ocs_ci/krkn_chaos/template/scenarios/openshift/node_scenarios.yml.j2
+++ b/ocs_ci/krkn_chaos/template/scenarios/openshift/node_scenarios.yml.j2
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=../plugin.schema.json
+# Node Scenarios - Simulates node failures on various cloud platforms
+# Supported cloud_types: aws, azure, openstack, ibm, alibaba, bm (baremetal), vmware
+# Supported actions: node_stop_start_scenario, node_reboot_scenario, node_termination_scenario,
+#                    node_disk_detach_attach_scenario, stop_kubelet_scenario, restart_kubelet_scenario
+node_scenarios:
+{%- for scenario in scenarios %}
+  - actions:
+{%- for action in scenario.actions %}
+    - {{ action }}
+{%- endfor %}
+{%- if scenario.node_name is defined and scenario.node_name %}
+    node_name: {{ scenario.node_name }}
+{%- else %}
+    node_name:
+{%- endif %}
+    label_selector: {{ scenario.label_selector | default('node-role.kubernetes.io/worker') }}
+    instance_count: {{ scenario.instance_count | default(1) }}
+{%- if scenario.runs is defined %}
+    runs: {{ scenario.runs }}
+{%- endif %}
+    timeout: {{ scenario.timeout | default(360) }}
+{%- if scenario.duration is defined %}
+    duration: {{ scenario.duration }}
+{%- endif %}
+{%- if scenario.parallel is defined %}
+    parallel: {{ scenario.parallel | lower }}
+{%- endif %}
+    cloud_type: {{ scenario.cloud_type | default('aws') }}
+{%- if scenario.kube_check is defined %}
+    kube_check: {{ scenario.kube_check | lower }}
+{%- endif %}
+{%- if scenario.poll_interval is defined %}
+    poll_interval: {{ scenario.poll_interval }}
+{%- endif %}
+{%- if scenario.disable_ssl_verification is defined %}
+    disable_ssl_verification: {{ scenario.disable_ssl_verification | lower }}  # Set to true for CI environments with certificate issues
+{%- endif %}
+{%- if scenario.skip_openshift_checks is defined %}
+    skip_openshift_checks: {{ scenario.skip_openshift_checks | lower }}
+{%- endif %}
+{%- if scenario.verify_nodes_ready is defined %}
+    verify_nodes_ready: {{ scenario.verify_nodes_ready | lower }}
+{%- endif %}
+{# BareMetal specific options #}
+{%- if scenario.bmc_user is defined %}
+    bmc_user: {{ scenario.bmc_user }}
+{%- endif %}
+{%- if scenario.bmc_password is defined %}
+    bmc_password: {{ scenario.bmc_password }}
+{%- endif %}
+{%- if scenario.bmc_info is defined %}
+    bmc_info:
+{%- for node_name, node_info in scenario.bmc_info.items() %}
+      {{ node_name }}:
+{%- if node_info.bmc_addr is defined %}
+        bmc_addr: {{ node_info.bmc_addr }}
+{%- endif %}
+{%- if node_info.bmc_user is defined %}
+        bmc_user: {{ node_info.bmc_user }}
+{%- endif %}
+{%- if node_info.bmc_password is defined %}
+        bmc_password: {{ node_info.bmc_password }}
+{%- endif %}
+{%- if node_info.disks is defined %}
+        disks: {{ node_info.disks }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- if scenario.service is defined %}
+    service: {{ scenario.service }}
+{%- endif %}
+{%- if scenario.ssh_private_key is defined %}
+    ssh_private_key: {{ scenario.ssh_private_key }}
+{%- endif %}
+{%- if scenario.ssh_user is defined %}
+    ssh_user: {{ scenario.ssh_user }}
+{%- endif %}
+{%- endfor %}

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3649,7 +3649,7 @@ MCLOCK_HIGH_RECOVERY_OPS = "high_recovery_ops"
 
 # chaos Tests constants
 KRKN_REPO_URL = "https://github.com/redhat-chaos/krkn.git"
-KRKN_VERSION = "v4.0.11"
+KRKN_VERSION = "v4.0.16"
 KRKN_DIR = os.path.join(DATA_DIR, "krkn")
 KRKN_CHAOS_DIR = os.path.join(TOP_DIR, "ocs_ci", "krkn_chaos")
 KRKN_SCENARIO_TEMPLATE_DIR = os.path.join(KRKN_CHAOS_DIR, "template")
@@ -3663,6 +3663,25 @@ KRKN_CHAOS_SCENARIO_DIR = os.path.join(DATA_DIR, "krkn_scenarios")
 KRKN_OUTPUT_DIR = os.path.join(DATA_DIR, "krkn_output")
 KRKN_RUN_CMD = os.path.join(KRKN_DIR, "run_kraken.py")
 KRKN_SCENARIO_TEMPLATE = os.path.join(KRKN_SCENARIO_TEMPLATE_DIR, "scenarios")
+
+# Krkn supported cloud types for node scenarios
+KRKN_CLOUD_AWS = "aws"
+KRKN_CLOUD_AZURE = "azure"
+KRKN_CLOUD_IBM = "ibm"
+KRKN_CLOUD_BAREMETAL = "bm"
+KRKN_CLOUD_VMWARE = "vmware"
+
+# Krkn node scenario actions
+KRKN_NODE_START = "node_start_scenario"
+KRKN_NODE_STOP = "node_stop_scenario"
+KRKN_NODE_STOP_START = "node_stop_start_scenario"
+KRKN_NODE_TERMINATION = "node_termination_scenario"
+KRKN_NODE_REBOOT = "node_reboot_scenario"
+KRKN_NODE_DISK_DETACH_ATTACH = "node_disk_detach_attach_scenario"
+KRKN_STOP_KUBELET = "stop_kubelet_scenario"
+KRKN_STOP_START_KUBELET = "stop_start_kubelet_scenario"
+KRKN_RESTART_KUBELET = "restart_kubelet_scenario"
+KRKN_NODE_CRASH = "node_crash_scenario"
 
 CSI_ADDONS_CONFIGMAP_NAME = "csi-addons-config"
 RBD_CSI_ADDONS_PLUGIN_DIR = (

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -240,13 +240,14 @@ class PVC(OCS):
                 attached_pods.append(pod_obj)
         return attached_pods
 
-    def create_snapshot(self, snapshot_name=None, wait=False):
+    def create_snapshot(self, snapshot_name=None, wait=False, timeout=60):
         """
         Take snapshot of the PVC
 
         Args:
             snapshot_name (str): Name to be provided for snapshot
             wait (bool): True to wait for snapshot to be ready, False otherwise
+            timeout (int): Timeout in seconds to wait for snapshot to be ready (default: 60)
 
         Returns:
             OCS: Kind Snapshot
@@ -285,6 +286,7 @@ class PVC(OCS):
             namespace=self.namespace,
             sc_name=snapshotclass,
             wait=wait,
+            timeout=timeout,
         )
         snapshot_obj.parent_access_mode = self.get_pvc_access_mode
         snapshot_obj.parent_sc = self.backed_sc
@@ -450,7 +452,7 @@ def get_deviceset_pvs():
 
 
 def create_pvc_snapshot(
-    pvc_name, snap_yaml, snap_name, namespace, sc_name=None, wait=False
+    pvc_name, snap_yaml, snap_name, namespace, sc_name=None, wait=False, timeout=60
 ):
     """
     Create snapshot of a PVC
@@ -462,6 +464,7 @@ def create_pvc_snapshot(
         namespace (str): The namespace for the snapshot creation
         sc_name (str): The name of the snapshot class
         wait (bool): True to wait for snapshot to be ready, False otherwise
+        timeout (int): Timeout in seconds to wait for snapshot to be ready (default: 60)
 
     Returns:
         OCS object
@@ -483,7 +486,7 @@ def create_pvc_snapshot(
             condition="true",
             resource_name=ocs_obj.name,
             column=constants.STATUS_READYTOUSE,
-            timeout=60,
+            timeout=timeout,
         )
     return ocs_obj
 

--- a/ocs_ci/resiliency/resiliency_workload_config.py
+++ b/ocs_ci/resiliency/resiliency_workload_config.py
@@ -212,6 +212,23 @@ class ResiliencyWorkloadConfig:
         vdbench_config = self.get_vdbench_config()
         return vdbench_config.get("workload_loop", 1)
 
+    def use_encrypted_pvc(self) -> bool:
+        """
+        Check if encrypted PVCs should be used for VDBENCH workloads.
+
+        NOTE: Only RBD (Ceph Block Pool) PVCs support encryption via storage class.
+              CephFS PVCs do NOT support per-PVC encryption (cluster-wide only).
+
+        When enabled:
+        - RBD PVCs will use encrypted storage class with KMS
+        - CephFS PVCs will use default storage class (no encryption)
+
+        Returns:
+            bool: True if encrypted RBD PVCs should be used (default: False)
+        """
+        vdbench_config = self.get_vdbench_config()
+        return vdbench_config.get("use_encrypted_pvc", False)
+
     def get_vdbench_block_config(self) -> Dict[str, Any]:
         """
         Get VDBENCH block configuration.

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -127,6 +127,27 @@ def get_region(cluster_path):
     return metadata["ibmcloud"]["region"]
 
 
+def get_ibmcloud_cluster_region():
+    """
+    Get IBM Cloud region from the cluster's infrastructure object.
+
+    This function queries the live cluster to retrieve the IBM Cloud region
+    from the infrastructure status, which may differ from the metadata.json file.
+
+    Returns:
+        str: IBM Cloud region where the cluster is deployed
+
+    Raises:
+        CommandFailed: If the oc command fails
+    """
+    ocp_obj = OCP()
+    region = ocp_obj.exec_oc_cmd(
+        "get infrastructure cluster -o jsonpath='{.status.platformStatus.ibmcloud.location}'"
+    )
+    logger.info(f"IBM Cloud cluster region: {region}")
+    return region.strip()
+
+
 def get_resource_group_name(cluster_path):
     """
     Get resource group from metadata.json in given cluster_path

--- a/tests/cross_functional/krkn_chaos/conftest.py
+++ b/tests/cross_functional/krkn_chaos/conftest.py
@@ -184,7 +184,7 @@ class WorkloadOps:
 
 
 @pytest.fixture
-def workload_ops(request, project_factory, multi_pvc_factory):
+def workload_ops(request, project_factory, multi_pvc_factory, storageclass_factory):
     """
     Simplified workload ops fixture with conditional fixture loading.
 
@@ -266,6 +266,7 @@ def workload_ops(request, project_factory, multi_pvc_factory):
         project_factory,
         multi_pvc_factory,
         loaded_fixtures=fixtures,  # Pass all loaded fixtures
+        storageclass_factory=storageclass_factory,  # Pass storageclass factory for encrypted PVCs
     )
 
     try:

--- a/tests/cross_functional/krkn_chaos/test_krkn_node_scenarios.py
+++ b/tests/cross_functional/krkn_chaos/test_krkn_node_scenarios.py
@@ -1,0 +1,719 @@
+"""
+Test suite for Krkn node chaos scenarios across multiple cloud platforms.
+
+This module provides comprehensive node chaos testing using the Krkn chaos engineering tool.
+It automatically detects the cloud platform from ENV_DATA['platform'] and applies
+appropriate node scenarios based on actual krkn scenario configurations:
+
+Supported Platforms and their scenarios:
+    - AWS: node_stop_start_scenario, node_reboot_scenario
+    - Azure: node_reboot_scenario, node_stop_start_scenario
+    - IBM Cloud: node_stop_start_scenario, node_reboot_scenario (with disable_ssl_verification)
+    - VMware/vSphere: node_reboot_scenario, node_stop_start_scenario
+    - BareMetal: node_stop_start_scenario (with BMC/IPMI support)
+"""
+
+import pytest
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad, chaos, polarion_id
+from ocs_ci.krkn_chaos.krkn_chaos import KrKnRunner
+from ocs_ci.krkn_chaos.krkn_config_generator import KrknConfigGenerator
+from ocs_ci.krkn_chaos.krkn_scenario_generator import NodeScenarios
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.krkn_chaos.krkn_helpers import (
+    KrknResultAnalyzer,
+    CephHealthHelper,
+    ValidationHelper,
+    get_krkn_cloud_type,
+    get_node_scenario_generator,
+)
+from ocs_ci.krkn_chaos.logging_helpers import log_test_start
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@chaos
+class TestKrknNodeScenarios:
+    """
+    Test suite for Krkn node chaos scenarios.
+
+    Automatically detects the cloud platform and applies appropriate
+    node failure scenarios based on actual krkn configuration files.
+    """
+
+    @polarion_id("OCS-7491")
+    def test_krkn_platform_node_scenarios(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Test node scenarios for the detected cloud platform.
+
+        This test automatically:
+        1. Detects the cloud platform from ENV_DATA['platform']
+        2. Uses the platform-specific node scenario generator
+        3. Applies all default scenarios for that platform
+        4. Iterates through instance counts of 1, 2, and 3
+        5. Validates cluster recovery
+
+        Platform-specific scenarios:
+        - AWS: stop/start (parallel, kube_check), reboot
+        - Azure: reboot (parallel, kube_check), stop/start
+        - IBM Cloud: stop/start, reboot (with disable_ssl_verification)
+        - VMware: reboot, stop/start (sequential)
+        - BareMetal: stop/start (with BMC/IPMI, kube_check)
+        """
+        generator, cloud_type, platform = get_node_scenario_generator()
+        scenario_dir = krkn_scenario_directory
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        # Setup workloads
+        log.info(f"Setting up workloads for {cloud_type} node scenarios")
+        workload_ops.setup_workloads()
+
+        # Iterate through instance counts of 1, 2, and 3
+        instance_counts = [1, 2, 3]
+        all_results = []
+
+        try:
+            for instance_count in instance_counts:
+                log_test_start(
+                    f"Platform Node Scenarios ({cloud_type}) - Instance Count: {instance_count}",
+                    f"{platform} platform",
+                    platform=platform,
+                    cloud_type=cloud_type,
+                    instance_count=instance_count,
+                )
+
+                try:
+                    # Create Krkn configuration
+                    krkn_config = KrknConfigGenerator()
+
+                    # Generate platform-specific node scenarios using the generator
+                    scenario_file = generator(
+                        scenario_dir=scenario_dir, instance_count=instance_count
+                    )
+
+                    log.info(
+                        f"Generated {cloud_type} node scenario file with "
+                        f"instance_count={instance_count}: {scenario_file}"
+                    )
+
+                    # Add scenario to Krkn config
+                    krkn_config.add_scenario("node_scenarios", scenario_file)
+
+                    # Configure and write Krkn configuration
+                    krkn_config.set_tunings(wait_duration=60, iterations=1)
+                    krkn_config.write_to_file(location=scenario_dir)
+
+                    # Execute Krkn
+                    log.info(
+                        f"Executing {cloud_type} node scenarios on {platform} with instance_count={instance_count}"
+                    )
+                    krkn_runner = KrKnRunner(krkn_config.global_config)
+                    krkn_runner.run_async()
+                    krkn_runner.wait_for_completion(check_interval=60)
+                    chaos_output = krkn_runner.get_chaos_data()
+
+                    log.info(
+                        f"{cloud_type} node scenarios execution completed for instance_count={instance_count}"
+                    )
+
+                    # Analyze results for this iteration
+                    total_executed, successful_executed, failing_executed = (
+                        analyzer.analyze_chaos_results(
+                            chaos_output, platform, detail_level="detailed"
+                        )
+                    )
+
+                    # Store results for this iteration
+                    all_results.append(
+                        {
+                            "instance_count": instance_count,
+                            "total_executed": total_executed,
+                            "successful_executed": successful_executed,
+                            "failing_executed": failing_executed,
+                        }
+                    )
+
+                    # Validate execution for this iteration
+                    validator.validate_chaos_execution(
+                        total_executed,
+                        successful_executed,
+                        platform,
+                        f"{cloud_type} node scenarios (instance_count={instance_count})",
+                    )
+
+                    # Check Ceph health after each iteration
+                    no_crashes, crash_details = health_helper.check_ceph_crashes(
+                        "cluster",
+                        f"{cloud_type} node scenarios (instance_count={instance_count})",
+                    )
+                    assert no_crashes, crash_details
+
+                    log.info(
+                        f"{cloud_type} node scenarios completed successfully for instance_count={instance_count}"
+                    )
+
+                except CommandFailed as e:
+                    validator.handle_krkn_command_failure(
+                        e,
+                        platform,
+                        f"{cloud_type} node scenarios (instance_count={instance_count})",
+                    )
+                    raise
+                except Exception as e:
+                    log.error(
+                        f"{cloud_type} node scenarios failed on {platform} for instance_count={instance_count}: {e}"
+                    )
+                    raise
+
+            # Summary log for all iterations
+            log.info(f"\n{'='*80}")
+            log.info(
+                f"SUMMARY: {cloud_type} node scenarios completed for all instance counts"
+            )
+            log.info(f"{'='*80}")
+            for result in all_results:
+                log.info(
+                    f"Instance Count {result['instance_count']}: "
+                    f"Total={result['total_executed']}, "
+                    f"Successful={result['successful_executed']}, "
+                    f"Failed={result['failing_executed']}"
+                )
+            log.info(f"{'='*80}")
+
+            log.info(
+                f"{cloud_type} node scenarios completed successfully on {platform} for all instance counts"
+            )
+
+        finally:
+            # Cleanup workloads after all iterations (always executes)
+            workload_ops.validate_and_cleanup()
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            pytest.param(
+                constants.KRKN_NODE_STOP_START,
+                marks=polarion_id("OCS-7437"),
+                id="node-stop-start",
+            ),
+            pytest.param(
+                constants.KRKN_NODE_REBOOT,
+                marks=polarion_id("OCS-7438"),
+                id="node-reboot",
+            ),
+        ],
+    )
+    def test_krkn_single_node_action(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        action,
+    ):
+        """
+        Test individual node chaos actions on the detected cloud platform.
+
+        This parameterized test runs individual node chaos actions:
+        - node_stop_start_scenario: Stop and start a node
+        - node_reboot_scenario: Reboot a node
+
+        The test automatically applies platform-specific configurations
+        like parallel execution, kube_check, poll_interval, etc.
+        """
+        platform = config.ENV_DATA.get("platform", "").lower()
+        cloud_type = get_krkn_cloud_type()
+        scenario_dir = krkn_scenario_directory
+
+        log_test_start(
+            f"Single Node Action: {action}",
+            f"{platform} platform ({cloud_type})",
+            platform=platform,
+            cloud_type=cloud_type,
+            action=action,
+        )
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        # Setup workloads
+        log.info(f"Setting up workloads for {action}")
+        workload_ops.setup_workloads()
+
+        try:
+            # Create Krkn configuration
+            krkn_config = KrknConfigGenerator()
+
+            # Build scenario configuration based on platform and action
+            scenario_params = {
+                "actions": [action],
+                "cloud_type": cloud_type,
+                "label_selector": constants.WORKER_LABEL,
+                "instance_count": 1,
+            }
+
+            # Set timeout and duration based on action
+            if action == constants.KRKN_NODE_STOP_START:
+                scenario_params["timeout"] = 360
+                scenario_params["duration"] = 120
+            else:  # reboot
+                scenario_params["timeout"] = 120
+
+            # Add platform-specific parameters
+            if cloud_type in [
+                constants.KRKN_CLOUD_AWS,
+                constants.KRKN_CLOUD_AZURE,
+            ]:
+                scenario_params["parallel"] = True
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_AWS:
+                scenario_params["poll_interval"] = 15
+
+            if cloud_type == constants.KRKN_CLOUD_IBM:
+                scenario_params["disable_ssl_verification"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_BAREMETAL:
+                scenario_params["parallel"] = False
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_VMWARE:
+                scenario_params["parallel"] = False
+
+            # Generate node scenario YAML
+            scenario_file = NodeScenarios.node_scenarios(
+                scenario_dir=scenario_dir,
+                cloud_type=cloud_type,
+                scenarios=[scenario_params],
+            )
+
+            log.info(f"Generated node scenario file: {scenario_file}")
+
+            # Add scenario to Krkn config
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+
+            # Configure and write Krkn configuration
+            krkn_config.set_tunings(wait_duration=60, iterations=1)
+            krkn_config.write_to_file(location=scenario_dir)
+
+            # Execute Krkn
+            log.info(f"Executing {action} on {platform} ({cloud_type})")
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info(f"{action} execution completed")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(e, platform, action)
+            raise
+        except Exception as e:
+            log.error(f"{action} failed on {platform}: {e}")
+            raise
+        finally:
+            workload_ops.validate_and_cleanup()
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output, platform, detail_level="detailed"
+            )
+        )
+
+        # Validate execution
+        validator.validate_chaos_execution(
+            total_executed, successful_executed, platform, action
+        )
+
+        # Check Ceph health
+        no_crashes, crash_details = health_helper.check_ceph_crashes("cluster", action)
+        assert no_crashes, crash_details
+
+        log.info(f"{action} completed successfully on {platform} ({cloud_type})")
+
+
+@green_squad
+@chaos
+class TestKrknAWSNodeScenarios:
+    """Test suite specifically for AWS node scenarios."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_not_aws(self):
+        """Skip tests if not running on AWS platform."""
+        platform = config.ENV_DATA.get("platform", "").lower()
+        if platform not in [
+            constants.AWS_PLATFORM,
+            constants.ROSA_PLATFORM,
+            constants.ROSA_HCP_PLATFORM,
+        ]:
+            pytest.skip(f"Test requires AWS platform, current platform: {platform}")
+
+    @polarion_id("OCS-7490")
+    def test_krkn_aws_node_stop_start_parallel(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Test AWS node stop/start scenario with parallel execution.
+
+        Based on krkn aws_node_scenarios.yml:
+        - instance_count: 2
+        - parallel: true
+        - kube_check: true
+        - poll_interval: 15
+        - duration: 20
+        """
+        scenario_dir = krkn_scenario_directory
+
+        log_test_start(
+            "AWS Node Stop/Start (Parallel)",
+            "AWS platform",
+            instance_count=2,
+            parallel=True,
+            kube_check=True,
+        )
+
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        workload_ops.setup_workloads()
+
+        try:
+            krkn_config = KrknConfigGenerator()
+
+            # AWS-specific stop/start scenario
+            scenarios = [
+                {
+                    "actions": [constants.KRKN_NODE_STOP_START],
+                    "cloud_type": constants.KRKN_CLOUD_AWS,
+                    "label_selector": constants.WORKER_LABEL,
+                    "instance_count": 2,
+                    "runs": 2,
+                    "timeout": 360,
+                    "duration": 20,
+                    "parallel": True,
+                    "kube_check": True,
+                    "poll_interval": 15,
+                },
+            ]
+
+            scenario_file = NodeScenarios.node_scenarios(
+                scenario_dir=scenario_dir,
+                cloud_type=constants.KRKN_CLOUD_AWS,
+                scenarios=scenarios,
+            )
+
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+            krkn_config.set_tunings(wait_duration=60, iterations=1)
+            krkn_config.write_to_file(location=scenario_dir)
+
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(e, "aws", "node stop/start parallel")
+            raise
+        finally:
+            workload_ops.validate_and_cleanup()
+
+        total_executed, successful_executed, _ = analyzer.analyze_chaos_results(
+            chaos_output, "aws", detail_level="detailed"
+        )
+        validator.validate_chaos_execution(
+            total_executed, successful_executed, "aws", "node stop/start parallel"
+        )
+
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            "cluster", "aws node stop/start"
+        )
+        assert no_crashes, crash_details
+
+
+@green_squad
+@chaos
+class TestKrknIBMCloudNodeScenarios:
+    """Test suite specifically for IBM Cloud node scenarios."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_not_ibmcloud(self):
+        """Skip tests if not running on IBM Cloud platform."""
+        platform = config.ENV_DATA.get("platform", "").lower()
+        ibm_platforms = [
+            constants.IBMCLOUD_PLATFORM,
+            constants.IBM_PLATFORM,
+            constants.IBM_POWER_PLATFORM,
+            constants.IBM_CLOUD_BAREMETAL_PLATFORM,
+        ]
+        if platform not in ibm_platforms:
+            pytest.skip(
+                f"Test requires IBM Cloud platform, current platform: {platform}"
+            )
+
+    @polarion_id("OCS-7487")
+    def test_krkn_ibmcloud_node_scenarios(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Test IBM Cloud node scenarios with SSL verification disabled.
+
+        Based on krkn ibmcloud_node_scenarios.yml:
+        - node_stop_start_scenario (timeout: 360, duration: 120)
+        - node_reboot_scenario (timeout: 120)
+        - disable_ssl_verification: true
+        """
+        scenario_dir = krkn_scenario_directory
+
+        log_test_start(
+            "IBM Cloud Node Scenarios",
+            "IBM Cloud platform",
+            disable_ssl_verification=True,
+        )
+
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        workload_ops.setup_workloads()
+
+        try:
+            krkn_config = KrknConfigGenerator()
+
+            # Use the IBM Cloud specific generator
+            scenario_file = NodeScenarios.ibmcloud_node_scenarios(
+                scenario_dir=scenario_dir
+            )
+
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+            krkn_config.set_tunings(wait_duration=60, iterations=1)
+            krkn_config.write_to_file(location=scenario_dir)
+
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(e, "ibm", "IBM Cloud node scenarios")
+            raise
+        finally:
+            workload_ops.validate_and_cleanup()
+
+        total_executed, successful_executed, _ = analyzer.analyze_chaos_results(
+            chaos_output, "ibm", detail_level="detailed"
+        )
+        validator.validate_chaos_execution(
+            total_executed, successful_executed, "ibm", "IBM Cloud node scenarios"
+        )
+
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            "cluster", "IBM Cloud node scenarios"
+        )
+        assert no_crashes, crash_details
+
+
+@green_squad
+@chaos
+class TestKrknVMwareNodeScenarios:
+    """Test suite specifically for VMware/vSphere node scenarios."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_not_vmware(self):
+        """Skip tests if not running on VMware/vSphere platform."""
+        platform = config.ENV_DATA.get("platform", "").lower()
+        vmware_platforms = [constants.VSPHERE_PLATFORM, constants.HCI_VSPHERE]
+        if platform not in vmware_platforms:
+            pytest.skip(
+                f"Test requires VMware/vSphere platform, current platform: {platform}"
+            )
+
+    @polarion_id("OCS-7488")
+    def test_krkn_vmware_node_scenarios(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Test VMware node scenarios.
+
+        Based on krkn vmware_node_scenarios.yml:
+        - node_reboot_scenario (timeout: 120)
+        - node_stop_start_scenario (timeout: 360, duration: 10, parallel: false)
+        """
+        scenario_dir = krkn_scenario_directory
+
+        log_test_start(
+            "VMware Node Scenarios",
+            "VMware/vSphere platform",
+            parallel=False,
+        )
+
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        workload_ops.setup_workloads()
+
+        try:
+            krkn_config = KrknConfigGenerator()
+
+            # Use the VMware specific generator
+            scenario_file = NodeScenarios.vmware_node_scenarios(
+                scenario_dir=scenario_dir
+            )
+
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+            krkn_config.set_tunings(wait_duration=60, iterations=1)
+            krkn_config.write_to_file(location=scenario_dir)
+
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(e, "vmware", "VMware node scenarios")
+            raise
+        finally:
+            workload_ops.validate_and_cleanup()
+
+        total_executed, successful_executed, _ = analyzer.analyze_chaos_results(
+            chaos_output, "vmware", detail_level="detailed"
+        )
+        validator.validate_chaos_execution(
+            total_executed, successful_executed, "vmware", "VMware node scenarios"
+        )
+
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            "cluster", "VMware node scenarios"
+        )
+        assert no_crashes, crash_details
+
+
+@green_squad
+@chaos
+class TestKrknBaremetalNodeScenarios:
+    """Test suite specifically for BareMetal node scenarios."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_not_baremetal(self):
+        """Skip tests if not running on BareMetal platform."""
+        platform = config.ENV_DATA.get("platform", "").lower()
+        baremetal_platforms = [
+            constants.BAREMETAL_PLATFORM,
+            constants.BAREMETALPSI_PLATFORM,
+            constants.HCI_BAREMETAL,
+        ]
+        if platform not in baremetal_platforms:
+            pytest.skip(
+                f"Test requires BareMetal platform, current platform: {platform}"
+            )
+
+    @polarion_id("OCS-7489")
+    def test_krkn_baremetal_node_scenarios(
+        self,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Test BareMetal node scenarios with IPMI/BMC support.
+
+        Based on krkn baremetal_node_scenarios.yml:
+        - node_stop_start_scenario (runs: 1, timeout: 360, duration: 120)
+        - parallel: false
+        - kube_check: true
+        - BMC credentials support (bmc_user, bmc_password, bmc_info)
+        """
+        scenario_dir = krkn_scenario_directory
+
+        log_test_start(
+            "BareMetal Node Scenarios",
+            "BareMetal platform",
+            parallel=False,
+            kube_check=True,
+        )
+
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        workload_ops.setup_workloads()
+
+        try:
+            krkn_config = KrknConfigGenerator()
+
+            # Get BMC credentials from config if available
+            bmc_user = config.ENV_DATA.get("bmc_user")
+            bmc_password = config.ENV_DATA.get("bmc_password")
+
+            # Use the BareMetal specific generator
+            scenario_file = NodeScenarios.baremetal_node_scenarios(
+                scenario_dir=scenario_dir,
+                bmc_user=bmc_user,
+                bmc_password=bmc_password,
+            )
+
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+            krkn_config.set_tunings(wait_duration=60, iterations=1)
+            krkn_config.write_to_file(location=scenario_dir)
+
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e, "baremetal", "BareMetal node scenarios"
+            )
+            raise
+        finally:
+            workload_ops.validate_and_cleanup()
+
+        total_executed, successful_executed, _ = analyzer.analyze_chaos_results(
+            chaos_output, "baremetal", detail_level="detailed"
+        )
+        validator.validate_chaos_execution(
+            total_executed, successful_executed, "baremetal", "BareMetal node scenarios"
+        )
+
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            "cluster", "BareMetal node scenarios"
+        )
+        assert no_crashes, crash_details

--- a/tests/cross_functional/resilience/conftest.py
+++ b/tests/cross_functional/resilience/conftest.py
@@ -40,6 +40,7 @@ def workload_ops(
     vdbench_block_config,
     vdbench_filesystem_config,
     awscli_pod,
+    storageclass_factory,
 ):
     """
     Workload ops fixture for resiliency testing.
@@ -118,6 +119,7 @@ def workload_ops(
         vdbench_block_config,
         vdbench_filesystem_config,
         awscli_pod=awscli_pod,
+        storageclass_factory=storageclass_factory,
         scaling_helper=scaling_helper,
     )
 


### PR DESCRIPTION
This PR adds a set of tests for Krkn node chaos scenarios across different cloud platforms. These tests check how well the ODF cluster handles node-level disruptions such as reboots and stop/start operations, and ensure the cluster recovers as expected.


Test Cases

1. TestKrknNodeScenarios (Platform-Agnostic)
    Generic test class that runs across all supported platforms:
    - test_krkn_platform_node_scenarios Runs node chaos scenarios with instance counts 1, 2, and 3 using platform-specific configurations.
    - test_krkn_single_node_action Parameterized test covering individual node actions such as stop/start and reboot.

⸻

2. TestKrknAWSNodeScenarios (AWS-Specific)

AWS-focused node chaos tests:
- test_krkn_aws_node_stop_start_parallel Validates parallel node stop/start behavior using AWS-specific settings. Features: parallel=true, kube_check=true, poll_interval=15

⸻

3. TestKrknIBMCloudNodeScenarios (IBM Cloud-Specific)

IBM Cloud–specific node chaos tests:
- test_krkn_ibmcloud_node_scenarios Executes node stop/start and reboot scenarios with SSL verification disabled.

⸻

4. TestKrknVMwareNodeScenarios (VMware / vSphere-Specific)

VMware-specific node chaos tests:
 - test_krkn_vmware_node_scenarios Executes node disruptions sequentially for controlled testing. Features: parallel=false

⸻

5. TestKrknBaremetalNodeScenarios (Bare Metal-Specific)

Bare metal node chaos tests:
- test_krkn_baremetal_node_scenarios Executes node operations using BMC/IPMI for hardware-level control. Features: IPMI credential support