### PR TITLE
Fixes 13645: test enhancement to resolve flakyness

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -625,7 +625,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 814,
+        "line_number": 823,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -633,7 +633,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 823,
+        "line_number": 832,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -641,7 +641,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1979,
+        "line_number": 1988,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +649,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2085,
+        "line_number": 2094,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +657,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2086,
+        "line_number": 2095,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +665,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2087,
+        "line_number": 2096,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +673,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2088,
+        "line_number": 2097,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +681,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2093,
+        "line_number": 2102,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +689,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2108,
+        "line_number": 2117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +697,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2109,
+        "line_number": 2118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +705,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2117,
+        "line_number": 2126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +713,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2118,
+        "line_number": 2127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +721,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2119,
+        "line_number": 2128,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +729,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2120,
+        "line_number": 2129,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +737,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2121,
+        "line_number": 2130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +745,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2852,
+        "line_number": 2861,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +753,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2853,
+        "line_number": 2862,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +761,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3574,
+        "line_number": 3583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +769,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3575,
+        "line_number": 3584,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -722,6 +722,14 @@ MGR_APP_LABEL = "app=rook-ceph-mgr"
 OSD_APP_LABEL = "app=rook-ceph-osd"
 OSD_PREPARE_APP_LABEL = "app=rook-ceph-osd-prepare"
 RGW_APP_LABEL = "app=rook-ceph-rgw"
+# Map performance profile component name to pod label selector for Ceph daemons
+CEPH_DAEMON_LABEL_BY_COMPONENT = {
+    "mgr": MGR_APP_LABEL,
+    "mon": MON_APP_LABEL,
+    "osd": OSD_APP_LABEL,
+    "mds": MDS_APP_LABEL,
+    "rgw": RGW_APP_LABEL,
+}
 EXPORTER_APP_LABEL = "app=rook-ceph-exporter"
 OPERATOR_LABEL = "app=rook-ceph-operator"
 ODF_CONSOLE = "app=odf-console"

--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -90,7 +90,7 @@ class TestProfileDefaultValuesCheck(ManageTest):
             # Wait up to 600 seconds for performance changes to reflect
             sample = TimeoutSampler(
                 timeout=600,
-                sleep=300,
+                sleep=60,
                 func=verify_performance_profile_change,
                 perf_profile=self.perf_profile,
             )
@@ -131,32 +131,108 @@ class TestProfileDefaultValuesCheck(ManageTest):
 
         label_selector = list(expected_cpu_limit_values.keys())
 
+        def _all_pods_match_profile():
+            """Return True only when all Ceph daemon pods have expected resources."""
+
+            for label in label_selector:
+                pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
+                pods = get_pods_having_label(
+                    label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
+                )
+                if not pods:
+                    log.info(f"No pods yet for {label} (selector {pod_label})")
+                    return False
+                ocp_pod = OCP(
+                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
+                )
+                for pod in pods:
+                    name = pod["metadata"]["name"]
+                    try:
+                        resource_dict = ocp_pod.get(resource_name=name)["spec"][
+                            "containers"
+                        ][0]["resources"]
+                    except (KeyError, TypeError):
+                        return False
+                    for key in ("limits", "requests"):
+                        if key not in resource_dict:
+                            return False
+                    if (
+                        resource_dict["limits"].get("cpu")
+                        != expected_cpu_limit_values[label]
+                        or resource_dict["limits"].get("memory")
+                        != expected_memory_limit_values[label]
+                        or resource_dict["requests"].get("cpu")
+                        != expected_cpu_request_values[label]
+                        or resource_dict["requests"].get("memory")
+                        != expected_memory_request_values[label]
+                    ):
+                        log.info(
+                            f"Pod {name} ({label}) resources not yet updated: "
+                            f"limits={resource_dict.get('limits')}, "
+                            f"requests={resource_dict.get('requests')}"
+                        )
+                        return False
+            return True
+
+        # Wait for operator to roll out daemon pods with new profile (up to 600s).
+        # verify_performance_profile_change only checks StorageCluster spec; pod
+        # resources can lag until deployments are updated and pods recreated.
+        sample = TimeoutSampler(
+            timeout=600,
+            sleep=30,
+            func=_all_pods_match_profile,
+        )
+        if not sample.wait_for_func_status(True):
+            log.warning(
+                f"Pod resources did not match {self.perf_profile} profile within timeout"
+            )
+        ocp_pod = OCP(namespace=config.ENV_DATA["cluster_namespace"], kind="pod")
+        mismatches = []
         for label in label_selector:
+            pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
             for pod in get_pods_having_label(
-                label=label, namespace=config.ENV_DATA["cluster_namespace"]
+                label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
             ):
                 pv_pod_obj.append(Pod(**pod))
                 podd = Pod(**pod)
-                log.info(f"Verifying memory and cpu values for pod {podd.name}")
+                log.info(
+                    f"Verifying memory and cpu values for pod {podd.name} ({label})"
+                )
                 log.info(f"RequestCPU{expected_cpu_request_values}")
                 log.info(f"LimitCPU{expected_cpu_limit_values}")
                 log.info(f"RequestMEM{expected_memory_request_values}")
                 log.info(f"LimitMEM{expected_memory_limit_values}")
-                resource_dict = OCP(
-                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
-                ).get(resource_name=podd.name)["spec"]["containers"][0]["resources"]
+                resource_dict = ocp_pod.get(resource_name=podd.name)["spec"][
+                    "containers"
+                ][0]["resources"]
                 log.info(
                     f"CPU request and limit values for pod {podd.name} are {resource_dict}"
                 )
-                assert (
-                    resource_dict["limits"]["cpu"] == expected_cpu_limit_values[label]
-                    and resource_dict["limits"]["memory"]
-                    == expected_memory_limit_values[label]
-                    and resource_dict["requests"]["cpu"]
-                    == expected_cpu_request_values[label]
-                    and resource_dict["requests"]["memory"]
-                    == expected_memory_request_values[label]
-                ), f"Resource values arent reflecting actual values for {label} pod "
+                actual_cpu_limit = resource_dict.get("limits", {}).get("cpu")
+                actual_mem_limit = resource_dict.get("limits", {}).get("memory")
+                actual_cpu_req = resource_dict.get("requests", {}).get("cpu")
+                actual_mem_req = resource_dict.get("requests", {}).get("memory")
+                expected_cpu_limit = expected_cpu_limit_values[label]
+                expected_mem_limit = expected_memory_limit_values[label]
+                expected_cpu_req = expected_cpu_request_values[label]
+                expected_mem_req = expected_memory_request_values[label]
+                if (
+                    actual_cpu_limit != expected_cpu_limit
+                    or actual_mem_limit != expected_mem_limit
+                    or actual_cpu_req != expected_cpu_req
+                    or actual_mem_req != expected_mem_req
+                ):
+                    mismatches.append(
+                        f"{label} pod {podd.name}: limits cpu {actual_cpu_limit!r} (expected {expected_cpu_limit!r}),"
+                        f"limits memory {actual_mem_limit!r} (expected {expected_mem_limit!r}), "
+                        f"requests cpu {actual_cpu_req!r} (expected {expected_cpu_req!r}), "
+                        f"requests memory {actual_mem_req!r} (expected {expected_mem_req!r})"
+                    )
+        if mismatches:
+            assert False, (
+                "Resource values are not reflecting actual values for one or more pods:\n"
+                + "\n".join(mismatches)
+            )
         log.info("All the memory and CPU values are matching in the profile")
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: suchita-g <sgatfane@redhat.com>

Reformatting the test test_validate_cluster_resource_profile to avoid inconsistent failuer and to get assertion report for all pod resources:

- Instead of asserting on the first mismatch, it appends each failure to a mismatches list. Each entry in mismatches which will give full report in one failure.
- after the StorageCluster spec is updated, the test now waits for actual pod resources to match the expected profile.
- The test checks Storagecluster spec every 60s instead of every 5 minutes.
Fixes: #13645