### PR TITLE
save DOM as html for UI analysis

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -779,7 +779,7 @@ def copy_dom(name_suffix: str = "", dom_folder=None):
         name_suffix = f"_{name_suffix}"
     filename = os.path.join(
         dom_folder,
-        f"{datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')}{name_suffix}_DOM.txt",
+        f"{datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S.%f')}{name_suffix}_DOM.html",
     )
     logger.info(f"Copy DOM file: {filename}")
     html = SeleniumDriver().page_source


### PR DESCRIPTION
With existing extension of the DOM file, saved as .txt, we can not interact with content and try out other locator strategies. 
In order to make it interactive we need to save it and run the file via browser. 

This PR proposes to make extension `.html` so we can run it directly from magna, not downloading and renaming it.
I expect Apache will map html to a Content-Type: text/html and it will be presented as a web page. 

This will seriously improve analysis and test adjustments. We will be able to:

Open dev tool and Navigate to console and run $x("xpath locator") or $$("css locator") to try out locators other than the failed one.

1.
<img width="1166" height="901" alt="image" src="https://github.com/user-attachments/assets/a628ac7a-75f1-40a4-b39e-7aef80fb449a" />
2.
<img width="1155" height="982" alt="image" src="https://github.com/user-attachments/assets/4073da4f-924c-4ee1-8c6f-235ec5d9a2c1" />
