### PR TITLE
Adding a fix to policy scenarios - adjust Principal to contain ARN

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3587,20 +3587,3 @@ def get_bucket_status_value(mcg_obj, bucket_name, key):
     op = bucket_status.split("\n")
     value = next(item.split(":")[1].strip() for item in op if key in item)
     return value
-
-
-def get_bucket_policy_user_list(obc_obj):
-    """
-    Helper function returning user list used to construct bucket policy depending on oc version
-    Args:
-        obc_obj (obj): Obc object
-    Returns:
-        str: user list to be used in policy
-    """
-    ocs_version = version.get_semantic_ocs_version_from_config()
-
-    user_list = (
-        obc_obj.obc_arn if ocs_version >= version.VERSION_4_21 else obc_obj.obc_account
-    )
-
-    return user_list

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -139,6 +139,18 @@ class OBC(object):
         )
         self.s3_client = self.s3_resource.meta.client
 
+    @property
+    def id_for_policy_principal(self):
+        """
+        Returns the ID for the OBC account to be used in bucket policies,
+        based on the OCS version.
+
+        Returns:
+            str: The ID for the OBC account to be used in bucket policies.
+        """
+        ocs_version = version.get_semantic_ocs_version_from_config()
+        return self.obc_arn if ocs_version >= version.VERSION_4_21 else self.obc_account
+
 
 class ObjectBucket(ABC):
     """

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -47,7 +47,6 @@ from ocs_ci.ocs.bucket_utils import (
     list_uploaded_parts,
     complete_multipart_upload,
     craft_s3_command,
-    get_bucket_policy_user_list,
 )
 from ocs_ci.ocs.defaults import website_config, index, error
 from ocs_ci.ocs.constants import (
@@ -294,7 +293,7 @@ class TestS3BucketPolicy(MCGTest):
         obc_obj = OBC(obc_name)
 
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["GetObject"],
             resources_list=[obc_obj.bucket_name],
         )
@@ -324,7 +323,7 @@ class TestS3BucketPolicy(MCGTest):
         actions = list(map(lambda action: "s3:%s" % action, actions_list))
 
         modified_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=actions_list,
             resources_list=[obc_obj.bucket_name],
         )
@@ -399,7 +398,7 @@ class TestS3BucketPolicy(MCGTest):
         obc_obj = OBC(obc_name)
 
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["PutBucketPolicy"],
             resources_list=[obc_obj.bucket_name],
         )
@@ -412,7 +411,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Verifying Put bucket policy by user by changing the actions to GetBucketPolicy & DeleteBucketPolicy
         user_generated_policy = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["GetBucketPolicy", "DeleteBucketPolicy"],
             resources_list=[obc_obj.bucket_name],
         )
@@ -466,7 +465,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets policy on obc bucket with obc account principal
         bucket_policy_generated = gen_bucket_policy(
-            user_list=[get_bucket_policy_user_list(obc_obj)],
+            user_list=[obc_obj.id_for_policy_principal],
             actions_list=(
                 ["PutObject"]
                 if version.get_semantic_ocs_version_from_config() <= version.VERSION_4_6
@@ -636,7 +635,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets policy with Put/Get bucket website actions
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=bucket_website_action_list,
             resources_list=[obc_obj.bucket_name, f'{obc_obj.bucket_name}/{"*"}'],
             effect="Allow",
@@ -700,7 +699,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin modifies policy to allow DeleteBucketWebsite action
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["DeleteBucketWebsite"],
             resources_list=[obc_obj.bucket_name, f'{obc_obj.bucket_name}/{"*"}'],
             effect="Allow",
@@ -738,7 +737,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets a policy on OBC bucket to allow versioning related actions
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=bucket_version_action_list,
             resources_list=[obc_obj.bucket_name, f'{obc_obj.bucket_name}/{"*"}'],
         )
@@ -770,7 +769,7 @@ class TestS3BucketPolicy(MCGTest):
         ), "Failed: GetBucketVersioning"
 
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["PutBucketVersioning"],
             resources_list=[obc_obj.bucket_name],
         )
@@ -830,7 +829,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets policy with Effect: Deny on obc bucket with obc-account principal
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["GetObject"],
             resources_list=[f"{obc_obj.bucket_name}/{object_key}"],
             effect="Deny",
@@ -867,7 +866,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Admin sets a new policy on same obc bucket with same account but with different action and resource
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["DeleteObject"],
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
             effect="Deny",
@@ -1033,7 +1032,7 @@ class TestS3BucketPolicy(MCGTest):
         # Policy tests invalid/non-existent S3 Action. ie: GetContent
         elif policy_name == "invalid_action":
             bucket_policy_generated = gen_bucket_policy(
-                user_list=get_bucket_policy_user_list(obc_obj),
+                user_list=obc_obj.id_for_policy_principal,
                 actions_list=[policy_param],
                 resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
                 effect="Allow",
@@ -1043,7 +1042,7 @@ class TestS3BucketPolicy(MCGTest):
         # Policy tests invalid/non-existent resource/bucket. ie: new_bucket
         elif policy_name == "invalid_resource":
             bucket_policy_generated = gen_bucket_policy(
-                user_list=get_bucket_policy_user_list(obc_obj),
+                user_list=obc_obj.id_for_policy_principal,
                 actions_list=["GetObject"],
                 resources_list=[policy_param],
                 effect="Allow",
@@ -1083,7 +1082,7 @@ class TestS3BucketPolicy(MCGTest):
         # Set bucket policy for obc_bucket
         bucket_policy_generated = gen_bucket_policy(
             principal_property="NotPrincipal",
-            user_list=[get_bucket_policy_user_list(obc_obj)],
+            user_list=[obc_obj.id_for_policy_principal],
             actions_list=["PutObject"],
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
             effect="Deny",
@@ -1132,7 +1131,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Set bucket policy for user
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj1),
+            user_list=obc_obj1.id_for_policy_principal,
             action_property="NotAction",
             actions_list=["DeleteBucket"],
             resources_list=[f'{obc_obj.bucket_name}/{"*"}'],
@@ -1233,7 +1232,7 @@ class TestS3BucketPolicy(MCGTest):
 
         # Set bucket policy for user
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["*"],
             resources_list=[obc_obj.bucket_name, f'{obc_obj.bucket_name}/{"*"}'],
             resource_property="NotResource",
@@ -1368,7 +1367,7 @@ class TestS3BucketPolicy(MCGTest):
         object_key = "MpuObjKey"
 
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=[
                 "ListBucketMultipartUploads",
                 "ListMultipartUploadParts",
@@ -1684,7 +1683,7 @@ class TestNoobaaUpgradeWithBucketPolicy:
 
         # Generate bucket policy
         bucket_policy_generated = gen_bucket_policy(
-            user_list=get_bucket_policy_user_list(obc_obj),
+            user_list=obc_obj.id_for_policy_principal,
             actions_list=["PutBucketPolicy", "GetBucketPolicy", "DeleteBucketPolicy"],
             resources_list=[obc_obj.bucket_name],
         )


### PR DESCRIPTION
This is is a fix to https://github.com/red-hat-storage/ocs-ci/issues/14333, https://github.com/red-hat-storage/ocs-ci/issues/14332 and https://github.com/red-hat-storage/ocs-ci/issues/14331. 
In 4.21 format of Principal in policy changed, it no longer contains a an account name but ARN. 
The tests were adjusted accordingly. 