### PR TITLE
Noobaa chaos scenarios

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -559,7 +559,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 331,
+        "line_number": 334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -567,7 +567,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 377,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -607,7 +607,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 760,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/ocsci/krkn_chaos_config.yaml
+++ b/conf/ocsci/krkn_chaos_config.yaml
@@ -1,4 +1,5 @@
 # Krkn chaos testing configuration
+# Krknctl plan templates use defaults; adjust PlanGenerator template_vars for your cluster if needed.
 
 ENV_DATA:
   # Krkn version to clone (e.g., 'v5.0.0', 'v5.1.0')
@@ -6,7 +7,7 @@ ENV_DATA:
   krkn_version: "v5.0.0"
 
   krkn_config:
-    # Workload types: VDBENCH, CNV_WORKLOAD, RGW_WORKLOAD, FIO
+    # Workload types: VDBENCH, CNV_WORKLOAD, RGW_WORKLOAD, MCG_WORKLOAD, WARP_WORKLOAD
     workloads:
       - VDBENCH
       - RGW_WORKLOAD
@@ -23,16 +24,16 @@ ENV_DATA:
       max_verification_threads: 16
       max_workload_restarts: 10
       workload_monitor_interval: 30
-      workload_loop: 20  # Number of times to run workload (1 = run once, 20 = run 20 times)
+      workload_loop: 20 # Number of times to run workload (1 = run once, 20 = run 20 times)
 
       # Deployment configuration
-      num_pvcs_per_interface: 5  # Number of PVCs to create per storage interface (CephFS, CephBlockPool)
-      pvc_size: 50  # PVC size in GiB
+      num_pvcs_per_interface: 5 # Number of PVCs to create per storage interface (CephFS, CephBlockPool)
+      pvc_size: 50 # PVC size in GiB
 
       # Encryption configuration (requires KMS to be configured)
       # NOTE: Only RBD (Ceph Block) PVCs support encryption via storage class
       #       CephFS PVCs do NOT support per-PVC encryption (cluster-wide only)
-      use_encrypted_pvc: false  # Set to true to use encrypted RBD PVCs with encrypted storage class
+      use_encrypted_pvc: false # Set to true to use encrypted RBD PVCs with encrypted storage class
       # Cron schedule for keyrotation.csiaddons.openshift.io/schedule on encrypted RBD StorageClass
       PV_ENCRYPTION_KEYROTATION_SCHEDULE: "*/3 * * * *"
 
@@ -47,20 +48,20 @@ ENV_DATA:
 
         patterns:
           - name: "random_write"
-            rdpct: 0      # Write-only
-            seekpct: 100  # Random I/O
+            rdpct: 0 # Write-only
+            seekpct: 100 # Random I/O
             xfersize: "4k"
             skew: 0
 
           - name: "random_read"
-            rdpct: 100    # Read-only
-            seekpct: 100  # Random I/O
+            rdpct: 100 # Read-only
+            seekpct: 100 # Random I/O
             xfersize: "8k"
             skew: 0
 
           - name: "mixed_workload"
-            rdpct: 50     # 50% reads, 50% writes
-            seekpct: 100  # Random I/O
+            rdpct: 50 # 50% reads, 50% writes
+            seekpct: 100 # Random I/O
             xfersize: "64k"
             skew: 0
 
@@ -71,25 +72,25 @@ ENV_DATA:
         width: 5
         files: 10
         file_size: "1m"
-        openflags: "o_direct"  # Options: o_direct, o_sync, o_dsync, fsync, or empty for buffered I/O
+        openflags: "o_direct" # Options: o_direct, o_sync, o_dsync, fsync, or empty for buffered I/O
         group_all_fwds_in_one_rd: true
 
         patterns:
           - name: "sequential_write"
-            rdpct: 0      # Write-only
-            seekpct: 0    # Sequential I/O
+            rdpct: 0 # Write-only
+            seekpct: 0 # Sequential I/O
             xfersize: "1m"
             skew: 0
 
           - name: "random_mixed"
-            rdpct: 70     # 70% reads, 30% writes
-            seekpct: 100  # Random I/O
+            rdpct: 70 # 70% reads, 30% writes
+            seekpct: 100 # Random I/O
             xfersize: "256k"
             skew: 0
 
           - name: "small_file_ops"
-            rdpct: 50     # 50% reads, 50% writes
-            seekpct: 100  # Random I/O
+            rdpct: 50 # 50% reads, 50% writes
+            seekpct: 100 # Random I/O
             xfersize: "4k"
             skew: 0
 
@@ -100,12 +101,43 @@ ENV_DATA:
       upload_multiplier: 1
       metadata_ops_enabled: false
       delay_between_iterations: 30
-      delete_bucket_on_cleanup: true  # Automatically delete buckets after workload completes
+      delete_bucket_on_cleanup: true # Automatically delete buckets after workload completes
       operation_types:
         - upload
         - download
         - list
         - delete
+
+    # MCG/NooBaa Workload configuration (S3 workload on MCG/NooBaa)
+    mcg_config:
+      num_buckets: 3
+      iteration_count: 10
+      upload_multiplier: 1
+      metadata_ops_enabled: true # Enable metadata operations for NooBaa testing
+      delay_between_iterations: 30
+      delete_bucket_on_cleanup: true
+      operation_types:
+        - upload
+        - download
+        - list
+        - delete
+
+    # Warp Workload configuration (High-performance MCG/NooBaa stress testing)
+    # Warp is MinIO's S3 benchmarking tool for intensive stress testing
+    warp_config:
+      # Namespace where Warp pods will be deployed
+      # Options: 'default', 'openshift-storage', or any custom namespace
+      namespace: "default"
+
+      # Optional Warp S3 keys: prefer_plain_http (default true), use_internal_s3_endpoint,
+      # s3_endpoint_override, warp_insecure_tls
+
+      num_workloads: 1 # Number of concurrent Warp workloads to run
+      workload_type: "mixed" # Options: mixed, get, put, delete, stat
+      duration: "10m" # Duration for each Warp iteration (e.g., "10m", "30s", "1h")
+      concurrent: 1 # Number of concurrent operations per workload
+      objects: 1000 # Number of objects to create/operate on
+      obj_size: "1MiB" # Object size (e.g., "1MiB", "10KiB", "100MiB")
 
     # Background Cluster Operations Configuration
     background_cluster_operations:
@@ -120,12 +152,12 @@ ENV_DATA:
 
       # Enabled operation types (comment out to disable specific operations)
       enabled_operations:
-        - snapshot_lifecycle      # PVC snapshot create/restore/delete/verify
-        - clone_lifecycle         # PVC clone create/attach/verify/delete
-        - node_taint_churn       # Node taints for pod rescheduling
-        - osd_operations         # OSD noout flag operations
-        - mds_failover           # MDS daemon failover (CephFS)
-        - rgw_restart            # RGW pod restart (ObjectStore)
-        - reclaim_space          # CSI-Addons ReclaimSpace on RBD volumes
-        - longevity_operations   # Comprehensive snapshot/restore/expand testing
+        - snapshot_lifecycle # PVC snapshot create/restore/delete/verify
+        - clone_lifecycle # PVC clone create/attach/verify/delete
+        - node_taint_churn # Node taints for pod rescheduling
+        - osd_operations # OSD noout flag operations
+        - mds_failover # MDS daemon failover (CephFS)
+        - rgw_restart # RGW pod restart (ObjectStore)
+        - reclaim_space # CSI-Addons ReclaimSpace on RBD volumes
+        - longevity_operations # Comprehensive snapshot/restore/expand testing
         # - volume_replication   # CSI-Addons VolumeReplication (requires DR)

--- a/conf/ocsci/krkn_noobaa_chaos_config.yaml
+++ b/conf/ocsci/krkn_noobaa_chaos_config.yaml
@@ -1,0 +1,30 @@
+# NooBaa pod-disruption + MCG S3 workload. Run: pytest --ocsci-conf conf/ocsci/krkn_noobaa_chaos_config.yaml tests/cross_functional/krkn_chaos/test_krkn_noobaa_chaos.py
+
+ENV_DATA:
+  krkn_config:
+    workloads:
+      - "MCG_WORKLOAD"  # S3 on MCG/NooBaa
+    run_workload: true
+
+    mcg_config:
+      num_buckets: 3
+      iteration_count: 20
+      operation_types:
+        - upload
+        - download
+        - list
+        - delete
+      upload_multiplier: 2
+      metadata_ops_enabled: true  # stress metadata path
+      delay_between_iterations: 20  # seconds
+      delete_bucket_on_cleanup: true
+
+    enable_verification: true  # S3 integrity after chaos
+
+    background_cluster_operations:
+      enabled: true
+      operation_interval: 60  # seconds
+      max_concurrent_operations: 2
+      enabled_operations:
+        - snapshot_lifecycle
+        - clone_lifecycle  # skip OSD/MDS for NooBaa-focused runs

--- a/conf/ocsci/warp_noobaa_stress.yaml
+++ b/conf/ocsci/warp_noobaa_stress.yaml
@@ -1,0 +1,20 @@
+# Krkn + Warp (MinIO S3 bench) on MCG/NooBaa; pass with --ocsci-conf alongside your test command.
+
+ENV_DATA:
+  krkn_config:
+    workloads:
+      - WARP_WORKLOAD
+    run_workload: true
+    enable_verification: false  # Warp validates its own runs
+
+    warp_config:
+      namespace: "default"  # or openshift-storage / custom
+      num_workloads: 1
+      workload_type: "mixed"  # mixed | put | get | delete | stat
+      duration: "10m"  # e.g. 30s, 10m, 1h
+      concurrent: 1
+      objects: 1000
+      obj_size: "1MiB"  # smaller = more metadata stress
+
+    background_cluster_operations:
+      enabled: false  # set true to add snapshot/clone etc. during chaos

--- a/examples/warp-noobaa-pod.yaml
+++ b/examples/warp-noobaa-pod.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: warp-noobaa
+  namespace: openshift-storage
+spec:
+  restartPolicy: Always
+  containers:
+  - name: warp
+    image: quay.io/ocsci/warp:latest
+    command: ["./warp"]
+    args:
+      - mixed
+      - --host=s3.openshift-storage.svc:443
+      - --tls
+      - --insecure
+      - --access-key
+      - $(AWS_ACCESS_KEY_ID)
+      - --secret-key
+      - $(AWS_SECRET_ACCESS_KEY)
+      - --bucket=warp-test
+      - --concurrent=1
+      - --objects=1000
+      - --obj.size=1MiB
+    env:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: noobaa-admin
+          key: AWS_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: noobaa-admin
+          key: AWS_SECRET_ACCESS_KEY

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -117,6 +117,10 @@ DEPLOYMENT:
   #api_ssl_cert: "data/api-cert.crt"
   #api_ssl_key: "data/api-cert.key"
   #api_ssl_ca_cert: "data/ca.crt"
+  # Boto3 S3 (MCG): skip TLS verification when true (e.g. ad-hoc clusters).
+  disable_s3_ssl_verify: false
+  # When true, do not apply IBM Cloud qe.rh-ocs.com S3 TLS workaround (use normal verify path).
+  force_s3_ssl_verify: false
   install_lvmo: False
   # AWS profile ( profile must exist in ~/.aws/credentials )
   aws_profile: "ocs_ci"

--- a/ocs_ci/krkn_chaos/krkn_chaos.py
+++ b/ocs_ci/krkn_chaos/krkn_chaos.py
@@ -8,7 +8,13 @@ import json
 import re
 import yaml
 
-from ocs_ci.ocs.constants import KRKN_OUTPUT_DIR, KRKN_RUN_CMD, KRKNCTL
+from ocs_ci.ocs.constants import (
+    HCI_VSPHERE,
+    KRKN_OUTPUT_DIR,
+    KRKN_RUN_CMD,
+    KRKNCTL,
+    VSPHERE_PLATFORM,
+)
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.krkn_chaos.krkn_port_manager import KrknPortManager
 from ocs_ci.framework import config
@@ -542,6 +548,35 @@ class KrKnRunner:
                     )
         except Exception as e:
             log.warning(f"Failed to set IBM Cloud credentials: {str(e)}")
+
+        # VMware: Krkn node_scenarios plugin requires VSPHERE_* (same as krknctl plan)
+        try:
+            platform = config.ENV_DATA.get("platform", "").lower()
+            if platform in (VSPHERE_PLATFORM.lower(), HCI_VSPHERE.lower()):
+                from ocs_ci.krkn_chaos.krkn_helpers import (
+                    vsphere_creds_for_krkn_from_ocs_config,
+                )
+
+                server, user, password = vsphere_creds_for_krkn_from_ocs_config()
+                if server and not env.get("VSPHERE_IP"):
+                    env["VSPHERE_IP"] = server
+                    log.info("Setting VSPHERE_IP for Krkn VMware node scenarios")
+                if user and not env.get("VSPHERE_USERNAME"):
+                    env["VSPHERE_USERNAME"] = user
+                    log.info("Setting VSPHERE_USERNAME for Krkn VMware node scenarios")
+                if password and not env.get("VSPHERE_PASSWORD"):
+                    env["VSPHERE_PASSWORD"] = password
+                    log.info(
+                        "Setting VSPHERE_PASSWORD for Krkn VMware node scenarios (value not logged)"
+                    )
+                if not (server and user and password):
+                    log.warning(
+                        "VMware platform but vSphere credentials incomplete in AUTH/ENV_DATA; "
+                        "Krkn node scenarios need VSPHERE_IP, VSPHERE_USERNAME, VSPHERE_PASSWORD. "
+                        "Set in data auth (vmware/vsphere) or export these env vars."
+                    )
+        except Exception as e:
+            log.warning("Failed to set VMware vSphere environment for Krkn: %s", e)
 
         # Use krkn venv python directly to run krkn
         # KRKN_RUN_CMD is data/krkn/run_kraken.py

--- a/ocs_ci/krkn_chaos/krkn_helpers.py
+++ b/ocs_ci/krkn_chaos/krkn_helpers.py
@@ -115,6 +115,41 @@ def get_krkn_cloud_type():
     return cloud_type
 
 
+def vsphere_creds_for_krkn_from_ocs_config():
+    """
+    vSphere server, user, and password from ``AUTH`` (``vmware`` / ``vsphere``) and
+    ``ENV_DATA`` (e.g. ``vsphere_server``), aligned with ``platform_nodes.VMWare``.
+
+    Returns:
+        tuple: (server or None, user or None, password or None)
+    """
+    vm_auth = {}
+    for key in ("vmware", "vsphere"):
+        block = config.AUTH.get(key)
+        if isinstance(block, dict):
+            vm_auth.update(block)
+
+    env_data = config.ENV_DATA or {}
+
+    server = (
+        vm_auth.get("vsphere_server")
+        or vm_auth.get("vsphere_ip")
+        or vm_auth.get("server")
+        or env_data.get("vsphere_server")
+    )
+    user = (
+        vm_auth.get("vsphere_user")
+        or vm_auth.get("username")
+        or env_data.get("vsphere_user")
+    )
+    password = (
+        vm_auth.get("vsphere_password")
+        or vm_auth.get("password")
+        or env_data.get("vsphere_password")
+    )
+    return server, user, password
+
+
 def get_node_scenario_generator():
     """
     Get the appropriate NodeScenarios generator method based on the platform.

--- a/ocs_ci/krkn_chaos/krkn_workload_config.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_config.py
@@ -95,6 +95,32 @@ class KrknWorkloadConfig:
         krkn_config = self.config.ENV_DATA.get("krkn_config", {})
         return krkn_config.get("cnv_config", {})
 
+    def get_mcg_config(self) -> Dict[str, Any]:
+        """
+        Get MCG/NooBaa configuration.
+
+        Returns:
+            dict: MCG configuration
+        """
+        krkn_config = self.config.ENV_DATA.get("krkn_config", {})
+        return krkn_config.get("mcg_config", {})
+
+    def get_warp_config(self) -> Dict[str, Any]:
+        """
+        Get Warp MCG stress workload configuration.
+
+        Returns:
+            dict: Warp configuration
+        """
+        krkn_config = self.config.ENV_DATA.get("krkn_config", {})
+        warp_config = krkn_config.get("warp_config", {})
+
+        # Set default namespace to 'default' if not specified
+        if "namespace" not in warp_config:
+            warp_config["namespace"] = "default"
+
+        return warp_config
+
     def get_background_cluster_operations_config(self) -> Dict[str, Any]:
         """
         Get background cluster operations configuration.
@@ -389,3 +415,5 @@ class KrknWorkloadConfig:
     VDBENCH = "VDBENCH"
     CNV_WORKLOAD = "CNV_WORKLOAD"
     RGW_WORKLOAD = "RGW_WORKLOAD"
+    MCG_WORKLOAD = "MCG_WORKLOAD"  # NooBaa/MCG S3 workload
+    WARP_WORKLOAD = "WARP_WORKLOAD"  # Warp MCG stress workload

--- a/ocs_ci/krkn_chaos/krkn_workload_factory.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_factory.py
@@ -109,6 +109,10 @@ class WorkloadOps:
                     self._validate_cnv_workload(workload)
                 elif workload_type == KrknWorkloadConfig.RGW_WORKLOAD:
                     self._validate_rgw_workload(workload)
+                elif workload_type == KrknWorkloadConfig.MCG_WORKLOAD:
+                    self._validate_mcg_workload(workload)
+                elif workload_type == KrknWorkloadConfig.WARP_WORKLOAD:
+                    self._validate_warp_workload(workload)
 
                 ready_count += 1
             except Exception as e:
@@ -191,6 +195,8 @@ class WorkloadOps:
                     self._validate_cnv_workload(workload)
                 elif workload_type == KrknWorkloadConfig.RGW_WORKLOAD:
                     self._validate_rgw_workload(workload)
+                elif workload_type == KrknWorkloadConfig.MCG_WORKLOAD:
+                    self._validate_mcg_workload(workload)
                 else:
                     log.warning(f"Unknown workload type: {workload_type}")
 
@@ -236,6 +242,10 @@ class WorkloadOps:
                     self._validate_cnv_workload(workload)
                 elif workload_type == KrknWorkloadConfig.RGW_WORKLOAD:
                     self._validate_rgw_workload(workload)
+                elif workload_type == KrknWorkloadConfig.MCG_WORKLOAD:
+                    self._validate_mcg_workload(workload)
+                elif workload_type == KrknWorkloadConfig.WARP_WORKLOAD:
+                    self._validate_warp_workload(workload)
                 else:
                     log.warning(f"Unknown workload type: {workload_type}")
 
@@ -300,7 +310,14 @@ class WorkloadOps:
                 return KrknWorkloadConfig.CNV_WORKLOAD
             elif "vdbench" in class_name:
                 return KrknWorkloadConfig.VDBENCH
+            elif "warp" in class_name:
+                return KrknWorkloadConfig.WARP_WORKLOAD
             elif "rgw" in class_name:
