### PR TITLE
Add YAML log filter to reduce PackageManifest verbosity in logs

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -45,6 +45,7 @@ from jinja2 import FileSystemLoader, Environment
 from ocs_ci.framework import config
 from ocs_ci.framework import GlobalVariables as GV
 from ocs_ci.ocs import constants, defaults
+from ocs_ci.utility.yaml_log_filter import filter_verbose_yaml
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
     CephHealthRecoveredException,
@@ -854,7 +855,8 @@ def exec_cmd(
         if threading_lock and cmd[0] == "oc":
             threading_lock.release()
     masked_stdout = mask_secrets(completed_process.stdout.decode(), secrets)
-    truncated_stdout = truncate_long_lines(masked_stdout)
+    log_stdout = filter_verbose_yaml(masked_stdout)
+    truncated_stdout = truncate_long_lines(log_stdout)
     if len(completed_process.stdout) > 0:
         truncated_stdout = truncate_large_base64(truncated_stdout)
         log.debug(f"Command stdout: {truncated_stdout}")

--- a/ocs_ci/utility/yaml_log_filter.py
+++ b/ocs_ci/utility/yaml_log_filter.py
@@ -1,0 +1,118 @@
+"""
+YAML Log Filter - Reduces verbose YAML output in logs.
+
+Filters verbose fields from `oc get -o yaml` outputs BEFORE logging,
+while keeping full data available for actual use.
+"""
+
+import logging
+import yaml
+
+log = logging.getLogger(__name__)
+
+# Fields to filter: {ResourceKind: {path.to.parent: [fields_to_remove]}}
+VERBOSE_FIELDS: dict[str, dict[str, list[str]]] = {
+    "PackageManifest": {
+        "status.channels": ["currentCSVDesc", "entries"],
+    },
+}
+
+MIN_SIZE_FOR_FILTERING = 5000
+
+
+def filter_verbose_yaml(yaml_str: str, min_size: int = MIN_SIZE_FOR_FILTERING) -> str:
+    """
+    Filter verbose fields from YAML string for logging purposes only.
+
+    Args:
+        yaml_str (str): Raw YAML string from oc command output.
+        min_size (int): Minimum size to trigger filtering.
+
+    Returns:
+        str: Summary string for logging.
+
+    """
+    if not yaml_str or len(yaml_str) < min_size:
+        return yaml_str
+
+    try:
+        data = yaml.safe_load(yaml_str)
+    except yaml.YAMLError:
+        return yaml_str
+
+    if not isinstance(data, dict):
+        return yaml_str
+
+    kind = data.get("kind", "")
+
+    # Check if this resource type should be filtered
+    if kind == "List":
+        item_kinds = {item.get("kind", "") for item in data.get("items", [])}
+        should_filter = any(k in VERBOSE_FIELDS for k in item_kinds)
+    else:
+        should_filter = kind in VERBOSE_FIELDS
+
+    if not should_filter:
+        return yaml_str
+
+    # Apply filtering
+    if kind == "List":
+        for item in data.get("items", []):
+            _filter_item(item)
+    else:
+        _filter_item(data)
+
+    return _format_summary(data, len(yaml_str))
+
+
+def _filter_item(item: dict) -> None:
+    """Remove verbose fields from a single openshift resource."""
+    kind = item.get("kind", "")
+    if kind not in VERBOSE_FIELDS:
+        return
+
+    for path, fields_to_remove in VERBOSE_FIELDS[kind].items():
+        target = _navigate_path(item, path)
+        if target is not None:
+            _remove_fields(target, fields_to_remove)
+
+
+def _navigate_path(data: dict, path: str):
+    """Navigate to a nested location using dot notation."""
+    current = data
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _remove_fields(target, fields: list[str]) -> None:
+    """Remove specified fields from target (list of dicts or dict)."""
+    if isinstance(target, list):
+        for entry in target:
+            if isinstance(entry, dict):
+                for field in fields:
+                    entry.pop(field, None)
+    elif isinstance(target, dict):
+        for field in fields:
+            target.pop(field, None)
+
+
+def _format_summary(data: dict, original_size: int) -> str:
+    """Create a concise summary string for logging."""
+    kind = data.get("kind", "Unknown")
+
+    if kind == "List":
+        items = data.get("items", [])
+        item_kinds: dict[str, int] = {}
+        for item in items:
+            k = item.get("kind", "Unknown")
+            item_kinds[k] = item_kinds.get(k, 0) + 1
+
+        summary = ", ".join(f"{count} {k}" for k, count in item_kinds.items())
+        return f"[List: {summary}] (filtered from {original_size:,} chars)"
+    else:
+        name = data.get("metadata", {}).get("name", "?")
+        return f"[{kind}: {name}] (filtered from {original_size:,} chars)"

--- a/ocs_ci/utility/yaml_log_filter.py
+++ b/ocs_ci/utility/yaml_log_filter.py
@@ -6,9 +6,10 @@ while keeping full data available for actual use.
 """
 
 import logging
+
 import yaml
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 # Fields to filter: {ResourceKind: {path.to.parent: [fields_to_remove]}}
 VERBOSE_FIELDS: dict[str, dict[str, list[str]]] = {
@@ -62,6 +63,11 @@ def filter_verbose_yaml(yaml_str: str, min_size: int = MIN_SIZE_FOR_FILTERING) -
     else:
         _filter_item(data)
 
+    logger.debug(
+        "Filtered verbose YAML output: kind=%s, original_size=%d chars",
+        kind,
+        len(yaml_str),
+    )
     return _format_summary(data, len(yaml_str))
 
 

--- a/ocs_ci/utility/yaml_log_filter.py
+++ b/ocs_ci/utility/yaml_log_filter.py
@@ -48,7 +48,9 @@ def filter_verbose_yaml(yaml_str: str, min_size: int = MIN_SIZE_FOR_FILTERING) -
 
     # Check if this resource type should be filtered
     if kind == "List":
-        item_kinds = {item.get("kind", "") for item in data.get("items", [])}
+        items = data.get("items")
+        items = items if isinstance(items, list) else []
+        item_kinds = {item.get("kind", "") for item in items if isinstance(item, dict)}
         should_filter = any(k in VERBOSE_FIELDS for k in item_kinds)
     else:
         should_filter = kind in VERBOSE_FIELDS
@@ -58,8 +60,11 @@ def filter_verbose_yaml(yaml_str: str, min_size: int = MIN_SIZE_FOR_FILTERING) -
 
     # Apply filtering
     if kind == "List":
-        for item in data.get("items", []):
-            _filter_item(item)
+        items = data.get("items")
+        items = items if isinstance(items, list) else []
+        for item in items:
+            if isinstance(item, dict):
+                _filter_item(item)
     else:
         _filter_item(data)
 
@@ -111,10 +116,11 @@ def _format_summary(data: dict, original_size: int) -> str:
     kind = data.get("kind", "Unknown")
 
     if kind == "List":
-        items = data.get("items", [])
+        items = data.get("items")
+        items = items if isinstance(items, list) else []
         item_kinds: dict[str, int] = {}
         for item in items:
-            k = item.get("kind", "Unknown")
+            k = item.get("kind", "Unknown") if isinstance(item, dict) else "Unknown"
             item_kinds[k] = item_kinds.get(k, 0) + 1
 
         summary = ", ".join(f"{count} {k}" for k, count in item_kinds.items())

--- a/ocs_ci/utility/yaml_log_filter.py
+++ b/ocs_ci/utility/yaml_log_filter.py
@@ -73,7 +73,9 @@ def filter_verbose_yaml(yaml_str: str, min_size: int = MIN_SIZE_FOR_FILTERING) -
         kind,
         len(yaml_str),
     )
-    return _format_summary(data, len(yaml_str))
+    summary = _format_summary(data, len(yaml_str))
+    filtered_yaml = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+    return f"{summary}\n{filtered_yaml}"
 
 
 def _filter_item(item: dict) -> None:


### PR DESCRIPTION
- [x] Created ocs_ci/utility/yaml_log_filter.py - new module for filtering verbose YAML
- [x] Added VERBOSE_FIELDS config for PackageManifest (removes currentCSVDesc, entries)
- [x] Implemented filter_verbose_yaml() function with summary output format
- [x] Integrated filter in ocs_ci/utility/utils.py:exec_cmd() before logging
- [x] Tested with test output YAML samples - 99.9% reduction for PackageManifest output

currently, this PR only handle `packageManifest` output (~80k chars) but it ready for more yaml filtering based on this module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive `oc ... -o yaml` debug output by filtering configured verbose YAML fields before truncation.
  * Preserved command execution results while improving how stdout is summarized for large YAML payloads.
  * Added support for handling YAML resource lists and removing matching verbose fields per resource kind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->