### PR TITLE
Fix: Skip retry when mirroring replaying count exceeds expected

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -455,8 +455,13 @@ def check_mirroring_status_ok(
             if current_stopped_value in expected_value:
                 logger.warning("Counting 'stopped' value due to the bug DFBUGS-1525")
                 return True
-            else:
-                return False
+            # Fail fast if count exceeds expected range - indicates leftover resources
+            if current_value > max(expected_value):
+                raise UnexpectedBehaviour(
+                    f"Replaying count ({current_value}) exceeds expected ({max(expected_value)}). "
+                    f"Clean up leftover DRPCs and namespaces before retrying."
+                )
+            return False
 
     return True
 


### PR DESCRIPTION
When the current replaying image count is greater than the expected count, retrying is pointless as the count won't decrease on its own. This typically indicates leftover resources from previous test runs.

This change:
- Raises UnexpectedBehaviour exception immediately when current > expected
- Saves up to 15 minutes of wasted retry time
- Provides clear error message with cleanup instructions