### PR TITLE
Skipped BM, Azure & IBM Power platform runs in test_automated_recovery_from_failed_nodes_reactive.py

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -694,6 +694,11 @@ skipif_vsphere_platform = pytest.mark.skipif(
     reason="Test will not run on vSphere cluster",
 )
 
+skipif_azure_platform = pytest.mark.skipif(
+    config.ENV_DATA["platform"].lower() == "azure",
+    reason="Test will not run on Azure deployed cluster",
+)
+
 skipif_tainted_nodes = pytest.mark.skipif(
     config.DEPLOYMENT.get("infra_nodes") is True
     or config.DEPLOYMENT.get("ocs_operator_nodes_to_taint") > 0,

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -315,6 +315,7 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
         ],
     )
     @skipif_external_mode
+    @skipif_ibm_cloud
     def test_automated_recovery_from_stopped_node_and_start(
         self, nodes, additional_node
     ):

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.testlib import (
     ignore_leftovers,
     skipif_external_mode,
     skipif_ibm_cloud,
+    skipif_bm,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import machine, constants
@@ -245,6 +246,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @tier4a
 @skipif_ibm_cloud
 @skipif_compact_mode
+@skipif_bm
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None
@@ -315,7 +317,6 @@ class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
         ],
     )
     @skipif_external_mode
-    @skipif_ibm_cloud
     def test_automated_recovery_from_stopped_node_and_start(
         self, nodes, additional_node
     ):

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -1,6 +1,10 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode, skipif_ibm_power
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    skipif_compact_mode,
+    skipif_ibm_power,
+)
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -4,6 +4,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     skipif_compact_mode,
     skipif_ibm_power,
+    skipif_azure_platform,
 )
 from ocs_ci.framework.testlib import (
     tier4a,
@@ -252,6 +253,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @skipif_compact_mode
 @skipif_bm
 @skipif_ibm_power
+@skipif_azure_platform
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode, skipif_ibm_power
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -247,6 +247,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @skipif_ibm_cloud
 @skipif_compact_mode
 @skipif_bm
+@skipif_ibm_power
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None


### PR DESCRIPTION
The test tries to scale up the cluster by adding a new worker node, then checks if pods successfully migrate over to that fresh node once the original one stays down. But as soon as the test tries to provision that new node, it crashes with a NotImplementedError as the code implementation is not present in platform_nodes.py. 

More info --> https://ibm-systems-storage.slack.com/archives/C06EEKSUPPZ/p1770725312412279