### PR TITLE
Skip testcase -  test_add_capacity , test_automated_recovery_from_stopped_node_and_start , 

### DIFF
--- a/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
+++ b/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.testlib import (
     BaseTest,
     polarion_id,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad, jira
+from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.ocs.resources.pod import (
     get_all_pods,
 )
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version("<4.20")
-@jira("DFBUGS-5080")
 class TestLiveResourcesPresenceAndFormat(BaseTest):
     """
     Functional test to verify that live pod resource values (requests/limits)

--- a/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
+++ b/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.testlib import (
     BaseTest,
     polarion_id,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad,jira
+from ocs_ci.framework.pytest_customization.marks import brown_squad, jira
 from ocs_ci.ocs.resources.pod import (
     get_all_pods,
 )

--- a/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
+++ b/tests/functional/pod_and_daemons/test_odf_resources_requests_and_limits.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.testlib import (
     BaseTest,
     polarion_id,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad,jira
 from ocs_ci.ocs.resources.pod import (
     get_all_pods,
 )
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @skipif_ocs_version("<4.20")
+@jira("DFBUGS-5080")
 class TestLiveResourcesPresenceAndFormat(BaseTest):
     """
     Functional test to verify that live pod resource values (requests/limits)

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -5,7 +5,7 @@ import pytest
 from ocs_ci.ocs.cluster import is_flexible_scaling_enabled
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, jira
 from ocs_ci.framework.testlib import (
     tier2,
     ignore_leftovers,
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@jira("DFBUGS-5191")
 class TestAddCapacity(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -1,6 +1,10 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode, jira
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    skipif_compact_mode,
+    jira,
+)
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode, jira
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -245,6 +245,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @tier4a
 @skipif_ibm_cloud
 @skipif_compact_mode
+@jira("DFBUGS-4533")
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None

--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp, jira
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -306,6 +306,7 @@ class TestDiskFailures(ManageTest):
     @skipif_ocs_version("<4.15")
     @pytest.mark.polarion_id("OCS-5502")
     @skipif_external_mode
+    @jira("DFBUGS-4534")
     def test_recovery_from_volume_deletion_cli_tool(
         self, nodes, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
     ):

--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,11 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp, jira
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    skipif_rosa_hcp,
+    jira,
+)
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,


### PR DESCRIPTION
Skipping testcases   test_add_capacity , test_automated_recovery_from_stopped_node_and_start , test_recovery_from_volume_deletion_cli_tool until below bugs are fixed

1. https://issues.redhat.com/browse/DFBUGS-4533
2. https://issues.redhat.com/browse/DFBUGS-4534
3. https://issues.redhat.com/browse/DFBUGS-5191