### PR TITLE
extend timeout for wait-for install-complete command

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -653,7 +653,7 @@ class BAREMETALUPI(BAREMETALBASE):
                 f"{self.installer} wait-for install-complete "
                 f"--dir {self.cluster_path} "
                 f"--log-level {log_cli_level}",
-                timeout=1800,
+                timeout=3600,
             )
             logger.info("Removing Bootstrap Ip for DNS Records")
             self.aws.update_hosted_zone_record(

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1144,7 +1144,6 @@ class VSPHEREUPI(VSPHEREBASE):
 
             OCP.set_kubeconfig(self.kubeconfig)
             if not config.ENV_DATA["sno"]:
-                timeout = 1800
                 # wait for all nodes to generate CSR
                 # From OCP version 4.4 and above, we have to approve CSR manually
                 # for all the nodes
@@ -1173,7 +1172,7 @@ class VSPHEREUPI(VSPHEREBASE):
                     f"{self.installer} wait-for install-complete "
                     f"--dir {self.cluster_path} "
                     f"--log-level {log_cli_level}",
-                    timeout=timeout,
+                    timeout=3600,
                 )
 
                 # Approving CSRs here in-case if any exists


### PR DESCRIPTION
The `openshift-install wait-for install-complete ...` command have internal timeout 40 minutes, so it doesn't make much sense to have shorter timeout for the command execution. Changing the command execution timeout for this command to 3600s so it will be the same for all the occurrences of this command.