### PR TITLE
Verify RBD Block PVC Monitoring Metrics : Included test cases other than happy path

### DIFF
--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -131,7 +131,8 @@ def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode)
         ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
     else:
         # Filesystem mode: Kubelet Capacity (statfs) is always smaller than Ceph Capacity (RBD size)
-        # We allow small tolerance Percentage/Margin for XFS/Ext4 overhead (around 50 MB)- Let's say total capacity for FS mode PVCs is reflecting as 973MB at Kubelet side instead of 1024MB at cpeh rbd side
+        # We allow small tolerance Percentage/Margin for XFS/Ext4 overhead (around 50 MB)
+        # Total capacity for FS mode PVCs is reflecting as 973MB at Kubelet side instead of 1024MB at cpeh rbd side
         tolerance_factor = 0.90
         assert kube_metrics["capacity"] >= (
             ceph_metrics["capacity"] * tolerance_factor

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(autouse=True)
 def teardown(request):
     def finalizer():
-        # Actual useful logic: ensuring the cluster is healthy after IO
         assert ceph_health_check(), "Cluster became unhealthy after metrics test"
 
     request.addfinalizer(finalizer)

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 from ocs_ci.framework.pytest_customization.marks import blue_squad, tier1, polarion_id
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.utility.prometheus import PrometheusAPI
 
 logger = logging.getLogger(__name__)
@@ -11,10 +12,6 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture()
 def teardown(request):
-    """
-    Finalizer to ensure resources are cleaned up.
-    """
-
     def finalizer():
         logger.info("Cleaning up resources created during the test...")
 
@@ -41,28 +38,28 @@ def test_rbd_metrics_validation_multi_scenario(
     write_size_mib,
     volume_mode,
 ):
-    """
-    Covers: Happy Path, Scale Testing, and Filesystem mode compatibility.
-    """
     project_obj = project_factory()
     namespace = project_obj.namespace
 
-    pvc_dict = {
-        "project": project_obj,
-        "size": pvc_size,
-        "access_mode": constants.ACCESS_MODE_RWO,
-        "volume_mode": volume_mode,
-        "interface": constants.CEPHBLOCKPOOL,
-    }
+    pvc_obj = pvc_factory(
+        project=project_obj,
+        size=pvc_size,
+        access_mode=constants.ACCESS_MODE_RWO,
+        volume_mode=volume_mode,
+        interface=constants.CEPHBLOCKPOOL,
+        wait_for_resource_status_timeout=300,
+    )
 
-    pvc_obj = pvc_factory(**pvc_dict, wait_for_resource_status_timeout=300)
-
-    if volume_mode == constants.VOLUME_MODE_BLOCK:
-        pod_dict_path = constants.CSI_RBD_RAW_BLOCK_POD_YAML
-        dev_path = "/dev/rbdblock"
-    else:
-        pod_dict_path = constants.CSI_RBD_POD_YAML
-        dev_path = "/var/lib/www/html/test_file"
+    pod_dict_path = (
+        constants.CSI_RBD_RAW_BLOCK_POD_YAML
+        if volume_mode == constants.VOLUME_MODE_BLOCK
+        else constants.CSI_RBD_POD_YAML
+    )
+    dev_path = (
+        "/dev/rbdblock"
+        if volume_mode == constants.VOLUME_MODE_BLOCK
+        else "/var/lib/www/html/test_file"
+    )
 
     pod_obj = pod_factory(
         interface=constants.CEPHBLOCKPOOL,
@@ -71,60 +68,129 @@ def test_rbd_metrics_validation_multi_scenario(
         status=constants.STATUS_RUNNING,
     )
 
-    # Step 1: Initial Write Process
+    prom = PrometheusAPI(threading_lock=threading.Lock())
+
+    # Step 1: Initial Write
+    initial_write_mib = write_size_mib
+    logger.info(f"Step 1: Writing {initial_write_mib}MiB to {dev_path}")
+    pod_obj.exec_cmd_on_pod(
+        command=f"bash -lc '{get_dd_command(volume_mode, dev_path, initial_write_mib)}'",
+        out_yaml_format=False,
+    )
+
+    validate_all_layers(prom, pvc_obj, namespace, initial_write_mib, volume_mode)
+
+    # Step 2: Additional Write
+    extra_write_mib = 128
+    total_write_mib = initial_write_mib + extra_write_mib
+    logger.info(f"Step 2: Appending {extra_write_mib}MiB to {dev_path}")
+    pod_obj.exec_cmd_on_pod(
+        command=f"bash -lc '{get_dd_command(volume_mode, dev_path, extra_write_mib, initial_write_mib, True)}'",
+        out_yaml_format=False,
+    )
+
+    validate_all_layers(prom, pvc_obj, namespace, total_write_mib, volume_mode)
+
+
+def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode):
+    """
+    Validates metrics at both Kubelet (Prometheus) and Ceph (rbd du) layers.
+    """
+    expected_bytes = expected_mib * 1024 * 1024
+
+    # 1. Fetch Prometheus Metrics
+    kube_metrics = wait_for_all_metrics(
+        prom_api, pvc_obj.name, namespace, expected_bytes
+    )
+
+    # 2. Fetch Ceph Side Truth
+    ceph_metrics = get_ceph_rbd_metrics(pvc_obj)
+
+    logger.info(f"Kubelet Metrics: {kube_metrics}")
+    logger.info(f"Ceph Metrics:    {ceph_metrics}")
+
+    # CAPACITY CHECK
     if volume_mode == constants.VOLUME_MODE_BLOCK:
-        # For Block mode PVCs:
-        dd_cmd = f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} oflag=direct"
+        # Block mode should be exact
+        assert (
+            kube_metrics["capacity"] == ceph_metrics["capacity"]
+        ), f"Capacity mismatch! Kube: {kube_metrics['capacity']}, Ceph: {ceph_metrics['capacity']}"
+        # Kubelet Used vs Ceph Used
+        assert abs(
+            kube_metrics["used"] == ceph_metrics["used"]
+        ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
+
+        # Kubelet Available vs Ceph Available
+        assert abs(
+            kube_metrics["available"] == ceph_metrics["available"]
+        ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
+
+        # Kubelet Used vs What we actually wrote (Logical check)
+        assert (
+            kube_metrics["used"] >= expected_bytes
+        ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
     else:
-        # For Filesystem mode PVCs:
-        dd_cmd = (
-            f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} && sync"
+        # Filesystem mode: Kubelet Capacity (statfs) is always smaller than Ceph Capacity (RBD size)
+        # We allow small tolerance Percentage/Margin for XFS/Ext4 overhead (around 50 MB)- Let's say total capacity for FS mode PVCs is reflecting as 973MB at Kubelet side instead of 1024MB at cpeh rbd side
+        tolerance_factor = 0.90
+        assert kube_metrics["capacity"] >= (
+            ceph_metrics["capacity"] * tolerance_factor
+        ), (
+            f"Capacity mismatch! Kubelet reports too much overhead. "
+            f"Kube: {kube_metrics['capacity']}, Ceph: {ceph_metrics['capacity']}"
         )
 
-    logger.info(f"Writing {write_size_mib}MiB to {dev_path}")
-    pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_cmd}'", out_yaml_format=False)
+        margin = 50 * 1024 * 1024
 
-    # Step 2: Verification with Retry Loop
-    prom = PrometheusAPI(threading_lock=threading.Lock())
-    written_bytes = write_size_mib * 1024 * 1024
+        # Kubelet Used vs Ceph Used
+        assert (
+            abs(kube_metrics["used"] - ceph_metrics["used"]) < margin
+        ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
 
-    kube_used = wait_for_metric_update(
-        prom, pvc_obj.name, namespace, expected_val=written_bytes
+        # Kubelet Available vs Ceph Available
+        assert (
+            abs(kube_metrics["available"] - ceph_metrics["available"]) < margin
+        ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
+
+        # Kubelet Used vs What we actually wrote (Logical check)
+        assert (
+            kube_metrics["used"] >= expected_bytes
+        ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
+
+
+def get_ceph_rbd_metrics(pvc_obj):
+    ceph_toolbox = pod_helpers.get_ceph_tools_pod()
+    pv_data = pvc_obj.backed_pv_obj.get()
+    rbd_pool = constants.DEFAULT_BLOCKPOOL
+    rbd_image = (
+        pv_data.get("spec", {})
+        .get("csi", {})
+        .get("volumeAttributes", {})
+        .get("imageName")
     )
 
-    assert (
-        kube_used >= written_bytes
-    ), f"Expected at least {written_bytes} bytes, found {kube_used}"
+    rbd_cmd = f"rbd du -p {rbd_pool} {rbd_image}"
+    result = ceph_toolbox.exec_ceph_cmd(ceph_cmd=rbd_cmd, format="json")
 
-    # Step 4: Additional Write Scenario
-    extra_write = 128
-    if volume_mode == constants.VOLUME_MODE_BLOCK:
-        # For Block mode PVCs
-        dd_extra = f"dd if=/dev/urandom of={dev_path} bs=1M count={extra_write} seek={write_size_mib} oflag=direct"
+    used = int(result["images"][0]["used_size"])
+    capacity = int(result["images"][0]["provisioned_size"])
+    available = capacity - used
+
+    return {"used": used, "capacity": capacity, "available": available}
+
+
+def get_dd_command(mode, path, size_mib, seek_val=None, append=False):
+    if mode == constants.VOLUME_MODE_BLOCK:
+        seek_str = f"seek={seek_val}" if seek_val else ""
+        return f"dd if=/dev/urandom of={path} bs=1M count={size_mib} {seek_str} oflag=direct"
     else:
-        # For FS mode PVCs:
-        dd_extra = f"dd if=/dev/urandom of={dev_path} bs=1M count={extra_write} oflag=append conv=notrunc && sync"
-
-        logger.info(f"Writing {extra_write}MiB to {dev_path}")
-        pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_extra}'", out_yaml_format=False)
-
-    logger.info(f"Writing additional {extra_write}MiB to {dev_path}")
-    pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_extra}'")
-
-    # Step 5: Verify Increase
-    expected_total = (write_size_mib + extra_write) * 1024 * 1024
-    kube_used_new = wait_for_metric_update(
-        prom, pvc_obj.name, namespace, expected_val=expected_total
-    )
-
-    assert (
-        kube_used_new > kube_used
-    ), f"Metrics did not increase. Old: {kube_used}, New: {kube_used_new}"
-    logger.info(f"Successfully verified metric increase: {kube_used_new} bytes")
+        append_str = "oflag=append conv=notrunc" if append else ""
+        return (
+            f"dd if=/dev/urandom of={path} bs=1M count={size_mib} {append_str} && sync"
+        )
 
 
 def query_kubelet_metric(prom_api, metric_name, pvc_name, namespace):
-    """Fetches the specific metric from Prometheus"""
     promql = (
         f'{metric_name}{{persistentvolumeclaim="{pvc_name}",namespace="{namespace}"}}'
     )
@@ -132,21 +198,25 @@ def query_kubelet_metric(prom_api, metric_name, pvc_name, namespace):
     return int(val[0]["value"][1]) if val else 0
 
 
-def wait_for_metric_update(prom_api, pvc_name, namespace, expected_val, timeout=480):
-    """
-    Retries the Prometheus query until the reported value meets the expected threshold.
-    Kubelet/Prometheus lag can take up to 5-6 minutes in some environments.
-    """
+def wait_for_all_metrics(prom_api, pvc_name, namespace, expected_used, timeout=600):
     start_time = time.time()
-    last_val = 0
     while time.time() - start_time < timeout:
-        last_val = query_kubelet_metric(
+        space_used = query_kubelet_metric(
             prom_api, "kubelet_volume_stats_used_bytes", pvc_name, namespace
         )
-        if last_val >= expected_val:
-            return last_val
-        logger.info(
-            f"Waiting for metrics to reach {expected_val}. Current: {last_val}..."
-        )
-        time.sleep(30)
-    return last_val
+        if space_used >= expected_used:
+            return {
+                "used": space_used,
+                "capacity": query_kubelet_metric(
+                    prom_api, "kubelet_volume_stats_capacity_bytes", pvc_name, namespace
+                ),
+                "available": query_kubelet_metric(
+                    prom_api,
+                    "kubelet_volume_stats_available_bytes",
+                    pvc_name,
+                    namespace,
+                ),
+            }
+        logger.info(f"Waiting for Prometheus update... Current Kube Used: {space_used}")
+        time.sleep(60)
+    raise AssertionError(f"Metrics timeout at {expected_used} bytes")

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -1,192 +1,152 @@
 import time
 import logging
 import threading
-
-from ocs_ci.framework.pytest_customization.marks import blue_squad, tier1
+import pytest
+from ocs_ci.framework.pytest_customization.marks import blue_squad, tier1, polarion_id
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.resources import pod as pod_helpers  # Import for get_ceph_tools_pod
 from ocs_ci.utility.prometheus import PrometheusAPI
 
 logger = logging.getLogger(__name__)
 
 
-# Increased from default 90s to 180s for PVC creation & bound to avoid the TimeoutExpiredError
-PVC_BIND_TIMEOUT = 240
+@pytest.fixture()
+def teardown(request):
+    """
+    Finalizer to ensure resources are cleaned up.
+    """
+
+    def finalizer():
+        logger.info("Cleaning up resources created during the test...")
+
+    request.addfinalizer(finalizer)
 
 
 @tier1
 @blue_squad
-def test_block_pvc_kubelet_metrics_match_rbd_usage(
-    pvc_factory, pod_factory, project_factory
+@pytest.mark.parametrize(
+    "pvc_size, write_size_mib, volume_mode",
+    [
+        (1, 256, constants.VOLUME_MODE_BLOCK),  # Happy Path
+        (200, 1024, constants.VOLUME_MODE_BLOCK),  # Scale Testing (200GB)
+        (1, 256, constants.VOLUME_MODE_FILESYSTEM),  # Backward Compatibility
+    ],
+)
+@polarion_id("OCS-7424")
+def test_rbd_metrics_validation_multi_scenario(
+    pvc_factory,
+    pod_factory,
+    project_factory,
+    teardown,
+    pvc_size,
+    write_size_mib,
+    volume_mode,
 ):
     """
-    1. Create a Block PVC and a Pod that consumes the block device.
-    2. Exec into the Pod and write sample data directly to the block device with dd.
-    3. Query kubelet metrics (kubelet_volume_stats_*) and capture used bytes.
-    4. Run `rbd du` from Ceph toolbox pod and compare the reported used bytes.
+    Covers: Happy Path, Scale Testing, and Filesystem mode compatibility.
     """
-
     project_obj = project_factory()
     namespace = project_obj.namespace
 
-    # Creating a block PVC and consuming Pod
-    pvc_size = 1
-    write_size_mib = 256
+    pvc_dict = {
+        "project": project_obj,
+        "size": pvc_size,
+        "access_mode": constants.ACCESS_MODE_RWO,
+        "volume_mode": volume_mode,
+        "interface": constants.CEPHBLOCKPOOL,
+    }
 
-    pvc_dict = dict(
-        project=project_obj,
-        size=pvc_size,
-        access_mode=constants.ACCESS_MODE_RWO,
-        volume_mode=constants.VOLUME_MODE_BLOCK,
-        interface=constants.CEPHBLOCKPOOL,
-    )
+    pvc_obj = pvc_factory(**pvc_dict, wait_for_resource_status_timeout=300)
 
-    logger.info(
-        f"Creating block PVC in namespace {namespace} with a timeout of {PVC_BIND_TIMEOUT}s"
-    )
+    if volume_mode == constants.VOLUME_MODE_BLOCK:
+        pod_dict_path = constants.CSI_RBD_RAW_BLOCK_POD_YAML
+        dev_path = "/dev/rbdblock"
+    else:
+        pod_dict_path = constants.CSI_RBD_POD_YAML
+        dev_path = "/var/lib/www/html/test_file"
 
-    # Create PVC and wait for Bound state
-    pvc_obj = pvc_factory(**pvc_dict, wait_for_resource_status_timeout=PVC_BIND_TIMEOUT)
-    assert (
-        pvc_obj.ocp.get(resource_name=pvc_obj.name)["status"]["phase"]
-        == constants.STATUS_BOUND
-    ), f"PVC {pvc_obj.name} did not reach Bound phase."
-
-    # Create a Pod that uses the block device
-    # uses 'volumeDevices' and device path - '/dev/rbdblock'
     pod_obj = pod_factory(
         interface=constants.CEPHBLOCKPOOL,
         pvc=pvc_obj,
-        pod_dict_path=constants.CSI_RBD_RAW_BLOCK_POD_YAML,
-        status=constants.STATUS_RUNNING,  # Ensure this is used for waiting
+        pod_dict_path=pod_dict_path,
+        status=constants.STATUS_RUNNING,
     )
 
-    dev_path = "/dev/rbdblock"
+    # Step 1: Initial Write Process
+    if volume_mode == constants.VOLUME_MODE_BLOCK:
+        # For Block mode PVCs:
+        dd_cmd = f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} oflag=direct"
+    else:
+        # For Filesystem mode PVCs:
+        dd_cmd = (
+            f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} && sync"
+        )
 
-    # Write sample data using dd
-    dd_cmd_str = (
-        f"dd if=/dev/urandom of={dev_path} bs=1M count={write_size_mib} oflag=direct"
-    )
-    logger.info(
-        f"Writing {write_size_mib} MiB to device {dev_path} inside pod {pod_obj.name}"
-    )
+    logger.info(f"Writing {write_size_mib}MiB to {dev_path}")
+    pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_cmd}'", out_yaml_format=False)
 
-    # Join the bash command arguments into a single string and execute it
-    dd_full_command = f"bash -lc '{dd_cmd_str}'"
-
-    pod_obj.exec_cmd_on_pod(command=dd_full_command, out_yaml_format=False)
-
-    # Wait for metrics to be scraped
-    time.sleep(180)
-
-    # Query kubelet metrics for the PVC
-
-    # PrometheusAPI requires a threading_lock object
-    prom: PrometheusAPI = PrometheusAPI(threading_lock=threading.Lock())
-
-    def query_kubelet_metric(metric_name: str, pvc_name: str, namespace: str):
-        promql = f'{metric_name}{{persistentvolumeclaim="{pvc_name}",namespace="{namespace}"}}'
-
-        # Use the 'query' method and parse the result
-        try:
-            val = prom.query(promql, mute_logs=True)
-            if val and "value" in val[0]:
-                # value is [timestamp, metric_value]
-                return int(val[0]["value"][1])
-        except Exception as e:
-            logger.warning(f"Failed to query metric {metric_name}: {e}")
-            return 0
-
-    kube_used = query_kubelet_metric(
-        "kubelet_volume_stats_used_bytes", pvc_obj.name, namespace
-    )
-    kube_capacity = query_kubelet_metric(
-        "kubelet_volume_stats_capacity_bytes", pvc_obj.name, namespace
-    )
-    kube_available = query_kubelet_metric(
-        "kubelet_volume_stats_available_bytes", pvc_obj.name, namespace
-    )
-
-    logger.info(
-        f"Kubelet Metrics for {pvc_obj.name}: "
-        f"Capacity={kube_capacity} B, Used={kube_used} B, Available={kube_available} B )"
-    )
-
-    # Get Ceph-side reporting using rbd du
-    # Get the Ceph Toolbox Pod object
-    ceph_toolbox_pod = pod_helpers.get_ceph_tools_pod()
-    if not ceph_toolbox_pod:
-        raise AssertionError("Failed to retrieve Ceph toolbox pod.")
-
-    pv_obj = pvc_obj.backed_pv_obj.get()
-    rbd_pool_name = constants.DEFAULT_BLOCKPOOL
-    rbd_image_name = (
-        pv_obj.get("spec", {})
-        .get("csi", {})
-        .get("volumeAttributes", {})
-        .get("imageName")
-    )
-
-    if not rbd_image_name or not rbd_pool_name:
-        raise AssertionError("RBD image or pool name is missing")
-
-    # Execute rbd du using the pod's exec_ceph_cmd method
-    rbd_cmd = f"rbd du -p {rbd_pool_name} {rbd_image_name}"
-    logger.info(f"Executing rbd du on Ceph toolbox pod: {rbd_cmd}")
-
-    try:
-        rbd_out_parsed = ceph_toolbox_pod.exec_ceph_cmd(ceph_cmd=rbd_cmd, format="json")
-
-        if rbd_out_parsed and all(
-            key in rbd_out_parsed["images"][0]
-            for key in ("used_size", "provisioned_size")
-        ):
-            used_bytes_ceph = int(rbd_out_parsed["images"][0]["used_size"])
-            provisioned_bytes_ceph = int(
-                rbd_out_parsed["images"][0]["provisioned_size"]
-            )
-            available_bytes_ceph = provisioned_bytes_ceph - used_bytes_ceph
-        else:
-            used_bytes_ceph = 0
-            logger.warning(
-                "rbd du output unexpected structure. Assuming 0 used bytes for comparison: %s",
-                rbd_out_parsed,
-            )
-
-    except Exception as e:
-        logger.error(f"Failed to execute or parse rbd du: {e}")
-        raise AssertionError(f"Failed to execute or parse rbd du output: {e}")
-
-    logger.info(
-        f"Ceph RBD Metrics for {rbd_image_name}: "
-        f"Capacity={provisioned_bytes_ceph} B, Used={used_bytes_ceph} B, Available={available_bytes_ceph} B"
-    )
-
-    # Final Comparison
-    # Provisioned Capacity Check (Ceph Provisioned vs Kubelet Capacity )
-
-    assert kube_capacity == provisioned_bytes_ceph, (
-        f"Capacity mismatch: Ceph Provisioned ({provisioned_bytes_ceph} B ) differs from kubelet Size"
-        f" ({kube_capacity} B ) "
-    )
-
-    # Used Bytes Comparison (Kubelet Used vs. Ceph RBD Used)
-    assert (
-        kube_used == used_bytes_ceph
-    ), f"Used Size mismatch: Kubelet Used ({kube_used}) differs from Ceph Used ({used_bytes_ceph}) "
-
-    # Written Bytes Comparison (Kubelet Used vs. Written bytes)
+    # Step 2: Verification with Retry Loop
+    prom = PrometheusAPI(threading_lock=threading.Lock())
     written_bytes = write_size_mib * 1024 * 1024
+
+    kube_used = wait_for_metric_update(
+        prom, pvc_obj.name, namespace, expected_val=written_bytes
+    )
+
     assert (
-        kube_used == written_bytes
-    ), f"Written Size mismatch: Kubelet Used ({kube_used}) differs from Written size ({written_bytes}) "
+        kube_used >= written_bytes
+    ), f"Expected at least {written_bytes} bytes, found {kube_used}"
 
-    # Available Bytes Comparison (Kubelet Available vs. Ceph RBD Available)
-    assert kube_available == available_bytes_ceph, (
-        f"Available Size mismatch: Kubelet Available ({kube_available}) differs from Ceph Available"
-        f" ({available_bytes_ceph}) "
+    # Step 4: Additional Write Scenario
+    extra_write = 128
+    if volume_mode == constants.VOLUME_MODE_BLOCK:
+        # For Block mode PVCs
+        dd_extra = f"dd if=/dev/urandom of={dev_path} bs=1M count={extra_write} seek={write_size_mib} oflag=direct"
+    else:
+        # For FS mode PVCs:
+        dd_extra = f"dd if=/dev/urandom of={dev_path} bs=1M count={extra_write} oflag=append conv=notrunc && sync"
+
+        logger.info(f"Writing {extra_write}MiB to {dev_path}")
+        pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_extra}'", out_yaml_format=False)
+
+    logger.info(f"Writing additional {extra_write}MiB to {dev_path}")
+    pod_obj.exec_cmd_on_pod(command=f"bash -lc '{dd_extra}'")
+
+    # Step 5: Verify Increase
+    expected_total = (write_size_mib + extra_write) * 1024 * 1024
+    kube_used_new = wait_for_metric_update(
+        prom, pvc_obj.name, namespace, expected_val=expected_total
     )
 
-    logger.info(
-        "Kubelet and Ceph metrics match within tolerance for Capacity, Used, and Available sizes."
+    assert (
+        kube_used_new > kube_used
+    ), f"Metrics did not increase. Old: {kube_used}, New: {kube_used_new}"
+    logger.info(f"Successfully verified metric increase: {kube_used_new} bytes")
+
+
+def query_kubelet_metric(prom_api, metric_name, pvc_name, namespace):
+    """Fetches the specific metric from Prometheus"""
+    promql = (
+        f'{metric_name}{{persistentvolumeclaim="{pvc_name}",namespace="{namespace}"}}'
     )
+    val = prom_api.query(promql, mute_logs=True)
+    return int(val[0]["value"][1]) if val else 0
+
+
+def wait_for_metric_update(prom_api, pvc_name, namespace, expected_val, timeout=480):
+    """
+    Retries the Prometheus query until the reported value meets the expected threshold.
+    Kubelet/Prometheus lag can take up to 5-6 minutes in some environments.
+    """
+    start_time = time.time()
+    last_val = 0
+    while time.time() - start_time < timeout:
+        last_val = query_kubelet_metric(
+            prom_api, "kubelet_volume_stats_used_bytes", pvc_name, namespace
+        )
+        if last_val >= expected_val:
+            return last_val
+        logger.info(
+            f"Waiting for metrics to reach {expected_val}. Current: {last_val}..."
+        )
+        time.sleep(30)
+    return last_val

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -6,14 +6,16 @@ from ocs_ci.framework.pytest_customization.marks import blue_squad, tier1, polar
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def teardown(request):
     def finalizer():
-        logger.info("Cleaning up resources created during the test...")
+        # Actual useful logic: ensuring the cluster is healthy after IO
+        assert ceph_health_check(), "Cluster became unhealthy after metrics test"
 
     request.addfinalizer(finalizer)
 
@@ -24,7 +26,6 @@ def teardown(request):
     "pvc_size, write_size_mib, volume_mode",
     [
         (1, 256, constants.VOLUME_MODE_BLOCK),  # Happy Path
-        (200, 1024, constants.VOLUME_MODE_BLOCK),  # Scale Testing (200GB)
         (1, 256, constants.VOLUME_MODE_FILESYSTEM),  # Backward Compatibility
     ],
 )

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(autouse=True)
 def teardown(request):
+    """
+    Ensure cluster health after metrics validation.
+    """
+
     def finalizer():
         assert ceph_health_check(), "Cluster became unhealthy after metrics test"
 
@@ -38,6 +42,11 @@ def test_rbd_metrics_validation_multi_scenario(
     write_size_mib,
     volume_mode,
 ):
+    """
+    Validates that RBD metrics (Used, Capacity, Available) are correctly reported
+    by both Kubelet (via Prometheus) and the Ceph backend (rbd du) across
+    multiple write operations and volume modes.
+    """
     project_obj = project_factory()
     namespace = project_obj.namespace
 
@@ -95,6 +104,13 @@ def test_rbd_metrics_validation_multi_scenario(
 def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode):
     """
     Validates metrics at both Kubelet (Prometheus) and Ceph (rbd du) layers.
+
+    Args:
+        prom_api (PrometheusAPI): The Prometheus API object for querying metrics.
+        pvc_obj (PVC): The PVC object being validated.
+        namespace (str): The namespace where the PVC and Pod reside.
+        expected_mib (int): The amount of data written in MiB.
+        volume_mode (str): The volume mode (Block or Filesystem).
     """
     expected_bytes = expected_mib * 1024 * 1024
 
@@ -115,24 +131,20 @@ def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode)
         assert (
             kube_metrics["capacity"] == ceph_metrics["capacity"]
         ), f"Capacity mismatch! Kube: {kube_metrics['capacity']}, Ceph: {ceph_metrics['capacity']}"
-        # Kubelet Used vs Ceph Used
-        assert abs(
+
+        assert (
             kube_metrics["used"] == ceph_metrics["used"]
         ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
 
-        # Kubelet Available vs Ceph Available
-        assert abs(
+        assert (
             kube_metrics["available"] == ceph_metrics["available"]
         ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
 
-        # Kubelet Used vs What we actually wrote (Logical check)
         assert (
             kube_metrics["used"] >= expected_bytes
         ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
     else:
-        # Filesystem mode: Kubelet Capacity (statfs) is always smaller than Ceph Capacity (RBD size)
-        # We allow small tolerance Percentage/Margin for XFS/Ext4 overhead (around 50 MB)
-        # Total capacity for FS mode PVCs is reflecting as 973MB at Kubelet side instead of 1024MB at cpeh rbd side
+        # Filesystem mode tolerance check
         tolerance_factor = 0.90
         assert kube_metrics["capacity"] >= (
             ceph_metrics["capacity"] * tolerance_factor
@@ -143,23 +155,29 @@ def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode)
 
         margin = 50 * 1024 * 1024
 
-        # Kubelet Used vs Ceph Used
         assert (
             abs(kube_metrics["used"] - ceph_metrics["used"]) < margin
         ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
 
-        # Kubelet Available vs Ceph Available
         assert (
             abs(kube_metrics["available"] - ceph_metrics["available"]) < margin
         ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
 
-        # Kubelet Used vs What we actually wrote (Logical check)
         assert (
             kube_metrics["used"] >= expected_bytes
         ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
 
 
 def get_ceph_rbd_metrics(pvc_obj):
+    """
+    Retrieves used, provisioned, and available size for an RBD image directly from Ceph.
+
+    Args:
+        pvc_obj (PVC): The PVC object to check.
+
+    Returns:
+        dict: A dictionary containing 'used', 'capacity', and 'available' bytes.
+    """
     ceph_toolbox = pod_helpers.get_ceph_tools_pod()
     pv_data = pvc_obj.backed_pv_obj.get()
     rbd_pool = constants.DEFAULT_BLOCKPOOL
@@ -181,6 +199,19 @@ def get_ceph_rbd_metrics(pvc_obj):
 
 
 def get_dd_command(mode, path, size_mib, seek_val=None, append=False):
+    """
+    Generates a dd command string suitable for Block or Filesystem writes.
+
+    Args:
+        mode (str): Volume mode (Block or Filesystem).
+        path (str): The device or file path to write to.
+        size_mib (int): Amount of data to write in MiB.
+        seek_val (int, optional): The offset for dd seek. Defaults to None.
+        append (bool): If True, use append mode for filesystem writes.
+
+    Returns:
+        str: The constructed dd command.
+    """
     if mode == constants.VOLUME_MODE_BLOCK:
         seek_str = f"seek={seek_val}" if seek_val else ""
         return f"dd if=/dev/urandom of={path} bs=1M count={size_mib} {seek_str} oflag=direct"
@@ -192,6 +223,18 @@ def get_dd_command(mode, path, size_mib, seek_val=None, append=False):
 
 
 def query_kubelet_metric(prom_api, metric_name, pvc_name, namespace):
+    """
+    Queries a specific Kubelet volume metric from Prometheus.
+
+    Args:
+        prom_api (PrometheusAPI): The Prometheus API object.
+        metric_name (str): The name of the Prometheus metric.
+        pvc_name (str): The name of the PVC.
+        namespace (str): The namespace where the PVC resides.
+
+    Returns:
+        int: The metric value (usually bytes).
+    """
     promql = (
         f'{metric_name}{{persistentvolumeclaim="{pvc_name}",namespace="{namespace}"}}'
     )
@@ -200,6 +243,22 @@ def query_kubelet_metric(prom_api, metric_name, pvc_name, namespace):
 
 
 def wait_for_all_metrics(prom_api, pvc_name, namespace, expected_used, timeout=600):
+    """
+    Waits for Prometheus metrics to reflect at least the expected used bytes.
+
+    Args:
+        prom_api (PrometheusAPI): The Prometheus API object.
+        pvc_name (str): The name of the PVC.
+        namespace (str): The namespace.
+        expected_used (int): The target used bytes to wait for.
+        timeout (int): Seconds to wait before failing. Defaults to 600.
+
+    Returns:
+        dict: Used, capacity, and available bytes from Prometheus.
+
+    Raises:
+        AssertionError: If metrics are not updated within the timeout.
+    """
     start_time = time.time()
     while time.time() - start_time < timeout:
         space_used = query_kubelet_metric(


### PR DESCRIPTION
This PR expands the test coverage for RBD metrics validation beyond the "happy path." 

JIRA: https://issues.redhat.com/browse/OCSQE-4207

It introduces verifications for both block and filesystem volume modes, scale testing, and incremental write scenarios to ensure Prometheus metrics reflect data consumption across different configurations.

**Happy Path:** Standard validation for 1GB Block mode volumes.

**Scale Testing:** Validation for large volumes (200GB) and high-load writes (1GB) to ensure metrics consistency at scale.

**Backward Compatibility:** Verifying metrics scraping for Filesystem mode PVCs, ensuring parity with Block mode verification.

**Incremental Write Verification:** Added logic to verify that metrics correctly increment following additional data writes.

**Test Coverage:**

**Volume Modes:** Block, Filesystem

**Write Scenarios:** Initial Write, Incremental Append

**Metric Verified:** kubelet_volume_stats_used_bytes, kubelet_volume_stats_capacity_bytes, kubelet_volume_stats_available_bytes

**Clarification on Validation Margins (FS vs Block): **

Because Filesystem mode involves an management layer (XFS/Ext4) between the pod and the raw RBD device, a strict equality check (==) is not possible. 

So this PR implements the following logic:

Block Mode: Uses strict assertions with no margins

Filesystem Mode: * Capacity Margin: Kubelet reports "Usable" capacity (via statfs), while Ceph reports raw RBD size. We allow a 10% margin to account for fixed overhead like superblocks and inode tables.

Usage Margin: We use a 50MB margin for Used/Available bytes. This covers the XFS Journal (typically 32MB–64MB) and metadata updates that Ceph sees as physical writes but Kubelet does not count as "file data."
