### PR TITLE
External replica1 exporter test

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -17,6 +17,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import defaults, constants
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import (
+    CommandFailed,
     ExternalClusterCephfsMissing,
     ExternalClusterCephSSHAuthDetailsMissing,
     ExternalClusterCrushRuleCreationFailed,
@@ -824,6 +825,57 @@ class ExternalCluster(object):
 
         return created_rules
 
+    def create_rbd_pool(
+        self,
+        pool_name: str,
+        pg_num: int,
+        pool_size: int,
+        crush_rule: str | None = None,
+        min_size: int | None = None,
+    ) -> None:
+        """
+        Create a single replicated RBD pool on the external Ceph cluster.
+
+        Args:
+            pool_name (str): Name of the pool to create.
+            pg_num (int): Placement groups for the pool.
+            pool_size (int): Replication factor.
+            crush_rule (str): Optional CRUSH rule name for the pool.
+            min_size (int): Optional minimum replication size.
+
+        Raises:
+            ExternalClusterPoolCreationFailed: If any step fails.
+
+        """
+        rule_part = f" {crush_rule}" if crush_rule else ""
+        self.exec_external_ceph_cmd(
+            cmd=f"ceph osd pool create {pool_name} {pg_num} {pg_num} replicated{rule_part}",
+            error_msg=f"Failed to create pool {pool_name}",
+            exception_class=ExternalClusterPoolCreationFailed,
+        )
+
+        force_flag = " --yes-i-really-mean-it" if pool_size == 1 else ""
+        self.exec_external_ceph_cmd(
+            cmd=f"ceph osd pool set {pool_name} size {pool_size}{force_flag}",
+            error_msg=f"Failed to set size {pool_size} for pool {pool_name}",
+            exception_class=ExternalClusterPoolCreationFailed,
+        )
+
+        if min_size is not None:
+            self.exec_external_ceph_cmd(
+                cmd=f"ceph osd pool set {pool_name} min_size {min_size}",
+                error_msg=f"Failed to set min_size {min_size} for pool {pool_name}",
+                exception_class=ExternalClusterPoolCreationFailed,
+            )
+
+        self.exec_external_ceph_cmd(
+            cmd=f"ceph osd pool application enable {pool_name} rbd",
+            error_msg=f"Failed to enable rbd for pool {pool_name}",
+            exception_class=ExternalClusterPoolCreationFailed,
+        )
+
+        logger.info(f"Created RBD pool: {pool_name} (size={pool_size})")
+
     def create_replica_one_pools(
         self, topology_config: TopologyReplica1Config
     ) -> list[str]:
@@ -869,53 +921,26 @@ class ExternalCluster(object):
                 created_pools.append(pool_name)
                 continue
 
-            logger.info(f"Creating replica-1 pool: {pool_name} with rule: {rule_name}")
-
-            # Create pool with CRUSH rule (pg_num appears twice for pg_num and pgp_num)
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool create {pool_name} {pg_num} {pg_num} replicated {rule_name}",
-                error_msg=f"Failed to create pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
+            self.create_rbd_pool(
+                pool_name,
+                pg_num=pg_num,
+                pool_size=1,
+                crush_rule=rule_name,
+                min_size=1,
             )
-
-            # Set pool size to 1
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool set {pool_name} size 1 --yes-i-really-mean-it",
-                error_msg=f"Failed to set size 1 for pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            # Set pool min_size to 1
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool set {pool_name} min_size 1",
-                error_msg=f"Failed to set min_size 1 for pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            # Enable RBD application
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool application enable {pool_name} rbd",
-                error_msg=f"Failed to enable rbd for pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            logger.info(f"Created replica-1 pool: {pool_name}")
             created_pools.append(pool_name)
 
         return created_pools
 
     def verify_replica_one_setup(
         self, expected_pools: list[str], expected_rules: list[str]
-    ) -> bool:
+    ) -> None:
         """
         Verify that replica-1 pools and CRUSH rules are properly configured.
 
         Args:
             expected_pools (list[str]): List of expected pool names.
             expected_rules (list[str]): List of expected CRUSH rule names.
-
-        Returns:
-            bool: True if all pools and rules exist with correct configuration.
 
         Raises:
             ExternalClusterReplica1ConfigurationFailed: If verification fails.
@@ -954,7 +979,64 @@ class ExternalCluster(object):
         logger.info(f"All expected pools have size 1: {expected_pools}")
 
         logger.info("Replica-1 setup verification passed")
-        return True
+
+    def discover_zones_from_crush_tree(self) -> list[ZoneConfig]:
+        """
+        Auto-detect zones from the external cluster's CRUSH tree.
+
+        Queries 'ceph osd tree' and extracts host-type buckets.
+        Each host becomes a zone (zone-a, zone-b, ...).
+
+        Returns:
+            list[ZoneConfig]: Zone configurations derived from CRUSH hosts.
+
+        Raises:
+            CommandFailed: If 'ceph osd tree' command fails.
+
+        """
+        _, out, _ = self.exec_external_ceph_cmd(
+            cmd="ceph osd tree --format json",
+            error_msg="Failed to get OSD tree from external cluster",
+            exception_class=CommandFailed,
+        )
+        osd_tree = json.loads(out)
+        hosts = [node["name"] for node in osd_tree["nodes"] if node["type"] == "host"]
+
+        zones = [
+            ZoneConfig(zone_name=f"zone-{chr(ord('a') + i)}", host_name=host)
+            for i, host in enumerate(hosts)
+        ]
+        logger.info(f"Auto-detected {len(zones)} zones from CRUSH tree: {zones}")
+        return zones
+
+    def build_topology_replica1_config(self) -> TopologyReplica1Config:
+        """
+        Build topology configuration from EXTERNAL_MODE config or CRUSH tree.
+
+        Reads replica1_zones from config.EXTERNAL_MODE if available.
+        Falls back to auto-detecting zones from the cluster's CRUSH tree.
+
+        Returns:
+            TopologyReplica1Config: Configuration for replica-1 setup.
+
+        """
+        zones_config = config.EXTERNAL_MODE.get("replica1_zones", [])
+        if zones_config:
+            logger.info(f"Using replica1_zones from config: {zones_config}")
+            zones = [
+                ZoneConfig(
+                    zone_name=z["zone_name"],
+                    host_name=z["host_name"],
+                    pool_name=z.get("pool_name", ""),
+                )
+                for z in zones_config
+            ]
+        else:
+            logger.info("replica1_zones not configured, auto-detecting from CRUSH tree")
+            zones = self.discover_zones_from_crush_tree()
+
+        logger.info(f"Built topology config with {len(zones)} zones")
+        return TopologyReplica1Config(zones=zones)
 
     def setup_topology_replica_one(
         self, topology_config: TopologyReplica1Config
@@ -1113,29 +1195,7 @@ class ExternalCluster(object):
                 created_pools.append(pool_name)
                 continue
 
-            logger.info(
-                f"Creating topology pool: {pool_name} (size={pool_size}, pg_num={pg_num})"
-            )
-
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool create {pool_name} {pg_num} {pg_num} replicated",
-                error_msg=f"Failed to create pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool set {pool_name} size {pool_size}",
-                error_msg=f"Failed to set size {pool_size} for pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            self.exec_external_ceph_cmd(
-                cmd=f"ceph osd pool application enable {pool_name} rbd",
-                error_msg=f"Failed to enable rbd for pool {pool_name}",
-                exception_class=ExternalClusterPoolCreationFailed,
-            )
-
-            logger.info(f"Created topology pool: {pool_name}")
+            self.create_rbd_pool(pool_name, pg_num=pg_num, pool_size=pool_size)
             created_pools.append(pool_name)
 
         return created_pools

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -11,6 +11,8 @@ import tempfile
 import uuid
 import os
 
+import yaml
+
 from ocs_ci.framework import config
 from ocs_ci.ocs import defaults, constants
 from ocs_ci.ocs.ocp import OCP
@@ -90,6 +92,17 @@ class TopologyReplica1Config:
     zones: list[ZoneConfig]
     pool_prefix: str = "rbd-zone"
     pg_num: int = 32
+
+    @property
+    def pool_names(self) -> list[str]:
+        return [
+            zone.pool_name or f"{self.pool_prefix}-{zone.zone_name}"
+            for zone in self.zones
+        ]
+
+    @property
+    def zone_names(self) -> list[str]:
+        return [zone.zone_name for zone in self.zones]
 
 
 class ExternalCluster(object):
@@ -846,10 +859,7 @@ class ExternalCluster(object):
         logger.debug(f"Existing pools: {existing_pools}")
 
         created_pools = []
-        for zone in topology_config.zones:
-            pool_name = (
-                zone.pool_name or f"{topology_config.pool_prefix}-{zone.zone_name}"
-            )
+        for zone, pool_name in zip(topology_config.zones, topology_config.pool_names):
             rule_name = f"{zone.zone_name}-rule"
             pg_num = topology_config.pg_num
 
@@ -1129,6 +1139,135 @@ class ExternalCluster(object):
             created_pools.append(pool_name)
 
         return created_pools
+
+    def run_topology_exporter_script(
+        self, topology_config: TopologyReplica1Config, additional_params: str = ""
+    ) -> list[dict]:
+        """
+        Run exporter script with topology flags for replica-1 pools.
+
+        Builds topology-specific parameters from the configuration:
+        - --topology-pools (comma-separated pool names)
+        - --topology-failure-domain-label (from constants.ZONE_LABEL)
+        - --topology-failure-domain-values (comma-separated zone names)
+        - --rbd-data-pool-name (first pool in list)
+        - --format json
+
+        Args:
+            topology_config (TopologyReplica1Config): Topology configuration with zones.
+            additional_params (str): Additional parameters to pass to the script.
+
+        Returns:
+            list[dict]: Parsed JSON output from the exporter script.
+
+        Raises:
+            ExternalClusterExporterRunFailed: If script execution fails.
+            ValueError: If topology_config.zones is empty.
+
+        """
+        if not topology_config.zones:
+            raise ValueError("topology_config.zones cannot be empty")
+
+        pool_names = topology_config.pool_names
+        zone_names = topology_config.zone_names
+
+        # Build topology params
+        topology_params = (
+            f"--rbd-data-pool-name {pool_names[0]} "
+            f"--topology-pools {','.join(pool_names)} "
+            f"--topology-failure-domain-label {constants.ZONE_LABEL} "
+            f"--topology-failure-domain-values {','.join(zone_names)} "
+            f"--format json"
+        )
+
+        if additional_params:
+            topology_params = f"{topology_params} {additional_params}"
+
+        logger.info(f"Running topology exporter with params: {topology_params}")
+
+        # Run the exporter script using existing infrastructure
+        out = self.run_exporter_script(params=topology_params)
+
+        # Parse JSON output
+        try:
+            resources = json.loads(out)
+            logger.info(f"Parsed {len(resources)} resources from exporter output")
+            return resources
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse exporter JSON output: {e}")
+            logger.debug(f"Raw output: {out}")
+            raise ExternalClusterExporterRunFailed(
+                f"Failed to parse topology exporter output as JSON: {e}"
+            ) from e
+
+    def apply_topology_export_resources(
+        self, resources: list[dict], namespace: str | None = None
+    ) -> dict[str, list[str]]:
+        """
+        Apply exported topology resources (secrets, configmaps) to the cluster.
+
+        Args:
+            resources (list[dict]): List of resource dicts from exporter script.
+                Each dict has 'name', 'kind', and 'data' keys.
+            namespace (str): Namespace to create resources in.
+                Defaults to cluster_namespace from config.
+
+        Returns:
+            dict[str, list[str]]: Dictionary with keys 'secrets' and 'configmaps',
+                each containing list of created resource names.
+
+        Raises:
+            CommandFailed: If resource creation fails.
+
+        """
+        namespace = namespace or config.ENV_DATA["cluster_namespace"]
+        created = {"secrets": [], "configmaps": []}
+
+        for resource in resources:
+            name = resource.get("name")
+            kind = resource.get("kind")
+            data = resource.get("data", {})
+
+            if kind == "Secret":
+                resource_data = {
+                    "apiVersion": "v1",
+                    "kind": "Secret",
+                    "metadata": {"name": name, "namespace": namespace},
+                    "type": "Opaque",
+                    "stringData": data,
+                }
+            elif kind == "ConfigMap":
+                resource_data = {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {"name": name, "namespace": namespace},
+                    "data": data,
+                }
+
+            else:
+                logger.debug(f"Skipping resource kind '{kind}': {name}")
+                continue
+
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".yaml", delete=False
+            ) as f:
+                yaml.dump(resource_data, f)
+                tmp_path = f.name
+
+            try:
+                ocp_resource = OCP(kind=kind, namespace=namespace)
+                ocp_resource.apply(yaml_file=tmp_path)
+                key = "secrets" if kind == "Secret" else "configmaps"
+                created[key].append(name)
+                logger.info(f"Created {kind}: {name}")
+            finally:
+                os.remove(tmp_path)
+
+        logger.info(
+            f"Applied topology resources - Secrets: {created['secrets']}, "
+            f"ConfigMaps: {created['configmaps']}"
+        )
+        return created
 
 
 def save_external_cluster_secret():

--- a/tests/functional/external_mode/test_replica1_external.py
+++ b/tests/functional/external_mode/test_replica1_external.py
@@ -1,0 +1,197 @@
+"""
+Test module for replica-1 pools on external RHCS clusters.
+
+This test validates topology-based replica-1 provisioning where each zone
+gets its own single-replica pool with a dedicated CRUSH rule.
+"""
+
+import json
+import logging
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    external_mode_required,
+    tier2,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.deployment.helpers.external_cluster_helpers import (
+    get_external_cluster_instance,
+    TopologyReplica1Config,
+    ZoneConfig,
+)
+from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterExporterRunFailed
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@tier2
+@external_mode_required
+class TestReplicaOneExternal(ManageTest):
+    """
+    Test replica-1 pool setup and I/O on external RHCS clusters.
+
+    This test:
+    1. Creates CRUSH rules for each zone
+    2. Creates replica-1 pools bound to those rules
+    3. Verifies the configuration
+    4. Cleans up on teardown
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_external_replica1(self, request):
+        """
+        Setup and cleanup fixture for external replica-1 test.
+
+        Creates ExternalCluster instance and builds topology config from
+        EXTERNAL_MODE configuration. Registers finalizer for cleanup.
+        """
+        self.ext_cluster = get_external_cluster_instance()
+        self.topology_config = self._build_topology_config()
+        self.created_pools = []
+        self.created_rules = []
+        self.setup_completed = False
+
+        def finalizer():
+            if not self.setup_completed:
+                log.error(
+                    "Setup did not complete. Potential orphaned resources "
+                    "on external cluster may require manual cleanup: "
+                    f"pools={self.topology_config.pool_names}, "
+                    f"rules={[f'{z.zone_name}-rule' for z in self.topology_config.zones]}"
+                )
+                return
+
+            log.info("Starting external replica-1 teardown")
+            try:
+                if self.created_pools:
+                    self.ext_cluster.cleanup_replica_one_pools(self.created_pools)
+            except CommandFailed as e:
+                log.warning(f"Pool cleanup failed: {e}")
+
+            try:
+                if self.created_rules:
+                    self.ext_cluster.cleanup_zone_crush_rules(self.created_rules)
+            except CommandFailed as e:
+                log.warning(f"CRUSH rule cleanup failed: {e}")
+
+            log.info("External replica-1 teardown completed")
+
+        request.addfinalizer(finalizer)
+
+    def _discover_zones_from_crush_tree(self) -> list[ZoneConfig]:
+        """
+        Auto-detect zones from the external cluster's CRUSH tree.
+
+        Queries 'ceph osd tree' and extracts host-type buckets.
+        Each host becomes a zone (zone-a, zone-b, ...).
+
+        Returns:
+            list[ZoneConfig]: Zone configurations derived from CRUSH hosts.
+
+        """
+        _, out, _ = self.ext_cluster.exec_external_ceph_cmd(
+            cmd="ceph osd tree --format json",
+            error_msg="Failed to get OSD tree from external cluster",
+            exception_class=CommandFailed,
+        )
+        osd_tree = json.loads(out)
+        hosts = [node["name"] for node in osd_tree["nodes"] if node["type"] == "host"]
+
+        if len(hosts) < 2:
+            pytest.skip(
+                f"Need at least 2 OSD hosts for replica-1 test, "
+                f"found {len(hosts)}: {hosts}"
+            )
+
+        zones = [
+            ZoneConfig(zone_name=f"zone-{chr(ord('a') + i)}", host_name=host)
+            for i, host in enumerate(hosts)
+        ]
+        log.info(f"Auto-detected {len(zones)} zones from CRUSH tree: {zones}")
+        return zones
+
+    def _build_topology_config(self) -> TopologyReplica1Config:
+        """
+        Build topology configuration from EXTERNAL_MODE config or CRUSH tree.
+
+        Reads replica1_zones from config.EXTERNAL_MODE if available.
+        Falls back to auto-detecting zones from the cluster's CRUSH tree.
+
+        Returns:
+            TopologyReplica1Config: Configuration for replica-1 setup.
+
+        """
+        zones_config = config.EXTERNAL_MODE.get("replica1_zones", [])
+        if zones_config:
+            log.info(f"Using replica1_zones from config: {zones_config}")
+            zones = [
+                ZoneConfig(
+                    zone_name=z["zone_name"],
+                    host_name=z["host_name"],
+                    pool_name=z.get("pool_name", ""),
+                )
+                for z in zones_config
+            ]
+        else:
+            log.info("replica1_zones not configured, auto-detecting from CRUSH tree")
+            zones = self._discover_zones_from_crush_tree()
+
+        log.info(f"Built topology config with {len(zones)} zones")
+        return TopologyReplica1Config(zones=zones)
+
+    def test_replica1_setup_and_verify(self):
+        """
+        Test replica-1 pool creation and verification on external cluster.
+
+        Steps:
+        1. Enable replica-1 pools (mon_allow_pool_size_one)
+        2. Create CRUSH rules for each zone
+        3. Create replica-1 pools
+        4. Verify pools have size=1
+        5. Run exporter script with topology flags
+        6. Apply exported resources to ODF
+
+        """
+        log.info("Starting external replica-1 setup test")
+
+        # Step 1-4: Setup replica-1 pools on Ceph cluster
+        result = self.ext_cluster.setup_topology_replica_one(self.topology_config)
+        self.created_pools = result["pools"]
+        self.created_rules = result["rules"]
+        self.setup_completed = True
+
+        log.info(f"Created pools: {self.created_pools}")
+        log.info(f"Created rules: {self.created_rules}")
+
+        # Verify pool setup completed successfully
+        assert self.created_pools, "No pools were created"
+        assert self.created_rules, "No CRUSH rules were created"
+        assert len(self.created_pools) == len(
+            self.topology_config.zones
+        ), f"Expected {len(self.topology_config.zones)} pools, got {len(self.created_pools)}"
+        assert len(self.created_rules) == len(
+            self.topology_config.zones
+        ), f"Expected {len(self.topology_config.zones)} CRUSH rules, got {len(self.created_rules)}"
+
+        # Step 5: Run exporter script with topology flags
+        log.info("Running topology exporter script")
+        try:
+            export_resources = self.ext_cluster.run_topology_exporter_script(
+                self.topology_config
+            )
+            log.info(f"Exporter returned {len(export_resources)} resources")
+
+            # Step 6: Apply exported resources to ODF cluster
+            log.info("Applying exported resources to ODF")
+            applied = self.ext_cluster.apply_topology_export_resources(export_resources)
+
+            log.info(f"Applied secrets: {applied['secrets']}")
+            log.info(f"Applied configmaps: {applied['configmaps']}")
+
+        except ExternalClusterExporterRunFailed as e:
+            pytest.skip(f"Exporter script not available: {e}")
+
+        log.info("External replica-1 setup test completed successfully")

