### PR TITLE
Check VGS in pod logs without logging container logs in console

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2707,7 +2707,7 @@ def validate_volumegroupsnapshot(vgs_namespace):
     Validates Volume Group Snapshot resource creation from odf external snapshotter
 
     Args:
-        namespace (str): the namespace of the Volume Group snapshot resources
+        vgs_namespace (str): the namespace of the Volume Group snapshot resources
 
     """
     namespace = config.ENV_DATA["cluster_namespace"]


### PR DESCRIPTION
Search for Volume Group Snapshot in snapshotter container logs without adding the container logs in console.
Fixes #14154 

Additional changes: Fix docstring, Use a specific Exception, Get cluster namespace from config.