### PR TITLE
remove ocs-metric pod check from mcg only deployment

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1468,6 +1468,9 @@ def verify_mcg_only_pods():
         constants.OPERATOR_LABEL: 1,
     }
     odf_running_version = get_ocs_version_from_csv(only_major_minor=True)
+    # DFBUGS-5211 ocs-metrics-exporter disabled from ODF 4.21
+    if odf_running_version >= version.VERSION_4_21:
+        del resources_dict[constants.OCS_METRICS_EXPORTER]
     if odf_running_version >= version.VERSION_4_19:
         del resources_dict[constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL]
         del resources_dict[constants.NOOBAA_DB_LABEL_47_AND_ABOVE]


### PR DESCRIPTION
As part of bug https://issues.redhat.com/browse/DFBUGS-5211, ocs-metrics- exporter has been disabled due to which verification step for this pod is failing in mcg-only-deployment