### PR TITLE
Changed the fixture scope from "session" to "class" in the TestCephtoolboxPod class.

### DIFF
--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 @brown_squad
 class TestCephtoolboxPod:
-    @pytest.fixture(scope="session", autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def teardown(self, request):
         def finalizer():
             """


### PR DESCRIPTION

Test test after test_nodeaffinity_to_ceph_toolbox_with_default_taints are failing to schedule pods due to the presence of taint in the worker nodes. The test case adds the node taints but the finalizer removes the taint which has session scope.
Changed the fixture scope from scope="session" to scope="class", The finalizer now runs after all tests in the TestCephtoolboxPod class complete