### PR TITLE
Update FDF IDMS with spectrum scale STG content

### DIFF
--- a/ocs_ci/templates/fusion-data-foundation/image-digest-mirror-set.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/image-digest-mirror-set.yaml
@@ -133,3 +133,12 @@ spec:
         - mirrors:
             - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/df/rhel9/postgresql-15
           source: registry.redhat.io/rhel9/postgresql-15
+        - mirrors:
+            - cp.stg.icr.io/cp/gpfs
+          source: cp.icr.io/cp/gpfs
+        - mirrors:
+            - cp.stg.icr.io/cp/spectrum/scale
+          source: cp.icr.io/cp/spectrum/scale
+        - mirrors:
+            - cp.stg.icr.io/cp
+          source: icr.io/cpopen


### PR DESCRIPTION
This file is actually not used and we are dynamically fetching this from FDF image, but I thought it's worth to udpate this as well in case we need to test something manually we know about those values.
Deepshikha will update in FDF builds to have it part of IDMS which we are fetching from there.