### PR TITLE
DFBUGS-5082:tc7:Validate socket creation for cephfs-csi-addon for provisioner

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,15 +641,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1973,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1970,
+        "line_number": 1979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,15 +649,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2079,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2076,
+        "line_number": 2085,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,52 +657,12 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2080,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2077,
+        "line_number": 2086,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2081,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2078,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2082,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2079,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2087,
@@ -726,55 +670,23 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2088,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2084,
+        "line_number": 2093,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2102,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2099,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2103,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2100,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2111,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2108,
@@ -782,15 +694,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2112,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
         "line_number": 2109,
@@ -798,10 +702,18 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2113,
+        "line_number": 2117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -809,7 +721,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2110,
+        "line_number": 2119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -817,15 +729,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2111,
+        "line_number": 2120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -833,15 +737,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2115,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2112,
+        "line_number": 2121,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -849,15 +745,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2846,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2843,
+        "line_number": 2852,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -865,15 +753,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2847,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2844,
+        "line_number": 2853,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -881,23 +761,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3568,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3545,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3546,
+        "line_number": 3574,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -905,23 +769,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3569,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3546,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3547,
+        "line_number": 3575,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1135,14 +983,6 @@
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
-      {
-        "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 576,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3769,7 +3769,12 @@ CSI_ADDONS_CONFIGMAP_NAME = "csi-addons-config"
 RBD_CSI_ADDONS_PLUGIN_DIR = (
     "/var/lib/kubelet/plugins/openshift-storage.rbd.csi.ceph.com"
 )
+CEPHFS_CSI_ADDONS_PLUGIN_DIR = (
+    "/var/lib/kubelet/plugins/openshift-storage.cephfs.csi.ceph.com"
+)
 RBD_CSI_ADDONS_SOCKET_NAME = "csi-addons.sock"
+CEPHFS_CSI_ADDONS_SOCKET_NAME = "csi-addons.sock"
+
 HYPERSHIFT_ADDON_DISCOVERYPREFIX = "dr"
 
 # Fill pool job and PVC Yaml files

--- a/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
+++ b/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
@@ -314,10 +314,26 @@ class TestCSIADDonDaemonset(ManageTest):
             namespace=namespace, pod_names=csi_addon_pod_names_list
         ), "CSI-addons pod didn't came up is running status "
 
-    @tier1
-    @green_squad
-    @polarion_id("OCS-7379")
-    def test_csi_addons_socket_creation_per_pods_node(self):
+    @pytest.mark.parametrize(
+        argnames=["pod_label", "plugin_dir", "socket_name"],
+        argvalues=[
+            pytest.param(
+                constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+                constants.RBD_CSI_ADDONS_PLUGIN_DIR,
+                constants.RBD_CSI_ADDONS_SOCKET_NAME,
+                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7379")],
+            ),
+            pytest.param(
+                constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+                constants.CEPHFS_CSI_ADDONS_PLUGIN_DIR,
+                constants.CEPHFS_CSI_ADDONS_SOCKET_NAME,
+                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7507")],
+            ),
+        ],
+    )
+    def test_csi_addons_socket_creation_per_pods_node(
+        self, pod_label, plugin_dir, socket_name
+    ):
         """
         csi-addons.sock are used for communication for csi-addons.
         This test ensure the socket creation of csi-addons.sock socket
@@ -326,22 +342,22 @@ class TestCSIADDonDaemonset(ManageTest):
         1. Get all csi-addons pods
         2. Get nodes of each csi-addons pod
         3. Verify socket creation on nodes
+        OCS-7507 is part verification of DFBUGS_5082 automation
+
         """
         logger.info(
             "Validating csi-addons socket creation on nodes of each csi-addons pod"
         )
         namespace = config.ENV_DATA["cluster_namespace"]
         # 1. Get all csi-addons pods
-        csi_addon_pods = get_pods_having_label(
-            constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420, namespace
-        )
+        csi_addon_pods = get_pods_having_label(pod_label, namespace)
         # Verify socket creation on node of each csi-addons pod
         for pod_obj in csi_addon_pods:
             csi_pod_running_node_name = pod_obj.get("spec").get("nodeName")
             assert verify_socket_on_node(
                 node_name=csi_pod_running_node_name,
-                host_path=constants.RBD_CSI_ADDONS_PLUGIN_DIR,
-                socket_name=constants.RBD_CSI_ADDONS_SOCKET_NAME,
+                host_path=plugin_dir,
+                socket_name=socket_name,
             ), f"csi-addons Socket not found on node {csi_pod_running_node_name}"
 
     @green_squad


### PR DESCRIPTION
- [DFBUGS-5082](https://issues.redhat.com//browse/DFBUGS-5082): [release-4.21] cephfs: deploy csi-addons daemonset. This is similar to rbd csiaddon feature of release 4.20:[RHSTOR-7086](https://issues.redhat.com//browse/RHSTOR-7086). [RHSTOR-7086](https://issues.redhat.com//browse/RHSTOR-7086): Use pod network for the RBD-csi-addons server. So the similar verifications applied cephfs csiaddons.
- This test covers the automation of [DFBUGS-5082](https://issues.redhat.com//browse/DFBUGS-5082): Validate socket creation for cephfs-csi-addon for provisioner