### PR TITLE
Verifying liveness and readiness probes of OCS & MCG operator (Happy Path)

### DIFF
--- a/tests/functional/monitoring/test_operator_probe_resilience.py
+++ b/tests/functional/monitoring/test_operator_probe_resilience.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.csv import get_csv_name_start_with_prefix
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.framework.pytest_customization.marks import tier4c, blue_squad
+from ocs_ci.framework.pytest_customization.marks import tier4c, blue_squad, polarion_id
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ OPERATOR_PROBE_PARAMS = [
 @tier4c
 @ignore_leftovers
 @blue_squad
+@polarion_id("OCS-7421")
 @pytest.mark.parametrize("csv_prefix, probe_type, healthy_path", OPERATOR_PROBE_PARAMS)
 class TestOperatorProbeResilience(ManageTest):
     """


### PR DESCRIPTION
As part of new testcase - test_operator_probe_resilience.py, we will be performing the below steps

1. Verify if liveness and readiness probes are configured with default values
2. Simulate failure by patching the respective CSV configs
3. Verify pod restarts and status changes
4. Restore probe values to default
5. Verify cleanup
JIRA: https://issues.redhat.com/browse/OCSQE-4029