### PR TITLE
add GNU coreutils to support advanced df flags

### DIFF
--- a/Docker_files/nginx/Dockerfile
+++ b/Docker_files/nginx/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=$BUILDPLATFORM nginx:alpine
 RUN apk update
 RUN apk upgrade
 RUN apk add fio bash
-RUN apk add --no-cache util-linux
+RUN apk add --no-cache util-linux coreutils
 
 
 # Build and Push the multi-architecture Docker image using Docker Buildx:

--- a/ocs_ci/resiliency/workloads/fio_workload_template.yaml
+++ b/ocs_ci/resiliency/workloads/fio_workload_template.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ fio_name }}
-  namespace: {{ namespace }}
+  name: "{{ fio_name }}"
+  namespace: "{{ namespace }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ fio_name }}
+      app: "{{ fio_name }}"
   template:
     metadata:
       labels:
-        app: {{ fio_name }}
+        app: "{{ fio_name }}"
     spec:
       containers:
         - name: fio
-          image: quay.io/ocsci/nginx:fio
+          image: quay.io/ocsci/nginx:fio_new
           command:
             - fio
           args:
@@ -31,24 +31,24 @@ spec:
             - "--time_based"
             - "--ioengine=libaio"
             - "--output={{ fio_output_file }}"
-            {%- if volume_mode == "Block" %}
+            # {% if volume_mode == "Block" %}
             - "--filename=/dev/rbdblock"
-            {%- else %}
+            # {% else %}
             - "--filename=/mnt/fio_file_workload"
-            {%- endif %}
-          {%- if volume_mode == "Block" %}
+            # {% endif %}
+          # {% if volume_mode == "Block" %}
           volumeDevices:
             - name: fio-volume
               devicePath: /dev/rbdblock
-          {%- else %}
+          # {% else %}
           volumeMounts:
             - name: fio-volume
               mountPath: /mnt
-          {%- endif %}
+          # {% endif %}
       restartPolicy: Always
       volumes:
         - name: fio-volume
           persistentVolumeClaim:
-            claimName: {{ pvc_claim_name }}
+            claimName: "{{ pvc_claim_name }}"
   strategy:
     type: Recreate

--- a/ocs_ci/templates/CSI/cephfs/pod.yaml
+++ b/ocs_ci/templates/CSI/cephfs/pod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: quay.io/ocsci/nginx:fio
+     image: quay.io/ocsci/nginx:fio_new
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/CSI/rbd/pod.yaml
+++ b/ocs_ci/templates/CSI/rbd/pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: quay.io/ocsci/nginx:fio
+     image: quay.io/ocsci/nginx:fio_new
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/app-pods/ephemeral_fs.yaml
+++ b/ocs_ci/templates/app-pods/ephemeral_fs.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: quay.io/ocsci/nginx:fio
+      image: quay.io/ocsci/nginx:fio_new
       volumeMounts:
         - mountPath: "/scratch"
           name: scratch-volume

--- a/ocs_ci/templates/app-pods/ephemeral_rbd.yaml
+++ b/ocs_ci/templates/app-pods/ephemeral_rbd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: web-server
-      image: quay.io/ocsci/nginx:fio
+      image: quay.io/ocsci/nginx:fio_new
       volumeMounts:
         - mountPath: "/scratch"
           name: scratch-volume

--- a/ocs_ci/templates/app-pods/nginx.yaml
+++ b/ocs_ci/templates/app-pods/nginx.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
    - name: web-server
-     image: quay.io/ocsci/nginx:fio
+     image: quay.io/ocsci/nginx:fio_new
      volumeMounts:
        - name: mypvc
          mountPath: /var/lib/www/html

--- a/ocs_ci/templates/app-pods/raw_block_pod.yaml
+++ b/ocs_ci/templates/app-pods/raw_block_pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: my-container
-      image: quay.io/ocsci/nginx:fio
+      image: quay.io/ocsci/nginx:fio_new
       securityContext:
          capabilities: {}
       volumeDevices:


### PR DESCRIPTION
#9416 
Issue: The current `nginx:alpine` image uses the BusyBox version of df, which lacks support for GNU-specific flags like `--output`. This causes scripts relying on these flags to fail with unrecognized option errors.

Solution: Installed the `coreutils` package via apk to provide the full GNU version of system utilities (including df).

https://quay.io/repository/ocsci/nginx?tab=tags&tag=latest