### PR TITLE
Fixed odf-cli path issue

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -5143,13 +5143,13 @@ def odf_cli_set_log_level(service, log_level, subsystem):
     """
     from pathlib import Path
 
-    if not (Path(config.RUN["bin_dir"]) / "odf-cli").exists():
+    if not (Path(config.RUN["bin_dir"]) / "odf").exists():
         retrieve_cli_binary(cli_type="odf")
 
     logger.info(
         f"Setting ceph log level for {service} on {subsystem} to {log_level} using odf-cli tool."
     )
-    cmd = f"odf-cli set ceph log-level {service} {subsystem} {log_level}"
+    cmd = f"odf set ceph log-level {service} {subsystem} {log_level}"
 
     logger.info(cmd)
     return exec_cmd(cmd, shell=True)

--- a/ocs_ci/ocs/osd_operations.py
+++ b/ocs_ci/ocs/osd_operations.py
@@ -1,5 +1,6 @@
 import random
 import logging
+import os
 
 from ocs_ci.framework import config
 from ocs_ci.utility import version
@@ -119,8 +120,9 @@ def osd_device_replacement(nodes, cli_tool=False):
 
     if cli_tool:
         retrieve_cli_binary(cli_type="odf")
+        odf_cli_path = os.path.join(config.RUN["bin_dir"], "odf")
         run_cmd_interactive(
-            cmd=f"odf-cli purge-osd {osd_id}",
+            cmd=f"{odf_cli_path} purge-osd {osd_id}",
             prompts_answers={
                 "yes-force-destroy-osd": "yes-force-destroy-osd",
                 "completed removal of OSD": "",

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1503,9 +1503,10 @@ class TestNfsEnable(ManageTest):
         self.retain_nfs_sc = nfs_utils.create_nfs_sc(
             sc_name_to_create=self.retain_nfs_sc_name, retain_reclaim_policy=True
         )
-        if not (Path(config.RUN["bin_dir"]) / "odf-cli").exists():
+        if not (Path(config.RUN["bin_dir"]) / "odf").exists():
             helpers.retrieve_cli_binary(cli_type="odf")
-        output = exec_cmd(cmd="odf-cli subvolume ls")
+        odf_cli_path = os.path.join(config.RUN["bin_dir"], "odf")
+        output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls")
         inital_subvolume_list = self.parse_subvolume_ls_output(output)
         log.info(f"{inital_subvolume_list=}")
 
@@ -1519,7 +1520,7 @@ class TestNfsEnable(ManageTest):
         )
 
         # checking subvolumes post pvc creation
-        output = exec_cmd(cmd="odf-cli subvolume ls")
+        output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls")
         later_subvolume_list = self.parse_subvolume_ls_output(output)
         old = set(inital_subvolume_list)
         new = set(later_subvolume_list)
@@ -1579,13 +1580,15 @@ class TestNfsEnable(ManageTest):
         pv_obj.delete(wait=True)
 
         # Checking for stale volumes
-        output = exec_cmd(cmd="odf-cli subvolume ls --stale")
+        output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
 
         # Deleteing stale subvolume
-        exec_cmd(cmd=f"odf-cli subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}")
+        exec_cmd(
+            cmd=f"{odf_cli_path} subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}"
+        )
 
         # Checking for stale volumes
-        output = exec_cmd(cmd="odf-cli subvolume ls --stale")
+        output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
         stale_volumes = self.parse_subvolume_ls_output(output)
         assert len(stale_volumes) == 0  # No stale volumes available
 


### PR DESCRIPTION
The test is failing because when it executes odf-cli subvolume ls, it's looking for odf-cli in the system PATH, but the binary is actually located in config.RUN["bin_dir"] (typically the bin/ directory in the project).