+                # Check if this is MCG or RGW based on bucket type
+                if hasattr(workload, "rgw_bucket") and workload.rgw_bucket:
+                    bucket_class_name = workload.rgw_bucket.__class__.__name__
+                    if "MCG" in bucket_class_name:
+                        return KrknWorkloadConfig.MCG_WORKLOAD
                 return KrknWorkloadConfig.RGW_WORKLOAD
 
         return (
@@ -362,6 +379,30 @@ class WorkloadOps:
                     log.warning("RGW workload reports as not running")
             except Exception as e:
                 log.warning(f"Failed to get RGW workload status: {e}")
+
+    def _validate_mcg_workload(self, workload):
+        """Validate MCG/NooBaa workload health."""
+        # MCG workload uses same RGWWorkload class, so validation is similar
+        self._validate_rgw_workload(workload)
+
+    def _validate_warp_workload(self, workload):
+        """Validate Warp workload health."""
+        # Check if Warp workload is still running
+        if hasattr(workload, "is_running") and callable(workload.is_running):
+            if not workload.is_running():
+                log.warning("Warp workload is not running")
+
+        # Check workload status
+        if hasattr(workload, "get_workload_status") and callable(
+            workload.get_workload_status
+        ):
+            try:
+                status = workload.get_workload_status()
+                log.info(f"Warp workload status: {status}")
+                if not status.get("is_running", False):
+                    log.warning("Warp workload reports as not running")
+            except Exception as e:
+                log.warning(f"Failed to get Warp workload status: {e}")
 
 
 class KrknWorkloadFactory:
@@ -1127,5 +1168,344 @@ class KrknWorkloadFactory:
             )
         else:
             log.info(f"✓ Successfully created all {len(workloads)} RGW workloads")
+
+        return workloads
+
+    def _create_mcg_workloads_for_project(
+        self, proj_obj, multi_pvc_factory, awscli_pod
+    ):
+        """
+        Create multiple MCG/NooBaa workloads with different configurations.
+
+        Args:
+            proj_obj: Project object
+            multi_pvc_factory: Multi-PVC factory (not used by MCG, but required for consistency)
+            awscli_pod: Pod with AWS CLI for S3 operations
+
+        Returns:
+            List of MCG workload objects (using RGWWorkload class for S3 operations)
+        """
+        from ocs_ci.resiliency.resiliency_workload import RGWWorkload
+
+        # Get MCG configuration from krkn_config
+        mcg_config = self.config.get_mcg_config()
+
+        # Configure workload parameters from config
+        num_buckets = mcg_config.get("num_buckets", 3)
+        iteration_count = mcg_config.get("iteration_count", 10)
+        operation_types = mcg_config.get(
+            "operation_types", ["upload", "download", "list", "delete"]
+        )
+        upload_multiplier = mcg_config.get("upload_multiplier", 1)
+        metadata_ops_enabled = mcg_config.get(
+            "metadata_ops_enabled", True
+        )  # Enable metadata ops for NooBaa
+        delay_between_iterations = mcg_config.get("delay_between_iterations", 30)
+        delete_bucket_on_cleanup = mcg_config.get("delete_bucket_on_cleanup", True)
+
+        workloads = []
+
+        log.info(f"Creating {num_buckets} MCG/NooBaa workloads")
+
+        # Pre-flight check: Verify NooBaa pods are running
+        try:
+            from ocs_ci.ocs.ocp import OCP
+            from ocs_ci.ocs import constants
+
+            log.info("Checking NooBaa pod health before creating buckets...")
+
+            # Check NooBaa core pods
+            noobaa_core_pods = OCP(
+                kind="pod", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            ).get(selector=constants.NOOBAA_CORE_POD_LABEL)
+
+            # Check NooBaa DB pods
+            noobaa_db_pods = OCP(
+                kind="pod", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            ).get(selector=constants.NOOBAA_DB_LABEL_419_AND_ABOVE)
+
+            if (
+                not noobaa_core_pods
+                or "items" not in noobaa_core_pods
+                or not noobaa_core_pods["items"]
+            ):
+                log.warning("No NooBaa core pods found - NooBaa may not be deployed")
+                raise RuntimeError("NooBaa core service is not available")
+
+            if (
+                not noobaa_db_pods
+                or "items" not in noobaa_db_pods
+                or not noobaa_db_pods["items"]
+            ):
+                log.warning(
+                    "No NooBaa DB pods found - NooBaa database may not be deployed"
+                )
+                raise RuntimeError("NooBaa database is not available")
+
+            # Check pod status
+            core_running = sum(
+                1
+                for pod in noobaa_core_pods["items"]
+                if pod.get("status", {}).get("phase") == "Running"
+            )
+            core_total = len(noobaa_core_pods["items"])
+
+            db_running = sum(
+                1
+                for pod in noobaa_db_pods["items"]
+                if pod.get("status", {}).get("phase") == "Running"
+            )
+            db_total = len(noobaa_db_pods["items"])
+
+            log.info(f"NooBaa core pods: {core_running}/{core_total} running")
+            log.info(f"NooBaa DB pods: {db_running}/{db_total} running")
+
+            if core_running == 0 or db_running == 0:
+                raise RuntimeError(
+                    "NooBaa services are not running. "
+                    "Ensure NooBaa is healthy in your ODF deployment."
+                )
+
+        except Exception as e:
+            log.error(f"NooBaa health check failed: {e}")
+            raise RuntimeError(f"Cannot create MCG workloads: {e}")
+
+        # Create MCG buckets for workload testing
+        try:
+            log.info("Creating MCG buckets for workload testing")
+
+            for i in range(num_buckets):
+                try:
+                    # Create MCG bucket using MCGOCBucket
+                    from ocs_ci.ocs.resources.objectbucket import MCGOCBucket
+                    import fauxfactory
+
+                    bucket_name = f"mcg-workload-{fauxfactory.gen_alpha(4).lower()}"
+                    log.info(f"Creating MCG bucket: {bucket_name}")
+
+                    # Create MCG bucket - it creates the OBC
+                    mcg_bucket = MCGOCBucket(bucket_name)
+
+                    # Give OBC a moment to be reconciled by the operator
+                    log.info(f"Waiting 15s for OBC {bucket_name} to be reconciled...")
+                    time.sleep(15)
+
+                    # Wait for bucket to be bound and ready (timeout 300s)
+                    log.info(
+                        f"Waiting for bucket {bucket_name} to be ready (up to 5 minutes)..."
+                    )
+                    try:
+                        mcg_bucket.verify_health(timeout=300)
+                        log.info(f"✓ Bucket {bucket_name} is ready")
+                    except Exception as e:
+                        log.error(f"Bucket {bucket_name} failed to become healthy: {e}")
+                        # Continue with next bucket instead of failing completely
+                        continue
+
+                    # Workload configuration
+                    workload_config = {
+                        "iteration_count": iteration_count,
+                        "operation_types": operation_types,
+                        "upload_multiplier": upload_multiplier,
+                        "metadata_ops_enabled": metadata_ops_enabled,
+                        "delay_between_iterations": delay_between_iterations,
+                    }
+
+                    # Create MCG workload (reuse RGWWorkload for S3 operations)
+                    mcg_workload = RGWWorkload(
+                        rgw_bucket=mcg_bucket,  # MCG bucket also works with RGWWorkload
+                        awscli_pod=awscli_pod,
+                        namespace=proj_obj.namespace,
+                        workload_config=workload_config,
+                        delete_bucket_on_cleanup=delete_bucket_on_cleanup,
+                    )
+
+                    # Start the workload
+                    mcg_workload.start_workload()
+
+                    workloads.append(mcg_workload)
+                    log.info(f"✓ Created and started MCG workload: {bucket_name}")
+
+                except Exception as e:
+                    log.error(f"Failed to create MCG workload {i + 1}: {e}")
+                    import traceback
+
+                    log.error(traceback.format_exc())
+                    # Continue with next workload instead of failing completely
+                    continue
+
+        except Exception as e:
+            log.error(f"Failed to create MCG workloads: {e}")
+            raise RuntimeError(f"Failed to create any MCG workloads: {e}")
+
+        if not workloads:
+            log.error("Failed to create any MCG workloads")
+            log.error(
+                "This may be due to NooBaa health issues. "
+                "Check NooBaa pod status and OBC controller health."
+            )
+            raise RuntimeError("Failed to create any MCG workloads")
+
+        if len(workloads) < num_buckets:
+            log.warning(
+                f"Only created {len(workloads)} out of {num_buckets} requested MCG workloads. "
+                f"Some buckets failed to bind - check cluster health."
+            )
+        else:
+            log.info(f"✓ Successfully created all {len(workloads)} MCG workloads")
+
+        return workloads
+
+    def _create_warp_workloads_for_project(
+        self, proj_obj, multi_pvc_factory, mcg_obj_session
+    ):
+        """
+        Create Warp workloads for high-intensity MCG/NooBaa stress testing.
+
+        Warp is MinIO's S3 benchmarking tool that provides high-performance
+        S3 operations for stress testing MCG/NooBaa.
+
+        Args:
+            proj_obj: Project object
+            multi_pvc_factory: Multi-PVC factory (not used by Warp, but required for consistency)
+            mcg_obj_session: MCG object for NooBaa access (session-scoped fixture)
+
+        Returns:
+            List of Warp workload objects
+        """
+        from ocs_ci.resiliency.resiliency_workload import WarpWorkload
+
+        # Get Warp configuration from krkn_config
+        warp_config = self.config.get_warp_config()
+
+        # Configure workload parameters from config
+        num_workloads = warp_config.get("num_workloads", 1)
+        workload_type = warp_config.get("workload_type", "mixed")
+        duration = warp_config.get("duration", "10m")
+        concurrent = warp_config.get("concurrent", 1)
+        objects = warp_config.get("objects", 1000)
+        obj_size = warp_config.get("obj_size", "1MiB")
+
+        # Get namespace configuration (default to 'default')
+        warp_namespace = warp_config.get("namespace", "default")
+        log.info(f"Warp workloads will be deployed in namespace: {warp_namespace}")
+
+        workloads = []
+
+        log.info(f"Creating {num_workloads} Warp MCG stress workloads")
+
+        # Pre-flight check: Verify NooBaa pods are running
+        try:
+            from ocs_ci.ocs.ocp import OCP
+            from ocs_ci.ocs import constants
+
+            log.info("Checking NooBaa pod health before creating Warp workloads...")
+
+            # Check NooBaa core pods
+            noobaa_core_pods = OCP(
+                kind="pod", namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+            ).get(selector=constants.NOOBAA_CORE_POD_LABEL)
+
+            if (
+                not noobaa_core_pods
+                or "items" not in noobaa_core_pods
+                or not noobaa_core_pods["items"]
+            ):
+                log.warning("No NooBaa core pods found - NooBaa may not be deployed")
+                raise RuntimeError("NooBaa core service is not available")
+
+            # Check pod status
+            core_running = sum(
+                1
+                for pod in noobaa_core_pods["items"]
+                if pod.get("status", {}).get("phase") == "Running"
+            )
+            core_total = len(noobaa_core_pods["items"])
+
+            log.info(f"NooBaa core pods: {core_running}/{core_total} running")
+
+            if core_running == 0:
+                raise RuntimeError(
+                    "NooBaa services are not running. "
+                    "Ensure NooBaa is healthy in your ODF deployment."
+                )
+
+        except Exception as e:
+            log.error(f"NooBaa health check failed: {e}")
+            raise RuntimeError(f"Cannot create Warp workloads: {e}")
+
+        # Create Warp workloads
+        try:
+            log.info("Creating Warp workloads for MCG stress testing")
+
+            for i in range(num_workloads):
+                try:
+                    # Create a unique bucket for each Warp workload
+                    import fauxfactory
+
+                    bucket_name = f"warp-test-{fauxfactory.gen_alpha(4).lower()}"
+                    log.info(
+                        f"Creating Warp workload {i + 1} with bucket: {bucket_name}"
+                    )
+
+                    # Create the bucket using MCG
+                    from ocs_ci.ocs.bucket_utils import s3_create_bucket
+
+                    s3_create_bucket(
+                        s3_obj=mcg_obj_session,
+                        bucket_name=bucket_name,
+                    )
+                    log.info(f"✓ Created bucket: {bucket_name}")
+
+                    # Workload configuration
+                    workload_config = {
+                        "workload_type": workload_type,
+                        "duration": duration,
+                        "concurrent": concurrent,
+                        "objects": objects,
+                        "obj_size": obj_size,
+                    }
+
+                    # Create Warp workload
+                    warp_workload = WarpWorkload(
+                        mcg_obj=mcg_obj_session,
+                        bucket_name=bucket_name,
+                        namespace=warp_namespace,  # Use configured namespace
+                        workload_config=workload_config,
+                    )
+
+                    # Start the workload
+                    warp_workload.start_workload()
+
+                    workloads.append(warp_workload)
+                    log.info(f"✓ Created and started Warp workload: {bucket_name}")
+
+                except Exception as e:
+                    log.error(f"Failed to create Warp workload {i + 1}: {e}")
+                    import traceback
+
+                    log.error(traceback.format_exc())
+                    # Continue with next workload instead of failing completely
+                    continue
+
+        except Exception as e:
+            log.error(f"Failed to create Warp workloads: {e}")
+            raise RuntimeError(f"Failed to create any Warp workloads: {e}")
+
+        if not workloads:
+            log.error("Failed to create any Warp workloads")
+            log.error(
+                "This may be due to NooBaa health issues. "
+                "Check NooBaa pod status and S3 service health."
+            )
+            raise RuntimeError("Failed to create any Warp workloads")
+
+        if len(workloads) < num_workloads:
+            log.warning(
+                f"Only created {len(workloads)} out of {num_workloads} requested Warp workloads. "
+                f"Some workloads failed to start - check cluster health."
+            )
+        else:
+            log.info(f"✓ Successfully created all {len(workloads)} Warp workloads")
 
         return workloads

--- a/ocs_ci/krkn_chaos/krkn_workload_registry.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_registry.py
@@ -143,6 +143,28 @@ KrknWorkloadRegistry.register(
     )
 )
 
+# MCG/NooBaa Workload (S3 workload on MCG/NooBaa buckets)
+KrknWorkloadRegistry.register(
+    WorkloadTypeConfig(
+        name="MCG_WORKLOAD",
+        required_fixtures=["awscli_pod"],
+        factory_method="_create_mcg_workloads_for_project",
+        fixture_params=["awscli_pod"],
+        description="MCG/NooBaa S3 workload for NooBaa chaos testing",
+    )
+)
+
+# WARP Workload (High-performance MCG/NooBaa stress testing with Warp)
+KrknWorkloadRegistry.register(
+    WorkloadTypeConfig(
+        name="WARP_WORKLOAD",
+        required_fixtures=["mcg_obj_session"],
+        factory_method="_create_warp_workloads_for_project",
+        fixture_params=["mcg_obj_session"],
+        description="Warp S3 benchmark for high-intensity MCG/NooBaa stress testing",
+    )
+)
+
 # ============================================================================
 # TO ADD A NEW WORKLOAD TYPE:
 # ============================================================================

--- a/ocs_ci/krkn_chaos/krknclt_helper.py
+++ b/ocs_ci/krkn_chaos/krknclt_helper.py
@@ -31,6 +31,8 @@ from ocs_ci.ocs.constants import (
     RGW_APP_LABEL,
     OPERATOR_LABEL,
     NOOBAA_APP_LABEL,
+    RBD_NODEPLUGIN_LABEL,
+    CEPHFS_NODEPLUGIN_LABEL,
 )
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.krkn_chaos.krkn_chaos import KrKnctlRunner
@@ -38,6 +40,7 @@ from ocs_ci.krkn_chaos.krkn_helpers import (
     CephHealthHelper,
     ValidationHelper,
     krknctl_random_test_exit_criteria,
+    vsphere_creds_for_krkn_from_ocs_config,
 )
 
 log = logging.getLogger(__name__)