--- a/tests/functional/external_mode/test_replica1_external.py
+++ b/tests/functional/external_mode/test_replica1_external.py
@@ -5,7 +5,6 @@ This test validates topology-based replica-1 provisioning where each zone
 gets its own single-replica pool with a dedicated CRUSH rule.
 """
 
-import json
 import logging
 import pytest
 
@@ -18,10 +17,9 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.deployment.helpers.external_cluster_helpers import (
     get_external_cluster_instance,
-    TopologyReplica1Config,
-    ZoneConfig,
 )
 from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterExporterRunFailed
+from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
@@ -49,12 +47,31 @@ class TestReplicaOneExternal(ManageTest):
         EXTERNAL_MODE configuration. Registers finalizer for cleanup.
         """
         self.ext_cluster = get_external_cluster_instance()
-        self.topology_config = self._build_topology_config()
+        self.topology_config = self._build_topology_config_or_skip()
         self.created_pools = []
         self.created_rules = []
+        self.applied_resources = {"secrets": [], "configmaps": []}
 
         def finalizer():
             log.info("Starting external replica-1 teardown")
+            namespace = config.ENV_DATA["cluster_namespace"]
+
+            for name in self.applied_resources.get("secrets", []):
+                try:
+                    OCP(kind="Secret", namespace=namespace).delete(resource_name=name)
+                    log.info(f"Deleted Secret: {name}")
+                except CommandFailed as e:
+                    log.warning(f"Failed to delete Secret {name}: {e}")
+
+            for name in self.applied_resources.get("configmaps", []):
+                try:
+                    OCP(kind="ConfigMap", namespace=namespace).delete(
+                        resource_name=name
+                    )
+                    log.info(f"Deleted ConfigMap: {name}")
+                except CommandFailed as e:
+                    log.warning(f"Failed to delete ConfigMap {name}: {e}")
+
             try:
                 if self.created_pools:
                     self.ext_cluster.cleanup_replica_one_pools(self.created_pools)
