### PR TITLE
Add osd_cleanup_state_check fixture for pre-test validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2326,6 +2326,30 @@ def resource_checker(request):
         )
 
 
+@pytest.fixture
+def osd_cleanup_state_check():
+    """
+    Opt-in fixture to validate OSD cleanup state before test.
+
+    Tests use this by adding it as a parameter:
+        def test_example(self, osd_cleanup_state_check):
+            ...
+
+    Skips test if pending OSD jobs or unexpected device classes are found.
+
+    """
+    from ocs_ci.helpers.sanity_helpers import check_osd_cleanup_state
+
+    log.info("Checking OSD cleanup state")
+    issues = check_osd_cleanup_state()
+
+    if issues:
+        issues_str = "\n  - ".join(issues)
+        pytest.skip(f"OSD cleanup state check failed:\n  - {issues_str}")
+
+    log.info("OSD cleanup state check passed")
+
+
 @pytest.fixture(scope="session")
 def log_cli_level(pytestconfig):
     """

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -212,7 +212,7 @@ class TestResizeOSD(ManageTest):
 
     @tier1
     @polarion_id("OCS-5506")
-    def test_resize_osd(self):
+    def test_resize_osd(self, osd_cleanup_state_check):
         """
         Test resize OSD
         """


### PR DESCRIPTION
- [x] Added function to detect pending OSD removal jobs
- [x] Added function function to detect leftover device classes
- [x] Added osd_cleanup_state_check as opt-in fixture
- [x] Added fixture usage to test_resize_osd

another check to prevent if other fixes failed https://github.com/red-hat-storage/ocs-ci/issues/13242