@@ -81,12 +84,17 @@ KRKNCTL_PLAN_SCENARIO_KEYS = (
     "application-outages",
     "application-outages-egress-only",
     "application-outages-ingress-only",
+    "application-outages-mds",
+    "application-outages-noobaa",
+    "application-outages-operator",
     "application-outages-osd",
     "application-outages-rgw",
     "container-scenarios",
     "container-scenarios-mds",
+    "container-scenarios-mgr",
     "container-scenarios-mon",
     "container-scenarios-osd",
+    "container-scenarios-rgw",
     "kubevirt-outage",
     "network-chaos",
     "network-chaos-egress-loss",
@@ -106,17 +114,28 @@ KRKNCTL_PLAN_SCENARIO_KEYS = (
     "pod-network-chaos-ingress-only",
     "pod-network-filter",
     "pod-scenarios",
+    "pod-scenarios-cephfs-plugin",
     "pod-scenarios-mgr",
+    "pod-scenarios-mds",
     "pod-scenarios-mon",
     "pod-scenarios-multi-disruption",
     "pod-scenarios-noobaa",
+    "pod-scenarios-operator",
     "pod-scenarios-rbd-plugin",
+    "pod-scenarios-rgw",
     "service-disruption-scenarios",
     "service-disruption-scenarios-rook",
     "syn-flood",
+    "syn-flood-mds",
     "syn-flood-mgr",
+    "syn-flood-noobaa",
+    "syn-flood-rgw",
     "time-scenarios",
+    "time-scenarios-mds",
+    "time-scenarios-mgr",
+    "time-scenarios-noobaa",
     "time-scenarios-osd",
+    "time-scenarios-rgw",
 )
 
 ROOT_SCENARIO_KEY = "root"
@@ -230,36 +249,10 @@ def _apply_vsphere_node_scenario_auth_from_config(template_vars):
     Only runs when ``cloud_type`` is VMware (``KRKN_CLOUD_VMWARE``). Does not overwrite
     keys already set (caller applies env overrides after this).
     """
-    from ocs_ci.framework import config
-
     if template_vars.get("cloud_type") != KRKN_CLOUD_VMWARE:
         return
 
-    vm_auth = {}
-    for key in ("vmware", "vsphere"):
-        block = config.AUTH.get(key)
-        if isinstance(block, dict):
-            vm_auth.update(block)
-
-    env_data = config.ENV_DATA or {}
-
-    server = (
-        vm_auth.get("vsphere_server")
-        or vm_auth.get("vsphere_ip")
-        or vm_auth.get("server")
-        or env_data.get("vsphere_server")
-    )
-    user = (
-        vm_auth.get("vsphere_user")
-        or vm_auth.get("username")
-        or env_data.get("vsphere_user")
-    )
-    password = (
-        vm_auth.get("vsphere_password")
-        or vm_auth.get("password")
-        or env_data.get("vsphere_password")
-    )
-
+    server, user, password = vsphere_creds_for_krkn_from_ocs_config()
     if server:
         template_vars.setdefault("vsphere_ip", server)
     if user:
@@ -670,6 +663,7 @@ class PlanGenerator:
         namespace="openshift-storage",
         include_scenarios=None,
         exclude_scenarios=None,
+        exclude_scenario_bases_exact=None,
         scenario_overrides=None,
         use_random_selectors=True,
         label_selectors=None,
@@ -680,6 +674,9 @@ class PlanGenerator:
             include_scenarios  # None or list; takes precedence over exclude
         )
         self.exclude_scenarios = exclude_scenarios or []
+        # Plan keys "base" before _<suffix>); match == only (no prefix variants), e.g.
+        # "service-disruption-scenarios" drops that node but not "service-disruption-scenarios-rook".
+        self.exclude_scenario_bases_exact = exclude_scenario_bases_exact or []
         self.scenario_overrides = scenario_overrides or {}
         self.use_random_selectors = use_random_selectors
         self.label_selectors = label_selectors  # list of pod label strings; expands app-outage/pod/container only
@@ -724,12 +721,33 @@ class PlanGenerator:
             label_selector = self.template_vars.get("label_selector", "")
             workers = self.template_vars.get("workers", "1")
 
+        # Component-specific labels must not use global `pod_label` (same as
+        # label_selector / random Ceph pick); named blocks in plan.json.j2 now use
+        # literal selectors per scenario so random globals do not override them.
+        # Generic pod-scenarios / multi-disruption OSD label is also literal; overrides
+        # remain available via scenario_overrides / template_vars for custom plans.
         context = {
             "suffix": self._suffix,
             "namespace": self.namespace,
             "pod_selector": pod_selector,
             "label_selector": label_selector,
             "pod_label": label_selector,
+            "noobaa_pod_label": self.template_vars.get(
+                "noobaa_pod_label", NOOBAA_APP_LABEL
+            ),
+            "mon_pod_label": self.template_vars.get("mon_pod_label", MON_APP_LABEL),
+            "mgr_pod_label": self.template_vars.get("mgr_pod_label", MGR_APP_LABEL),
+            "rbd_plugin_pod_label": self.template_vars.get(
+                "rbd_plugin_pod_label", RBD_NODEPLUGIN_LABEL
+            ),
+            "mds_pod_label": self.template_vars.get("mds_pod_label", MDS_APP_LABEL),
+            "rgw_pod_label": self.template_vars.get("rgw_pod_label", RGW_APP_LABEL),
+            "operator_pod_label": self.template_vars.get(
+                "operator_pod_label", OPERATOR_LABEL
+            ),
+            "cephfs_plugin_pod_label": self.template_vars.get(
+                "cephfs_plugin_pod_label", CEPHFS_NODEPLUGIN_LABEL
+            ),
             "workers": workers,
             "worker_instance_count": worker_instance_count,
         }
@@ -775,12 +793,14 @@ class PlanGenerator:
             json.dump(plan_data, f, indent=2)
 
         log.info(
-            "Generated krknctl plan: %s (namespace=%s, suffix=%s, include=%s, exclude=%s)",
+            "Generated krknctl plan: %s (namespace=%s, suffix=%s, include=%s, "
+            "exclude=%s, exclude_bases_exact=%s)",
             self.plan_path,
             self.namespace,
             self._suffix,
             self.include_scenarios,
             self.exclude_scenarios,
+            self.exclude_scenario_bases_exact,
         )
         return os.path.abspath(self.plan_path)
 
@@ -898,10 +918,32 @@ class PlanGenerator:
 
     def _remove_excluded(self, plan_data):
         """
-        Drop excluded scenario nodes. A template base name like ``network-chaos`` also
-        removes hyphenated variants (``network-chaos-ingress-latency``, etc.) so exclude
-        lists match krkn-hub scenario families in plan.json.j2.
+        Drop excluded scenario nodes.
+
+        ``exclude_scenario_bases_exact``: plan key base must match exactly (no
+        ``base.startswith(ex + "-")``), e.g. remove ``service-disruption-scenarios``
+        (namespace + ``LABEL_SELECTOR: ""`` in plan.json.j2) but keep
+        ``service-disruption-scenarios-rook``.
+
+        ``exclude_scenarios``: a base like ``network-chaos`` also removes hyphenated
+        variants (``network-chaos-ingress-latency``, etc.) so exclude lists match
+        krkn-hub scenario families in plan.json.j2.
         """
+        exact_set = set(self.exclude_scenario_bases_exact)
+        for k in list(plan_data.keys()):
+            if k.startswith("_"):
+                continue
+            base = k.rsplit("_", 1)[0] if "_" in k else k
+            for ex in exact_set:
+                if base == ex:
+                    del plan_data[k]
+                    log.debug(
+                        "Excluded scenario from plan: %s (exact base, matched %s)",
+                        k,
+                        ex,
+                    )
+                    break
+
         excluded_set = set(self.exclude_scenarios)
         for k in list(plan_data.keys()):
             if k.startswith("_"):
@@ -950,6 +992,7 @@ def generate_plan_file(
     namespace="openshift-storage",
     include_scenarios=None,
     exclude_scenarios=None,
+    exclude_scenario_bases_exact=None,
     scenario_overrides=None,
     use_random_selectors=True,
     **template_vars,
@@ -960,12 +1003,14 @@ def generate_plan_file(
     Uses PlanGenerator: parses template, fills parameters, writes file.
     When include_scenarios is set, only those scenarios (plus root if listed) are kept;
     otherwise exclude_scenarios is used to remove scenarios.
+    ``exclude_scenario_bases_exact`` removes only exact plan key bases (see PlanGenerator).
     Returns the plan file path.
     """
     generator = PlanGenerator(
         namespace=namespace,
         include_scenarios=include_scenarios,
         exclude_scenarios=exclude_scenarios,
+        exclude_scenario_bases_exact=exclude_scenario_bases_exact,
         scenario_overrides=scenario_overrides,
         use_random_selectors=use_random_selectors,
         **template_vars,
@@ -977,6 +1022,7 @@ def generate_random_plan_file(
     namespace="openshift-storage",
     include_scenarios=None,
     exclude_scenarios=None,
+    exclude_scenario_bases_exact=None,
     scenario_overrides=None,
     **kwargs,
 ):
@@ -990,6 +1036,7 @@ def generate_random_plan_file(
         namespace=namespace,
         include_scenarios=include_scenarios,
         exclude_scenarios=exclude_scenarios,
+        exclude_scenario_bases_exact=exclude_scenario_bases_exact,
         scenario_overrides=scenario_overrides,
         use_random_selectors=True,
         **kwargs,

--- a/ocs_ci/krkn_chaos/noobaa_chaos_helper.py
+++ b/ocs_ci/krkn_chaos/noobaa_chaos_helper.py
@@ -1,0 +1,518 @@
+"""
+NooBaa-specific helper functions for Krkn chaos testing.
+
+This module provides utility functions for NooBaa chaos testing including:
+- Node discovery for NooBaa components
+- NooBaa health validation
+- Component-specific helpers
+
+Used by:
+- test_krkn_noobaa_chaos.py (pod disruption)
+- test_krkn_noobaa_container_chaos.py (container kill)
+- test_krkn_noobaa_node_disruption.py (node disruption)
+"""
+
+import logging
+
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.resources.pod import (
+    get_pods_having_label,
+    get_primary_nb_db_pod,
+    Pod,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Node Discovery Functions
+# ============================================================================
+
+
+def get_node_hosting_noobaa_db_primary():
+    """
+    Get the node name hosting the NooBaa database primary pod.
+
+    Returns:
+        str: Node name hosting NooBaa DB primary pod
+
+    Raises:
+        Exception: If primary pod not found or node name not available
+
+    Example:
+        >>> node = get_node_hosting_noobaa_db_primary()
+        >>> print(node)
+        'worker-0'
+    """
+    try:
+        # Get NooBaa DB primary pod
+        primary_pod = get_primary_nb_db_pod()
+        node_name = primary_pod.get()["spec"]["nodeName"]
+        log.info(
+            f"NooBaa DB primary pod '{primary_pod.name}' is running on node '{node_name}'"
+        )
+        return node_name
+    except Exception as e:
+        log.error(f"Failed to get node hosting NooBaa DB primary: {e}")
+        raise
+
+
+def get_nodes_hosting_noobaa_db_replicas():
+    """
+    Get list of node names hosting NooBaa database replica pods.
+
+    Returns:
+        list: List of node names hosting NooBaa DB replica pods
+
+    Example:
+        >>> nodes = get_nodes_hosting_noobaa_db_replicas()
+        >>> print(nodes)
+        ['worker-1', 'worker-2']
+    """
+    nodes = []
+    try:
+        # Get NooBaa DB replica pods
+        replica_pods = get_pods_having_label(
+            label=constants.NB_DB_SECONDARY_POD_LABEL,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+
+        for pod_info in replica_pods:
+            pod_obj = Pod(**pod_info)
+            node_name = pod_obj.get()["spec"]["nodeName"]
+            nodes.append(node_name)
+            log.info(
+                f"NooBaa DB replica pod '{pod_obj.name}' is running on node '{node_name}'"
+            )
+
+        return nodes
+    except Exception as e:
+        log.warning(f"Failed to get nodes hosting NooBaa DB replicas: {e}")
+        return []
+
+
+def get_nodes_hosting_noobaa_core():
+    """
+    Get list of node names hosting NooBaa core pods.
+
+    Returns:
+        list: List of node names hosting NooBaa core pods
+
+    Example:
+        >>> nodes = get_nodes_hosting_noobaa_core()
+        >>> print(nodes)
+        ['worker-0', 'worker-2']
+    """
+    nodes = []
+    try:
+        # Get NooBaa core pods
+        core_pods = get_pods_having_label(
+            label=constants.NOOBAA_CORE_POD_LABEL,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+
+        for pod_info in core_pods:
+            pod_obj = Pod(**pod_info)
+            node_name = pod_obj.get()["spec"]["nodeName"]
+            nodes.append(node_name)
+            log.info(
+                f"NooBaa core pod '{pod_obj.name}' is running on node '{node_name}'"
+            )
+
+        return nodes
+    except Exception as e:
+        log.warning(f"Failed to get nodes hosting NooBaa core: {e}")
+        return []
+
+
+def get_nodes_hosting_noobaa_operator():
+    """
+    Get list of node names hosting NooBaa operator pods.
+
+    Returns:
+        list: List of node names hosting NooBaa operator pods
+
+    Example:
+        >>> nodes = get_nodes_hosting_noobaa_operator()
+        >>> print(nodes)
+        ['worker-1']
+    """
+    nodes = []
+    try:
+        # Get NooBaa operator pods
+        operator_pods = get_pods_having_label(
+            label=constants.NOOBAA_OPERATOR_POD_LABEL,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+
+        for pod_info in operator_pods:
+            pod_obj = Pod(**pod_info)
+            node_name = pod_obj.get()["spec"]["nodeName"]
+            nodes.append(node_name)
+            log.info(
+                f"NooBaa operator pod '{pod_obj.name}' is running on node '{node_name}'"
+            )
+
+        return nodes
+    except Exception as e:
+        log.warning(f"Failed to get nodes hosting NooBaa operator: {e}")
+        return []
+
+
+def get_nodes_hosting_noobaa_endpoints():
+    """
+    Get list of node names hosting NooBaa endpoint pods.
+
+    Returns:
+        list: List of node names hosting NooBaa endpoint pods
+
+    Example:
+        >>> nodes = get_nodes_hosting_noobaa_endpoints()
+        >>> print(nodes)
+        ['worker-0', 'worker-1', 'worker-2']
+    """
+    nodes = []
+    try:
+        # Get NooBaa endpoint pods
+        endpoint_pods = get_pods_having_label(
+            label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+
+        for pod_info in endpoint_pods:
+            pod_obj = Pod(**pod_info)
+            node_name = pod_obj.get()["spec"]["nodeName"]
+            nodes.append(node_name)
+            log.info(
+                f"NooBaa endpoint pod '{pod_obj.name}' is running on node '{node_name}'"
+            )
+
+        return nodes
+    except Exception as e:
+        log.warning(f"Failed to get nodes hosting NooBaa endpoints: {e}")
+        return []
+
+
+def get_all_noobaa_nodes():
+    """
+    Get all nodes hosting any NooBaa component pods.
+
+    Returns:
+        dict: Dictionary with keys for each component containing node names:
+            - 'primary': Node hosting DB primary
+            - 'replicas': List of nodes hosting DB replicas
+            - 'core': List of nodes hosting core pods
+            - 'operator': List of nodes hosting operator pods
+            - 'endpoints': List of nodes hosting endpoint pods
+
+    Example:
+        >>> nodes = get_all_noobaa_nodes()
+        >>> print(nodes)
+        {
+            'primary': 'worker-0',
+            'replicas': ['worker-1', 'worker-2'],
+            'core': ['worker-0'],
+            'operator': ['worker-1'],
+            'endpoints': ['worker-0', 'worker-1', 'worker-2']
+        }
+    """
+    return {
+        "primary": get_node_hosting_noobaa_db_primary(),
+        "replicas": get_nodes_hosting_noobaa_db_replicas(),
+        "core": get_nodes_hosting_noobaa_core(),
+        "operator": get_nodes_hosting_noobaa_operator(),
+        "endpoints": get_nodes_hosting_noobaa_endpoints(),
+    }
+
+
+def get_unique_noobaa_nodes():
+    """
+    Get a unique set of all nodes hosting NooBaa components.
+
+    Returns:
+        set: Set of unique node names hosting any NooBaa component
+
+    Example:
+        >>> nodes = get_unique_noobaa_nodes()
+        >>> print(nodes)
+        {'worker-0', 'worker-1', 'worker-2'}
+    """
+    all_nodes_dict = get_all_noobaa_nodes()
+    unique_nodes = set()
+
+    # Add primary node
+    unique_nodes.add(all_nodes_dict["primary"])
+
+    # Add all replica nodes
+    unique_nodes.update(all_nodes_dict["replicas"])
+
+    # Add all core nodes
+    unique_nodes.update(all_nodes_dict["core"])
+
+    # Add all operator nodes
+    unique_nodes.update(all_nodes_dict["operator"])
+
+    # Add all endpoint nodes
+    unique_nodes.update(all_nodes_dict["endpoints"])
+
+    log.info(f"Found {len(unique_nodes)} unique nodes hosting NooBaa: {unique_nodes}")
+    return unique_nodes
+
+
+# ============================================================================
+# NooBaa Health Validation Functions
+# ============================================================================
+
+
+def validate_noobaa_health(component_name="NooBaa"):
+    """
+    Validate NooBaa health after chaos testing.
+
+    This function checks:
+    1. NooBaa pods are running
+    2. NooBaa database is accessible
+    3. No permanent errors in NooBaa logs
+    4. S3 endpoints are responsive
+
+    Args:
+        component_name (str): Component name for logging purposes
+
+    Raises:
+        AssertionError: If critical NooBaa health checks fail
+
+    Example:
+        >>> validate_noobaa_health("noobaa-db-primary")
+        # Logs validation results and raises assertion if checks fail
+    """
+    log.info(f"Validating NooBaa health for {component_name}")
+
+    # Check NooBaa pods are running
+    log.info("   Checking NooBaa pod status...")
+    noobaa_pods = [
+        (constants.NOOBAA_DB_LABEL_419_AND_ABOVE, "NooBaa DB"),
+        (constants.NOOBAA_CORE_POD_LABEL, "NooBaa Core"),
+        (constants.NOOBAA_OPERATOR_POD_LABEL, "NooBaa Operator"),
+    ]
+
+    for label, name in noobaa_pods:
+        pods = get_pods_having_label(
+            label=label,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+        assert len(pods) > 0, f"No {name} pods found after chaos"
+
+        # Check pod status
+        for pod in pods:
+            pod_name = pod["metadata"]["name"]
+            pod_obj = ocp.OCP(
+                kind=constants.POD,
+                namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+                resource_name=pod_name,
+            )
+            status = pod_obj.get()["status"]["phase"]
+            log.info(f"      {pod_name}: {status}")
+            # Allow pods to be in Running or ContainerCreating state
+            # (they may still be recovering from the last kill)
+            assert status in [
+                "Running",
+                "ContainerCreating",
+                "Pending",
+            ], f"{pod_name} is in unexpected state: {status}"
+
+    log.info("   ✅ NooBaa pods are healthy")
+
+    # Note: We don't fail on temporary service disruptions
+    # Pod restarts and temporary S3 failures are expected during chaos testing
+    log.info("   ℹ️  Temporary service disruptions during chaos are expected")
+    log.info("✅ NooBaa health validation completed")
+
+
+def validate_noobaa_db_health():
+    """
+    Validate NooBaa database health specifically.
+
+    Checks:
+    - Database pods are running
+    - Primary is elected
+    - Replication is working (if replicas exist)
+
+    Raises:
+        AssertionError: If database checks fail
+    """
+    log.info("Validating NooBaa database health")
+
+    # Check database pods
+    db_pods = get_pods_having_label(
+        label=constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+
+    assert len(db_pods) > 0, "No NooBaa database pods found"
+    log.info(f"   Found {len(db_pods)} NooBaa database pod(s)")
+
+    # Check primary pod exists
+    try:
+        primary_pod = get_primary_nb_db_pod()
+        log.info(f"   ✅ Primary pod: {primary_pod.name}")
+    except Exception as e:
+        raise AssertionError(f"Failed to get NooBaa DB primary pod: {e}")
+
+    # Check replica pods if they exist
+    replica_pods = get_pods_having_label(
+        label=constants.NB_DB_SECONDARY_POD_LABEL,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+
+    if replica_pods:
+        log.info(f"   ✅ Found {len(replica_pods)} replica pod(s)")
+        for pod_info in replica_pods:
+            log.info(f"      - {pod_info['metadata']['name']}")
+    else:
+        log.info("   ℹ️  No replica pods found (may be expected in some deployments)")
+
+    log.info("✅ NooBaa database health validation completed")
+
+
+def validate_noobaa_core_health():
+    """
+    Validate NooBaa core service health.
+
+    Checks:
+    - Core pods are running
+    - S3 service is accessible
+
+    Raises:
+        AssertionError: If core service checks fail
+    """
+    log.info("Validating NooBaa core service health")
+
+    # Check core pods
+    core_pods = get_pods_having_label(
+        label=constants.NOOBAA_CORE_POD_LABEL,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+
+    assert len(core_pods) > 0, "No NooBaa core pods found"
+    log.info(f"   Found {len(core_pods)} NooBaa core pod(s)")
+
+    for pod_info in core_pods:
+        pod_name = pod_info["metadata"]["name"]
+        pod_obj = ocp.OCP(
+            kind=constants.POD,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            resource_name=pod_name,
+        )
+        status = pod_obj.get()["status"]["phase"]
+        log.info(f"      {pod_name}: {status}")
+        assert status in [
+            "Running",
+            "ContainerCreating",
+        ], f"Core pod {pod_name} is in unexpected state: {status}"
+
+    log.info("✅ NooBaa core service health validation completed")
+
+
+def validate_noobaa_endpoints_health():
+    """
+    Validate NooBaa S3 endpoints health.
+
+    Checks:
+    - Endpoint pods are running
+    - Minimum endpoints are available
+
+    Raises:
+        AssertionError: If endpoint checks fail
+    """
+    log.info("Validating NooBaa endpoints health")
+
+    # Check endpoint pods
+    endpoint_pods = get_pods_having_label(
+        label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+
+    # At least 1 endpoint should be running
+    assert len(endpoint_pods) > 0, "No NooBaa endpoint pods found"
+    log.info(f"   Found {len(endpoint_pods)} NooBaa endpoint pod(s)")
+
+    for pod_info in endpoint_pods:
+        pod_name = pod_info["metadata"]["name"]
+        pod_obj = ocp.OCP(
+            kind=constants.POD,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            resource_name=pod_name,
+        )
+        status = pod_obj.get()["status"]["phase"]
+        log.info(f"      {pod_name}: {status}")
+        assert status in [
+            "Running",
+            "ContainerCreating",
+        ], f"Endpoint pod {pod_name} is in unexpected state: {status}"
+
+    log.info("✅ NooBaa endpoints health validation completed")
+
+
+# ============================================================================
+# Component Label Mapping
+# ============================================================================
+
+
+def get_noobaa_component_label(component_name):
+    """
+    Get the Kubernetes label selector for a NooBaa component.
+
+    Args:
+        component_name (str): Component name (e.g., 'db', 'core', 'operator', 'endpoint')
+
+    Returns:
+        str: Label selector for the component
+
+    Raises:
+        ValueError: If component name is not recognized
+
+    Example:
+        >>> label = get_noobaa_component_label('core')
+        >>> print(label)
+        'noobaa-core=noobaa'
+    """
+    component_labels = {
+        "db": constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
+        "db_primary": constants.NB_DB_PRIMARY_POD_LABEL,
+        "db_replica": constants.NB_DB_SECONDARY_POD_LABEL,
+        "core": constants.NOOBAA_CORE_POD_LABEL,
+        "operator": constants.NOOBAA_OPERATOR_POD_LABEL,
+        "endpoint": constants.NOOBAA_ENDPOINT_POD_LABEL,
+        "all": constants.NOOBAA_APP_LABEL,
+    }
+
+    if component_name not in component_labels:
+        raise ValueError(
+            f"Unknown NooBaa component: {component_name}. "
+            f"Valid components: {list(component_labels.keys())}"
+        )
+
+    return component_labels[component_name]
+
+
+def get_noobaa_component_pods(component_name):
+    """
+    Get all pods for a specific NooBaa component.
+
+    Args:
+        component_name (str): Component name (e.g., 'db', 'core', 'operator', 'endpoint')
+
+    Returns:
+        list: List of pod info dictionaries
+
+    Example:
+        >>> pods = get_noobaa_component_pods('core')
+        >>> for pod in pods:
+        ...     print(pod['metadata']['name'])
+        noobaa-core-0
+    """
+    label = get_noobaa_component_label(component_name)
+    pods = get_pods_having_label(
+        label=label,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+    return pods

--- a/ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2
+++ b/ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2
@@ -1,6 +1,6 @@
 {
   "_comment": {
-    "_comment": "Jinja catalog for krknctl plans (OCS-oriented defaults). Covers all named krkn-hub tags on quay.io/krkn-chaos/krkn-hub except chaos-recommender (separate workflow; see krkn-chaos.dev docs). dummy-scenario is for CI/local and may not exist as a public Quay tag. Cerberus is quay.io/krkn-chaos/cerberus, not a krkn-hub scenario. Cloud scenarios need creds from Jenkins."
+    "_comment": "Jinja2 krknctl plan catalog: each block defines a krkn-hub scenario. Labels, images, and options are filled from template variables and krkn chaos configuration."
   },
   "root_{{ suffix }}": {
     "image": "quay.io/krkn-chaos/krkn-hub:dummy-scenario",
@@ -17,7 +17,7 @@
       "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
       "DURATION": "600",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mgr}') }}",
+      "POD_SELECTOR": "{app: rook-ceph-mgr}",
       "WAIT_DURATION": "60",
       "KRKN_DEBUG": "False"
     },
@@ -30,7 +30,7 @@
       "BLOCK_TRAFFIC_TYPE": "[Ingress]",
       "DURATION": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mgr}') }}",
+      "POD_SELECTOR": "{app: rook-ceph-mgr}",
       "WAIT_DURATION": "60",
       "KRKN_DEBUG": "False"
     },
@@ -43,7 +43,7 @@
       "BLOCK_TRAFFIC_TYPE": "[Egress]",
       "DURATION": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mon}') }}",
+      "POD_SELECTOR": "{app: rook-ceph-mon}",
       "WAIT_DURATION": "60",
       "KRKN_DEBUG": "False"
     },
@@ -56,7 +56,7 @@
       "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
       "DURATION": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-osd}') }}",
+      "POD_SELECTOR": "{app: rook-ceph-osd}",
       "WAIT_DURATION": "60",
       "KRKN_DEBUG": "False"
     },
@@ -69,7 +69,46 @@
       "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
       "DURATION": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-rgw}') }}",
+      "POD_SELECTOR": "{app: rook-ceph-rgw}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-mds_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{app: rook-ceph-mds}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-noobaa_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{app: noobaa}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-operator_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{app: rook-ceph-operator}",
       "WAIT_DURATION": "60",
       "KRKN_DEBUG": "False"
     },
@@ -83,7 +122,7 @@
       "CONTAINER_NAME": "",
       "DISRUPTION_COUNT": "1",
       "EXPECTED_RECOVERY_TIME": "60",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-osd",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
     },
     "depends_on": "root_{{ suffix }}"
@@ -96,7 +135,7 @@
       "CONTAINER_NAME": "",
       "DISRUPTION_COUNT": "1",
       "EXPECTED_RECOVERY_TIME": "120",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-osd",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
     },
     "depends_on": "root_{{ suffix }}"
@@ -109,7 +148,7 @@
       "CONTAINER_NAME": "{{ ceph_mds_container | default('mds') }}",
       "DISRUPTION_COUNT": "1",
       "EXPECTED_RECOVERY_TIME": "120",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-mds') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-mds",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
     },
     "depends_on": "root_{{ suffix }}"
@@ -122,7 +161,33 @@
       "CONTAINER_NAME": "{{ ceph_mon_container | default('mon') }}",
       "DISRUPTION_COUNT": "1",
       "EXPECTED_RECOVERY_TIME": "120",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-mon') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-mon",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios-mgr_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "{{ ceph_mgr_container | default('mgr') }}",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "LABEL_SELECTOR": "app=rook-ceph-mgr",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios-rgw_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "{{ ceph_rgw_container | default('rgw') }}",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "LABEL_SELECTOR": "app=rook-ceph-rgw",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
     },
     "depends_on": "root_{{ suffix }}"
@@ -295,7 +360,7 @@
       "EGRESS_PORTS": "[]",
       "INGRESS_PORTS": "[]",
       "INSTANCE_COUNT": "{{ worker_instance_count }}",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-osd",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "TEST_DURATION": "120",
       "TRAFFIC_TYPE": "[egress]",
@@ -310,7 +375,7 @@
       "EGRESS_PORTS": "[]",
       "INGRESS_PORTS": "[]",
       "INSTANCE_COUNT": "{{ worker_instance_count }}",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-osd",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "TEST_DURATION": "180",
       "TRAFFIC_TYPE": "[ingress,egress]",
@@ -325,7 +390,7 @@
       "EGRESS_PORTS": "[]",
       "INGRESS_PORTS": "[]",
       "INSTANCE_COUNT": "{{ worker_instance_count }}",
-      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "LABEL_SELECTOR": "app=rook-ceph-osd",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "TEST_DURATION": "120",
       "TRAFFIC_TYPE": "[ingress]",
@@ -338,7 +403,7 @@
     "name": "pod-network-filter",
     "env": {
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "POD_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "POD_SELECTOR": "app=rook-ceph-osd",
       "INSTANCE_COUNT": "{{ worker_instance_count }}",
       "EXECUTION": "parallel",
       "INGRESS": "true",
@@ -358,7 +423,7 @@
       "KILL_TIMEOUT": "240",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": ".*",
-      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-mon') }}",
+      "POD_LABEL": "{{ mon_pod_label | default('app=rook-ceph-mon') }}",
       "WAIT_DURATION": "1"
     },
     "depends_on": "root_{{ suffix }}"
@@ -372,7 +437,7 @@
       "KILL_TIMEOUT": "180",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": ".*",
-      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-mgr') }}",
+      "POD_LABEL": "{{ mgr_pod_label | default('app=rook-ceph-mgr') }}",
       "WAIT_DURATION": "1"
     },
     "depends_on": "root_{{ suffix }}"
@@ -386,7 +451,7 @@
       "KILL_TIMEOUT": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": ".*",
-      "POD_LABEL": "{{ pod_label | default('app=noobaa') }}",
+      "POD_LABEL": "{{ noobaa_pod_label | default('app=noobaa') }}",
       "WAIT_DURATION": "30"
     },
     "depends_on": "root_{{ suffix }}"