@@ -71,66 +88,17 @@ class TestReplicaOneExternal(ManageTest):
 
         request.addfinalizer(finalizer)
 
-    def _discover_zones_from_crush_tree(self) -> list[ZoneConfig]:
+    def _build_topology_config_or_skip(self):
         """
-        Auto-detect zones from the external cluster's CRUSH tree.
-
-        Queries 'ceph osd tree' and extracts host-type buckets.
-        Each host becomes a zone (zone-a, zone-b, ...).
-
-        Returns:
-            list[ZoneConfig]: Zone configurations derived from CRUSH hosts.
-
+        Build topology config from ExternalCluster, skip if too few hosts.
         """
-        _, out, _ = self.ext_cluster.exec_external_ceph_cmd(
-            cmd="ceph osd tree --format json",
-            error_msg="Failed to get OSD tree from external cluster",
-            exception_class=CommandFailed,
-        )
-        osd_tree = json.loads(out)
-        hosts = [node["name"] for node in osd_tree["nodes"] if node["type"] == "host"]
-
-        if len(hosts) < 2:
+        topology_config = self.ext_cluster.build_topology_replica1_config()
+        if len(topology_config.zones) < 2:
             pytest.skip(
                 f"Need at least 2 OSD hosts for replica-1 test, "
-                f"found {len(hosts)}: {hosts}"
+                f"found {len(topology_config.zones)}"
             )
