### PR TITLE
Fix discovered-apps teardown failures and update test naming and doctrings

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -115,19 +115,18 @@ class TestFailoverAndRelocateWithDiscoveredApps:
     )
     def test_failover_and_relocate_discovered_apps(
         self,
-        discovered_apps_dr_workload,
         primary_cluster_down,
         pvc_interface,
-        nodes_multicluster,
         kubeobject,
         recipe,
         iterations,
+        discovered_apps_dr_workload,
+        nodes_multicluster,
+        node_restart_teardown,
     ):
         """
-        Tests to verify application failover and Relocate with Discovered Apps
-        There are two test cases:
-            1) Failover to secondary cluster when primary cluster is UP
-            2) Relocate back to primary
+        Tests to verify application failover and relocate with discovered applications
+        Covers primary cluster up or down, and single or multiple (3) iterations.
 
         """
         rdr_workloads = discovered_apps_dr_workload(

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps_multi_ns.py
@@ -21,9 +21,9 @@ logger = logging.getLogger(__name__)
 @tier1
 @turquoise_squad
 @skipif_ocs_version("<4.16")
-class TestFailoverAndRelocateWithDiscoveredApps:
+class TestFailoverAndRelocateWithDiscoveredAppsMultiNs:
     """
-    Test Failover and Relocate with Discovered Apps
+    Test Failover and Relocate with Discovered Apps spread across multiple namespaces.
 
     """
 
@@ -38,14 +38,11 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             ),
         ],
     )
-    def test_failover_and_relocate_discovered_apps(
+    def test_failover_and_relocate_discovered_apps_multi_ns(
         self, pvc_interface, discovered_apps_dr_workload
     ):
         """
-        Tests to verify application failover and Relocate with Discovered Apps
-        There are two test cases:
-            1) Failover to secondary cluster when primary cluster is UP
-            2) Relocate back to primary
+        Tests to verify failover and relocate with discovered applications spread across multiple namespaces.
 
         """
         rdr_workload = discovered_apps_dr_workload(


### PR DESCRIPTION
Add node_restart_teardown fixture to test_failover_and_relocate_discovered_apps so nodes are restored when a test fails mid-run, preventing subsequent tests from failing due to primary cluster nodes left down. Also update docstrings and parametrized arg order. 
Rename class and test in the multi-namespace test for clarity and improved documentation.