### PR TITLE
Validating Node Availability (CPU & Memory) to Prevent Pod Scheduling Failures

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -7,6 +7,9 @@ from collections import defaultdict
 from operator import itemgetter
 import random
 import json
+import pytest
+import unicodedata
+from ocs_ci.ocs.ocp import exec_cmd
 
 from subprocess import TimeoutExpired
 from semantic_version import Version
@@ -3436,3 +3439,135 @@ def mark_masters_schedulable():
     assert scheduler_obj.patch(
         params=params, format_type="json"
     ), "Failed to run patch command to update control nodes as scheduleable"
+
+
+def check_cluster_resource_availability(needed_ram_gb, needed_cpu_cores):
+    """
+    Validates if the worker nodes have sufficient unreserved CPU and RAM.
+    Parses 'oc describe node' to identify resource usage and skips the test
+    if the requirement isn't met, providing a namespace-level breakdown.
+
+    Args:
+        needed_ram_gb (int): Required RAM in Gigabytes.
+        needed_cpu_cores (int): Required CPU cores.
+
+    Raises:
+        pytest.skip: If available resources are below the required threshold.
+    """
+    worker_names = get_worker_nodes()
+    total_free_ram_kb = 0
+    total_free_cpu_m = 0
+
+    namespace_ram = defaultdict(int)
+    namespace_cpu = defaultdict(int)
+    ocp_node_obj = OCP(kind=constants.NODE)
+
+    for name in worker_names:
+        # Use exec_cmd instead of deprecated run_cmd
+        node_data_raw = exec_cmd(f"oc describe node {name}").stdout.decode()
+        # Normalize hidden characters (like \xa0) to standard spaces
+        node_data = unicodedata.normalize("NFKD", node_data_raw)
+        node_info = ocp_node_obj.get(resource_name=name)
+
+        # 1. Base Allocatable precision from node status
+        alloc_ram_kb = int(
+            node_info["status"]["allocatable"]["memory"].replace("Ki", "")
+        )
+        cpu_raw = node_info["status"]["allocatable"]["cpu"]
+        alloc_cpu_m = (
+            int(cpu_raw.replace("m", "")) if "m" in cpu_raw else int(cpu_raw) * 1000
+        )
+
+        # 2. Parse overall reservation percentages
+        mem_res_match = re.search(r"memory\s+(\d+)Mi\s+\((\d+)%\)", node_data)
+        cpu_res_match = re.search(r"cpu\s+(\d+)m\s+\((\d+)%\)", node_data)
+
+        if mem_res_match:
+            used_percent = int(mem_res_match.group(2))
+            total_free_ram_kb += alloc_ram_kb * (1.0 - (used_percent / 100.0))
+        if cpu_res_match:
+            used_percent = int(cpu_res_match.group(2))
+            total_free_cpu_m += alloc_cpu_m * (1.0 - (used_percent / 100.0))
+
+        # 3. Component Breakdown Parsing
+        try:
+            # Finding the pod section between anchors
+            pod_section = node_data.split("Non-terminated Pods:")[1].split(
+                "Allocated resources:"
+            )[0]
+            for line in pod_section.strip().split("\n"):
+                parts = line.split()
+                if len(parts) >= 7 and "(" in line and "%" in line:
+                    ns = parts[0]
+                    if ns.lower() in ["namespace", "name"] or ns.startswith("("):
+                        continue
+
+                    cpu_usage = re.findall(r"(\d+m?)\s+\(", line)
+                    mem_usage = re.findall(r"(\d+[GMK]i)\s+\(", line)
+
+                    if cpu_usage:
+                        raw_c = cpu_usage[0]
+                        c_val = int(re.search(r"\d+", raw_c).group())
+                        if "m" not in raw_c:
+                            c_val *= 1000
+                        namespace_cpu[ns] += c_val
+
+                    if mem_usage:
+                        raw_m = mem_usage[0]
+                        m_val = int(re.search(r"\d+", raw_m).group())
+                        if "Gi" in raw_m:
+                            m_val *= 1024 * 1024
+                        elif "Mi" in raw_m:
+                            m_val *= 1024
+                        namespace_ram[ns] += m_val
+        except (IndexError, ValueError, KeyError) as e:
+            log.debug(f"Parsing row failed for node {name}: {e}")
+
+    actual_free_ram_gb = total_free_ram_kb / (1024 * 1024)
+    actual_free_cpu = total_free_cpu_m / 1000
+
+    log.info(
+        f"Available Capacity: {actual_free_ram_gb:.2f}GB RAM | {actual_free_cpu:.2f} CPU Cores"
+    )
+
+    # UPDATED: Now checking both RAM and CPU cores
+    if actual_free_ram_gb < needed_ram_gb or actual_free_cpu < needed_cpu_cores:
+        header = "{:<45} | {:<12} | {:<12}".format(
+            "Namespace", "RAM Req(GB)", "CPU Req(Cores)"
+        )
+        table_rows = [header, "-" * 75]
+
+        # Sort by the resource that is lacking (defaulting to RAM for sorting)
+        sorted_ns = sorted(
+            namespace_ram.keys(), key=lambda x: namespace_ram[x], reverse=True
+        )
+
+        for ns in sorted_ns:
+            ram_gb = namespace_ram[ns] / (1024 * 1024)
+            cpu_c = namespace_cpu[ns] / 1000
+            # Show namespaces that use significant amounts of either resource
+            if ram_gb > 0.1 or cpu_c > 0.1:
+                table_rows.append(
+                    "{:<45} | {:<12.2f} | {:<12.2f}".format(ns, ram_gb, cpu_c)
+                )
+
+        breakdown_msg = "\n" + "\n".join(table_rows)
+
+        # Determine specific failure reason for the error log
+        failure_reasons = []
+        if actual_free_ram_gb < needed_ram_gb:
+            failure_reasons.append(
+                f"RAM (Need {needed_ram_gb}GB, Have {actual_free_ram_gb:.2f}GB)"
+            )
+        if actual_free_cpu < needed_cpu_cores:
+            failure_reasons.append(
+                f"CPU (Need {needed_cpu_cores}, Have {actual_free_cpu:.2f} cores)"
+            )
+
+        log.error(f"RESOURCE GATEKEEPER FAILED: {' and '.join(failure_reasons)}")
+        log.error(breakdown_msg)
+
+        # Trigger the skip
+        pytest.skip(
+            f"Insufficient Resources: {actual_free_ram_gb:.2f}GB RAM / {actual_free_cpu:.2f} CPU cores available."
+        )

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -28,6 +28,7 @@ from ocs_ci.ocs.resources import pod as pod_helpers, storage_cluster
 from ocs_ci.ocs.resources.storage_cluster import osd_encryption_verification
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.utility.version import get_semantic_ocp_running_version, VERSION_4_16
+from ocs_ci.ocs.bucket_utils import s3_io_create_delete, obc_io_create_delete
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
**Summary** 
Regression test (test_add_capacity specifically) is frequently failing due to Failed Pod Scheduling. Analysis identifies two primary blockers:

1. Resource Exhaustion: Insufficient Memory and CPU requests available on worker nodes.

2. Scheduling Constraints: Presence of Node Taints or missing Tolerations that prevent pod placement.

**Goal**
Implement a proactive "Gatekeeper" mechanism to validate cluster health and resource capacity before the test begins. This prevents long, expensive test runs from failing due to predictable infrastructure issues.

**Proposed Solution**
Auto-use Fixture: Develop a fixture (e.g., resource_check) that runs during the test setup phase.

Capacity Validation: Calculate "Real" available capacity (Allocatable minus current Reservations).

Pre-emptive Skipping: If the cluster cannot satisfy the test's resource requirements, the test should Skip immediately with a detailed breakdown of current resource "hogs" (e.g., leftover namespaces or ODF overhead).

Successfully implemented a parser that provides a namespace-level breakdown of RAM and CPU requests.