@@ -400,7 +465,7 @@
       "KILL_TIMEOUT": "180",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": ".*",
-      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-osd') }}",
+      "POD_LABEL": "app=rook-ceph-osd",
       "WAIT_DURATION": "1"
     },
     "depends_on": "root_{{ suffix }}"
@@ -414,7 +479,7 @@
       "KILL_TIMEOUT": "300",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": "{{ pod_name_pattern | default('.*') }}",
-      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-osd') }}",
+      "POD_LABEL": "app=rook-ceph-osd",
       "WAIT_DURATION": "30"
     },
     "depends_on": "root_{{ suffix }}"
@@ -428,8 +493,64 @@
       "KILL_TIMEOUT": "180",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "NAME_PATTERN": ".*",
-      "POD_LABEL": "{{ pod_label | default('app=csi-rbdplugin') }}",
+      "POD_LABEL": "{{ rbd_plugin_pod_label | default('app=openshift-storage.rbd.csi.ceph.com-nodeplugin') }}",
       "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-cephfs-plugin_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "KILL_TIMEOUT": "180",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ cephfs_plugin_pod_label | default('app=openshift-storage.cephfs.csi.ceph.com-nodeplugin') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-mds_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "KILL_TIMEOUT": "180",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ mds_pod_label | default('app=rook-ceph-mds') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-rgw_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "180",
+      "KILL_TIMEOUT": "240",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ rgw_pod_label | default('app=rook-ceph-rgw') }}",
+      "WAIT_DURATION": "5"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-operator_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "300",
+      "KILL_TIMEOUT": "360",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ operator_pod_label | default('app=rook-ceph-operator') }}",
+      "WAIT_DURATION": "30"
     },
     "depends_on": "root_{{ suffix }}"
   },
