### PR TITLE
Remove excessive logging from ODFCLIRunner::run_noobaa

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -344,8 +344,6 @@ class ODFCliRunner:
         else:
             output = exec_cmd(full_command, ignore_error=ignore_error, **kwargs)
 
-        log.info(f"output type: {type(output)}")
-        log.info(f"*Command output*: {output}")
         return output
 
     def run_maintenance_start(self, deployment_name):


### PR DESCRIPTION
[ODFCLI::run_noobaa](https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/helpers/odf_cli.py/#L294-L349) has been logging the *full* JSON output of every `mcg-cli` command.

Whether its while listing buckets, creating OBCs or checking on the health of NooBaa - whenever we use `run_noobaa` for these purposes, we're extracting the necessary sub-parts from the JSON and logging what's needed anyway. This makes the logging of the entire output excessive and often redundant.