### PR TITLE
AMQ::is_amq_pod_running - increase the time to wait for the pods to get ready

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -185,14 +185,9 @@ class AMQ(object):
         """
 
         _rc = True
-        get_pods_timeout = 300
-
-        # In FIPS mode the entity-operator pod takes longer to start up
-        if config.ENV_DATA.get("fips"):
-            get_pods_timeout = 900
 
         for pod in TimeoutSampler(
-            get_pods_timeout, 10, get_pod_name_by_pattern, pod_pattern, namespace
+            900, 10, get_pod_name_by_pattern, pod_pattern, namespace
         ):
             try:
                 if pod is not None and len(pod) == expected_pods:


### PR DESCRIPTION
In a previous PR we've increased the timeout only to FIPs clusters, but since then I've seen more cases where AMQ's pods fail to setup in the given 300 seconds yet they appear in the must-gather logs.