### PR TITLE
RHSTOR-7671: Test to verify upgrade False status when storagecluster not ready

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -626,6 +626,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 808,
+        "line_number": 808,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,6 +635,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 817,
+        "line_number": 817,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -641,7 +643,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1964,
+        "line_number": 1965,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +651,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2070,
+        "line_number": 2071,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +659,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2071,
+        "line_number": 2072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +667,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2072,
+        "line_number": 2073,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +675,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2073,
+        "line_number": 2074,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +683,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2078,
+        "line_number": 2079,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +691,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2093,
+        "line_number": 2094,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +699,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2094,
+        "line_number": 2095,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +707,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2102,
+        "line_number": 2103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +715,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2103,
+        "line_number": 2104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +723,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +731,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2105,
+        "line_number": 2106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +739,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2106,
+        "line_number": 2107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +747,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2837,
+        "line_number": 2838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +755,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2838,
+        "line_number": 2839,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +763,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3539,
+        "line_number": 3540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +771,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3540,
+        "line_number": 3541,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1577,6 +1577,7 @@ ALERT_ODF_PERSISTENT_VOLUME_MIRROR_STATUS = "ODFPersistentVolumeMirrorStatus"
 ALERT_OBC_QUOTA_BYTES_ALERT = "ObcQuotaBytesAlert"
 ALERT_MDSCACHEUSAGEHIGH = "MDSCacheUsageHigh"
 ALERT_MDSCPUUSAGEHIGH = "MDSCPUUsageHigh"
+ALERT_ODFOPERATORNOTUPGRADABLE = "ODFOperatorNotUpgradeable"
 
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"

--- a/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
+++ b/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
@@ -19,22 +19,75 @@ from ocs_ci.ocs.resources.csv import (
     get_operator_csv_names,
     check_operatorcondition_upgradeable_false,
 )
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.storage_cluster import StorageCluster
 
 log = logging.getLogger(__name__)
+
+
+def verify_odf_not_upgradeable(threading_lock):
+    """
+    This Function Verifies ODFOperatorNotUpgradeable alert using PrometheusAPI
+
+    Args:
+        threading_lock: Threading lock for Prometheus API calls
+
+    Returns:
+        bool: True if ODFOperatorNotUpgradeable alert found otherwise False
+
+    """
+    log.info("Verifying ODFOperatorNotUpgradeable alert is shown")
+
+    alert_name = constants.ALERT_ODFOPERATORNOTUPGRADABLE
+
+    try:
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        # Wait for alert to appear (may take some time)
+        alerts = prometheus.wait_for_alert(
+            name=alert_name,
+            state="firing",
+            timeout=300,
+            sleep=10,
+        )
+        if alerts:
+            log.info(f"✓ Alert {alert_name} is firing as expected")
+            log.info(f"Alert details: {alerts}")
+            return True
+        else:
+            # Also check if alert exists in any state
+            alerts_response = prometheus.get(
+                "alerts", payload={"silenced": False, "inhibited": False}
+            )
+            if alerts_response.ok:
+                all_alerts = alerts_response.json().get("data", {}).get("alerts", [])
+                for alert in all_alerts:
+                    if alert.get("labels", {}).get("alertname") == alert_name:
+                        log.info(
+                            f"✓ Alert {alert_name} found "
+                            f"(state: {alert.get('state')})"
+                        )
+                        log.info(f"Alert details: {alert}")
+                        return True
+            return False
+    except Exception as e:
+        log.warning(f"Could not check for {alert_name} alert: {e}. ")
+        return False
 
 
 @brown_squad
 @skipif_mcg_only
 @tier2
