### PR TITLE
Increase timeout for PVC clone and restore in tests

### DIFF
--- a/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
@@ -115,7 +115,7 @@ class TestCloneWithDifferentAccessMode(ManageTest):
         log.info("Verifying cloned PVCs are Bound")
         for pvc_obj in cloned_pvcs:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=200
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=480
             )
             pvc_obj.reload()
         log.info("Verified: Cloned PVCs are Bound")

--- a/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
@@ -157,7 +157,7 @@ class TestSnapshotRestoreWithDifferentAccessMode(ManageTest):
         log.info("Verifying restored PVCs are Bound")
         for pvc_obj in restore_pvcs:
             helpers.wait_for_resource_state(
-                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=200
+                resource=pvc_obj, state=constants.STATUS_BOUND, timeout=480
             )
             pvc_obj.reload()
         log.info("Verified: Restored PVCs are Bound")


### PR DESCRIPTION
Test cases are test_clone_with_different_access_mode and test_snapshot_restore_with_different_access_mode.
Fixes #14486 