### PR TITLE
Add RGW bucket UI support with selector and tests

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2459,6 +2459,10 @@ NOOBAA_DB_SERVICE_ACCOUNT = NB_SERVICE_ACCOUNT_BASE.format(
 RGW_SERVICE_INTERNAL_MODE = "rook-ceph-rgw-ocs-storagecluster-cephobjectstore"
 RGW_SERVICE_EXTERNAL_MODE = "rook-ceph-rgw-ocs-external-storagecluster-cephobjectstore"
 
+# S3 UI Provider Types (matches odf-console S3ProviderType enum)
+S3_PROVIDER_NOOBAA = "noobaa"
+S3_PROVIDER_RGW_INTERNAL = "rgwInternal"
+
 # Routes
 RGW_ROUTE_INTERNAL_MODE = "ocs-storagecluster-cephobjectstore"
 RGW_ROUTE_INTERNAL_MODE_SECURE = "ocs-storagecluster-cephobjectstore-secure"

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -14,7 +14,7 @@ from selenium.common.exceptions import (
 
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ocp import get_ocp_url
-from ocs_ci.ocs import exceptions
+from ocs_ci.ocs import constants, exceptions
 from ocs_ci.ocs.ui.page_objects.confirm_dialog import ConfirmDialog
 from ocs_ci.ocs.ui.page_objects.object_storage import ObjectStorage
 from ocs_ci.utility import version
@@ -472,7 +472,13 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             logger.exception("Error navigating to previous page")
             return False
 
-    def delete_bucket_ui(self, delete_via, expect_fail, resource_name):
+    def delete_bucket_ui(
+        self,
+        delete_via: str,
+        expect_fail: bool,
+        resource_name: str,
+        provider: str = constants.S3_PROVIDER_NOOBAA,
+    ):
         """
         Delete an Object Bucket via the UI
 
@@ -480,9 +486,12 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             delete_via (str): delete via 'OB/Actions' or via 'three dots'
             expect_fail (bool): verify if OB removal fails with proper PopUp message
             resource_name (str): Object Bucket Claim's name. The resource with its suffix will be deleted
+            provider (str): Storage provider - constants.S3_PROVIDER_NOOBAA or
+                constants.S3_PROVIDER_RGW_INTERNAL.
+
         """
         logger.info(f"Attempting to delete bucket: {resource_name}")
-        self.navigate_buckets_page()
+        self.navigate_buckets_page(provider=provider)
 
         logger.info(f"Searching for bucket: {resource_name}")
         self.do_send_keys(self.generic_locators["search_resource_field"], resource_name)
@@ -647,16 +656,22 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
                 f"Upload failed: {folder_name} not found in bucket"
             ) from err
 
-    def navigate_to_bucket(self, bucket_name: str) -> None:
+    def navigate_to_bucket(
+        self, bucket_name: str, provider: str = constants.S3_PROVIDER_NOOBAA
+    ) -> None:
         """
         Navigate to object storage and select the specific test bucket by name.
 
         Args:
             bucket_name (str): Name of the bucket to navigate to.
+            provider (str): Storage provider - constants.S3_PROVIDER_NOOBAA or
+                constants.S3_PROVIDER_RGW_INTERNAL.
+
         """
-        self.nav_object_storage_page()
+        obj_storage = self.nav_object_storage_page()
+        if provider != constants.S3_PROVIDER_NOOBAA:
+            obj_storage.select_storage_provider(provider)
         logger.info(f"Navigating to bucket: {bucket_name}")
-        logger.info(f"Looking for bucket link with text: {bucket_name}")
         bucket_link_locator = f"//tr//a[contains(text(), '{bucket_name}')]"
         self.do_click((bucket_link_locator, By.XPATH))
         logger.info(f"Successfully navigated into bucket: {bucket_name}")

--- a/ocs_ci/ocs/ui/page_objects/page_navigator.py
+++ b/ocs_ci/ocs/ui/page_objects/page_navigator.py
@@ -316,13 +316,19 @@ class PageNavigator(BaseUI):
             enable_screenshot=False,
         )
 
