### PR TITLE
DFBUGS-5082:TC4:validate cephfs-CSI addon DaemonSet status arguments

### DIFF
--- a/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
+++ b/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
@@ -168,22 +168,34 @@ class TestCSIADDonDaemonset(ManageTest):
             "CSI-addon DaemonSet pods using pod network instead of host-network"
         )
 
-    @tier1
-    @green_squad
-    @polarion_id("OCS-7375")
-    def test_csi_addon_daemonset_desired_vs_ready(self):
+    @pytest.mark.parametrize(
+        argnames=["daemonset_name"],
+        argvalues=[
+            pytest.param(
+                constants.DAEMONSET_CSI_RBD_CSI_ADDONS,
+                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7375")],
+            ),
+            pytest.param(
+                constants.DAEMONSET_CSI_CEPHFS_CSI_ADDONS,
+                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7504")],
+            ),
+        ],
+    )
+    def test_csi_addon_daemonset_desired_vs_ready(self, daemonset_name):
         """
         Verify that CSI addon DaemonSet has desired number of ready and available pods
         Step:
         1. Get CSI-addon DaemonSet status
         2. Compare desired Vs ready pod counts
         3. Verify all pods are available
+        OCS-7504 is part verification of DFBUGS_5082 automation
+
         """
         logger.info(
             "Validating CSI-addon DaemonSet has correct number of Desired, ready and available pods"
         )
         csi_addon_daemonset = DaemonSet(
-            resource_name=constants.DAEMONSET_CSI_RBD_CSI_ADDONS,
+            resource_name=daemonset_name,
             namespace=config.ENV_DATA["cluster_namespace"],
         )
         csi_addon_daemonset_status = csi_addon_daemonset.get_status()


### PR DESCRIPTION
[DFBUGS-5082](https://issues.redhat.com//browse/DFBUGS-5082): [release-4.21] cephfs: deploy csi-addons daemonset.
 This is similar to rbd csiaddon feature of release 4.20: [RHSTOR-7086](https://issues.redhat.com//browse/RHSTOR-7086) : Use pod network for the RBD-csi-addons server.
So the similar verifications applies to cephfs csiaddons. This test covers the automation of [DFBUGS-5082](https://issues.redhat.com//browse/DFBUGS-5082), to verify cephfs-CSI addon DaemonSet status arguments