### PR TITLE
Corrects volume snapshot class name for db backup and recovery process

### DIFF
--- a/tests/functional/object/mcg/test_noobaa_db_backup_recovery.py
+++ b/tests/functional/object/mcg/test_noobaa_db_backup_recovery.py
@@ -114,7 +114,7 @@ class TestNoobaaDbBackupRecoveryOps:
         )
         # patch storagecluster object
         num_backups = 2
-        snapshot_class = "vpc-block-snapshot"
+        snapshot_class = constants.DEFAULT_VOLUMESNAPSHOTCLASS_RBD
         schedule_cron_interval = 5
 
         # TO DO


### PR DESCRIPTION
While testing MCG only deployment, I changed volumesnapshot class from `ocs-storagecluster-rbdplugin-snapclass` to `vpc-block-snapshot` and while doing some cosmetic changes in #14062 , Mistakenly I pushed the code with `vpc-block-snapshot` 

this value has been corrected in this PR