### PR TITLE
Resolving issue #13645 by running test steps on hub cluster

### DIFF
--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ignore_leftovers,
     brown_squad,
+    runs_on_provider,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -30,6 +31,7 @@ log = logging.getLogger(__name__)
 
 @brown_squad
 @tier4a
+@runs_on_provider
 @skipif_external_mode
 @skipif_managed_service
 @skipif_ocs_version("<4.15")


### PR DESCRIPTION
Fixes: issue #13645 , in case of multiclient cluster setup, storagecluster is only available on hub cluster and not on spoke cluster. Runnig the test on hub cluster only.