-    def navigate_buckets_page(self):
+    def navigate_buckets_page(self, provider: str = constants.S3_PROVIDER_NOOBAA):
         """
-        Navigate to Object Buckets Page
+        Navigate to Object Buckets Page with optional provider selection.
+
+        Args:
+            provider (str): Storage provider - constants.S3_PROVIDER_NOOBAA (default) or
+                constants.S3_PROVIDER_RGW_INTERNAL.
 
         """
-
-        return self.nav_object_storage_page().nav_buckets_tab()
+        obj_storage = self.nav_object_storage_page()
+        if provider != constants.S3_PROVIDER_NOOBAA:
+            obj_storage.select_storage_provider(provider)
+        return obj_storage.nav_buckets_tab()
 
     def navigate_object_bucket_claims_page(self):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2883,6 +2883,9 @@ alerting = {
 }
 
 bucket_tab = {
+    "provider_card_rgw": ("#rgw-s3", By.CSS_SELECTOR),
+    "provider_radio_rgw": ("#rgwInternal", By.CSS_SELECTOR),
+    "provider_card_mcg": ("#mcg-s3", By.CSS_SELECTOR),
     "create_bucket_button_obc": (
         "//div[text()='Create via Object Bucket Claim']",
         By.XPATH,
@@ -2970,7 +2973,8 @@ bucket_tab = {
     ),
     "bucket_list_items": (
         "//a[starts-with(@href, '/odf/object-storage/buckets/')] |"
-        "//a[starts-with(@href, '/odf/object-storage/noobaa/buckets/')]",
+        "//a[starts-with(@href, '/odf/object-storage/noobaa/buckets/')] |"
+        "//a[starts-with(@href, '/odf/object-storage/rgwInternal/buckets/')]",
         By.XPATH,
     ),
     "bucket_action_button": (

--- a/tests/functional/object/mcg/ui/test_rgw_bucket_ui.py
+++ b/tests/functional/object/mcg/ui/test_rgw_bucket_ui.py
@@ -1,0 +1,152 @@
+import logging
+import time
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    red_squad,
+    rgw,
+    skipif_hci_provider_and_client,
+)
+from ocs_ci.framework.testlib import (
+    tier1,
+    tier2,
+    ui,
+    post_upgrade,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import get_rgw_pods
+from ocs_ci.ocs.ui.page_objects.buckets_tab import BucketsTab
+
+
+logger = logging.getLogger(__name__)
+
+
+@ui
+@rgw
+@red_squad
+@skipif_hci_provider_and_client
+class TestRGWBucketUI:
+    """
+    Test RGW bucket operations via the Object Browser UI.
+    Requires ODF 4.19+ with RGW provider support.
+    """
+
+    @tier1
+    @post_upgrade
+    @pytest.mark.polarion_id("OCS-7746")
+    def test_navigate_to_rgw_object_browser(self, setup_ui_class):
+        """
+        Verify navigation to the RGW object browser and bucket list loading.
+
+        Steps:
+        1. Navigate to Object Storage page
+        2. Verify RGW provider card is available and enabled
+        3. Select RGW provider
+        4. Verify bucket list loads
+
+        """
+        if not get_rgw_pods():
+            pytest.skip("No RGW pods running on this cluster")
+        bucket_ui = BucketsTab()
+        obj_storage = bucket_ui.nav_object_storage_page()
+
+        if not obj_storage.is_rgw_provider_available():
+            pytest.skip("RGW provider card is not available or is disabled")
+
+        obj_storage.select_storage_provider(constants.S3_PROVIDER_RGW_INTERNAL)
+        bucket_ui.page_has_loaded(retries=15)
+
+        buckets = bucket_ui.get_buckets_list()
+        logger.info(f"RGW bucket list loaded with {len(buckets)} buckets")
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-7743")
+    def test_create_rgw_bucket(self, setup_ui_class):
+        """
+        Create an S3 bucket via the RGW provider.
+
+        Steps:
+        1. Navigate to Object Storage page, select RGW provider
+        2. Click 'Create bucket', select S3 tile
+        3. Fill bucket name, submit
+        4. Verify bucket appears in the RGW bucket list
+
+        """
+        if not get_rgw_pods():
+            pytest.skip("No RGW pods running on this cluster")
+        bucket_ui = BucketsTab()
+        bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+
+        _, bucket_name = bucket_ui.create_bucket_ui_with_details(method="s3")
+        logger.info(f"Created RGW bucket: {bucket_name}")
+        time.sleep(10)
+
+        bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+        buckets = bucket_ui.get_buckets_list()
+        assert (
+            bucket_name in buckets
+        ), f"Bucket '{bucket_name}' not found in RGW bucket list: {buckets}"
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-7744")
+    def test_list_rgw_buckets(self, setup_ui_class):
+        """
+        Verify RGW buckets are displayed correctly.
+
+        Steps:
+        1. Navigate to RGW bucket list
+        2. Create a test bucket if none exist
+        3. Verify bucket list is non-empty
+        4. Verify bucket names are displayed
+
+        """
+        if not get_rgw_pods():
+            pytest.skip("No RGW pods running on this cluster")
+        bucket_ui = BucketsTab()
+        bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+
+        buckets = bucket_ui.get_buckets_list()
+        if not buckets:
+            _, bucket_name = bucket_ui.create_bucket_ui_with_details(method="s3")
+            logger.info(f"Created test bucket: {bucket_name}")
+            time.sleep(10)
+            bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+            buckets = bucket_ui.get_buckets_list()
+
+        assert len(buckets) > 0, "Expected at least 1 RGW bucket"
+        logger.info(f"Found {len(buckets)} RGW buckets: {buckets}")
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-7745")
+    def test_delete_rgw_bucket(self, setup_ui_class):
+        """
+        Delete an RGW bucket via the UI.
+
+        Steps:
+        1. Navigate to RGW bucket list, create a test bucket
+        2. Delete the bucket using three_dots menu
+        3. Verify bucket no longer appears in the list
+
+        """
+        if not get_rgw_pods():
+            pytest.skip("No RGW pods running on this cluster")
+        bucket_ui = BucketsTab()
+        bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+
+        _, bucket_name = bucket_ui.create_bucket_ui_with_details(method="s3")
+        logger.info(f"Created bucket for deletion test: {bucket_name}")
+        time.sleep(10)
+
+        bucket_ui.delete_bucket_ui(
+            delete_via="three_dots",
+            expect_fail=False,
+            resource_name=bucket_name,
+            provider=constants.S3_PROVIDER_RGW_INTERNAL,
+        )
+
+        bucket_ui.navigate_buckets_page(provider=constants.S3_PROVIDER_RGW_INTERNAL)
+        updated_buckets = bucket_ui.get_buckets_list()
+        assert (
+            bucket_name not in updated_buckets
+        ), f"Bucket '{bucket_name}' still present after deletion"


### PR DESCRIPTION
- [x] Add endpoint selection methods to ObjectStorage page object
- [x] Extend navigation and bucket operations to support provider param
- [x] Add 4 UI tests for RGW bucket lifecycle
- [x] Tests use runtime RGW pod detection to skip on clusters without RGW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting and navigating between NooBaa and RGW Internal S3 providers in the object-storage interface.
  - Added RGW provider availability detection.
  - Enabled bucket creation, listing, navigation, and deletion through the RGW Object Browser.

- **Bug Fixes**
  - Improved bucket navigation and deletion flows when multiple storage providers are available.

- **Tests**
  - Added functional coverage for RGW bucket browsing, creation, listing, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->