### PR TITLE
Add high priority tests for RHSTOR-7576 (NooBaa optimization utilizing secondary DB pod)

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1939,7 +1939,7 @@ def get_pod_logs(
     tail=None,
     grep=None,
     regex=False,
-    case_senitive=False,
+    case_sensitive=False,
     context=0,
     return_empty_string=True,
     first_match_only=True,
@@ -1958,7 +1958,7 @@ def get_pod_logs(
         grep (str): filter the logs by the given string
         regex (bool): True, if the grep is a regex. False otherwise.
             Applicable only if grep is provided.
-        case_senitive (bool): True, if the grep is case sensitive. False otherwise.
+        case_sensitive (bool): True, if the grep is case sensitive. False otherwise.
             Applicable only if grep is provided.
         context (int): number of lines to show before and after the matching line
             Applicable only if grep is provided.
@@ -1987,7 +1987,7 @@ def get_pod_logs(
     if grep:
         regex_flag = "-E" if regex else ""
         cmd += f" | grep {regex_flag} '{grep}'"
-        if not case_senitive:
+        if not case_sensitive:
             cmd += " -i"
         if context:
             cmd += f" -C {context}"

--- a/tests/functional/object/mcg/test_secondary_db_optimization.py
+++ b/tests/functional/object/mcg/test_secondary_db_optimization.py
@@ -1,7 +1,8 @@
+import pytest
 import json
 import logging
 from time import sleep
-import pytest
+from ocs_ci.framework.pytest_customization.marks import tier4
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
@@ -12,13 +13,21 @@ from ocs_ci.framework.testlib import (
     tier2,
 )
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import (
+    compare_directory,
+    sync_object_directory,
+    write_random_test_objects_to_bucket,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import (
     get_pod_logs,
+    wait_for_pods_to_be_running,
 )
-from ocs_ci.utility.utils import get_secondary_nb_db_pod
+from ocs_ci.utility.utils import get_primary_nb_db_pod, get_secondary_nb_db_pod
 
 logger = logging.getLogger(__name__)
+
+WAIT_TIME = 90  # seconds
 
 
 @red_squad
@@ -65,14 +74,18 @@ class TestSecondaryDbOptimization(MCGTest):
                 )
             else:
                 ocp_obj.patch(
-                    resource_name=constants.NB_DB_CNPG_CLUSTER_NAME,
                     params='[{"op": "remove", "path": "/spec/postgresql/parameters/log_statement"}]',
                     format_type="json",
                 )
 
         def implementation():
-            original_log_level = ocp_obj.get()["spec"]["postgresql"]["parameters"].get(
-                "log_statement"
+            nonlocal original_log_level
+            original_log_level = (
+                ocp_obj.get()
+                .get("spec", {})
+                .get("postgresql", {})
+                .get("parameters", {})
+                .get("log_statement")
             )
             if original_log_level != "all":
                 params_dict["spec"]["postgresql"]["parameters"]["log_statement"] = "all"
@@ -83,29 +96,14 @@ class TestSecondaryDbOptimization(MCGTest):
         request.addfinalizer(finalizer)
         implementation()
 
-    @tier2
-    @polarion_id("OCS-7410")
     @config.run_with_provider_context_if_available
-    def test_secondary_db_ro_queries(self, add_env_vars_to_noobaa_core):
+    @pytest.fixture(autouse=True, scope="class")
+    def decrease_nb_core_bg_ops_interval(self, add_env_vars_to_noobaa_core_class):
         """
-        Test that the secondary DB is now receiving the expected read-only operations instead
-        of the primary DB.
-
-        1. Increase the frequency relevant noobaa-core background operations
-        2. Wait a bit for the expected queries to be executed
-        3. Verify that in the noobaa-core logs that the expected queries were sent to the secondary DB
-        4. Verify that the secondary DB pod is receiving the expected queries
+        Decrease the interval of the noobaa-core background operations.
+        This is required to guarantee that the expected queries are executed on the secondary DB.
         """
-        WAIT_TIME = 90  # seconds
-
-        EXPECTED_QUERIES_TO_KEYWORDS = {
-            "DB Cleaner": ["datablocks", "deleted"],
-            "Object Reclaimer": ["objectmds", "reclaimed"],
-            "Scrubber": ["datachunks", "deleted"],
-        }
-
-        # 1. Increase the frequency relevant noobaa-core background operations
-        add_env_vars_to_noobaa_core(
+        add_env_vars_to_noobaa_core_class(
             [
                 (constants.SCRUBBER_INTERVAL, 1 * 60 * 1000),
                 (constants.OBJECT_RECLAIMER_INTERVAL, 1 * 60 * 1000),
@@ -117,46 +115,205 @@ class TestSecondaryDbOptimization(MCGTest):
             ]
         )
 
-        # 2. Wait a bit for the expected queries to be executed
+    @tier2
+    @polarion_id("OCS-7410")
+    @config.run_with_provider_context_if_available
+    def test_secondary_db_ro_queries(self, add_env_vars_to_noobaa_core):
+        """
+        Test that the secondary DB is now receiving the expected read-only operations instead
+        of the primary DB.
+
+        1. Wait a bit for the expected queries to be executed
+        2. Verify that in the noobaa-core logs that the expected queries were sent to the secondary DB
+        3. Verify that the secondary DB pod is receiving the expected queries
+        """
+        WAIT_TIME = 90  # seconds
+
+        EXPECTED_QUERIES_TO_KEYWORDS = {
+            "DB Cleaner": ["datablocks", "deleted"],
+            "Object Reclaimer": ["objectmds", "reclaimed"],
+            "Scrubber": ["datachunks", "deleted"],
+        }
+
+        # 1. Wait a bit for the expected queries to be executed
         logger.info(
             f"Waiting {WAIT_TIME} seconds for the expected queries to be executed"
         )
         sleep(WAIT_TIME)
 
-        # 3. Verify that in the noobaa-core logs that the expected queries were sent to the secondary DB
+        # 2. Verify that in the noobaa-core logs that the expected queries were sent to the secondary DB
         nb_core_ro_queries = get_pod_logs(
             pod_name=constants.NOOBAA_CORE_POD,
             namespace=config.ENV_DATA["cluster_namespace"],
             since="5m",
             grep=f"pg_client.*host.*{constants.CNPG_READ_ONLY_HOST}.*SELECT",
             regex=True,
+            case_sensitive=True,
             first_match_only=False,
         ).split("\n")
         for expected_query, keywords in EXPECTED_QUERIES_TO_KEYWORDS.items():
             assert any(
-                all(kword in query for kword in keywords)
-                for query in nb_core_ro_queries
+                all(word in query for word in keywords) for query in nb_core_ro_queries
             ), f"noobaa-core logs do not contain the expected query for: {expected_query}"
 
-        # 4. Verify that the secondary DB pod is receiving the expected queries
-        db_pod = get_secondary_nb_db_pod()
-        db_ro_queries_raw_logs = [
-            line
-            for line in get_pod_logs(
-                pod_name=db_pod.name,
-                namespace=config.ENV_DATA["cluster_namespace"],
-                since="5m",
-                grep="nbcore.*statement.*SELECT",
-                regex=True,
-                first_match_only=False,
-            ).split("\n")
-            if line  # filter out empty lines for json parsing
-        ]
-        db_ro_queries = [
-            json.loads(json_line).get("record", {}).get("message")
-            for json_line in db_ro_queries_raw_logs
-        ]
+        # 3. Verify that the secondary DB pod is receiving the expected queries
+        db_ro_queries = _get_secondary_db_ro_noobaa_queries()
         for expected_query, keywords in EXPECTED_QUERIES_TO_KEYWORDS.items():
             assert any(
-                all(kword in query for kword in keywords) for query in db_ro_queries
+                all(word in query for word in keywords) for query in db_ro_queries
             ), f"secondary DB pod logs do not contain the expected query for: {expected_query}"
+
+    @config.run_with_provider_context_if_available
+    @pytest.mark.parametrize(
+        argnames=["fetch_cnpg_pod_func"],
+        argvalues=[
+            pytest.param(
+                get_primary_nb_db_pod,
+                marks=[tier4, pytest.mark.polarion_id("OCS-7416")],
+            ),
+            pytest.param(
+                get_secondary_nb_db_pod,
+                marks=[tier4, pytest.mark.polarion_id("OCS-7417")],
+            ),
+        ],
+        ids=[
+            "primary-db-pod",
+            "secondary-db-pod",
+        ],
+    )
+    def test_secondary_queries_after_cnpg_pod_respin(
+        self,
+        fetch_cnpg_pod_func,
+        bucket_factory,
+        awscli_pod,
+        mcg_obj,
+        test_directory_setup,
+    ):
+        """
+        Verify data integrity and read-only queries traffic after respinning CNPG's pods
+
+        1. Create a bucket and populate it with random objects
+        2. Respin the CNPG pod
+        3. Download and compare integrity to the original files
+        4. Create another bucket and populate it with random objects
+        5. Download and compare integrity to the original files
+        6. Check that read-only queries traffic is still going to the secondary DB pod
+        """
+        OBJ_AMOUNT = 2
+
+        # 1. Create first bucket and write random objects
+        first_bucket = bucket_factory(amount=1, interface="OC")[0].name
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=first_bucket,
+            file_dir=test_directory_setup.origin_dir,
+            amount=OBJ_AMOUNT,
+            pattern="NbDbRespinA-",
+            mcg_obj=mcg_obj,
+        )
+        sync_object_directory(
+            awscli_pod,
+            f"s3://{first_bucket}/",
+            test_directory_setup.result_dir,
+            s3_obj=mcg_obj,
+        )
+        assert compare_directory(
+            awscli_pod=awscli_pod,
+            original_dir=test_directory_setup.origin_dir,
+            result_dir=test_directory_setup.result_dir,
+            amount=OBJ_AMOUNT,
+            pattern="NbDbRespinA-",
+        ), "Objects are not the same on the first bucket before respinning CNPG pod"
+
+        # 2. Respin the requested CNPG pod and wait for it to return to Running
+        cnpg_pod = fetch_cnpg_pod_func()
+        logger.info(f"Respining CNPG pod {cnpg_pod.name}")
+        cnpg_pod.delete(force=True)
+        assert wait_for_pods_to_be_running(
+            pod_names=[cnpg_pod.name],
+            raise_pod_not_found_error=True,
+            timeout=300,
+            sleep=10,
+        ), f"CNPG pod {cnpg_pod.name} did not return to Running state in time"
+
+        # 3. Download and compare integrity to the original files
+        sync_object_directory(
+            awscli_pod,
+            f"s3://{first_bucket}/",
+            test_directory_setup.result_dir,
+            s3_obj=mcg_obj,
+        )
+        assert compare_directory(
+            awscli_pod=awscli_pod,
+            original_dir=test_directory_setup.origin_dir,
+            result_dir=test_directory_setup.result_dir,
+            amount=OBJ_AMOUNT,
+            pattern="NbDbRespinA-",
+        ), "Objects are not the same on the first bucket after respinning CNPG pod"
+
+        # 4. Create another bucket and populate it with random objects
+        second_bucket = bucket_factory(amount=1, interface="OC")[0].name
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=second_bucket,
+            file_dir=test_directory_setup.origin_dir,
+            amount=OBJ_AMOUNT,
+            pattern="NbDbRespinB-",
+            mcg_obj=mcg_obj,
+        )
+
+        # 5. Download and compare integrity to the original files
+        sync_object_directory(
+            awscli_pod,
+            f"s3://{second_bucket}/",
+            test_directory_setup.result_dir,
+            s3_obj=mcg_obj,
+        )
+        assert compare_directory(
+            awscli_pod=awscli_pod,
+            original_dir=test_directory_setup.origin_dir,
+            result_dir=test_directory_setup.result_dir,
+            amount=OBJ_AMOUNT,
+            pattern="NbDbRespinB-",
+        ), "Objects are not the same on the new bucket after respinning CNPG pod"
+
+        # 6. Validate RO queries are still going to the secondary DB pod
+        logger.info(
+            f"Waiting {WAIT_TIME} seconds for the expected queries to be executed"
+        )
+        sleep(WAIT_TIME)
+        secondary_db_ro_queries = _get_secondary_db_ro_noobaa_queries()
+        assert (
+            len(secondary_db_ro_queries) > 0
+        ), "secondary DB pod logs do not contain any SELECT queries"
+
+
+def _get_secondary_db_ro_noobaa_queries():
+    """
+    Get RO noobaa queries that are made against a given CNPG pod.
+
+    Args:
+        timeout (int): Timeout to wait for the logs
+
+    Returns:
+        list of strings: The RO noobaa queries that are made against the secondary DB pod
+    """
+    db_ro_queries_raw_logs = [
+        line
+        for line in get_pod_logs(
+            pod_name=get_secondary_nb_db_pod().name,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            since="5m",
+            grep="nbcore.*statement.*SELECT",
+            regex=True,
+            first_match_only=False,
+            case_sensitive=False,
+        ).split("\n")
+        if line  # filter out empty lines for json parsing
+    ]
+    db_ro_queries = [
+        json.loads(json_line).get("record", {}).get("message")
+        for json_line in db_ro_queries_raw_logs
+    ]
+    return db_ro_queries

--- a/tests/functional/object/mcg/test_secondary_db_optimization.py
+++ b/tests/functional/object/mcg/test_secondary_db_optimization.py
@@ -127,8 +127,6 @@ class TestSecondaryDbOptimization(MCGTest):
         2. Verify that in the noobaa-core logs that the expected queries were sent to the secondary DB
         3. Verify that the secondary DB pod is receiving the expected queries
         """
-        WAIT_TIME = 90  # seconds
-
         EXPECTED_QUERIES_TO_KEYWORDS = {
             "DB Cleaner": ["datablocks", "deleted"],
             "Object Reclaimer": ["objectmds", "reclaimed"],


### PR DESCRIPTION
The high priority tests for https://issues.redhat.com/browse/RHSTOR-7576, which is about utilizing the secondary NooBaa DB pod for handling some of the read-only queries.

The added tests are:
-  `test_secondary_queries_after_cnpg_pod_respin[primary-db-pod]`
-  `test_secondary_queries_after_cnpg_pod_respin[secondary-db-pod]`

They both check the effect of deleting the CNPG pods on object data integrity and the persistence of the redirection of the read only queries to the secondary DB pod.