### PR TITLE
Add dev user infrastructure for S3 Object Browser UI

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -559,7 +559,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 327,
+        "line_number": 325,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -567,7 +567,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 370,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -646,10 +646,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1970,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2070,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2076,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -662,10 +678,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2077,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2072,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2078,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -678,10 +710,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2079,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2078,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -694,10 +742,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2099,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2094,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,10 +774,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2108,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2103,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -726,10 +806,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2105,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -742,10 +838,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2112,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2837,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2843,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -758,6 +870,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2844,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
@@ -766,10 +886,42 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3545,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3546,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
         "line_number": 3540,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3546,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3547,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -853,7 +1005,7 @@
         "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 331,
+        "line_number": 329,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -861,7 +1013,7 @@
         "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 643,
+        "line_number": 641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -869,7 +1021,7 @@
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 644,
+        "line_number": 642,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -983,6 +1135,14 @@
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
+      {
+        "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 576,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1186,6 +1186,12 @@ OPERATOR_SOURCE_SECRET_YAML = os.path.join(
 OPERATOR_SOURCE_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "operator-source.yaml")
 
 HTPASSWD_IDP_YAML = os.path.join(TEMPLATE_AUTHENTICATION_DIR, "htpasswd_provider.yaml")
+NOOBAA_ODF_UI_CLUSTERROLE_YAML = os.path.join(
+    TEMPLATE_AUTHENTICATION_DIR, "noobaa_odf_ui_clusterrole.yaml"
+)
+NOOBAA_ODF_UI_CLUSTERROLEBINDING_YAML = os.path.join(
+    TEMPLATE_AUTHENTICATION_DIR, "noobaa_odf_ui_clusterrolebinding.yaml"
+)
 
 IBM_COS_SECRET_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "ibm-cloud-secret.yaml")
 OCS_OPERATOR_CSV_YAML = "ocs-operator.clusterserviceversion.yaml"

--- a/ocs_ci/templates/authentication/noobaa_odf_ui_clusterrole.yaml
+++ b/ocs_ci/templates/authentication/noobaa_odf_ui_clusterrole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: noobaa-odf-ui
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - noobaa.io
+    resources:
+      - noobaas
+      - bucketclasses
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ""
+    resources:
+      - namespaces
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ""
+    resources:
+      - secrets

--- a/ocs_ci/templates/authentication/noobaa_odf_ui_clusterrolebinding.yaml
+++ b/ocs_ci/templates/authentication/noobaa_odf_ui_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: noobaa-odf-ui-binding-PLACEHOLDER
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: PLACEHOLDER_USERNAME
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: noobaa-odf-ui


### PR DESCRIPTION
Adds automation for creating dev users with minimal RBAC permissions to test the Object Browser S3 login feature

- [x] Add DevUser dataclass to hold OpenShift and S3 credentials
- [x] Add dev_user_factory fixture that creates htpasswd users with NooBaa accounts
- [x] Add noobaa-odf-ui ClusterRole with permissions for noobaa.io, namespaces, and secrets
- [x] Add RBAC helper functions
