### PR TITLE
[release-4.15] add workaround for issues with uefi boot order

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -301,6 +301,8 @@ higher priority).
             * `private_gw` - GW for the private interface
             * `root_disk_id` - ID of the root disk
             * `root_disk_sn` - Serial number of the root disk
+            * `fix_uefi_boot_order_first_option` - string identifying the PXE boot option which should be set to first place, if defined
+                (this is a workaround for UEFI boot order getting changed on some servers during the OCP deployment)
 
 #### UPGRADE
 


### PR DESCRIPTION
We are facing an issue with one of the baremetal servers, that UEFI boot order getting changed during OCP deployment and PXE boot is not on first place which leads to an issue during the next deployment.
This workaround will try to change the boot order using efibootmgr command and set PXE boot on the first place.

backport of https://github.com/red-hat-storage/ocs-ci/pull/11610/