### PR TITLE
Added version check

### DIFF
--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -1,7 +1,6 @@
 import collections
 import logging
 import pytest
-import re
 
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
@@ -271,52 +270,45 @@ class TestCephDefaultValuesCheck(ManageTest):
     @post_ocs_upgrade
     @pytest.mark.polarion_id("OCS-2739")
     @skipif_managed_service
-    @skipif_ocs_version("<4.9")
+    @skipif_ocs_version(["<4.9", ">=4.19"])
     @tier2
     def test_noobaa_postgres_cm_post_ocs_upgrade(self):
         """
-        Impotant !!! Postgres configmap replaced with CNPG in 4.19.
+        Important: Postgres configmap is replaced with CNPG in 4.19.
+        Skip the test for ocs >= 4.19.
 
-        Validate noobaa postgres configmap post OCS upgrade
-
+        Validate noobaa postgres configmap post OCS upgrade.
         """
-        ocs_version = version.get_semantic_ocs_version_from_config()
-        log.info(f"ocs version----{ocs_version}")
+        cm_obj = OCP(
+            kind=constants.CONFIGMAP,
+            resource_name=constants.NOOBAA_POSTGRES_CONFIGMAP,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
 
-        # ConfigMap is not present from OCS 4.19 onwards
-        if ocs_version <= version.VERSION_4_18:
-            cm_obj = OCP(
-                kind=constants.CONFIGMAP,
-                resource_name=constants.NOOBAA_POSTGRES_CONFIGMAP,
-                namespace=config.ENV_DATA["cluster_namespace"],
-            )
-            config_data = cm_obj.get().get("data").get("noobaa-postgres.conf")
-            config_data = config_data.split("\n")
-            config_data = config_data[5:]
-
-        else:
-            nooba_db_primary_pod = pod.get_primary_nb_db_pod()
-            raw_data = nooba_db_primary_pod.exec_cmd_on_pod(
-                "cat /var/lib/postgresql/data/pgdata/custom.conf"
-            )
-            config_data = re.findall(r"\S+\s*=\s*'[^']*'", raw_data)
+        config_data = cm_obj.get().get("data").get("noobaa-postgres.conf")
+        config_data = config_data.split("\n")[5:]
 
         log.info(
-            "Validating that the values configured in noobaa-postgres configmap or in CNPG's config "
-            "match the ones stored in ocs-ci"
+            "Validating that the values configured in noobaa-postgres "
+            "configmap match the ones stored in ocs-ci"
         )
+
+        ocs_version = version.get_semantic_ocs_version_from_config()
+        log.info("OCS version: %s", ocs_version)
+
         if ocs_version <= version.VERSION_4_8:
             stored_values = constants.NOOBAA_POSTGRES_TUNING_VALUES.split("\n")
-
-        elif ocs_version >= version.VERSION_4_9:
+        else:
             stored_values = constants.NOOBAA_POSTGRES_TUNING_VALUES_4_9.split("\n")
 
-        stored_values = [v.strip() for v in stored_values if v.strip()]
+        stored_values = [value for value in stored_values if value]
+
         assert collections.Counter(config_data) == collections.Counter(stored_values), (
             f"The config set in {constants.NOOBAA_POSTGRES_CONFIGMAP} "
-            f"is different than the expected. Please inform OCS-QE about this discrepancy. "
-            f"The expected values are:\n{stored_values}\n"
-            f"The cluster's existing values are:{config_data}"
+            "is different than expected. Please inform OCS-QE about this "
+            "discrepancy.\n"
+            f"Expected values:\n{stored_values}\n"
+            f"Cluster values:\n{config_data}"
         )
 
     @post_ocs_upgrade


### PR DESCRIPTION
Postgres configmap replaced with CNPG in 4.19. skipping the test for ocs>=4.19