### PR TITLE
Fix-issue-14388: factory was updated so workload_path is optional and defaults to workload_dir when missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7486,7 +7486,9 @@ def create_workload_factory():
                 workload_pod_count=workload_details["pod_count"],
                 workload_pvc_count=workload_details["pvc_count"],
                 pvc_interface=pvc_interface,
-                workload_path=workload_details["workload_path"],
+                workload_path=workload_details.get(
+                    "workload_path", workload_details["workload_dir"]
+                ),
             )
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]
@@ -7507,7 +7509,9 @@ def create_workload_factory():
                 workload_pvc_selector=workload_details["dr_workload_app_pvc_selector"],
                 appset_model=appset_model,
                 pvc_interface=pvc_interface,
-                workload_path=workload_details["workload_path"],
+                workload_path=workload_details.get(
+                    "workload_path", workload_details["workload_dir"]
+                ),
             )
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]


### PR DESCRIPTION
Fixes: #14388 