### PR TITLE
make rosa HCP roles usage explicit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -977,7 +977,7 @@
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 686,
+        "line_number": 709,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -176,6 +176,29 @@ def create_cluster(cluster_name, version_str, region):
         wait_operator_roles(prefix)
         cmd += f" --operator-roles-prefix {prefix} "
         cmd += " --hosted-cp "
+        installer_role_arn = (
+            f"arn:aws:iam::{aws_account_id}:role/"
+            f"{account_roles_prefix}-HCP-ROSA-Installer-Role"
+        )
+        support_role_arn = (
+            f"arn:aws:iam::{aws_account_id}:role/"
+            f"{account_roles_prefix}-HCP-ROSA-Support-Role"
+        )
+        worker_role_arn = (
+            f"arn:aws:iam::{aws_account_id}:role/"
+            f"{account_roles_prefix}-HCP-ROSA-Worker-Role"
+        )
+        cmd += (
+            f" --role-arn {installer_role_arn}"
+            f" --support-role-arn {support_role_arn}"
+            f" --worker-iam-role-arn {worker_role_arn}"
+        )
+        logger.info(
+            f"Explicit IAM role ARNs for cluster '{cluster_name}': "
+            f"installer={installer_role_arn}, "
+            f"support={support_role_arn}, "
+            f"worker={worker_role_arn}"
+        )
 
     log_step("Running create rosa cluster command")
     utils.run_cmd(cmd, timeout=create_timeout)


### PR DESCRIPTION
machines are not set up with OCP because of the Roles mismatch. Using roles explicitly now.  