### PR TITLE
RHSTOR-7656 - Test generation of MDS alert for xattr latency

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3685,7 +3685,7 @@ METAIO = os.path.join(TEMPLATE_WORKLOAD_DIR, "helper_scripts/meta_data_io.py")
 FILE_CREATOR_IO = os.path.join(
     TEMPLATE_WORKLOAD_DIR, "helper_scripts/file_creator_io.py"
 )
-EXTENTDED_ATTRIBUTES = os.path.join(
+EXTENDED_ATTRIBUTES = os.path.join(
     TEMPLATE_WORKLOAD_DIR, "helper_scripts/check_xattr.py"
 )
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1627,6 +1627,7 @@ ALERT_ODF_NODE_MTU_LESS_THAN_9000 = "ODFNodeMTULessThan9000"
 ALERT_CEPHFS_ORPHANED_SNAPSHOT = "CephFSOrphanedSnapshot"
 CEPHFS_SNAPSHOT_STATE_ORPHANED = "orphaned"
 CEPHFS_SNAPSHOT_STATE_BOUND = "bound"
+ALERT_MDSXATTR = "CephXattrSetLatency"
 
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"
@@ -3683,6 +3684,9 @@ METAIO = os.path.join(TEMPLATE_WORKLOAD_DIR, "helper_scripts/meta_data_io.py")
 # helper script to perform file creation IO on app pod to fill MDS cpu
 FILE_CREATOR_IO = os.path.join(
     TEMPLATE_WORKLOAD_DIR, "helper_scripts/file_creator_io.py"
+)
+EXTENTDED_ATTRIBUTES = os.path.join(
+    TEMPLATE_WORKLOAD_DIR, "helper_scripts/check_xattr.py"
 )
 
 # workaround: marking disks as ssd

--- a/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
+++ b/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
@@ -1,0 +1,134 @@
+import os
+import errno
+import sys
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+
+
+def print_help():
+    """Print help message and exit."""
+    help_text = """
+Usage: python check_xattr.py [DIRECTORY] [FILE_COUNT] [MAX_WORKERS]
+
+Creates test files and continuously toggles extended attributes (xattr) on them in parallel.
+
+Arguments:
+  DIRECTORY     Directory name to store test files (default: test_directory)
+  FILE_COUNT    Number of test files to create (default: 5)
+  MAX_WORKERS   Number of parallel worker threads (default: 10, max: 100)
+  -h, --help    Show this help message and exit
+
+Examples:
+  python check_xattr.py              # 5 files, 10 workers, test_directory
+  python check_xattr.py 20           # 20 files, 10 workers, test_directory
+  python check_xattr.py 20 5         # 20 files, 5 workers, test_directory
+  python check_xattr.py my_dir       # 5 files, 10 workers, my_dir
+  python check_xattr.py my_dir 20    # 20 files, 10 workers, my_dir
+  python check_xattr.py my_dir 20 5  # 20 files, 5 workers, my_dir
+  python check_xattr.py -h           # Show this help message
+
+The program will continuously toggle the 'user.author' extended attribute
+on each file between 'kevin' and 'michael'. Press Ctrl+C to stop gracefully.
+    """
+    print(help_text)
+    sys.exit(0)
+
+
+def create_files(prefix: str, count: int, directory: str = ".") -> list[str]:
+    """
+    Create `count` empty files named <prefix>1, <prefix>2, ... in `directory`.
+    Returns a list of created file paths (strings).
+    """
+    if count < 1:
+        return []
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    created = []
+    for i in range(1, count + 1):
+        p = dir_path / f"{prefix}{i}"
+        p.touch(exist_ok=True)
+        created.append(str(p))
+    return created
+
+
+def toggle_author_xattr(path: str) -> bytes:
+    """
+    Ensure file at `path` has user.author xattr.
+    - If attribute missing: set to b'kevin'
+    - If present and equals b'kevin': change to b'michael'
+    - If present and not b'kevin': change to b'kevin'
+    Returns the new value (bytes).
+    Raises OSError on underlying errors.
+    """
+    name = b"user.author"
+    try:
+        val = os.getxattr(path, name)
+    except OSError as e:
+        # ENODATA (Linux) / ENOATTR (macOS) when attribute is missing
+        # Other errors (like file not found, permission) propagate
+        if e.errno in (errno.ENODATA, errno.ENOTSUP) or getattr(e, "errno", None) in (
+            None,
+        ):
+            val = None
+        else:
+            raise
+
+    new = b"kevin"
+    # If attribute present
+    if val == new:
+        new = b"michael"
+
+    os.setxattr(path, name, new)
+    return new
+
+
+if __name__ == "__main__":
+    # Check for help flag anywhere in sys.argv
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print_help()
+
+    # Parse arguments: if first arg is a string (not a number), use it as directory name
+    directory = "test_directory"
+    file_count = 5
+    max_workers = 10
+
+    if len(sys.argv) > 1:
+        try:
+            # Try to convert first argument to int
+            file_count = int(sys.argv[1])
+            # Get max_workers from second argument if provided
+            if len(sys.argv) > 2:
+                max_workers = int(sys.argv[2]) if sys.argv[2].isdigit() else max_workers
+        except ValueError:
+            # First argument is a string, use it as directory name
+            directory = sys.argv[1]
+            # Get file_count from second argument if provided
+            if len(sys.argv) > 2:
+                file_count = int(sys.argv[2]) if sys.argv[2].isdigit() else file_count
+            # Get max_workers from third argument if provided
+            if len(sys.argv) > 3:
+                max_workers = int(sys.argv[3]) if sys.argv[3].isdigit() else max_workers
+
+    # Cap max_workers to 100 and ensure it doesn't exceed file_count
+    max_workers = min(max_workers, 100, file_count)
+
+    # Example usage
+    files = create_files("testfile_", file_count, directory)
+    print(f"Creation of {len(files)} files in '{directory}' directory completed.")
+
+    # Toggle author xattr for each file continuously in parallel batches
+    try:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            while True:
+                futures = [executor.submit(toggle_author_xattr, file) for file in files]
+                for file, future in zip(files, futures):
+                    _ = future.result()
+                print(".", end="", flush=True)
+    except KeyboardInterrupt:
+        print("\nInterrupted by user. Shutting down gracefully...")
+        # ThreadPoolExecutor context manager automatically calls shutdown(wait=True)
+        # which waits for all pending tasks to complete before exiting
+    except Exception as e:
+        print(f"Error occurred: {e}")
+    finally:
+        print(f"All resources released. Worker threads: {max_workers}. Exiting...")

--- a/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
+++ b/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
@@ -1,8 +1,11 @@
 import os
 import errno
 import sys
+import logging
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
+
+log = logging.getLogger(__name__)
 
 
 def print_help():
@@ -30,7 +33,7 @@ Examples:
 The program will continuously toggle the 'user.author' extended attribute
 on each file between 'kevin' and 'michael'. Press Ctrl+C to stop gracefully.
     """
-    print(help_text)
+    log.info(help_text)
     sys.exit(0)
 
 
@@ -114,7 +117,7 @@ if __name__ == "__main__":
 
     # Example usage
     files = create_files("testfile_", file_count, directory)
-    print(f"Creation of {len(files)} files in '{directory}' directory completed.")
+    log.info(f"Creation of {len(files)} files in '{directory}' directory completed.")
 
     # Toggle author xattr for each file continuously in parallel batches
     try:
@@ -123,12 +126,12 @@ if __name__ == "__main__":
                 futures = [executor.submit(toggle_author_xattr, file) for file in files]
                 for file, future in zip(files, futures):
                     _ = future.result()
-                print(".", end="", flush=True)
+                log.info(".", end="", flush=True)
     except KeyboardInterrupt:
-        print("\nInterrupted by user. Shutting down gracefully...")
+        log.info("\nInterrupted by user. Shutting down gracefully...")
         # ThreadPoolExecutor context manager automatically calls shutdown(wait=True)
         # which waits for all pending tasks to complete before exiting
     except Exception as e:
-        print(f"Error occurred: {e}")
+        log.info(f"Error occurred: {e}")
     finally:
-        print(f"All resources released. Worker threads: {max_workers}. Exiting...")
+        log.info(f"All resources released. Worker threads: {max_workers}. Exiting...")

--- a/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
+++ b/ocs_ci/templates/workloads/helper_scripts/check_xattr.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
                 futures = [executor.submit(toggle_author_xattr, file) for file in files]
                 for file, future in zip(files, futures):
                     _ = future.result()
-                log.info(".", end="", flush=True)
+                log.info(".")
     except KeyboardInterrupt:
         log.info("\nInterrupted by user. Shutting down gracefully...")
         # ThreadPoolExecutor context manager automatically calls shutdown(wait=True)

--- a/ocs_ci/templates/workloads/helper_scripts/meta_data_io.py
+++ b/ocs_ci/templates/workloads/helper_scripts/meta_data_io.py
@@ -10,6 +10,8 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 import fcntl
 
+from ocs_ci.helpers import helpers
+
 logging.basicConfig(
     filename="metadata_operations.log",
     level=logging.INFO,
@@ -54,6 +56,35 @@ def set_extended_attribute(file_path, attr_name, attr_value):
         os.setxattr(file_path, attr_name, attr_value.encode("utf-8"))
     except (OSError, IOError) as e:
         logger.error(f"Error setting extended attribute: {str(e)}")
+
+
+def perform_xattr_only_operations(file, pod_obj):
+    logger.info("Copying check_xattr.py to fedora pod")
+    cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/mnt/"
+    helpers.run_cmd(cmd=cmd)
+    logger.info("check_xattr.py copied successfully")
+    logger.info("Setting extended attributes from fedora pod")
+    cmd = (
+        "bash -c 'cd /mnt; "
+        "for i in {1..6}; do "
+        'dir="my_test_dir${i}"; '
+        'python3 check_xattr.py "$dir" 10000 100 > "${dir}.log" 2>&1 & '
+        "sleep 5; "
+        "done'"
+    )
+    pod_obj.exec_sh_cmd_on_pod(cmd)
+    time.sleep(10)
+
+    ls_output = pod_obj.exec_sh_cmd_on_pod("ls /mnt")
+    for i in range(1, 7):
+        dir_name = f"my_test_dir{i}"
+        log_name = f"{dir_name}.log"
+        assert (
+            dir_name in ls_output
+        ), f"Expected directory {dir_name} was not created under /mnt"
+        assert (
+            log_name in ls_output
+        ), f"Expected log file {log_name} was not created under /mnt"
 
 
 def perform_metadata_operations(file_path):

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -90,6 +90,56 @@ def check_alert_list(
     logger.info("Alerts were triggered correctly during utilization")
 
 
+def validate_alert(
+    threading_lock,
+    alert_constant,
+    message,
+    description,
+    runbook,
+    severity="warning",
+    state="pending",
+    timeout=1200,
+    sleep=None,
+):
+    """
+    Wait for an alert and validate its properties.
+
+    Args:
+        threading_lock: Threading lock object for thread-safe Prometheus API operations
+        alert_constant (str): Alert name constant
+        message (str): Expected alert message
+        description (str): Expected alert description
+        runbook (str): Expected runbook URL
+        severity (str): Expected severity
+        state (str): Alert state to wait for
+        timeout (int): Timeout in seconds to wait for the alert
+        sleep (int): Optional polling interval for alert wait
+
+    Returns:
+        bool: True if alert is validated successfully, False otherwise
+    """
+    api = PrometheusAPI(threading_lock=threading_lock)
+    wait_kwargs = {"name": alert_constant, "state": state, "timeout": timeout}
+    if sleep is not None:
+        wait_kwargs["sleep"] = sleep
+    alerts = api.wait_for_alert(**wait_kwargs)
+
+    try:
+        check_alert_list(
+            label=alert_constant,
+            msg=message,
+            description=description,
+            runbook=runbook,
+            states=[state],
+            severity=severity,
+            alerts=alerts,
+        )
+        logger.info("Alert verified successfully")
+        return True
+    except AssertionError:
+        return False
+
+
 def check_query_range_result_viafunction(
     result,
     is_value_good,

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -276,12 +276,6 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Validating the alert after ocs-metrics-exporter pod restart")
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearanace()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
-
     def test_alert_after_recovering_prometheus_from_failures(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
@@ -301,12 +295,6 @@ class TestMdsXattrAlerts(E2ETest):
         delete_pods(list_of_prometheus_pod_obj)
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
-
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearanace()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
 
     def test_alert_after_active_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -343,12 +331,6 @@ class TestMdsXattrAlerts(E2ETest):
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
         assert MDSxattr_alert_values(threading_lock, timeout=60)
-
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearanace()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
 
     def test_alert_with_both_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -398,12 +380,6 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearanace()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
-
     def test_alert_with_mds_running_node_restart(
         self, set_xattr_with_high_cpu_usage, threading_lock, nodes
     ):
@@ -425,9 +401,3 @@ class TestMdsXattrAlerts(E2ETest):
         )
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
-
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearanace()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        assert MDSxattr_alert_values(threading_lock, timeout=30) is False

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,0 +1,154 @@
+import logging
+import pytest
+
+from concurrent.futures import ThreadPoolExecutor
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.testlib import E2ETest, tier2
+from ocs_ci.framework import config
+from ocs_ci.helpers import helpers
+from ocs_ci.ocs import cluster, constants
+from ocs_ci.utility import prometheus
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import delete_deployment_pods
+from ocs_ci.utility.utils import ceph_health_check_base
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+def set_xattr_with_high_cpu_usage(request, pvc_factory, deployment_pod_factory):
+    """
+    This function facilitates
+    1. Create Pod and PVC with Cephfs, access mode RWX for setting extended atrributed
+       for multiple files in MDS server
+    2. Copy helper_scripts/check_xattr.py to deployment pod
+    3. Create pvc's and deployment pod's with Fedora image for running file creator IO for
+       increasing CPU utilization in the cluster.
+    4. Copy helper_scripts/file_creator_io.py to Fedora pods
+    5. Run file_creator_io.py on fedora pods
+
+    """
+    log.info("setting extented attributes value for multiple files in MDS server ")
+    active_mds_node_name = cluster.get_active_mds_info()["node_name"]
+    file = constants.EXTENTDED_ATTRIBUTES
+
+    # Creating PVC to attach POD to it
+    pvc_obj = pvc_factory(
+        interface=constants.CEPHFILESYSTEM,
+        access_mode=constants.ACCESS_MODE_RWX,
+        size="200",
+        status=constants.STATUS_BOUND,
+        project=OCP(kind="Project", namespace=config.ENV_DATA["cluster_namespace"]),
+    )
+    # Create service_account to get privilege for deployment pods
+    sa_name = helpers.create_serviceaccount(pvc_obj.project.namespace)
+
+    helpers.add_scc_policy(sa_name=sa_name.name, namespace=pvc_obj.project.namespace)
+    pod_obj = helpers.create_pod(
+        interface_type=constants.CEPHFILESYSTEM,
+        pvc_name=pvc_obj.name,
+        namespace=pvc_obj.project.namespace,
+        sa_name=sa_name.name,
+        node_name=active_mds_node_name,
+        deployment=True,
+    )
+    log.info("Copying check_xattr.py to fedora pod ")
+    cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/mnt/"
+    helpers.run_cmd(cmd=cmd)
+    log.info("check_xattr.py copied successfully ")
+    log.info("Setting extended attributed from fedora pod ")
+    cmd = (
+        "bash -c 'cd /mnt; "
+        "for i in {1..6}; do "
+        'dir="my_test_dir${i}"; '
+        'python3 check_xattr.py "$dir" 10000 100 > "${dir}.log" 2>&1 & '
+        "sleep 5; "
+        "done'"
+    )
+    pod_obj.exec_sh_cmd_on_pod(cmd)
+
+    file1 = constants.FILE_CREATOR_IO
+    log.info("Checking for Ceph Health OK")
+    ceph_health_check_base()
+
+    # increasing cpu usage in cluster
+    for dc_pod in range(10):
+        log.info("Creating fedora dc pod")
+        pod_obj1 = deployment_pod_factory(
+            size="15",
+            access_mode=constants.ACCESS_MODE_RWX,
+            interface=constants.CEPHFILESYSTEM,
+        )
+        log.info("Copying file_creator_io.py to fedora pod ")
+        cmd1 = f"oc cp {file1} {pod_obj1.namespace}/{pod_obj1.name}:/"
+        helpers.run_cmd(cmd=cmd1)
+        log.info("file_creator_io.py copied successfully ")
+        log.info("Running file creator IO on fedora pod ")
+        metaio_executor = ThreadPoolExecutor(max_workers=1)
+        metaio_executor.submit(
+            pod_obj1.exec_sh_cmd_on_pod, command="python3 file_creator_io.py"
+        )
+
+    def finalizer():
+        delete_deployment_pods(pod_obj)
+
+    request.addfinalizer(finalizer)
+
+
+def MDSxattr_alert_values(threading_lock):
+    """
+    This function validates the mds alert using prometheus api
+    """
+    MDSxattr_alert = constants.ALERT_MDSXATTR
+
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    alert = api.wait_for_alert(name=MDSxattr_alert, state="firing")
+    message = (
+        "There is a latency in setting the 'xattr' values for Ceph Metadata Servers."
+    )
+    description = (
+        "This latency can be caused by different factors like high CPU usage or network"
+        " related issues etc. Please see the runbook URL link to get further help on mitigating the issue."
+    )
+    runbook = (
+        "https://github.com/openshift/runbooks/blob/master/alerts/"
+        "openshift-container-storage-operator/CephXattrSetLatency.md"
+    )
+    severity = "warning"
+    state = ["firing"]
+
+    prometheus.check_alert_list(
+        label=MDSxattr_alert,
+        msg=message,
+        description=description,
+        runbook=runbook,
+        states=state,
+        severity=severity,
+        alerts=alert,
+    )
+    log.info("Alert verified successfully")
+    return True
+
+
+@magenta_squad
+@tier2
+class TestMdsXattrAlerts(E2ETest):
+    @pytest.fixture(scope="function", autouse=True)
+    def teardown(self, request):
+        def finalizer():
+            """
+            This function will call a function to clear the mds memory usage gradually
+
+            """
+            cluster.bring_down_mds_memory_usage_gradually()
+
+        request.addfinalizer(finalizer)
+
+    def test_mds_xattr_alert_triggered(
+        self, set_xattr_with_high_cpu_usage, threading_lock
+    ):
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
+import time
 
-from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.framework import config
@@ -9,14 +9,34 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import cluster, constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources.pod import delete_deployment_pods
-from ocs_ci.utility.utils import ceph_health_check_base
+from ocs_ci.ocs.resources.pod import (
+    delete_deployment_pods,
+    get_operator_pods,
+    delete_pods,
+    get_prometheus_pods,
+    get_pods_having_label,
+)
+from ocs_ci.helpers.cephfs_stress_helpers import CephFSStressTestManager
+from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.node import wait_for_nodes_status
+from ocs_ci.ocs.exceptions import CommandFailed
 
 log = logging.getLogger(__name__)
 
+OCP_POD_OBJ = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
+
+# get storagecluster object
+storagecluster_obj = OCP(
+    kind="storagecluster",
+    namespace=config.ENV_DATA["cluster_namespace"],
+    resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+)
+
 
 @pytest.fixture(scope="function")
-def set_xattr_with_high_cpu_usage(request, pvc_factory, deployment_pod_factory):
+def set_xattr_with_high_cpu_usage(
+    request, pvc_factory, deployment_pod_factory, storageclass_factory
+):
     """
     This function facilitates
     1. Create Pod and PVC with Cephfs, access mode RWX for setting extended atrributed
@@ -31,6 +51,10 @@ def set_xattr_with_high_cpu_usage(request, pvc_factory, deployment_pod_factory):
     log.info("setting extented attributes value for multiple files in MDS server ")
     active_mds_node_name = cluster.get_active_mds_info()["node_name"]
     file = constants.EXTENTDED_ATTRIBUTES
+    stress_mgr = CephFSStressTestManager(namespace=constants.DEFAULT_NAMESPACE)
+    m_factor = "1,2,3,4"
+    parallelism = 5
+    completions = 5
 
     # Creating PVC to attach POD to it
     pvc_obj = pvc_factory(
@@ -67,42 +91,66 @@ def set_xattr_with_high_cpu_usage(request, pvc_factory, deployment_pod_factory):
     )
     pod_obj.exec_sh_cmd_on_pod(cmd)
 
-    file1 = constants.FILE_CREATOR_IO
-    log.info("Checking for Ceph Health OK")
-    ceph_health_check_base()
+    log.info(
+        "Setting up cephfs stress job for increasing CPU utilization in the cluster"
+    )
 
-    # increasing cpu usage in cluster
-    for dc_pod in range(10):
-        log.info("Creating fedora dc pod")
-        pod_obj1 = deployment_pod_factory(
-            size="15",
-            access_mode=constants.ACCESS_MODE_RWX,
+    # Create storageclass with security context
+    sc_name = "ocs-storagecluster-cephfs-selinux-relabel"
+    try:
+        storage_class = storageclass_factory(
+            sc_name=sc_name,
             interface=constants.CEPHFILESYSTEM,
+            kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
         )
-        log.info("Copying file_creator_io.py to fedora pod ")
-        cmd1 = f"oc cp {file1} {pod_obj1.namespace}/{pod_obj1.name}:/"
-        helpers.run_cmd(cmd=cmd1)
-        log.info("file_creator_io.py copied successfully ")
-        log.info("Running file creator IO on fedora pod ")
-        metaio_executor = ThreadPoolExecutor(max_workers=1)
-        metaio_executor.submit(
-            pod_obj1.exec_sh_cmd_on_pod, command="python3 file_creator_io.py"
+        log.info(f"Storage class {sc_name} created successfully !")
+
+    except CommandFailed as ecf:
+        assert "AlreadyExists" in str(ecf)
+        log.info(
+            f"Cannot create two StorageClasses with same name !"
+            f" Error message:  \n"
+            f"{ecf}"
         )
+
+    pvc_obj1 = pvc_factory(
+        access_mode=constants.ACCESS_MODE_RWX,
+        status=constants.STATUS_BOUND,
+        project=OCP(kind="Project", namespace=constants.DEFAULT_NAMESPACE),
+        storageclass=storage_class,
+        size="200",
+    )
+    cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
+        pvc_name=pvc_obj1.name,
+        multiplication_factors=m_factor,
+        parallelism=parallelism,
+        completions=completions,
+        base_file_count=7000,
+        files_size=6,
+        threads=16,
+    )
+    log.info(f"The CephFS-stress Job {cephfs_stress_job_obj.name} has been submitted")
 
     def finalizer():
+
         delete_deployment_pods(pod_obj)
+        job_obj = OCP(
+            kind="Job",
+            namespace=constants.DEFAULT_NAMESPACE,
+        )
+        job_obj.delete(resource_name="cephfs-stress-job")
 
     request.addfinalizer(finalizer)
 
 
-def MDSxattr_alert_values(threading_lock):
+def MDSxattr_alert_values(threading_lock, timeout):
     """
     This function validates the mds alert using prometheus api
     """
     MDSxattr_alert = constants.ALERT_MDSXATTR
 
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-    alert = api.wait_for_alert(name=MDSxattr_alert, state="firing")
+    alert = api.wait_for_alert(name=MDSxattr_alert, state="pending", timeout=timeout)
     message = (
         "There is a latency in setting the 'xattr' values for Ceph Metadata Servers."
     )
@@ -115,19 +163,34 @@ def MDSxattr_alert_values(threading_lock):
         "openshift-container-storage-operator/CephXattrSetLatency.md"
     )
     severity = "warning"
-    state = ["firing"]
+    state = ["pending"]
+    try:
+        prometheus.check_alert_list(
+            label=MDSxattr_alert,
+            msg=message,
+            description=description,
+            runbook=runbook,
+            states=state,
+            severity=severity,
+            alerts=alert,
+        )
+        log.info("Alert verified successfully")
+        return True
+    except Exception:
+        return False
 
-    prometheus.check_alert_list(
-        label=MDSxattr_alert,
-        msg=message,
-        description=description,
-        runbook=runbook,
-        states=state,
-        severity=severity,
-        alerts=alert,
+
+def initiate_alert_clearanace():
+    """
+    This function initiates the clerance of mds alert
+    """
+    log.info("Increase MDS CPU Resources")
+
+    storagecluster_obj.patch(
+        resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+        params='{"spec": {"resources": {"mds": {"limits": {"cpu": "16"}, "requests": {"cpu": "16"}}}}}',
+        format_type="merge",
     )
-    log.info("Alert verified successfully")
-    return True
 
 
 @magenta_squad
@@ -140,6 +203,13 @@ class TestMdsXattrAlerts(E2ETest):
             This function will call a function to clear the mds memory usage gradually
 
             """
+            log.info("Setting MDS CPU Resources back to original values")
+
+            storagecluster_obj.patch(
+                resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+                params='{"spec": {"resources": {"mds": {"limits": {"cpu": "2"}, "requests": {"cpu": "2"}}}}}',
+                format_type="merge",
+            )
             cluster.bring_down_mds_memory_usage_gradually()
 
         request.addfinalizer(finalizer)
@@ -151,4 +221,213 @@ class TestMdsXattrAlerts(E2ETest):
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
         )
-        assert MDSxattr_alert_values(threading_lock)
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
+
+    def test_alert_triggered_by_restarting_operator_and_metrics_pods(
+        self, set_xattr_with_high_cpu_usage, threading_lock
+    ):
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Restart the rook-operator pod")
+        operator_pod_obj = get_operator_pods()
+        delete_pods(pod_objs=operator_pod_obj)
+        OCP_POD_OBJ.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector=constants.OPERATOR_LABEL,
+        )
+        log.info("Validating the alert after the rook-operator pod restart")
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Respin the ocs-metrics-exporter pod")
+        # metrics_pods = OCP_POD_OBJ.get(selector="app.kubernetes.io/name=ocs-metrics-exporter")[
+        #     "items"
+        # ]
+        # metrics_pods.delete(force=True)
+        metrics_pods = get_pods_having_label(
+            label="app.kubernetes.io/name=ocs-metrics-exporter",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+
+        assert metrics_pods, "No ocs-metrics-exporter pods found"
+        metrics_pod = metrics_pods[0]
+        metrics_pod_name = metrics_pod["metadata"]["name"]
+        log.info(f"Initial ocs-metrics-exporter pod: {metrics_pod_name}")
+
+        OCP_POD_OBJ.delete(resource_name=metrics_pod_name)
+
+        log.info("Wait for ocs-metrics-exporter pod to come up")
+        assert OCP_POD_OBJ.wait_for_resource(
+            condition="Running",
+            selector="app.kubernetes.io/name=ocs-metrics-exporter",
+            resource_count=1,
+            timeout=600,
+        )
+
+        log.info("Validating the alert after ocs-metrics-exporter pod restart")
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
+
+    def test_alert_after_recovering_prometheus_from_failures(
+        self, set_xattr_with_high_cpu_usage, threading_lock
+    ):
+        """
+        This test function verifies the mds cache alert and fails the prometheus.
+        It also verifies the alert after recovering prometheus from failures.
+
+        """
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Bring down the prometheus")
+        list_of_prometheus_pod_obj = get_prometheus_pods()
+        delete_pods(list_of_prometheus_pod_obj)
+
+        assert MDSxattr_alert_values(threading_lock, timeout=300)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
+
+    def test_alert_after_active_mds_scaledown(
+        self, set_xattr_with_high_cpu_usage, threading_lock
+    ):
+        """
+        This test function verifies the mds alert with active mds scale down and up
+        """
+
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        active_mds = cluster.get_active_mds_info()["mds_daemon"]
+        active_mds_pod = cluster.get_active_mds_info()["active_pod"]
+        deployment_name = "rook-ceph-mds-" + active_mds
+
+        log.info(f"Scale down {deployment_name} to 0")
+        helpers.modify_deployment_replica_count(
+            deployment_name=deployment_name, replica_count=0
+        )
+        OCP_POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
+        log.info(f"Scale up {deployment_name} to 1")
+        helpers.modify_deployment_replica_count(
+            deployment_name=deployment_name, replica_count=1
+        )
+        log.info(
+            " Script will be in sleep for 60 seconds to make sure mds scale up completed."
+        )
+        time.sleep(60)
+        mds_pods = cluster.get_mds_pods()
+        for pd in mds_pods:
+            helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
+
+        assert MDSxattr_alert_values(threading_lock, timeout=60)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
+
+    def test_alert_with_both_mds_scaledown(
+        self, set_xattr_with_high_cpu_usage, threading_lock
+    ):
+        """
+        This test function verifies the mds alert with both active and standby mds scale down and up
+        """
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        active_mds = cluster.get_active_mds_info()["mds_daemon"]
+        standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
+        active_mds_d = "rook-ceph-mds-" + active_mds
+        standby_mds_d = "rook-ceph-mds-" + standby_mds
+        active_mds_pod = cluster.get_active_mds_info()["active_pod"]
+        standby_mds_pod = cluster.get_mds_standby_replay_info()["standby_replay_pod"]
+        mds_dc_pods = [active_mds_d, standby_mds_d]
+
+        log.info(f"Scale down {active_mds_d} to 0")
+        helpers.modify_deployment_replica_count(
+            deployment_name=active_mds_d, replica_count=0
+        )
+        OCP_POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
+
+        log.info(f"Scale down {standby_mds_d} to 0")
+        helpers.modify_deployment_replica_count(
+            deployment_name=standby_mds_d, replica_count=0
+        )
+        OCP_POD_OBJ.wait_for_delete(resource_name=standby_mds_pod)
+
+        for mds_pod_obj in mds_dc_pods:
+            log.info(f"Scale up {mds_pod_obj} to 1")
+            helpers.modify_deployment_replica_count(
+                deployment_name=mds_pod_obj, replica_count=1
+            )
+        log.info(
+            " Script will be in sleep for 60 seconds to make sure both mds scale up completed."
+        )
+        time.sleep(60)
+
+        mds_pods = cluster.get_mds_pods()
+        for pd in mds_pods:
+            helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
+
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False
+
+    def test_alert_with_mds_running_node_restart(
+        self, set_xattr_with_high_cpu_usage, threading_lock, nodes
+    ):
+        """
+        This test function verifies the mds alert when the active mds running node is restart.
+        #"""
+        log.info(
+            "Setting extended attributes and file creation IO started in the background."
+            " Script will look for CephXattrSetLatency  alert"
+        )
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        active_mds_pod_obj = cluster.get_active_mds_info()["active_pod_obj"]
+        log.info("Restart active mds running node")
+        active_mds_node = pod.get_pod_node(active_mds_pod_obj)
+        nodes.restart_nodes([active_mds_node])
+        wait_for_nodes_status(
+            [active_mds_node.name], constants.STATUS_READY, timeout=420
+        )
+
+        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearanace()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        assert MDSxattr_alert_values(threading_lock, timeout=30) is False

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -186,6 +186,28 @@ def MDSxattr_alert_values(threading_lock, timeout):
     )
 
 
+def ceph_not_health_error():
+    """
+    Check if Ceph is not in HEALTH_ERR state.
+
+    Returns:
+        bool: True if Ceph state is not HEALTH_ERR
+    """
+    ceph_status = cluster.get_ceph_health()
+    log.info(f"Ceph status is: {ceph_status}")
+    return ceph_status != "HEALTH_ERR"
+
+
+def is_cluster_healthy():
+    """
+    Wrapper function for cluster health check
+
+    Returns:
+        bool: True if all checks passed, False otherwise
+    """
+    return ceph_not_health_error() and pod.wait_for_pods_to_be_running(timeout=900)
+
+
 def initiate_alert_clearance():
     """
     Initiate clearance of MDS xattr latency alert by increasing MDS CPU resources.
@@ -552,12 +574,8 @@ class TestMdsXattrAlerts(E2ETest):
         wait_for_nodes_status(
             [active_mds_node.name], constants.STATUS_READY, timeout=420
         )
-        assert OCP_POD_OBJ.wait_for_resource(
-            condition=constants.STATUS_RUNNING,
-            resource_count=len(OCP_POD_OBJ.get().get("items", [])),
-            timeout=1200,
-            sleep=10,
-        ), "Not all pods in openshift-storage namespace are in Running state"
-        cluster.ceph_health_check()
+        assert (
+            is_cluster_healthy()
+        ), "Cluster is not healthy after active MDS node restart"
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -159,7 +159,7 @@ def set_xattr_with_high_cpu_usage(
         pvc_obj1.delete()
         pvc_obj1.ocp.wait_for_delete(resource_name=pvc_obj1.name)
         delete_released_pvs_in_sc(sc_name)
-        log.info("All rsources cleaned up successully")
+        log.info("All resources cleaned up successully")
 
     request.addfinalizer(finalizer)
 
@@ -315,9 +315,8 @@ class TestMdsXattrAlerts(E2ETest):
         initiate_alert_clearance()
         # waiting for sometime for load distribution
         time.sleep(600)
-        # assert MDSxattr_alert_values(threading_lock, timeout=30) is False
         api.check_alert_cleared(
-            label=constants.ALERT_MDSXATTR, measure_end_time=300, time_min=30
+            label=constants.ALERT_MDSXATTR, measure_end_time=600, time_min=30
         )
 
     @pytest.mark.polarion_id("OCS-7734")

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -196,7 +196,7 @@ class TestMdsXattrAlerts(E2ETest):
     """
 
     @pytest.fixture(scope="function", autouse=True)
-    def teardown(self, request):
+    def teardown(self, request, threading_lock):
         """
         Teardown fixture to restore MDS CPU resources and clear memory usage.
 
@@ -206,6 +206,7 @@ class TestMdsXattrAlerts(E2ETest):
 
         Args:
             request: pytest request object for finalizer registration
+            threading_lock: Threading lock fixture for Prometheus API calls
 
         """
 
@@ -214,11 +215,19 @@ class TestMdsXattrAlerts(E2ETest):
             Finalizer function to restore MDS resources and clear memory usage.
 
             This function:
-            1. Patches the storage cluster to restore MDS CPU limits and requests to 2 CPUs
+            1. Verifies that the alert is cleared (if test passed)
             2. Waits for toolbox pod to be in running state (up to 10 minutes)
             3. Calls cluster function to gradually bring down MDS memory usage
 
             """
+            try:
+                verify_alert_cleared(threading_lock)
+            except Exception as e:
+                log.warning(
+                    f"Failed to verify alert cleared in teardown: {e}. "
+                    "This may happen if the test failed before alert was triggered."
+                )
+
             log.info(
                 "Waiting for toolbox pod to be in running state (timeout: 900 seconds)"
             )
@@ -258,9 +267,6 @@ class TestMdsXattrAlerts(E2ETest):
             " Script will look for CephXattrSetLatency  alert"
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
-
-        log.info("Checking for clearance of alert")
-        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(
@@ -324,8 +330,6 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Validating the alert after ocs-metrics-exporter pod restart")
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        verify_alert_cleared(threading_lock)
-
     @pytest.mark.polarion_id("OCS-7735")
     def test_alert_after_recovering_prometheus_from_failures(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -355,8 +359,6 @@ class TestMdsXattrAlerts(E2ETest):
         delete_pods(list_of_prometheus_pod_obj)
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
-
-        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
@@ -409,8 +411,6 @@ class TestMdsXattrAlerts(E2ETest):
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
         assert MDSxattr_alert_values(threading_lock, timeout=60)
-
-        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
@@ -479,8 +479,6 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        verify_alert_cleared(threading_lock)
-
     @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
         self, set_xattr_with_high_cpu_usage, threading_lock, nodes
@@ -522,5 +520,3 @@ class TestMdsXattrAlerts(E2ETest):
         ), "Cluster is not healthy after active MDS node restart"
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
-
-        verify_alert_cleared(threading_lock)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -318,9 +318,10 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Checking for clearance of alert")
         initiate_alert_clearance()
         # waiting for sometime for load distribution
-        time.sleep(720)
+        time.sleep(600)
+        test_end_time = int(time.time())
         api.check_alert_cleared(
-            label=constants.ALERT_MDSXATTR, measure_end_time=600, time_min=30
+            label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
         )
 
     @pytest.mark.polarion_id("OCS-7734")

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -23,7 +23,6 @@ from ocs_ci.helpers.cephfs_stress_helpers import CephFSStressTestManager
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pv import delete_released_pvs_in_sc
 from ocs_ci.ocs.node import wait_for_nodes_status
-from ocs_ci.ocs.exceptions import CommandFailed
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +65,7 @@ def set_xattr_with_high_cpu_usage(
         None: This fixture sets up the environment and cleans up resources in finalizer
 
     """
-    log.info("setting extented attributes value for multiple files in MDS server ")
+    log.info("setting extended attributes value for multiple files in MDS server ")
     active_mds_node_name = cluster.get_active_mds_info()["node_name"]
     file = constants.EXTENDED_ATTRIBUTES
     stress_mgr = CephFSStressTestManager(namespace=constants.DEFAULT_NAMESPACE)
@@ -82,16 +81,11 @@ def set_xattr_with_high_cpu_usage(
         status=constants.STATUS_BOUND,
         project=OCP(kind="Project", namespace=config.ENV_DATA["cluster_namespace"]),
     )
-    # Create service_account to get privilege for deployment pods
-    sa_obj = helpers.create_serviceaccount(pvc_obj.project.namespace)
-
-    helpers.add_scc_policy(sa_name=sa_obj.name, namespace=pvc_obj.project.namespace)
 
     pod_obj = deployment_pod_factory(
         interface=constants.CEPHFILESYSTEM,
         pvc=pvc_obj,
         node_name=active_mds_node_name,
-        sa_obj=sa_obj,
     )
 
     log.info("Copying check_xattr.py to fedora pod ")
@@ -108,28 +102,33 @@ def set_xattr_with_high_cpu_usage(
         "done'"
     )
     pod_obj.exec_sh_cmd_on_pod(cmd)
+    time.sleep(10)
+
+    ls_output = pod_obj.exec_sh_cmd_on_pod("ls /mnt")
+    for i in range(1, 7):
+        dir_name = f"my_test_dir{i}"
+        log_name = f"{dir_name}.log"
+        assert (
+            dir_name in ls_output
+        ), f"Expected directory {dir_name} was not created under /mnt"
+        assert (
+            log_name in ls_output
+        ), f"Expected log file {log_name} was not created under /mnt"
 
     log.info(
         "Setting up cephfs stress job for increasing CPU utilization in the cluster"
     )
 
     # Create storageclass with security context
-    sc_name = "ocs-storagecluster-cephfs-selinux-relabel"
-    try:
-        storage_class = storageclass_factory(
-            sc_name=sc_name,
-            interface=constants.CEPHFILESYSTEM,
-            kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
-        )
-        log.info(f"Storage class {sc_name} created successfully !")
-
-    except CommandFailed as ecf:
-        assert "AlreadyExists" in str(ecf)
-        log.info(
-            f"Cannot create two StorageClasses with same name !"
-            f" Error message:  \n"
-            f"{ecf}"
-        )
+    sc_name = helpers.create_unique_resource_name(
+        "ocs-storagecluster-cephfs-selinux-relabel", "storageclass"
+    )
+    storage_class = storageclass_factory(
+        sc_name=sc_name,
+        interface=constants.CEPHFILESYSTEM,
+        kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
+    )
+    log.info(f"Storage class {sc_name} created successfully !")
 
     pvc_obj1 = pvc_factory(
         access_mode=constants.ACCESS_MODE_RWX,
@@ -151,10 +150,8 @@ def set_xattr_with_high_cpu_usage(
 
     def finalizer():
 
-        # delete_deployment_pods(pod_obj)
-
         job_obj = OCP(
-            kind="Job",
+            kind=constants.JOB,
             namespace=constants.DEFAULT_NAMESPACE,
         )
         job_obj.delete(resource_name="cephfs-stress-job")
@@ -170,50 +167,23 @@ def set_xattr_with_high_cpu_usage(
 def MDSxattr_alert_values(threading_lock, timeout):
     """
     Validate MDS xattr latency alert using Prometheus API.
-
-    This function checks for the CephXattrSetLatency alert in Prometheus and validates
-    its properties including message, description, runbook URL, severity, and state.
-
-    Args:
-        threading_lock: Threading lock object for thread-safe Prometheus API operations
-        timeout (int): Timeout in seconds to wait for the alert to appear
-
-    Returns:
-        bool: True if alert is validated successfully with all expected properties,
-              False if validation fails or alert is not found
-
     """
-    MDSxattr_alert = constants.ALERT_MDSXATTR
-
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-    alert = api.wait_for_alert(name=MDSxattr_alert, state="pending", timeout=timeout)
-    message = (
-        "There is a latency in setting the 'xattr' values for Ceph Metadata Servers."
+    return prometheus.validate_alert(
+        threading_lock=threading_lock,
+        alert_constant=constants.ALERT_MDSXATTR,
+        message="There is a latency in setting the 'xattr' values for Ceph Metadata Servers.",
+        description=(
+            "This latency can be caused by different factors like high CPU usage or network"
+            " related issues etc. Please see the runbook URL link to get further help on mitigating the issue."
+        ),
+        runbook=(
+            "https://github.com/openshift/runbooks/blob/master/alerts/"
+            "openshift-container-storage-operator/CephXattrSetLatency.md"
+        ),
+        severity="warning",
+        state="pending",
+        timeout=timeout,
     )
-    description = (
-        "This latency can be caused by different factors like high CPU usage or network"
-        " related issues etc. Please see the runbook URL link to get further help on mitigating the issue."
-    )
-    runbook = (
-        "https://github.com/openshift/runbooks/blob/master/alerts/"
-        "openshift-container-storage-operator/CephXattrSetLatency.md"
-    )
-    severity = "warning"
-    state = ["pending"]
-    try:
-        prometheus.check_alert_list(
-            label=MDSxattr_alert,
-            msg=message,
-            description=description,
-            runbook=runbook,
-            states=state,
-            severity=severity,
-            alerts=alert,
-        )
-        log.info("Alert verified successfully")
-        return True
-    except Exception:
-        return False
 
 
 def initiate_alert_clearance():
@@ -261,9 +231,6 @@ class TestMdsXattrAlerts(E2ETest):
 
         Args:
             request: pytest request object for finalizer registration
-
-        Returns:
-            None
 
         """
 
@@ -585,5 +552,11 @@ class TestMdsXattrAlerts(E2ETest):
         wait_for_nodes_status(
             [active_mds_node.name], constants.STATUS_READY, timeout=420
         )
+        OCP_POD_OBJ.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            timeout=600,
+            sleep=10,
+        )
+        cluster.ceph_health_check()
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -22,9 +22,7 @@ from ocs_ci.ocs.resources.pod import (
     get_prometheus_pods,
     get_pods_having_label,
 )
-from ocs_ci.helpers.cephfs_stress_helpers import CephFSStressTestManager
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.resources.pv import delete_released_pvs_in_sc
 from ocs_ci.ocs.node import wait_for_nodes_status
 from ocs_ci.utility.utils import ceph_health_check
 
@@ -72,10 +70,6 @@ def set_xattr_with_high_cpu_usage(
     log.info("setting extended attributes value for multiple files in MDS server ")
     active_mds_node_name = cluster.get_active_mds_info()["node_name"]
     file = constants.EXTENDED_ATTRIBUTES
-    stress_mgr = CephFSStressTestManager(namespace=constants.DEFAULT_NAMESPACE)
-    m_factor = "1,2,3,4"
-    parallelism = 5
-    completions = 5
 
     # Creating PVC to attach POD to it
     pvc_obj = pvc_factory(
@@ -94,53 +88,18 @@ def set_xattr_with_high_cpu_usage(
 
     perform_xattr_only_operations(file=file, pod_obj=pod_obj)
 
-    log.info(
-        "Setting up cephfs stress job for increasing CPU utilization in the cluster"
+    time.sleep(120)
+
+    log.info("Reducing MDS CPU resources to trigger MDS xattr latency alert")
+    storagecluster_obj.patch(
+        resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+        params=(
+            '{"spec": {"resources": {"mds": {"limits": {"cpu": "250m", '
+            '"memory": "512Mi"}, "requests": {"cpu": "250m", "memory": '
+            '"512Mi"}}}}}'
+        ),
+        format_type="merge",
     )
-
-    # Create storageclass with security context
-    sc_name = helpers.create_unique_resource_name(
-        "ocs-storagecluster-cephfs-selinux-relabel", "storageclass"
-    )
-    storage_class = storageclass_factory(
-        sc_name=sc_name,
-        interface=constants.CEPHFILESYSTEM,
-        kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
-    )
-    log.info(f"Storage class {sc_name} created successfully !")
-
-    pvc_obj1 = pvc_factory(
-        access_mode=constants.ACCESS_MODE_RWX,
-        status=constants.STATUS_BOUND,
-        project=OCP(kind="Project", namespace=constants.DEFAULT_NAMESPACE),
-        storageclass=storage_class,
-        size="200",
-    )
-    cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
-        pvc_name=pvc_obj1.name,
-        multiplication_factors=m_factor,
-        parallelism=parallelism,
-        completions=completions,
-        base_file_count=7000,
-        files_size=6,
-        threads=16,
-    )
-    log.info(f"The CephFS-stress Job {cephfs_stress_job_obj.name} has been submitted")
-
-    def finalizer():
-
-        job_obj = OCP(
-            kind=constants.JOB,
-            namespace=constants.DEFAULT_NAMESPACE,
-        )
-        job_obj.delete(resource_name="cephfs-stress-job")
-
-        pvc_obj1.delete()
-        pvc_obj1.ocp.wait_for_delete(resource_name=pvc_obj1.name)
-        delete_released_pvs_in_sc(sc_name)
-        log.info("All resources cleaned up successully")
-
-    request.addfinalizer(finalizer)
 
 
 def MDSxattr_alert_values(threading_lock, timeout):
@@ -203,11 +162,15 @@ def initiate_alert_clearance():
         None
 
     """
-    log.info("Increase MDS CPU Resources")
+    log.info("Increasing MDS CPU and memory resources to clear MDS xattr latency alert")
 
     storagecluster_obj.patch(
         resource_name=constants.DEFAULT_STORAGE_CLUSTER,
-        params='{"spec": {"resources": {"mds": {"limits": {"cpu": "16"}, "requests": {"cpu": "16"}}}}}',
+        params=(
+            '{"spec": {"resources": {"mds": {"limits": {"cpu": "2", '
+            '"memory": "6Gi"}, "requests": {"cpu": "2", "memory": '
+            '"6Gi"}}}}}'
+        ),
         format_type="merge",
     )
 
@@ -249,15 +212,6 @@ class TestMdsXattrAlerts(E2ETest):
             3. Calls cluster function to gradually bring down MDS memory usage
 
             """
-            # skipping this step as alert clearance is skipped for sometime
-            # log.info("Setting MDS CPU Resources back to original values")
-
-            # storagecluster_obj.patch(
-            #     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
-            #     params='{"spec": {"resources": {"mds": {"limits": {"cpu": "2"}, "requests": {"cpu": "2"}}}}}',
-            #     format_type="merge",
-            # )
-
             log.info(
                 "Waiting for toolbox pod to be in running state (timeout: 900 seconds)"
             )
@@ -292,7 +246,7 @@ class TestMdsXattrAlerts(E2ETest):
             6. Verify alert is cleared within 300 seconds
 
         """
-        # api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+        api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
         log.info(
             "Setting extended attributes and file creation IO started in the background."
@@ -300,15 +254,14 @@ class TestMdsXattrAlerts(E2ETest):
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        # TODO - work on fixing alert clearance part
-        # log.info("Checking for clearance of alert")
-        # initiate_alert_clearance()
-        # # waiting for sometime for load distribution
-        # time.sleep(600)
-        # test_end_time = int(time.time())
-        # api.check_alert_cleared(
-        #     label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
-        # )
+        log.info("Checking for clearance of alert")
+        initiate_alert_clearance()
+        # waiting for sometime for load distribution
+        time.sleep(600)
+        test_end_time = int(time.time())
+        api.check_alert_cleared(
+            label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
+        )
 
     @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -13,7 +13,6 @@ from ocs_ci.templates.workloads.helper_scripts.meta_data_io import (
     perform_xattr_only_operations,
 )
 from ocs_ci.ocs import cluster, constants
-from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import ocp
@@ -27,6 +26,7 @@ from ocs_ci.helpers.cephfs_stress_helpers import CephFSStressTestManager
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pv import delete_released_pvs_in_sc
 from ocs_ci.ocs.node import wait_for_nodes_status
+from ocs_ci.utility.utils import ceph_health_check
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +40,6 @@ storagecluster_obj = OCP(
     namespace=config.ENV_DATA["cluster_namespace"],
     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
 )
-ceph_cluster = CephCluster()
 
 
 @pytest.fixture(scope="function")
@@ -168,11 +167,18 @@ def MDSxattr_alert_values(threading_lock, timeout):
 
 def ceph_not_health_error():
     """
-    Check if Ceph is not in HEALTH_ERR state.
+    Check if Ceph health is good.
 
     """
-    ceph_status = ceph_cluster.get_ceph_health()
-    return ceph_status != "HEALTH_ERR"
+    try:
+        ceph_health_check(
+            namespace=config.ENV_DATA["cluster_namespace"],
+            tries=3,
+        )
+        return True
+    except Exception as ex:
+        log.warning(f"Ceph health check failed: {ex}")
+        return False
 
 
 def is_cluster_healthy():

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -9,6 +9,7 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import cluster, constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import ocp
 from ocs_ci.ocs.resources.pod import (
     get_operator_pods,
     delete_pods,
@@ -23,7 +24,9 @@ from ocs_ci.ocs.exceptions import CommandFailed
 
 log = logging.getLogger(__name__)
 
-OCP_POD_OBJ = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"])
+OCP_POD_OBJ = ocp.OCP(
+    kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
+)
 
 # get storagecluster object
 storagecluster_obj = OCP(
@@ -38,14 +41,26 @@ def set_xattr_with_high_cpu_usage(
     request, pvc_factory, deployment_pod_factory, storageclass_factory
 ):
     """
-    This function facilitates
-    1. Create Pod and PVC with Cephfs, access mode RWX for setting extended atrributed
-       for multiple files in MDS server
-    2. Copy helper_scripts/check_xattr.py to deployment pod
-    3. Create pvc's and deployment pod's with Fedora image for running file creator IO for
-       increasing CPU utilization in the cluster.
-    4. Copy helper_scripts/file_creator_io.py to Fedora pods
-    5. Run file_creator_io.py on fedora pods
+    Fixture to set up extended attributes with high CPU usage for MDS xattr latency alert testing.
+
+    This fixture performs the following operations:
+    1. Creates a PVC with CephFS interface and RWX access mode for setting extended attributes
+       on multiple files in the MDS server
+    2. Creates a deployment pod on the active MDS node with service account and SCC policy
+    3. Copies helper_scripts/check_xattr.py to the deployment pod
+    4. Executes the check_xattr.py script to set extended attributes on multiple directories
+    5. Creates a storage class with SELinux security context for CephFS stress testing
+    6. Creates additional PVC and CephFS stress job to increase CPU utilization in the cluster
+    7. Submits the CephFS stress job with specified parallelism and file creation parameters
+
+    Args:
+        request: pytest request object for finalizer registration
+        pvc_factory: Factory fixture to create PVC objects
+        deployment_pod_factory: Factory fixture to create deployment pod objects
+        storageclass_factory: Factory fixture to create storage class objects
+
+    Yields:
+        None: This fixture sets up the environment and cleans up resources in finalizer
 
     """
     log.info("setting extented attributes value for multiple files in MDS server ")
@@ -68,14 +83,7 @@ def set_xattr_with_high_cpu_usage(
     sa_obj = helpers.create_serviceaccount(pvc_obj.project.namespace)
 
     helpers.add_scc_policy(sa_name=sa_obj.name, namespace=pvc_obj.project.namespace)
-    # pod_obj = helpers.create_pod(
-    #     interface_type=constants.CEPHFILESYSTEM,
-    #     pvc_name=pvc_obj.name,
-    #     namespace=pvc_obj.project.namespace,
-    #     sa_name=sa_name.name,
-    #     node_name=active_mds_node_name,
-    #     deployment=True,
-    # )
+
     pod_obj = deployment_pod_factory(
         interface=constants.CEPHFILESYSTEM,
         pvc=pvc_obj,
@@ -149,7 +157,7 @@ def set_xattr_with_high_cpu_usage(
         job_obj.delete(resource_name="cephfs-stress-job")
 
         pvc_obj1.delete()
-        pvc_obj1.wait_for_delete(resource_name=pvc_obj1.name)
+        pvc_obj1.ocp.wait_for_delete(resource_name=pvc_obj1.name)
         delete_released_pvs_in_sc(sc_name)
         log.info("All rsources cleaned up successully")
 
@@ -158,7 +166,19 @@ def set_xattr_with_high_cpu_usage(
 
 def MDSxattr_alert_values(threading_lock, timeout):
     """
-    This function validates the mds alert using prometheus api
+    Validate MDS xattr latency alert using Prometheus API.
+
+    This function checks for the CephXattrSetLatency alert in Prometheus and validates
+    its properties including message, description, runbook URL, severity, and state.
+
+    Args:
+        threading_lock: Threading lock object for thread-safe Prometheus API operations
+        timeout (int): Timeout in seconds to wait for the alert to appear
+
+    Returns:
+        bool: True if alert is validated successfully with all expected properties,
+              False if validation fails or alert is not found
+
     """
     MDSxattr_alert = constants.ALERT_MDSXATTR
 
@@ -195,7 +215,15 @@ def MDSxattr_alert_values(threading_lock, timeout):
 
 def initiate_alert_clearance():
     """
-    This function initiates the clerance of mds alert
+    Initiate clearance of MDS xattr latency alert by increasing MDS CPU resources.
+
+    This function patches the storage cluster to increase MDS CPU limits and requests
+    from default values to 16 CPUs, which helps clear the CephXattrSetLatency alert
+    by providing more resources to handle the xattr operations.
+
+    Returns:
+        None
+
     """
     log.info("Increase MDS CPU Resources")
 
@@ -209,11 +237,39 @@ def initiate_alert_clearance():
 @blue_squad
 @tier2
 class TestMdsXattrAlerts(E2ETest):
+    """
+    Test class for MDS xattr latency alert validation.
+
+    This test class validates the CephXattrSetLatency alert behavior under various
+    scenarios including normal operations, pod restarts, Prometheus failures,
+    MDS scale operations, and node restarts.
+
+    """
+
     @pytest.fixture(scope="function", autouse=True)
     def teardown(self, request):
+        """
+        Teardown fixture to restore MDS CPU resources and clear memory usage.
+
+        This fixture is automatically used for all test methods in the class.
+        It restores MDS CPU resources to original values (2 CPUs) and gradually
+        brings down MDS memory usage after each test execution.
+
+        Args:
+            request: pytest request object for finalizer registration
+
+        Returns:
+            None
+
+        """
+
         def finalizer():
             """
-            This function will call a function to clear the mds memory usage gradually
+            Finalizer function to restore MDS resources and clear memory usage.
+
+            This function:
+            1. Patches the storage cluster to restore MDS CPU limits and requests to 2 CPUs
+            2. Calls cluster function to gradually bring down MDS memory usage
 
             """
             log.info("Setting MDS CPU Resources back to original values")
@@ -227,9 +283,26 @@ class TestMdsXattrAlerts(E2ETest):
 
         request.addfinalizer(finalizer)
 
+    @pytest.mark.polarion_id("OCS-7733")
     def test_mds_xattr_alert_triggered(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
+        """
+        Test MDS xattr latency alert triggering and clearance.
+
+        This test validates that the CephXattrSetLatency alert is triggered when
+        extended attributes are set with high CPU usage, and verifies that the
+        alert clears after increasing MDS CPU resources.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Validate alert properties (message, description, runbook, severity, state)
+            4. Initiate alert clearance by increasing MDS CPU resources to 16 CPUs
+            5. Wait for 600 seconds for load distribution
+            6. Verify alert is cleared within 300 seconds
+
+        """
         api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
         log.info(
@@ -247,9 +320,28 @@ class TestMdsXattrAlerts(E2ETest):
             label=constants.ALERT_MDSXATTR, measure_end_time=300, time_min=30
         )
 
+    @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
+        """
+        Test MDS xattr latency alert persistence after restarting operator and metrics pods.
+
+        This test validates that the CephXattrSetLatency alert remains active and
+        can be re-validated after restarting the rook-operator pod and
+        ocs-metrics-exporter pod.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Restart the rook-operator pod
+            4. Wait for rook-operator pod to reach Running state
+            5. Re-validate the alert after operator restart (timeout: 1200s)
+            6. Delete the ocs-metrics-exporter pod
+            7. Wait for ocs-metrics-exporter pod to come up (timeout: 600s)
+            8. Re-validate the alert after metrics exporter restart (timeout: 1200s)
+
+        """
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
@@ -290,14 +382,24 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Validating the alert after ocs-metrics-exporter pod restart")
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+    @pytest.mark.polarion_id("OCS-7735")
     def test_alert_after_recovering_prometheus_from_failures(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
         """
-        This test function verifies the mds cache alert and fails the prometheus.
-        It also verifies the alert after recovering prometheus from failures.
+        Test MDS xattr latency alert persistence after Prometheus pod failures.
 
+        This test validates that the CephXattrSetLatency alert can be recovered
+        and re-validated after Prometheus pods are deleted and recreated.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Delete all Prometheus pods to simulate failure
+            4. Wait for Prometheus pods to be recreated automatically
+            5. Re-validate the alert after Prometheus recovery (timeout: 300s)
         """
+
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
@@ -310,11 +412,27 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
 
+    @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
         """
-        This test function verifies the mds alert with active mds scale down and up
+        Test MDS xattr latency alert persistence after active MDS scale down and up.
+
+        This test validates that the CephXattrSetLatency alert remains active
+        after scaling down the active MDS deployment to 0 and scaling it back up to 1.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Identify the active MDS daemon and its deployment
+            4. Scale down the active MDS deployment to 0 replicas
+            5. Wait for the active MDS pod to be deleted
+            6. Scale up the active MDS deployment back to 1 replica
+            7. Wait 60 seconds for MDS scale up to complete
+            8. Wait for all MDS pods to reach Running state
+            9. Re-validate the alert after MDS scale operations (timeout: 60s)
+
         """
 
         log.info(
@@ -346,11 +464,30 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=60)
 
+    @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
     ):
         """
-        This test function verifies the mds alert with both active and standby mds scale down and up
+        Test MDS xattr latency alert persistence after both active and standby MDS scale down and up.
+
+        This test validates that the CephXattrSetLatency alert remains active
+        after scaling down both active and standby-replay MDS deployments to 0
+        and scaling them back up to 1.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Identify active and standby-replay MDS daemons and their deployments
+            4. Scale down the active MDS deployment to 0 replicas
+            5. Wait for the active MDS pod to be deleted
+            6. Scale down the standby-replay MDS deployment to 0 replicas
+            7. Wait for the standby-replay MDS pod to be deleted
+            8. Scale up both MDS deployments back to 1 replica each
+            9. Wait 60 seconds for both MDS scale up operations to complete
+            10. Wait for all MDS pods to reach Running state
+            11. Re-validate the alert after MDS scale operations (timeout: 1200s)
+
         """
         log.info(
             "Setting extended attributes and file creation IO started in the background."
@@ -394,12 +531,29 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+    @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
         self, set_xattr_with_high_cpu_usage, threading_lock, nodes
     ):
         """
-        This test function verifies the mds alert when the active mds running node is restart.
-        #"""
+        Test MDS xattr latency alert persistence after active MDS node restart.
+
+        This test validates that the CephXattrSetLatency alert remains active
+        after restarting the node where the active MDS pod is running.
+
+        Test Steps:
+            1. Set up extended attributes and file creation IO using fixture
+            2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
+            3. Identify the active MDS pod and its running node
+            4. Restart the node where active MDS is running
+            5. Wait for the node to reach Ready state (timeout: 420s)
+            6. Wait for MDS pods to be rescheduled and reach Running state
+            7. Re-validate the alert after node restart (timeout: 1200s)
+
+        Args:
+            nodes: Node fixture for performing node operations
+
+        """
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -552,11 +552,12 @@ class TestMdsXattrAlerts(E2ETest):
         wait_for_nodes_status(
             [active_mds_node.name], constants.STATUS_READY, timeout=420
         )
-        OCP_POD_OBJ.wait_for_resource(
+        assert OCP_POD_OBJ.wait_for_resource(
             condition=constants.STATUS_RUNNING,
-            timeout=600,
+            resource_count=len(OCP_POD_OBJ.get().get("items", [])),
+            timeout=1200,
             sleep=10,
-        )
+        ), "Not all pods in openshift-storage namespace are in Running state"
         cluster.ceph_health_check()
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -273,16 +273,29 @@ class TestMdsXattrAlerts(E2ETest):
 
             This function:
             1. Patches the storage cluster to restore MDS CPU limits and requests to 2 CPUs
-            2. Calls cluster function to gradually bring down MDS memory usage
+            2. Waits for toolbox pod to be in running state (up to 10 minutes)
+            3. Calls cluster function to gradually bring down MDS memory usage
 
             """
-            log.info("Setting MDS CPU Resources back to original values")
+            # skipping this step as alert clearance is skipped for sometime
+            # log.info("Setting MDS CPU Resources back to original values")
 
-            storagecluster_obj.patch(
-                resource_name=constants.DEFAULT_STORAGE_CLUSTER,
-                params='{"spec": {"resources": {"mds": {"limits": {"cpu": "2"}, "requests": {"cpu": "2"}}}}}',
-                format_type="merge",
+            # storagecluster_obj.patch(
+            #     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+            #     params='{"spec": {"resources": {"mds": {"limits": {"cpu": "2"}, "requests": {"cpu": "2"}}}}}',
+            #     format_type="merge",
+            # )
+
+            log.info(
+                "Waiting for toolbox pod to be in running state (timeout: 900 seconds)"
             )
+            OCP_POD_OBJ.wait_for_resource(
+                condition=constants.STATUS_RUNNING,
+                selector=constants.TOOL_APP_LABEL,
+                timeout=900,
+                resource_count=1,
+            )
+
             cluster.bring_down_mds_memory_usage_gradually()
 
         request.addfinalizer(finalizer)
@@ -307,7 +320,7 @@ class TestMdsXattrAlerts(E2ETest):
             6. Verify alert is cleared within 300 seconds
 
         """
-        api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+        # api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
         log.info(
             "Setting extended attributes and file creation IO started in the background."
@@ -315,14 +328,15 @@ class TestMdsXattrAlerts(E2ETest):
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        log.info("Checking for clearance of alert")
-        initiate_alert_clearance()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        test_end_time = int(time.time())
-        api.check_alert_cleared(
-            label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
-        )
+        # TODO - work on fixing alert clearance part
+        # log.info("Checking for clearance of alert")
+        # initiate_alert_clearance()
+        # # waiting for sometime for load distribution
+        # time.sleep(600)
+        # test_end_time = int(time.time())
+        # api.check_alert_cleared(
+        #     label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
+        # )
 
     @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -2,7 +2,10 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    ignore_leftovers,
+)
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
@@ -236,6 +239,7 @@ def initiate_alert_clearance():
 
 @blue_squad
 @tier2
+@ignore_leftovers
 class TestMdsXattrAlerts(E2ETest):
     """
     Test class for MDS xattr latency alert validation.
@@ -314,7 +318,7 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Checking for clearance of alert")
         initiate_alert_clearance()
         # waiting for sometime for load distribution
-        time.sleep(600)
+        time.sleep(720)
         api.check_alert_cleared(
             label=constants.ALERT_MDSXATTR, measure_end_time=600, time_min=30
         )

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import cluster, constants
+from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import ocp
@@ -36,6 +37,7 @@ storagecluster_obj = OCP(
     namespace=config.ENV_DATA["cluster_namespace"],
     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
 )
+ceph_cluster = CephCluster()
 
 
 @pytest.fixture(scope="function")
@@ -190,11 +192,8 @@ def ceph_not_health_error():
     """
     Check if Ceph is not in HEALTH_ERR state.
 
-    Returns:
-        bool: True if Ceph state is not HEALTH_ERR
     """
-    ceph_status = cluster.get_ceph_health()
-    log.info(f"Ceph status is: {ceph_status}")
+    ceph_status = ceph_cluster.get_ceph_health()
     return ceph_status != "HEALTH_ERR"
 
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -131,8 +131,7 @@ def ceph_not_health_error():
     """
     try:
         ceph_health_check(
-            namespace=config.ENV_DATA["cluster_namespace"],
-            tries=3,
+            namespace=config.ENV_DATA["cluster_namespace"], tries=45, delay=60
         )
         return True
     except Exception as ex:
@@ -152,11 +151,7 @@ def is_cluster_healthy():
 
 def initiate_alert_clearance():
     """
-    Initiate clearance of MDS xattr latency alert by increasing MDS CPU resources.
-
-    This function patches the storage cluster to increase MDS CPU limits and requests
-    from default values to 16 CPUs, which helps clear the CephXattrSetLatency alert
-    by providing more resources to handle the xattr operations.
+    Initiate clearance of MDS xattr latency alert by increasing MDS resources.
 
     Returns:
         None
@@ -172,6 +167,18 @@ def initiate_alert_clearance():
             '"6Gi"}}}}}'
         ),
         format_type="merge",
+    )
+
+
+def verify_alert_cleared(threading_lock):
+
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    initiate_alert_clearance()
+    # waiting for sometime for load distribution
+    time.sleep(400)
+    test_end_time = int(time.time())
+    api.check_alert_cleared(
+        label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
     )
 
 
@@ -246,8 +253,6 @@ class TestMdsXattrAlerts(E2ETest):
             6. Verify alert is cleared within 300 seconds
 
         """
-        api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
@@ -255,13 +260,7 @@ class TestMdsXattrAlerts(E2ETest):
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
         log.info("Checking for clearance of alert")
-        initiate_alert_clearance()
-        # waiting for sometime for load distribution
-        time.sleep(600)
-        test_end_time = int(time.time())
-        api.check_alert_cleared(
-            label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
-        )
+        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(
@@ -325,6 +324,8 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Validating the alert after ocs-metrics-exporter pod restart")
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+        verify_alert_cleared(threading_lock)
+
     @pytest.mark.polarion_id("OCS-7735")
     def test_alert_after_recovering_prometheus_from_failures(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -354,6 +355,8 @@ class TestMdsXattrAlerts(E2ETest):
         delete_pods(list_of_prometheus_pod_obj)
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
+
+        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
@@ -406,6 +409,8 @@ class TestMdsXattrAlerts(E2ETest):
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
         assert MDSxattr_alert_values(threading_lock, timeout=60)
+
+        verify_alert_cleared(threading_lock)
 
     @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
@@ -474,6 +479,8 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+        verify_alert_cleared(threading_lock)
+
     @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
         self, set_xattr_with_high_cpu_usage, threading_lock, nodes
@@ -515,3 +522,5 @@ class TestMdsXattrAlerts(E2ETest):
         ), "Cluster is not healthy after active MDS node restart"
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        verify_alert_cleared(threading_lock)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -9,6 +9,9 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
+from ocs_ci.templates.workloads.helper_scripts.meta_data_io import (
+    perform_xattr_only_operations,
+)
 from ocs_ci.ocs import cluster, constants
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.utility import prometheus
@@ -90,32 +93,7 @@ def set_xattr_with_high_cpu_usage(
         node_name=active_mds_node_name,
     )
 
-    log.info("Copying check_xattr.py to fedora pod ")
-    cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/mnt/"
-    helpers.run_cmd(cmd=cmd)
-    log.info("check_xattr.py copied successfully ")
-    log.info("Setting extended attributed from fedora pod ")
-    cmd = (
-        "bash -c 'cd /mnt; "
-        "for i in {1..6}; do "
-        'dir="my_test_dir${i}"; '
-        'python3 check_xattr.py "$dir" 10000 100 > "${dir}.log" 2>&1 & '
-        "sleep 5; "
-        "done'"
-    )
-    pod_obj.exec_sh_cmd_on_pod(cmd)
-    time.sleep(10)
-
-    ls_output = pod_obj.exec_sh_cmd_on_pod("ls /mnt")
-    for i in range(1, 7):
-        dir_name = f"my_test_dir{i}"
-        log_name = f"{dir_name}.log"
-        assert (
-            dir_name in ls_output
-        ), f"Expected directory {dir_name} was not created under /mnt"
-        assert (
-            log_name in ls_output
-        ), f"Expected log file {log_name} was not created under /mnt"
+    perform_xattr_only_operations(file=file, pod_obj=pod_obj)
 
     log.info(
         "Setting up cephfs stress job for increasing CPU utilization in the cluster"

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -3,10 +3,7 @@ import pytest
 import subprocess
 import time
 
-from ocs_ci.framework.pytest_customization.marks import (
-    blue_squad,
-    ignore_leftovers,
-)
+from ocs_ci.framework.pytest_customization.marks import blue_squad
 from ocs_ci.framework.testlib import E2ETest, tier2, tier4b, tier4c
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -143,6 +140,17 @@ def set_xattr_with_high_cpu_usage(
 def MDSxattr_alert_values(threading_lock, timeout):
     """
     Validate MDS xattr latency alert using Prometheus API.
+
+    This function validates the CephXattrSetLatency alert by checking its
+    properties including message, description, runbook URL, severity, and state.
+
+    Args:
+        threading_lock: Threading lock for Prometheus API calls
+        timeout (int): Timeout in seconds to wait for the alert to appear
+
+    Returns:
+        bool: True if alert is found and validated successfully, False otherwise
+
     """
     return prometheus.validate_alert(
         threading_lock=threading_lock,
@@ -164,7 +172,11 @@ def MDSxattr_alert_values(threading_lock, timeout):
 
 def ceph_not_health_error():
     """
-    Check if Ceph health is good.
+    Check if Ceph cluster health is in a healthy state.
+
+    Returns:
+        bool: True if Ceph health check passes (cluster is healthy),
+              False if health check fails or raises an exception
 
     """
     try:
@@ -227,7 +239,6 @@ def verify_alert_cleared(threading_lock):
 
 @blue_squad
 @tier2
-@ignore_leftovers
 @pytest.mark.skipif(
     config.ENV_DATA.get("platform") == "external",
     reason="MDS xattr tests require internal MDS management, not supported in external mode",
@@ -284,8 +295,6 @@ class TestMdsXattrAlerts(E2ETest):
                 timeout=900,
                 resource_count=1,
             )
-
-            cluster.bring_down_mds_memory_usage_gradually()
 
         request.addfinalizer(finalizer)
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -6,8 +6,9 @@ from ocs_ci.framework.pytest_customization.marks import (
     blue_squad,
     ignore_leftovers,
 )
-from ocs_ci.framework.testlib import E2ETest, tier2
+from ocs_ci.framework.testlib import E2ETest, tier2, tier4b, tier4c
 from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.helpers import helpers
 from ocs_ci.templates.workloads.helper_scripts.meta_data_io import (
     perform_xattr_only_operations,
@@ -38,6 +39,40 @@ storagecluster_obj = OCP(
     namespace=config.ENV_DATA["cluster_namespace"],
     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
 )
+
+
+def cleanup_pvc_with_timeout_handling(pvc_obj, max_retries=9, retry_delay=60):
+    """
+    Clean up PVC with timeout handling and retries.
+
+    Args:
+        pvc_obj: PVC object to delete
+        max_retries: Maximum number of retries (default: 3)
+        retry_delay: Delay between retries in seconds (default: 60)
+    """
+    if pvc_obj.is_deleted:
+        return
+
+    for attempt in range(max_retries):
+        try:
+            pvc_obj.delete()
+            pvc_obj.ocp.wait_for_delete(pvc_obj.name, timeout=900)
+            return
+        except TimeoutExpiredError:
+            try:
+                pvc_obj.ocp.get(resource_name=pvc_obj.name)
+                if attempt < max_retries - 1:
+                    log.info(f"PVC still exists, waiting {retry_delay}s before retry")
+                    time.sleep(retry_delay)
+                else:
+                    log.error(
+                        f"PVC {pvc_obj.name} still exists after {max_retries} attempts"
+                    )
+                    raise
+            except Exception:
+                log.info(f"PVC {pvc_obj.name} successfully deleted despite timeout")
+                pvc_obj._is_deleted = True
+                return
 
 
 @pytest.fixture(scope="function")
@@ -100,6 +135,13 @@ def set_xattr_with_high_cpu_usage(
         ),
         format_type="merge",
     )
+
+    def finalizer():
+        """Custom finalizer to handle PVC cleanup with timeout handling"""
+
+        cleanup_pvc_with_timeout_handling(pvc_obj)
+
+    request.addfinalizer(finalizer)
 
 
 def MDSxattr_alert_values(threading_lock, timeout):
@@ -171,7 +213,12 @@ def initiate_alert_clearance():
 
 
 def verify_alert_cleared(threading_lock):
+    """
+    Verify that MDS xattr latency alert is cleared after increasing resources.
 
+    Args:
+        threading_lock: Threading lock for Prometheus API calls
+    """
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     initiate_alert_clearance()
     # waiting for sometime for load distribution
@@ -185,6 +232,10 @@ def verify_alert_cleared(threading_lock):
 @blue_squad
 @tier2
 @ignore_leftovers
+@pytest.mark.skipif(
+    config.ENV_DATA.get("platform") == "external",
+    reason="MDS xattr tests require internal MDS management, not supported in external mode",
+)
 class TestMdsXattrAlerts(E2ETest):
     """
     Test class for MDS xattr latency alert validation.
@@ -268,6 +319,7 @@ class TestMdsXattrAlerts(E2ETest):
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+    @tier4c
     @pytest.mark.polarion_id("OCS-7734")
     def test_alert_triggered_by_restarting_operator_and_metrics_pods(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -360,6 +412,7 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
 
+    @tier4c
     @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -479,6 +532,7 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+    @tier4b
     @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
         self, set_xattr_with_high_cpu_usage, threading_lock, nodes

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -22,6 +22,7 @@ from ocs_ci.ocs.resources.pod import (
     delete_pods,
     get_prometheus_pods,
     get_pods_having_label,
+    get_mds_pods,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.node import wait_for_nodes_status
@@ -190,29 +191,44 @@ def verify_alert_cleared(threading_lock):
 
 def recover_mds_pods_if_not_running(nodes):
     """
-    Check if MDS pods are running and restart nodes if they are not.
+    Check MDS deployments and scale up if any are at 0 replicas.
 
-    This function is used in test teardowns to ensure MDS pods are in a healthy
-    state before the next test runs.
+    This function is used in test teardowns to ensure MDS deployments are scaled
+    to 1 replica if they were scaled down during the test.
 
     Args:
         nodes: nodes fixture for node operations
     """
-    log.info("Teardown: Checking if MDS pods are running")
-    mds_pods = cluster.get_mds_pods()
+    log.info("Teardown: Checking MDS deployments and scaling if needed")
 
-    all_running = True
-    for pd in mds_pods:
-        try:
-            helpers.wait_for_resource_state(
-                resource=pd, state=constants.STATUS_RUNNING, timeout=60
+    # Get all MDS deployments
+    mds_deployments = ocp.OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        selector=constants.MDS_APP_LABEL,
+    ).get()
+
+    if not mds_deployments or "items" not in mds_deployments:
+        log.warning("No MDS deployments found")
+        return
+
+    # Check each deployment and scale up if needed
+    scaled_any = False
+    for deployment in mds_deployments["items"]:
+        deployment_name = deployment["metadata"]["name"]
+        replicas = deployment["spec"]["replicas"]
+
+        log.info(f"MDS deployment {deployment_name} has {replicas} replica(s)")
+
+        if replicas == 0:
+            log.info(f"Scaling up MDS deployment {deployment_name} from 0 to 1")
+            helpers.modify_deployment_replica_count(
+                deployment_name=deployment_name, replica_count=1
             )
-        except Exception:
-            all_running = False
-            break
+            scaled_any = True
 
-    if not all_running:
-        nodes.restart_nodes_by_stop_and_start_teardown()
+    if not scaled_any:
+        log.info("No MDS deployments needed scaling")
 
 
 @blue_squad
@@ -452,7 +468,7 @@ class TestMdsXattrAlerts(E2ETest):
             " Script will be in sleep for 60 seconds to make sure mds scale up completed."
         )
         time.sleep(60)
-        mds_pods = cluster.get_mds_pods()
+        mds_pods = get_mds_pods()
         for pd in mds_pods:
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
@@ -537,7 +553,7 @@ class TestMdsXattrAlerts(E2ETest):
         )
         time.sleep(60)
 
-        mds_pods = cluster.get_mds_pods()
+        mds_pods = get_mds_pods()
         for pd in mds_pods:
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -3,7 +3,7 @@ import pytest
 import subprocess
 import time
 
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad, skipif_external_mode
 from ocs_ci.framework.testlib import E2ETest, tier2, tier4b, tier4c
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -199,16 +199,19 @@ def is_cluster_healthy():
     return ceph_not_health_error() and pod.wait_for_pods_to_be_running(timeout=900)
 
 
-def initiate_alert_clearance():
+def verify_alert_cleared(threading_lock):
     """
-    Initiate clearance of MDS xattr latency alert by increasing MDS resources.
+    Verify that MDS xattr latency alert is cleared after restoring MDS resources.
 
-    Returns:
-        None
+    This function restores MDS CPU and memory resources to default values (2 CPU, 6Gi memory),
+    waits for load distribution, and verifies that the alert is cleared.
 
+    Args:
+        threading_lock: Threading lock for Prometheus API calls
     """
-    log.info("Increasing MDS CPU and memory resources to clear MDS xattr latency alert")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
+    log.info("Restoring MDS CPU and memory resources to default values to clear alert")
     storagecluster_obj.patch(
         resource_name=constants.DEFAULT_STORAGE_CLUSTER,
         params=(
@@ -219,16 +222,6 @@ def initiate_alert_clearance():
         format_type="merge",
     )
 
-
-def verify_alert_cleared(threading_lock):
-    """
-    Verify that MDS xattr latency alert is cleared after increasing resources.
-
-    Args:
-        threading_lock: Threading lock for Prometheus API calls
-    """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-    initiate_alert_clearance()
     # waiting for sometime for load distribution
     time.sleep(400)
     test_end_time = int(time.time())
@@ -238,11 +231,7 @@ def verify_alert_cleared(threading_lock):
 
 
 @blue_squad
-@tier2
-@pytest.mark.skipif(
-    config.ENV_DATA.get("platform") == "external",
-    reason="MDS xattr tests require internal MDS management, not supported in external mode",
-)
+@skipif_external_mode
 class TestMdsXattrAlerts(E2ETest):
     """
     Test class for MDS xattr latency alert validation.
@@ -270,34 +259,30 @@ class TestMdsXattrAlerts(E2ETest):
 
         def finalizer():
             """
-            Finalizer function to restore MDS resources and clear memory usage.
+            Finalizer function to ensure toolbox pod is ready and restore MDS resources.
 
-            This function:
-            1. Verifies that the alert is cleared (if test passed)
-            2. Waits for toolbox pod to be in running state (up to 10 minutes)
-            3. Calls cluster function to gradually bring down MDS memory usage
+            This function waits for toolbox pod to be in running state before cleanup,
+            then restores MDS CPU and memory resources to default values as a safety measure.
+            Alert verification is done at the end of each test method.
 
             """
-            try:
-                verify_alert_cleared(threading_lock)
-            except Exception as e:
-                log.warning(
-                    f"Failed to verify alert cleared in teardown: {e}. "
-                    "This may happen if the test failed before alert was triggered."
-                )
 
             log.info(
-                "Waiting for toolbox pod to be in running state (timeout: 900 seconds)"
+                "Restoring MDS CPU and memory resources to default values in teardown"
             )
-            OCP_POD_OBJ.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                selector=constants.TOOL_APP_LABEL,
-                timeout=900,
-                resource_count=1,
+            storagecluster_obj.patch(
+                resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+                params=(
+                    '{"spec": {"resources": {"mds": {"limits": {"cpu": "2", '
+                    '"memory": "6Gi"}, "requests": {"cpu": "2", "memory": '
+                    '"6Gi"}}}}}'
+                ),
+                format_type="merge",
             )
 
         request.addfinalizer(finalizer)
 
+    @tier2
     @pytest.mark.polarion_id("OCS-7733")
     def test_mds_xattr_alert_triggered(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -313,9 +298,7 @@ class TestMdsXattrAlerts(E2ETest):
             1. Set up extended attributes and file creation IO using fixture
             2. Wait for CephXattrSetLatency alert to trigger (timeout: 1200s)
             3. Validate alert properties (message, description, runbook, severity, state)
-            4. Initiate alert clearance by increasing MDS CPU resources to 16 CPUs
-            5. Wait for 600 seconds for load distribution
-            6. Verify alert is cleared within 300 seconds
+            4. Verify alert is cleared after test completion
 
         """
         log.info(
@@ -323,6 +306,8 @@ class TestMdsXattrAlerts(E2ETest):
             " Script will look for CephXattrSetLatency  alert"
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        verify_alert_cleared(threading_lock)
 
     @tier4c
     @pytest.mark.polarion_id("OCS-7734")
@@ -345,6 +330,7 @@ class TestMdsXattrAlerts(E2ETest):
             6. Delete the ocs-metrics-exporter pod
             7. Wait for ocs-metrics-exporter pod to come up (timeout: 600s)
             8. Re-validate the alert after metrics exporter restart (timeout: 1200s)
+            9. Verify alert is cleared after test completion
 
         """
         log.info(
@@ -387,6 +373,9 @@ class TestMdsXattrAlerts(E2ETest):
         log.info("Validating the alert after ocs-metrics-exporter pod restart")
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+        verify_alert_cleared(threading_lock)
+
+    @tier2
     @pytest.mark.polarion_id("OCS-7735")
     def test_alert_after_recovering_prometheus_from_failures(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -403,6 +392,7 @@ class TestMdsXattrAlerts(E2ETest):
             3. Delete all Prometheus pods to simulate failure
             4. Wait for Prometheus pods to be recreated automatically
             5. Re-validate the alert after Prometheus recovery (timeout: 300s)
+            6. Verify alert is cleared after test completion
         """
 
         log.info(
@@ -416,6 +406,8 @@ class TestMdsXattrAlerts(E2ETest):
         delete_pods(list_of_prometheus_pod_obj)
 
         assert MDSxattr_alert_values(threading_lock, timeout=300)
+
+        verify_alert_cleared(threading_lock)
 
     @tier4c
     @pytest.mark.polarion_id("OCS-7736")
@@ -438,6 +430,7 @@ class TestMdsXattrAlerts(E2ETest):
             7. Wait 60 seconds for MDS scale up to complete
             8. Wait for all MDS pods to reach Running state
             9. Re-validate the alert after MDS scale operations (timeout: 60s)
+            10. Verify alert is cleared after test completion
 
         """
 
@@ -470,6 +463,9 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=60)
 
+        verify_alert_cleared(threading_lock)
+
+    @tier2
     @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
         self, set_xattr_with_high_cpu_usage, threading_lock
@@ -493,6 +489,7 @@ class TestMdsXattrAlerts(E2ETest):
             9. Wait 60 seconds for both MDS scale up operations to complete
             10. Wait for all MDS pods to reach Running state
             11. Re-validate the alert after MDS scale operations (timeout: 1200s)
+            12. Verify alert is cleared after test completion
 
         """
         log.info(
@@ -537,6 +534,8 @@ class TestMdsXattrAlerts(E2ETest):
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+        verify_alert_cleared(threading_lock)
+
     @tier4b
     @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
@@ -554,8 +553,9 @@ class TestMdsXattrAlerts(E2ETest):
             3. Identify the active MDS pod and its running node
             4. Restart the node where active MDS is running
             5. Wait for the node to reach Ready state (timeout: 420s)
-            6. Wait for MDS pods to be rescheduled and reach Running state
+            6. Verify cluster health after node restart
             7. Re-validate the alert after node restart (timeout: 1200s)
+            8. Verify alert is cleared after test completion
 
         Args:
             nodes: Node fixture for performing node operations
@@ -589,3 +589,5 @@ class TestMdsXattrAlerts(E2ETest):
         ), "Cluster is not healthy after active MDS node restart"
 
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        verify_alert_cleared(threading_lock)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -218,17 +218,48 @@ def recover_mds_pods_if_not_running(nodes):
         deployment_name = deployment["metadata"]["name"]
         replicas = deployment["spec"]["replicas"]
 
-        log.info(f"MDS deployment {deployment_name} has {replicas} replica(s)")
-
         if replicas == 0:
-            log.info(f"Scaling up MDS deployment {deployment_name} from 0 to 1")
-            helpers.modify_deployment_replica_count(
-                deployment_name=deployment_name, replica_count=1
+            try:
+                helpers.modify_deployment_replica_count(
+                    deployment_name=deployment_name, replica_count=1
+                )
+                scaled_any = True
+                log.info(f"Successfully scaled {deployment_name} to 1 replica")
+            except Exception as e:
+                log.error(f"Failed to scale MDS deployment {deployment_name}: {e}")
+                raise AssertionError(
+                    f"Teardown failed: Could not scale MDS deployment {deployment_name} from 0 to 1"
+                )
+        else:
+            log.info(
+                f"MDS deployment {deployment_name} already has {replicas} replica(s), no scaling needed"
             )
-            scaled_any = True
 
     if not scaled_any:
         log.info("No MDS deployments needed scaling")
+
+    # Verify MDS pods are running after scaling
+    if scaled_any:
+        log.info("Waiting for MDS pods to be in Running state after scaling")
+        time.sleep(30)  # Give pods time to start
+
+        mds_pods = get_mds_pods()
+        if not mds_pods:
+            raise AssertionError("No MDS pods found after scaling deployments")
+
+        log.info(f"Found {len(mds_pods)} MDS pod(s), verifying they are running")
+        for mds_pod in mds_pods:
+            try:
+                helpers.wait_for_resource_state(
+                    resource=mds_pod, state=constants.STATUS_RUNNING, timeout=120
+                )
+            except Exception as e:
+                log.error(f"MDS pod {mds_pod.name} failed to reach Running state: {e}")
+                raise AssertionError(
+                    f"Teardown failed: MDS pod {mds_pod.name} did not reach Running state after scaling"
+                )
+
+        log.info("All MDS pods are running successfully")
 
 
 @blue_squad

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -604,8 +604,11 @@ class TestMdsXattrAlerts(E2ETest):
         """
 
         def finalizer():
-            """Teardown to ensure all nodes are up after test"""
+            """Teardown to ensure all nodes are up and cluster is healthy after test"""
             nodes.restart_nodes_by_stop_and_start_teardown()
+            assert (
+                is_cluster_healthy()
+            ), "Cluster is not healthy after node restart in teardown"
 
         request.addfinalizer(finalizer)
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -206,7 +206,6 @@ def recover_mds_pods_if_not_running():
     Returns:
         None
     """
-    log.info("Teardown: Checking MDS deployments and scaling if needed")
 
     # Get all MDS deployments
     mds_deployments = ocp.OCP(
@@ -215,58 +214,38 @@ def recover_mds_pods_if_not_running():
         selector=constants.MDS_APP_LABEL,
     ).get()
 
-    if not mds_deployments or "items" not in mds_deployments:
-        log.warning("No MDS deployments found")
+    # Filter deployments that need scaling (replicas == 0)
+    deployments_to_scale = [
+        d for d in mds_deployments["items"] if d.get("spec", {}).get("replicas") == 0
+    ]
+
+    if not deployments_to_scale:
+        log.info("No MDS deployments needed scaling")
         return
 
-    # Check each deployment and scale up if needed
-    scaled_any = False
-    for deployment in mds_deployments["items"]:
-        deployment_name = deployment["metadata"]["name"]
-        replicas = deployment["spec"]["replicas"]
+    log.info(f"Found {len(deployments_to_scale)} MDS deployment(s) at 0 replicas")
 
-        if replicas == 0:
-            try:
-                helpers.modify_deployment_replica_count(
-                    deployment_name=deployment_name, replica_count=1
-                )
-                scaled_any = True
-                log.info(f"Successfully scaled {deployment_name} to 1 replica")
-            except Exception as e:
-                log.error(f"Failed to scale MDS deployment {deployment_name}: {e}")
-                raise AssertionError(
-                    f"Teardown failed: Could not scale MDS deployment {deployment_name} from 0 to 1"
-                )
-        else:
-            log.info(
-                f"MDS deployment {deployment_name} already has {replicas} replica(s), no scaling needed"
+    # Scale up each deployment from 0 to 1
+    for deployment in deployments_to_scale:
+        deployment_name = deployment["metadata"]["name"]
+        try:
+            helpers.modify_deployment_replica_count(
+                deployment_name=deployment_name, replica_count=1
+            )
+            log.info(f"Successfully scaled {deployment_name} to 1 replica")
+        except Exception as e:
+            log.error(f"Failed to scale MDS deployment {deployment_name}: {e}")
+            raise AssertionError(
+                f"Teardown failed: Could not scale MDS deployment {deployment_name} from 0 to 1"
             )
 
-    if not scaled_any:
-        log.info("No MDS deployments needed scaling")
-
-    # Verify MDS pods are running after scaling
-    if scaled_any:
-        log.info("Waiting for MDS pods to be in Running state after scaling")
-        time.sleep(30)  # Give pods time to start
-
-        mds_pods = get_mds_pods()
-        if not mds_pods:
-            raise AssertionError("No MDS pods found after scaling deployments")
-
-        log.info(f"Found {len(mds_pods)} MDS pod(s), verifying they are running")
-        for mds_pod in mds_pods:
-            try:
-                helpers.wait_for_resource_state(
-                    resource=mds_pod, state=constants.STATUS_RUNNING, timeout=120
-                )
-            except Exception as e:
-                log.error(f"MDS pod {mds_pod.name} failed to reach Running state: {e}")
-                raise AssertionError(
-                    f"Teardown failed: MDS pod {mds_pod.name} did not reach Running state after scaling"
-                )
-
-        log.info("All MDS pods are running successfully")
+    pod.wait_for_pods_to_be_running(
+        namespace=config.ENV_DATA["cluster_namespace"],
+        selector=constants.MDS_APP_LABEL,
+        timeout=180,
+        sleep=10,
+    )
+    log.info("All MDS pods are running successfully")
 
 
 @blue_squad

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -189,15 +189,22 @@ def verify_alert_cleared(threading_lock):
     )
 
 
-def recover_mds_pods_if_not_running(nodes):
+def recover_mds_pods_if_not_running():
     """
-    Check MDS deployments and scale up if any are at 0 replicas.
+    Recover MDS deployments and verify pods are running.
 
-    This function is used in test teardowns to ensure MDS deployments are scaled
-    to 1 replica if they were scaled down during the test.
+    This function is used in test teardowns to:
+    1. Check all MDS deployments
+    2. Scale up any deployments that are at 0 replicas to 1
+    3. Verify all MDS pods reach Running state after scaling
 
-    Args:
-        nodes: nodes fixture for node operations
+    If scaling or pod verification fails, the test will fail with AssertionError.
+
+    Raises:
+        AssertionError: If deployment scaling fails or pods don't reach Running state
+
+    Returns:
+        None
     """
     log.info("Teardown: Checking MDS deployments and scaling if needed")
 
@@ -469,10 +476,9 @@ class TestMdsXattrAlerts(E2ETest):
 
         def finalizer():
             """
-            Teardown to ensure MDS pods are running.
-            If MDS pods are not running, restart nodes to recover.
+            Teardown to ensure MDS deployments are scaled up and pods are running.
             """
-            recover_mds_pods_if_not_running(nodes)
+            recover_mds_pods_if_not_running()
 
         request.addfinalizer(finalizer)
 
@@ -541,10 +547,9 @@ class TestMdsXattrAlerts(E2ETest):
 
         def finalizer():
             """
-            Teardown to ensure MDS pods are running.
-            If MDS pods are not running, restart nodes to recover.
+            Teardown to ensure MDS deployments are scaled up and pods are running.
             """
-            recover_mds_pods_if_not_running(nodes)
+            recover_mds_pods_if_not_running()
 
         request.addfinalizer(finalizer)
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import subprocess
 import time
 
 from ocs_ci.framework.pytest_customization.marks import (
@@ -58,11 +59,11 @@ def cleanup_pvc_with_timeout_handling(pvc_obj, max_retries=9, retry_delay=60):
             pvc_obj.delete()
             pvc_obj.ocp.wait_for_delete(pvc_obj.name, timeout=900)
             return
-        except TimeoutExpiredError:
+        except (TimeoutExpiredError, subprocess.TimeoutExpired):
+
             try:
                 pvc_obj.ocp.get(resource_name=pvc_obj.name)
                 if attempt < max_retries - 1:
-                    log.info(f"PVC still exists, waiting {retry_delay}s before retry")
                     time.sleep(retry_delay)
                 else:
                     log.error(
@@ -136,12 +137,7 @@ def set_xattr_with_high_cpu_usage(
         format_type="merge",
     )
 
-    def finalizer():
-        """Custom finalizer to handle PVC cleanup with timeout handling"""
-
-        cleanup_pvc_with_timeout_handling(pvc_obj)
-
-    request.addfinalizer(finalizer)
+    return pvc_obj
 
 
 def MDSxattr_alert_values(threading_lock, timeout):
@@ -535,7 +531,7 @@ class TestMdsXattrAlerts(E2ETest):
     @tier4b
     @pytest.mark.polarion_id("OCS-7738")
     def test_alert_with_mds_running_node_restart(
-        self, set_xattr_with_high_cpu_usage, threading_lock, nodes
+        self, set_xattr_with_high_cpu_usage, threading_lock, nodes, request
     ):
         """
         Test MDS xattr latency alert persistence after active MDS node restart.
@@ -554,8 +550,18 @@ class TestMdsXattrAlerts(E2ETest):
 
         Args:
             nodes: Node fixture for performing node operations
+            request: pytest request for finalizer
 
         """
+        # Get the PVC object from fixture for custom cleanup
+        pvc_obj = set_xattr_with_high_cpu_usage
+
+        def finalizer():
+            """Custom finalizer for PVC cleanup with timeout handling"""
+            cleanup_pvc_with_timeout_handling(pvc_obj)
+
+        request.addfinalizer(finalizer)
+
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -48,24 +48,14 @@ def set_xattr_with_high_cpu_usage(
     """
     Fixture to set up extended attributes with high CPU usage for MDS xattr latency alert testing.
 
-    This fixture performs the following operations:
-    1. Creates a PVC with CephFS interface and RWX access mode for setting extended attributes
-       on multiple files in the MDS server
-    2. Creates a deployment pod on the active MDS node with service account and SCC policy
-    3. Copies helper_scripts/check_xattr.py to the deployment pod
-    4. Executes the check_xattr.py script to set extended attributes on multiple directories
-    5. Creates a storage class with SELinux security context for CephFS stress testing
-    6. Creates additional PVC and CephFS stress job to increase CPU utilization in the cluster
-    7. Submits the CephFS stress job with specified parallelism and file creation parameters
-
     Args:
         request: pytest request object for finalizer registration
         pvc_factory: Factory fixture to create PVC objects
         deployment_pod_factory: Factory fixture to create deployment pod objects
         storageclass_factory: Factory fixture to create storage class objects
 
-    Yields:
-        None: This fixture sets up the environment and cleans up resources in finalizer
+    Returns:
+        PVC: The PVC object created for extended attribute operations
 
     """
     log.info("setting extended attributes value for multiple files in MDS server ")

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,6 +1,5 @@
 import logging
 import pytest
-import subprocess
 import time
 
 from ocs_ci.framework.pytest_customization.marks import (
@@ -10,7 +9,6 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework.testlib import E2ETest, tier2, tier4b, tier4c
 from ocs_ci.framework import config
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.helpers import helpers
 from ocs_ci.templates.workloads.helper_scripts.meta_data_io import (
     perform_xattr_only_operations,
@@ -41,40 +39,6 @@ storagecluster_obj = OCP(
     namespace=config.ENV_DATA["cluster_namespace"],
     resource_name=constants.DEFAULT_STORAGE_CLUSTER,
 )
-
-
-def cleanup_pvc_with_timeout_handling(pvc_obj, max_retries=9, retry_delay=60):
-    """
-    Clean up PVC with timeout handling and retries.
-
-    Args:
-        pvc_obj: PVC object to delete
-        max_retries: Maximum number of retries (default: 3)
-        retry_delay: Delay between retries in seconds (default: 60)
-    """
-    if pvc_obj.is_deleted:
-        return
-
-    for attempt in range(max_retries):
-        try:
-            pvc_obj.delete()
-            pvc_obj.ocp.wait_for_delete(pvc_obj.name, timeout=900)
-            return
-        except (TimeoutExpiredError, subprocess.TimeoutExpired):
-
-            try:
-                pvc_obj.ocp.get(resource_name=pvc_obj.name)
-                if attempt < max_retries - 1:
-                    time.sleep(retry_delay)
-                else:
-                    log.error(
-                        f"PVC {pvc_obj.name} still exists after {max_retries} attempts"
-                    )
-                    raise
-            except Exception:
-                log.info(f"PVC {pvc_obj.name} successfully deleted despite timeout")
-                pvc_obj._is_deleted = True
-                return
 
 
 @pytest.fixture(scope="function")
@@ -232,6 +196,29 @@ def verify_alert_cleared(threading_lock):
     api.check_alert_cleared(
         label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
     )
+
+
+def ensure_mds_deployments_scaled(deployment_names):
+    """
+    Ensure MDS deployments are scaled to 1 replica.
+
+    Checks if both MDS pods are running. If not, scales the deployments to 1
+    and waits for all MDS pods to reach Running state.
+
+    Args:
+        deployment_names: List of MDS deployment names to check/scale
+    """
+    mds_pods = cluster.get_mds_pods()
+    if len(mds_pods) < 2:
+        log.info("Scaling MDS deployments to 1")
+        for deployment_name in deployment_names:
+            helpers.modify_deployment_replica_count(
+                deployment_name=deployment_name, replica_count=1
+            )
+        time.sleep(60)
+        mds_pods = cluster.get_mds_pods()
+    for pd in mds_pods:
+        helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
 
 @blue_squad
@@ -417,7 +404,7 @@ class TestMdsXattrAlerts(E2ETest):
     @tier4c
     @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
-        self, set_xattr_with_high_cpu_usage, threading_lock
+        self, set_xattr_with_high_cpu_usage, threading_lock, request
     ):
         """
         Test MDS xattr latency alert persistence after active MDS scale down and up.
@@ -449,6 +436,12 @@ class TestMdsXattrAlerts(E2ETest):
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         deployment_name = "rook-ceph-mds-" + active_mds
 
+        def finalizer():
+            """Ensure MDS deployment is scaled to 1"""
+            ensure_mds_deployments_scaled([deployment_name])
+
+        request.addfinalizer(finalizer)
+
         log.info(f"Scale down {deployment_name} to 0")
         helpers.modify_deployment_replica_count(
             deployment_name=deployment_name, replica_count=0
@@ -473,7 +466,7 @@ class TestMdsXattrAlerts(E2ETest):
     @tier2
     @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
-        self, set_xattr_with_high_cpu_usage, threading_lock
+        self, set_xattr_with_high_cpu_usage, threading_lock, request
     ):
         """
         Test MDS xattr latency alert persistence after both active and standby MDS scale down and up.
@@ -496,17 +489,28 @@ class TestMdsXattrAlerts(E2ETest):
             11. Re-validate the alert after MDS scale operations (timeout: 1200s)
             12. Verify alert is cleared after test completion
 
+        Args:
+            request: pytest request for finalizer registration
+
         """
+        # Get MDS info first for teardown
+        active_mds = cluster.get_active_mds_info()["mds_daemon"]
+        standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
+        active_mds_d = "rook-ceph-mds-" + active_mds
+        standby_mds_d = "rook-ceph-mds-" + standby_mds
+
+        def finalizer():
+            """Ensure both MDS deployments are scaled to 1"""
+            ensure_mds_deployments_scaled([active_mds_d, standby_mds_d])
+
+        request.addfinalizer(finalizer)
+
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
-        active_mds = cluster.get_active_mds_info()["mds_daemon"]
-        standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
-        active_mds_d = "rook-ceph-mds-" + active_mds
-        standby_mds_d = "rook-ceph-mds-" + standby_mds
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         standby_mds_pod = cluster.get_mds_standby_replay_info()["standby_replay_pod"]
         mds_dc_pods = [active_mds_d, standby_mds_d]
@@ -564,15 +568,13 @@ class TestMdsXattrAlerts(E2ETest):
 
         Args:
             nodes: Node fixture for performing node operations
-            request: pytest request for finalizer
+            request: pytest request for finalizer registration
 
         """
-        # Get the PVC object from fixture for custom cleanup
-        pvc_obj = set_xattr_with_high_cpu_usage
 
         def finalizer():
-            """Custom finalizer for PVC cleanup with timeout handling"""
-            cleanup_pvc_with_timeout_handling(pvc_obj)
+            """Teardown to ensure all nodes are up after test"""
+            nodes.restart_nodes_by_stop_and_start_teardown()
 
         request.addfinalizer(finalizer)
 

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -200,10 +200,11 @@ def verify_alert_cleared(threading_lock):
 
 def ensure_mds_deployments_scaled(deployment_names):
     """
-    Ensure MDS deployments are scaled to 1 replica.
+    Ensure MDS deployments are scaled to 1 replica and MDS daemons are active.
 
-    Checks if both MDS pods are running. If not, scales the deployments to 1
-    and waits for all MDS pods to reach Running state.
+    Checks if both MDS pods are running and MDS daemons are active. If not,
+    scales the deployments to 1 and waits for all MDS pods to reach Running
+    state and for MDS daemons to become active.
 
     Args:
         deployment_names: List of MDS deployment names to check/scale
@@ -217,8 +218,32 @@ def ensure_mds_deployments_scaled(deployment_names):
             )
         time.sleep(60)
         mds_pods = cluster.get_mds_pods()
+
+    # Wait for all MDS pods to be Running
     for pd in mds_pods:
         helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
+
+    # Wait for MDS daemons to become active
+    log.info("Waiting for MDS daemons to become active")
+    timeout = 500  # 5 minutes timeout
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        try:
+            active_mds = cluster.get_active_mds_info()
+            standby_mds = cluster.get_mds_standby_replay_info()
+
+            if active_mds and standby_mds:
+                log.info(
+                    f"MDS daemons are active: active={active_mds['mds_daemon']}, standby={standby_mds['mds_daemon']}"
+                )
+                break
+        except Exception as e:
+            log.debug(f"MDS daemons not yet active: {e}")
+
+        time.sleep(10)
+    else:
+        log.warning("Timeout waiting for MDS daemons to become active, but continuing")
 
 
 @blue_squad

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -198,52 +198,31 @@ def verify_alert_cleared(threading_lock):
     )
 
 
-def ensure_mds_deployments_scaled(deployment_names):
+def recover_mds_pods_if_not_running(nodes):
     """
-    Ensure MDS deployments are scaled to 1 replica and MDS daemons are active.
+    Check if MDS pods are running and restart nodes if they are not.
 
-    Checks if both MDS pods are running and MDS daemons are active. If not,
-    scales the deployments to 1 and waits for all MDS pods to reach Running
-    state and for MDS daemons to become active.
+    This function is used in test teardowns to ensure MDS pods are in a healthy
+    state before the next test runs.
 
     Args:
-        deployment_names: List of MDS deployment names to check/scale
+        nodes: nodes fixture for node operations
     """
+    log.info("Teardown: Checking if MDS pods are running")
     mds_pods = cluster.get_mds_pods()
-    if len(mds_pods) < 2:
-        log.info("Scaling MDS deployments to 1")
-        for deployment_name in deployment_names:
-            helpers.modify_deployment_replica_count(
-                deployment_name=deployment_name, replica_count=1
-            )
-        time.sleep(60)
-        mds_pods = cluster.get_mds_pods()
 
-    # Wait for all MDS pods to be Running
+    all_running = True
     for pd in mds_pods:
-        helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
-
-    # Wait for MDS daemons to become active
-    log.info("Waiting for MDS daemons to become active")
-    timeout = 500  # 5 minutes timeout
-    start_time = time.time()
-
-    while time.time() - start_time < timeout:
         try:
-            active_mds = cluster.get_active_mds_info()
-            standby_mds = cluster.get_mds_standby_replay_info()
+            helpers.wait_for_resource_state(
+                resource=pd, state=constants.STATUS_RUNNING, timeout=60
+            )
+        except Exception:
+            all_running = False
+            break
 
-            if active_mds and standby_mds:
-                log.info(
-                    f"MDS daemons are active: active={active_mds['mds_daemon']}, standby={standby_mds['mds_daemon']}"
-                )
-                break
-        except Exception as e:
-            log.debug(f"MDS daemons not yet active: {e}")
-
-        time.sleep(10)
-    else:
-        log.warning("Timeout waiting for MDS daemons to become active, but continuing")
+    if not all_running:
+        nodes.restart_nodes_by_stop_and_start_teardown()
 
 
 @blue_squad
@@ -429,7 +408,7 @@ class TestMdsXattrAlerts(E2ETest):
     @tier4c
     @pytest.mark.polarion_id("OCS-7736")
     def test_alert_after_active_mds_scaledown(
-        self, set_xattr_with_high_cpu_usage, threading_lock, request
+        self, set_xattr_with_high_cpu_usage, threading_lock, request, nodes
     ):
         """
         Test MDS xattr latency alert persistence after active MDS scale down and up.
@@ -451,6 +430,15 @@ class TestMdsXattrAlerts(E2ETest):
 
         """
 
+        def finalizer():
+            """
+            Teardown to ensure MDS pods are running.
+            If MDS pods are not running, restart nodes to recover.
+            """
+            recover_mds_pods_if_not_running(nodes)
+
+        request.addfinalizer(finalizer)
+
         log.info(
             "Setting extended attributes and file creation IO started in the background."
             " Script will look for CephXattrSetLatency  alert"
@@ -460,12 +448,6 @@ class TestMdsXattrAlerts(E2ETest):
         active_mds = cluster.get_active_mds_info()["mds_daemon"]
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         deployment_name = "rook-ceph-mds-" + active_mds
-
-        def finalizer():
-            """Ensure MDS deployment is scaled to 1"""
-            ensure_mds_deployments_scaled([deployment_name])
-
-        request.addfinalizer(finalizer)
 
         log.info(f"Scale down {deployment_name} to 0")
         helpers.modify_deployment_replica_count(
@@ -491,7 +473,7 @@ class TestMdsXattrAlerts(E2ETest):
     @tier2
     @pytest.mark.polarion_id("OCS-7737")
     def test_alert_with_both_mds_scaledown(
-        self, set_xattr_with_high_cpu_usage, threading_lock, request
+        self, set_xattr_with_high_cpu_usage, threading_lock, request, nodes
     ):
         """
         Test MDS xattr latency alert persistence after both active and standby MDS scale down and up.
@@ -516,17 +498,16 @@ class TestMdsXattrAlerts(E2ETest):
 
         Args:
             request: pytest request for finalizer registration
+            nodes: nodes fixture for node operations
 
         """
-        # Get MDS info first for teardown
-        active_mds = cluster.get_active_mds_info()["mds_daemon"]
-        standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
-        active_mds_d = "rook-ceph-mds-" + active_mds
-        standby_mds_d = "rook-ceph-mds-" + standby_mds
 
         def finalizer():
-            """Ensure both MDS deployments are scaled to 1"""
-            ensure_mds_deployments_scaled([active_mds_d, standby_mds_d])
+            """
+            Teardown to ensure MDS pods are running.
+            If MDS pods are not running, restart nodes to recover.
+            """
+            recover_mds_pods_if_not_running(nodes)
 
         request.addfinalizer(finalizer)
 
@@ -536,6 +517,10 @@ class TestMdsXattrAlerts(E2ETest):
         )
         assert MDSxattr_alert_values(threading_lock, timeout=1200)
 
+        active_mds = cluster.get_active_mds_info()["mds_daemon"]
+        standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
+        active_mds_d = "rook-ceph-mds-" + active_mds
+        standby_mds_d = "rook-ceph-mds-" + standby_mds
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         standby_mds_pod = cluster.get_mds_standby_replay_info()["standby_replay_pod"]
         mds_dc_pods = [active_mds_d, standby_mds_d]

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -3,7 +3,11 @@ import pytest
 import subprocess
 import time
 
-from ocs_ci.framework.pytest_customization.marks import blue_squad, skipif_external_mode
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    ignore_leftovers,
+    skipif_external_mode,
+)
 from ocs_ci.framework.testlib import E2ETest, tier2, tier4b, tier4c
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -231,6 +235,7 @@ def verify_alert_cleared(threading_lock):
 
 
 @blue_squad
+@ignore_leftovers
 @skipif_external_mode
 class TestMdsXattrAlerts(E2ETest):
     """


### PR DESCRIPTION
Happy path automation for [RHSTOR-7656](https://issues.redhat.com//browse/RHSTOR-7656)] - Test will verify generation of CephXattrSetLatency alert generation during intensive extended attribute operation on MDS along with high CPU utilization in the cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CephXattrSetLatency alert and tooling to exercise CephFS extended-attribute (xattr) operations, including a helper script that creates files and toggles xattrs in parallel.
  * Prometheus validation helper for checking alert lifecycle and metadata (message, description, runbook, severity).

* **Tests**
  * End-to-end tests validating MDS xattr latency alert behavior across operator restarts, Prometheus recovery, MDS scaling scenarios, and node restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/14045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->