### PR TITLE
Submariner Azure details is needed for IPI deployment only

### DIFF
--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -278,7 +278,7 @@ class AcmAddClusters(AcmPageNavigator):
             for cluster_index in [primary_index, secondary_index]
             if config.clusters[cluster_index].ENV_DATA["platform"]
             == constants.AZURE_PLATFORM
-            and config.ENV_DATA["deployment_type"] == "ipi"
+            and config.clusters[cluster_index].ENV_DATA.get("deployment_type") == "ipi"
         ]
 
         increase_gateway_number = 2


### PR DESCRIPTION
Azure specific details during submariner addon installation from ACM UI is required for Azure IPI deployment only. This is not needed for Azure RedHat OpenShift cluster.