### PR TITLE
Update filter to skip volsync PVCs with new naming pattern

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1235,7 +1235,8 @@ def get_backend_volumes_for_pvcs(namespace):
         logger.info(f"Fetching backend volume names for PVCs in namespace: {namespace}")
         all_pvcs = get_all_pvc_objs(namespace=namespace)
         for pvc_obj in all_pvcs:
-            if pvc_obj.name.startswith("volsync"):
+            # Skip volsync related PVCs
+            if pvc_obj.name.startswith("volsync") or pvc_obj.name.startswith("vs-"):
                 continue
 
             if pvc_obj.backed_sc in [


### PR DESCRIPTION
Update the filter to also skip PVCs that start with "vs-" in addition to "volsync". 

Fixes: #14134
Fixes: #13538 