-
-        zones = [
-            ZoneConfig(zone_name=f"zone-{chr(ord('a') + i)}", host_name=host)
-            for i, host in enumerate(hosts)
-        ]
-        log.info(f"Auto-detected {len(zones)} zones from CRUSH tree: {zones}")
-        return zones
-
-    def _build_topology_config(self) -> TopologyReplica1Config:
-        """
-        Build topology configuration from EXTERNAL_MODE config or CRUSH tree.
-
-        Reads replica1_zones from config.EXTERNAL_MODE if available.
-        Falls back to auto-detecting zones from the cluster's CRUSH tree.
-
-        Returns:
-            TopologyReplica1Config: Configuration for replica-1 setup.
-
-        """
-        zones_config = config.EXTERNAL_MODE.get("replica1_zones", [])
-        if zones_config:
-            log.info(f"Using replica1_zones from config: {zones_config}")
-            zones = [
-                ZoneConfig(
-                    zone_name=z["zone_name"],
-                    host_name=z["host_name"],
-                    pool_name=z.get("pool_name", ""),
-                )
-                for z in zones_config
-            ]
-        else:
-            log.info("replica1_zones not configured, auto-detecting from CRUSH tree")
-            zones = self._discover_zones_from_crush_tree()
-
-        log.info(f"Built topology config with {len(zones)} zones")
-        return TopologyReplica1Config(zones=zones)
+        return topology_config
 
     def test_replica1_setup_and_verify(self):
         """
@@ -156,8 +124,6 @@ class TestReplicaOneExternal(ManageTest):
         log.info(f"Created rules: {self.created_rules}")
 
         # Verify pool setup completed successfully
-        assert self.created_pools, "No pools were created"
-        assert self.created_rules, "No CRUSH rules were created"
         assert len(self.created_pools) == len(
             self.topology_config.zones
         ), f"Expected {len(self.topology_config.zones)} pools, got {len(self.created_pools)}"
@@ -176,11 +142,14 @@ class TestReplicaOneExternal(ManageTest):
             # Step 6: Apply exported resources to ODF cluster
             log.info("Applying exported resources to ODF")
             applied = self.ext_cluster.apply_topology_export_resources(export_resources)
+            self.applied_resources = applied
 
             log.info(f"Applied secrets: {applied['secrets']}")
             log.info(f"Applied configmaps: {applied['configmaps']}")
 
         except ExternalClusterExporterRunFailed as e:
+            if "Failed to parse" in str(e):
+                raise
             pytest.skip(f"Exporter script not available: {e}")
 
         log.info("External replica-1 setup test completed successfully")

--- a/tests/functional/external_mode/test_replica1_external.py
+++ b/tests/functional/external_mode/test_replica1_external.py
@@ -52,18 +52,8 @@ class TestReplicaOneExternal(ManageTest):
         self.topology_config = self._build_topology_config()
         self.created_pools = []
         self.created_rules = []
-        self.setup_completed = False
 
         def finalizer():
-            if not self.setup_completed:
-                log.error(
-                    "Setup did not complete. Potential orphaned resources "
-                    "on external cluster may require manual cleanup: "
-                    f"pools={self.topology_config.pool_names}, "
-                    f"rules={[f'{z.zone_name}-rule' for z in self.topology_config.zones]}"
-                )
-                return
-
             log.info("Starting external replica-1 teardown")
             try:
                 if self.created_pools:
@@ -161,7 +151,6 @@ class TestReplicaOneExternal(ManageTest):
         result = self.ext_cluster.setup_topology_replica_one(self.topology_config)
         self.created_pools = result["pools"]
         self.created_rules = result["rules"]
-        self.setup_completed = True
 
         log.info(f"Created pools: {self.created_pools}")
         log.info(f"Created rules: {self.created_rules}")

--- a/tests/functional/external_mode/test_replica1_external.py
+++ b/tests/functional/external_mode/test_replica1_external.py
@@ -8,7 +8,6 @@ gets its own single-replica pool with a dedicated CRUSH rule.
 import logging
 import pytest
 
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     external_mode_required,
@@ -19,7 +18,6 @@ from ocs_ci.deployment.helpers.external_cluster_helpers import (
     get_external_cluster_instance,
 )
 from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterExporterRunFailed
-from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
@@ -50,35 +48,9 @@ class TestReplicaOneExternal(ManageTest):
         self.topology_config = self._build_topology_config_or_skip()
         self.created_pools = []
         self.created_rules = []
-        self.applied_resources = {"secrets": [], "configmaps": []}
-
-        def _force_delete_resource(kind, name, namespace):
-            """Delete a resource, stripping finalizers if deletion blocks."""
-            ocp_obj = OCP(kind=kind, namespace=namespace)
-            try:
-                ocp_obj.delete(resource_name=name, wait=False, timeout=60)
-                log.info(f"Deleted {kind}: {name}")
-            except CommandFailed as e:
-                log.warning(f"Normal delete failed for {kind}/{name}: {e}")
-            try:
-                ocp_obj.patch(
-                    resource_name=name,
-                    params='{"metadata":{"finalizers":null}}',
-                    format_type="merge",
-                )
-                log.info(f"Stripped finalizers from {kind}/{name}")
-            except CommandFailed:
-                pass
 
         def finalizer():
             log.info("Starting external replica-1 teardown")
-            namespace = config.ENV_DATA["cluster_namespace"]
-
-            for name in self.applied_resources.get("secrets", []):
-                _force_delete_resource("Secret", name, namespace)
-
-            for name in self.applied_resources.get("configmaps", []):
-                _force_delete_resource("ConfigMap", name, namespace)
 
             try:
                 if self.created_pools:
@@ -150,7 +122,6 @@ class TestReplicaOneExternal(ManageTest):
             # Step 6: Apply exported resources to ODF cluster
             log.info("Applying exported resources to ODF")
             applied = self.ext_cluster.apply_topology_export_resources(export_resources)
-            self.applied_resources = applied
 
             log.info(f"Applied secrets: {applied['secrets']}")
             log.info(f"Applied configmaps: {applied['configmaps']}")

--- a/tests/functional/external_mode/test_replica1_external.py
+++ b/tests/functional/external_mode/test_replica1_external.py
@@ -52,25 +52,33 @@ class TestReplicaOneExternal(ManageTest):
         self.created_rules = []
         self.applied_resources = {"secrets": [], "configmaps": []}
 
+        def _force_delete_resource(kind, name, namespace):
+            """Delete a resource, stripping finalizers if deletion blocks."""
+            ocp_obj = OCP(kind=kind, namespace=namespace)
+            try:
+                ocp_obj.delete(resource_name=name, wait=False, timeout=60)
+                log.info(f"Deleted {kind}: {name}")
+            except CommandFailed as e:
+                log.warning(f"Normal delete failed for {kind}/{name}: {e}")
+            try:
+                ocp_obj.patch(
+                    resource_name=name,
+                    params='{"metadata":{"finalizers":null}}',
+                    format_type="merge",
+                )
+                log.info(f"Stripped finalizers from {kind}/{name}")
+            except CommandFailed:
+                pass
+
         def finalizer():
             log.info("Starting external replica-1 teardown")
             namespace = config.ENV_DATA["cluster_namespace"]
 
             for name in self.applied_resources.get("secrets", []):
-                try:
-                    OCP(kind="Secret", namespace=namespace).delete(resource_name=name)
-                    log.info(f"Deleted Secret: {name}")
-                except CommandFailed as e:
-                    log.warning(f"Failed to delete Secret {name}: {e}")
+                _force_delete_resource("Secret", name, namespace)
 
             for name in self.applied_resources.get("configmaps", []):
-                try:
-                    OCP(kind="ConfigMap", namespace=namespace).delete(
-                        resource_name=name
-                    )
-                    log.info(f"Deleted ConfigMap: {name}")
-                except CommandFailed as e:
-                    log.warning(f"Failed to delete ConfigMap {name}: {e}")
+                _force_delete_resource("ConfigMap", name, namespace)
 
             try:
                 if self.created_pools:


### PR DESCRIPTION
- [x] Add `run_topology_exporter_script()` and `apply_topology_export_resources()` to run the Rook exporter with topology flags and apply resulting K8s resources
- [x] Add `pool_names`/`zone_names` properties to `TopologyReplica1Config`
- [x] Add test for the full replica-1 setup flow with teardown



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology-aware replica‑1 provisioning with automatic zone discovery and computed pool/zone names.
  * Topology exporter integration: run exporter, decode its JSON output, and apply exported cluster resources (only Secrets and ConfigMaps).

* **Tests**
  * New functional tests validating replica‑1 external provisioning, exporter execution/output handling, resource application, and best-effort cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/14476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->