### PR TITLE
verify_provider_mode_deployment - remove redundancy

### DIFF
--- a/ocs_ci/deployment/provider_client/storage_client_deployment.py
+++ b/ocs_ci/deployment/provider_client/storage_client_deployment.py
@@ -43,12 +43,6 @@ def verify_provider_mode_deployment():
     )
     pod_obj.wait_for_resource(
         condition=constants.STATUS_RUNNING,
-        selector=constants.RGW_APP_LABEL,
-        resource_count=1,
-        timeout=300,
-    )
-    pod_obj.wait_for_resource(
-        condition=constants.STATUS_RUNNING,
         selector=constants.PROVIDER_SERVER_LABEL,
         resource_count=1,
         timeout=300,


### PR DESCRIPTION
correction to avoid [failure](https://url.corp.redhat.com/0a024b2) on cloud platforms: 

```
2026-01-01 12:03:19  05:03:18 - MainThread - ocs_ci.ocs.ocp - ERROR  - timeout expired: Timed out after 300s running get("", True, "app=rook-ceph-rgw")
...
False):
2026-01-01 12:03:19  >                       verify_provider_mode_deployment()
2026-01-01 12:03:19  
2026-01-01 12:03:19  tests/functional/deployment/test_deployment.py:64: 
2026-01-01 12:03:19  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-01-01 12:03:19  ocs_ci/deployment/provider_client/storage_client_deployment.py:44: in verify_provider_mode_deployment
2026-01-01 12:03:19      pod_obj.wait_for_resource(
2026-01-01 12:03:19  ocs_ci/ocs/ocp.py:1124: in wait_for_resource
2026-01-01 12:03:19      raise (ex)
2026-01-01 12:03:19  ocs_ci/ocs/ocp.py:1015: in wait_for_resource
2026-01-01 12:03:19      for sample in TimeoutSampler(
2026-01-01 12:03:19  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-01-01 12:03:19  
2026-01-01 12:03:19  self = <ocs_ci.utility.utils.TimeoutSampler object at 0x7f24d599d750>
2026-01-01 12:03:19  
2026-01-01 12:03:19      def __iter__(self):
2026-01-01 12:03:19          if self.start_time is None:
2026-01-01 12:03:19              self.start_time = time.time()
2026-01-01 12:03:19          while True:
2026-01-01 12:03:19              self.last_sample_time = time.time()
2026-01-01 12:03:19              if self.timeout <= (self.last_sample_time - self.start_time):
2026-01-01 12:03:19  >               raise self.timeout_exc_cls(*self.timeout_exc_args)
2026-01-01 12:03:19  E               ocs_ci.ocs.exceptions.TimeoutExpiredError: Timed out after 300s running get("", True, "app=rook-ceph-rgw")
2026-01-01 12:03:19  
2026-01-01 12:03:19  ocs_ci/utility/utils.py:1564: TimeoutExpiredError
2026-01-01 12:03:19  
```