### PR TITLE
Add automation for Protected Applications list view feature [RHSTOR-7239]

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -561,7 +561,7 @@ def check_mirroring_status_ok(
                 logger.warning("Counting 'stopped' value due to the bug DFBUGS-1525")
                 return True
             # Fail fast if count exceeds expected range - indicates leftover resources
-            if current_value > max(expected_value):
+            if current_value is not None and current_value > max(expected_value):
                 raise UnexpectedBehaviour(
                     f"Replaying count ({current_value}) exceeds expected ({max(expected_value)}). "
                     f"Clean up leftover DRPCs and namespaces before retrying."
@@ -614,6 +614,14 @@ def wait_for_mirroring_status_ok(
         logger.info(
             f"Validating mirroring status on cluster {cluster.ENV_DATA['cluster_name']}"
         )
+        # Pre-check: Fail fast if replaying count exceeds expected (indicates leftover resources)
+        # This avoids waiting for full timeout when the issue is leftover DRPCs/namespaces
+        try:
+            check_mirroring_status_ok(replaying_images=replaying_images)
+        except UnexpectedBehaviour:
+            config.switch_ctx(restore_index)
+            raise
+
         sample = TimeoutSampler(
             timeout=timeout,
             sleep=5,
@@ -1461,7 +1469,7 @@ def get_backend_volumes_for_pvcs(namespace):
         logger.info(f"Fetching backend volume names for PVCs in namespace: {namespace}")
         all_pvcs = get_all_pvc_objs(namespace=namespace)
         for pvc_obj in all_pvcs:
-            # Skip volsync related PVCs
+            # Skip VolSync-related PVCs (prefixed with "volsync" or "vs-")
             if pvc_obj.name.startswith("volsync") or pvc_obj.name.startswith("vs-"):
                 continue
 

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1838,3 +1838,879 @@ def navigate_using_fleet_virtualization(acm_obj):
             acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
 
     return True
+
+
+def navigate_to_protected_applications_page(acm_obj, timeout=120):
+    """
+    Navigate to Protected Applications page under Data Services -> Disaster Recovery on ACM UI.
+
+    This page displays both managed (AppSet) and discovered applications that are DR protected.
+    Feature applicable from ODF 4.21+.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        timeout (int): Timeout to wait for page elements
+
+    Returns:
+        bool: True if successfully navigated to Protected Applications page
+
+    Raises:
+        NoSuchElementException: If Protected Applications tab is not found
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    # First navigate to Data Services -> Disaster Recovery
+    log.info("Navigating to Data Services -> Disaster Recovery page")
+    acm_obj.navigate_data_services()
+
+    # Take screenshot after navigating to DR page
+    acm_obj.take_screenshot("dr_overview_page")
+
+    # Click on Protected Applications tab
+    log.info("Clicking on 'Protected applications' tab")
+    protected_app_tab = acm_obj.wait_until_expected_text_is_found(
+        locator=acm_loc["protected-applications-tab"],
+        expected_text="Protected applications",
+        timeout=timeout,
+    )
+    if protected_app_tab:
+        acm_obj.do_click(
+            acm_loc["protected-applications-tab"],
+            avoid_stale=True,
+            enable_screenshot=True,
+        )
+        # Wait for page to load
+        acm_obj.wait_for_element_to_be_visible(
+            acm_loc["protected-app-list-table"], timeout=30
+        )
+        acm_obj.take_screenshot("protected_applications_page")
+        log.info("Successfully navigated to Protected Applications page")
+        return True
+    else:
+        log.error("Protected Applications tab not found on Disaster Recovery page")
+        acm_obj.take_screenshot("protected_app_tab_not_found")
+        raise NoSuchElementException("Protected Applications tab not found")
+
+
+def _clear_filters_and_search_protected_app(acm_obj, app_name, timeout=60):
+    """
+    Helper function to clear filters and search for an application on Protected Applications page.
+
+    This is a common operation used by multiple verification functions.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the application to search for
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        tuple: (app_locator, app_found) where app_locator is the formatted locator
+               and app_found is boolean indicating if app was found
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    # Clear any existing filters (button only appears when filters are active)
+    try:
+        clear_filter_present = acm_obj.check_element_presence(
+            (acm_loc["clear-filter"][1], acm_loc["clear-filter"][0]),
+            timeout=5,
+        )
+        if clear_filter_present:
+            log.info("Clearing existing filters")
+            acm_obj.do_click(acm_loc["clear-filter"])
+    except Exception:
+        pass
+
+    # Click on search bar and enter the app name
+    log.info(f"Searching for application: {app_name}")
+    acm_obj.do_click(acm_loc["protected-app-search-bar"], timeout=timeout)
+    acm_obj.do_clear(acm_loc["protected-app-search-bar"])
+    acm_obj.do_send_keys(acm_loc["protected-app-search-bar"], text=app_name)
+
+    # Wait for search results to load
+    app_locator = format_locator(acm_loc["protected-app-name-in-list"], app_name)
+
+    # Try to wait for element visibility, but don't fail if not found
+    # This is important when verifying app removal (expected_present=False)
+    try:
+        acm_obj.wait_for_element_to_be_visible(app_locator, timeout=10)
+        app_found = True
+    except SeleniumTimeoutException:
+        log.info(f"Application '{app_name}' not visible in search results")
+        app_found = False
+
+    # Take screenshot after search
+    acm_obj.take_screenshot(f"search_result_{app_name}")
+
+    return app_locator, app_found
+
+
+def verify_app_in_protected_applications_list(
+    acm_obj, app_name, timeout=60, expected_present=True, retry_interval=10
+):
+    """
+    Verify if an application is present in the Protected Applications list view.
+
+    This function searches for a specific application on the Protected Applications page
+    which lists both managed (AppSet) and discovered applications.
+
+    The function polls with retries for both presence and absence checks:
+    - When expected_present=True: Polls until app appears or timeout (useful after DR apply)
+    - When expected_present=False: Polls until app disappears or timeout (useful after DR removal)
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the application to search for
+        timeout (int): Total timeout for polling/retry attempts
+        expected_present (bool): If True, expects app to be present; if False, expects app to be absent
+        retry_interval (int): Seconds to wait between retry attempts
+
+    Returns:
+        bool: True if verification passes (app found when expected_present=True,
+              or app not found when expected_present=False)
+
+    """
+    state_desc = "presence" if expected_present else "removal"
+    log.info(
+        f"Verifying application '{app_name}' {state_desc} in Protected Applications list "
+        f"(timeout={timeout}s, retry_interval={retry_interval}s)"
+    )
+
+    end_time = time.time() + timeout
+    attempt = 0
+
+    while time.time() < end_time:
+        attempt += 1
+        log.info(
+            f"Attempt {attempt}: Checking '{app_name}' {state_desc}..."
+        )
+
+        # Navigate to Protected Applications page to refresh the view
+        navigate_to_protected_applications_page(acm_obj)
+
+        # Search for the app
+        _, app_found = _clear_filters_and_search_protected_app(
+            acm_obj, app_name, timeout=30  # Shorter timeout for individual search
+        )
+
+        if expected_present and app_found:
+            log.info(
+                f"Application '{app_name}' found in Protected Applications list "
+                f"(attempt {attempt})"
+            )
+            return True
+        elif not expected_present and not app_found:
+            log.info(
+                f"Application '{app_name}' correctly not present in "
+                f"Protected Applications list (attempt {attempt})"
+            )
+            return True
+
+        # Condition not met yet, log and retry
+        if expected_present:
+            log.info(
+                f"Application '{app_name}' not found yet, "
+                f"waiting {retry_interval}s before next check..."
+            )
+        else:
+            log.info(
+                f"Application '{app_name}' still present, "
+                f"waiting {retry_interval}s before next check..."
+            )
+        time.sleep(retry_interval)
+
+    # Timeout reached
+    if expected_present:
+        log.error(
+            f"Application '{app_name}' NOT found in Protected Applications list "
+            f"after {timeout}s timeout"
+        )
+    else:
+        log.error(
+            f"Application '{app_name}' still found in Protected Applications list "
+            f"after {timeout}s timeout"
+        )
+    return False
+
+
+def verify_protected_applications_list_view(
+    acm_obj,
+    appset_workloads=None,
+    discovered_workloads=None,
+    timeout=60,
+):
+    """
+    Verify that both managed (AppSet) and discovered applications appear
+    on the Protected Applications list view page.
+
+    This is the main verification function for the Protected Applications list view feature
+    which enhances the page to display both managed and discovered applications.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        appset_workloads (list): List of AppSet workload objects (used to derive namespace-based names)
+        discovered_workloads (list): List of Discovered Apps workload objects with
+                                     discovered_apps_placement_name attribute
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if all applications are verified on the Protected Applications page
+
+    Raises:
+        AssertionError: If any application is not found on the Protected Applications page
+
+    """
+    log.info("Starting verification of Protected Applications list view")
+
+    # Navigate to Protected Applications page
+    navigate_to_protected_applications_page(acm_obj, timeout=timeout)
+
+    apps_to_verify = []
+
+    # Collect AppSet workload names
+    if appset_workloads:
+        # Derive name from workload namespace (remove 'appset-' prefix if present)
+        for workload in appset_workloads:
+            # The ApplicationSet name is typically the namespace without 'appset-' prefix
+            # e.g., namespace 'appset-busybox-1-cephfs' -> app name 'busybox-1-cephfs'
+            namespace = workload.workload_namespace
+            if namespace.startswith("appset-"):
+                app_name = namespace[len("appset-") :]
+            else:
+                app_name = namespace
+            apps_to_verify.append(("AppSet/Managed", app_name))
+            log.info(f"Will verify AppSet workload (derived from namespace): {app_name}")
+
+    # Collect Discovered Apps workload names
+    if discovered_workloads:
+        for workload in discovered_workloads:
+            app_name = workload.discovered_apps_placement_name
+            apps_to_verify.append(("Discovered", app_name))
+            log.info(f"Will verify Discovered Apps workload: {app_name}")
+
+    # Verify each application
+    # Note: verify_app_in_protected_applications_list() uses the helper function
+    # _clear_filters_and_search_protected_app() which clears filters before each search
+    for app_type, app_name in apps_to_verify:
+        log.info(f"Verifying {app_type} application: {app_name}")
+        app_found = verify_app_in_protected_applications_list(
+            acm_obj, app_name, timeout=timeout, expected_present=True
+        )
+        if app_found:
+            log.info(
+                f"{app_type} application '{app_name}' successfully verified on Protected Applications page"
+            )
+        else:
+            log.error(
+                f"{app_type} application '{app_name}' NOT found on Protected Applications page"
+            )
+            raise AssertionError(
+                f"{app_type} application '{app_name}' NOT found on Protected Applications page"
+            )
+
+    log.info(
+        "Successfully verified all applications on Protected Applications list view page"
+    )
+
+    return True
+
+
+def verify_protected_app_kebab_menu_actions(
+    acm_obj,
+    app_name,
+    expected_actions=None,
+    timeout=60,
+):
+    """
+    Verify the kebab menu actions available for a protected application.
+
+    This function clicks on the kebab menu for a specific application and verifies
+    that the expected action items are present.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the application to verify kebab menu for
+        expected_actions (list): List of expected action names. Defaults to
+                                 ["Edit configuration", "Failover", "Relocate",
+                                  "Remove disaster recovery"] for managed apps.
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if all expected actions are present
+
+    Raises:
+        AssertionError: If any expected action is not found in the kebab menu
+
+    """
+    if expected_actions is None:
+        expected_actions = [
+            "Edit configuration",
+            "Failover",
+            "Relocate",
+            "Manage disaster recovery",
+        ]
+
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    log.info(f"Verifying kebab menu actions for app: {app_name}")
+
+    # Clear filters and search for the application
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout)
+
+    # Click on the kebab menu for this application
+    log.info(f"Clicking kebab menu for app: {app_name}")
+    kebab_locator = format_locator(acm_loc["protected-app-kebab-menu"], app_name)
+    acm_obj.do_click(kebab_locator, timeout=timeout, enable_screenshot=True)
+
+    # Wait for dropdown menu to appear
+    first_action_locator = format_locator(
+        acm_loc["protected-app-action-menu-item"], expected_actions[0]
+    )
+    acm_obj.wait_for_element_to_be_visible(first_action_locator, timeout=10)
+    acm_obj.take_screenshot(f"kebab_menu_{app_name}")
+
+    # Verify each expected action is present
+    all_actions_found = True
+    for action in expected_actions:
+        log.info(f"Checking for action: {action}")
+
+        # Use the parameterized locator for menu item
+        action_locator = format_locator(
+            acm_loc["protected-app-action-menu-item"], action
+        )
+
+        action_found = acm_obj.check_element_presence(
+            (action_locator[1], action_locator[0]), timeout=10
+        )
+
+        if action_found:
+            log.info(f"Action '{action}' found in kebab menu")
+        else:
+            log.error(f"Action '{action}' NOT found in kebab menu")
+            all_actions_found = False
+
+    # Close the kebab menu by pressing Escape
+    try:
+        from selenium.webdriver.common.keys import Keys
+
+        acm_obj.driver.find_element("tag name", "body").send_keys(Keys.ESCAPE)
+        time.sleep(1)
+    except Exception as e:
+        log.debug(f"Could not close kebab menu: {e}")
+
+    if all_actions_found:
+        log.info(
+            f"All expected actions verified for app '{app_name}': {expected_actions}"
+        )
+    else:
+        acm_obj.take_screenshot(f"kebab_menu_actions_missing_{app_name}")
+        raise AssertionError(
+            f"Not all expected actions found in kebab menu for app '{app_name}'. "
+            f"Expected: {expected_actions}"
+        )
+
+    return all_actions_found
+
+
+def verify_protected_app_dr_status(
+    acm_obj,
+    app_name,
+    expected_status,
+    timeout=120,
+):
+    """
+    Verify the DR status of a protected application on the Protected Applications page.
+
+    This function navigates to the Protected Applications page, searches for the
+    specified application, and verifies its DR status matches the expected value.
+
+    DR Status values:
+        - Protecting: Initial sync in progress
+        - Healthy: Sync completed successfully
+        - Warning: Sync delayed beyond threshold
+        - Critical: Sync failed or cluster issues
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the application to verify DR status for
+        expected_status (str): Expected DR status (Protecting, Healthy, Warning, Critical)
+        timeout (int): Timeout to wait for expected status
+
+    Returns:
+        bool: True if DR status matches expected value
+
+    Raises:
+        AssertionError: If DR status does not match expected value within timeout
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    log.info(f"Verifying DR status for app '{app_name}', expected: '{expected_status}'")
+
+    # Navigate to Protected Applications page if not already there
+    navigate_to_protected_applications_page(acm_obj, timeout=timeout)
+
+    # Clear filters and search for the application
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout=30)
+
+    # Get DR status locator for this app
+    status_locator = format_locator(acm_loc["protected-app-dr-status"], app_name)
+
+    # Wait for status element to be visible and get actual status
+    acm_obj.wait_for_element_to_be_visible(status_locator, timeout=timeout)
+
+    try:
+        actual_status = acm_obj.get_element_text(status_locator)
+    except Exception:
+        actual_status = "Unknown"
+
+    acm_obj.take_screenshot(f"dr_status_{app_name}_{expected_status}")
+
+    # Case-insensitive comparison for status
+    if actual_status.lower() == expected_status.lower():
+        log.info(f"App '{app_name}' has expected DR status: '{actual_status}'")
+        return True
+    else:
+        log.error(
+            f"App '{app_name}' DR status mismatch. "
+            f"Expected: '{expected_status}', Actual: '{actual_status}'"
+        )
+        acm_obj.take_screenshot(f"dr_status_mismatch_{app_name}")
+        raise AssertionError(
+            f"DR status for app '{app_name}' is '{actual_status}', "
+            f"expected '{expected_status}'"
+        )
+
+
+def verify_manage_dr_modal_for_managed_app(
+    acm_obj,
+    app_name,
+    expected_policy_name,
+    drpc_obj=None,
+    timeout=60,
+):
+    """
+    Verify the Manage DR modal for a managed application shows correct details.
+
+    This function opens the kebab menu for the specified managed app, clicks
+    "Manage disaster recovery" action, and verifies the modal content including:
+    - DR Policy name (with "Validated" status)
+    - Volume group replication status (Enabled)
+    - Last sync time (matches CLI if drpc_obj provided)
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the managed application
+        expected_policy_name (str): Expected DR policy name (e.g., "odr-policy-5m")
+        drpc_obj (DRPC): DRPC object to get CLI last sync time for comparison (optional)
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if all verifications pass
+
+    Raises:
+        AssertionError: If any verification fails
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    log.info(f"Verifying Manage DR modal for managed app: {app_name}")
+
+    # Navigate to Protected Applications page
+    navigate_to_protected_applications_page(acm_obj, timeout=timeout)
+
+    # Clear filters and search for the application
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout=30)
+
+    # Click kebab menu for this app
+    kebab_locator = format_locator(acm_loc["protected-app-kebab-menu"], app_name)
+    acm_obj.do_click(kebab_locator, timeout=timeout)
+    log.info(f"Clicked kebab menu for app: {app_name}")
+
+    # Click "Manage disaster recovery" action
+    action_locator = format_locator(
+        acm_loc["protected-app-action-menu-item"], "Manage disaster recovery"
+    )
+    acm_obj.do_click(action_locator, timeout=timeout)
+    log.info("Clicked 'Manage disaster recovery' action")
+
+    # Wait for modal to appear
+    acm_obj.wait_for_element_to_be_visible(
+        acm_loc["manage-dr-modal"], timeout=timeout
+    )
+    acm_obj.take_screenshot(f"manage_dr_modal_{app_name}")
+    log.info("Manage DR modal opened successfully")
+
+    verification_results = []
+
+    # Verify DR Policy name
+    policy_locator = format_locator(
+        acm_loc["manage-dr-policy-name"], expected_policy_name
+    )
+    policy_found = acm_obj.check_element_presence(
+        (policy_locator[1], policy_locator[0]), timeout=30
+    )
+    if policy_found:
+        log.info(f"Verified DR Policy name: {expected_policy_name}")
+        verification_results.append(("DR Policy name", True))
+    else:
+        log.error(f"DR Policy name '{expected_policy_name}' NOT found in modal")
+        verification_results.append(("DR Policy name", False))
+
+    # Verify Volume group replication is Enabled
+    vrg_found = acm_obj.check_element_presence(
+        (acm_loc["manage-dr-vrg-status"][1], acm_loc["manage-dr-vrg-status"][0]),
+        timeout=30,
+    )
+    if vrg_found:
+        log.info("Verified Volume group replication: Enabled")
+        verification_results.append(("VRG Enabled", True))
+    else:
+        log.error("Volume group replication 'Enabled' NOT found in modal")
+        verification_results.append(("VRG Enabled", False))
+
+    # Verify Last sync time is present
+    sync_time_found = acm_obj.check_element_presence(
+        (
+            acm_loc["manage-dr-last-sync-time"][1],
+            acm_loc["manage-dr-last-sync-time"][0],
+        ),
+        timeout=30,
+    )
+    if sync_time_found:
+        try:
+            sync_time_element = acm_obj.find_an_element_by_xpath(
+                acm_loc["manage-dr-last-sync-time"][0]
+            )
+            ui_sync_time_text = sync_time_element.text
+            log.info(f"Last sync time from UI: {ui_sync_time_text}")
+            verification_results.append(("Last sync time present", True))
+
+            # If DRPC object provided, compare with CLI
+            if drpc_obj:
+                cli_sync_time = drpc_obj.get_last_group_sync_time()
+                log.info(f"Last sync time from CLI (DRPC): {cli_sync_time}")
+                # UI format: "Last synced on 9 Feb 2026, 08:15 UTC"
+                # CLI format: "2026-02-09T08:15:00Z"
+                # For basic validation, just log both values
+                log.info(
+                    f"UI sync time: {ui_sync_time_text}, CLI sync time: {cli_sync_time}"
+                )
+        except Exception as e:
+            log.warning(f"Could not get last sync time text: {e}")
+    else:
+        log.error("Last sync time NOT found in modal")
+        verification_results.append(("Last sync time present", False))
+
+    acm_obj.take_screenshot(f"manage_dr_modal_verified_{app_name}")
+
+    # Close the modal
+    try:
+        acm_obj.do_click(acm_loc["manage-dr-modal-close"], timeout=10)
+        log.info("Closed Manage DR modal")
+    except Exception as e:
+        log.warning(f"Could not close modal using close button: {e}")
+        # Try pressing Escape key as fallback
+        from selenium.webdriver.common.keys import Keys
+
+        acm_obj.send_keys(Keys.ESCAPE)
+
+    # Check all verifications passed
+    failed_checks = [name for name, passed in verification_results if not passed]
+    if failed_checks:
+        raise AssertionError(
+            f"Manage DR modal verification failed for app '{app_name}'. "
+            f"Failed checks: {failed_checks}"
+        )
+
+    log.info(f"All Manage DR modal verifications passed for app: {app_name}")
+    return True
+
+
+def failover_from_protected_app_page(
+    acm_obj,
+    app_name,
+    expected_target_cluster,
+    drpc_obj=None,
+    timeout=120,
+):
+    """
+    Perform failover for a managed application from the Protected Applications page.
+
+    This function:
+    1. Navigates to Protected Applications page
+    2. Searches for the app and clicks Failover from kebab menu
+    3. Verifies failover modal content (target cluster, readiness)
+    4. Clicks Initiate to start failover
+    5. Waits for failover completion via CLI (DRPC status)
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the managed application to failover
+        expected_target_cluster (str): Expected target cluster name for failover
+        drpc_obj (DRPC): DRPC object for CLI verification (optional)
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if failover initiated successfully
+
+    Raises:
+        AssertionError: If failover readiness is not Ready or target cluster mismatch
+
+    """
+    from ocs_ci.ocs import constants
+
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    log.info(f"Initiating failover for app '{app_name}' to cluster '{expected_target_cluster}'")
+
+    # Navigate to Protected Applications page
+    navigate_to_protected_applications_page(acm_obj, timeout=timeout)
+
+    # Clear filters and search for the application
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout=30)
+
+    # Click kebab menu for this app
+    kebab_locator = format_locator(acm_loc["protected-app-kebab-menu"], app_name)
+    acm_obj.do_click(kebab_locator, timeout=timeout)
+    log.info(f"Clicked kebab menu for app: {app_name}")
+
+    # Click "Failover" action
+    action_locator = format_locator(acm_loc["protected-app-action-menu-item"], "Failover")
+    acm_obj.do_click(action_locator, timeout=timeout)
+    log.info("Clicked 'Failover' action from kebab menu")
+
+    # Wait for failover modal to appear
+    acm_obj.wait_for_element_to_be_visible(acm_loc["failover-modal"], timeout=timeout)
+    acm_obj.take_screenshot(f"failover_modal_{app_name}")
+    log.info("Failover modal opened successfully")
+
+    # Verify target cluster name is present in modal
+    target_cluster_locator = format_locator(
+        acm_loc["failover-target-cluster-text"], expected_target_cluster
+    )
+    target_found = acm_obj.check_element_presence(
+        (target_cluster_locator[1], target_cluster_locator[0]), timeout=30
+    )
+    if not target_found:
+        acm_obj.take_screenshot(f"failover_target_cluster_not_found_{app_name}")
+        raise AssertionError(
+            f"Target cluster '{expected_target_cluster}' not found in Failover modal"
+        )
+    log.info(f"Verified target cluster: {expected_target_cluster}")
+
+    # Verify failover readiness is "Ready"
+    readiness_found = acm_obj.check_element_presence(
+        (acm_loc["failover-ready-status"][1], acm_loc["failover-ready-status"][0]),
+        timeout=60,
+    )
+    if not readiness_found:
+        acm_obj.take_screenshot(f"failover_not_ready_{app_name}")
+        raise AssertionError(f"Failover readiness is not 'Ready' for app '{app_name}'")
+    log.info("Verified failover readiness: Ready")
+
+    acm_obj.take_screenshot(f"failover_modal_verified_{app_name}")
+
+    # Click Initiate button to start failover
+    log.info("Clicking Initiate button to start failover")
+    acm_obj.do_click(acm_loc["failover-initiate-btn"], timeout=timeout)
+    log.info(f"Failover initiated for app: {app_name}")
+
+    acm_obj.take_screenshot(f"failover_initiated_{app_name}")
+
+    # Wait for failover completion via CLI if DRPC object provided
+    if drpc_obj:
+        log.info(f"Waiting for DRPC to reach {constants.STATUS_FAILEDOVER} phase")
+        drpc_obj.wait_for_phase(constants.STATUS_FAILEDOVER, timeout=600)
+        log.info(f"DRPC reached {constants.STATUS_FAILEDOVER} phase - failover complete")
+
+    return True
+
+
+def relocate_from_protected_app_page(
+    acm_obj,
+    app_name,
+    expected_target_cluster,
+    drpc_obj=None,
+    timeout=120,
+):
+    """
+    Perform relocate for a managed application from the Protected Applications page.
+
+    This function:
+    1. Navigates to Protected Applications page
+    2. Searches for the app and clicks Relocate from kebab menu
+    3. Verifies relocate modal content (target cluster, readiness)
+    4. Clicks Initiate to start relocate
+    5. Waits for relocate completion via CLI (DRPC status)
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the managed application to relocate
+        expected_target_cluster (str): Expected target cluster name for relocate
+        drpc_obj (DRPC): DRPC object for CLI verification (optional)
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if relocate initiated successfully
+
+    Raises:
+        AssertionError: If relocate readiness is not Ready or target cluster mismatch
+
+    """
+    from ocs_ci.ocs import constants
+
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    log.info(f"Initiating relocate for app '{app_name}' to cluster '{expected_target_cluster}'")
+
+    # Navigate to Protected Applications page
+    navigate_to_protected_applications_page(acm_obj, timeout=timeout)
+
+    # Clear filters and search for the application
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout=30)
+
+    # Click kebab menu for this app
+    kebab_locator = format_locator(acm_loc["protected-app-kebab-menu"], app_name)
+    acm_obj.do_click(kebab_locator, timeout=timeout)
+    log.info(f"Clicked kebab menu for app: {app_name}")
+
+    # Click "Relocate" action
+    action_locator = format_locator(acm_loc["protected-app-action-menu-item"], "Relocate")
+    acm_obj.do_click(action_locator, timeout=timeout)
+    log.info("Clicked 'Relocate' action from kebab menu")
+
+    # Wait for relocate modal to appear
+    acm_obj.wait_for_element_to_be_visible(acm_loc["relocate-modal"], timeout=timeout)
+    acm_obj.take_screenshot(f"relocate_modal_{app_name}")
+    log.info("Relocate modal opened successfully")
+
+    # Verify target cluster name is present in modal
+    target_cluster_locator = format_locator(
+        acm_loc["relocate-target-cluster-text"], expected_target_cluster
+    )
+    target_found = acm_obj.check_element_presence(
+        (target_cluster_locator[1], target_cluster_locator[0]), timeout=30
+    )
+    if not target_found:
+        acm_obj.take_screenshot(f"relocate_target_cluster_not_found_{app_name}")
+        raise AssertionError(
+            f"Target cluster '{expected_target_cluster}' not found in Relocate modal"
+        )
+    log.info(f"Verified target cluster: {expected_target_cluster}")
+
+    # Verify relocate readiness is "Ready"
+    readiness_found = acm_obj.check_element_presence(
+        (acm_loc["relocate-ready-status"][1], acm_loc["relocate-ready-status"][0]),
+        timeout=60,
+    )
+    if not readiness_found:
+        acm_obj.take_screenshot(f"relocate_not_ready_{app_name}")
+        raise AssertionError(f"Relocate readiness is not 'Ready' for app '{app_name}'")
+    log.info("Verified relocate readiness: Ready")
+
+    acm_obj.take_screenshot(f"relocate_modal_verified_{app_name}")
+
+    # Click Initiate button to start relocate
+    log.info("Clicking Initiate button to start relocate")
+    acm_obj.do_click(acm_loc["relocate-initiate-btn"], timeout=timeout)
+    log.info(f"Relocate initiated for app: {app_name}")
+
+    acm_obj.take_screenshot(f"relocate_initiated_{app_name}")
+
+    # Wait for relocate completion via CLI if DRPC object provided
+    if drpc_obj:
+        log.info(f"Waiting for DRPC to reach {constants.STATUS_RELOCATED} phase")
+        drpc_obj.wait_for_phase(constants.STATUS_RELOCATED, timeout=600)
+        log.info(f"DRPC reached {constants.STATUS_RELOCATED} phase - relocate complete")
+
+    return True
+
+
+def remove_dr_from_protected_app_page(acm_obj, app_name, timeout=120):
+    """
+    Remove DR protection for an application from the Protected Applications page.
+
+    This function:
+    1. Navigates to the Protected Applications page
+    2. Searches for the application
+    3. Clicks the kebab menu and selects "Manage disaster recovery"
+    4. Clicks "Remove disaster recovery" button in the modal
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        app_name (str): Name of the application to remove DR protection from
+        timeout (int): Timeout for UI operations
+
+    Returns:
+        bool: True if DR removal was initiated successfully
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    # Navigate to Protected Applications page
+    log.info(f"Navigating to Protected Applications page to remove DR for: {app_name}")
+    navigate_to_protected_applications_page(acm_obj)
+
+    # Search for the application
+    log.info(f"Searching for application: {app_name}")
+    _clear_filters_and_search_protected_app(acm_obj, app_name, timeout)
+
+    # Click on kebab menu for the application
+    log.info(f"Opening kebab menu for app: {app_name}")
+    kebab_locator = format_locator(acm_loc["protected-app-kebab-menu"], app_name)
+    acm_obj.do_click(kebab_locator, enable_screenshot=True, timeout=timeout)
+
+    # Click on "Manage disaster recovery" action
+    log.info("Clicking 'Manage disaster recovery' action")
+    action_locator = format_locator(
+        acm_loc["protected-app-action-menu-item"], "Manage disaster recovery"
+    )
+    acm_obj.do_click(action_locator, enable_screenshot=True, timeout=timeout)
+
+    # Wait for Manage DR modal to appear
+    log.info("Waiting for Manage DR modal to appear")
+    acm_obj.wait_for_element_to_be_visible(acm_loc["manage-dr-modal"], timeout=30)
+    acm_obj.take_screenshot(f"manage_dr_modal_{app_name}")
+
+    # Click on "Remove disaster recovery" button
+    log.info("Clicking 'Remove disaster recovery' button")
+    acm_obj.do_click(acm_loc["remove-dr-btn"], enable_screenshot=True, timeout=timeout)
+
+    # Wait for confirmation dialog to appear
+    log.info("Waiting for confirmation dialog...")
+    time.sleep(2)
+    acm_obj.take_screenshot(f"dr_removal_confirmation_dialog_{app_name}")
+
+    # Click on "Confirm remove" button
+    log.info("Clicking 'Confirm remove' button")
+    acm_obj.do_click(
+        acm_loc["confirm-remove-dr-btn"], enable_screenshot=True, timeout=timeout
+    )
+
+    log.info(f"DR removal confirmed for app: {app_name}")
+    acm_obj.take_screenshot(f"dr_removal_confirmed_{app_name}")
+
+    # Wait for DR removal to complete and modal to close
+    time.sleep(5)
+
+    # Close the Manage DR modal if it's still open
+    log.info("Checking if modal needs to be closed...")
+    try:
+        modal_close_btn = acm_obj.check_element_presence(
+            (acm_loc["manage-dr-modal-close"][1], acm_loc["manage-dr-modal-close"][0]),
+            timeout=5,
+        )
+        if modal_close_btn:
+            acm_obj.do_click(
+                acm_loc["manage-dr-modal-close"], enable_screenshot=True, timeout=10
+            )
+            log.info("Manage DR modal closed successfully")
+    except Exception as e:
+        log.info(f"Modal may have closed automatically: {e}")
+
+    acm_obj.take_screenshot(f"dr_removal_complete_{app_name}")
+
+    return True

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1586,6 +1586,7 @@ acm_configuration_4_12 = {
     "failover-preferred-cluster-name": ("//button[text()='{}']", By.XPATH),
     "operation-readiness": ("//*[contains(text(), 'Ready')]", By.XPATH),
     "peer-ready": ("//i[normalize-space()='Peer ready']", By.XPATH),
+    # Note: "intiate" is intentional - matches typo in UI source code (bug reported)
     "initiate-action": ("#modal-intiate-action", By.CSS_SELECTOR),
     "close-action-modal": ("//button[normalize-space()='Close']", By.XPATH),
     "close-action-modal-page": ("//*[text()='Close']", By.XPATH),
@@ -1843,6 +1844,7 @@ acm_configuration_4_20 = {
 }
 
 acm_configuration_4_21 = {
+    # VM-related locators
     "vm-actions": ('//button[@data-test="actions-dropdown"]', By.XPATH),
     "dr-policy": (
         "//button[@aria-label='Typeahead single select']",
@@ -1859,6 +1861,127 @@ acm_configuration_4_21 = {
     "assign": (
         "//button[contains(@class, 'c-button pf-m-primary pf-m-progress') and contains(text(), 'Assign')]",
         By.XPATH,
+    ),
+    # Protected Applications list view locators
+    "protected-applications-tab": (
+        "//a[normalize-space()='Protected applications'] | "
+        "//a[@data-test-id='horizontal-link-Protected applications']",
+        By.XPATH,
+    ),
+    "protected-app-search-bar": (
+        "//input[contains(@placeholder, 'Search') or contains(@aria-label, 'Search')]",
+        By.XPATH,
+    ),
+    "protected-app-list-table": (
+        "//table",
+        By.XPATH,
+    ),
+    "protected-app-name-in-list": (
+        "//a[@data-test='resource-link-{}']",
+        By.XPATH,
+    ),
+    "protected-app-kebab-menu": (
+        "//tr[.//a[@data-test='resource-link-{}']]//button[@aria-label='Kebab toggle' or contains(@class, 'pf-v5-c-menu-toggle')]",
+        By.XPATH,
+    ),
+    "protected-app-action-menu-item": (
+        "//button[@role='menuitem'][contains(., '{}')]",
+        By.XPATH,
+    ),
+    "protected-app-dr-status": (
+        "//tr[.//a[@data-test='resource-link-{}']]//span[@data-test='status-text']",
+        By.XPATH,
+    ),
+    "manage-dr-modal": (
+        "//div[@role='dialog'][contains(@aria-label, 'Manage')]",
+        By.XPATH,
+    ),
+    "manage-dr-modal-close": (
+        "//div[@role='dialog']//button[@aria-label='Close']",
+        By.XPATH,
+    ),
+    "manage-dr-policy-name": (
+        "//*[contains(text(), 'Name:')][contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "manage-dr-vrg-status": (
+        "//*[contains(text(), 'Volume group replication:')]//following-sibling::*[contains(text(), 'Enabled')] | "
+        "//*[contains(text(), 'Volume group replication:')]/parent::*//*[contains(text(), 'Enabled')]",
+        By.XPATH,
+    ),
+    "manage-dr-last-sync-time": (
+        "//*[contains(., 'Last synced on')]",
+        By.XPATH,
+    ),
+    "remove-dr-btn": (
+        "#disable-dr-action",
+        By.CSS_SELECTOR,
+    ),
+    "confirm-remove-dr-btn": (
+        "#confirm-disable-dr-action",
+        By.CSS_SELECTOR,
+    ),
+    "cancel-remove-dr-btn": (
+        "#cancel-disable-dr-action",
+        By.CSS_SELECTOR,
+    ),
+    "failover-modal": (
+        "//div[@role='dialog'][contains(., 'Failover application')]",
+        By.XPATH,
+    ),
+    "failover-target-cluster-container": (
+        "//div[contains(@class, 'mco-dr-action-body__target-cluster')]",
+        By.XPATH,
+    ),
+    "failover-readiness-label": (
+        "//strong[contains(text(), 'Failover readiness:')]",
+        By.XPATH,
+    ),
+    "failover-last-synced": (
+        "//*[contains(text(), 'Volume last synced on:')]/following-sibling::*",
+        By.XPATH,
+    ),
+    "failover-target-cluster-text": (
+        "//div[contains(@class, 'mco-dr-action-body__target-cluster')]//*[contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "failover-ready-status": (
+        "//strong[contains(text(), 'Failover readiness:')]/../..//*[text()='Ready']",
+        By.XPATH,
+    ),
+    # Note: "intiate" is intentional - matches typo in UI source code (bug reported)
+    "failover-initiate-btn": (
+        "#modal-intiate-action, #modal-initiate-action",
+        By.CSS_SELECTOR,
+    ),
+    "failover-cancel-btn": (
+        "#modal-cancel-action",
+        By.CSS_SELECTOR,
+    ),
+    "relocate-modal": (
+        "//div[@role='dialog'][contains(., 'Relocate application')]",
+        By.XPATH,
+    ),
+    "relocate-target-cluster-container": (
+        "//div[contains(@class, 'mco-dr-action-body__target-cluster')]",
+        By.XPATH,
+    ),
+    "relocate-target-cluster-text": (
+        "//div[contains(@class, 'mco-dr-action-body__target-cluster')]//*[contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "relocate-ready-status": (
+        "//strong[contains(text(), 'Relocate readiness:')]/../..//*[text()='Ready']",
+        By.XPATH,
+    ),
+    "relocate-last-synced-label": (
+        "//strong[contains(text(), 'Volume last synced on:')]",
+        By.XPATH,
+    ),
+    # Note: "intiate" is intentional - matches typo in UI source code (bug reported)
+    "relocate-initiate-btn": (
+        "#modal-intiate-action, #modal-initiate-action",
+        By.CSS_SELECTOR,
     ),
 }
 

--- a/tests/functional/disaster-recovery/regional-dr/test_protected_application_list_view.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_protected_application_list_view.py
@@ -1,0 +1,536 @@
+import logging
+from time import sleep
+
+import pytest
+
+from ocs_ci.framework.testlib import tier1, skipif_ocs_version
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.framework import config
+from ocs_ci.helpers.dr_helpers_ui import (
+    verify_protected_applications_list_view,
+    verify_protected_app_kebab_menu_actions,
+    verify_protected_app_dr_status,
+    verify_manage_dr_modal_for_managed_app,
+    failover_from_protected_app_page,
+    relocate_from_protected_app_page,
+    remove_dr_from_protected_app_page,
+    verify_app_in_protected_applications_list,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.drpc import DRPC
+from ocs_ci.ocs.acm.acm import AcmAddClusters
+
+logger = logging.getLogger(__name__)
+
+
+@rdr
+@tier1
+@turquoise_squad
+@skipif_ocs_version("<4.21")
+class TestProtectedApplicationListView:
+    """
+    Test class for Protected Application list view feature.
+    Validates that both managed (AppSet) and discovered applications
+    are displayed on the Protected Applications page in ACM UI.
+
+    This test deploys:
+    - 2 Managed (AppSet) applications:
+      - App1: Used for UI verification (Steps 1-5), Failover, and Relocate
+      - App2: Used for Remove DR action (independent of failover/relocate)
+    - 1 Discovered application: Used for UI verification only
+    """
+
+    @pytest.mark.polarion_id("OCS-7426")
+    @pytest.mark.parametrize(
+        argnames=["pvc_interface"],
+        argvalues=[
+            pytest.param(
+                constants.CEPHBLOCKPOOL,
+                id="rbd",
+            ),
+            pytest.param(
+                constants.CEPHFILESYSTEM,
+                id="cephfs",
+            ),
+        ],
+    )
+    def test_protected_application_list_view(
+        self,
+        pvc_interface,
+        setup_acm_ui,
+        dr_workload,
+        discovered_apps_dr_workload,
+    ):
+        """
+        Test to verify Protected Application list view displays both
+        managed (AppSet) and discovered applications, and validates
+        UI-driven DR actions (Failover, Relocate, Remove DR).
+
+        Test Flow:
+        - Deploy 2 AppSet workloads and 1 Discovered Apps workload
+        - Steps 1-5: UI verification (list view, DR status, kebab menu, modal)
+        - Step 6: Failover app1 from UI
+        - Step 7: Relocate app1 from UI (depends on failover success)
+        - Step 8: Remove DR for app2 from UI
+        """
+        storage_type = "RBD" if pvc_interface == constants.CEPHBLOCKPOOL else "CephFS"
+        logger.info(f"Running test with storage interface: {storage_type}")
+
+        # Deploy workloads
+        appset_workloads = dr_workload(
+            num_of_subscription=0,
+            num_of_appset=2,
+            pvc_interface=pvc_interface,
+        )
+        logger.info(
+            f"AppSet workload 1 deployed in namespace: {appset_workloads[0].workload_namespace}"
+        )
+        logger.info(
+            f"AppSet workload 2 deployed in namespace: {appset_workloads[1].workload_namespace}"
+        )
+
+        discovered_workload = discovered_apps_dr_workload(
+            kubeobject=1,
+            recipe=0,
+            pvc_interface=pvc_interface,
+        )
+        logger.info(
+            f"Discovered Apps workload deployed in namespace: "
+            f"{discovered_workload[0].workload_namespace}"
+        )
+
+        # Setup DRPC objects
+        drpc_app1 = DRPC(
+            namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+            resource_name=f"{appset_workloads[0].appset_placement_name}-drpc",
+        )
+        drpc_app2 = DRPC(
+            namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+            resource_name=f"{appset_workloads[1].appset_placement_name}-drpc",
+        )
+        drpc_discovered = DRPC(namespace=constants.DR_OPS_NAMESPACE)
+        drpc_objs = [drpc_app1, drpc_app2, drpc_discovered]
+
+        # Wait for initial sync
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        wait_time = 2 * scheduling_interval
+        logger.info(f"Waiting for {wait_time} minutes for initial sync to complete...")
+        sleep(wait_time * 60)
+
+        for drpc_obj in drpc_objs:
+            progression_status = drpc_obj.get_progression_status()
+            logger.info(
+                f"DRPC {drpc_obj.resource_name} PROGRESSION status: {progression_status}"
+            )
+            assert progression_status == constants.STATUS_COMPLETED, (
+                f"DRPC {drpc_obj.resource_name} PROGRESSION status is {progression_status}, "
+                f"expected {constants.STATUS_COMPLETED}"
+            )
+
+        for drpc_obj in drpc_objs:
+            dr_helpers.verify_last_group_sync_time(drpc_obj, scheduling_interval)
+
+        # Derive application names for UI verification
+        def derive_app_name(workload):
+            namespace = workload.workload_namespace
+            if namespace.startswith("appset-"):
+                return namespace[len("appset-"):]
+            return namespace
+
+        app1_name = derive_app_name(appset_workloads[0])
+        app2_name = derive_app_name(appset_workloads[1])
+        discovered_app_name = discovered_workload[0].discovered_apps_placement_name
+
+        logger.info(f"App1 (failover/relocate): {app1_name}")
+        logger.info(f"App2 (remove DR): {app2_name}")
+        logger.info(f"Discovered app: {discovered_app_name}")
+
+        # Initialize ACM UI and error tracking
+        acm_obj = AcmAddClusters()
+        verification_errors = []
+
+        # Step 1: Verify applications on Protected Applications page
+        logger.info("=" * 60)
+        logger.info("Step 1: Verify applications on Protected Applications page")
+        logger.info("=" * 60)
+        try:
+            verify_protected_applications_list_view(
+                acm_obj=acm_obj,
+                appset_workloads=appset_workloads,
+                discovered_workloads=discovered_workload,
+                timeout=120,
+            )
+            logger.info("Step 1 PASSED: All applications verified on Protected Applications page")
+        except Exception as e:
+            error_msg = f"Step 1 FAILED: Verify applications on page - {e}"
+            logger.error(error_msg)
+            verification_errors.append(error_msg)
+
+        # Step 2: Verify DR status "Healthy" for all apps
+        logger.info("=" * 60)
+        logger.info("Step 2: Verify DR status 'Healthy' for all apps")
+        logger.info("=" * 60)
+        for app_name in [app1_name, app2_name, discovered_app_name]:
+            try:
+                verify_protected_app_dr_status(
+                    acm_obj=acm_obj,
+                    app_name=app_name,
+                    expected_status="healthy",
+                    timeout=60,
+                )
+                logger.info(f"Step 2 PASSED: DR status 'healthy' for: {app_name}")
+            except Exception as e:
+                error_msg = f"Step 2 FAILED: DR status check for {app_name} - {e}"
+                logger.error(error_msg)
+                verification_errors.append(error_msg)
+
+        # Step 3: Verify kebab menu actions for managed apps
+        logger.info("=" * 60)
+        logger.info("Step 3: Verify kebab menu actions for managed apps")
+        logger.info("=" * 60)
+        for app_name in [app1_name, app2_name]:
+            try:
+                verify_protected_app_kebab_menu_actions(
+                    acm_obj=acm_obj,
+                    app_name=app_name,
+                    expected_actions=[
+                        "Edit configuration",
+                        "Failover",
+                        "Relocate",
+                        "Manage disaster recovery",
+                    ],
+                    timeout=60,
+                )
+                logger.info(f"Step 3 PASSED: Kebab menu verified for managed app: {app_name}")
+            except Exception as e:
+                error_msg = f"Step 3 FAILED: Kebab menu for managed app {app_name} - {e}"
+                logger.error(error_msg)
+                verification_errors.append(error_msg)
+
+        # Step 4: Verify kebab menu actions for discovered app
+        logger.info("=" * 60)
+        logger.info("Step 4: Verify kebab menu actions for discovered app")
+        logger.info("=" * 60)
+        try:
+            verify_protected_app_kebab_menu_actions(
+                acm_obj=acm_obj,
+                app_name=discovered_app_name,
+                expected_actions=[
+                    "Edit configuration",
+                    "Failover",
+                    "Relocate",
+                    "Remove disaster recovery",
+                ],
+                timeout=60,
+            )
+            logger.info(f"Step 4 PASSED: Kebab menu verified for discovered app: {discovered_app_name}")
+        except Exception as e:
+            error_msg = f"Step 4 FAILED: Kebab menu for discovered app {discovered_app_name} - {e}"
+            logger.error(error_msg)
+            verification_errors.append(error_msg)
+
+        # Step 5: Verify Manage DR modal for managed app
+        logger.info("=" * 60)
+        logger.info("Step 5: Verify Manage DR modal for managed app")
+        logger.info("=" * 60)
+        dr_policy_name = appset_workloads[0].dr_policy_name
+        try:
+            verify_manage_dr_modal_for_managed_app(
+                acm_obj=acm_obj,
+                app_name=app1_name,
+                expected_policy_name=dr_policy_name,
+                drpc_obj=drpc_app1,
+                timeout=60,
+            )
+            logger.info(f"Step 5 PASSED: Manage DR modal verified for: {app1_name}")
+        except Exception as e:
+            error_msg = f"Step 5 FAILED: Manage DR modal for {app1_name} - {e}"
+            logger.error(error_msg)
+            verification_errors.append(error_msg)
+
+        # DR Action Steps - Get cluster info before failover
+        dr_action_errors = []
+        primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        primary_cluster_index = config.get_cluster_index_by_name(primary_cluster_name)
+        secondary_cluster_index = config.get_cluster_index_by_name(secondary_cluster_name)
+        dr_status_timeout = 3 * scheduling_interval * 60
+        failover_success = False
+        relocate_success = False
+        remove_dr_success = False
+
+        # Step 6: Failover app1 from Protected Applications page
+        logger.info("=" * 60)
+        logger.info("Step 6: Failover app1 from Protected Applications page")
+        logger.info("=" * 60)
+        logger.info(
+            f"Before failover - Primary: {primary_cluster_name}, Secondary: {secondary_cluster_name}"
+        )
+
+        try:
+            failover_from_protected_app_page(
+                acm_obj=acm_obj,
+                app_name=app1_name,
+                expected_target_cluster=secondary_cluster_name,
+                drpc_obj=drpc_app1,
+                timeout=120,
+            )
+            logger.info(f"Failover initiated for app: {app1_name}")
+
+            config.switch_ctx(primary_cluster_index)
+            logger.info(f"Switched to old primary: {primary_cluster_name}")
+            dr_helpers.wait_for_all_resources_deletion(
+                appset_workloads[0].workload_namespace
+            )
+            logger.info(f"Resources deleted from old primary: {primary_cluster_name}")
+
+            config.switch_ctx(secondary_cluster_index)
+            logger.info(f"Switched to new primary: {secondary_cluster_name}")
+            dr_helpers.wait_for_all_resources_creation(
+                appset_workloads[0].workload_pvc_count,
+                appset_workloads[0].workload_pod_count,
+                appset_workloads[0].workload_namespace,
+                performed_dr_action=True,
+            )
+            logger.info(f"Resources running on new primary: {secondary_cluster_name}")
+
+            if pvc_interface == constants.CEPHBLOCKPOOL:
+                all_workloads = appset_workloads + discovered_workload
+                dr_helpers.wait_for_mirroring_status_ok(
+                    replaying_images=sum([wl.workload_pvc_count for wl in all_workloads])
+                )
+                logger.info("RBD mirroring status OK after failover")
+            elif pvc_interface == constants.CEPHFILESYSTEM:
+                cg_enabled = dr_helpers.is_cg_cephfs_enabled()
+                if cg_enabled:
+                    # Verify deletion of ReplicationGroupDestination on old secondary
+                    config.switch_to_cluster_by_name(primary_cluster_name)
+                    dr_helpers.wait_for_resource_existence(
+                        kind=constants.REPLICATION_GROUP_DESTINATION,
+                        namespace=appset_workloads[0].workload_namespace,
+                        should_exist=False,
+                    )
+                    logger.info("ReplicationGroupDestination deleted from old secondary")
+
+                # Verify ReplicationSource creation on new primary
+                config.switch_to_cluster_by_name(secondary_cluster_name)
+                dr_helpers.wait_for_replication_resources_creation(
+                    count=appset_workloads[0].workload_pvc_count,
+                    namespace=appset_workloads[0].workload_namespace,
+                    timeout=300,
+                )
+                logger.info("CephFS ReplicationSource verified after failover")
+
+                if cg_enabled:
+                    # Verify ReplicationGroupDestination creation on new secondary
+                    config.switch_to_cluster_by_name(primary_cluster_name)
+                    dr_helpers.wait_for_resource_existence(
+                        kind=constants.REPLICATION_GROUP_DESTINATION,
+                        namespace=appset_workloads[0].workload_namespace,
+                        should_exist=True,
+                    )
+                    dr_helpers.wait_for_resource_count(
+                        kind=constants.VOLUMESNAPSHOT,
+                        namespace=appset_workloads[0].workload_namespace,
+                        expected_count=appset_workloads[0].workload_pvc_count,
+                    )
+                    logger.info("CG-CephFS resources verified after failover")
+
+            config.switch_acm_ctx()
+            dr_helpers.verify_last_group_sync_time(drpc_app1, scheduling_interval)
+            logger.info("Verified lastGroupSyncTime after failover")
+
+            verify_protected_app_dr_status(
+                acm_obj=acm_obj,
+                app_name=app1_name,
+                expected_status="healthy",
+                timeout=dr_status_timeout,
+            )
+            logger.info(f"Step 6 PASSED: Failover completed for: {app1_name}")
+            failover_success = True
+
+        except Exception as e:
+            error_msg = f"Step 6 FAILED: Failover for {app1_name} - {e}"
+            logger.error(error_msg)
+            dr_action_errors.append(error_msg)
+            config.switch_acm_ctx()
+
+        # Step 7: Relocate app1 back to original primary
+        logger.info("=" * 60)
+        logger.info("Step 7: Relocate app1 back to original primary")
+        logger.info("=" * 60)
+
+        if not failover_success:
+            skip_msg = "Step 7 SKIPPED: Relocate skipped because failover failed"
+            logger.warning(skip_msg)
+            dr_action_errors.append(skip_msg)
+        else:
+            logger.info(
+                f"Relocate target: {primary_cluster_name} (original primary, now secondary)"
+            )
+            try:
+                relocate_from_protected_app_page(
+                    acm_obj=acm_obj,
+                    app_name=app1_name,
+                    expected_target_cluster=primary_cluster_name,
+                    drpc_obj=drpc_app1,
+                    timeout=120,
+                )
+                logger.info(f"Relocate initiated for app: {app1_name}")
+
+                config.switch_ctx(secondary_cluster_index)
+                dr_helpers.wait_for_all_resources_deletion(
+                    appset_workloads[0].workload_namespace
+                )
+                logger.info(f"Resources deleted from: {secondary_cluster_name}")
+
+                config.switch_ctx(primary_cluster_index)
+                logger.info(f"Switched to original primary: {primary_cluster_name}")
+                dr_helpers.wait_for_all_resources_creation(
+                    appset_workloads[0].workload_pvc_count,
+                    appset_workloads[0].workload_pod_count,
+                    appset_workloads[0].workload_namespace,
+                    performed_dr_action=True,
+                )
+                logger.info(f"Resources running on: {primary_cluster_name}")
+
+                if pvc_interface == constants.CEPHBLOCKPOOL:
+                    all_workloads = appset_workloads + discovered_workload
+                    dr_helpers.wait_for_mirroring_status_ok(
+                        replaying_images=sum([wl.workload_pvc_count for wl in all_workloads])
+                    )
+                    logger.info("RBD mirroring status OK after relocate")
+                elif pvc_interface == constants.CEPHFILESYSTEM:
+                    cg_enabled = dr_helpers.is_cg_cephfs_enabled()
+                    if cg_enabled:
+                        # Verify deletion of ReplicationGroupDestination on old secondary
+                        config.switch_to_cluster_by_name(secondary_cluster_name)
+                        dr_helpers.wait_for_resource_existence(
+                            kind=constants.REPLICATION_GROUP_DESTINATION,
+                            namespace=appset_workloads[0].workload_namespace,
+                            should_exist=False,
+                        )
+                        logger.info("ReplicationGroupDestination deleted from old secondary")
+
+                    # Verify ReplicationSource creation on new primary
+                    config.switch_to_cluster_by_name(primary_cluster_name)
+                    dr_helpers.wait_for_replication_resources_creation(
+                        count=appset_workloads[0].workload_pvc_count,
+                        namespace=appset_workloads[0].workload_namespace,
+                        timeout=300,
+                    )
+                    logger.info("CephFS ReplicationSource verified after relocate")
+
+                    if cg_enabled:
+                        # Verify ReplicationGroupDestination creation on new secondary
+                        config.switch_to_cluster_by_name(secondary_cluster_name)
+                        dr_helpers.wait_for_resource_existence(
+                            kind=constants.REPLICATION_GROUP_DESTINATION,
+                            namespace=appset_workloads[0].workload_namespace,
+                            should_exist=True,
+                        )
+                        dr_helpers.wait_for_resource_count(
+                            kind=constants.VOLUMESNAPSHOT,
+                            namespace=appset_workloads[0].workload_namespace,
+                            expected_count=appset_workloads[0].workload_pvc_count,
+                        )
+                        logger.info("CG-CephFS resources verified after relocate")
+
+                config.switch_acm_ctx()
+                dr_helpers.verify_last_group_sync_time(drpc_app1, scheduling_interval)
+                logger.info("Verified lastGroupSyncTime after relocate")
+
+                verify_protected_app_dr_status(
+                    acm_obj=acm_obj,
+                    app_name=app1_name,
+                    expected_status="healthy",
+                    timeout=dr_status_timeout,
+                )
+                logger.info(f"Step 7 PASSED: Relocate completed for: {app1_name}")
+                relocate_success = True
+
+            except Exception as e:
+                error_msg = f"Step 7 FAILED: Relocate for {app1_name} - {e}"
+                logger.error(error_msg)
+                dr_action_errors.append(error_msg)
+                config.switch_acm_ctx()
+
+        # Step 8: Remove DR Protection for app2
+        logger.info("=" * 60)
+        logger.info("Step 8: Remove DR Protection for app2 via UI (Independent)")
+        logger.info("=" * 60)
+
+        config.switch_acm_ctx()
+
+        try:
+            logger.info(f"Removing DR protection for: {app2_name}")
+            remove_dr_from_protected_app_page(
+                acm_obj=acm_obj,
+                app_name=app2_name,
+                timeout=120,
+            )
+            logger.info(f"DR removal initiated for: {app2_name}")
+
+            logger.info(f"Verifying '{app2_name}' is NOT on Protected Applications page")
+            app2_removed = verify_app_in_protected_applications_list(
+                acm_obj=acm_obj,
+                app_name=app2_name,
+                expected_present=False,
+                timeout=180,
+                retry_interval=15,
+            )
+            if not app2_removed:
+                raise AssertionError(
+                    f"App '{app2_name}' should NOT be listed after DR removal"
+                )
+            logger.info(f"Step 8 PASSED: '{app2_name}' removed from Protected Applications list")
+            remove_dr_success = True
+
+        except Exception as e:
+            error_msg = f"Step 8 FAILED: Remove DR for {app2_name} - {e}"
+            logger.error(error_msg)
+            dr_action_errors.append(error_msg)
+
+        # Final Test Summary
+        logger.info("=" * 60)
+        logger.info("TEST SUMMARY")
+        logger.info("=" * 60)
+
+        all_errors = verification_errors + dr_action_errors
+
+        # Determine status for each step group
+        verification_status = "PASSED" if not verification_errors else "FAILED"
+        failover_status = "PASSED" if failover_success else "FAILED"
+        relocate_status = "PASSED" if relocate_success else ("SKIPPED" if not failover_success else "FAILED")
+        remove_dr_status = "PASSED" if remove_dr_success else "FAILED"
+
+        logger.info("Step Results:")
+        logger.info(f"  Step 1-5 (UI Verification): {verification_status}")
+        logger.info(f"  Step 6 (Failover):          {failover_status}")
+        logger.info(f"  Step 7 (Relocate):          {relocate_status}")
+        logger.info(f"  Step 8 (Remove DR):         {remove_dr_status}")
+        logger.info("-" * 60)
+
+        if all_errors:
+            logger.error(f"Test completed with {len(all_errors)} error(s):")
+            for i, error in enumerate(all_errors, 1):
+                logger.error(f"  {i}. {error}")
+            logger.info("=" * 60)
+
+            pytest.fail(
+                f"Test failed with {len(all_errors)} error(s):\n"
+                + "\n".join(f"  - {e}" for e in all_errors)
+            )
+        else:
+            logger.info("All steps PASSED!")
+            logger.info("=" * 60)


### PR DESCRIPTION
This test validates the Protected Applications page which displays both managed (AppSet) and discovered applications.

Test Steps:
1. Deploy AppSet and Discovered Apps workloads
2. Verify DRPC PROGRESSION and lastGroupSyncTime
3. Navigate to Protected Applications page in ACM UI
4. Verify both apps are listed
5. Verify kebab menu actions for managed app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Protected Applications UI support for searching, listing, and verifying application health and disaster-recovery status.
  - Added support for managed and discovered applications, including DR management, failover, relocation, and removal workflows.
  - Added validation for application action menus and cleanup notifications.

- **Bug Fixes**
  - Improved mirroring-status checks to safely handle missing replaying-image data.
  - Added immediate detection and reporting of leftover resources before waiting for mirroring operations.
  - Clarified exclusion of VolSync-related resources from relevant checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->