### PR TITLE
increase mce timeouts for cloud provider platforms

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -206,11 +206,18 @@ class MCEInstaller(object):
             namespace=constants.HYPERSHIFT_NAMESPACE,
         )
 
+        check_resources_timeout = 600
+        if config.ENV_DATA["platform"] in constants.CLOUD_PLATFORMS:
+            logger.info(
+                "Cloud platform detected; wait for hypershift supported-versions configmap twice longer"
+            )
+            check_resources_timeout = check_resources_timeout * 2
+
         # configMap is created during hypershift installation in around 5 min.
         # Increasing this timeout to 10 min for safer deployment.
         if not configmaps_obj.check_resource_existence(
             should_exist=True,
-            timeout=600,
+            timeout=check_resources_timeout,
             resource_name=constants.SUPPORTED_VERSIONS_CONFIGMAP,
         ):
             raise UnavailableResourceException(


### PR DESCRIPTION
Unblocks automation for https://issues.redhat.com/browse/RHSTOR-7339 

Fixes: 
```
2025-12-28 11:46:53  04:46:53 - MainThread - ocs_ci.utility.utils - INFO  - Going to sleep for 10 seconds before next iteration
2025-12-28 11:47:03  04:47:03 - MainThread - ocs_ci.utility.utils - ERROR  - function <lambda> failed to return expected value True after multiple retries during 600 second timeout
```

Issue with MCE on AWS and potentially on other cloud platform providers