### PR TITLE
Extending pods in exclusion list for test_live_resources_presence_and_format

### DIFF
--- a/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
+++ b/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
@@ -43,7 +43,8 @@ class TestLiveResourcesPresenceAndFormat(BaseTest):
         """
         pod_name_exclude_patterns = [
             "storageclient-",
-            "rook-ceph-osd-prepare-ocs-deviceset-",
+            "rook-ceph-tools-external-",
+            "rook-ceph-osd-prepare-",
             "pod-test-",
             "test",
             "session",


### PR DESCRIPTION
Following changes are made as part of this pull request

1. Adding "rook-ceph-tools-external-" pod name identifier in exclusion list while doing liveness check after discussion with Nikhil , who is the feature owner.
2. Updating an already existing pod name identifier as few pods like rook-ceph-osd-prepare-<>" are getting included in the check