### PR TITLE
RGW-HA: high priority tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,6 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1993,
         "line_number": 1964,
         "type": "Secret Keyword",
         "verified_result": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -625,7 +625,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 823,
+        "line_number": 808,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -633,7 +633,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 832,
+        "line_number": 817,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,6 +642,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 1993,
+        "line_number": 1964,
         "type": "Secret Keyword",
         "verified_result": null
       },

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7149,3 +7149,58 @@ def wait_for_osds_down(osd_ids: list[str], timeout: int = 300, sleep: int = 10) 
         )
 
     log.info(f"All OSDs {osd_ids} are now marked as 'down'")
+
+
+def wait_for_all_containers_ready(pod, timeout=300):
+    """
+    Wait for all containers of the pod to be ready
+
+    Args:
+        pod: a pod object of the pod which container is to be checked
+        timeout: timeout in seconds to wait for all containers to be ready
+
+    Raises:
+        TimeoutExpiredError: If all containers are not ready within timeout
+    """
+    logger.info(f"Waiting for all containers of the pod {pod.name} to be ready")
+
+    def _are_containers_ready(pod):
+        return all(
+            container["ready"] for container in pod.get()["status"]["containerStatuses"]
+        )
+
+    sampler = TimeoutSampler(
+        timeout=timeout,
+        sleep=5,
+        func=_are_containers_ready,
+        pod=pod,
+    )
+    sampler.wait_for_func_status(result=True)
+    if not sampler.wait_for_func_status(result=True):
+        raise TimeoutExpiredError(
+            f"All containers of the pod {pod.name} are not ready within {timeout} seconds"
+        )
+    logger.info(f"All containers of the pod {pod.name} are ready")
+
+
+def wait_for_prometheus_ready(timeout=300):
+    """
+    Wait for all of Prometheus pods to be running
+    and for their containers to be ready
+
+    Raises:
+        TimeoutExpiredError: If Prometheus is not ready within timeout
+    """
+    pod.wait_for_pods_by_label_count(
+        label=constants.PROMETHEUS_POD_LABEL,
+        namespace=constants.OPENSHIFT_MONITORING_NAMESPACE,
+        expected_count=2,
+        timeout=timeout,
+    )
+    pods_dicts = pod.get_pods_having_label(
+        label=constants.PROMETHEUS_POD_LABEL,
+        namespace=constants.OPENSHIFT_MONITORING_NAMESPACE,
+    )
+    for pod_dict in pods_dicts:
+        pod_obj = pod.Pod(**pod_dict)
+        wait_for_all_containers_ready(pod_obj, timeout=timeout)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3808,6 +3808,10 @@ THANOS_QUERIER_INTERNAL_ADDRESS = "https://thanos-querier.openshift-monitoring.s
 CLUSTER_MONITORING_VIEW_ROLE = "cluster-monitoring-view"
 CEPHOBJECTSTORE_NAME = f"{DEFAULT_STORAGE_CLUSTER}-{CEPHOBJECTSTORE}"
 ENABLE_RGW_HPA_ANNOTATION_KEY = "ocs.openshift.io/enable-rgw-autoscale"
+PUSHGATEWAY_YAML = os.path.join(TEMPLATE_DIR, "pushgateway", "pushgateway.yaml")
+PUSHGATEWAY_APP_LABEL = "app=pushgateway"
+CLUSTER_MONITORING_CONFIGMAP_NAME = "cluster-monitoring-config"
+
 
 # Monitoring status
 MON_STATUS_UP = "up"

--- a/ocs_ci/ocs/resources/pushgateway.py
+++ b/ocs_ci/ocs/resources/pushgateway.py
@@ -1,0 +1,144 @@
+import logging
+import requests
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.helpers.helpers import create_resource
+from ocs_ci.ocs.resources.pod import wait_for_pods_by_label_count
+from ocs_ci.utility import templating
+
+logger = logging.getLogger(__name__)
+
+
+class Pushgateway:
+    """
+    A class to manage Pushgateway installation and configuration.
+
+    Pushgateway allows pushing custom metrics to Prometheus.
+    """
+
+    def __init__(self, namespace):
+        """
+        Initialize Pushgateway instance.
+
+        Args:
+            namespace (str): Namespace where Pushgateway will be deployed
+        """
+        self.namespace = namespace
+        self.ocp_obj = OCP(namespace=self.namespace)
+        self.pod = None
+        self.service_url = None
+
+    def install(self):
+        """
+        Install Pushgateway from the template.
+
+        Raises:
+            AssertionError: If Pushgateway installation fails.
+        """
+        logger.info(f"Installing Pushgateway in namespace {self.namespace}")
+
+        try:
+            # Load and create pushgateway resources from template
+            pushgateway_data = list(
+                templating.load_yaml(constants.PUSHGATEWAY_YAML, multi_document=True)
+            )
+
+            for resource in pushgateway_data:
+                if "metadata" in resource:
+                    resource["metadata"]["namespace"] = self.namespace
+
+            for resource in pushgateway_data:
+                create_resource(**resource)
+
+            # Wait for pushgateway pod to be running
+            wait_for_pods_by_label_count(
+                label=constants.PUSHGATEWAY_APP_LABEL,
+                expected_count=1,
+                namespace=self.namespace,
+            )
+
+            # Get service URL
+            ocp_route = OCP(kind=constants.ROUTE, namespace=self.namespace)
+            routes = ocp_route.get(selector=constants.PUSHGATEWAY_APP_LABEL)
+
+            if not routes.get("items"):
+                raise Exception(
+                    f"Pushgateway route not found in namespace {self.namespace}"
+                )
+
+            host = routes["items"][0]["spec"]["host"]
+            if not host:
+                raise Exception("Pushgateway route does not have a host configured")
+
+            self.service_url = f"http://{host}"
+
+            logger.info(
+                f"Pushgateway installed successfully in namespace {self.namespace}"
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to install Pushgateway: {e}")
+            raise
+
+    def send_custom_metric(self, metric_name, metric_value, job_name="test_job"):
+        """
+        Send a custom metric to Pushgateway.
+
+        Args:
+            metric_name (str): Name of the metric
+            metric_value (str): Value of the metric
+            job_name (str): Job name for the metric (default: "test_job")
+
+        Raises:
+            Exception: If sending metric fails
+        """
+        if not self.service_url:
+            raise Exception(
+                "Pushgateway service URL not available. Ensure install() was called."
+            )
+
+        url = f"{self.service_url}/metrics/job/{job_name}"
+        metric_data = f"{metric_name} {metric_value}\n"
+
+        logger.info(f"Sending metric to Pushgateway: {url} = {metric_value}")
+
+        try:
+            response = requests.post(
+                url,
+                data=metric_data.encode("utf-8"),
+                headers={"Content-Type": "text/plain"},
+                timeout=10,
+            )
+            response.raise_for_status()
+            logger.info(
+                f"Successfully sent metric {metric_name}={metric_value} to Pushgateway"
+            )
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to send metric to Pushgateway: {e}")
+            raise
+
+    def cleanup(self):
+        """
+        Cleanup Pushgateway resources.
+        """
+        logger.info(f"Cleaning up Pushgateway in namespace {self.namespace}")
+
+        try:
+            # Delete resources by label
+            self.ocp_obj.exec_oc_cmd(
+                f"delete all,service,route,ServiceMonitor -l {constants.PUSHGATEWAY_APP_LABEL}",
+                timeout=120,
+            )
+            logger.info("Pushgateway resources deleted")
+        except CommandFailed as e:
+            logger.warning(f"Failed to delete some Pushgateway resources: {e}")
+
+        # Wait for resources to be deleted
+        try:
+            OCP(kind=constants.NAMESPACE).wait_for_delete(self.namespace, timeout=60)
+        except Exception as e:
+            logger.warning(f"Namespace deletion check failed: {e}")
+
+        logger.info("Pushgateway cleanup completed")

--- a/ocs_ci/ocs/resources/pushgateway.py
+++ b/ocs_ci/ocs/resources/pushgateway.py
@@ -1,5 +1,4 @@
 import logging
-import requests
 
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
@@ -29,8 +28,7 @@ class Pushgateway:
         """
         self.namespace = namespace
         self.ocp_obj = OCP(namespace=self.namespace)
-        self.pod = None
-        self.service_url = None
+        self._exec_pod = None
 
     def install(self):
         """
@@ -67,20 +65,16 @@ class Pushgateway:
             )
             wait_for_container_status_ready(pod=pod_obj)
 
