### PR TITLE
Refactor Storage Autoscaler tests to use FillPoolJob instead of FIO benchmarks

### DIFF
--- a/ocs_ci/helpers/storage_auto_scaler.py
+++ b/ocs_ci/helpers/storage_auto_scaler.py
@@ -104,7 +104,7 @@ def wait_for_auto_scaler_status(
 
 
 def generate_fixed_scaling_threshold(
-    fix_capacity_to_fillup: int = 240,
+    fix_capacity_to_fillup: int = 280,
     max_scaling_threshold: int = 35,
 ) -> int:
     """

--- a/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
@@ -63,6 +63,7 @@ from ocs_ci.ocs.cluster import (
 )
 from ocs_ci.helpers.ceph_helpers import wait_for_percent_used_capacity_reached
 from ocs_ci.ocs.node import select_osd_node
+from ocs_ci.ocs.benchmark_operator_fio import get_file_size
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +83,8 @@ class TestStorageAutoscalerBase(ManageTest):
     Abstract base class with fixtures and helpers for the StorageAutoscaler test procedure
     """
 
-    benchmark_workload_storageutilization: any = None
-    benchmark_obj: any = None
+    fill_job_factory: any = None
+    fill_job_objs: list = []
     is_cleanup_cluster: bool = False
     used_capacity: float = None
     old_storage_size: str = None
@@ -108,7 +109,7 @@ class TestStorageAutoscalerBase(ManageTest):
         self,
         request,
         create_pvcs_and_pods,
-        benchmark_workload_storageutilization,
+        fill_job_factory,
         pause_and_resume_cluster_load,
     ):
         """
@@ -116,10 +117,8 @@ class TestStorageAutoscalerBase(ManageTest):
         resize OSD procedure, as the StorageAutoscaler will perform the Resize OSD when it triggers.
 
         """
-        self.benchmark_workload_storageutilization = (
-            benchmark_workload_storageutilization
-        )
-        self.benchmark_obj = None
+        self.fill_job_factory = fill_job_factory
+        self.fill_job_objs = []
         self.is_cleanup_cluster = False
 
         self.used_capacity = get_percent_used_capacity()
@@ -175,9 +174,7 @@ class TestStorageAutoscalerBase(ManageTest):
 
         request.addfinalizer(finalizer)
 
-    def fill_up_cluster(
-        self, target_percentage, bs="4096KiB", is_completed=True, fast_fill_up=True
-    ):
+    def fill_up_cluster(self, target_percentage, is_completed=True):
         """
         Fill up the cluster to a target percentage of total storage capacity using FIO-based load.
 
@@ -188,46 +185,45 @@ class TestStorageAutoscalerBase(ManageTest):
 
         Args:
             target_percentage (int): Desired percentage of used cluster storage to reach.
-            bs (str): Block size used for the workload. Default is "4096KiB".
             is_completed (bool): Whether to wait until the benchmark workload completes.
-            fast_fill_up (bool): If True, use aggressive parameters (higher iodepth, numjobs)
-                                 for faster cluster fill-up. The target percentage is adjusted.
+
         """
+        storage_to_fill = get_file_size(
+            expected_used_capacity_percent=target_percentage
+        )
+        # Divide the storage to fill between zero and random modes. The random mode will
+        # fill 25% of the total. This is to optimize the time taken to fill the cluster,
+        # as the zero mode is faster.
+        storage_to_fill_random_mode = int(storage_to_fill // 4)
+        storage_to_fill_zero_mode = storage_to_fill - storage_to_fill_random_mode
         logger.info(
-            f"Fill up the cluster to {target_percentage}% of it's storage capacity "
-            f"(fast_fill_up={fast_fill_up})"
+            f"Total storage to fill the cluster: {storage_to_fill}Gi, "
+            f"Storage to fill in zero mode: {storage_to_fill_zero_mode}Gi, "
+            f"Storage to fill in random mode: {storage_to_fill_random_mode}Gi"
         )
-
-        numjobs = 1
-        iodepth = 16
-        max_servers = 20
-
-        if fast_fill_up:
-            numjobs = 4
-            iodepth = 32
-            max_servers = 40
-            # Reduce the target to compensate for likely overshoot
-            target_percentage = int(target_percentage - target_percentage / 5)
-            logger.info(
-                f"Target percentage adjusted to {target_percentage}% due to fast_fill_up mode"
-            )
-
-        self.benchmark_obj = self.benchmark_workload_storageutilization(
-            target_percentage,
-            bs=bs,
-            is_completed=is_completed,
-            numjobs=numjobs,
-            iodepth=iodepth,
-            max_servers=max_servers,
+        fill_job_obj = self.fill_job_factory(
+            fill_mode="zero",
+            storage=f"{storage_to_fill_zero_mode}Gi",
         )
+        self.fill_job_objs.append(fill_job_obj)
+        fill_job_obj = self.fill_job_factory(
+            fill_mode="random",
+            storage=f"{storage_to_fill_random_mode}Gi",
+        )
+        self.fill_job_objs.append(fill_job_obj)
+
+        if is_completed:
+            for fill_job in self.fill_job_objs:
+                fill_job.wait_for_completion(timeout=1800, sleep=30)
 
     def cleanup_cluster(self):
         """
         Clean up the cluster from the benchmark operator project
 
         """
-        if self.benchmark_obj and not self.is_cleanup_cluster:
-            self.benchmark_obj.cleanup()
+        if self.fill_job_objs and not self.is_cleanup_cluster:
+            for fill_job in self.fill_job_objs:
+                fill_job.cleanup()
             self.is_cleanup_cluster = True
             config.RUN["cleanup_cluster_time"] = time.time()
 


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/13654

This PR refactors the Storage Autoscaler functional tests to use the FillPoolJob factory instead of the FIO-based benchmark operator. This change provides a more robust and lightweight method for filling cluster capacity, specifically handling scenarios where volumes reach 100% utilization without triggering job failures.

**Core Changes:**

- **Fixture Replacement:** Replaced the `benchmark_workload_storageutilization` fixture with `fill_job_factory` across the test base class and setup methods.

- **Graceful Error Handling:** Updated the dd command logic in `FillPoolJob` to capture standard error. If the command fails due to "No space left on device," the job now exits with Status 0 instead of failing, ensuring tests can proceed once capacity is reached. 


- **Job Management:** Added a new `wait_for_completion` method to the FillPoolJob class to wait for the pod completion.

- **Workload Optimization:** Modified `fill_up_cluster` to split the storage requirement. It now fills 75% of the target using "zero" mode (for speed) and 25% using "random" mode. 


- **Threshold Adjustment:** Updated the `generate_fixed_scaling_threshold` helper to increase the default `fix_capacity_to_fillup` value from 240 to 280.