@@ -460,7 +581,7 @@
     "name": "syn-flood",
     "env": {
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "TARGET_SERVICE_LABEL": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "TARGET_SERVICE_LABEL": "app=rook-ceph-osd",
       "TARGET_PORT": "8080",
       "TOTAL_CHAOS_DURATION": "180",
       "NUMBER_OF_PODS": "2"
@@ -472,7 +593,43 @@
     "name": "syn-flood",
     "env": {
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
-      "TARGET_SERVICE_LABEL": "{{ label_selector | default('app=rook-ceph-mgr') }}",
+      "TARGET_SERVICE_LABEL": "app=rook-ceph-mgr",
+      "TARGET_PORT": "8080",
+      "TOTAL_CHAOS_DURATION": "120",
+      "NUMBER_OF_PODS": "2"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "syn-flood-mds_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:syn-flood",
+    "name": "syn-flood",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TARGET_SERVICE_LABEL": "app=rook-ceph-mds",
+      "TARGET_PORT": "8080",
+      "TOTAL_CHAOS_DURATION": "120",
+      "NUMBER_OF_PODS": "2"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "syn-flood-rgw_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:syn-flood",
+    "name": "syn-flood",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TARGET_SERVICE_LABEL": "app=rook-ceph-rgw",
+      "TARGET_PORT": "8080",
+      "TOTAL_CHAOS_DURATION": "180",
+      "NUMBER_OF_PODS": "2"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "syn-flood-noobaa_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:syn-flood",
+    "name": "syn-flood",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TARGET_SERVICE_LABEL": "app=noobaa",
       "TARGET_PORT": "8080",
       "TOTAL_CHAOS_DURATION": "120",
       "NUMBER_OF_PODS": "2"
@@ -499,6 +656,58 @@
       "ACTION": "{{ time_action | default('skew_date') }}",
       "CONTAINER_NAME": "{{ time_container | default('') }}",
       "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios-mgr_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-mgr') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios-mds_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-mds') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios-rgw_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-rgw') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios-noobaa_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=noobaa') }}",
       "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
       "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
       "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1629,17 +1629,35 @@ def obc_io_create_delete(mcg_obj, awscli_pod, bucket_factory):
 
 
 def retrieve_verification_mode():
+    if config.DEPLOYMENT.get("disable_s3_ssl_verify"):
+        logger.info(
+            "S3 boto3 TLS verification disabled (DEPLOYMENT.disable_s3_ssl_verify)"
+        )
+        return False
+    base_domain = config.ENV_DATA.get("base_domain") or ""
     if (
-        (
-            config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
-            and config.ENV_DATA["deployment_type"] == "managed"
+        not config.DEPLOYMENT.get("force_s3_ssl_verify")
+        and config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
+        and "qe.rh-ocs.com" in base_domain
+    ):
+        # Router CA (DEFAULT_INGRESS_CRT_LOCAL_PATH) and public CAs often do not
+        # validate the NooBaa S3 HTTPS endpoint chain on IBM Cloud QE (self-signed
+        # intermediates, or routes not signed by router-ca). Boto3 then fails with
+        # SSL: CERTIFICATE_VERIFY_FAILED. AWS CLI in-cluster uses SERVICE_CA mounts;
+        # the Jenkins runner only has local PEMs, so we skip verify on this domain.
+        logger.info(
+            "S3 boto3 TLS verification disabled for IBM Cloud QE base_domain "
+            "(non-matching S3 certificate chain). "
+            "Set DEPLOYMENT.force_s3_ssl_verify: true to enforce verification."
         )
-        or config.ENV_DATA["platform"] == constants.ROSA_HCP_PLATFORM
-        or (
-            config.DEPLOYMENT.get("use_custom_ingress_ssl_cert")
-            and config.DEPLOYMENT["custom_ssl_cert_provider"]
-            == constants.SSL_CERT_PROVIDER_LETS_ENCRYPT
-        )
+        return False
+    # IBM Cloud managed: do not use verify=True here. Many QE clusters present
+    # S3 endpoints with a self-signed chain; MCG.__init__ already writes the
+    # cluster router CA to DEFAULT_INGRESS_CRT_LOCAL_PATH for boto3.
+    if config.ENV_DATA["platform"] == constants.ROSA_HCP_PLATFORM or (
+        config.DEPLOYMENT.get("use_custom_ingress_ssl_cert")
+        and config.DEPLOYMENT["custom_ssl_cert_provider"]
+        == constants.SSL_CERT_PROVIDER_LETS_ENCRYPT
     ):
         verify = True
     elif (

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -2,9 +2,11 @@ import concurrent.futures as futures
 from io import StringIO
 import logging
 import os
+import shlex
 from tempfile import mkdtemp
 import threading
 import time
+from urllib.parse import urlparse
 
 import pandas as pd
 
@@ -22,6 +24,47 @@ from ocs_ci.ocs.ui.workload_ui import wait_for_container_status_ready
 log = logging.getLogger(__name__)
 
 
+def warp_host_and_tls_from_noobaa_endpoint(endpoint_url, storage_namespace=None):
+    """
+    Map a NooBaa S3 base URL to warp ``--host`` (``host:port``) and the ``--tls`` flag.
+
+    Accepts ``MCG.s3_endpoint`` (external / Route) or ``MCG.s3_internal_endpoint``
+    (CR internalDNS). Explicit ports and scheme matter for SigV4 and TLS.
+
+    Args:
+        endpoint_url: HTTPS or HTTP URL, or host:port without scheme
+        storage_namespace: OpenShift namespace where NooBaa runs (default: openshift-storage)
+
+    Returns:
+        tuple: (host_colon_port, use_tls)
+    """
+    ns = storage_namespace or constants.OPENSHIFT_STORAGE_NAMESPACE
+    default_host = f"s3.{ns}.svc:443"
+    if not endpoint_url or not str(endpoint_url).strip():
+        log.warning("No S3 endpoint; defaulting Warp --host to %s", default_host)
+        return default_host, True
+    raw = str(endpoint_url).strip()
+    if "://" not in raw:
+        raw = "https://" + raw
+    parsed = urlparse(raw)
+    hostport = parsed.netloc
+    if not hostport:
+        hostport = parsed.path.strip("/")
+    if not hostport:
+        log.warning(
+            "Could not parse S3 endpoint %r; defaulting Warp --host to %s",
+            endpoint_url,
+            default_host,
+        )
+        return default_host, True
+    use_tls = parsed.scheme == "https"
+    if use_tls and ":" not in hostport:
+        hostport = f"{hostport}:443"
+    elif not use_tls and ":" not in hostport:
+        hostport = f"{hostport}:80"
+    return hostport, use_tls
+
+
 class Warp(object):
     """
     Warp - S3 benchmarking tool: https://github.com/minio/warp
@@ -31,24 +74,41 @@ class Warp(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, pod_name_suffix=None, namespace=None, s3_host=None):
         """
         Initializer to create warp pod to running warp benchmark
 
+        Args:
+            pod_name_suffix (str): Optional suffix for pod name to make it unique
+            namespace (str): Namespace to deploy Warp pods (default: cluster_namespace from config)
+            s3_host (str): S3 endpoint host (default: s3.{cluster_namespace}.svc)
         """
         self.pod_dic_path = constants.WARP_YAML
-        self.namespace = config.ENV_DATA["cluster_namespace"]
+        # Use provided namespace or fall back to cluster_namespace
+        self.namespace = namespace or config.ENV_DATA.get(
+            "cluster_namespace", "openshift-storage"
+        )
         self.ocp_obj = OCP(namespace=self.namespace)
         self.bucket_name = None
         self.warp_cr = templating.load_yaml(constants.WARP_OBJ_YAML)
-        # avoid failing DNS server to resolve hostname, when running on cluster with custom storage namespace
-        self.host = f"s3.{config.ENV_DATA['cluster_namespace']}.svc"
+        # Use provided S3 host or construct from cluster namespace
+        if s3_host:
+            self.host = s3_host
+        else:
+            # For default namespace, use openshift-storage for S3 endpoint
+            storage_namespace = config.ENV_DATA.get(
+                "cluster_namespace", "openshift-storage"
+            )
+            self.host = f"s3.{storage_namespace}.svc"
         self.duration = self.warp_cr["duration"]
         self.concurrent = self.warp_cr["concurrent"]
         self.obj_size = self.warp_cr["obj.size"]
         self.warp_bin_dir = self.warp_cr["warp_bin_dir"]
         self.output_file = "output.csv"
         self.warp_dir = mkdtemp(prefix="warp-")
+        self.pod_name_suffix = pod_name_suffix
+
+        log.info(f"Warp initialized: namespace={self.namespace}, s3_host={self.host}")
 
     def create_resource_warp(self, multi_client=False, replicas=1):
         """
@@ -75,7 +135,11 @@ class Warp(object):
         # Create test pvc+pod
         log.info(f"Create Warp pod to generate S3 workload in {self.namespace}")
         pvc_size = "50Gi"
-        self.pod_name = "warppod"
+        # Use unique pod name if suffix provided
+        if self.pod_name_suffix:
+            self.pod_name = f"warppod-{self.pod_name_suffix}"
+        else:
+            self.pod_name = "warppod"
         self.pvc_obj = helpers.create_pvc(
             sc_name=constants.DEFAULT_STORAGECLASS_CEPHFS,
             namespace=self.namespace,
@@ -117,6 +181,71 @@ class Warp(object):
                 ip = p.exec_cmd_on_pod(command="hostname -i")
                 self.client_ips[p.name] = ip
 
+    def _exec_warp_resilient(self, command, exec_timeout):
+        """
+        Run a warp-related shell command via oc exec; retry on transient container/exec errors.
+
+        After OOM/restart, kubelet may not have the ``warp`` container attached yet,
+        which surfaces as ``container not found`` or ``unable to upgrade connection``.
+
+        Concurrent cluster load (e.g. volume snapshots, node I/O) can keep the pod or
+        container unready longer than a short sleep; we wait for Ready before retrying.
+
+        Args:
+            command: Full command string passed to exec (e.g. blocking ``sh -c`` or
+                ``nohup ... &`` for background).
+            exec_timeout: ``oc exec`` timeout in seconds. Use the full benchmark
+                timeout when running warp synchronously; use a short value when the
+                command returns immediately (background start).
+        """
+        transient_markers = (
+            "container not found",
+            "unable to upgrade connection",
+        )
+        max_attempts = 24
+        delay_seconds = 15
+        wait_ready_timeout = 120
+        wait_ready_interval = 5
+        need_container_wait = False
+        for attempt in range(1, max_attempts + 1):
+            if need_container_wait:
+                log.info(
+                    "Waiting up to %ss for warp pod %s containers to be ready before retry",
+                    wait_ready_timeout,
+                    self.pod_obj.name,
+                )
+                wait_for_container_status_ready(
+                    self.pod_obj,
+                    timeout=wait_ready_timeout,
+                    interval=wait_ready_interval,
+                )
+                time.sleep(delay_seconds)
+            try:
+                self.pod_obj.exec_cmd_on_pod(
+                    command,
+                    out_yaml_format=False,
+                    timeout=exec_timeout,
+                    container_name="warp",
+                )
+                if attempt > 1:
+                    log.info("Warp exec succeeded after %s attempts", attempt)
+                return
+            except CommandFailed as exc:
+                msg = str(exc).lower()
+                retryable = any(marker in msg for marker in transient_markers)
+                if retryable and attempt < max_attempts:
+                    log.warning(
+                        "Warp exec not ready (attempt %s/%s): %s; "
+                        "next attempt will wait for container Ready (up to %ss) then retry",
+                        attempt,
+                        max_attempts,
+                        exc,
+                        wait_ready_timeout,
+                    )
+                    need_container_wait = True
+                else:
+                    raise
+
     def run_benchmark(
         self,
         bucket_name=None,
@@ -133,6 +262,7 @@ class Warp(object):
         insecure=False,
         debug=False,
         workload_type="put",
+        s3_region=None,
         kwargs=None,
     ):
         """
@@ -148,12 +278,16 @@ class Warp(object):
             objects (int): number of objects
             obj_size (int): size of object
             timeout (int): timeout in seconds
-            validate (Boolean): Validates whether running workload is completed.
+            validate (Boolean): If True, run warp synchronously until completion then
+                check ``output.csv``; if False, start warp in the background (returns
+                quickly; no CSV validation in this method).
             multi_client (Boolean): If True, then run multi client benchmarking
             tls (Boolean): Use TLS (HTTPS) for transport
             insecure (Boolean): disable TLS certification verification
             debug (Boolean): Enable debug output
             workload_type (str): Type of workload to run (put, get, stat, mixed, etc.)
+            s3_region (str): AWS SigV4 signing region. NooBaa expects ``us-east-1`` in
+                most deployments; do not pass cloud ENV_DATA region (e.g. IBM) here.
             kwargs (dict): Additional keyword arguments to pass to the warp command
         """
 
@@ -166,15 +300,23 @@ class Warp(object):
         self.duration = duration if duration else self.duration["duration"]
         self.concurrent = concurrent if concurrent else self.concurrent["concurrent"]
         self.obj_size = obj_size if obj_size else self.obj_size["obj.size"]
+        # Note: upstream minio/warp newer releases add --lookup; quay.io/ocsci/warp:latest
+        # may be older and does not support that flag.
+        warp_region = s3_region if s3_region is not None else "us-east-1"
+        objects_opt = ""
+        if objects is not None:
+            objects_opt = f"--objects={int(objects)} "
         base_options = "".join(
             f"--duration={self.duration} "
             f"--host={self.host} "
+            f"--region={warp_region} "
             f"--insecure={insecure} "
             f"--tls={tls} "
             f"--debug={debug} "
             f"--access-key={self.access_key} "
             f"--secret-key={self.secret_key} "
             f"--noclear --noprefix --concurrent={self.concurrent} "
+            f"{objects_opt}"
             f"--obj.size={self.obj_size} "
             f"--bucket={self.bucket_name} "
             f"--analyze.out={self.output_file} "
@@ -202,7 +344,27 @@ class Warp(object):
             + base_options
             + multi_client_options
         )
-        self.pod_obj.exec_cmd_on_pod(cmd, out_yaml_format=False, timeout=timeout)
+        # Background: avoid bash -c '...' (extra fork + brittle quoting for secrets).
+        # nohup + sh -c with shlex.quote handles special characters in keys; stdin
+        # detached from /dev/null. Under Krkn chaos, "can't fork" is mitigated
+        # slightly by one fewer shell layer than bash -c.
+        inner = f"{cmd} > /tmp/warp.log 2>&1"
+        if validate:
+            # Synchronous run: block until warp finishes so output.csv exists for validation.
+            cmd_blocking = f"sh -c {shlex.quote(inner)}"
+            self._exec_warp_resilient(cmd_blocking, exec_timeout=timeout)
+            log.info(
+                "Warp benchmark finished (synchronous run; validation will follow)"
+            )
+        else:
+            cmd_with_logging = f"nohup sh -c {shlex.quote(inner)} </dev/null &"
+            self._exec_warp_resilient(cmd_with_logging, exec_timeout=10)
+            log.info(
+                "Warp benchmark started in background. Check logs with: "
+                "oc exec %s -n %s -c warp -- tail -f /tmp/warp.log",
+                self.pod_obj.name,
+                self.namespace,
+            )
 
         if validate:
             self.validate_warp_workload()
@@ -230,6 +392,43 @@ class Warp(object):
                 f"Output file {self.output_file} is empty, "
                 "Warp workload doesn't run as expected..."
             )
+
+    def get_warp_logs(self, lines=50):
+        """
+        Get Warp workload logs from the pod.
+
+        Args:
+            lines (int): Number of log lines to retrieve
+
+        Returns:
+            str: Warp log output
+        """
+        try:
+            cmd = f"tail -n {lines} /tmp/warp.log 2>/dev/null || echo 'Warp log not available yet'"
+            result = self.pod_obj.exec_cmd_on_pod(
+                cmd, out_yaml_format=False, container_name="warp"
+            )
+            return result
+        except Exception as e:
+            log.warning(f"Could not retrieve Warp logs: {e}")
+            return None
+
+    def is_warp_running(self):
+        """
+        Check if Warp process is currently running in the pod.
+
+        Returns:
+            bool: True if Warp is running, False otherwise
+        """
+        try:
+            cmd = "ps aux | grep '[w]arp mixed\\|[w]arp get\\|[w]arp put\\|[w]arp delete\\|[w]arp stat'"
+            result = self.pod_obj.exec_cmd_on_pod(
+                cmd, out_yaml_format=False, container_name="warp"
+            )
+            return bool(result and "warp" in result)
+        except Exception as e:
+            log.warning(f"Could not check Warp status: {e}")
+            return False
 
     def cleanup(self, multi_client=False):
         """

--- a/ocs_ci/resiliency/resiliency_workload.py
+++ b/ocs_ci/resiliency/resiliency_workload.py
@@ -414,6 +414,287 @@ class RGWWorkload(Workload):
         return self.workload_impl.get_workload_status()
 
 
+class WarpWorkload(Workload):
+    """
+    Warp workload wrapper for MCG/NooBaa stress testing.
+
+    This class provides Warp S3 benchmark operations for high-intensity
+    MCG/NooBaa chaos and stress testing.
+
+    Warp is MinIO's S3 benchmarking tool that provides:
+    - High-performance S3 operations (GET, PUT, DELETE, LIST)
+    - Mixed workload support
+    - Continuous stress testing capabilities
+    - Detailed performance metrics
+
+    Args:
+        mcg_obj: MCG object for NooBaa access
+        bucket_name (str): Name of the bucket to use for testing
+        namespace (str): Kubernetes namespace
+        workload_config (dict): Configuration for Warp operations
+    """
+
+    def __init__(
+        self,
+        mcg_obj,
+        bucket_name,
+        namespace=None,
+        workload_config=None,
+    ):
+        super().__init__(namespace=namespace or constants.OPENSHIFT_STORAGE_NAMESPACE)
+        self.mcg_obj = mcg_obj
+        self.bucket_name = bucket_name
+        self.workload_config = workload_config or {}
+        self.warp_pod = None
+        self.is_workload_running = False
+        self.workload_thread = None
+        self.stop_event = None
+        self._warp_stopped_after_consecutive_failures = False
+
+        log.info(
+            f"Initialized Warp workload for MCG stress testing: bucket={bucket_name}"
+        )
+
+    def start_workload(self):
+        """Start the Warp workload in a background thread."""
+        import threading
+        from ocs_ci.ocs.warp import Warp, warp_host_and_tls_from_noobaa_endpoint
+
+        log.info(f"Starting Warp workload for bucket: {self.bucket_name}")
+
+        self._warp_stopped_after_consecutive_failures = False
+        # Extract suffix from bucket name (e.g., "warp-test-abc" -> "abc")
+        pod_suffix = (
+            self.bucket_name.split("-")[-1]
+            if "-" in self.bucket_name
+            else self.bucket_name[:8]
+        )
+
+        # Default: plain HTTP to in-cluster S3 Service port 80 — same style as
+        # tests/cross_functional/scale/noobaa/test_warp.py (run_benchmark omits tls=True).
+        # HTTPS to the external Route or :443 internal often yields Access Denied with
+        # this older minio/warp binary against NooBaa (SigV4 / virtual-host semantics).
+        storage_namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+        prefer_plain = self.workload_config.get("prefer_plain_http", True)
+        if prefer_plain:
+            s3_host = f"s3.{storage_namespace}.svc:80"
+            s3_tls = False
+            ep_label = "plain HTTP in-cluster :80 (see test_warp.py)"
+        else:
+            use_internal = self.workload_config.get("use_internal_s3_endpoint", False)
+            override = self.workload_config.get("s3_endpoint_override")
+            if override:
+                endpoint_src = override
+                ep_label = "override"
+            elif use_internal:
+                endpoint_src = getattr(self.mcg_obj, "s3_internal_endpoint", None)
+                ep_label = "internal (NooBaa CR)"
+            else:
+                endpoint_src = getattr(self.mcg_obj, "s3_endpoint", None) or getattr(
+                    self.mcg_obj, "s3_internal_endpoint", None
+                )
+                ep_label = "external (fallback internal if unset)"
+            s3_host, s3_tls = warp_host_and_tls_from_noobaa_endpoint(
+                endpoint_src,
+                storage_namespace=storage_namespace,
+            )
+        tls_skip_verify = s3_tls and self.workload_config.get("warp_insecure_tls", True)
+        log.info(
+            "Warp S3: host=%s tls=%s verify_tls=%s (source=%s)",
+            s3_host,
+            s3_tls,
+            tls_skip_verify,
+            ep_label,
+        )
+
+        self.warp = Warp(
+            pod_name_suffix=pod_suffix, namespace=self.namespace, s3_host=s3_host
+        )
+        self.warp.create_resource_warp()
+
+        # Get workload configuration
+        workload_type = self.workload_config.get("workload_type", "mixed")
+        duration = self.workload_config.get("duration", "10m")
+        concurrent = self.workload_config.get("concurrent", 1)
+        objects = self.workload_config.get("objects", 1000)
+        obj_size = self.workload_config.get("obj_size", "1MiB")
+
+        # Get NooBaa credentials
+        access_key = self.mcg_obj.access_key_id
+        secret_key = self.mcg_obj.access_key
+
+        # Set up stop event
+        self.stop_event = threading.Event()
+
+        # Stop retrying after repeated permanent failures (bad bucket, auth, etc.)
+        max_consecutive_failures = int(
+            self.workload_config.get("max_consecutive_warp_failures", 5)
+        )
+
+        def run_warp_continuous():
+            """Run Warp benchmark continuously until stopped or failure budget exceeded."""
+            consecutive_failures = 0
+            while not self.stop_event.is_set():
+                try:
+                    log.info(f"Running Warp {workload_type} workload iteration")
+                    self.warp.run_benchmark(
+                        workload_type=workload_type,
+                        bucket_name=self.bucket_name,
+                        access_key=access_key,
+                        secret_key=secret_key,
+                        duration=duration,
+                        concurrent=concurrent,
+                        objects=objects,
+                        obj_size=obj_size,
+                        tls=s3_tls,
+                        insecure=tls_skip_verify,
+                        validate=False,
+                        multi_client=False,
+                    )
+                    consecutive_failures = 0
+                except Exception as e:
+                    consecutive_failures += 1
+                    log.warning(
+                        "Warp workload iteration failed (%s/%s): %s",
+                        consecutive_failures,
+                        max_consecutive_failures,
+                        e,
+                    )
+                    if self.stop_event.is_set():
+                        break
+                    if consecutive_failures >= max_consecutive_failures:
+                        log.error(
+                            "Stopping Warp background workload after %s consecutive "
+                            "failures (max_consecutive_warp_failures=%s). Last error: %s",
+                            consecutive_failures,
+                            max_consecutive_failures,
+                            e,
+                        )
+                        self.is_workload_running = False
+                        self._warp_stopped_after_consecutive_failures = True
+                        break
+                    self.stop_event.wait(10)
+
+        # Start workload thread
+        self.workload_thread = threading.Thread(target=run_warp_continuous)
+        self.workload_thread.daemon = True
+        self.workload_thread.start()
+        self.is_workload_running = True
+
+        log.info("Warp workload started in background thread")
+
+    def scale_up_pods(self, desired_count):
+        """Warp workload doesn't support pod scaling."""
+        log.warning("Warp workload does not support pod scaling")
+
+    def scale_down_pods(self, desired_count):
+        """Warp workload doesn't support pod scaling."""
+        log.warning("Warp workload does not support pod scaling")
+
+    def stop_workload(self):
+        """Stop the Warp workload."""
+        log.info("Stopping Warp workload")
+        if self.stop_event:
+            self.stop_event.set()
+
+        if self.workload_thread and self.workload_thread.is_alive():
+            self.workload_thread.join(timeout=120)
+            if self.workload_thread.is_alive():
+                log.warning("Warp workload thread did not stop gracefully")
+
+        self.is_workload_running = False
+        log.info("Warp workload stopped")
+
+    def cleanup_workload(self):
+        """Cleanup Warp workload resources."""
+        log.info(f"Cleaning up Warp workload for bucket: {self.bucket_name}")
+
+        # Stop the workload thread first
+        try:
+            self.stop_workload()
+        except Exception as e:
+            log.warning(f"Error stopping workload: {e}")
+
+        # Cleanup Warp pod and resources
+        if hasattr(self, "warp") and self.warp:
+            try:
+                log.info(
+                    f"Cleaning up Warp pod: {self.warp.pod_name if hasattr(self.warp, 'pod_name') else 'unknown'}"
+                )
+                self.warp.cleanup(multi_client=False)
+                log.info("✓ Warp pod, PVC, and ServiceAccount cleaned up")
+            except Exception as e:
+                log.warning(f"Error cleaning up Warp resources: {e}")
+
+        # Delete the bucket
+        if self.bucket_name and self.mcg_obj:
+            try:
+                log.info(f"Deleting Warp test bucket: {self.bucket_name}")
+                from ocs_ci.ocs.bucket_utils import s3_delete_bucket
+
+                # First, try to empty the bucket (delete all objects)
+                try:
+                    log.info(f"Emptying bucket {self.bucket_name} before deletion...")
+                    from ocs_ci.ocs.bucket_utils import rm_object_recursive
+                    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+                    # Get awscli pod if available
+                    awscli_pods = get_pods_having_label(
+                        label="app=awscli-pod", namespace=self.namespace
+                    )
+                    if awscli_pods:
+                        awscli_pod = awscli_pods[0]
+                        from ocs_ci.ocs.resources.pod import Pod
+
+                        pod_obj = Pod(**awscli_pod)
+                        rm_object_recursive(
+                            pod_obj,
+                            self.bucket_name,
+                            self.mcg_obj,
+                            option="",
+                        )
+                        log.info(f"✓ Bucket {self.bucket_name} emptied")
+                except Exception as e:
+                    log.warning(f"Could not empty bucket (will try force delete): {e}")
+
+                # Delete the bucket
+                s3_delete_bucket(
+                    s3_obj=self.mcg_obj,
+                    bucket_name=self.bucket_name,
+                )
+                log.info(f"✓ Bucket {self.bucket_name} deleted successfully")
+            except Exception as e:
+                log.warning(f"Error deleting bucket {self.bucket_name}: {e}")
+                log.info("Bucket may need manual cleanup if it still exists")
+
+        log.info(f"✓ Warp workload cleanup completed for bucket: {self.bucket_name}")
+
+    def pause_workload(self):
+        """Pause the Warp workload."""
+        log.info("Pausing Warp workload (stopping)")
+        self.stop_workload()
+
+    def resume_workload(self):
+        """Resume the Warp workload."""
+        log.info("Resuming Warp workload (restarting)")
+        self.start_workload()
+
+    def is_running(self):
+        """Check if workload is running."""
+        return self.is_workload_running and (
+            self.workload_thread and self.workload_thread.is_alive()
+        )
+
+    def get_workload_status(self):
+        """Get workload status."""
+        return {
+            "is_running": self.is_running(),
+            "bucket_name": self.bucket_name,
+            "workload_type": self.workload_config.get("workload_type", "mixed"),
+            "stopped_after_consecutive_failures": self._warp_stopped_after_consecutive_failures,
+        }
+
+
 def workload_object(workload_type, namespace):
     """
     Factory method to create a workload object based on type.

--- a/ocs_ci/templates/app-pods/warp.yaml
+++ b/ocs_ci/templates/app-pods/warp.yaml
@@ -25,9 +25,14 @@ spec:
       - name: warp
         image: quay.io/ocsci/warp:latest
         resources:
+          requests:
+            memory: "512Mi"
+            cpu: "100m"
           limits:
-            memory: "2048Mi"
-            cpu: "150m"
+            # Mixed/long-duration Warp runs can spike during analysis; chaos + S3 stress
+            # often needs more than 4Gi on busy clusters.
+            memory: "8Gi"
+            cpu: "2000m"
         command: ["/bin/bash", "-ce", "tail -f /dev/null" ]
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/tests/cross_functional/krkn_chaos/test_krkn_noobaa_chaos.py
+++ b/tests/cross_functional/krkn_chaos/test_krkn_noobaa_chaos.py
@@ -1,0 +1,417 @@
+"""
+Test suite for Krkn NooBaa pod disruption chaos scenarios.
+
+This module provides comprehensive tests for NooBaa pod disruption using the Krkn chaos
+engineering tool with continuous pod killing while S3 metadata workload is running.
+
+Target Pods:
+- Primary: noobaa-db-pg (NooBaa PostgreSQL database)
+- Secondary: noobaa-core (NooBaa core service)
+- Secondary: noobaa-operator (NooBaa operator)
+
+Chaos Behavior:
+- Force delete pods (no graceful shutdown) at fixed intervals
+- Deletions happen periodically throughout the test duration
+- Chaos overlaps with active S3 metadata workload
+- Pods may be killed multiple times during one test run
+
+The tests validate system resilience by:
+- Running continuous S3 operations during chaos
+- Verifying NooBaa can recover from repeated pod disruptions
+- Ensuring no permanent database corruption
+- Validating S3 service availability during pod restarts
+"""
+
+import pytest
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad, chaos, polarion_id
+from ocs_ci.krkn_chaos.krkn_config_generator import KrknConfigGenerator
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
+from ocs_ci.krkn_chaos.krkn_helpers import (
+    KrknExecutionHelper,
+    KrknResultAnalyzer,
+    ValidationHelper,
+)
+from ocs_ci.krkn_chaos.logging_helpers import log_test_start
+from ocs_ci.krkn_chaos.krkn_scenario_generator import PodScenarios
+from ocs_ci.krkn_chaos.noobaa_chaos_helper import validate_noobaa_health
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@chaos
+class TestKrKnNooBaaChaos:
+    """
+    Test suite for Krkn NooBaa pod disruption chaos scenarios.
+
+    These tests repeatedly kill NooBaa pods at fixed intervals while S3 metadata
+    workload is running, validating NooBaa resilience and data integrity.
+    """
+
+    @pytest.mark.parametrize(
+        "target_pod,duration_seconds,kill_interval_seconds",
+        [
+            # NooBaa DB PRIMARY pod - most critical for testing failover
+            # Specifically targets the primary pod by exact name
+            ("noobaa-db-pg-cluster-1", 1200, 180),  # 20 min test, kill every 3 min
+            ("noobaa-db-pg-cluster-1", 1800, 240),  # 30 min test, kill every 4 min
+            ("noobaa-db-pg-cluster-1", 3600, 300),  # 60 min test, kill every 5 min
+            # NooBaa core pod - critical for S3 operations
+            ("noobaa-core-0", 1200, 180),  # 20 min test, kill every 3 min
+            ("noobaa-core-0", 1800, 240),  # 30 min test, kill every 4 min
+            # NooBaa operator pod - manages NooBaa lifecycle
+            ("noobaa-operator.*", 1200, 180),  # 20 min test, kill every 3 min
+        ],
+        ids=[
+            "noobaa-db-primary-20min-180s-interval",
+            "noobaa-db-primary-30min-240s-interval",
+            "noobaa-db-primary-60min-300s-interval",
+            "noobaa-core-20min-180s-interval",
+            "noobaa-core-30min-240s-interval",
+            "noobaa-operator-20min-180s-interval",
+        ],
+    )
+    @polarion_id("OCS-7342")
+    def test_krkn_noobaa_pod_disruption_with_s3_workload(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        target_pod,
+        duration_seconds,
+        kill_interval_seconds,
+    ):
+        """
+        Test NooBaa pod disruption with continuous pod killing and S3 workload.
+
+        This chaos test validates NooBaa resilience by:
+        1. Starting S3 metadata workload (continuous operations)
+        2. Repeatedly killing NooBaa pods at fixed intervals
+        3. Validating NooBaa recovers from each pod kill
+        4. Ensuring S3 workload continues despite disruptions
+        5. Verifying no permanent database corruption
+
+        The test uses KRKN pod-disruption scenarios to force delete pods without
+        graceful shutdown, simulating abrupt failures.
+
+        Args:
+            request: pytest request (finalizer for workload cleanup on failure)
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture that provides pre-configured S3 workloads
+            target_pod: Pod name or pattern to kill (e.g., "noobaa-db-pg-0")
+            duration_seconds: Total chaos duration in seconds
+            kill_interval_seconds: Interval between pod kills in seconds
+        """
+        # Use helper function for standardized test start logging
+        log_test_start(
+            "NooBaa pod disruption",
+            target_pod,
+            component_name=target_pod,
+            duration=f"{duration_seconds}s",
+            kill_interval=f"{kill_interval_seconds}s",
+        )
+
+        # WORKLOAD SETUP - Start S3 workloads before chaos
+        log.info("Setting up S3 workloads for NooBaa chaos testing")
+        log.info(f"🎯 Target pod: {target_pod}")
+        log.info(
+            f"⏱️  Total duration: {duration_seconds}s ({duration_seconds // 60} minutes)"
+        )
+        log.info(f"🔄 Kill interval: {kill_interval_seconds}s")
+        log.info(f"🔥 Expected pod kills: ~{duration_seconds // kill_interval_seconds}")
+
+        workload_ops.setup_workloads()
+
+        _workload_cleanup_done = []
+
+        def _workload_validate_and_cleanup_once():
+            if _workload_cleanup_done:
+                return
+            try:
+                workload_ops.validate_and_cleanup()
+                log.info("✅ S3 workloads validated and cleaned up successfully")
+            except (UnexpectedBehaviour, CommandFailed) as e:
+                log.warning(
+                    "⚠️  Workload validation/cleanup issue (finalizer or post-chaos): %s",
+                    str(e),
+                )
+                log.info(
+                    "Temporary S3 failures during pod disruption are expected behavior"
+                )
+            finally:
+                _workload_cleanup_done.append(True)
+
+        request.addfinalizer(_workload_validate_and_cleanup_once)
+
+        # Calculate number of iterations for repeated pod kills
+        # We'll use KRKN's iteration feature to repeat the chaos
+        num_iterations = max(1, duration_seconds // kill_interval_seconds)
+
+        log.info(
+            f"📋 Configuring {num_iterations} pod kill iterations with "
+            f"{kill_interval_seconds}s wait between kills"
+        )
+
+        # Create pod kill scenario using PodScenarios
+        # Use name_pattern to match the target pod (regex patterns work directly)
+        scenario_file = PodScenarios.regex_openshift_pod_kill(
+            scenario_dir=krkn_scenario_directory,
+            namespace_pattern="^openshift-storage$",
+            name_pattern=target_pod,  # Use the regex pattern directly
+            kill=1,  # Kill 1 pod at a time
+            krkn_pod_recovery_time=kill_interval_seconds,  # Recovery time = kill interval
+        )
+
+        log.info(f"📋 Generated pod disruption scenario: {scenario_file}")
+
+        # Configure Krkn with iterations for repeated chaos
+        config = KrknConfigGenerator()
+        config.add_scenario("pod_disruption_scenarios", scenario_file)
+
+        # Set tunings for repeated pod kills
+        # wait_duration is the time between iterations
+        config.set_tunings(
+            wait_duration=kill_interval_seconds,  # Wait between kills
+            iterations=num_iterations,  # Number of times to repeat
+        )
+        config.write_to_file(location=krkn_scenario_directory)
+
+        log.info(f"🚀 Starting NooBaa pod disruption chaos for {duration_seconds}s")
+        log.info(f"⚡ Pods will be killed every {kill_interval_seconds}s")
+        log.info(f"💥 Total expected disruptions: {num_iterations}")
+
+        # Execute chaos scenarios using KrknExecutionHelper
+        executor = KrknExecutionHelper(namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        chaos_data = executor.execute_chaos_scenarios(
+            config, target_pod, "NooBaa pod disruption"
+        )
+
+        log.info("✅ Chaos execution completed")
+        log.info(f"📊 Total iterations executed: {num_iterations}")
+
+        # Validate workloads (idempotent with finalizer: runs once if not already done)
+        log.info("🔍 Validating S3 workload health after chaos")
+        _workload_validate_and_cleanup_once()
+
+        # Analyze results
+        analyzer = KrknResultAnalyzer()
+        total_scenarios, successful_scenarios, failing_scenarios = (
+            analyzer.analyze_application_outage_results(chaos_data, target_pod)
+        )
+
+        log.info("📊 Chaos Results:")
+        log.info(f"   Total scenarios: {total_scenarios}")
+        log.info(f"   Successful: {successful_scenarios}")
+        log.info(f"   Failed: {failing_scenarios}")
+
+        # Validate chaos execution using ValidationHelper
+        # We expect some transient failures during pod kills
+        validator = ValidationHelper()
+        validator.validate_chaos_execution(
+            total_scenarios,
+            successful_scenarios,
+            target_pod,
+            "NooBaa pod disruption chaos",
+        )
+
+        # Final NooBaa health check
+        log.info("🔍 Performing final NooBaa health validation")
+        validate_noobaa_health(target_pod)
+
+        log.info(
+            f"🎉 NooBaa pod disruption test for {target_pod} completed successfully"
+        )
+
+    @pytest.mark.parametrize(
+        "stress_level,duration_multiplier,kill_interval",
+        [
+            ("high", 3, 120),  # High stress: 3x duration, kill every 2 min
+            ("extreme", 5, 90),  # Extreme stress: 5x duration, kill every 90s
+            ("ultimate", 8, 60),  # Ultimate stress: 8x duration, kill every 60s
+        ],
+        ids=[
+            "noobaa-high-stress",
+            "noobaa-extreme-stress",
+            "noobaa-ultimate-stress",
+        ],
+    )
+    @polarion_id("OCS-7343")
+    def test_krkn_noobaa_strength_testing(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        stress_level,
+        duration_multiplier,
+        kill_interval,
+    ):
+        """
+        Extreme NooBaa strength testing with aggressive pod disruption.
+
+        This test pushes NooBaa to its limits with:
+        - Multiple NooBaa components targeted simultaneously
+        - Rapid pod kills at short intervals
+        - Extended test duration
+        - Continuous S3 metadata operations
+
+        The test validates that NooBaa can withstand:
+        - Repeated database pod failures
+        - Concurrent core and operator disruptions
+        - High-frequency pod kills
+        - Sustained chaos over long durations
+
+        Args:
+            request: pytest request (finalizer for workload cleanup on failure)
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture that provides pre-configured S3 workloads
+            stress_level: Level of stress testing (high, extreme, ultimate)
+            duration_multiplier: Multiplier for base duration
+            kill_interval: Interval between pod kills in seconds
+        """
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"{stress_level.upper()} NooBaa strength testing",
+            "noobaa-all-pods",
+            component_name="noobaa",
+            stress_level=stress_level.upper(),
+            duration_multiplier=duration_multiplier,
+            kill_interval=f"{kill_interval}s",
+        )
+
+        log.info(
+            f"⚠️  {stress_level.upper()} TESTING WARNING: This test will aggressively disrupt NooBaa pods"
+        )
+        log.info(
+            f"🔥 Configuration: {duration_multiplier}x duration, {kill_interval}s kill interval"
+        )
+
+        # WORKLOAD SETUP
+        log.info("Setting up S3 workloads for strength testing")
+        workload_ops.setup_workloads()
+
+        _workload_cleanup_done = []
+
+        def _workload_validate_and_cleanup_once():
+            if _workload_cleanup_done:
+                return
+            try:
+                workload_ops.validate_and_cleanup()
+                log.info(
+                    "💪 Workloads survived strength testing - resilience confirmed!"
+                )
+            except (UnexpectedBehaviour, CommandFailed) as e:
+                validator = ValidationHelper()
+                validator.handle_workload_validation_failure(
+                    e, "noobaa", f"{stress_level} strength testing"
+                )
+            finally:
+                _workload_cleanup_done.append(True)
+
+        request.addfinalizer(_workload_validate_and_cleanup_once)
+
+        # Base duration for stress testing
+        base_duration = 600  # 10 minutes base
+        total_duration = base_duration * duration_multiplier
+
+        # Create multiple scenarios for different NooBaa pods
+        scenarios = []
+
+        # Target multiple NooBaa components for strength testing
+        # Specifically targeting primary DB pod for realistic failover testing
+        target_pods = [
+            (
+                "noobaa-db-pg-cluster-1",
+                "NooBaa Database Primary",
+            ),  # Targets primary pod specifically
+            ("noobaa-core-0", "NooBaa Core"),
+            ("noobaa-operator.*", "NooBaa Operator"),
+        ]
+
+        log.info(f"📋 Creating {len(target_pods)} pod disruption scenarios")
+
+        for pod_pattern, description in target_pods:
+            num_iterations = max(1, total_duration // kill_interval)
+
+            scenario_file = PodScenarios.regex_openshift_pod_kill(
+                scenario_dir=krkn_scenario_directory,
+                namespace_pattern="^openshift-storage$",
+                name_pattern=pod_pattern,  # Use the regex pattern directly
+                kill=1,
+                krkn_pod_recovery_time=kill_interval,
+            )
+            scenarios.append(scenario_file)
+            log.info(
+                f"   ✓ {description}: {num_iterations} iterations at {kill_interval}s intervals"
+            )
+
+        # Configure and execute all scenarios
+        config = KrknConfigGenerator()
+        for scenario in scenarios:
+            config.add_scenario("pod_disruption_scenarios", scenario)
+
+        num_iterations = max(1, total_duration // kill_interval)
+        config.set_tunings(
+            wait_duration=kill_interval,
+            iterations=num_iterations,
+        )
+        config.write_to_file(location=krkn_scenario_directory)
+
+        log.info(f"🚀 Starting {stress_level.upper()} NooBaa strength testing")
+        log.info(
+            f"⏱️  Total duration: {total_duration}s ({total_duration // 60} minutes)"
+        )
+        log.info(f"💥 Expected disruptions per pod: ~{num_iterations}")
+
+        # Execute strength test scenarios
+        executor = KrknExecutionHelper(namespace=constants.OPENSHIFT_STORAGE_NAMESPACE)
+        chaos_data = executor.execute_strength_test_scenarios(
+            config, "noobaa", stress_level
+        )
+
+        # Enhanced validation for strength testing (idempotent with finalizer)
+        log.info("🔍 Validating workloads after strength testing")
+        _workload_validate_and_cleanup_once()
+
+        # Analyze results with strength-specific criteria
+        analyzer = KrknResultAnalyzer()
+        total_scenarios, successful_scenarios, strength_score = (
+            analyzer.analyze_strength_test_results(chaos_data, "noobaa", stress_level)
+        )
+
+        log.info("📊 Strength Test Results:")
+        log.info(f"   Total scenarios: {total_scenarios}")
+        log.info(f"   Successful: {successful_scenarios}")
+        log.info(f"   Strength score: {strength_score:.1f}%")
+
+        # Validate strength test results
+        # Set appropriate success thresholds based on stress level
+        min_success_rates = {
+            "high": 70,
+            "extreme": 60,
+            "ultimate": 50,
+        }
+
+        validator = ValidationHelper()
+        validator.validate_strength_test_results(
+            strength_score,
+            len(chaos_data["telemetry"]["scenarios"]),
+            "noobaa",
+            stress_level,
+            min_success_rate=min_success_rates.get(stress_level, 60),
+        )
+
+        # Final NooBaa health check
+        log.info("🔍 Performing final NooBaa health validation")
+        validate_noobaa_health("noobaa-all-pods")
+
+        log.info(
+            f"🎉 STRENGTH TEST PASSED: NooBaa achieved {strength_score:.1f}% "
+            f"resilience under {stress_level} stress!"
+        )

--- a/tests/cross_functional/krkn_chaos/test_krkn_noobaa_container_chaos.py
+++ b/tests/cross_functional/krkn_chaos/test_krkn_noobaa_container_chaos.py
@@ -1,0 +1,736 @@
+"""
+Test suite for Krkn NooBaa container kill chaos scenarios with various signals.
+
+This module provides comprehensive tests for NooBaa container disruption using the Krkn chaos
+engineering tool with different kill signals (SIGKILL, SIGTERM, SIGHUP, SIGINT, SIGQUIT).
+
+Target Components:
+- NooBaa Core (noobaa-core): Main S3 service container
+- NooBaa Database (noobaa-db-pg): PostgreSQL database containers
+- NooBaa Operator (noobaa-operator): Operator managing NooBaa lifecycle
+- NooBaa Endpoint (noobaa-s3): S3 endpoint service containers
+
+Kill Signals:
+- SIGKILL (9): Immediate termination, no cleanup
+- SIGTERM (15): Graceful termination request
+- SIGHUP (1): Hang up signal, typically causes reload
+- SIGINT (2): Interrupt signal (Ctrl+C equivalent)
+- SIGQUIT (3): Quit signal with core dump
+
+The tests validate system resilience by:
+- Running continuous Warp S3 workload during chaos
+- Verifying NooBaa containers recover from various signal types
+- Ensuring no permanent data corruption
+- Validating S3 service availability during container restarts
+"""
+
+import pytest
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import green_squad, chaos, polarion_id
+from ocs_ci.krkn_chaos.krkn_chaos import KrKnRunner
+from ocs_ci.krkn_chaos.krkn_config_generator import KrknConfigGenerator
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.krkn_chaos.krkn_helpers import (
+    KrknResultAnalyzer,
+    CephHealthHelper,
+    ValidationHelper,
+    ContainerScenarioHelper,
+)
+from ocs_ci.krkn_chaos.krkn_scenario_generator import ContainerScenarios
+from ocs_ci.krkn_chaos.logging_helpers import log_test_start
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@chaos
+class TestKrKnNooBaaContainerChaos:
+    """
+    Test suite for NooBaa container kill chaos scenarios with various signals.
+
+    Contains parameterized tests that target different NooBaa components with
+    different kill signals to validate container-level resilience.
+    """
+
+    @pytest.mark.parametrize(
+        "kill_signal",
+        [
+            "SIGKILL",  # Force kill - immediate termination
+            "SIGTERM",  # Graceful termination
+            "SIGHUP",  # Hang up - often triggers reload
+            "SIGINT",  # Interrupt signal
+            "SIGQUIT",  # Quit with core dump
+        ],
+        ids=[
+            "sigkill-noobaa",
+            "sigterm-noobaa",
+            "sighup-noobaa",
+            "sigint-noobaa",
+            "sigquit-noobaa",
+        ],
+    )
+    @polarion_id("OCS-7344")
+    def test_krkn_noobaa_container_kill_signals(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        kill_signal,
+    ):
+        """
+        Test NooBaa container disruption with various kill signals.
+
+        This test validates NooBaa resilience by killing all NooBaa containers
+        with different signals:
+        - SIGKILL: Immediate termination without cleanup
+        - SIGTERM: Graceful shutdown allowing cleanup
+        - SIGHUP: Hang up signal (often triggers config reload)
+        - SIGINT: Interrupt signal (Ctrl+C equivalent)
+        - SIGQUIT: Quit signal with core dump
+
+        The test runs Warp S3 workload continuously while killing containers
+        to ensure NooBaa can handle container-level disruptions gracefully.
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+            kill_signal: Kill signal to use for container termination
+        """
+        scenario_dir = krkn_scenario_directory
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"NooBaa container kill ({kill_signal})",
+            "all-noobaa-containers",
+            component_name=f"noobaa-containers-{kill_signal.lower()}",
+            signal=kill_signal,
+            safety_info=f"Testing all NooBaa containers with {kill_signal} signal",
+        )
+
+        # WORKLOAD SETUP - Start Warp S3 workloads before chaos
+        log.info(
+            f"Setting up Warp S3 workloads for NooBaa container chaos testing with {kill_signal}"
+        )
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        try:
+            # =================================================================
+            # NOOBAA CONTAINER KILL SCENARIOS
+            # =================================================================
+            log.info(
+                f"Creating NooBaa container kill configuration with {kill_signal} signal"
+            )
+
+            # Define NooBaa-specific components for container kill
+            noobaa_components = [
+                {
+                    "name": "noobaa",
+                    "description": "NooBaa (All Components)",
+                },
+            ]
+
+            # Build container kill scenarios using the helper class
+            scenario_helper = ContainerScenarioHelper()
+            noobaa_scenarios = scenario_helper.build_unified_scenarios(
+                namespace="openshift-storage",
+                kill_signal=kill_signal,
+                count=1,  # Kill 1 container at a time
+                expected_recovery_time=120,
+                container_name="",  # Leave blank to target all containers in the pod
+                components=noobaa_components,
+            )
+
+            # Log scenario details
+            scenario_helper.log_scenario_details(
+                noobaa_scenarios,
+                title=f"NOOBAA CONTAINER KILL SCENARIOS ({kill_signal})",
+                kill_signal=kill_signal,
+                style="detailed",
+            )
+
+            # Create container chaos scenario file
+            scenario_file = ContainerScenarios.container_kill(
+                scenario_dir=scenario_dir,
+                scenarios=noobaa_scenarios,
+            )
+
+            log.info(f"Created NooBaa container kill scenario file: {scenario_file}")
+
+            # Create Krkn configuration
+            config = KrknConfigGenerator()
+            config.add_scenario("container_scenarios", scenario_file)
+
+            # =================================================================
+            # EXECUTION: Single Krkn run with specified kill signal
+            # =================================================================
+            log.info(f"Executing NooBaa container chaos with {kill_signal}")
+
+            # Configure and write Krkn configuration to file
+            config.set_tunings(wait_duration=60, iterations=1)
+            config.write_to_file(location=krkn_scenario_directory)
+
+            # Execute Krkn
+            krkn_runner = KrKnRunner(config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info(f"NooBaa container chaos with {kill_signal} completed")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                f"noobaa-container-{kill_signal.lower()}",
+                f"NooBaa container chaos ({kill_signal})",
+            )
+            raise
+        except Exception as e:
+            log.error(f"❌ NooBaa container chaos with {kill_signal} failed: {e}")
+            raise
+
+        # =================================================================
+        # RESULTS ANALYSIS
+        # =================================================================
+        log.info(f"NOOBAA CONTAINER CHAOS RESULTS ({kill_signal}):")
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output,
+                f"noobaa-container-{kill_signal.lower()}",
+                detail_level="detailed",
+            )
+        )
+
+        overall_success_rate = (
+            (successful_executed / total_executed * 100) if total_executed > 0 else 0
+        )
+
+        log.info(
+            f"EXECUTION RESULTS: Signal: {kill_signal}, "
+            f"Total scenarios: {total_executed}, "
+            f"Successful: {successful_executed}, "
+            f"Failed: {failing_executed}, "
+            f"Success rate: {overall_success_rate:.1f}%"
+        )
+
+        # Validate success rate
+        min_success_rate = 70  # NooBaa containers should recover well from signals
+        validator.validate_chaos_execution(
+            total_executed,
+            successful_executed,
+            f"noobaa-container-{kill_signal.lower()}",
+            f"NooBaa container chaos ({kill_signal})",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_executed,
+            successful_executed,
+            f"noobaa-container-{kill_signal.lower()}",
+            f"NooBaa container chaos ({kill_signal})",
+            min_success_rate,
+        )
+
+        # Final health check
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"NooBaa container chaos ({kill_signal})"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 NooBaa container chaos testing with {kill_signal} completed successfully! "
+            f"All NooBaa containers handled {kill_signal} with {overall_success_rate:.1f}% success rate."
+        )
+
+    @pytest.mark.parametrize(
+        "component,kill_signal,iterations",
+        [
+            # NooBaa Core - main S3 service
+            ("noobaa-core", "SIGKILL", 3),
+            ("noobaa-core", "SIGTERM", 3),
+            ("noobaa-core", "SIGHUP", 3),
+            # NooBaa Database - PostgreSQL
+            ("noobaa-db", "SIGKILL", 3),
+            ("noobaa-db", "SIGTERM", 3),
+            # NooBaa Operator
+            ("noobaa-operator", "SIGKILL", 3),
+            ("noobaa-operator", "SIGTERM", 3),
+            # NooBaa Endpoint - S3 endpoints
+            ("noobaa-endpoint", "SIGKILL", 3),
+            ("noobaa-endpoint", "SIGTERM", 3),
+        ],
+        ids=[
+            "noobaa-core-sigkill-3x",
+            "noobaa-core-sigterm-3x",
+            "noobaa-core-sighup-3x",
+            "noobaa-db-sigkill-3x",
+            "noobaa-db-sigterm-3x",
+            "noobaa-operator-sigkill-3x",
+            "noobaa-operator-sigterm-3x",
+            "noobaa-endpoint-sigkill-3x",
+            "noobaa-endpoint-sigterm-3x",
+        ],
+    )
+    @polarion_id("OCS-7345")
+    def test_krkn_noobaa_component_container_kill(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        component,
+        kill_signal,
+        iterations,
+    ):
+        """
+        Test individual NooBaa component container disruption with specific signals.
+
+        This test targets specific NooBaa components (core, db, operator, endpoint)
+        and kills their containers multiple times to validate component-specific
+        resilience.
+
+        Components:
+        - noobaa-core: Main NooBaa service handling S3 operations
+        - noobaa-db: PostgreSQL database storing NooBaa metadata
+        - noobaa-operator: Operator managing NooBaa lifecycle
+        - noobaa-endpoint: S3 endpoint service pods
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+            component: Component name (noobaa-core, noobaa-db, etc.)
+            kill_signal: Kill signal to use
+            iterations: Number of times to repeat the chaos
+        """
+        scenario_dir = krkn_scenario_directory
+
+        # Map component names to their label selectors
+        component_labels = {
+            "noobaa-core": constants.NOOBAA_CORE_POD_LABEL,
+            "noobaa-db": constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
+            "noobaa-operator": constants.NOOBAA_OPERATOR_POD_LABEL,
+            "noobaa-endpoint": constants.NOOBAA_ENDPOINT_POD_LABEL,
+        }
+
+        if component not in component_labels:
+            raise ValueError(f"Unknown component: {component}")
+
+        label_selector = component_labels[component]
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"{component} container kill ({kill_signal})",
+            component,
+            component_name=f"{component}-{kill_signal.lower()}",
+            signal=kill_signal,
+            iterations=iterations,
+        )
+
+        # WORKLOAD SETUP
+        log.info(
+            f"Setting up Warp S3 workloads for {component} container chaos testing"
+        )
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        try:
+            # =================================================================
+            # COMPONENT-SPECIFIC CONTAINER KILL SCENARIO
+            # =================================================================
+            log.info(
+                f"Creating {component} container kill configuration with {kill_signal} signal, "
+                f"{iterations} iterations"
+            )
+
+            # Create single scenario for the specific component
+            scenario = {
+                "name": f"{component.replace('-', '_')}_{kill_signal.lower()}_kill",
+                "namespace": "openshift-storage",
+                "label_selector": label_selector,
+                "container_name": "",  # Target all containers in the pod
+                "kill_signal": kill_signal,
+                "count": 1,
+                "expected_recovery_time": 120,
+                "description": f"{component} component",
+            }
+
+            log.info(
+                f"Scenario: {scenario['name']}, "
+                f"Label: {label_selector}, "
+                f"Signal: {kill_signal}, "
+                f"Iterations: {iterations}"
+            )
+
+            # Create container chaos scenario file
+            scenario_file = ContainerScenarios.container_kill(
+                scenario_dir=scenario_dir,
+                scenarios=[scenario],
+            )
+
+            log.info(f"Created scenario file: {scenario_file}")
+
+            # Create Krkn configuration
+            config = KrknConfigGenerator()
+            config.add_scenario("container_scenarios", scenario_file)
+
+            # =================================================================
+            # EXECUTION: Repeated chaos with specified iterations
+            # =================================================================
+            log.info(
+                f"Executing {component} container chaos: {iterations} iterations with {kill_signal}"
+            )
+
+            # Configure with multiple iterations
+            config.set_tunings(wait_duration=60, iterations=iterations)
+            config.write_to_file(location=krkn_scenario_directory)
+
+            # Execute Krkn
+            krkn_runner = KrKnRunner(config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info(f"{component} container chaos completed")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                f"{component}-{kill_signal.lower()}",
+                f"{component} container chaos ({kill_signal})",
+            )
+            raise
+        except Exception as e:
+            log.error(f"❌ {component} container chaos with {kill_signal} failed: {e}")
+            raise
+
+        # =================================================================
+        # RESULTS ANALYSIS
+        # =================================================================
+        log.info(f"{component.upper()} CONTAINER CHAOS RESULTS ({kill_signal}):")
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output,
+                f"{component}-{kill_signal.lower()}",
+                detail_level="detailed",
+            )
+        )
+
+        overall_success_rate = (
+            (successful_executed / total_executed * 100) if total_executed > 0 else 0
+        )
+
+        log.info(
+            f"EXECUTION RESULTS: Component: {component}, "
+            f"Signal: {kill_signal}, "
+            f"Total iterations: {total_executed}, "
+            f"Successful: {successful_executed}, "
+            f"Failed: {failing_executed}, "
+            f"Success rate: {overall_success_rate:.1f}%"
+        )
+
+        # Validate success rate (adjust based on component criticality)
+        min_success_rates = {
+            "noobaa-core": 70,  # Core service is critical
+            "noobaa-db": 60,  # DB might need more recovery time
+            "noobaa-operator": 80,  # Operator should be resilient
+            "noobaa-endpoint": 75,  # Endpoints should recover quickly
+        }
+        min_success_rate = min_success_rates.get(component, 70)
+
+        validator.validate_chaos_execution(
+            total_executed,
+            successful_executed,
+            f"{component}-{kill_signal.lower()}",
+            f"{component} container chaos ({kill_signal})",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_executed,
+            successful_executed,
+            f"{component}-{kill_signal.lower()}",
+            f"{component} container chaos ({kill_signal})",
+            min_success_rate,
+        )
+
+        # Final health check
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"{component} container chaos ({kill_signal})"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 {component} container chaos testing with {kill_signal} completed successfully! "
+            f"Executed {iterations} iterations with {overall_success_rate:.1f}% success rate."
+        )
+
+    @pytest.mark.parametrize(
+        "stress_level,duration_multiplier,signals",
+        [
+            ("moderate", 2, ["SIGKILL", "SIGTERM"]),
+            ("high", 3, ["SIGKILL", "SIGTERM", "SIGHUP"]),
+            ("extreme", 4, ["SIGKILL", "SIGTERM", "SIGHUP", "SIGINT", "SIGQUIT"]),
+        ],
+        ids=[
+            "moderate-2signals",
+            "high-3signals",
+            "extreme-5signals",
+        ],
+    )
+    @polarion_id("OCS-7346")
+    def test_krkn_noobaa_multi_signal_strength_test(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        stress_level,
+        duration_multiplier,
+        signals,
+    ):
+        """
+        Comprehensive NooBaa strength testing with multiple kill signals.
+
+        This test validates NooBaa resilience under stress by:
+        - Testing multiple kill signals in sequence
+        - Targeting all NooBaa components
+        - Running extended duration tests
+        - Continuous Warp S3 workload throughout
+
+        Stress Levels:
+        - MODERATE: 2 signals (SIGKILL, SIGTERM)
+        - HIGH: 3 signals (SIGKILL, SIGTERM, SIGHUP)
+        - EXTREME: 5 signals (SIGKILL, SIGTERM, SIGHUP, SIGINT, SIGQUIT)
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+            stress_level: Level of stress testing
+            duration_multiplier: Multiplier for base duration
+            signals: List of signals to test
+        """
+        scenario_dir = krkn_scenario_directory
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"{stress_level.upper()} NooBaa multi-signal strength test",
+            "all-noobaa-components",
+            component_name=f"noobaa-multi-signal-{stress_level}",
+            stress_level=stress_level.upper(),
+            signals=", ".join(signals),
+        )
+
+        log.info(
+            f"⚠️  {stress_level.upper()} STRENGTH TESTING: Multiple signals across all NooBaa components"
+        )
+        log.info(f"🔥 Signals to test: {', '.join(signals)}")
+        log.info(f"⏱️  Duration multiplier: {duration_multiplier}x")
+
+        # WORKLOAD SETUP
+        log.info("Setting up Warp S3 workloads for multi-signal strength testing")
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+        scenario_helper = ContainerScenarioHelper()
+
+        # Collect results from all signal tests
+        all_results = []
+
+        try:
+            # =================================================================
+            # MULTI-SIGNAL STRENGTH TEST
+            # =================================================================
+            for signal in signals:
+                log.info("=" * 80)
+                log.info(f"Testing with signal: {signal}")
+                log.info("=" * 80)
+
+                # NooBaa components to test
+                noobaa_components = [
+                    {"name": "noobaa", "description": "NooBaa (All Components)"},
+                ]
+
+                # Build scenarios for this signal
+                noobaa_scenarios = scenario_helper.build_unified_scenarios(
+                    namespace="openshift-storage",
+                    kill_signal=signal,
+                    count=1,
+                    expected_recovery_time=120,
+                    container_name="",
+                    components=noobaa_components,
+                )
+
+                # Create scenario file
+                scenario_file = ContainerScenarios.container_kill(
+                    scenario_dir=scenario_dir,
+                    scenarios=noobaa_scenarios,
+                )
+
+                # Create Krkn configuration
+                config = KrknConfigGenerator()
+                config.add_scenario("container_scenarios", scenario_file)
+
+                # Number of iterations based on stress level
+                base_iterations = 2
+                iterations = base_iterations * duration_multiplier
+
+                log.info(
+                    f"Executing {iterations} iterations of NooBaa container kill with {signal}"
+                )
+
+                # Configure and execute
+                config.set_tunings(wait_duration=60, iterations=iterations)
+                config.write_to_file(location=krkn_scenario_directory)
+
+                # Execute Krkn
+                krkn_runner = KrKnRunner(config.global_config)
+                krkn_runner.run_async()
+                krkn_runner.wait_for_completion(check_interval=60)
+                chaos_output = krkn_runner.get_chaos_data()
+
+                log.info(f"Completed testing with {signal}")
+
+                # Analyze results for this signal
+                total_executed, successful_executed, failing_executed = (
+                    analyzer.analyze_chaos_results(
+                        chaos_output,
+                        f"noobaa-{signal.lower()}",
+                        detail_level="detailed",
+                    )
+                )
+
+                signal_success_rate = (
+                    (successful_executed / total_executed * 100)
+                    if total_executed > 0
+                    else 0
+                )
+
+                all_results.append(
+                    {
+                        "signal": signal,
+                        "total": total_executed,
+                        "successful": successful_executed,
+                        "failed": failing_executed,
+                        "success_rate": signal_success_rate,
+                    }
+                )
+
+                log.info(
+                    f"Signal {signal} results: {successful_executed}/{total_executed} "
+                    f"({signal_success_rate:.1f}% success)"
+                )
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                f"noobaa-multi-signal-{stress_level}",
+                f"NooBaa multi-signal strength test ({stress_level})",
+            )
+            raise
+        except Exception as e:
+            log.error(
+                f"❌ NooBaa multi-signal strength test ({stress_level}) failed: {e}"
+            )
+            raise
+
+        # =================================================================
+        # COMPREHENSIVE RESULTS ANALYSIS
+        # =================================================================
+        log.info("=" * 80)
+        log.info(f"MULTI-SIGNAL STRENGTH TEST RESULTS ({stress_level.upper()})")
+        log.info("=" * 80)
+
+        # Calculate overall statistics
+        total_all_signals = sum(r["total"] for r in all_results)
+        successful_all_signals = sum(r["successful"] for r in all_results)
+        overall_success_rate = (
+            (successful_all_signals / total_all_signals * 100)
+            if total_all_signals > 0
+            else 0
+        )
+
+        log.info("Overall Statistics:")
+        log.info(f"  Total scenarios across all signals: {total_all_signals}")
+        log.info(f"  Successful scenarios: {successful_all_signals}")
+        log.info(f"  Overall success rate: {overall_success_rate:.1f}%")
+        log.info("")
+        log.info("Per-Signal Breakdown:")
+
+        for result in all_results:
+            log.info(
+                f"  {result['signal']:10s}: {result['successful']:3d}/{result['total']:3d} "
+                f"({result['success_rate']:5.1f}%) - "
+                f"{'✅ PASS' if result['success_rate'] >= 60 else '⚠️  MARGINAL'}"
+            )
+
+        # Validate overall success rate based on stress level
+        min_success_rates = {
+            "moderate": 75,
+            "high": 65,
+            "extreme": 55,
+        }
+        min_success_rate = min_success_rates.get(stress_level, 60)
+
+        log.info(f"Minimum required success rate: {min_success_rate}%")
+
+        validator.validate_chaos_execution(
+            total_all_signals,
+            successful_all_signals,
+            f"noobaa-multi-signal-{stress_level}",
+            f"NooBaa multi-signal strength test ({stress_level})",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_all_signals,
+            successful_all_signals,
+            f"noobaa-multi-signal-{stress_level}",
+            f"NooBaa multi-signal strength test ({stress_level})",
+            min_success_rate,
+        )
+
+        # Final health check
+        log.info("Performing final NooBaa health validation")
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"NooBaa multi-signal strength test ({stress_level})"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 NooBaa multi-signal strength test ({stress_level.upper()}) completed successfully! "
+            f"Tested {len(signals)} signals with {overall_success_rate:.1f}% overall success rate. "
+            f"Total scenarios executed: {total_all_signals}"
+        )

--- a/tests/cross_functional/krkn_chaos/test_krkn_noobaa_node_disruption.py
+++ b/tests/cross_functional/krkn_chaos/test_krkn_noobaa_node_disruption.py
@@ -1,0 +1,735 @@
+"""
+Test suite for Krkn node disruption scenarios targeting NooBaa database nodes.
+
+This module provides comprehensive node disruption testing specifically for nodes
+hosting NooBaa database pods. The tests validate NooBaa's resilience when the
+underlying infrastructure fails.
+
+Node Disruption Actions:
+- node_stop_start: Stop and restart the node
+- node_reboot: Reboot the node
+
+Target Nodes:
+- Nodes hosting NooBaa DB primary pod (noobaa-db-pg-cluster-1)
+- Nodes hosting NooBaa DB replica pods (noobaa-db-pg-cluster-2, etc.)
+- Nodes hosting NooBaa core pods
+
+The tests validate:
+- NooBaa database failover from primary to replica
+- S3 service availability during node disruption
+- Data integrity after node recovery
+- Pod rescheduling to healthy nodes
+"""
+
+import pytest
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import green_squad, chaos, polarion_id
+from ocs_ci.krkn_chaos.krkn_chaos import KrKnRunner
+from ocs_ci.krkn_chaos.krkn_config_generator import KrknConfigGenerator
+from ocs_ci.krkn_chaos.krkn_scenario_generator import NodeScenarios
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.krkn_chaos.krkn_helpers import (
+    KrknResultAnalyzer,
+    CephHealthHelper,
+    ValidationHelper,
+    get_krkn_cloud_type,
+)
+from ocs_ci.krkn_chaos.logging_helpers import log_test_start
+from ocs_ci.krkn_chaos.noobaa_chaos_helper import (
+    get_node_hosting_noobaa_db_primary,
+    get_nodes_hosting_noobaa_db_replicas,
+    get_nodes_hosting_noobaa_core,
+    get_unique_noobaa_nodes,
+)
+
+log = logging.getLogger(__name__)
+
+
+@green_squad
+@chaos
+class TestKrknNooBaaNodeDisruption:
+    """
+    Test suite for NooBaa node disruption scenarios.
+
+    Tests node-level failures for nodes hosting NooBaa database and core pods,
+    validating database failover and S3 service resilience.
+    """
+
+    @pytest.mark.parametrize(
+        "action,target_component",
+        [
+            ("node_stop_start_scenario", "db_primary"),
+            ("node_reboot_scenario", "db_primary"),
+            ("node_stop_start_scenario", "db_replica"),
+            ("node_reboot_scenario", "db_replica"),
+            ("node_stop_start_scenario", "core"),
+            ("node_reboot_scenario", "core"),
+        ],
+        ids=[
+            "stop-start-db-primary",
+            "reboot-db-primary",
+            "stop-start-db-replica",
+            "reboot-db-replica",
+            "stop-start-core",
+            "reboot-core",
+        ],
+    )
+    @polarion_id("OCS-7347")
+    def test_krkn_noobaa_node_disruption(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        action,
+        target_component,
+    ):
+        """
+        Test node disruption for nodes hosting NooBaa components.
+
+        This test:
+        1. Identifies nodes hosting NooBaa components (DB primary, replica, core)
+        2. Performs node disruption (stop/start or reboot)
+        3. Validates NooBaa recovery and S3 service availability
+        4. Runs Warp S3 workload continuously during disruption
+
+        Components:
+        - db_primary: Node hosting NooBaa database primary pod
+        - db_replica: Node hosting NooBaa database replica pod
+        - core: Node hosting NooBaa core service pod
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+            action: Node action (stop_start or reboot)
+            target_component: NooBaa component whose node to disrupt
+        """
+        scenario_dir = krkn_scenario_directory
+        platform = config.ENV_DATA.get("platform", "").lower()
+        cloud_type = get_krkn_cloud_type()
+
+        # Get node hosting the target component
+        log.info(f"Identifying node hosting NooBaa {target_component}")
+
+        if target_component == "db_primary":
+            target_node = get_node_hosting_noobaa_db_primary()
+        elif target_component == "db_replica":
+            replica_nodes = get_nodes_hosting_noobaa_db_replicas()
+            if not replica_nodes:
+                pytest.skip("No NooBaa DB replica pods found")
+            target_node = replica_nodes[0]  # Target first replica node
+        elif target_component == "core":
+            core_nodes = get_nodes_hosting_noobaa_core()
+            if not core_nodes:
+                pytest.skip("No NooBaa core pods found")
+            target_node = core_nodes[0]  # Target first core node
+        else:
+            raise ValueError(f"Unknown target component: {target_component}")
+
+        log.info(f"Target node for {target_component}: {target_node}")
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"NooBaa node disruption: {action} on {target_component}",
+            target_node,
+            platform=platform,
+            cloud_type=cloud_type,
+            action=action,
+            component=target_component,
+        )
+
+        # WORKLOAD SETUP - Start Warp S3 workloads before disruption
+        log.info("Setting up Warp S3 workloads for NooBaa node disruption testing")
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        try:
+            # =================================================================
+            # NODE DISRUPTION SCENARIO CONFIGURATION
+            # =================================================================
+            log.info(
+                f"Creating node disruption configuration: {action} on node {target_node}"
+            )
+
+            # Create Krkn configuration
+            krkn_config = KrknConfigGenerator()
+
+            # Build scenario configuration
+            scenario_params = {
+                "actions": [action],
+                "cloud_type": cloud_type,
+                "node_name": target_node,  # Target specific node
+                "instance_count": 1,
+            }
+
+            # Set timeout and duration based on action
+            if action == "node_stop_start_scenario":
+                scenario_params["timeout"] = 600  # Longer timeout for NooBaa recovery
+                scenario_params["duration"] = 180  # 3 minutes down time
+            else:  # reboot
+                scenario_params["timeout"] = 300
+
+            # Add platform-specific parameters
+            if cloud_type in [
+                constants.KRKN_CLOUD_AWS,
+                constants.KRKN_CLOUD_AZURE,
+            ]:
+                scenario_params["parallel"] = False  # Sequential for specific node
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_AWS:
+                scenario_params["poll_interval"] = 15
+
+            if cloud_type == constants.KRKN_CLOUD_IBM:
+                scenario_params["disable_ssl_verification"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_BAREMETAL:
+                scenario_params["parallel"] = False
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_VMWARE:
+                scenario_params["parallel"] = False
+
+            # Generate node scenario YAML
+            scenario_file = NodeScenarios.node_scenarios(
+                scenario_dir=scenario_dir,
+                cloud_type=cloud_type,
+                scenarios=[scenario_params],
+            )
+
+            log.info(f"Created scenario file: {scenario_file}")
+
+            # Add scenario to Krkn config
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+
+            # =================================================================
+            # EXECUTION: Node disruption
+            # =================================================================
+            log.info(
+                f"Executing node disruption: {action} on {target_node} hosting {target_component}"
+            )
+
+            # Configure and write Krkn configuration
+            krkn_config.set_tunings(wait_duration=120, iterations=1)
+            krkn_config.write_to_file(location=krkn_scenario_directory)
+
+            # Execute Krkn
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info(f"Node disruption completed for {target_component}")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                f"noobaa-{target_component}",
+                f"NooBaa node disruption ({action})",
+            )
+            raise
+        except Exception as e:
+            log.error(
+                f"❌ NooBaa node disruption failed for {target_component} with {action}: {e}"
+            )
+            raise
+
+        # =================================================================
+        # RESULTS ANALYSIS
+        # =================================================================
+        log.info(f"NOOBAA NODE DISRUPTION RESULTS ({target_component}):")
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output,
+                f"noobaa-{target_component}",
+                detail_level="detailed",
+            )
+        )
+
+        overall_success_rate = (
+            (successful_executed / total_executed * 100) if total_executed > 0 else 0
+        )
+
+        log.info(
+            f"EXECUTION RESULTS: Component: {target_component}, "
+            f"Action: {action}, "
+            f"Node: {target_node}, "
+            f"Total scenarios: {total_executed}, "
+            f"Successful: {successful_executed}, "
+            f"Failed: {failing_executed}, "
+            f"Success rate: {overall_success_rate:.1f}%"
+        )
+
+        # Validate success rate
+        # DB primary disruption is more critical, lower threshold
+        min_success_rates = {
+            "db_primary": 60,  # Database failover takes time
+            "db_replica": 75,  # Replica disruption less impact
+            "core": 70,  # Core service disruption moderate impact
+        }
+        min_success_rate = min_success_rates.get(target_component, 70)
+
+        validator.validate_chaos_execution(
+            total_executed,
+            successful_executed,
+            f"noobaa-{target_component}",
+            f"NooBaa node disruption ({action})",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_executed,
+            successful_executed,
+            f"noobaa-{target_component}",
+            f"NooBaa node disruption ({action})",
+            min_success_rate,
+        )
+
+        # Final health check
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"NooBaa node disruption ({target_component})"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 NooBaa node disruption test for {target_component} completed successfully! "
+            f"Node {target_node} recovered with {overall_success_rate:.1f}% success rate."
+        )
+
+    @pytest.mark.parametrize(
+        "iterations",
+        [2, 3, 5],
+        ids=[
+            "2-iterations",
+            "3-iterations",
+            "5-iterations",
+        ],
+    )
+    @polarion_id("OCS-7348")
+    def test_krkn_noobaa_db_primary_node_reboot_repeated(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+        iterations,
+    ):
+        """
+        Repeated node reboot test for NooBaa database primary node.
+
+        This stress test repeatedly reboots the node hosting NooBaa database
+        primary pod to validate:
+        - Database failover mechanism under repeated stress
+        - Pod rescheduling reliability
+        - S3 service recovery consistency
+        - Data integrity across multiple failovers
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+            iterations: Number of times to reboot the node
+        """
+        scenario_dir = krkn_scenario_directory
+        platform = config.ENV_DATA.get("platform", "").lower()
+        cloud_type = get_krkn_cloud_type()
+
+        # Get node hosting NooBaa DB primary
+        log.info("Identifying node hosting NooBaa database primary pod")
+        target_node = get_node_hosting_noobaa_db_primary()
+        log.info(f"Target node: {target_node}")
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            f"NooBaa DB primary node reboot (repeated {iterations}x)",
+            target_node,
+            platform=platform,
+            cloud_type=cloud_type,
+            iterations=iterations,
+        )
+
+        # WORKLOAD SETUP
+        log.info("Setting up Warp S3 workloads for repeated node reboot testing")
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        try:
+            # =================================================================
+            # REPEATED NODE REBOOT SCENARIO
+            # =================================================================
+            log.info(
+                f"Creating repeated node reboot configuration: {iterations} iterations on {target_node}"
+            )
+
+            # Create Krkn configuration
+            krkn_config = KrknConfigGenerator()
+
+            # Build scenario configuration
+            scenario_params = {
+                "actions": ["node_reboot_scenario"],
+                "cloud_type": cloud_type,
+                "node_name": target_node,
+                "instance_count": 1,
+                "timeout": 300,
+            }
+
+            # Add platform-specific parameters
+            if cloud_type in [
+                constants.KRKN_CLOUD_AWS,
+                constants.KRKN_CLOUD_AZURE,
+            ]:
+                scenario_params["parallel"] = False
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_AWS:
+                scenario_params["poll_interval"] = 15
+
+            if cloud_type == constants.KRKN_CLOUD_IBM:
+                scenario_params["disable_ssl_verification"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_BAREMETAL:
+                scenario_params["parallel"] = False
+                scenario_params["kube_check"] = True
+
+            if cloud_type == constants.KRKN_CLOUD_VMWARE:
+                scenario_params["parallel"] = False
+
+            # Generate node scenario YAML
+            scenario_file = NodeScenarios.node_scenarios(
+                scenario_dir=scenario_dir,
+                cloud_type=cloud_type,
+                scenarios=[scenario_params],
+            )
+
+            log.info(f"Created scenario file: {scenario_file}")
+
+            # Add scenario to Krkn config
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+
+            # =================================================================
+            # EXECUTION: Repeated node reboots
+            # =================================================================
+            log.info(
+                f"Executing repeated node reboot: {iterations} iterations on {target_node}"
+            )
+
+            # Configure with multiple iterations
+            krkn_config.set_tunings(wait_duration=120, iterations=iterations)
+            krkn_config.write_to_file(location=krkn_scenario_directory)
+
+            # Execute Krkn
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info(f"Repeated node reboot completed: {iterations} iterations")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                "noobaa-db-primary-repeated",
+                f"NooBaa DB primary node reboot ({iterations}x)",
+            )
+            raise
+        except Exception as e:
+            log.error(
+                f"❌ NooBaa DB primary repeated node reboot failed ({iterations}x): {e}"
+            )
+            raise
+
+        # =================================================================
+        # RESULTS ANALYSIS
+        # =================================================================
+        log.info(f"REPEATED NODE REBOOT RESULTS ({iterations} iterations):")
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output,
+                "noobaa-db-primary-repeated",
+                detail_level="detailed",
+            )
+        )
+
+        overall_success_rate = (
+            (successful_executed / total_executed * 100) if total_executed > 0 else 0
+        )
+
+        log.info(
+            f"EXECUTION RESULTS: "
+            f"Iterations requested: {iterations}, "
+            f"Total executed: {total_executed}, "
+            f"Successful: {successful_executed}, "
+            f"Failed: {failing_executed}, "
+            f"Success rate: {overall_success_rate:.1f}%"
+        )
+
+        # Validate success rate (lower threshold for repeated stress)
+        min_success_rates = {
+            2: 65,  # 2 iterations should have high success
+            3: 60,  # 3 iterations moderate stress
+            5: 55,  # 5 iterations high stress
+        }
+        min_success_rate = min_success_rates.get(iterations, 60)
+
+        validator.validate_chaos_execution(
+            total_executed,
+            successful_executed,
+            "noobaa-db-primary-repeated",
+            f"NooBaa DB primary node reboot ({iterations}x)",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_executed,
+            successful_executed,
+            "noobaa-db-primary-repeated",
+            f"NooBaa DB primary node reboot ({iterations}x)",
+            min_success_rate,
+        )
+
+        # Final health check
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"NooBaa DB primary repeated reboot ({iterations}x)"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 NooBaa DB primary repeated node reboot test completed successfully! "
+            f"Node {target_node} recovered from {iterations} reboots with {overall_success_rate:.1f}% success rate."
+        )
+
+    @polarion_id("OCS-7349")
+    def test_krkn_noobaa_all_nodes_stop_start(
+        self,
+        request,
+        krkn_setup,
+        krkn_scenario_directory,
+        workload_ops,
+    ):
+        """
+        Stop and start all nodes hosting NooBaa components simultaneously.
+
+        This extreme test stops all nodes hosting NooBaa pods at once to validate:
+        - Complete NooBaa infrastructure failure
+        - Cluster-wide recovery
+        - S3 service restoration after total outage
+        - Data integrity after catastrophic failure
+
+        Warning: This is a destructive test that causes complete NooBaa outage.
+
+        Args:
+            krkn_setup: Krkn setup fixture
+            krkn_scenario_directory: Directory for scenario configuration files
+            workload_ops: WorkloadOps fixture providing Warp S3 workloads
+        """
+        scenario_dir = krkn_scenario_directory
+        platform = config.ENV_DATA.get("platform", "").lower()
+        cloud_type = get_krkn_cloud_type()
+
+        # Get all nodes hosting NooBaa components
+        log.info("Identifying all nodes hosting NooBaa components")
+
+        # Use helper function to get unique nodes
+        all_nodes = list(get_unique_noobaa_nodes())
+
+        log.info(f"Total unique nodes hosting NooBaa: {len(all_nodes)}")
+        log.info(f"Nodes: {', '.join(all_nodes)}")
+
+        if len(all_nodes) == 0:
+            pytest.skip("No nodes found hosting NooBaa components")
+
+        # Use helper function for standardized test start logging
+        log_test_start(
+            "NooBaa all nodes stop/start",
+            f"{len(all_nodes)} nodes",
+            platform=platform,
+            cloud_type=cloud_type,
+            nodes=all_nodes,
+        )
+
+        log.warning(
+            f"⚠️  EXTREME TEST: This will stop ALL {len(all_nodes)} nodes hosting NooBaa simultaneously"
+        )
+
+        # WORKLOAD SETUP
+        log.info("Setting up Warp S3 workloads (will fail during total outage)")
+        workload_ops.setup_workloads()
+
+        # Register finalizer for cleanup
+        request.addfinalizer(lambda: workload_ops.validate_and_cleanup())
+
+        # Initialize helpers
+        validator = ValidationHelper()
+        health_helper = CephHealthHelper(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        analyzer = KrknResultAnalyzer()
+
+        try:
+            # =================================================================
+            # ALL NODES STOP/START SCENARIO
+            # =================================================================
+            log.info(
+                f"Creating all-nodes stop/start configuration for {len(all_nodes)} nodes"
+            )
+
+            # Create Krkn configuration
+            krkn_config = KrknConfigGenerator()
+
+            # Create scenarios for each node
+            scenarios = []
+            for node in all_nodes:
+                scenario_params = {
+                    "actions": ["node_stop_start_scenario"],
+                    "cloud_type": cloud_type,
+                    "node_name": node,
+                    "instance_count": 1,
+                    "timeout": 600,  # Longer timeout for recovery
+                    "duration": 240,  # 4 minutes down time
+                }
+
+                # Add platform-specific parameters
+                if cloud_type in [
+                    constants.KRKN_CLOUD_AWS,
+                    constants.KRKN_CLOUD_AZURE,
+                ]:
+                    scenario_params["parallel"] = True  # Stop all nodes simultaneously
+                    scenario_params["kube_check"] = True
+
+                if cloud_type == constants.KRKN_CLOUD_AWS:
+                    scenario_params["poll_interval"] = 15
+
+                if cloud_type == constants.KRKN_CLOUD_IBM:
+                    scenario_params["disable_ssl_verification"] = True
+
+                if cloud_type == constants.KRKN_CLOUD_BAREMETAL:
+                    scenario_params["parallel"] = True
+                    scenario_params["kube_check"] = True
+
+                if cloud_type == constants.KRKN_CLOUD_VMWARE:
+                    scenario_params["parallel"] = True
+
+                scenarios.append(scenario_params)
+
+            # Generate node scenario YAML
+            scenario_file = NodeScenarios.node_scenarios(
+                scenario_dir=scenario_dir,
+                cloud_type=cloud_type,
+                scenarios=scenarios,
+            )
+
+            log.info(f"Created scenario file with {len(scenarios)} node disruptions")
+
+            # Add scenario to Krkn config
+            krkn_config.add_scenario("node_scenarios", scenario_file)
+
+            # =================================================================
+            # EXECUTION: Stop/start all NooBaa nodes
+            # =================================================================
+            log.info(
+                f"Executing all-nodes stop/start: {len(all_nodes)} nodes simultaneously"
+            )
+
+            # Configure and write Krkn configuration
+            krkn_config.set_tunings(wait_duration=180, iterations=1)
+            krkn_config.write_to_file(location=krkn_scenario_directory)
+
+            # Execute Krkn
+            krkn_runner = KrKnRunner(krkn_config.global_config)
+            krkn_runner.run_async()
+            krkn_runner.wait_for_completion(check_interval=60)
+            chaos_output = krkn_runner.get_chaos_data()
+
+            log.info("All-nodes stop/start completed")
+
+        except CommandFailed as e:
+            validator.handle_krkn_command_failure(
+                e,
+                "noobaa-all-nodes",
+                "NooBaa all nodes stop/start",
+            )
+            raise
+        except Exception as e:
+            log.error(f"❌ NooBaa all nodes stop/start failed: {e}")
+            raise
+
+        # =================================================================
+        # RESULTS ANALYSIS
+        # =================================================================
+        log.info("ALL NODES STOP/START RESULTS:")
+
+        # Analyze results
+        total_executed, successful_executed, failing_executed = (
+            analyzer.analyze_chaos_results(
+                chaos_output,
+                "noobaa-all-nodes",
+                detail_level="detailed",
+            )
+        )
+
+        overall_success_rate = (
+            (successful_executed / total_executed * 100) if total_executed > 0 else 0
+        )
+
+        log.info(
+            f"EXECUTION RESULTS: "
+            f"Nodes disrupted: {len(all_nodes)}, "
+            f"Total scenarios: {total_executed}, "
+            f"Successful: {successful_executed}, "
+            f"Failed: {failing_executed}, "
+            f"Success rate: {overall_success_rate:.1f}%"
+        )
+
+        # Validate success rate (very low threshold for catastrophic failure test)
+        min_success_rate = 50  # Complete outage expected, focus on recovery
+
+        validator.validate_chaos_execution(
+            total_executed,
+            successful_executed,
+            "noobaa-all-nodes",
+            "NooBaa all nodes stop/start",
+        )
+
+        analyzer.evaluate_chaos_success_rate(
+            total_executed,
+            successful_executed,
+            "noobaa-all-nodes",
+            "NooBaa all nodes stop/start",
+            min_success_rate,
+        )
+
+        # Final health check
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, "NooBaa all nodes stop/start"
+        )
+        assert no_crashes, crash_details
+
+        log.info(
+            f"🏆 NooBaa all nodes stop/start test completed successfully! "
+            f"All {len(all_nodes)} nodes recovered with {overall_success_rate:.1f}% success rate. "
+            f"✨ NooBaa survived catastrophic infrastructure failure!"
+        )

--- a/tests/cross_functional/krkn_chaos/test_random_chaos.py
+++ b/tests/cross_functional/krkn_chaos/test_random_chaos.py
@@ -28,7 +28,13 @@ from ocs_ci.krkn_chaos.logging_helpers import log_test_start
 
 log = logging.getLogger(__name__)
 
+# DFBUGS-6519: exclude only the plan node service-disruption-scenarios_* (name
+# service-disruption-scenarios, LABEL_SELECTOR ""). Do not use the broad
+# exclude list for that name — it would also drop service-disruption-scenarios-rook_*.
 DEFAULT_EXCLUDE_SCENARIOS = []
+DEFAULT_EXCLUDE_SCENARIO_BASES_EXACT = [
+    "service-disruption-scenarios",
+]
 
 
 @green_squad
@@ -84,10 +90,15 @@ class TestKrKnctlRandomChaos:
         )
 
         # Generate random plan file (before workload)
-        log.info("Generating random plan file (exclude=%s)", DEFAULT_EXCLUDE_SCENARIOS)
+        log.info(
+            "Generating random plan file (exclude=%s, exclude_bases_exact=%s)",
+            DEFAULT_EXCLUDE_SCENARIOS,
+            DEFAULT_EXCLUDE_SCENARIO_BASES_EXACT,
+        )
         generator = PlanGenerator(
             namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
             exclude_scenarios=DEFAULT_EXCLUDE_SCENARIOS,
+            exclude_scenario_bases_exact=DEFAULT_EXCLUDE_SCENARIO_BASES_EXACT,
             use_random_selectors=True,
         )
         generator.generate()


### PR DESCRIPTION
*Chaos added*

- NooBaa pod disruption — repeated kills of noobaa-db-pg-0, noobaa-core-0, noobaa-operator (incl. parametrized duration / kill interval and strength tiers).
- NooBaa container chaos — container-level faults while the stack is exercised (test_krkn_noobaa_container_chaos.py).
- NooBaa node disruption — node-level failure scenarios (test_krkn_noobaa_node_disruption.py).
- Krkn / krknctl — NooBaa-oriented scenarios wired through helpers, plan template (plan.json.j2), and OCSCI Krkn config updates.

*Workloads added*

- MCG S3 workload — MCG_WORKLOAD in config: buckets + upload / download / list / delete, metadata-heavy options, verification after chaos (krkn_noobaa_chaos_config.yaml + workload factory/registry).
- WARP on NooBaa — WARP stress path for NooBaa (warp_noobaa_stress.yaml, examples/warp-noobaa-pod.yaml, warp.py / template + bucket helper changes).

*Supporting pieces (one line)*

- noobaa_chaos_helper.py, README_NOOBAA_CHAOS.md, resiliency_workload.py — orchestration, docs, and resiliency glue for the above.