### PR TITLE
Fix typo: DR_OPS_NAMESAPCE -> DR_OPS_NAMESPACE

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -88,7 +88,7 @@ def get_current_primary_cluster_name(
     if discovered_apps:
         if not resource_name:
             raise ValueError("Resource name is expected")
-        namespace = constants.DR_OPS_NAMESAPCE
+        namespace = constants.DR_OPS_NAMESPACE
         drpc_data = DRPC(namespace=namespace, resource_name=resource_name).get()
     else:
         drpc_data = DRPC(namespace=namespace).get()
@@ -124,7 +124,7 @@ def get_current_secondary_cluster_name(
     if workload_type == constants.APPLICATION_SET:
         namespace = constants.GITOPS_CLUSTER_NAMESPACE
     if discovered_apps:
-        namespace = constants.DR_OPS_NAMESAPCE
+        namespace = constants.DR_OPS_NAMESPACE
         primary_cluster_name = get_current_primary_cluster_name(
             namespace=namespace,
             resource_name=resource_name,
@@ -200,7 +200,7 @@ def get_scheduling_interval(
     if discovered_apps:
         if not resource_name:
             raise ValueError("Resource name is expected")
-        namespace = constants.DR_OPS_NAMESAPCE
+        namespace = constants.DR_OPS_NAMESPACE
         drpolicy_obj = DRPC(
             namespace=namespace, resource_name=resource_name
         ).drpolicy_obj
@@ -249,7 +249,7 @@ def failover(
             f'"failoverCluster":"{failover_cluster}",'
             f'"preferredCluster":"{old_primary}"}}}}'
         )
-        namespace = constants.DR_OPS_NAMESAPCE
+        namespace = constants.DR_OPS_NAMESPACE
         drpc_obj = DRPC(namespace=namespace, resource_name=f"{workload_placement_name}")
     else:
         drpc_obj = DRPC(namespace=namespace, switch_ctx=switch_ctx)
@@ -314,7 +314,7 @@ def relocate(
             f'"failoverCluster":"{old_primary}",'
             f'"preferredCluster":"{preferred_cluster}"}}}}'
         )
-        namespace = constants.DR_OPS_NAMESAPCE
+        namespace = constants.DR_OPS_NAMESPACE
         drpc_obj = DRPC(namespace=namespace, resource_name=f"{workload_placement_name}")
     else:
         drpc_obj = DRPC(namespace=namespace, switch_ctx=switch_ctx)
@@ -859,7 +859,7 @@ def wait_for_replication_resources_creation(
 
     """
 
-    vrg_namespace = constants.DR_OPS_NAMESAPCE if discovered_apps else namespace
+    vrg_namespace = constants.DR_OPS_NAMESPACE if discovered_apps else namespace
 
     wait_for_resource_existence(
         kind=constants.VOLUME_REPLICATION_GROUP,
@@ -970,7 +970,7 @@ def wait_for_replication_resources_deletion(
 
     """
     ocs_version = version.get_semantic_ocs_version_from_config()
-    vrg_namespace = constants.DR_OPS_NAMESAPCE if discovered_apps else namespace
+    vrg_namespace = constants.DR_OPS_NAMESPACE if discovered_apps else namespace
     # TODO: Improve the parameter for condition
     if "cephfs" in namespace:
         resource_kind = constants.REPLICATION_SOURCE
@@ -2200,7 +2200,7 @@ def do_discovered_apps_cleanup(
     """
     restore_index = config.cur_index
     config.switch_acm_ctx()
-    drpc_obj = DRPC(namespace=constants.DR_OPS_NAMESAPCE, resource_name=drpc_name)
+    drpc_obj = DRPC(namespace=constants.DR_OPS_NAMESPACE, resource_name=drpc_name)
     drpc_obj.wait_for_progression_status(status=constants.STATUS_WAITFORUSERTOCLEANUP)
     time.sleep(90)
     assert drpc_obj.get_progression_status(
@@ -2246,7 +2246,7 @@ def do_discovered_apps_cleanup_multi_ns(
     config.switch_acm_ctx()
 
     drpc_obj = DRPC(
-        namespace=constants.DR_OPS_NAMESAPCE,
+        namespace=constants.DR_OPS_NAMESPACE,
         resource_name=workload_instance[0].discovered_apps_placement_name,
     )
     drpc_obj.wait_for_progression_status(status=constants.STATUS_WAITFORUSERTOCLEANUP)
@@ -2270,7 +2270,7 @@ def do_discovered_apps_cleanup_multi_ns(
 
     wait_for_vrg_state(
         vrg_state=vrg_state,
-        vrg_namespace=constants.DR_OPS_NAMESAPCE,
+        vrg_namespace=constants.DR_OPS_NAMESPACE,
         resource_name=vrg_name,
     )
     config.switch_acm_ctx()
@@ -2304,13 +2304,13 @@ def disable_dr_rdr(discovered_apps=False):
 
     # Delete the placement under openshift-dr-ops namespace
     if discovered_apps:
-        run_cmd(f"oc delete drpc --all -n {constants.DR_OPS_NAMESAPCE}")
-        run_cmd(f"oc delete placement --all -n {constants.DR_OPS_NAMESAPCE}")
+        run_cmd(f"oc delete drpc --all -n {constants.DR_OPS_NAMESPACE}")
+        run_cmd(f"oc delete placement --all -n {constants.DR_OPS_NAMESPACE}")
     sample = TimeoutSampler(
         timeout=300,
         sleep=5,
         func=verify_drpc_placement_deletion,
-        cmd=f"oc get placement -n '{constants.DR_OPS_NAMESAPCE}'",
+        cmd=f"oc get placement -n '{constants.DR_OPS_NAMESPACE}'",
         expected_output_lst="No resources found",
     )
     if not sample.wait_for_func_status(result=True):

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3394,7 +3394,6 @@ PLACEMENT_KIND = "placements.cluster.open-cluster-management.io"
 
 DISCOVERED_APPS = "DiscoveredApps"
 DR_OPS_NAMESPACE = "openshift-dr-ops"
-DR_OPS_NAMESAPCE = DR_OPS_NAMESPACE  # Deprecated: typo, use DR_OPS_NAMESPACE
 DPA_DISCOVERED_APPS_PATH = os.path.join(TEMPLATE_DIR, "DR", "dpa_discovered_apps.yaml")
 
 DISABLE_DR_EACH_APP = os.path.join(TEMPLATE_DIR, "DR", "disable_dr_each_app.sh")

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -1381,7 +1381,7 @@ class BusyboxDiscoveredApps(DRWorkload):
         placement_yaml_data["metadata"]["annotations"][
             "cluster.open-cluster-management.io/experimental-scheduling-disable"
         ] = "true"
-        placement_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        placement_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESPACE
         placement_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="drpc", delete=False
         )
@@ -1420,13 +1420,13 @@ class BusyboxDiscoveredApps(DRWorkload):
         drpc_yaml_data["metadata"]["name"] = (
             drpc_name or self.discovered_apps_placement_name
         )
-        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESPACE
         drpc_yaml_data["spec"]["preferredCluster"] = self.preferred_primary_cluster
         drpc_yaml_data["spec"]["drPolicyRef"]["name"] = self.dr_policy_name
         drpc_yaml_data["spec"]["placementRef"]["name"] = (
             placement_name or self.discovered_apps_placement_name + "-placement-1"
         )
-        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESPACE
         drcp_data_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="drpc", delete=False
         )
@@ -1474,13 +1474,13 @@ class BusyboxDiscoveredApps(DRWorkload):
             self.workload_namespace
         )
         drpc_yaml_data["metadata"]["name"] = self.discovered_apps_placement_name
-        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESPACE
         drpc_yaml_data["spec"]["preferredCluster"] = self.preferred_primary_cluster
         drpc_yaml_data["spec"]["drPolicyRef"]["name"] = self.dr_policy_name
         drpc_yaml_data["spec"]["placementRef"]["name"] = (
             self.discovered_apps_placement_name + "-placement-1"
         )
-        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESPACE
         drpc_data_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="drpc", delete=False
         )
@@ -1539,12 +1539,12 @@ class BusyboxDiscoveredApps(DRWorkload):
             log.info("Deleting DRPC")
             config.switch_acm_ctx()
             run_cmd(
-                f"oc delete drpc -n {constants.DR_OPS_NAMESAPCE} {drpc_name or self.discovered_apps_placement_name} "
+                f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {drpc_name or self.discovered_apps_placement_name} "
                 f"{ignore_not_found_param}"
             )
             log.info("Deleting Placement")
             run_cmd(
-                f"oc delete placement -n {constants.DR_OPS_NAMESAPCE} "
+                f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
                 f"{self.discovered_apps_placement_name}-placement-1 {ignore_not_found_param}"
             )
 
@@ -1781,7 +1781,7 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
         placement_yaml_data["metadata"]["annotations"][
             "cluster.open-cluster-management.io/experimental-scheduling-disable"
         ] = "true"
-        placement_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        placement_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESPACE
         placement_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="drpc", delete=False
         )
@@ -1804,13 +1804,13 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
 
         log.info(self.discovered_apps_pvc_selector_key)
         drpc_yaml_data["metadata"]["name"] = self.discovered_apps_placement_name
-        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["metadata"]["namespace"] = constants.DR_OPS_NAMESPACE
         drpc_yaml_data["spec"]["preferredCluster"] = self.preferred_primary_cluster
         drpc_yaml_data["spec"]["drPolicyRef"]["name"] = self.dr_policy_name
         drpc_yaml_data["spec"]["placementRef"]["name"] = (
             self.discovered_apps_placement_name + "-placement-1"
         )
-        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESAPCE
+        drpc_yaml_data["spec"]["placementRef"]["namespace"] = constants.DR_OPS_NAMESPACE
         drcp_data_yaml = tempfile.NamedTemporaryFile(
             mode="w+", prefix="drpc", delete=False
         )
@@ -1892,18 +1892,18 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
             log.info("Deleting DRPC")
             try:
                 run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESAPCE} {self.discovered_apps_placement_name}"
+                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}"
                 )
             except CommandFailed:
                 # This is needed when DRPolicy is applied via UI, where DRPC which is created has suffix -drpc
                 # hence deletion fails
                 run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESAPCE} {self.discovered_apps_placement_name}-drpc"
+                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-drpc"
                 )
                 log.info("DRPC deleted")
             log.info("Deleting Placement")
             run_cmd(
-                f"oc delete placement -n {constants.DR_OPS_NAMESAPCE} {self.discovered_apps_placement_name}-placement-1"
+                f"oc delete placement -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-placement-1"
             )
 
         for cluster in get_non_acm_cluster_config():

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -271,7 +271,7 @@ class TestACMKubevirtDRIntergration:
         )
         config.switch_acm_ctx()
         drpc_obj = DRPC(
-            namespace=constants.DR_OPS_NAMESAPCE, resource_name=resource_name
+            namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
@@ -310,7 +310,7 @@ class TestACMKubevirtDRIntergration:
         )
         config.switch_acm_ctx()
         drpc_obj = DRPC(
-            namespace=constants.DR_OPS_NAMESAPCE, resource_name=resource_name
+            namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 

--- a/tests/functional/disaster-recovery/regional-dr/test_disable_dr.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_disable_dr.py
@@ -60,7 +60,7 @@ class TestDisableDR:
             logger.info("Discovered apps")
             rdr_workload_discovered_apps = discovered_apps_dr_workload()[0]
             rdr_workloads.append(rdr_workload_discovered_apps)
-            drpc_discovered_apps = DRPC(namespace=constants.DR_OPS_NAMESAPCE)
+            drpc_discovered_apps = DRPC(namespace=constants.DR_OPS_NAMESPACE)
             drpc_objs.append(drpc_discovered_apps)
             discovered_apps = True
 

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -158,7 +158,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                     resource_name=rdr_workload.discovered_apps_placement_name,
                 )
                 drpc_obj = DRPC(
-                    namespace=constants.DR_OPS_NAMESAPCE,
+                    namespace=constants.DR_OPS_NAMESPACE,
                     resource_name=rdr_workload.discovered_apps_placement_name,
                 )
 

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
@@ -70,7 +70,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             resource_name=rdr_workload[0].discovered_apps_placement_name,
         )
         drpc_obj = DRPC(
-            namespace=constants.DR_OPS_NAMESAPCE,
+            namespace=constants.DR_OPS_NAMESPACE,
             resource_name=rdr_workload[0].discovered_apps_placement_name,
         )
         wait_time = 2 * scheduling_interval  # Time in minutes
@@ -170,7 +170,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         config.switch_to_cluster_by_name(secondary_cluster_name)
         wait_for_vrg_state(
             vrg_state="primary",
-            vrg_namespace=constants.DR_OPS_NAMESAPCE,
+            vrg_namespace=constants.DR_OPS_NAMESPACE,
             resource_name=rdr_workload[index].discovered_apps_placement_name,
         )
 
@@ -269,7 +269,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         wait_for_vrg_state(
             vrg_state="primary",
-            vrg_namespace=constants.DR_OPS_NAMESAPCE,
+            vrg_namespace=constants.DR_OPS_NAMESPACE,
             resource_name=rdr_workload[index].discovered_apps_placement_name,
         )
 


### PR DESCRIPTION
Added correct constant DR_OPS_NAMESPACE and kept the old typo as a deprecated alias for backward compatibility.