### PR TITLE
Fix pool creation in UI for 4.21

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1537,7 +1537,11 @@ block_pool = {
     "pool_type_block": ("type-block", By.ID),
     "first_select_replica": ('button[data-test="replica-dropdown"]', By.CSS_SELECTOR),
     "second_select_replica_2": ("//button[text()='2-way Replication']", By.XPATH),
-    "second_select_replica_3": ("//button[text()='3-way Replication']", By.XPATH),
+    "second_select_replica_3": (
+        "//button[text()='3-way Replication'] | "
+        "//button[descendant::span[text()='3-way Replication']]",
+        By.XPATH,
+    ),
     "conpression_checkbox": (
         'input[data-test="compression-checkbox"]',
         By.CSS_SELECTOR,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1555,7 +1555,10 @@ block_pool = {
         "//a[normalize-space()='Edit labels'] | //button[@id='Edit Labels']",
         By.XPATH,
     ),
-    "edit_labels_of_pool_input": ("#tags-input", By.TAG_NAME),
+    "edit_labels_of_pool_input": (
+        "//button[descendant::span[text()='Edit labels']]",
+        By.XPATH,
+    ),
     "invalid_label_name_note_edit_label_pool": (
         "//h4[contains(@class, 'c-alert__title')]",
         By.XPATH,


### PR DESCRIPTION
Pool creation failed because the locator for 3-way replication button has changed: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/62618/testReport/tests.functional.ui.test_error_improvements/TestErrorMessageImprovements/test_blocking_pool_creation_rules/