### PR TITLE
Added retry to delete storageclass operation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2816,
+        "line_number": 2900,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 799,
+        "line_number": 833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 807,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1953,
+        "line_number": 2035,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2059,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2060,
+        "line_number": 2143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2061,
+        "line_number": 2144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2062,
+        "line_number": 2145,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2067,
+        "line_number": 2150,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2082,
+        "line_number": 2165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2083,
+        "line_number": 2166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2091,
+        "line_number": 2174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2092,
+        "line_number": 2175,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2093,
+        "line_number": 2176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2094,
+        "line_number": 2177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,15 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2095,
+        "line_number": 2178,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2774,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2931,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2808,
+        "line_number": 2932,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3507,
+        "line_number": 3653,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3508,
+        "line_number": 3654,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2931,
+        "line_number": 2816,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 799,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2030,
+        "line_number": 1953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2137,
+        "line_number": 2059,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2138,
+        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2139,
+        "line_number": 2061,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2140,
+        "line_number": 2062,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2145,
+        "line_number": 2067,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2160,
+        "line_number": 2082,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2161,
+        "line_number": 2083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2169,
+        "line_number": 2091,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2170,
+        "line_number": 2092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2171,
+        "line_number": 2093,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2172,
+        "line_number": 2094,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,15 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2173,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2769,
+        "line_number": 2095,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +765,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2926,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +773,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2927,
+        "line_number": 2808,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +781,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3648,
+        "line_number": 3507,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +789,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3649,
+        "line_number": 3508,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/deployment/ibm.py
+++ b/ocs_ci/deployment/ibm.py
@@ -15,6 +15,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources import pvc
+from ocs_ci.ocs.resources.storage_cluster import patch_storageclass_ocs_external_label
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +199,7 @@ class IBMDeployment(Deployment):
         for sc in storageclasses["items"]:
             if sc["provisioner"].startswith("openshift-storage."):
                 sc_name = sc["metadata"]["name"]
+                patch_storageclass_ocs_external_label(sc_name)
                 ocp.OCP().exec_oc_cmd(f"delete storageclass {sc_name}")
         volumesnapclasses = ocp.OCP(kind="VolumeSnapshotClass").get(all_namespaces=True)
         for vsc in volumesnapclasses["items"]:

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1402,8 +1402,12 @@ def delete_storageclasses(sc_objs):
     Returns:
         bool: True if deletion is successful
     """
+    from ocs_ci.ocs.resources.storage_cluster import (
+        patch_storageclass_ocs_external_label,
+    )
 
     for sc in sc_objs:
+        patch_storageclass_ocs_external_label(sc.name)
         logger.info("Deleting StorageClass with name %s", sc.name)
         sc.delete()
     return True

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -605,6 +605,10 @@ DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD_NAMESPACE_PREFIX = (
     f"{DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD}-rados-namespace"
 )
 
+# External / independent cluster: label expected on RBD/CephFS StorageClasses.
+OCS_EXTERNAL_STORAGECLASS_LABEL = "storageclass.ocs.openshift.io/is-external"
+OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE = "true"
+
 # Default StorageClass for Provider-mode
 DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{STORAGE_CLIENT_NAME}-cephfs"
 DEFAULT_STORAGECLASS_CLIENT_RBD = f"{STORAGE_CLIENT_NAME}-ceph-rbd"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -155,6 +155,53 @@ def verify_osd_tree_schema(ct_pod, deviceset_pvcs):
     )
 
 
+def _storageclass_ocs_external_label_patch():
+    """Merge-patch body for ``storageclass.ocs.openshift.io/is-external``."""
+    return {
+        "metadata": {
+            "labels": {
+                constants.OCS_EXTERNAL_STORAGECLASS_LABEL: (
+                    constants.OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE
+                ),
+            }
+        }
+    }
+
+
+def patch_storageclass_ocs_external_label(resource_name):
+    """
+    Merge-patch ``storageclass.ocs.openshift.io/is-external: "true"`` on a
+    StorageClass if it exists.
+
+    Used immediately before deleting StorageClasses in external mode so teardown
+    matches ODF expectations. No-op when ``DEPLOYMENT["external_mode"]`` is false.
+    """
+    if not config.DEPLOYMENT.get("external_mode"):
+        return
+
+    sc_ocp = OCP(kind=constants.STORAGECLASS)
+    if not sc_ocp.is_exist(resource_name=resource_name):
+        log.warning(
+            f"StorageClass {resource_name} not found; skipping pre-delete external OCS label patch"
+        )
+        return
+    log.info(
+        f"Patching StorageClass {resource_name} before delete: "
+        f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL}="
+        f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE}"
+    )
+    try:
+        sc_ocp.patch(
+            resource_name=resource_name,
+            params=json.dumps(_storageclass_ocs_external_label_patch()),
+            format_type="merge",
+        )
+    except CommandFailed as err:
+        log.warning(
+            f"Pre-delete label patch failed for StorageClass {resource_name}: {err}"
+        )
+
+
 def ocs_install_verification(
     timeout=600,
     skip_osd_distribution_check=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1286,6 +1286,9 @@ def storageclass_factory_fixture(
         """
         Delete the storageclass with retry
         """
+        from ocs_ci.ocs.resources.storage_cluster import (
+            patch_storageclass_ocs_external_label,
+        )
 
         @retry((CommandFailed, TimeoutExpiredError), tries=3, delay=5, backoff=2)
         def delete_storageclass_with_retry(sc_instance):
@@ -1300,6 +1303,7 @@ def storageclass_factory_fixture(
                 TimeoutExpiredError: If wait_for_delete times out
             """
             log.info(f"Attempting to delete storageclass: {sc_instance.name}")
+            patch_storageclass_ocs_external_label(sc_instance.name)
             sc_instance.delete()
             sc_instance.ocp.wait_for_delete(sc_instance.name, timeout=120)
             log.info(f"Successfully deleted storageclass: {sc_instance.name}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1284,11 +1284,33 @@ def storageclass_factory_fixture(
 
     def finalizer():
         """
-        Delete the storageclass
+        Delete the storageclass with retry
         """
+
+        @retry((CommandFailed, TimeoutExpiredError), tries=3, delay=5, backoff=2)
+        def delete_storageclass_with_retry(sc_instance):
+            """
+            Delete storageclass with retry on failure
+
+            Args:
+                sc_instance: StorageClass instance to delete
+
+            Raises:
+                CommandFailed: If delete operation fails
+                TimeoutExpiredError: If wait_for_delete times out
+            """
+            log.info(f"Attempting to delete storageclass: {sc_instance.name}")
+            sc_instance.delete()
+            sc_instance.ocp.wait_for_delete(sc_instance.name, timeout=120)
+            log.info(f"Successfully deleted storageclass: {sc_instance.name}")
+
         for instance in instances:
-            instance.delete()
-            instance.ocp.wait_for_delete(instance.name, timeout=120)
+            try:
+                delete_storageclass_with_retry(instance)
+            except (CommandFailed, TimeoutExpiredError) as e:
+                log.error(
+                    f"Failed to delete storageclass {instance.name} after retries: {e}"
+                )
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
Added retry to delete storageclass operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StorageClass cleanup for external OCS deployments: StorageClasses are now labeled appropriately before removal and deletion retries/reporting are more robust.

* **New Features**
  * Added explicit support for marking StorageClasses as external in external-cluster deployments.

* **Chores**
  * Updated baseline configuration for secret scanning to correct re-detected locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/14174)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->