### PR TITLE
Fix test_csv_script_equal_to_configmap_script on ODF 4.19+

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -1015,10 +1015,29 @@ def get_exporter_script_from_csv():
     """
     Get the external exporter script from the csv.
 
+    From ODF 4.19 the external mode script was removed from the CSV and is
+    shipped only in the ConfigMap (rook-ceph-external-cluster-script-config).
+    This function must not be used for ODF 4.19+; use get_exporter_script_from_configmap()
+    or get_exporter_script(use_configmap=True) instead.
+
     Returns:
         str: The exporter script from the csv
 
+    Raises:
+        ValueError: If running ODF version is 4.19 or above (script is no longer in CSV).
     """
+    # From 4.19 the script is only in ConfigMap; avoid KeyError on missing annotation
+    try:
+        odf_running_version = version.get_ocs_version_from_csv(only_major_minor=True)
+    except Exception:
+        odf_running_version = version.get_semantic_ocs_version_from_config()
+    if odf_running_version >= version.VERSION_4_19:
+        raise ValueError(
+            "From ODF 4.19 the external mode script is no longer in the CSV; "
+            "it is shipped only in the ConfigMap rook-ceph-external-cluster-script-config. "
+            "Use get_exporter_script(use_configmap=True) or get_exporter_script_from_configmap()."
+        )
+
     ocs_version = version.get_semantic_ocs_version_from_config()
     operator_name = defaults.ROOK_CEPH_OPERATOR
 
@@ -1037,14 +1056,18 @@ def get_exporter_script_from_csv():
     for each_csv in ocs_operator_data["status"]["channels"]:
         if each_csv["currentCSV"] == csv_name:
             logger.info(f"exporter script for csv: {each_csv['currentCSV']}")
+            annotations = each_csv["currentCSVDesc"].get("annotations", {})
             if ocs_version >= version.VERSION_4_16:
-                exporter_script = each_csv["currentCSVDesc"]["annotations"][
-                    "externalClusterScript"
-                ]
+                exporter_script = annotations.get("externalClusterScript")
             else:
-                exporter_script = each_csv["currentCSVDesc"]["annotations"][
+                exporter_script = annotations.get(
                     "external.features.ocs.openshift.io/export-script"
-                ]
+                )
+            if not exporter_script:
+                raise ValueError(
+                    "CSV does not contain the external mode script annotation. "
+                    "On ODF 4.19+ the script is only in ConfigMap; use use_configmap=True."
+                )
             break
 
     return exporter_script

--- a/tests/functional/external_mode/test_external_mode_script.py
+++ b/tests/functional/external_mode/test_external_mode_script.py
@@ -1,6 +1,8 @@
 import logging
 import filecmp
 
+import pytest
+
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     external_mode_required,
@@ -12,6 +14,7 @@ from ocs_ci.framework.testlib import (
     tier1,
 )
 from ocs_ci.deployment.helpers.external_cluster_helpers import generate_exporter_script
+from ocs_ci.utility import version
 
 log = logging.getLogger(__name__)
 
@@ -27,12 +30,25 @@ class TestExternalModeScript(ManageTest):
     """
 
     @post_ocs_upgrade
+    @skipif_ocs_version(">=4.19")
     def test_csv_script_equal_to_configmap_script(self):
         """
         Test that the external mode script from the CSV is equal to the external mode script
         from the configmap.
 
+        Relevant only for ODF 4.18: from ODF 4.19 the script was removed from the CSV
+        and is shipped only in the ConfigMap (rook-ceph-external-cluster-script-config),
+        so this comparison is no longer applicable and the test is skipped on 4.19+.
         """
+        # Skip at runtime when running cluster is 4.19+ (e.g. post-upgrade; config may still be 4.18)
+        try:
+            odf_running = version.get_ocs_version_from_csv(only_major_minor=True)
+            if odf_running >= version.VERSION_4_19:
+                pytest.skip(
+                    "From ODF 4.19 the script is only in ConfigMap; CSV comparison N/A."
+                )
+        except Exception:
+            pass
         file_name1 = generate_exporter_script(use_configmap=False)
         file_name2 = generate_exporter_script(use_configmap=True)
         assert filecmp.cmp(


### PR DESCRIPTION
Handle CSV script removal in 4.19: raise clear error in helper and skip test at runtime when running ODF is 4.19+
Fixes: #13647