### PR TITLE
Skip serviceexport if ocs-provider-server service type is NodePort or if client cluster

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2583,8 +2583,8 @@ def create_service_exporter(annotate=True):
         index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)
         if (
-            get_provider_service_type() != "NodePort"
-            and cluster.ENV_DATA.get("cluster_type").lower() == constants.HCI_CLIENT
+            get_provider_service_type() == "NodePort"
+            or cluster.ENV_DATA.get("cluster_type").lower() == constants.HCI_CLIENT
         ):
             logger.info("Skipping ServiceExport creation for multiclient cluster")
             continue


### PR DESCRIPTION
ServiceExport is not needed for client cluster and for df cluster if ocs-provider-server service type is NodePort 