### PR TITLE
Fix AttributeError in Sanity.create_resources() 

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -130,7 +130,8 @@ class Sanity:
                 )
             )
 
-            self.ceph_cluster.wait_for_noobaa_health_ok()
+            if not is_hci_client_cluster():
+                self.ceph_cluster.wait_for_noobaa_health_ok()
 
     def delete_resources(self):
         """


### PR DESCRIPTION
Guard `wait_for_noobaa_health_ok()` in `Sanity.create_resources()` with is_hci_client_cluster() check — ceph_cluster is not initialized on HCI client clusters
fixes #14443 