-            # Get service URL
-            ocp_route = OCP(kind=constants.ROUTE, namespace=self.namespace)
-            routes = ocp_route.get(selector=constants.PUSHGATEWAY_APP_LABEL)
-
-            if not routes.get("items"):
+            # Resolve one Prometheus pod (has curl) for exec when sending metrics
+            prometheus_pods = pod.get_pods_having_label(
+                label=constants.PROMETHEUS_POD_LABEL,
+                namespace=constants.OPENSHIFT_MONITORING_NAMESPACE,
+            )
+            if not prometheus_pods:
                 raise Exception(
-                    f"Pushgateway route not found in namespace {self.namespace}"
+                    f"No Prometheus pod found in {constants.OPENSHIFT_MONITORING_NAMESPACE}"
                 )
-
-            host = routes["items"][0]["spec"]["host"]
-            if not host:
-                raise Exception("Pushgateway route does not have a host configured")
-
-            self.service_url = f"http://{host}"
+            self._exec_pod = pod.Pod(**prometheus_pods[0])
 
             logger.info(
                 f"Pushgateway installed successfully in namespace {self.namespace}"
@@ -92,7 +86,7 @@ class Pushgateway:
 
     def send_custom_metric(self, metric_name, metric_value, job_name="test_job"):
         """
-        Send a custom metric to Pushgateway.
+        Send a custom metric to Pushgateway via exec from a Prometheus pod (curl to Service).
 
         Args:
             metric_name (str): Name of the metric
@@ -102,28 +96,35 @@ class Pushgateway:
         Raises:
             Exception: If sending metric fails
         """
-        if not self.service_url:
+        if not self._exec_pod:
             raise Exception(
-                "Pushgateway service URL not available. Ensure install() was called."
+                "Pushgateway install not complete (no exec pod). Ensure install() was called."
             )
 
-        url = f"{self.service_url}/metrics/job/{job_name}"
-        metric_data = f"{metric_name} {metric_value}\n"
+        url = (
+            f"http://pushgateway.{self.namespace}.svc.cluster.local:9091"
+            f"/metrics/job/{job_name}"
+        )
+        payload = f"{metric_name} {metric_value}\n"
+        # Escape single quotes for use inside single-quoted shell string
+        escaped_payload = payload.replace("'", "'\"'\"'")
+        curl_cmd = (
+            f"curl -s -S -X POST -H 'Content-Type: text/plain' "
+            f"--data-binary '{escaped_payload}' '{url}'"
+        )
 
-        logger.info(f"Sending metric to Pushgateway: {url} = {metric_value}")
+        logger.info(
+            f"Sending metric to Pushgateway via pod exec: {url} = {metric_value}"
+        )
 
         try:
-            response = requests.post(
-                url,
-                data=metric_data.encode("utf-8"),
-                headers={"Content-Type": "text/plain"},
-                timeout=10,
+            self._exec_pod.exec_cmd_on_pod(
+                command=curl_cmd, out_yaml_format=False, timeout=15
             )
-            response.raise_for_status()
             logger.info(
                 f"Successfully sent metric {metric_name}={metric_value} to Pushgateway"
             )
-        except requests.exceptions.RequestException as e:
+        except CommandFailed as e:
             logger.error(f"Failed to send metric to Pushgateway: {e}")
             raise
 

--- a/ocs_ci/ocs/resources/pushgateway.py
+++ b/ocs_ci/ocs/resources/pushgateway.py
@@ -5,7 +5,9 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.helpers.helpers import create_resource
+from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import wait_for_pods_by_label_count
+from ocs_ci.ocs.ui.workload_ui import wait_for_container_status_ready
 from ocs_ci.utility import templating
 
 logger = logging.getLogger(__name__)
@@ -52,12 +54,18 @@ class Pushgateway:
             for resource in pushgateway_data:
                 create_resource(**resource)
 
-            # Wait for pushgateway pod to be running
+            # Wait for pushgateway pod to be ready
             wait_for_pods_by_label_count(
                 label=constants.PUSHGATEWAY_APP_LABEL,
                 expected_count=1,
                 namespace=self.namespace,
             )
+            pod_obj = pod.Pod(
+                **pod.get_pods_having_label(
+                    label=constants.PUSHGATEWAY_APP_LABEL, namespace=self.namespace
+                )[0]
+            )
+            wait_for_container_status_ready(pod=pod_obj)
 
             # Get service URL
             ocp_route = OCP(kind=constants.ROUTE, namespace=self.namespace)

--- a/ocs_ci/ocs/resources/pushgateway.py
+++ b/ocs_ci/ocs/resources/pushgateway.py
@@ -1,5 +1,7 @@
 import logging
 
+import requests
+
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -8,6 +10,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import wait_for_pods_by_label_count
 from ocs_ci.ocs.ui.workload_ui import wait_for_container_status_ready
 from ocs_ci.utility import templating
+from ocs_ci.utility.utils import TimeoutExpiredError, TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +31,7 @@ class Pushgateway:
         """
         self.namespace = namespace
         self.ocp_obj = OCP(namespace=self.namespace)
-        self._exec_pod = None
+        self.service_url = None
 
     def install(self):
         """
@@ -65,16 +68,21 @@ class Pushgateway:
             )
             wait_for_container_status_ready(pod=pod_obj)
 
-            # Resolve one Prometheus pod (has curl) for exec when sending metrics
-            prometheus_pods = pod.get_pods_having_label(
-                label=constants.PROMETHEUS_POD_LABEL,
-                namespace=constants.OPENSHIFT_MONITORING_NAMESPACE,
-            )
-            if not prometheus_pods:
+            # Get service URL (Route)
+            ocp_route = OCP(kind=constants.ROUTE, namespace=self.namespace)
+            routes = ocp_route.get(selector=constants.PUSHGATEWAY_APP_LABEL)
+
+            if not routes.get("items"):
                 raise Exception(
-                    f"No Prometheus pod found in {constants.OPENSHIFT_MONITORING_NAMESPACE}"
+                    f"Pushgateway route not found in namespace {self.namespace}"
                 )
-            self._exec_pod = pod.Pod(**prometheus_pods[0])
+
+            host = routes["items"][0]["spec"]["host"]
+            if not host:
+                raise Exception("Pushgateway route does not have a host configured")
+
+            self.service_url = f"http://{host}"
+            self._wait_for_pushgateway_reachable()  # Avoid 503 on first send
 
             logger.info(
                 f"Pushgateway installed successfully in namespace {self.namespace}"
@@ -84,9 +92,38 @@ class Pushgateway:
             logger.error(f"Failed to install Pushgateway: {e}")
             raise
 
+    def _wait_for_pushgateway_reachable(self):
+        """
+        Wait for Pushgateway endpoint to be reachable.
+
+        Raises:
+            TimeoutExpiredError: If Pushgateway endpoint is not reachable within 60s
+        """
+        logger.info(
+            f"Waiting for Pushgateway endpoint to be reachable: {self.service_url}"
+        )
+        try:
+            for response in TimeoutSampler(
+                timeout=60,
+                sleep=3,
+                func=requests.get,
+                url=self.service_url,
+                allow_redirects=True,
+            ):
+                if response.status_code in (200, 405):
+                    logger.info("Pushgateway endpoint is reachable")
+                    break
+        except TimeoutExpiredError:
+            message = (
+                f"Pushgateway at {self.service_url} did not become reachable "
+                f"within 60s (503 or connection error)"
+            )
+            logger.error(response)
+            raise TimeoutExpiredError(message)
+
     def send_custom_metric(self, metric_name, metric_value, job_name="test_job"):
         """
-        Send a custom metric to Pushgateway via exec from a Prometheus pod (curl to Service).
+        Send a custom metric to Pushgateway.
 
         Args:
             metric_name (str): Name of the metric
@@ -96,35 +133,28 @@ class Pushgateway:
         Raises:
             Exception: If sending metric fails
         """
-        if not self._exec_pod:
+        if not self.service_url:
             raise Exception(
-                "Pushgateway install not complete (no exec pod). Ensure install() was called."
+                "Pushgateway service URL not available. Ensure install() was called."
             )
 
-        url = (
-            f"http://pushgateway.{self.namespace}.svc.cluster.local:9091"
-            f"/metrics/job/{job_name}"
-        )
-        payload = f"{metric_name} {metric_value}\n"
-        # Escape single quotes for use inside single-quoted shell string
-        escaped_payload = payload.replace("'", "'\"'\"'")
-        curl_cmd = (
-            f"curl -s -S -X POST -H 'Content-Type: text/plain' "
-            f"--data-binary '{escaped_payload}' '{url}'"
-        )
+        url = f"{self.service_url}/metrics/job/{job_name}"
+        metric_data = f"{metric_name} {metric_value}\n"
 
-        logger.info(
-            f"Sending metric to Pushgateway via pod exec: {url} = {metric_value}"
-        )
+        logger.info(f"Sending metric to Pushgateway: {url} = {metric_value}")
 
         try:
-            self._exec_pod.exec_cmd_on_pod(
-                command=curl_cmd, out_yaml_format=False, timeout=15
+            response = requests.post(
+                url,
+                data=metric_data.encode("utf-8"),
+                headers={"Content-Type": "text/plain"},
+                timeout=10,
             )
+            response.raise_for_status()
             logger.info(
                 f"Successfully sent metric {metric_name}={metric_value} to Pushgateway"
             )
-        except CommandFailed as e:
+        except requests.exceptions.RequestException as e:
             logger.error(f"Failed to send metric to Pushgateway: {e}")
             raise
 

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -155,6 +155,7 @@ class Warp(object):
             insecure (Boolean): disable TLS certification verification
             debug (Boolean): Enable debug output
             workload_type (str): Type of workload to run (put, get, stat, mixed, etc.)
+            clear_objects (Boolean): Whether to delete objects from the bucket after the benchmark
             kwargs (dict): Additional keyword arguments to pass to the warp command
         """
 
@@ -281,7 +282,7 @@ class Warp(object):
 
         if last_report is None:
             raise UnexpectedBehaviour(
-                f"Last report is empty, Warp workload didn't run as expected..."
+                "Last report is empty, Warp workload didn't run as expected..."
             )
 
         avg_throughput = (

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -232,7 +232,7 @@ class Warp(object):
         else:
             raise UnexpectedBehaviour(
                 f"Output file {self.output_file} is empty, "
-                "Warp workload doesn't run as expected..."
+                "Warp workload didn't run as expected..."
             )
 
     def cleanup(self, multi_client=False):

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -367,6 +367,7 @@ class WarpWorkloadRunner:
                         insecure=True,
                         validate=False,
                         multi_client=False,
+                        clear_objects=True,
                     )
                 except Exception as e:
                     log.warning(f"Warp workload iteration failed: {e}")

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -13,7 +13,6 @@ from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
 from ocs_ci.utility import templating
@@ -30,6 +29,8 @@ class Warp(object):
     WARP measures GET and PUT performance from multiple clients against a MinIO cluster.
 
     """
+
+    WARP_POD_LABEL = "app=warppod"
 
     def __init__(self):
         """
@@ -99,7 +100,7 @@ class Warp(object):
         all_warp_pods = [
             Pod(**pod_info)
             for pod_info in get_pods_having_label(
-                label="app=warppod", namespace=self.pod_obj.namespace
+                label=self.WARP_POD_LABEL, namespace=self.pod_obj.namespace
             )
         ]
 
@@ -247,7 +248,15 @@ class Warp(object):
                 self.service_obj.delete()
         log.info("Deleting pods and deployment config")
         if self.pod_obj:
-            pod.delete_deployment_pods(self.pod_obj)
+            try:
+                ocp_obj = OCP(namespace=self.namespace)
+                ocp_obj.exec_oc_cmd(
+                    f"delete {constants.DEPLOYMENT} -l {self.WARP_POD_LABEL}"
+                )
+            except CommandFailed as e:
+                log.warning(
+                    f"Failed to delete deployment with label {self.WARP_POD_LABEL}: {e}"
+                )
         if self.pvc_obj:
             self.pvc_obj.delete()
 

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -14,9 +14,12 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
+from ocs_ci.ocs.resources.pod import (
+    Pod,
+    get_pods_having_label,
+    wait_for_pods_by_label_count,
+)
 from ocs_ci.utility import templating
-from ocs_ci.ocs.ui.workload_ui import wait_for_container_status_ready
 
 log = logging.getLogger(__name__)
 
@@ -104,8 +107,13 @@ class Warp(object):
             )
         ]
 
+        wait_for_pods_by_label_count(
+            label=self.WARP_POD_LABEL,
+            expected_count=replicas,
+            namespace=self.namespace,
+        )
         for con in all_warp_pods:
-            wait_for_container_status_ready(pod=con)
+            helpers.wait_for_all_containers_ready(pod=con)
 
         if multi_client:
             self.client_pods = [

--- a/ocs_ci/ocs/warp.py
+++ b/ocs_ci/ocs/warp.py
@@ -196,11 +196,18 @@ class Warp(object):
         # Setup warp clients on warp client pods
         self.client_str = ""
         multi_client_options = ""
+        client_futures = []
         if multi_client:
             thread_exec = futures.ThreadPoolExecutor(max_workers=len(self.client_pods))
             for p in self.client_pods:
                 command = f"{self.warp_bin_dir} client"
-                thread_exec.submit(p.exec_cmd_on_pod, command=command, timeout=timeout)
+                fut = thread_exec.submit(
+                    p.exec_cmd_on_pod,
+                    command=command,
+                    out_yaml_format=False,
+                    timeout=timeout,
+                )
+                client_futures.append(fut)
             log.info("Wait for 5 seconds after the clients are started listening!")
             time.sleep(5)
             for client in self.client_ips:
@@ -219,6 +226,23 @@ class Warp(object):
 
         if validate:
             self.validate_warp_workload()
+
+        # Kill warp clients
+        if multi_client:
+            log.info("Killing warp clients")
+            for p in self.client_pods:
+                p.exec_cmd_on_pod(command="pkill warp", timeout=timeout)
+
+            log.info("Waiting for warp clients threads to finish")
+            for fut in client_futures:
+                try:
+                    fut.result(timeout=timeout)
+
+                # Ignoring the expected process-killed stderr
+                except CommandFailed as e:
+                    if "143" in str(e):
+                        log.info("Thread killed by signal 143")
+            log.info("Warp clients threads finished")
 
     def validate_warp_workload(self):
         """

--- a/ocs_ci/templates/app-pods/warp.yaml
+++ b/ocs_ci/templates/app-pods/warp.yaml
@@ -33,3 +33,11 @@ spec:
         volumeMounts:
         - mountPath: /mnt
           name: warp-vol
+        readinessProbe:
+          exec:
+            command: ["true"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3

--- a/ocs_ci/templates/pushgateway/pushgateway.yaml
+++ b/ocs_ci/templates/pushgateway/pushgateway.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pushgateway
+  template:
+    metadata:
+      labels:
+        app: pushgateway
+    spec:
+      containers:
+      - name: pushgateway
+        image: quay.io/prometheus/pushgateway:latest
+        ports:
+        - containerPort: 9091
+          name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  ports:
+  - port: 9091
+    targetPort: 9091
+    protocol: TCP
+    name: http
+  selector:
+    app: pushgateway
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  subdomain: ''
+  to:
+    kind: Service
+    name: pushgateway
+    weight: 100
+  port:
+    targetPort: 9091
+  wildcardPolicy: None
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  selector:
+    matchLabels:
+      app: pushgateway
+  endpoints:
+  - port: http
+    interval: 30s

--- a/ocs_ci/templates/pushgateway/pushgateway.yaml
+++ b/ocs_ci/templates/pushgateway/pushgateway.yaml
@@ -20,6 +20,15 @@ spec:
         ports:
         - containerPort: 9091
           name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
 ---
 apiVersion: v1
 kind: Service

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import base64
 import copy
 import logging
 import os
+from ocs_ci.ocs.resources.pushgateway import Pushgateway
 import pandas as pd
 import random
 import string
@@ -11578,3 +11579,63 @@ def keda_fixture(request):
         raise UnexpectedBehaviour("KEDA setup to read Thanos metrics failed")
 
     return keda
+
+
+@pytest.fixture(scope="function")
+def enable_custom_metrics(request):
+    """
+    Enable custom metrics for the cluster.
+    """
+    original_config_yaml = None
+
+    def modify_cm_cfg():
+        """
+        Modify the cluster-monitoring-config configmap to enable custom metrics.
+        """
+        nonlocal original_config_yaml
+        ocp_obj = OCP(
+            kind=constants.CONFIGMAP,
+            namespace=constants.MONITORING_NAMESPACE,
+            resource_name=constants.CLUSTER_MONITORING_CONFIGMAP_NAME,
+        )
+        original_config_yaml = ocp_obj.get().get("data", {}).get("config.yaml", "")
+        new_config_yaml = templating.to_nice_yaml({"enableUserWorkload": True})
+        patch_params = json.dumps({"data": {"config.yaml": new_config_yaml}})
+        ocp_obj.patch(params=patch_params, format_type="merge")
+
+    def revert_cm_cfg_change():
+        """
+        Revert the change to the cluster-monitoring-config configmap.
+        """
+        nonlocal original_config_yaml
+        ocp_obj = OCP(
+            kind=constants.CONFIGMAP,
+            namespace=constants.MONITORING_NAMESPACE,
+            resource_name=constants.CLUSTER_MONITORING_CONFIGMAP_NAME,
+        )
+        patch_params = json.dumps({"data": {"config.yaml": original_config_yaml}})
+        ocp_obj.patch(params=patch_params, format_type="merge")
+
+    request.addfinalizer(revert_cm_cfg_change)
+    modify_cm_cfg()
+
+
+@pytest.fixture(scope="function")
+def pushgateway(request, project_factory, enable_custom_metrics):
+    """
+    TODO
+    """
+    return pushgateway_fixture(request, project_factory)
+
+
+def pushgateway_fixture(request, project_factory):
+    """
+    TODO
+    """
+    project_obj = project_factory(
+        project_name=create_unique_resource_name("pushgateway", "project")
+    )
+    pushgateway = Pushgateway(namespace=project_obj.namespace)
+    request.addfinalizer(pushgateway.cleanup)
+    pushgateway.install()
+    return pushgateway

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,6 @@ from ocs_ci.ocs.exceptions import (
     CephHealthNotRecoveredException,
     CephHealthRecoveredException,
     ResourceWrongStatusException,
-    UnexpectedBehaviour,
     UnsupportedPlatformError,
     PoolDidNotReachReadyState,
     StorageclassNotCreated,
@@ -11575,8 +11574,6 @@ def keda_fixture(request):
         log.info("KEDA is already installed, skipping installation")
 
     keda.setup_access_to_thanos_metrics()
-    if not keda.can_read_thanos_metrics():
-        raise UnexpectedBehaviour("KEDA setup to read Thanos metrics failed")
 
     return keda
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11623,14 +11623,18 @@ def enable_custom_metrics(request):
 @pytest.fixture(scope="function")
 def pushgateway(request, project_factory, enable_custom_metrics):
     """
-    TODO
+    Install Pushgateway in a new project and return the Pushgateway object.
+
+
     """
     return pushgateway_fixture(request, project_factory)
 
 
 def pushgateway_fixture(request, project_factory):
     """
-    TODO
+    Install Pushgateway in a new project and return the Pushgateway object.
+
+    Pushgateway is a 3rd party tool that allows pushing custom metrics to Prometheus.
     """
     project_obj = project_factory(
         project_name=create_unique_resource_name("pushgateway", "project")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11625,17 +11625,16 @@ def pushgateway(request, project_factory, enable_custom_metrics):
     """
     Install Pushgateway in a new project and return the Pushgateway object.
 
+    Pushgateway is a 3rd party tool that allows pushing custom metrics to Prometheus.
 
+    The enable_custom_metrics fixture is required to allow Pushgateway
+    to push custom metrics to Prometheus.
     """
     return pushgateway_fixture(request, project_factory)
 
 
 def pushgateway_fixture(request, project_factory):
-    """
-    Install Pushgateway in a new project and return the Pushgateway object.
-
-    Pushgateway is a 3rd party tool that allows pushing custom metrics to Prometheus.
-    """
+    """Install Pushgateway in a new project and return the Pushgateway object"""
     project_obj = project_factory(
         project_name=create_unique_resource_name("pushgateway", "project")
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,7 @@ from ocs_ci.helpers.helpers import (
     modify_deployment_replica_count,
     create_resource,
     create_network_fence_class,
+    wait_for_prometheus_ready,
     wait_for_resource_state,
     storagecluster_independent_check,
     get_schedule_precedance_value_from_csi_addons_configmap,
@@ -11589,6 +11590,10 @@ def enable_custom_metrics(request):
         """
         Modify the cluster-monitoring-config configmap to enable custom metrics.
         """
+        log.info(
+            "Modifying the cluster-monitoring-config configmap to enable custom metrics"
+        )
+
         nonlocal original_config_yaml
         ocp_obj = OCP(
             kind=constants.CONFIGMAP,
@@ -11600,10 +11605,17 @@ def enable_custom_metrics(request):
         patch_params = json.dumps({"data": {"config.yaml": new_config_yaml}})
         ocp_obj.patch(params=patch_params, format_type="merge")
 
+        log.info("Waiting for 30 seconds for the changes to take effect")
+        time.sleep(30)
+
+        wait_for_prometheus_ready(timeout=300)
+        log.info("Custom metrics enabled successfully")
+
     def revert_cm_cfg_change():
         """
         Revert the change to the cluster-monitoring-config configmap.
         """
+        log.info("Reverting the change to the cluster-monitoring-config configmap")
         nonlocal original_config_yaml
         ocp_obj = OCP(
             kind=constants.CONFIGMAP,
@@ -11612,6 +11624,12 @@ def enable_custom_metrics(request):
         )
         patch_params = json.dumps({"data": {"config.yaml": original_config_yaml}})
         ocp_obj.patch(params=patch_params, format_type="merge")
+
+        log.info("Waiting for 30 seconds for the changes to take effect")
+        time.sleep(30)
+
+        wait_for_prometheus_ready(timeout=300)
+        log.info("Custom metrics reverted successfully")
 
     request.addfinalizer(revert_cm_cfg_change)
     modify_cm_cfg()

--- a/tests/functional/object/rgw/test_keda_ha.py
+++ b/tests/functional/object/rgw/test_keda_ha.py
@@ -154,3 +154,12 @@ class TestKedaHA:
         except TimeoutExpiredError:
             logger.error("RGW did not downscale as expected.")
             raise
+
+    def test_pushgateway_integration(self, pushgateway):
+        """
+        Test the integration of the Pushgateway with the RGW deployment
+        """
+        pushgateway.send_custom_metric(
+            metric_name="test_metric",
+            metric_value="300",
+        )

--- a/tests/functional/object/rgw/test_keda_ha.py
+++ b/tests/functional/object/rgw/test_keda_ha.py
@@ -148,10 +148,11 @@ class TestKedaHA:
         THRESHOLD = "5.0"
         METRIC_NAME = "custom_rgw_metric"
         EXPORTED_JOB_NAME = "rgw_flapping_test"
-        FLAPPING_DURATION = 120  # 2 minutes
-        FLAPPING_INTERVAL = 5  # 5 seconds
+        FLAPPING_DURATION = 120
+        FLAPPING_INTERVAL = 5
         VALUE_ABOVE_THRESHOLD = "20.0"
         VALUE_BELOW_THRESHOLD = "1.0"
+        SCALE_TIMEOUT = 600
 
         # 1. Create a ScaledObject to autoscale the RGW deployment based on custom metric
         logger.info(f"Creating ScaledObject to monitor custom metric '{METRIC_NAME}'")
@@ -194,8 +195,8 @@ class TestKedaHA:
         assert wait_for_pods_by_label_count(
             label=constants.RGW_APP_LABEL,
             expected_count=TARGET_MAX_REPLICAS,
-            timeout=300,
-        ), f"RGW did not scale up to {TARGET_MAX_REPLICAS} replica(s) after threshold flapping within 300s"
+            timeout=SCALE_TIMEOUT,
+        ), f"RGW did not scale up to {TARGET_MAX_REPLICAS} replica(s) after threshold flapping within {SCALE_TIMEOUT}s"
 
         # 4. Set the metric below the threshold and wait for RGW to scale down
         logger.info(f"Setting metric below threshold ({VALUE_BELOW_THRESHOLD})")
@@ -205,8 +206,11 @@ class TestKedaHA:
         assert wait_for_pods_by_label_count(
             label=constants.RGW_APP_LABEL,
             expected_count=self.DEFAULT_MIN_REPLICAS,
-            timeout=300,
-        ), f"RGW did not scale down to {self.DEFAULT_MIN_REPLICAS} replica(s) after threshold flapping within 300s"
+            timeout=SCALE_TIMEOUT,
+        ), (
+            f"RGW did not scale down to {self.DEFAULT_MIN_REPLICAS} replica(s) "
+            f"after threshold flapping within {SCALE_TIMEOUT}s"
+        )
 
     @tier2
     @polarion_id("OCS-7518")

--- a/tests/functional/object/rgw/test_keda_ha.py
+++ b/tests/functional/object/rgw/test_keda_ha.py
@@ -1,5 +1,9 @@
+import json
 import logging
+import time
 
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.utility.utils import TimeoutSampler
 import pytest
 
 from ocs_ci.framework import config
@@ -9,14 +13,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     rgw,
     skipif_disconnected_cluster,
     tier1,
+    tier2,
+    tier3,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import OBC
-from ocs_ci.ocs.resources.pod import get_pods_having_label
-from ocs_ci.ocs.warp import WarpWorkloadRunner
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.resources.pod import get_pods_having_label, wait_for_pods_by_label_count
+from ocs_ci.ocs.warp import Warp, WarpWorkloadRunner
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +40,12 @@ class TestKedaHA:
     Test RGW's integration with the KEDA autoscaler
     """
 
-    @pytest.fixture(autouse=True, scope="class")
+    # Class-level constants
+    DEFAULT_MIN_REPLICAS = 1
+    DEFAULT_MAX_REPLICAS = 5
+    DEFAULT_THRESHOLD = "7.00"
+
+    @pytest.fixture(scope="function")
     def enable_rgw_hpa(self, request):
         """
         Annotate the OCS StorageCluster to enable RGW HPA and remove the annotation after the test
@@ -61,39 +70,35 @@ class TestKedaHA:
             resource_name=constants.DEFAULT_STORAGE_CLUSTER,
         )
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def warp_workload_runner(self, request):
         host = f"{constants.RGW_SERVICE_INTERNAL_MODE}.{config.ENV_DATA['cluster_namespace']}.svc:443"
         return WarpWorkloadRunner(request, host)
 
     @tier1
     @polarion_id("OCS-7408")
-    def test_rgw_keda_ha(self, keda_class, rgw_bucket_factory, warp_workload_runner):
+    def test_rgw_keda_ha(
+        self, keda_class, rgw_bucket_factory, warp_workload_runner, enable_rgw_hpa
+    ):
         """
         Test RGW's integration with Keda autoscaler
 
-        1. Create a ScaledObject to autoscale the RGW deployment with a low
-        threshold.
+        1. Create a ScaledObject to autoscale the RGW deployment with a low threshold
         2. Start a warp workload on an RGW bucket to run in the background
         3. Wait for the RGW pods to upscale to the target max replicas
         4. Stop the warp workload
         5. Wait for the RGW pods to downscale to the min replica count
         """
-        TARGET_MAX_REPLICAS = 5
-        TARGET_MIN_REPLICAS = 1
-        THRESHOLD = "7.00"
-
         # 1. Create a ScaledObject to autoscale the RGW deployment
-        scaled_object = keda_class.create_thanos_metric_scaled_object(
+        keda_class.create_thanos_metric_scaled_object(
             {
                 "scaleTargetRef": RGW_SCALE_TARGET_REF,
                 "query": "sum(rate(ceph_rgw_req[1m]))",
-                "threshold": THRESHOLD,
-                "minReplicaCount": TARGET_MIN_REPLICAS,
-                "maxReplicaCount": TARGET_MAX_REPLICAS,
+                "threshold": self.DEFAULT_THRESHOLD,
+                "minReplicaCount": self.DEFAULT_MIN_REPLICAS,
+                "maxReplicaCount": self.DEFAULT_MAX_REPLICAS,
             }
         )
-        logger.info(f"ScaledObject: {scaled_object}")
 
         # 2. Start a warp workload on an RGW bucket to run in the background
         bucket = rgw_bucket_factory(1, "RGW-OC")[0]
@@ -112,54 +117,329 @@ class TestKedaHA:
 
         # 3. Wait for the RGW pods to upscale
         try:
-            for rgw_pods_sampled in TimeoutSampler(
-                timeout=300,
-                sleep=30,
-                func=get_pods_having_label,
+            assert wait_for_pods_by_label_count(
                 label=constants.RGW_APP_LABEL,
-                namespace=config.ENV_DATA["cluster_namespace"],
-            ):
-                pod_names = "\n".join(
-                    [pod["metadata"]["name"] for pod in rgw_pods_sampled]
-                )
-                logger.info(f"RGW pods running:\n{pod_names}")
-                if len(rgw_pods_sampled) == TARGET_MAX_REPLICAS:
-                    logger.info("RGW pods upscaled to target max replicas as expected.")
-                    break
-        except TimeoutExpiredError:
-            logger.error("RGW did not upscale as expected.")
-            raise
+                expected_count=self.DEFAULT_MAX_REPLICAS,
+                timeout=300,
+            ), f"RGW did not scale up to {self.DEFAULT_MAX_REPLICAS} replica(s) within 300s"
         finally:
             # 4. Stop the warp workload
             warp_workload_runner.stop()
 
         # 5. Wait for the RGW pods to downscale to the min replica count
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=self.DEFAULT_MIN_REPLICAS,
+            timeout=300,
+        ), f"RGW did not scale down to {self.DEFAULT_MIN_REPLICAS} replica(s) within 300s"
+
+    @tier2
+    @polarion_id("OCS-7517")
+    def test_threshold_flapping(self, keda_class, pushgateway, enable_rgw_hpa):
+        """
+        Test RGW autoscaling stability when metrics rapidly fluctuate (threshold flapping)
+
+        1. Setup a ScaledObject to scale RGW based off a custom metric
+        2. Set the metric repeatedly above and below the ScaledObject's threshold every 5 seconds over 2 minutes
+        3. Set the metric above the threshold, and wait for RGW to scale up
+        4. Set the metric below the threshold, and wait for RGW to scale back down
+        """
+        TARGET_MAX_REPLICAS = 3
+        THRESHOLD = "5.0"
+        METRIC_NAME = "custom_rgw_metric"
+        EXPORTED_JOB_NAME = "rgw_flapping_test"
+        FLAPPING_DURATION = 120  # 2 minutes
+        FLAPPING_INTERVAL = 5  # 5 seconds
+        VALUE_ABOVE_THRESHOLD = "20.0"
+        VALUE_BELOW_THRESHOLD = "1.0"
+
+        # 1. Create a ScaledObject to autoscale the RGW deployment based on custom metric
+        logger.info(f"Creating ScaledObject to monitor custom metric '{METRIC_NAME}'")
+        keda_class.create_thanos_metric_scaled_object(
+            {
+                "scaleTargetRef": RGW_SCALE_TARGET_REF,
+                "query": f"{METRIC_NAME}{{exported_job='{EXPORTED_JOB_NAME}'}}",
+                "threshold": THRESHOLD,
+                "minReplicaCount": self.DEFAULT_MIN_REPLICAS,
+                "maxReplicaCount": TARGET_MAX_REPLICAS,
+            }
+        )
+
+        # 2. Simulate metric flapping: alternate above and below threshold
+        iterations = FLAPPING_DURATION // FLAPPING_INTERVAL
+        logger.info(
+            f"Starting metric flapping test: {iterations} iterations over "
+            f"{FLAPPING_DURATION} seconds (every {FLAPPING_INTERVAL} seconds)"
+        )
+
+        for i in range(iterations):
+            metric_value = (
+                VALUE_ABOVE_THRESHOLD if i % 2 == 0 else VALUE_BELOW_THRESHOLD
+            )
+            threshold_relation = "ABOVE" if i % 2 == 0 else "BELOW"
+            logger.info(
+                f"Iteration {i + 1}/{iterations}: Setting metric {threshold_relation} "
+                f"threshold ({metric_value} vs {THRESHOLD})"
+            )
+            pushgateway.send_custom_metric(METRIC_NAME, metric_value, EXPORTED_JOB_NAME)
+            time.sleep(FLAPPING_INTERVAL)
+
+        logger.info("Metric flapping phase completed")
+
+        # 3. Set the metric above the threshold and wait for RGW to scale up
+        logger.info(f"Setting metric above threshold ({VALUE_ABOVE_THRESHOLD})")
+        pushgateway.send_custom_metric(
+            METRIC_NAME, VALUE_ABOVE_THRESHOLD, EXPORTED_JOB_NAME
+        )
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=TARGET_MAX_REPLICAS,
+            timeout=300,
+        ), f"RGW did not scale up to {TARGET_MAX_REPLICAS} replica(s) after threshold flapping within 300s"
+
+        # 4. Set the metric below the threshold and wait for RGW to scale down
+        logger.info(f"Setting metric below threshold ({VALUE_BELOW_THRESHOLD})")
+        pushgateway.send_custom_metric(
+            METRIC_NAME, VALUE_BELOW_THRESHOLD, EXPORTED_JOB_NAME
+        )
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=self.DEFAULT_MIN_REPLICAS,
+            timeout=300,
+        ), f"RGW did not scale down to {self.DEFAULT_MIN_REPLICAS} replica(s) after threshold flapping within 300s"
+
+    @tier2
+    @polarion_id("OCS-7518")
+    def test_min_max_boundaries(self, keda_class, pushgateway, enable_rgw_hpa):
+        """
+        Test that KEDA respects minReplicaCount and maxReplicaCount boundaries
+
+        1. Setup a ScaledObject to scale RGW based off a custom metric
+        2. Assert RGW replica count matches the default minimum of 1
+        3. Set minReplicaCount=2 and wait for RGW to scale up to 2 replicas
+        4. Set maxReplicaCount=2 and push an above-threshold custom metric
+        5. Assert RGW stays at replica count 2 for over 2 minutes
+        """
+        MIN_REPLICAS = 2
+        MAX_REPLICAS = 2
+        THRESHOLD = "5.0"
+        METRIC_NAME = "custom_rgw_boundary_metric"
+        EXPORTED_JOB_NAME = "rgw_boundary_test"
+        VALUE_ABOVE_THRESHOLD = "20.0"  # High value to trigger scaling
+        VALUE_BELOW_THRESHOLD = "1.0"
+        MONITORING_DURATION = 120  # 2 minutes
+
+        # 1. Create a ScaledObject with initial min=1, max=5
+        scaled_object = keda_class.create_thanos_metric_scaled_object(
+            {
+                "scaleTargetRef": RGW_SCALE_TARGET_REF,
+                "query": f"{METRIC_NAME}{{exported_job='{EXPORTED_JOB_NAME}'}}",
+                "threshold": THRESHOLD,
+                "minReplicaCount": self.DEFAULT_MIN_REPLICAS,
+                "maxReplicaCount": self.DEFAULT_MAX_REPLICAS,
+            }
+        )
+
+        # Push a low metric value to keep it at minimum
+        pushgateway.send_custom_metric(
+            METRIC_NAME, VALUE_BELOW_THRESHOLD, EXPORTED_JOB_NAME
+        )
+        logger.info(
+            f"Pushed low metric value ({VALUE_BELOW_THRESHOLD}) to trigger scale-up attempt"
+            f"Waiting a bit to see if RGW scales up when it shouldn't"
+        )
+        time.sleep(60)
+
+        # 2. Assert RGW replica count matches the initial minimum of 1
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=self.DEFAULT_MIN_REPLICAS,
+            timeout=300,
+        ), f"RGW did not reach initial minimum of {self.DEFAULT_MIN_REPLICAS} replica(s) within 300s"
+
+        # 3. Update minReplicaCount to 2 and wait for RGW to scale up
+        logger.info(f"Updating ScaledObject minReplicaCount to {MIN_REPLICAS}")
+        scaled_object.update_from_dict({"minReplicaCount": MIN_REPLICAS})
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=MIN_REPLICAS,
+            timeout=300,
+        ), f"RGW did not scale up to new minimum of {MIN_REPLICAS} replica(s) within 300s"
+
+        # 4. Update maxReplicaCount to 2 and push high metric value
+        logger.info(
+            f"Updating ScaledObject maxReplicaCount to {MAX_REPLICAS} "
+            "(same as minReplicaCount)"
+        )
+        scaled_object.update_from_dict({"maxReplicaCount": MAX_REPLICAS})
+
+        logger.info(
+            f"Pushing high metric value ({VALUE_ABOVE_THRESHOLD}) to trigger scale-up attempt"
+        )
+        pushgateway.send_custom_metric(
+            METRIC_NAME, VALUE_ABOVE_THRESHOLD, EXPORTED_JOB_NAME
+        )
+
+        # 5. Monitor RGW for 2+ minutes to ensure it stays at 2 replicas
+        logger.info(
+            f"Monitoring RGW for {MONITORING_DURATION} seconds to verify it respects "
+            f"maxReplicaCount boundary of {MAX_REPLICAS}"
+        )
+
         try:
-            for rgw_pods_sampled in TimeoutSampler(
-                timeout=300,
-                sleep=30,
+            for rgw_pods in TimeoutSampler(
+                timeout=MONITORING_DURATION,
+                sleep=5,
                 func=get_pods_having_label,
                 label=constants.RGW_APP_LABEL,
                 namespace=config.ENV_DATA["cluster_namespace"],
             ):
-                pod_names = "\n".join(
-                    [pod["metadata"]["name"] for pod in rgw_pods_sampled]
-                )
-                logger.info(f"RGW pods running:\n{pod_names}")
-                if len(rgw_pods_sampled) == TARGET_MIN_REPLICAS:
-                    logger.info(
-                        "RGW pods downscaled to target min replicas as expected."
+                if len(rgw_pods) > MAX_REPLICAS:
+                    logger.error(
+                        f"RGW exceeded maxReplicaCount boundary! "
+                        f"Current: {len(rgw_pods)}, Max: {MAX_REPLICAS}\n"
+                        f"RGW pods:\n{rgw_pods}"
                     )
-                    break
+                    raise AssertionError(
+                        f"RGW scaled beyond maxReplicaCount boundary: "
+                        f"{len(rgw_pods)} > {MAX_REPLICAS}"
+                    )
         except TimeoutExpiredError:
-            logger.error("RGW did not downscale as expected.")
-            raise
+            logger.info(
+                f"Successfully verified: RGW respected maxReplicaCount boundary of "
+                f"{MAX_REPLICAS} for {MONITORING_DURATION} seconds despite high metric value"
+            )
 
-    def test_pushgateway_integration(self, pushgateway):
+    @pytest.fixture(scope="function")
+    def warp_multi_client(self, request):
+        """Fixture to create Warp instance with 3 clients for multi-client benchmarking"""
+        warp = Warp()
+        warp.host = f"{constants.RGW_SERVICE_INTERNAL_MODE}.{config.ENV_DATA['cluster_namespace']}.svc:443"
+        warp.create_resource_warp(multi_client=True, replicas=3)
+        request.addfinalizer(lambda: warp.cleanup(multi_client=True))
+        return warp
+
+    @pytest.fixture(scope="function")
+    def cleanup_manual_upscale(self, request):
         """
-        Test the integration of the Pushgateway with the RGW deployment
+        Cleanup the manual upscale of RGW if it was performed
         """
-        pushgateway.send_custom_metric(
-            metric_name="test_metric",
-            metric_value="300",
+
+        def finalizer():
+            storagecluster_obj = OCP(
+                kind=constants.STORAGECLUSTER,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+            )
+            patch_params = {"spec": {"managedResources": {"cephObjectStores": None}}}
+            storagecluster_obj.patch(
+                resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+                params=json.dumps(patch_params),
+                format_type="merge",
+            )
+            assert wait_for_pods_by_label_count(
+                label=constants.RGW_APP_LABEL,
+                expected_count=1,
+                timeout=300,
+            ), f"RGW did not scale down to {self.DEFAULT_MIN_REPLICAS} replica(s)"
+
+        request.addfinalizer(finalizer)
+
+    @tier3
+    def test_manual_upscale_performance(
+        self, rgw_bucket_factory, warp_multi_client, cleanup_manual_upscale
+    ):
+        """
+        Test the performance of RGW after manually upscaling its pods
+
+        1. Run Warp benchmark on RGW and record the baseline throughput
+        2. Manually upscale RGW's deployment by patching the ocs-storagecluster
+        3. Re-run the Warp benchmark and verify throughput improvement after upscale
+        """
+
+        WARP_DURATION = "1m"
+
+        WARP_OBJ_SIZE = "512KiB"
+        WARP_CONCURRENCY = 32
+
+        MANUAL_UPSCALE_REPLICAS = 3
+        MANUAL_UPSCALE_TIMEOUT = 300
+        initial_throughput = None
+        final_throughput = None
+
+        # 1. Run Warp benchmark on RGW and record the baseline throughput
+        bucket = rgw_bucket_factory(1, "RGW-OC")[0]
+        bucketname = bucket.name
+        obc_obj = OBC(bucketname)
+
+        warp_multi_client.run_benchmark(
+            access_key=obc_obj.access_key_id,
+            secret_key=obc_obj.access_key,
+            bucket_name=bucketname,
+            workload_type="mixed",
+            duration=WARP_DURATION,
+            concurrent=WARP_CONCURRENCY,
+            obj_size=WARP_OBJ_SIZE,
+            timeout=600,
+            tls=True,
+            insecure=True,
+            multi_client=True,
+            clear_objects=True,
+        )
+        initial_throughput = warp_multi_client.get_last_avg_throughput()
+
+        # 2. Manually upscale RGW's deployment by patching the ocs-storagecluster
+        storagecluster_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+
+        patch_params = {
+            "spec": {
+                "managedResources": {
+                    "cephObjectStores": {"gatewayInstances": MANUAL_UPSCALE_REPLICAS}
+                }
+            }
+        }
+        storagecluster_obj.patch(
+            resource_name=constants.DEFAULT_STORAGE_CLUSTER,
+            params=json.dumps(patch_params),
+            format_type="merge",
+        )
+        assert wait_for_pods_by_label_count(
+            label=constants.RGW_APP_LABEL,
+            expected_count=MANUAL_UPSCALE_REPLICAS,
+            timeout=MANUAL_UPSCALE_TIMEOUT,
+        ), f"RGW did not scale up to {MANUAL_UPSCALE_REPLICAS} replica(s) within {MANUAL_UPSCALE_TIMEOUT} seconds"
+        logger.info(
+            "Waiting a bit more to ensure RGW's pods are properly initialized after the upscale"
+        )
+        time.sleep(60)
+
+        # 3. Re-run the Warp benchmark and verify throughput improvement after upscale
+        warp_multi_client.run_benchmark(
+            access_key=obc_obj.access_key_id,
+            secret_key=obc_obj.access_key,
+            bucket_name=bucketname,
+            workload_type="mixed",
+            duration=WARP_DURATION,
+            concurrent=WARP_CONCURRENCY,
+            obj_size=WARP_OBJ_SIZE,
+            timeout=600,
+            tls=True,
+            insecure=True,
+            multi_client=True,
+            clear_objects=True,
+        )
+        final_throughput = warp_multi_client.get_last_avg_throughput()
+
+        logger.info(f"Initial throughput: {initial_throughput} MiB/s")
+        logger.info(f"Final throughput: {final_throughput} MiB/s")
+        throughput_increase = (
+            (final_throughput - initial_throughput) / initial_throughput
+        ) * 100
+        logger.info(f"Throughput increase: {throughput_increase:.2f}%")
+        assert final_throughput > initial_throughput, (
+            f"Final throughput {final_throughput} MiB/s is not greater "
+            f"than initial throughput {initial_throughput} MiB/s"
         )

--- a/tests/functional/object/rgw/test_keda_ha.py
+++ b/tests/functional/object/rgw/test_keda_ha.py
@@ -318,9 +318,9 @@ class TestKedaHA:
     def warp_multi_client(self, request):
         """Fixture to create Warp instance with 3 clients for multi-client benchmarking"""
         warp = Warp()
+        request.addfinalizer(lambda: warp.cleanup(multi_client=True))
         warp.host = f"{constants.RGW_SERVICE_INTERNAL_MODE}.{config.ENV_DATA['cluster_namespace']}.svc:443"
         warp.create_resource_warp(multi_client=True, replicas=3)
-        request.addfinalizer(lambda: warp.cleanup(multi_client=True))
         return warp
 
     @pytest.fixture(scope="function")


### PR DESCRIPTION
This PR adds end-to-end tests for RGW autoscaling with KEDA, and introduces a Pushgateway-based path for testing autoscaling via custom Prometheus metrics. It also improves the Warp runner to better support these tests (throughput extraction, safer stop/timeout behavior, and optional object cleanup).

### Main changes

- Pushgateway integration
    - New Pushgateway resource helper (ocs_ci/ocs/resources/pushgateway.py)
    - Pushgateway deployment template (ocs_ci/templates/pushgateway/pushgateway.yaml) including ServiceMonitor + Route
    - New constants in ocs_ci/ocs/constants.py
    - New pytest fixtures in tests/conftest.py:
         - enable_custom_metrics (enables user workload monitoring via cluster monitoring config)
         - pushgateway (installs/cleans Pushgateway for tests)

 - RGW KEDA autoscaling test suite (tests/functional/object/rgw/test_keda_ha.py
    - test_threshold_flapping (Tier 2): validates stability under rapid metric oscillation
    - test_min_max_boundaries (Tier 2): validates min/maxReplicaCount enforcement (including updates)
    - test_manual_upscale_performance (Tier 3): compares throughput pre/post manual upscale using Warp multi-client

 - Warp enhancements (ocs_ci/ocs/warp.py)
    - clear_objects option
    - get_last_avg_throughput() helper
    - more robust WarpWorkloadRunner.stop() (timeouts + progress logging)