### PR TITLE
`test_bucket_replication_with_versioning.py`: Verify health after applying a replication policy to the OBCs

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -2212,6 +2212,25 @@ def update_replication_policy(bucket_name, replication_policy_dict):
 
 
 @config.run_with_provider_context_if_available
+def update_replication_policy_and_verify_health(bucket_obj, replication_policy_dict):
+    """
+    Updates the replication policy of a bucket and verifies the health of the bucket.
+    This is useful because the bucket may not be immediately available after the
+    replication policy is updated.
+
+    Args:
+        bucket_obj (ObjectBucket): The bucket object to update the replication policy of
+        replication_policy_dict (dict): A dictionary containing the new replication
+        policy
+
+    Raises:
+        TimeoutExpiredError: If the bucket does not reach a healthy state within 120 seconds
+    """
+    update_replication_policy(bucket_obj.name, replication_policy_dict)
+    bucket_obj.verify_health(timeout=120)
+
+
+@config.run_with_provider_context_if_available
 def get_replication_policy(bucket_name):
     """
     Get the replication policy on a bucket

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     get_obj_versions,
     put_bucket_versioning_via_awscli,
-    update_replication_policy,
+    update_replication_policy_and_verify_health,
     upload_obj_versions,
     wait_for_object_versions_match,
 )
@@ -125,7 +125,9 @@ class TestReplicationWithVersioning(MCGTest):
             replication_policy = ReplicationPolicyWithVersioning(
                 target_bucket=target_bucket.name
             )
-            update_replication_policy(source_bucket.name, replication_policy.to_dict())
+            update_replication_policy_and_verify_health(
+                source_bucket, replication_policy.to_dict()
+            )
 
         # 3. Write some versions to the source buckets
         for source_bucket, _ in bucket_pairs:
@@ -178,12 +180,16 @@ class TestReplicationWithVersioning(MCGTest):
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=bucket_b.name, prefix=a_to_b_prefix
         )
-        update_replication_policy(bucket_a.name, replication_policy.to_dict())
+        update_replication_policy_and_verify_health(
+            bucket_a, replication_policy.to_dict()
+        )
 
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=bucket_a.name, prefix=b_to_a_prefix
         )
-        update_replication_policy(bucket_b.name, replication_policy.to_dict())
+        update_replication_policy_and_verify_health(
+            bucket_b, replication_policy.to_dict()
+        )
 
         # 3. Write some versions to each bucket
         for bucket in (bucket_a, bucket_b):
@@ -240,7 +246,9 @@ class TestReplicationWithVersioning(MCGTest):
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=target_bucket.name
         )
-        update_replication_policy(source_bucket.name, replication_policy.to_dict())
+        update_replication_policy_and_verify_health(
+            source_bucket, replication_policy.to_dict()
+        )
 
         # 3. Suspend the versioning on the source bucket
         put_bucket_versioning_via_awscli(

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -18,9 +18,9 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     get_obj_versions,
     put_bucket_versioning_via_awscli,
-    update_replication_policy_and_verify_health,
     upload_obj_versions,
     wait_for_object_versions_match,
+    update_replication_policy,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
@@ -125,8 +125,11 @@ class TestReplicationWithVersioning(MCGTest):
             replication_policy = ReplicationPolicyWithVersioning(
                 target_bucket=target_bucket.name
             )
-            update_replication_policy_and_verify_health(
-                source_bucket, replication_policy.to_dict()
+            update_replication_policy(
+                source_bucket.name,
+                replication_policy.to_dict(),
+                verify_health=True,
+                bucket_obj=source_bucket,
             )
 
         # 3. Write some versions to the source buckets
@@ -180,15 +183,21 @@ class TestReplicationWithVersioning(MCGTest):
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=bucket_b.name, prefix=a_to_b_prefix
         )
-        update_replication_policy_and_verify_health(
-            bucket_a, replication_policy.to_dict()
+        update_replication_policy(
+            bucket_a.name,
+            replication_policy.to_dict(),
+            verify_health=True,
+            bucket_obj=bucket_a,
         )
 
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=bucket_a.name, prefix=b_to_a_prefix
         )
-        update_replication_policy_and_verify_health(
-            bucket_b, replication_policy.to_dict()
+        update_replication_policy(
+            bucket_b.name,
+            replication_policy.to_dict(),
+            verify_health=True,
+            bucket_obj=bucket_b,
         )
 
         # 3. Write some versions to each bucket
@@ -246,8 +255,11 @@ class TestReplicationWithVersioning(MCGTest):
         replication_policy = ReplicationPolicyWithVersioning(
             target_bucket=target_bucket.name
         )
-        update_replication_policy_and_verify_health(
-            source_bucket, replication_policy.to_dict()
+        update_replication_policy(
+            source_bucket.name,
+            replication_policy.to_dict(),
+            verify_health=True,
+            bucket_obj=source_bucket,
         )
 
         # 3. Suspend the versioning on the source bucket


### PR DESCRIPTION
Sometimes (in under ~25% of runs), the first operation on a bucket immediately after applying a replication policy fails with a NoSuchBucket error:

```
E ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig ...
...

An error occurred (NoSuchBucket) when calling the PutObject operation: The specified bucket does not exist.
```

This PR stabilizes the tests by reusing the existing ObjectBucket::verify_health check after applying the replication policy, and waiting until the bucket is reported as healthy before proceeding.

To keep the scope contained, the change is currently limited to test_bucket_replication_with_versioning.py. Additional tests will be updated once we have sufficient signal that this improves overall stability.