### PR TITLE
Optimize FillPoolJob with greater block size and direct I/O

### DIFF
--- a/ocs_ci/ocs/fill_pool_job.py
+++ b/ocs_ci/ocs/fill_pool_job.py
@@ -29,7 +29,7 @@ class FillPoolJob(object):
     def create(
         self,
         name=None,
-        block_size="1M",
+        block_size="4M",
         cpu_request="100m",
         mem_request="128Mi",
         cpu_limit="500m",
@@ -91,7 +91,8 @@ class FillPoolJob(object):
         # Insure to handle the case of "No space left on device" error gracefully
         dd_cmd = (
             f'echo "Filling PVC with {fill_mode} data..."; '
-            f"dd if={input_source} of=/mnt/fill/testfile bs=${{BLOCK_SIZE:-{block_size}}} 2>/tmp/dd_err; "
+            f"dd if={input_source} of=/mnt/fill/testfile bs=${{BLOCK_SIZE:-{block_size}}} "
+            f"oflag=direct 2>/tmp/dd_err; "
             f"EXIT_STATUS=$?; "
             f"if [ $EXIT_STATUS -ne 0 ] && grep -q 'No space left on device' /tmp/dd_err; then "
             f"  cat /tmp/dd_err; echo 'Capacity reached. Exiting successfully.'; exit 0; "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11425,7 +11425,7 @@ def fill_job_factory(request):
 
     def factory(
         name=None,
-        block_size="1M",
+        block_size="4M",
         cpu_request="100m",
         mem_request="128Mi",
         cpu_limit="500m",


### PR DESCRIPTION
This pull request updates the FillPoolJob class and its associated factory to improve 
the efficiency of PVC filling operations.

**Key Changes:**

- Default Block Size: Increased from `1M` to `4M` to reduce the number of I/O operations and speed up the filling process.

- Direct I/O: Added the `oflag=direct` flag to the dd command. This bypasses the page cache, ensuring that the storage backend is tested directly and providing more accurate results during capacity exhaustion scenarios.

- Create a new test `test_fill_pool_job_zero_mode` to fill the cluster with zero mode only.

- Increase the timeout, block size, and cpu/resources with the vSphere platform to improve performance.
