### PR TITLE
Use Deployment in the fixture create_pvcs_and_pods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7059,7 +7059,7 @@ def create_pvcs_and_pods(multi_pvc_factory, pod_factory, service_account_factory
                 interface = constants.CEPHBLOCKPOOL
 
             if deployment:
-                pod_dict_path = pod_dict_path or constants.FEDORA_DC_YAML
+                pod_dict_path = pod_dict_path or constants.FEDORA_DEPLOY_YAML
             elif pvc_obj.volume_mode == "Block":
                 pod_dict_path = pod_dict_path or constants.CSI_RBD_RAW_BLOCK_POD_YAML
             else:


### PR DESCRIPTION
Use Deployment in the fixture create_pvcs_and_pods instead of DeploymentConfig.
Fixes #14194 