-@pytest.mark.polarion_id("OCS-7422")
-class TestODFUpgradePrecheckCephHealth(ManageTest):
+class TestODFUpgradePrecheckConditions(ManageTest):
     """
-    Test class for ODF upgrade pre-check conditions related to Ceph health.
+    Test class for ODF upgrade pre-check conditions like
+    1. Ceph Heath Not OK state (warn/error)
+    2. Storagecluster not Ready State ( progressing/Error/degraded)
 
     This class contains tests that verify upgrade is blocked when
-    Ceph cluster health is not in optimal state.
+    ODF upgrade pre-check conditions not met
     """
 
+    @pytest.mark.polarion_id("OCS-7422")
     def test_ceph_health_warning_blocks_upgrade(self, mon_pod_down, threading_lock):
         """
         Test that ODF upgrade is blocked when Ceph cluster health is in WARN state.
@@ -82,18 +135,22 @@ class TestODFUpgradePrecheckCephHealth(ManageTest):
         log.info(f"OCS CSV name: {ocs_csv_name}")
         log.info(f"ODF CSV name: {odf_csv_name}")
 
-        # Check OCS OperatorCondition
+        # Check OCS OperatorCondition with specific reason
         ocs_condition_met = check_operatorcondition_upgradeable_false(
             operator_name="OCS",
             csv_name=ocs_csv_name,
             namespace=namespace,
+            reason="CephClusterHealthNotOK",
+            message_pattern="CephCluster health is HEALTH_WARN.",
         )
 
-        # Check ODF OperatorCondition
+        # Check ODF OperatorCondition with specific reason
         odf_condition_met = check_operatorcondition_upgradeable_false(
             operator_name="ODF",
             csv_name=odf_csv_name,
             namespace=namespace,
+            reason="CephClusterHealthNotOK",
+            message_pattern="CephCluster health is HEALTH_WARN.",
         )
 
         # Log assertion results
@@ -108,46 +165,9 @@ class TestODFUpgradePrecheckCephHealth(ManageTest):
             log.warning("⚠ ODF OperatorCondition check did not pass ")
 
         # Verify ODFOperatorNotUpgradeable alert is shown
-        log.info("Verifying ODFOperatorNotUpgradeable alert is shown")
+        alert_found = verify_odf_not_upgradeable(threading_lock)
 
-        alert_name = "ODFOperatorNotUpgradeable"
-        alert_found = False
-
-        try:
-            prometheus = PrometheusAPI(threading_lock=threading_lock)
-            # Wait for alert to appear (may take some time)
-            alerts = prometheus.wait_for_alert(
-                name=alert_name,
-                state="firing",
-                timeout=300,
-                sleep=10,
-            )
-            if alerts:
-                log.info(f"✓ Alert {alert_name} is firing as expected")
-                log.info(f"Alert details: {alerts}")
-                alert_found = True
-            else:
-                # Also check if alert exists in any state
-                alerts_response = prometheus.get(
-                    "alerts", payload={"silenced": False, "inhibited": False}
-                )
-                if alerts_response.ok:
-                    all_alerts = (
-                        alerts_response.json().get("data", {}).get("alerts", [])
-                    )
-                    for alert in all_alerts:
-                        if alert.get("labels", {}).get("alertname") == alert_name:
-                            log.info(
-                                f"✓ Alert {alert_name} found "
-                                f"(state: {alert.get('state')})"
-                            )
-                            log.info(f"Alert details: {alert}")
-                            alert_found = True
-                            break
-        except Exception as e:
-            log.warning(f"Could not check for {alert_name} alert: {e}. ")
-
-        # Summary
+        # Test Summary
         log.info("=" * 80)
         log.info("Test Summary:")
         log.info(
@@ -177,4 +197,103 @@ class TestODFUpgradePrecheckCephHealth(ManageTest):
         log.info(
             "Test completed: Upgrade should be blocked when Ceph health "
             "is in WARN state"
+        )
+
+    @pytest.mark.polarion_id("OCS-4172")
+    def test_storagecluster_not_ready_blocks_upgrade(
+        self, storagecluster_to_progressing, threading_lock
+    ):
+        """
+        Test that ODF upgrade is blocked when StorageCluster is not in Ready
+        state (Progressing, Not Ready, or Degraded).
+
+        Steps:
+        1. Push a StorageCluster intentionally to a state which is not
+           a "Ready" state (handled by fixture)
+           Method: Changes the resourceProfile spec field, which triggers a
+           Progressing state transition (3-5 minutes).
+
+        2. Verify StorageCluster status Ready=progressing
+
+        Expected Result:
+        1. ODF OperatorCondition CR: Upgradeable=False,
+           Reason: "StorageClusterNotReady"
+        2. The operator being not Upgradeable should be shown as an Alert
+           ODFOperatorNotUpgradeable
+
+        Args:
+            storagecluster_to_progressing: Fixture that patches StorageCluster
+                resourceProfile to Progressing state and restores it in teardown
+            threading_lock: Threading lock for Prometheus API calls
+
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # Step 1: Push StorageCluster to Progressing state (handled by fixture)
+        log.info(
+            "Step 1: StorageCluster resourceProfile is patched to trigger "
+            "Progressing state (handled by fixture)"
+        )
+
+        # Step 2: Verify StorageCluster status is Progressing
+        log.info("Step 2: Verifying StorageCluster status is Progressing")
+
+        sc_name = storagecluster_to_progressing
+        storage_cluster = StorageCluster(resource_name=sc_name, namespace=namespace)
+        storage_cluster.reload_data()
+        phase = storage_cluster.data.get("status", {}).get("phase")
+        log.info(f"StorageCluster {sc_name} phase: {phase}")
+
+        # Verify phase is Progressing
+        assert (
+            phase == constants.STATUS_PROGRESSING
+        ), f"Expected Progressing phase but got: {phase}"
+
+        # Check OperatorCondition CR for ODF operator
+        log.info("Checking OperatorCondition CR for ODF operator")
+
+        # Get CSV name for ODF operator
+        _, odf_csv_name = get_operator_csv_names(namespace=namespace)
+
+        log.info(f"ODF CSV name: {odf_csv_name}")
+
+        # Check ODF OperatorCondition with specific reason
+        odf_condition_met = check_operatorcondition_upgradeable_false(
+            operator_name="ODF",
+            csv_name=odf_csv_name,
+            namespace=namespace,
+            reason="StorageClusterNotReady",
+        )
+
+        # Log assertion results
+        if odf_condition_met:
+            log.info("✓ ODF OperatorCondition correctly shows Upgradeable=False")
+        else:
+            log.warning("⚠ ODF OperatorCondition check did not pass ")
+
+        # Verify ODFOperatorNotUpgradeable alert is shown
+        alert_found = verify_odf_not_upgradeable(threading_lock)
+
+        # Summary
+        log.info("=" * 80)
+        log.info("Test Summary:")
+        log.info(
+            f"  ODF OperatorCondition Upgradeable=False: "
+            f"{'✓' if odf_condition_met else '⚠'}"
+        )
+        log.info(
+            f"  ODFOperatorNotUpgradeable Alert: " f"{'✓' if alert_found else '⚠'}"
+        )
+        log.info("=" * 80)
+
+        # Assertions for test validation
+        assert odf_condition_met, (
+            "ODF OperatorCondition should show Upgradeable=False with reason "
+            "'StorageClusterNotReady'"
+        )
+        assert alert_found, "ODFOperatorNotUpgradeable alert not found."
+
+        log.info(
+            "Test completed: Upgrade should be blocked when StorageCluster "
+            "is not in Ready state"
         )


### PR DESCRIPTION
- [RHSTOR-7671](https://issues.redhat.com//browse/RHSTOR-7671): Test that ODF upgrade is blocked/False when StorageCluster is not in Ready state (Progressing)
- Reformat the previous test case for code optimisation
- Update check_operatorcondition_upgradeable_false () to be used generically. 
- Update test with function for alert verification, to be used by other tests in existing test file. 