### PR TITLE
Add retry config to the boto3 client of the OBC class

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -128,12 +128,18 @@ class OBC(object):
                 constants.CEPH_OBJECTSTOREUSER_SECRET
             )
 
+        retry_cfg = botocore.config.Config(
+            retries={
+                "max_attempts": 8,
+            }
+        )
         self.s3_resource = boto3.resource(
             "s3",
             verify=retrieve_verification_mode(),
             endpoint_url=self.s3_external_endpoint,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.access_key,
+            config=retry_cfg,
         )
         self.s3_client = self.s3_resource.meta.client
 


### PR DESCRIPTION
In #13017 we added a retry config to the MCG class's boto3 client - this reduced the amount of false failures due to intermittent issues.

This PR adds the same to the [OBC class](https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/ocs/resources/objectbucket.py/#L39-L144), which would stabilize tests that use it such as [test_bucket_policy_elements_NotAction](https://github.com/red-hat-storage/ocs-ci/blob/master/tests/functional/object/mcg/test_bucket_policy.py/#L1113-L1216)