### PR TITLE
[release-4.14] add possibility to pack mg log files to one tarball

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -167,6 +167,8 @@ Reporting related config. (Do not store secret data in the repository!).
 * `save_mem_report` - If True, test run memory report CSV file will be saved in `RUN["log_dir"]/stats_log_dir_<run_id>`
   directory along with <test name>.peak_rss_table, <test name>.peak_vms_table reports. The option may be enforced by
   exporting env variable: export SAVE_MEM_REPORT=true
+* `tarball_mg_logs` - pack MG files to tarball
+* `delete_packed_mg_logs` - applicable only if `tarball_mg_logs` is True, delete the individual MG files in case they were successfully packed
 
 #### ENV_DATA
 

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -136,6 +136,8 @@ REPORTING:
   gather_on_deploy_failure: true
   collect_logs_on_success_run: False
   rp_client_log_level: "ERROR"
+  tarball_mg_logs: true
+  delete_packed_mg_logs: true
 
 # This is the default information about environment.
 ENV_DATA:

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -4,10 +4,12 @@ import logging
 import os
 import pickle
 import re
+import tarfile
 import time
 import traceback
 import subprocess
 import shlex
+import shutil
 from subprocess import TimeoutExpired
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -903,7 +905,8 @@ def run_must_gather(log_dir_path, image, command=None, cluster_config=None):
     Runs the must-gather tool against the cluster
 
     Args:
-        log_dir_path (str): directory for dumped must-gather logs
+        log_dir_path (str): directory for dumped must-gather logs (if REPORTING["tarball_mg_logs"] is set, this
+            directory will be packed to the parent directory with extension .tar.gz)
         image (str): must-gather image registry path
         command (str): optional command to execute within the must-gather image
         cluster_config (MultiClusterConfig): Holds specifc cluster config object in case of multicluster
@@ -957,6 +960,17 @@ def run_must_gather(log_dir_path, image, command=None, cluster_config=None):
             f"Must-Gather Output: {mg_output}"
         )
         export_mg_pods_logs(log_dir_path=log_dir_path)
+
+    if ocsci_config.REPORTING.get("tarball_mg_logs"):
+        tarball_path = f"{log_dir_path}.tar.gz"
+        try:
+            with tarfile.open(tarball_path, "w:gz") as tar:
+                tar.add(log_dir_path, arcname=os.path.basename(log_dir_path))
+            if ocsci_config.REPORTING.get("delete_packed_mg_logs"):
+                shutil.rmtree(log_dir_path)
+        except Exception as err:
+            log.error(f"Failed during packing files! Error: {err}")
+
     return mg_output
 
 
@@ -1620,7 +1634,8 @@ def collect_pod_container_rpm_package(dir_name):
     Collect information about rpm packages from all containers + go version
 
     Args:
-        dir_name(str): directory to store container rpm package info
+        dir_name(str): directory to store container rpm package info (if REPORTING["tarball_mg_logs"] is set, this
+            directory will be packed to the parent directory with extension .tar.gz)
 
     """
     # Import pod here to avoid circular dependency issue
@@ -1670,3 +1685,13 @@ def collect_pod_container_rpm_package(dir_name):
                     go_log_file_name = f"{package_log_dir_path}/{pod_obj.name}-{container_name}-go-version.log"
                     with open(go_log_file_name, "w") as f:
                         f.write(go_output)
+
+    if ocsci_config.REPORTING.get("tarball_mg_logs"):
+        tarball_path = f"{package_log_dir_path}.tar.gz"
+        try:
+            with tarfile.open(tarball_path, "w:gz") as tar:
+                tar.add(log_dir_path, arcname=os.path.basename(log_dir_path))
+            if ocsci_config.REPORTING.get("delete_packed_mg_logs"):
+                shutil.rmtree(log_dir_path)
+        except Exception as err:
+            log.error(f"Failed during packing files! Error: {err}")


### PR DESCRIPTION
This is backport of [PR#14117](https://github.com/red-hat-storage/ocs-ci/pull/14117).

The aim of this PR is to allow packing all individual MG (and related) files to one tarball. There are two reasons for this approach:
* save space (the tarballed MG files are 10 times smaller than the original files)
* allow easy download for local examination