### PR TITLE
Fix `test_deletion_sync_after_node_restart` S3 failures after node restart

### DIFF
--- a/ocs_ci/ocs/resources/mockup_bucket_logger.py
+++ b/ocs_ci/ocs/resources/mockup_bucket_logger.py
@@ -37,7 +37,6 @@ class MockupBucketLogger:
 
         self.awscli_pod = awscli_pod
         self.mcg_obj = mcg_obj
-        self.log_files_dir = setup_pod_directories(awscli_pod, ["bucket_logs_dir"])[0]
 
         logger.info("Creating the AWS logs bucket Namespacestore")
 
@@ -59,6 +58,13 @@ class MockupBucketLogger:
     @property
     def standard_test_obj_list(self):
         return self._standard_test_obj_list
+
+    @property
+    def log_files_dir(self):
+        # Repeated calls are safe and idempotent.
+        # This also covers the case where the AWS CLI pod restarts
+        # and its local filesystem is wiped.
+        return setup_pod_directories(self.awscli_pod, ["bucket_logs_dir"])[0]
 
     def upload_test_objs_and_log(self, bucket_name):
         """

--- a/tests/functional/object/mcg/test_log_based_bucket_replication.py
+++ b/tests/functional/object/mcg/test_log_based_bucket_replication.py
@@ -24,7 +24,6 @@ from ocs_ci.ocs.bucket_utils import (
 )
 from ocs_ci.ocs.resources.mcg_replication_policy import AwsLogBasedReplicationPolicy
 from ocs_ci.ocs.resources.mockup_bucket_logger import MockupBucketLogger
-from ocs_ci.ocs.resources.pod import get_noobaa_pods, get_pod_node
 from ocs_ci.ocs.scale_noobaa_lib import noobaa_running_node_restart
 
 logger = logging.getLogger(__name__)
@@ -399,8 +398,6 @@ class TestLogBasedBucketReplication(MCGTest):
             self.DEFAULT_TIMEOUT,
         )
 
-    _nodes_tested = []
-
     @tier4b
     @skipif_vsphere_ipi
     @pytest.mark.parametrize(
@@ -433,23 +430,6 @@ class TestLogBasedBucketReplication(MCGTest):
         """
         mockup_logger, source_bucket, target_bucket = log_based_replication_setup
 
-        # Skip the rest of the test and pass if the target pod's node
-        # was already reset with a previous passing parametrization of this test
-        logger.info(
-            f"Checking if {target_pod_name}'s node has already passed this test with a previous param"
-        )
-        target_pod = [
-            pods for pods in get_noobaa_pods() if target_pod_name in pods.name
-        ][0]
-        target_node_name = get_pod_node(target_pod).name
-        if target_node_name in self._nodes_tested:
-            logger.info(
-                f"Skipping the rest of the test because {target_pod_name}'s node has already passed this test"
-            )
-            return
-        else:
-            logger.info(f"{target_pod_name}'s node has not passed this test yet")
-
         upload_test_objects_to_source_and_wait_for_replication(
             mcg_obj_session,
             source_bucket,
@@ -469,9 +449,6 @@ class TestLogBasedBucketReplication(MCGTest):
             mockup_logger,
             self.DEFAULT_TIMEOUT,
         )
-
-        # Keep track of the target node to prevent its redundant testing in this scenario
-        self._nodes_tested.append(target_node_name)
 
 
 def upload_test_objects_to_source_and_wait_for_replication(

--- a/tests/functional/object/mcg/test_log_based_bucket_replication.py
+++ b/tests/functional/object/mcg/test_log_based_bucket_replication.py
@@ -460,6 +460,7 @@ class TestLogBasedBucketReplication(MCGTest):
 
         logger.info(f"Restarting {target_pod_name}'s node")
         noobaa_running_node_restart(pod_name=target_pod_name)
+        mcg_obj_session.wait_for_ready_status()
 
         delete_objects_from_source_and_wait_for_deletion_sync(
             mcg_obj_session,


### PR DESCRIPTION
### Summary
- Add `wait_for_ready_status()` after node restart to ensure the NooBaa S3 endpoint is operational before performing S3
operations
- Make `log_files_dir` a lazy property so it survives awscli pod restarts
- Remove redundant `_nodes_tested` skip logic that masked independent parametrization failures

### Problem
The test was hitting `InternalError` on `ListObjectsV2` immediately after the node restart because `noobaa_running_node_restart` only waits for the pod to be `Running` — not for the NooBaa system and its backing/namespace stores to be fully `Ready`. The S3 endpoint would accept connections but couldn't proxy requests to the underlying AWS namespace stores yet.
