### PR TITLE
Use run_io direct=1 when PVC volume mode is Block

### DIFF
--- a/tests/cross_functional/system_test/multicluster/test_acceptance.py
+++ b/tests/cross_functional/system_test/multicluster/test_acceptance.py
@@ -101,6 +101,7 @@ class TestAcceptance(ManageTest):
                     storage_type=storage_type,
                     size="1GB",
                     verify=True,
+                    direct=int(mode[2] == constants.VOLUME_MODE_BLOCK),
                 )
                 self.pod_objs.append(pod_obj)
 

--- a/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -227,6 +227,7 @@ class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
                 size=f"{io_size}G",
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_io",
+                direct=int(storage_type == "block"),
             )
 
     @polarion_id("OCS-2755")

--- a/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
+++ b/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
@@ -141,6 +141,7 @@ class TestRbdBlockPvc(ManageTest):
             io_direction="write",
             runtime=30,
             end_fsync=1,
+            direct=1,
         )
         log.info(f"IO started on the new pod {pod_obj_new.name}")
 

--- a/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_resource_deletion_during_pvc_pod_creation_deletion_and_io.py
@@ -230,6 +230,7 @@ class TestResourceDeletionDuringMultipleCreateDeleteOperations(ManageTest):
                 size=f"{io_size}G",
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_io",
+                direct=int(storage_type == "block"),
             )
 
     @polarion_id("OCS-5176")

--- a/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
@@ -72,6 +72,7 @@ class TestCloneWithDifferentAccessMode(ManageTest):
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on all pods")

--- a/tests/functional/pv/pvc_clone/test_node_restart_during_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_node_restart_during_pvc_clone.py
@@ -90,6 +90,7 @@ class TestNodeRestartDuringPvcClone(ManageTest):
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on all pods")
@@ -200,6 +201,7 @@ class TestNodeRestartDuringPvcClone(ManageTest):
                 runtime=20,
                 fio_filename=f"{file_name}_1",
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on the new pods")

--- a/tests/functional/pv/pvc_clone/test_resource_deletion_during_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_resource_deletion_during_pvc_clone.py
@@ -96,6 +96,7 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
                 runtime=30,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
 
         log.info("Wait for IO to complete on pods")
@@ -231,6 +232,7 @@ class TestResourceDeletionDuringPvcClone(ManageTest):
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
 
         log.info("Wait for IO to complete on new pods")

--- a/tests/functional/pv/pvc_resize/test_node_restart_during_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_node_restart_during_pvc_expansion.py
@@ -196,6 +196,7 @@ class TestNodeRestartDuringPvcExpansion(ManageTest):
                 runtime=30,
                 fio_filename=f"{pod_obj.name}_file",
                 end_fsync=1,
+                direct=int(storage_type == "block"),
             )
 
         assert (

--- a/tests/functional/pv/pvc_resize/test_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_pvc_expansion.py
@@ -168,6 +168,7 @@ class TestPvcExpand(ManageTest):
                 io_direction="write",
                 runtime=60,
                 fio_filename=f"{pod_obj.name}_{io_phase}",
+                direct=int(storage_type == "block"),
             )
             log.info(f"{io_phase} IO started on pod {pod_obj.name}.")
         log.info(f"{io_phase} IO started on pods.")

--- a/tests/functional/pv/pvc_resize/test_resource_deletion_during_pvc_expansion.py
+++ b/tests/functional/pv/pvc_resize/test_resource_deletion_during_pvc_expansion.py
@@ -109,6 +109,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
                 runtime=30,
                 rate="10M",
                 fio_filename=f"{pod_obj.name}_f1",
+                direct=int(storage_type == "block"),
             )
 
         log.info("Wait for IO to complete on pods")
@@ -198,6 +199,7 @@ class TestResourceDeletionDuringPvcExpansion(ManageTest):
                 rate="10M",
                 fio_filename=f"{pod_obj.name}_f2",
                 end_fsync=1,
+                direct=int(storage_type == "block"),
             )
 
         log.info("Wait for IO to complete on all pods")

--- a/tests/functional/pv/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
+++ b/tests/functional/pv/pvc_snapshot/test_resource_deletion_during_snapshot_restore.py
@@ -80,6 +80,7 @@ class TestResourceDeletionDuringSnapshotRestore(ManageTest):
                 runtime=30,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
 
         log.info("Wait for IO to complete on pods")
@@ -248,6 +249,7 @@ class TestResourceDeletionDuringSnapshotRestore(ManageTest):
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
 
         log.info("Wait for IO to complete on new pods")

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
@@ -81,6 +81,7 @@ class TestRestoreSnapshotWhenParentPVCDeleted(ManageTest):
                 runtime=20,
                 fio_filename=file_name,
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on all pods")

--- a/tests/functional/storageclass/test_storageclassclaim.py
+++ b/tests/functional/storageclass/test_storageclassclaim.py
@@ -112,6 +112,7 @@ class TestStorageClassClaim(ManageTest):
                 runtime=20,
                 fio_filename="file1",
                 end_fsync=1,
+                direct=int(pod_obj.pvc.volume_mode == constants.VOLUME_MODE_BLOCK),
             )
             log.info(f"IO started on pod {pod_obj.name}")
         log.info("Started IO on all pods")


### PR DESCRIPTION
Use direct=1 when calling run_io function if the volume mode of the PVC is Block.
Fixes #14229 as well as some other tests.