### PR TITLE
Fix locator for test_store_creation_and_deletion

### DIFF
--- a/ocs_ci/ocs/ui/helpers_ui.py
+++ b/ocs_ci/ocs/ui/helpers_ui.py
@@ -75,7 +75,7 @@ def ui_deployment_conditions():
         return True
 
 
-def format_locator(locator, *args):
+def format_locator(locator, *args, **kwargs):
     """
     Use this function format_locator when working with dynamic locators.
 
@@ -83,12 +83,14 @@ def format_locator(locator, *args):
         locator (tuple): (GUI element needs to operate on (str), type (By))
         *args (str): Name of the variable (string) which contains the dynamic web element
             when generated on certain action
+        **kwargs (str): Keyword arguments(string) where the key matches the placeholder name in the locator
+            to which value is assigned to dynamically format the web element.
 
     return:
         formats the locator using .format() function which takes string to be inserted as an argument
 
     """
-    return locator[0].format(*args), locator[1]
+    return locator[0].format(*args, **kwargs), locator[1]
 
 
 def ui_add_capacity_conditions():

--- a/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
+++ b/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
@@ -533,12 +533,14 @@ class CreateResourceForm(PageNavigator):
         provider = "AWS S3" if provider.lower() == "aws" else provider
         self.do_click(self.mcg_stores["store_provider_dropdown"])
         self.do_click(
-            format_locator(self.mcg_stores["store_dropdown_option"], provider)
+            format_locator(self.mcg_stores["store_dropdown_option"], value=provider)
         )
 
         logger.info("Select region")
         self.do_click(self.mcg_stores["store_region_dropdown"])
-        self.do_click(format_locator(self.mcg_stores["store_dropdown_option"], region))
+        self.do_click(
+            format_locator(self.mcg_stores["store_dropdown_option"], value=region)
+        )
 
         logger.info("Select secret")
         self.do_click(self.mcg_stores["store_secret_dropdown"])

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -490,7 +490,8 @@ mcg_stores = {
         By.XPATH,
     ),
     "store_dropdown_option": (
-        "//ul[contains(@class, 'c-dropdown__menu')]//a[normalize-space()='{}']",
+        "//ul[contains(@class, 'c-dropdown__menu')]//a[normalize-space()='{value}'] | "
+        "//ul[contains(@class, 'c-menu__list')]//button[@id='{value}']",
         By.XPATH,
     ),
     "store_secret_option": ("//*[contains(text(), '{}')]", By.XPATH),


### PR DESCRIPTION
Fix #14010 , provider selection is not happening in test_store_creation_and_deletion due to locator change because of pattern fly changes introduced in 4.21