### PR TITLE
remove cluster net route from multus nncps

### DIFF
--- a/ocs_ci/templates/ocs-deployment/node_network_configuration_policy.yaml
+++ b/ocs_ci/templates/ocs-deployment/node_network_configuration_policy.yaml
@@ -27,5 +27,3 @@ spec:
       config:
         - destination: 192.168.20.0/24
           next-hop-interface: odf-pub-shim
-        - destination: 192.168.30.0/24
-          next-hop-interface: odf-pub-shim

--- a/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_ipv6.yaml
+++ b/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_ipv6.yaml
@@ -27,5 +27,3 @@ spec:
       config:
         - destination: fd01:db8:1:1::/96
           next-hop-interface: odf-pub-shim
-        - destination: fd01:db8:2:1::/96
-          next-hop-interface: odf-pub-shim


### PR DESCRIPTION
Remove the NodeNetworkConfigurationPolicy route that directs host traffic to the Multus cluster network from the IPv4 and IPv6 NNCP template yaml files. This is unneeded by ODF, and there is a small chance that it may be causing multus tests to fail unexpectedly.