### PR TITLE
Fix for mon recovery1

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -587,7 +587,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2812,
+        "line_number": 2831,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4253,25 +4253,9 @@ def induce_mon_quorum_loss():
     # Wait for sometime after the mon crashes
     time.sleep(300)
 
-    # Check the operator log mon quorum lost
-    operator_logs = get_logs_rook_ceph_operator()
-    pattern = (
-        "op-mon: failed to check mon health. "
-        "failed to get mon quorum status: mon "
-        "quorum status failed: exit status 1"
-    )
-    logger.info(f"Check the operator log for the pattern : {pattern}")
-    if not re.search(pattern=pattern, string=operator_logs):
-        logger.error(
-            f"Pattern {pattern} couldn't find in operator logs. "
-            "Mon quorum may not have been lost after deleting "
-            "var/lib/ceph/mon. Please check"
-        )
-        raise UnexpectedBehaviour(
-            f"Pattern {pattern} not found in operator logs. "
-            "Maybe mon quorum not failed or  mon crash failed Please check"
-        )
-    logger.info(f"Pattern found: {pattern}. Mon quorum lost")
+    # Check the mon pods status to verify mon quorum lost
+    for mon in mon_pod_obj:
+        wait_for_resource_state(resource=mon, state=constants.STATUS_CLBO)
 
     return mon_pod_obj_list, mon_pod_running[0], ceph_mon_daemon_id
 

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -10,6 +10,7 @@ import re
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
+    jira,
     skipif_ocs_version,
     ignore_leftovers,
     skipif_openshift_dedicated,
@@ -111,6 +112,10 @@ class TestMonitorRecovery(E2ETest):
             data=self.object_data,
         ), "Failed: PutObject"
 
+    @jira("DFBUGS-4322")
+    @pytest.mark.skip(
+        reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/14384"
+    )
     def test_monitor_recovery(
         self,
         deployment_pod_factory,


### PR DESCRIPTION
Adding skip for test_monitor_recovery.py and updating steps to verify mon quorum is loss for test_restore_ceph_mon_quorum.py