### PR TITLE
WIP: Add live cluster debugger for autonomous failure investigation

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import os
 import shutil
+import threading
 
 import pandas as pd
 import pytest
@@ -67,6 +68,52 @@ log = logging.getLogger(__name__)
 
 # Global variable to store test start time
 test_start_time = None
+
+# Collects live debugger results across all tests for the session report
+live_debug_results = []
+# Lock for thread-safe appending to live_debug_results
+_live_debug_lock = threading.Lock()
+
+
+def _run_live_debug(
+    test_name, test_nodeid, test_source_path, traceback_text,
+    markers_str, start_time_str, failure_phase, test_log_path, log_dir,
+):
+    """
+    Run live cluster debugging in a background thread.
+
+    This function is the target for the debugger thread spawned in
+    ``pytest_runtest_makereport``. Results are appended to the global
+    ``live_debug_results`` list for the session report.
+    """
+    try:
+        from ocs_ci.utility.live_debugger import LiveClusterDebugger
+
+        cli_params = ocsci_config.RUN.get("cli_params", {})
+        model = cli_params.get("live_debug_model", "sonnet")
+        budget = cli_params.get("live_debug_budget", 1.00)
+        timeout = cli_params.get("live_debug_timeout", 300)
+
+        debugger = LiveClusterDebugger(
+            model=model,
+            max_budget_usd=budget,
+            timeout=timeout,
+        )
+        result = debugger.investigate(
+            test_name=test_name,
+            test_nodeid=test_nodeid,
+            test_source_path=test_source_path,
+            traceback_text=traceback_text,
+            markers=markers_str,
+            test_start_time=start_time_str,
+            failure_phase=failure_phase,
+            test_log_path=test_log_path,
+            log_dir=log_dir,
+        )
+        with _live_debug_lock:
+            live_debug_results.append(result)
+    except Exception:
+        log.exception(f"Live debugger failed for {test_name}")
 
 
 def _pytest_addoption_cluster_specific(parser):
@@ -390,6 +437,33 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help=("Skips the RPM and go version collection for every pod for session"),
+    )
+    parser.addoption(
+        "--live-debug",
+        dest="live_debug",
+        action="store_true",
+        default=False,
+        help="Invoke Claude Code to investigate cluster on test failure",
+    )
+    parser.addoption(
+        "--live-debug-model",
+        dest="live_debug_model",
+        default="sonnet",
+        help="AI model for live debugging (default: sonnet)",
+    )
+    parser.addoption(
+        "--live-debug-budget",
+        dest="live_debug_budget",
+        type=float,
+        default=1.00,
+        help="Max USD per investigation (default: 1.00)",
+    )
+    parser.addoption(
+        "--live-debug-timeout",
+        dest="live_debug_timeout",
+        type=int,
+        default=300,
+        help="Timeout seconds per investigation (default: 300)",
     )
 
 
@@ -811,6 +885,10 @@ def process_cluster_cli_params(config):
     )
     ocsci_config.RUN["skip_rpm_go_version_collection"] = skip_rpm_go_version_collection
     ocsci_config.ENV_DATA["product_type"] = get_cli_param(config, "product_type")
+    get_cli_param(config, "live_debug")
+    get_cli_param(config, "live_debug_model")
+    get_cli_param(config, "live_debug_budget")
+    get_cli_param(config, "live_debug_timeout")
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -889,7 +967,61 @@ def pytest_collection_modifyitems(session, config, items):
 def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
-    # we only look at actual failing test calls, not setup/teardown
+
+    debugger_thread = None
+
+    # Launch live debugger in background thread BEFORE must-gather
+    # so they run in parallel. Triggers on all failure phases.
+    if (
+        rep.failed
+        and ocsci_config.RUN.get("cli_params", {}).get("live_debug")
+        and not ocsci_config.RUN.get("cli_params", {}).get("deploy")
+    ):
+        global test_start_time
+        try:
+            from ocs_ci.utility.utils import ocsci_log_path
+
+            markers_str = ",".join(m.name for m in item.iter_markers())
+            start_time_str = (
+                test_start_time.isoformat() + "Z" if test_start_time else ""
+            )
+            test_source_path = str(item.fspath)
+
+            # Get the per-test log path if available
+            test_log_path = None
+            log_base = ocsci_log_path()
+            if log_base and os.path.isdir(log_base):
+                # pytest-logger writes per-test logs using the test node id
+                candidate = os.path.join(log_base, item.name + ".log")
+                if os.path.isfile(candidate):
+                    test_log_path = candidate
+
+            traceback_text = str(rep.longrepr) if rep.longrepr else ""
+
+            debugger_thread = threading.Thread(
+                target=_run_live_debug,
+                args=(
+                    item.name,
+                    item.nodeid,
+                    test_source_path,
+                    traceback_text,
+                    markers_str,
+                    start_time_str,
+                    rep.when,
+                    test_log_path,
+                    log_base,
+                ),
+                daemon=True,
+            )
+            debugger_thread.start()
+            log.info(
+                f"Live debugger started for {item.name} (phase={rep.when})"
+            )
+        except Exception:
+            log.exception("Failed to start live debugger thread")
+            debugger_thread = None
+
+    # Must-gather runs as before (synchronous, blocking)
     # Don't collect must-gather for deployment here since its already
     # handled in deployment
     if (
@@ -938,7 +1070,6 @@ def pytest_runtest_makereport(item, call):
             if not ocsci_config.RUN.get("is_ocp_deployment_failed"):
                 # Format test start time in RFC3339 format for must-gather
                 # Subtract 5 minutes buffer to capture events before test started
-                global test_start_time
                 since_time_str = None
                 if test_start_time:
                     # Add 5 minute buffer before test start time
@@ -1020,6 +1151,12 @@ def pytest_runtest_makereport(item, call):
         ) as file:
             file.write(f"{test_name}\n")
 
+    # Wait for live debugger to finish before moving to next test
+    if debugger_thread is not None:
+        log.info(f"Waiting for live debugger to complete for {item.name}...")
+        debugger_thread.join()
+        log.info(f"Live debugger completed for {item.name}")
+
 
 def set_log_level(config):
     """
@@ -1031,6 +1168,28 @@ def set_log_level(config):
     """
     level = config.getini("log_cli_level") or "INFO"
     log.setLevel(logging.getLevelName(level))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Generate aggregated live debug report after all tests complete."""
+    if live_debug_results:
+        try:
+            from ocs_ci.utility.live_debugger.report_builder import DebugReportBuilder
+            from ocs_ci.utility.utils import ocsci_log_path
+
+            log_dir = ocsci_log_path()
+            builder = DebugReportBuilder()
+            report_path = builder.build_session_report(live_debug_results, log_dir)
+            if report_path:
+                log.info(f"Live debug session report: {report_path}")
+
+            total_cost = sum(r.get("cost_usd", 0) for r in live_debug_results)
+            log.info(
+                f"Live debugger session summary: {len(live_debug_results)} tests "
+                f"investigated, total cost: ${total_cost:.4f}"
+            )
+        except Exception:
+            log.exception("Failed to generate live debug session report")
 
 
 global consumed_ram_start_test

--- a/ocs_ci/utility/live_debugger/README.md
+++ b/ocs_ci/utility/live_debugger/README.md
@@ -1,0 +1,171 @@
+# Live Cluster Debugger
+
+When a test fails during execution, the live debugger spawns a Claude Code session that autonomously investigates the **live cluster** to determine the root cause. It reads the test source code and logs, runs read-only `oc` commands, and classifies the failure.
+
+## Quick Start
+
+```bash
+# Basic usage — investigate failures with default settings
+run-ci ... --live-debug
+
+# With must-gather (runs in parallel)
+run-ci ... --live-debug --collect-logs
+
+# Custom model, budget, and timeout
+run-ci ... --live-debug --live-debug-model opus --live-debug-budget 2.00 --live-debug-timeout 600
+```
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--live-debug` | `False` | Enable live cluster debugging on test failure |
+| `--live-debug-model` | `sonnet` | Claude model to use (`sonnet`, `opus`, `haiku`) |
+| `--live-debug-budget` | `1.00` | Max USD spend per investigation |
+| `--live-debug-timeout` | `300` | Timeout in seconds per investigation |
+
+## How It Works
+
+```
+Test fails in pytest
+    │
+    ├── [Thread 1] must-gather (existing, unchanged, if --collect-logs)
+    │
+    └── [Thread 2] Live Debugger
+            │
+            └── claude -p <prompt> --tools "Bash,Read" --output-format json
+                    │
+                    ├── Phase 1: Understand the test
+                    │   ├── Read test source file (item.fspath)
+                    │   ├── Read test log file (per-test log from pytest-logger)
+                    │   └── Analyze the traceback
+                    │
+                    ├── Phase 2: Targeted cluster investigation
+                    │   ├── oc get/describe resources
+                    │   ├── oc logs <pod> --tail=100
+                    │   ├── oc get events --sort-by='.lastTimestamp'
+                    │   ├── oc exec <tools-pod> -- ceph status
+                    │   └── ... (follows the evidence chain)
+                    │
+                    └── Phase 3: Classify and recommend
+                        ├── product_bug / test_bug / infra_issue / known_issue
+                        ├── Root cause + evidence
+                        └── Code fix suggestion (if test_bug)
+```
+
+### Execution Flow
+
+1. The debugger thread starts **before** must-gather, so they run in parallel.
+2. Must-gather runs synchronously as before.
+3. After must-gather and other post-failure processing, pytest **waits** for the debugger thread to complete before moving to the next test.
+4. This means the debugger adds zero wall-clock time when it finishes before must-gather, and only the delta when it takes longer.
+
+### Failure Phases
+
+The debugger triggers on **all failure phases**: setup, call, and teardown. This is independent of `--collect-logs` — the debugger works standalone.
+
+## Output
+
+### Per-test output (in `ocsci_log_path()`)
+
+- `{test_name}_live_debug.json` — structured investigation results
+- `{test_name}_live_debug.html` — single-test HTML report
+
+### Session-level output
+
+- `live_debug_report.html` — aggregated report with:
+  - Summary table (test name, category, root cause, cost)
+  - Category breakdown (product_bug: N, test_bug: N, etc.)
+  - Total cost and timing
+  - Per-test expandable sections with full investigation narrative
+
+## Module Structure
+
+```
+ocs_ci/utility/live_debugger/
+├── __init__.py                          # Public API: LiveClusterDebugger
+├── debugger.py                          # Core class — spawns claude -p
+├── safety.py                            # Post-hoc command audit
+├── report_builder.py                    # HTML report generation
+├── prompt_templates/
+│   └── investigate_failure.j2           # The investigation prompt
+└── README.md                            # This file
+```
+
+### `debugger.py` — `LiveClusterDebugger`
+
+The core class. Key method:
+
+```python
+debugger = LiveClusterDebugger(model="sonnet", max_budget_usd=1.00, timeout=300)
+result = debugger.investigate(
+    test_name="test_create_pvc",
+    test_nodeid="tests/functional/pv/test_pvc.py::TestPVC::test_create_pvc",
+    test_source_path="/path/to/test_pvc.py",
+    traceback_text="AssertionError: ...",
+    markers="green_squad,tier1",
+    test_start_time="2025-01-15T10:30:00Z",
+    failure_phase="call",           # setup, call, or teardown
+    test_log_path="/path/to/log",   # optional
+    log_dir="/path/to/output",      # optional, saves JSON+HTML
+)
+```
+
+Returns a dict:
+```python
+{
+    "test_name": "test_create_pvc",
+    "test_nodeid": "tests/.../test_pvc.py::TestPVC::test_create_pvc",
+    "failure_phase": "call",
+    "investigation": "Full narrative...",
+    "category": "product_bug",      # product_bug|test_bug|infra_issue|known_issue|unknown
+    "root_cause": "OSD pod crashlooping due to OOM",
+    "evidence": ["OSD pod restarted 5 times", "Memory limit 2Gi exceeded"],
+    "recommended_action": "File Jira bug for OSD memory limits",
+    "cost_usd": 0.0312,
+    "num_turns": 8,
+    "duration_seconds": 45.2,
+    "error": null,
+    "commands_executed": ["oc get pods -n openshift-storage", ...],
+    "safety_violations": []
+}
+```
+
+### `safety.py` — Command Audit
+
+Defense-in-depth layer. After Claude finishes, all executed commands are checked against allow/deny lists:
+
+- **Allowed**: `oc get`, `oc describe`, `oc logs`, `oc events`, `oc adm top`, `oc exec -- ceph status`
+- **Forbidden**: `oc delete`, `oc apply`, `oc create`, `oc patch`, `oc edit`, `oc scale`, `oc debug`, `rm`, etc.
+
+Violations are logged as warnings and included in the report.
+
+### `report_builder.py` — HTML Reports
+
+Generates styled HTML reports with:
+- Color-coded category badges
+- Expandable investigation narratives
+- Code blocks for command output
+- Safety violation warnings (if any)
+
+## Integration Point
+
+All integration is in `ocs_ci/framework/pytest_customization/ocscilib.py`:
+
+- **`pytest_addoption`** — registers the `--live-debug*` CLI flags
+- **`process_cluster_cli_params`** — stores params in `config.RUN["cli_params"]`
+- **`pytest_runtest_makereport`** — launches debugger thread on failure, waits at end
+- **`pytest_sessionfinish`** — generates the aggregated session report
+
+## Environment
+
+The debugger subprocess inherits:
+- **`KUBECONFIG`** from `config.RUN["kubeconfig"]` (same as `exec_cmd` in `utils.py`)
+- **`CLAUDECODE`** env var is removed to allow nested Claude Code sessions
+
+## Cost Control
+
+- Default budget: $1.00 per investigation
+- Typical investigation: $0.02–0.10 (5–15 turns)
+- Session total logged at end with per-test breakdown
+- Budget is a hard cap enforced by Claude Code CLI

--- a/ocs_ci/utility/live_debugger/__init__.py
+++ b/ocs_ci/utility/live_debugger/__init__.py
@@ -1,0 +1,29 @@
+"""
+Live Cluster Debugger for OCS-CI.
+
+When a test fails during execution, this module spawns a Claude Code session
+that investigates the live cluster to determine the root cause. It reads the
+test source code, test logs, and runs read-only ``oc`` commands to classify
+the failure as product_bug, test_bug, infra_issue, or known_issue.
+
+Usage::
+
+    from ocs_ci.utility.live_debugger import LiveClusterDebugger
+
+    debugger = LiveClusterDebugger(model="sonnet", max_budget_usd=1.00)
+    result = debugger.investigate(
+        test_name="test_create_pvc",
+        test_nodeid="tests/functional/pv/test_pvc.py::TestPVC::test_create_pvc",
+        test_source_path="/path/to/test_pvc.py",
+        traceback_text="...",
+        markers="green_squad,tier1",
+        test_start_time="2025-01-15T10:30:00Z",
+    )
+
+The module is integrated into the pytest hooks via ``--live-debug`` CLI flag
+in ``ocscilib.py``.
+"""
+
+from ocs_ci.utility.live_debugger.debugger import LiveClusterDebugger
+
+__all__ = ["LiveClusterDebugger"]

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -161,6 +161,44 @@ class LiveClusterDebugger:
         if kubeconfig:
             env["KUBECONFIG"] = kubeconfig
 
+        # Save prompt and debug file BEFORE running, for diagnostics
+        safe_name = re.sub(r"[^\w\-.]", "_", test_name)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+            # Save prompt for manual reproduction
+            prompt_path = os.path.join(
+                log_dir, f"{safe_name}_live_debug_prompt.txt"
+            )
+            try:
+                with open(prompt_path, "w") as f:
+                    f.write(prompt)
+            except OSError as e:
+                logger.warning(f"Could not save prompt: {e}")
+
+            # Add --debug-file so Claude Code writes internal debug logs
+            debug_log_path = os.path.join(
+                log_dir, f"{safe_name}_live_debug_claude_debug.log"
+            )
+            cmd.extend(["--debug-file", debug_log_path])
+
+            # Save reproduction script
+            repro_path = os.path.join(
+                log_dir, f"{safe_name}_live_debug_repro.sh"
+            )
+            try:
+                repro_lines = ["#!/bin/bash", "# Reproduction script"]
+                if kubeconfig:
+                    repro_lines.append(f"export KUBECONFIG={kubeconfig}")
+                repro_lines.append(
+                    f"time cat {prompt_path} | "
+                    + " ".join(cmd)
+                )
+                with open(repro_path, "w") as f:
+                    f.write("\n".join(repro_lines) + "\n")
+                os.chmod(repro_path, 0o755)
+            except OSError as e:
+                logger.warning(f"Could not save repro script: {e}")
+
         logger.info(
             f"Live debugger: investigating {test_name} "
             f"(model={self.model}, resolved_model={resolved_model}, "
@@ -189,6 +227,12 @@ class LiveClusterDebugger:
             logger.error(f"Partial stdout on timeout: {partial_stdout}")
             logger.error(f"Partial stderr on timeout: {partial_stderr}")
             if log_dir:
+                debug_log = os.path.join(
+                    log_dir, f"{safe_name}_live_debug_claude_debug.log"
+                )
+                logger.error(
+                    f"Check Claude debug log for details: {debug_log}"
+                )
                 self._save_results(result, test_name, log_dir)
             return result
         except FileNotFoundError:
@@ -206,8 +250,6 @@ class LiveClusterDebugger:
 
         # Save raw output to log file for debugging
         if log_dir:
-            safe_name = re.sub(r"[^\w\-.]", "_", test_name)
-            os.makedirs(log_dir, exist_ok=True)
             raw_log_path = os.path.join(
                 log_dir, f"{safe_name}_live_debug_raw.log"
             )

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -66,10 +66,10 @@ class LiveClusterDebugger:
         """
         Spawn ``claude -p`` to investigate a test failure on the live cluster.
 
-        Uses subprocess.Popen with ``--output-format stream-json`` so that
-        Claude's progress is logged in real-time to both a log file and the
-        pytest console. Each line of stdout is a JSON event (NDJSON format).
-        The final ``result`` event contains the investigation text and cost.
+        The prompt is passed via stdin and the response is captured as a
+        single JSON blob (``--output-format json``). This avoids the
+        ``--verbose`` flag which enables extended thinking and adds
+        significant per-turn latency on Vertex AI.
 
         Args:
             test_name: Short test name (e.g. ``test_create_pvc``).
@@ -140,15 +140,14 @@ class LiveClusterDebugger:
 
         # Build the command — prompt is passed via stdin to avoid
         # shell argument length limits on large prompts.
-        # Use stream-json so we get real-time NDJSON events instead of
-        # a single buffered JSON blob (which blocks all streaming).
+        # Use --output-format json (NOT stream-json) to avoid needing
+        # --verbose which enables extended thinking and adds latency.
         cmd = [
             "claude",
             "-p",
             "--tools", "Bash,Read",
             "--dangerously-skip-permissions",
-            "--verbose",
-            "--output-format", "stream-json",
+            "--output-format", "json",
             "--model", resolved_model,
             "--max-budget-usd", str(self.max_budget_usd),
         ]
@@ -170,99 +169,28 @@ class LiveClusterDebugger:
         )
         logger.info(f"Live debugger command: {' '.join(cmd)}")
 
-        # Set up the streaming log file
-        safe_name = re.sub(r"[^\w\-.]", "_", test_name)
-        stream_log_path = None
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-            stream_log_path = os.path.join(
-                log_dir, f"{safe_name}_live_debug_stream.log"
-            )
-
-        # Use Popen for streaming output with stream-json format.
-        # Each line is a JSON event (NDJSON). We parse events in real-time
-        # for logging and collect the final result event at the end.
-        stream_events = []
-        timed_out = False
-        proc = None
-        final_result_event = None
-
         try:
-            proc = subprocess.Popen(
+            proc = subprocess.run(
                 cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                input=prompt,
+                capture_output=True,
                 text=True,
+                timeout=self.timeout,
                 env=env,
             )
-
-            # Send prompt via stdin and close it
-            proc.stdin.write(prompt)
-            proc.stdin.close()
-
-            # Open stream log file if we have a log_dir
-            stream_log_file = None
-            if stream_log_path:
-                try:
-                    stream_log_file = open(stream_log_path, "w")
-                except OSError as e:
-                    logger.warning(f"Could not open stream log file: {e}")
-
-            # Read stdout line by line — each line is a JSON event
-            deadline = time.time() + self.timeout
-            try:
-                for raw_line in proc.stdout:
-                    raw_line = raw_line.rstrip("\n")
-                    if not raw_line:
-                        continue
-
-                    # Write raw NDJSON to stream log file
-                    if stream_log_file:
-                        stream_log_file.write(raw_line + "\n")
-                        stream_log_file.flush()
-
-                    # Parse the JSON event
-                    try:
-                        event = json.loads(raw_line)
-                    except json.JSONDecodeError:
-                        logger.debug(
-                            f"Live debugger [{test_name}]: "
-                            f"non-JSON line: {raw_line[:200]}"
-                        )
-                        continue
-
-                    stream_events.append(event)
-                    event_type = event.get("type", "")
-
-                    # Log human-readable progress based on event type
-                    self._log_stream_event(test_name, event)
-
-                    # Capture the final result event
-                    if event_type == "result":
-                        final_result_event = event
-
-                    # Check timeout
-                    if time.time() > deadline:
-                        timed_out = True
-                        logger.error(
-                            f"Live debugger timed out after {self.timeout}s "
-                            f"for {test_name} "
-                            f"(collected {len(stream_events)} events)"
-                        )
-                        proc.kill()
-                        break
-            finally:
-                if stream_log_file:
-                    stream_log_file.close()
-
-            # Wait for process to finish (or confirm it was killed)
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-
+        except subprocess.TimeoutExpired as e:
+            partial_stdout = (e.stdout or "")[:500] if e.stdout else ""
+            partial_stderr = (e.stderr or "")[:500] if e.stderr else ""
+            result["error"] = (
+                f"Live debugger timed out after {self.timeout}s for {test_name}"
+            )
+            result["duration_seconds"] = time.time() - start
+            logger.error(result["error"])
+            logger.error(f"Partial stdout on timeout: {partial_stdout}")
+            logger.error(f"Partial stderr on timeout: {partial_stderr}")
+            if log_dir:
+                self._save_results(result, test_name, log_dir)
+            return result
         except FileNotFoundError:
             result["error"] = "Claude Code CLI ('claude') not found"
             result["duration_seconds"] = time.time() - start
@@ -276,58 +204,55 @@ class LiveClusterDebugger:
 
         result["duration_seconds"] = time.time() - start
 
-        if stream_log_path:
-            logger.info(f"Live debugger stream log: {stream_log_path}")
-
-        # Reconstruct the investigation text from stream events
-        result_text = self._extract_result_from_stream(
-            stream_events, final_result_event
-        )
-
-        if timed_out:
-            result["error"] = (
-                f"Live debugger timed out after {self.timeout}s for {test_name}. "
-                f"Collected {len(stream_events)} events before timeout."
+        # Save raw output to log file for debugging
+        if log_dir:
+            safe_name = re.sub(r"[^\w\-.]", "_", test_name)
+            os.makedirs(log_dir, exist_ok=True)
+            raw_log_path = os.path.join(
+                log_dir, f"{safe_name}_live_debug_raw.log"
             )
-            # Still use whatever text we managed to collect
-            result["investigation"] = result_text
-            result["category"] = self._extract_category(result_text)
-            result["root_cause"] = self._extract_section(result_text, "ROOT CAUSE")
+            try:
+                with open(raw_log_path, "w") as f:
+                    f.write(f"=== STDOUT ({len(proc.stdout)} chars) ===\n")
+                    f.write(proc.stdout)
+                    f.write(f"\n=== STDERR ({len(proc.stderr)} chars) ===\n")
+                    f.write(proc.stderr)
+                logger.info(f"Live debugger raw log: {raw_log_path}")
+            except OSError as e:
+                logger.warning(f"Could not write raw log: {e}")
+
+        if proc.returncode != 0:
+            stderr_text = proc.stderr.strip()[:500] if proc.stderr else ""
+            stdout_text = proc.stdout.strip()[:500] if proc.stdout else ""
+            result["error"] = (
+                f"Claude Code exited with code {proc.returncode}: "
+                f"stderr={stderr_text} stdout={stdout_text}"
+            )
+            logger.error(result["error"])
+            logger.error(f"Command was: {' '.join(cmd)}")
             if log_dir:
                 self._save_results(result, test_name, log_dir)
             return result
 
-        returncode = proc.returncode if proc else -1
-
-        if returncode != 0:
-            stderr_text = ""
-            if proc and proc.stderr:
-                try:
-                    stderr_text = proc.stderr.read()[:500]
-                except Exception:
-                    pass
+        # Parse the JSON response
+        try:
+            response = json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
             result["error"] = (
-                f"Claude Code exited with code {returncode}: "
-                f"stderr={stderr_text}"
+                f"Failed to parse Claude response as JSON: {e}. "
+                f"Output length: {len(proc.stdout)} chars"
             )
             logger.error(result["error"])
-            logger.error(f"Command was: {' '.join(cmd)}")
-            # Still save partial results if we have them
-            if result_text:
-                result["investigation"] = result_text
-                result["category"] = self._extract_category(result_text)
-                result["root_cause"] = self._extract_section(
-                    result_text, "ROOT CAUSE"
-                )
-                if log_dir:
-                    self._save_results(result, test_name, log_dir)
+            result["investigation"] = proc.stdout
+            if log_dir:
+                self._save_results(result, test_name, log_dir)
             return result
 
-        # Extract result text and metadata from the final result event
+        # Extract result text and metadata
+        result_text = response.get("result", "")
         result["investigation"] = result_text
-        if final_result_event:
-            result["cost_usd"] = final_result_event.get("total_cost_usd", 0.0)
-            result["num_turns"] = final_result_event.get("num_turns", 0)
+        result["cost_usd"] = response.get("total_cost_usd", 0.0)
+        result["num_turns"] = response.get("num_turns", 0)
 
         # Parse structured fields from the investigation narrative
         result["category"] = self._extract_category(result_text)
@@ -338,7 +263,7 @@ class LiveClusterDebugger:
         )
 
         # Safety audit -- check what commands were executed
-        commands = self._extract_commands_from_stream(stream_events)
+        commands = self._extract_commands_from_response(response)
         result["commands_executed"] = commands
         violations = audit_commands(commands)
         result["safety_violations"] = violations
@@ -409,89 +334,21 @@ class LiveClusterDebugger:
                 points.append(re.sub(r"^\d+\.\s*", "", line).strip())
         return points
 
-    def _log_stream_event(self, test_name, event):
-        """Log a human-readable summary of a stream-json event."""
-        event_type = event.get("type", "")
-        tag = f"Live debugger [{test_name}]"
-
-        if event_type == "assistant":
-            # Assistant message — extract text content blocks
-            message = event.get("message", {})
-            for block in message.get("content", []):
-                if block.get("type") == "text":
-                    text = block.get("text", "")
-                    # Log first 300 chars of text blocks
-                    for line in text.split("\n"):
-                        line = line.strip()
-                        if line:
-                            logger.info(f"{tag}: {line[:300]}")
-                elif block.get("type") == "tool_use":
-                    tool_name = block.get("name", "?")
-                    tool_input = block.get("input", {})
-                    if tool_name == "Bash":
-                        cmd = tool_input.get("command", "")
-                        logger.info(f"{tag}: [Bash] {cmd[:200]}")
-                    elif tool_name == "Read":
-                        path = tool_input.get("file_path", "")
-                        logger.info(f"{tag}: [Read] {path}")
-                    else:
-                        logger.info(f"{tag}: [Tool: {tool_name}]")
-
-        elif event_type == "tool_result":
-            # Tool result — just log that it completed (output can be huge)
-            tool_name = event.get("tool_name", "?")
-            logger.info(f"{tag}: [Result from {tool_name}]")
-
-        elif event_type == "result":
-            # Final result — log summary
-            cost = event.get("total_cost_usd", 0)
-            turns = event.get("num_turns", 0)
-            logger.info(
-                f"{tag}: Investigation complete "
-                f"(cost=${cost:.4f}, turns={turns})"
-            )
-
-        elif event_type == "system":
-            # System messages (init, etc.)
-            msg = event.get("message", "")
-            if msg:
-                logger.info(f"{tag}: [system] {str(msg)[:200]}")
-
-    def _extract_result_from_stream(self, stream_events, final_result_event):
-        """Extract the investigation text from stream events.
-
-        If we have a final ``result`` event, use its ``result`` field.
-        Otherwise, concatenate all assistant text blocks as a fallback
-        (useful when the process was killed before finishing).
-        """
-        if final_result_event:
-            return final_result_event.get("result", "")
-
-        # Fallback: collect all assistant text blocks
-        text_parts = []
-        for event in stream_events:
-            if event.get("type") == "assistant":
-                message = event.get("message", {})
-                for block in message.get("content", []):
-                    if block.get("type") == "text":
-                        text_parts.append(block.get("text", ""))
-        return "\n".join(text_parts)
-
-    def _extract_commands_from_stream(self, stream_events):
-        """Extract bash commands that Claude executed from stream events."""
+    def _extract_commands_from_response(self, response):
+        """Extract bash commands that Claude executed from the JSON response."""
         commands = []
-        for event in stream_events:
-            if event.get("type") != "assistant":
-                continue
-            message = event.get("message", {})
-            for block in message.get("content", []):
-                if (
-                    block.get("type") == "tool_use"
-                    and block.get("name") == "Bash"
-                ):
-                    cmd = block.get("input", {}).get("command", "")
-                    if cmd:
-                        commands.append(cmd)
+        result_text = response.get("result", "")
+        # Look for commands in code blocks within the result
+        for match in re.finditer(
+            r"```(?:bash|shell)?\s*\n(.*?)```", result_text, re.DOTALL
+        ):
+            for line in match.group(1).strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    commands.append(line)
+        # Also look for $ prefixed commands
+        for match in re.finditer(r"^\$\s+(.+)$", result_text, re.MULTILINE):
+            commands.append(match.group(1).strip())
         return commands
 
     def _save_results(self, result, test_name, log_dir):

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -156,9 +156,11 @@ class LiveClusterDebugger:
 
         logger.info(
             f"Live debugger: investigating {test_name} "
-            f"(model={self.model}, budget=${self.max_budget_usd:.2f}, "
-            f"timeout={self.timeout}s)"
+            f"(model={self.model}, resolved_model={resolved_model}, "
+            f"budget=${self.max_budget_usd:.2f}, timeout={self.timeout}s, "
+            f"prompt_len={len(prompt)} chars)"
         )
+        logger.info(f"Live debugger command: {' '.join(cmd)}")
 
         try:
             proc = subprocess.run(
@@ -169,12 +171,17 @@ class LiveClusterDebugger:
                 timeout=self.timeout,
                 env=env,
             )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
+            # Capture any partial output from the timed-out process
+            partial_stdout = (e.stdout or "")[:500] if e.stdout else ""
+            partial_stderr = (e.stderr or "")[:500] if e.stderr else ""
             result["error"] = (
                 f"Live debugger timed out after {self.timeout}s for {test_name}"
             )
             result["duration_seconds"] = time.time() - start
             logger.error(result["error"])
+            logger.error(f"Partial stdout on timeout: {partial_stdout}")
+            logger.error(f"Partial stderr on timeout: {partial_stderr}")
             return result
         except FileNotFoundError:
             result["error"] = "Claude Code CLI ('claude') not found"

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -66,6 +66,10 @@ class LiveClusterDebugger:
         """
         Spawn ``claude -p`` to investigate a test failure on the live cluster.
 
+        Uses subprocess.Popen with streaming output so that Claude's progress
+        is logged in real-time to both a log file and the pytest console.
+        The final JSON result (from --output-format json) is parsed at the end.
+
         Args:
             test_name: Short test name (e.g. ``test_create_pvc``).
             test_nodeid: Full pytest node ID.
@@ -162,27 +166,80 @@ class LiveClusterDebugger:
         )
         logger.info(f"Live debugger command: {' '.join(cmd)}")
 
+        # Set up the streaming log file
+        safe_name = re.sub(r"[^\w\-.]", "_", test_name)
+        stream_log_path = None
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+            stream_log_path = os.path.join(
+                log_dir, f"{safe_name}_live_debug_stream.log"
+            )
+
+        # Use Popen for streaming output instead of subprocess.run
+        # This gives us real-time visibility into what Claude is doing
+        all_output = []
+        timed_out = False
+        proc = None
+
         try:
-            proc = subprocess.run(
+            proc = subprocess.Popen(
                 cmd,
-                input=prompt,
-                capture_output=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=self.timeout,
                 env=env,
             )
-        except subprocess.TimeoutExpired as e:
-            # Capture any partial output from the timed-out process
-            partial_stdout = (e.stdout or "")[:500] if e.stdout else ""
-            partial_stderr = (e.stderr or "")[:500] if e.stderr else ""
-            result["error"] = (
-                f"Live debugger timed out after {self.timeout}s for {test_name}"
-            )
-            result["duration_seconds"] = time.time() - start
-            logger.error(result["error"])
-            logger.error(f"Partial stdout on timeout: {partial_stdout}")
-            logger.error(f"Partial stderr on timeout: {partial_stderr}")
-            return result
+
+            # Send prompt via stdin and close it
+            proc.stdin.write(prompt)
+            proc.stdin.close()
+
+            # Open stream log file if we have a log_dir
+            stream_log_file = None
+            if stream_log_path:
+                try:
+                    stream_log_file = open(stream_log_path, "w")
+                except OSError as e:
+                    logger.warning(f"Could not open stream log file: {e}")
+
+            # Read stdout line by line with timeout
+            deadline = time.time() + self.timeout
+            try:
+                for line in proc.stdout:
+                    line = line.rstrip("\n")
+                    all_output.append(line)
+
+                    # Write to stream log file
+                    if stream_log_file:
+                        stream_log_file.write(line + "\n")
+                        stream_log_file.flush()
+
+                    # Log progress lines to pytest console
+                    # Skip very long lines (likely JSON result) in console
+                    if len(line) < 500:
+                        logger.info(f"Live debugger [{test_name}]: {line}")
+
+                    # Check timeout
+                    if time.time() > deadline:
+                        timed_out = True
+                        logger.error(
+                            f"Live debugger timed out after {self.timeout}s "
+                            f"for {test_name} (collected {len(all_output)} lines)"
+                        )
+                        proc.kill()
+                        break
+            finally:
+                if stream_log_file:
+                    stream_log_file.close()
+
+            # Wait for process to finish (or confirm it was killed)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
         except FileNotFoundError:
             result["error"] = "Claude Code CLI ('claude') not found"
             result["duration_seconds"] = time.time() - start
@@ -196,25 +253,56 @@ class LiveClusterDebugger:
 
         result["duration_seconds"] = time.time() - start
 
-        if proc.returncode != 0:
-            stderr_text = proc.stderr.strip()[:500] if proc.stderr else ""
-            stdout_text = proc.stdout.strip()[:500] if proc.stdout else ""
+        # Combine all output
+        full_output = "\n".join(all_output)
+
+        if stream_log_path:
+            logger.info(f"Live debugger stream log: {stream_log_path}")
+
+        if timed_out:
             result["error"] = (
-                f"Claude Code exited with code {proc.returncode}: "
-                f"stderr={stderr_text} stdout={stdout_text}"
+                f"Live debugger timed out after {self.timeout}s for {test_name}. "
+                f"Collected {len(all_output)} lines before timeout."
             )
-            logger.error(result["error"])
-            # Log the command (without the full prompt) for debugging
-            cmd_summary = [c for c in cmd if c != prompt]
-            logger.error(f"Command was: {' '.join(cmd_summary)}")
+            # Still try to extract useful info from partial output
+            result["investigation"] = full_output
+            result["category"] = self._extract_category(full_output)
+            result["root_cause"] = self._extract_section(full_output, "ROOT CAUSE")
+            if log_dir:
+                self._save_results(result, test_name, log_dir)
             return result
 
-        # Parse the JSON response
-        try:
-            response = json.loads(proc.stdout)
-        except json.JSONDecodeError as e:
-            result["error"] = f"Failed to parse Claude response as JSON: {e}"
+        returncode = proc.returncode if proc else -1
+
+        if returncode != 0 and not timed_out:
+            stderr_text = ""
+            if proc and proc.stderr:
+                try:
+                    stderr_text = proc.stderr.read()[:500]
+                except Exception:
+                    pass
+            result["error"] = (
+                f"Claude Code exited with code {returncode}: "
+                f"stderr={stderr_text} stdout={full_output[:500]}"
+            )
             logger.error(result["error"])
+            logger.error(f"Command was: {' '.join(cmd)}")
+            return result
+
+        # Parse the JSON response — it's the complete output when using
+        # --output-format json (single JSON blob)
+        try:
+            response = json.loads(full_output)
+        except json.JSONDecodeError as e:
+            result["error"] = (
+                f"Failed to parse Claude response as JSON: {e}. "
+                f"Output length: {len(full_output)} chars"
+            )
+            logger.error(result["error"])
+            # Still save the raw output as investigation text
+            result["investigation"] = full_output
+            if log_dir:
+                self._save_results(result, test_name, log_dir)
             return result
 
         # Extract result text and metadata

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -128,7 +128,7 @@ class LiveClusterDebugger:
         # aliases in older Claude Code CLI versions
         model_aliases = {
             "opus": "claude-opus-4-6",
-            "sonnet": "claude-sonnet-4-5-20250514",
+            "sonnet": "claude-sonnet-4-6",
             "haiku": "claude-haiku-4-5-20251001",
         }
         resolved_model = model_aliases.get(self.model, self.model)

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -1,0 +1,336 @@
+"""
+Live Cluster Debugger -- investigates test failures on a live OpenShift cluster.
+
+When a test fails during execution, this module spawns a Claude Code session
+that reads the test source code and logs, then runs read-only ``oc`` commands
+to diagnose the root cause and classify the failure.
+"""
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+
+from jinja2 import Environment, FileSystemLoader
+
+from ocs_ci.framework import config as ocsci_config
+from ocs_ci.utility.live_debugger.safety import audit_commands
+
+logger = logging.getLogger(__name__)
+
+PROMPT_TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "prompt_templates")
+
+
+class LiveClusterDebugger:
+    """
+    Spawns ``claude -p`` with Bash and Read tools to investigate a live
+    cluster after a test failure.
+
+    The Claude session can:
+    - Read the test source file to understand the test flow
+    - Read the test log file to see what commands ran
+    - Run ``oc`` commands to inspect live cluster state
+    """
+
+    def __init__(self, model="sonnet", max_budget_usd=1.00, timeout=300):
+        """
+        Args:
+            model: Claude model to use (sonnet, opus, haiku).
+            max_budget_usd: Maximum spend per investigation in USD.
+            timeout: Subprocess timeout in seconds.
+        """
+        self.model = model
+        self.max_budget_usd = max_budget_usd
+        self.timeout = timeout
+        self.jinja_env = Environment(
+            loader=FileSystemLoader(PROMPT_TEMPLATES_DIR),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def investigate(
+        self,
+        test_name,
+        test_nodeid,
+        test_source_path,
+        traceback_text,
+        markers,
+        test_start_time,
+        failure_phase="call",
+        test_log_path=None,
+        log_dir=None,
+    ):
+        """
+        Spawn ``claude -p`` to investigate a test failure on the live cluster.
+
+        Args:
+            test_name: Short test name (e.g. ``test_create_pvc``).
+            test_nodeid: Full pytest node ID.
+            test_source_path: Absolute path to the test source file.
+            traceback_text: The Python traceback string.
+            markers: Comma-separated marker names (squad, feature tags).
+            test_start_time: UTC datetime string (ISO format) when the test started.
+            failure_phase: Which phase failed (setup, call, teardown).
+            test_log_path: Path to the per-test log file (if available).
+            log_dir: Directory to write result files into.
+
+        Returns:
+            dict with keys: investigation, category, root_cause, evidence,
+            recommended_action, cost_usd, num_turns, duration_seconds, error
+        """
+        start = time.time()
+        result = {
+            "test_name": test_name,
+            "test_nodeid": test_nodeid,
+            "failure_phase": failure_phase,
+            "investigation": "",
+            "category": "unknown",
+            "root_cause": "",
+            "evidence": [],
+            "recommended_action": "",
+            "cost_usd": 0.0,
+            "num_turns": 0,
+            "duration_seconds": 0.0,
+            "error": None,
+            "commands_executed": [],
+            "safety_violations": [],
+        }
+
+        if not shutil.which("claude"):
+            result["error"] = "Claude Code CLI ('claude') not found on PATH"
+            logger.error(result["error"])
+            return result
+
+        # Build the prompt
+        cluster_namespace = ocsci_config.ENV_DATA.get(
+            "cluster_namespace", "openshift-storage"
+        )
+        platform = ocsci_config.ENV_DATA.get("platform", "unknown")
+
+        template = self.jinja_env.get_template("investigate_failure.j2")
+        prompt = template.render(
+            test_name=test_name,
+            test_nodeid=test_nodeid,
+            test_source_path=test_source_path,
+            traceback_text=self._truncate(traceback_text, 6000),
+            markers=markers,
+            test_start_time=test_start_time,
+            failure_phase=failure_phase,
+            test_log_path=test_log_path or "",
+            cluster_namespace=cluster_namespace,
+            platform=platform,
+        )
+
+        # Build the command
+        cmd = [
+            "claude",
+            "-p", prompt,
+            "--tools", "Bash,Read",
+            "--dangerously-skip-permissions",
+            "--output-format", "json",
+            "--model", self.model,
+            "--max-budget-usd", str(self.max_budget_usd),
+        ]
+
+        # Prepare environment -- same patterns as exec_cmd and claude_code_backend
+        env = os.environ.copy()
+        # Remove CLAUDECODE to allow nested sessions
+        env.pop("CLAUDECODE", None)
+        # Set KUBECONFIG so oc commands work
+        kubeconfig = ocsci_config.RUN.get("kubeconfig")
+        if kubeconfig:
+            env["KUBECONFIG"] = kubeconfig
+
+        logger.info(
+            f"Live debugger: investigating {test_name} "
+            f"(model={self.model}, budget=${self.max_budget_usd:.2f}, "
+            f"timeout={self.timeout}s)"
+        )
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            result["error"] = (
+                f"Live debugger timed out after {self.timeout}s for {test_name}"
+            )
+            result["duration_seconds"] = time.time() - start
+            logger.error(result["error"])
+            return result
+        except FileNotFoundError:
+            result["error"] = "Claude Code CLI ('claude') not found"
+            result["duration_seconds"] = time.time() - start
+            logger.error(result["error"])
+            return result
+        except OSError as e:
+            result["error"] = f"Failed to run Claude Code CLI: {e}"
+            result["duration_seconds"] = time.time() - start
+            logger.error(result["error"])
+            return result
+
+        result["duration_seconds"] = time.time() - start
+
+        if proc.returncode != 0:
+            result["error"] = (
+                f"Claude Code exited with code {proc.returncode}: "
+                f"{proc.stderr.strip()[:500]}"
+            )
+            logger.error(result["error"])
+            return result
+
+        # Parse the JSON response
+        try:
+            response = json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            result["error"] = f"Failed to parse Claude response as JSON: {e}"
+            logger.error(result["error"])
+            return result
+
+        # Extract result text and metadata
+        result_text = response.get("result", "")
+        result["investigation"] = result_text
+        result["cost_usd"] = response.get("total_cost_usd", 0.0)
+        result["num_turns"] = response.get("num_turns", 0)
+
+        # Parse structured fields from the investigation narrative
+        result["category"] = self._extract_category(result_text)
+        result["root_cause"] = self._extract_section(result_text, "ROOT CAUSE")
+        result["evidence"] = self._extract_evidence(result_text)
+        result["recommended_action"] = self._extract_section(
+            result_text, "RECOMMENDED ACTION"
+        )
+
+        # Safety audit -- check what commands were executed
+        commands = self._extract_commands_from_response(response)
+        result["commands_executed"] = commands
+        violations = audit_commands(commands)
+        result["safety_violations"] = violations
+        if violations:
+            logger.warning(
+                f"Live debugger safety violations for {test_name}: {violations}"
+            )
+
+        logger.info(
+            f"Live debugger completed for {test_name}: "
+            f"category={result['category']}, "
+            f"cost=${result['cost_usd']:.4f}, "
+            f"turns={result['num_turns']}, "
+            f"duration={result['duration_seconds']:.1f}s"
+        )
+
+        # Save per-test results
+        if log_dir:
+            self._save_results(result, test_name, log_dir)
+
+        return result
+
+    def _extract_category(self, text):
+        """Extract the failure category from the investigation text."""
+        # Look for **CATEGORY:** pattern
+        match = re.search(
+            r"\*\*CATEGORY:\*\*\s*(product_bug|test_bug|infra_issue|known_issue)",
+            text,
+            re.IGNORECASE,
+        )
+        if match:
+            return match.group(1).lower()
+        # Fallback: look for CATEGORY: without markdown
+        match = re.search(
+            r"CATEGORY:\s*(product_bug|test_bug|infra_issue|known_issue)",
+            text,
+            re.IGNORECASE,
+        )
+        if match:
+            return match.group(1).lower()
+        return "unknown"
+
+    def _extract_section(self, text, section_name):
+        """Extract content after a **SECTION:** header."""
+        pattern = rf"\*\*{re.escape(section_name)}:\*\*\s*\n?(.*?)(?:\n\*\*|\Z)"
+        match = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+        # Fallback without markdown
+        pattern = rf"{re.escape(section_name)}:\s*\n?(.*?)(?:\n[A-Z]+:|\Z)"
+        match = re.search(pattern, text, re.DOTALL | re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+        return ""
+
+    def _extract_evidence(self, text):
+        """Extract evidence bullet points from the investigation text."""
+        section = self._extract_section(text, "EVIDENCE")
+        if not section:
+            return []
+        # Parse bullet points
+        points = []
+        for line in section.split("\n"):
+            line = line.strip()
+            if line.startswith("- ") or line.startswith("* "):
+                points.append(line[2:].strip())
+            elif line.startswith("1.") or line.startswith("2.") or line.startswith("3."):
+                points.append(re.sub(r"^\d+\.\s*", "", line).strip())
+        return points
+
+    def _extract_commands_from_response(self, response):
+        """Extract bash commands that Claude executed from the JSON response."""
+        commands = []
+        # The JSON response may contain tool use records in various formats
+        # Try to extract from the result text or conversation history
+        result_text = response.get("result", "")
+        # Look for commands in code blocks within the result
+        for match in re.finditer(r"```(?:bash|shell)?\s*\n(.*?)```", result_text, re.DOTALL):
+            for line in match.group(1).strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    commands.append(line)
+        # Also look for $ prefixed commands
+        for match in re.finditer(r"^\$\s+(.+)$", result_text, re.MULTILINE):
+            commands.append(match.group(1).strip())
+        return commands
+
+    def _save_results(self, result, test_name, log_dir):
+        """Save investigation results as JSON and HTML files."""
+        os.makedirs(log_dir, exist_ok=True)
+
+        # Sanitize test name for filesystem
+        safe_name = re.sub(r"[^\w\-.]", "_", test_name)
+
+        # Save JSON
+        json_path = os.path.join(log_dir, f"{safe_name}_live_debug.json")
+        try:
+            with open(json_path, "w") as f:
+                json.dump(result, f, indent=2, default=str)
+            logger.info(f"Live debug JSON saved: {json_path}")
+        except OSError as e:
+            logger.error(f"Failed to save debug JSON: {e}")
+
+        # Save HTML
+        from ocs_ci.utility.live_debugger.report_builder import DebugReportBuilder
+        builder = DebugReportBuilder()
+        html_path = os.path.join(log_dir, f"{safe_name}_live_debug.html")
+        try:
+            html_content = builder.build_single_report(result)
+            with open(html_path, "w") as f:
+                f.write(html_content)
+            logger.info(f"Live debug HTML saved: {html_path}")
+        except OSError as e:
+            logger.error(f"Failed to save debug HTML: {e}")
+
+    @staticmethod
+    def _truncate(text, max_chars):
+        """Truncate text to max_chars with a notice."""
+        if not text or len(text) <= max_chars:
+            return text or ""
+        return (
+            text[:max_chars]
+            + f"\n... [truncated, {len(text) - max_chars} chars omitted]"
+        )

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -134,7 +134,7 @@ class LiveClusterDebugger:
         model_aliases = {
             "opus": "claude-opus-4-6",
             "sonnet": "claude-sonnet-4-6",
-            "haiku": "claude-haiku-4-5-20251001",
+            "haiku": "claude-haiku-4-5",
         }
         resolved_model = model_aliases.get(self.model, self.model)
 

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -66,9 +66,10 @@ class LiveClusterDebugger:
         """
         Spawn ``claude -p`` to investigate a test failure on the live cluster.
 
-        Uses subprocess.Popen with streaming output so that Claude's progress
-        is logged in real-time to both a log file and the pytest console.
-        The final JSON result (from --output-format json) is parsed at the end.
+        Uses subprocess.Popen with ``--output-format stream-json`` so that
+        Claude's progress is logged in real-time to both a log file and the
+        pytest console. Each line of stdout is a JSON event (NDJSON format).
+        The final ``result`` event contains the investigation text and cost.
 
         Args:
             test_name: Short test name (e.g. ``test_create_pvc``).
@@ -138,13 +139,15 @@ class LiveClusterDebugger:
         resolved_model = model_aliases.get(self.model, self.model)
 
         # Build the command — prompt is passed via stdin to avoid
-        # shell argument length limits on large prompts
+        # shell argument length limits on large prompts.
+        # Use stream-json so we get real-time NDJSON events instead of
+        # a single buffered JSON blob (which blocks all streaming).
         cmd = [
             "claude",
             "-p",
             "--tools", "Bash,Read",
             "--dangerously-skip-permissions",
-            "--output-format", "json",
+            "--output-format", "stream-json",
             "--model", resolved_model,
             "--max-budget-usd", str(self.max_budget_usd),
         ]
@@ -175,11 +178,13 @@ class LiveClusterDebugger:
                 log_dir, f"{safe_name}_live_debug_stream.log"
             )
 
-        # Use Popen for streaming output instead of subprocess.run
-        # This gives us real-time visibility into what Claude is doing
-        all_output = []
+        # Use Popen for streaming output with stream-json format.
+        # Each line is a JSON event (NDJSON). We parse events in real-time
+        # for logging and collect the final result event at the end.
+        stream_events = []
         timed_out = False
         proc = None
+        final_result_event = None
 
         try:
             proc = subprocess.Popen(
@@ -203,29 +208,46 @@ class LiveClusterDebugger:
                 except OSError as e:
                     logger.warning(f"Could not open stream log file: {e}")
 
-            # Read stdout line by line with timeout
+            # Read stdout line by line — each line is a JSON event
             deadline = time.time() + self.timeout
             try:
-                for line in proc.stdout:
-                    line = line.rstrip("\n")
-                    all_output.append(line)
+                for raw_line in proc.stdout:
+                    raw_line = raw_line.rstrip("\n")
+                    if not raw_line:
+                        continue
 
-                    # Write to stream log file
+                    # Write raw NDJSON to stream log file
                     if stream_log_file:
-                        stream_log_file.write(line + "\n")
+                        stream_log_file.write(raw_line + "\n")
                         stream_log_file.flush()
 
-                    # Log progress lines to pytest console
-                    # Skip very long lines (likely JSON result) in console
-                    if len(line) < 500:
-                        logger.info(f"Live debugger [{test_name}]: {line}")
+                    # Parse the JSON event
+                    try:
+                        event = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        logger.debug(
+                            f"Live debugger [{test_name}]: "
+                            f"non-JSON line: {raw_line[:200]}"
+                        )
+                        continue
+
+                    stream_events.append(event)
+                    event_type = event.get("type", "")
+
+                    # Log human-readable progress based on event type
+                    self._log_stream_event(test_name, event)
+
+                    # Capture the final result event
+                    if event_type == "result":
+                        final_result_event = event
 
                     # Check timeout
                     if time.time() > deadline:
                         timed_out = True
                         logger.error(
                             f"Live debugger timed out after {self.timeout}s "
-                            f"for {test_name} (collected {len(all_output)} lines)"
+                            f"for {test_name} "
+                            f"(collected {len(stream_events)} events)"
                         )
                         proc.kill()
                         break
@@ -253,28 +275,30 @@ class LiveClusterDebugger:
 
         result["duration_seconds"] = time.time() - start
 
-        # Combine all output
-        full_output = "\n".join(all_output)
-
         if stream_log_path:
             logger.info(f"Live debugger stream log: {stream_log_path}")
+
+        # Reconstruct the investigation text from stream events
+        result_text = self._extract_result_from_stream(
+            stream_events, final_result_event
+        )
 
         if timed_out:
             result["error"] = (
                 f"Live debugger timed out after {self.timeout}s for {test_name}. "
-                f"Collected {len(all_output)} lines before timeout."
+                f"Collected {len(stream_events)} events before timeout."
             )
-            # Still try to extract useful info from partial output
-            result["investigation"] = full_output
-            result["category"] = self._extract_category(full_output)
-            result["root_cause"] = self._extract_section(full_output, "ROOT CAUSE")
+            # Still use whatever text we managed to collect
+            result["investigation"] = result_text
+            result["category"] = self._extract_category(result_text)
+            result["root_cause"] = self._extract_section(result_text, "ROOT CAUSE")
             if log_dir:
                 self._save_results(result, test_name, log_dir)
             return result
 
         returncode = proc.returncode if proc else -1
 
-        if returncode != 0 and not timed_out:
+        if returncode != 0:
             stderr_text = ""
             if proc and proc.stderr:
                 try:
@@ -283,33 +307,26 @@ class LiveClusterDebugger:
                     pass
             result["error"] = (
                 f"Claude Code exited with code {returncode}: "
-                f"stderr={stderr_text} stdout={full_output[:500]}"
+                f"stderr={stderr_text}"
             )
             logger.error(result["error"])
             logger.error(f"Command was: {' '.join(cmd)}")
+            # Still save partial results if we have them
+            if result_text:
+                result["investigation"] = result_text
+                result["category"] = self._extract_category(result_text)
+                result["root_cause"] = self._extract_section(
+                    result_text, "ROOT CAUSE"
+                )
+                if log_dir:
+                    self._save_results(result, test_name, log_dir)
             return result
 
-        # Parse the JSON response — it's the complete output when using
-        # --output-format json (single JSON blob)
-        try:
-            response = json.loads(full_output)
-        except json.JSONDecodeError as e:
-            result["error"] = (
-                f"Failed to parse Claude response as JSON: {e}. "
-                f"Output length: {len(full_output)} chars"
-            )
-            logger.error(result["error"])
-            # Still save the raw output as investigation text
-            result["investigation"] = full_output
-            if log_dir:
-                self._save_results(result, test_name, log_dir)
-            return result
-
-        # Extract result text and metadata
-        result_text = response.get("result", "")
+        # Extract result text and metadata from the final result event
         result["investigation"] = result_text
-        result["cost_usd"] = response.get("total_cost_usd", 0.0)
-        result["num_turns"] = response.get("num_turns", 0)
+        if final_result_event:
+            result["cost_usd"] = final_result_event.get("total_cost_usd", 0.0)
+            result["num_turns"] = final_result_event.get("num_turns", 0)
 
         # Parse structured fields from the investigation narrative
         result["category"] = self._extract_category(result_text)
@@ -320,7 +337,7 @@ class LiveClusterDebugger:
         )
 
         # Safety audit -- check what commands were executed
-        commands = self._extract_commands_from_response(response)
+        commands = self._extract_commands_from_stream(stream_events)
         result["commands_executed"] = commands
         violations = audit_commands(commands)
         result["safety_violations"] = violations
@@ -391,21 +408,89 @@ class LiveClusterDebugger:
                 points.append(re.sub(r"^\d+\.\s*", "", line).strip())
         return points
 
-    def _extract_commands_from_response(self, response):
-        """Extract bash commands that Claude executed from the JSON response."""
+    def _log_stream_event(self, test_name, event):
+        """Log a human-readable summary of a stream-json event."""
+        event_type = event.get("type", "")
+        tag = f"Live debugger [{test_name}]"
+
+        if event_type == "assistant":
+            # Assistant message — extract text content blocks
+            message = event.get("message", {})
+            for block in message.get("content", []):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    # Log first 300 chars of text blocks
+                    for line in text.split("\n"):
+                        line = line.strip()
+                        if line:
+                            logger.info(f"{tag}: {line[:300]}")
+                elif block.get("type") == "tool_use":
+                    tool_name = block.get("name", "?")
+                    tool_input = block.get("input", {})
+                    if tool_name == "Bash":
+                        cmd = tool_input.get("command", "")
+                        logger.info(f"{tag}: [Bash] {cmd[:200]}")
+                    elif tool_name == "Read":
+                        path = tool_input.get("file_path", "")
+                        logger.info(f"{tag}: [Read] {path}")
+                    else:
+                        logger.info(f"{tag}: [Tool: {tool_name}]")
+
+        elif event_type == "tool_result":
+            # Tool result — just log that it completed (output can be huge)
+            tool_name = event.get("tool_name", "?")
+            logger.info(f"{tag}: [Result from {tool_name}]")
+
+        elif event_type == "result":
+            # Final result — log summary
+            cost = event.get("total_cost_usd", 0)
+            turns = event.get("num_turns", 0)
+            logger.info(
+                f"{tag}: Investigation complete "
+                f"(cost=${cost:.4f}, turns={turns})"
+            )
+
+        elif event_type == "system":
+            # System messages (init, etc.)
+            msg = event.get("message", "")
+            if msg:
+                logger.info(f"{tag}: [system] {str(msg)[:200]}")
+
+    def _extract_result_from_stream(self, stream_events, final_result_event):
+        """Extract the investigation text from stream events.
+
+        If we have a final ``result`` event, use its ``result`` field.
+        Otherwise, concatenate all assistant text blocks as a fallback
+        (useful when the process was killed before finishing).
+        """
+        if final_result_event:
+            return final_result_event.get("result", "")
+
+        # Fallback: collect all assistant text blocks
+        text_parts = []
+        for event in stream_events:
+            if event.get("type") == "assistant":
+                message = event.get("message", {})
+                for block in message.get("content", []):
+                    if block.get("type") == "text":
+                        text_parts.append(block.get("text", ""))
+        return "\n".join(text_parts)
+
+    def _extract_commands_from_stream(self, stream_events):
+        """Extract bash commands that Claude executed from stream events."""
         commands = []
-        # The JSON response may contain tool use records in various formats
-        # Try to extract from the result text or conversation history
-        result_text = response.get("result", "")
-        # Look for commands in code blocks within the result
-        for match in re.finditer(r"```(?:bash|shell)?\s*\n(.*?)```", result_text, re.DOTALL):
-            for line in match.group(1).strip().split("\n"):
-                line = line.strip()
-                if line and not line.startswith("#"):
-                    commands.append(line)
-        # Also look for $ prefixed commands
-        for match in re.finditer(r"^\$\s+(.+)$", result_text, re.MULTILINE):
-            commands.append(match.group(1).strip())
+        for event in stream_events:
+            if event.get("type") != "assistant":
+                continue
+            message = event.get("message", {})
+            for block in message.get("content", []):
+                if (
+                    block.get("type") == "tool_use"
+                    and block.get("name") == "Bash"
+                ):
+                    cmd = block.get("input", {}).get("command", "")
+                    if cmd:
+                        commands.append(cmd)
         return commands
 
     def _save_results(self, result, test_name, log_dir):

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -147,6 +147,7 @@ class LiveClusterDebugger:
             "-p",
             "--tools", "Bash,Read",
             "--dangerously-skip-permissions",
+            "--verbose",
             "--output-format", "stream-json",
             "--model", resolved_model,
             "--max-budget-usd", str(self.max_budget_usd),

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -133,10 +133,11 @@ class LiveClusterDebugger:
         }
         resolved_model = model_aliases.get(self.model, self.model)
 
-        # Build the command
+        # Build the command — prompt is passed via stdin to avoid
+        # shell argument length limits on large prompts
         cmd = [
             "claude",
-            "-p", prompt,
+            "-p",
             "--tools", "Bash,Read",
             "--dangerously-skip-permissions",
             "--output-format", "json",
@@ -162,6 +163,7 @@ class LiveClusterDebugger:
         try:
             proc = subprocess.run(
                 cmd,
+                input=prompt,
                 capture_output=True,
                 text=True,
                 timeout=self.timeout,

--- a/ocs_ci/utility/live_debugger/debugger.py
+++ b/ocs_ci/utility/live_debugger/debugger.py
@@ -124,6 +124,15 @@ class LiveClusterDebugger:
             platform=platform,
         )
 
+        # Resolve model short names to full model IDs to avoid stale
+        # aliases in older Claude Code CLI versions
+        model_aliases = {
+            "opus": "claude-opus-4-6",
+            "sonnet": "claude-sonnet-4-5-20250514",
+            "haiku": "claude-haiku-4-5-20251001",
+        }
+        resolved_model = model_aliases.get(self.model, self.model)
+
         # Build the command
         cmd = [
             "claude",
@@ -131,7 +140,7 @@ class LiveClusterDebugger:
             "--tools", "Bash,Read",
             "--dangerously-skip-permissions",
             "--output-format", "json",
-            "--model", self.model,
+            "--model", resolved_model,
             "--max-budget-usd", str(self.max_budget_usd),
         ]
 
@@ -179,11 +188,16 @@ class LiveClusterDebugger:
         result["duration_seconds"] = time.time() - start
 
         if proc.returncode != 0:
+            stderr_text = proc.stderr.strip()[:500] if proc.stderr else ""
+            stdout_text = proc.stdout.strip()[:500] if proc.stdout else ""
             result["error"] = (
                 f"Claude Code exited with code {proc.returncode}: "
-                f"{proc.stderr.strip()[:500]}"
+                f"stderr={stderr_text} stdout={stdout_text}"
             )
             logger.error(result["error"])
+            # Log the command (without the full prompt) for debugging
+            cmd_summary = [c for c in cmd if c != prompt]
+            logger.error(f"Command was: {' '.join(cmd_summary)}")
             return result
 
         # Parse the JSON response

--- a/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
+++ b/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
@@ -1,0 +1,151 @@
+You are an expert SRE and OpenShift Data Foundation (ODF/OCS) engineer performing live cluster debugging.
+A test has just failed and the cluster is still running. Your job is to investigate the failure,
+determine the root cause, and classify it.
+
+## Test Information
+- Test name: {{ test_name }}
+- Node ID: {{ test_nodeid }}
+- Test source file: {{ test_source_path }}
+- Failure phase: {{ failure_phase }}
+- Markers: {{ markers }}
+- Platform: {{ platform }}
+- Cluster namespace: {{ cluster_namespace }}
+- Test start time (UTC): {{ test_start_time }}
+{% if test_log_path %}
+- Test log file: {{ test_log_path }}
+{% endif %}
+
+## Traceback
+```
+{{ traceback_text }}
+```
+
+## Investigation Instructions
+
+Follow these three phases in order. Be methodical and focused.
+
+### Phase 1 -- Understand the test and error
+
+1. Read the test source file at `{{ test_source_path }}` to understand what the test was trying to do.
+   - What resources does it create? What operations does it perform? What does it assert?
+{% if test_log_path %}
+2. Read the test log file at `{{ test_log_path }}` to see the sequence of actions and where it broke.
+   - What commands ran successfully before the failure?
+   - What was the last successful operation?
+{% endif %}
+3. Analyze the traceback above to identify the specific error.
+
+### Phase 2 -- Targeted cluster investigation
+
+Based on the specific error from Phase 1, investigate the relevant cluster state.
+Do NOT check everything -- focus on the error area. Follow the evidence chain:
+each finding should guide your next command.
+
+Choose from these investigation approaches based on the error type:
+
+**Resource not found / wrong status:**
+- `oc get <resource-type> -n {{ cluster_namespace }}`
+- `oc describe <resource> -n {{ cluster_namespace }}`
+- `oc get events -n {{ cluster_namespace }} --sort-by='.lastTimestamp' | tail -30`
+
+**Pod failure / timeout / crash:**
+- `oc get pods -n {{ cluster_namespace }} | grep -v Running`
+- `oc describe pod <pod-name> -n {{ cluster_namespace }}`
+- `oc logs <pod-name> -n {{ cluster_namespace }} --tail=100`
+- `oc logs <pod-name> -n {{ cluster_namespace }} --previous` (for crash loops)
+
+**Ceph health issues:**
+- Find the tools pod: `oc get pods -n {{ cluster_namespace }} | grep rook-ceph-tools`
+- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph status`
+- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph health detail`
+- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph osd tree`
+- `oc exec <tools-pod> -n {{ cluster_namespace }} -- rados df`
+
+**PVC / StorageClass issues:**
+- `oc get pvc -n {{ cluster_namespace }}`
+- `oc get pvc -A | grep -i pending`
+- `oc describe pvc <pvc-name> -n {{ cluster_namespace }}`
+- `oc get sc`
+- Check provisioner pods
+
+**Node issues:**
+- `oc get nodes -o wide`
+- `oc describe node <node-name>` (look at Conditions and Taints)
+- `oc adm top nodes`
+
+**Resource exhaustion:**
+- `oc adm top nodes`
+- `oc adm top pods -n {{ cluster_namespace }} --sort-by=memory | head -20`
+
+**Networking / DNS:**
+- `oc exec <pod> -n {{ cluster_namespace }} -- nslookup <hostname>`
+- `oc exec <pod> -n {{ cluster_namespace }} -- curl -s -o /dev/null -w '%{http_code}' <url>`
+
+**Operator issues:**
+- `oc get csv -n {{ cluster_namespace }}`
+- `oc get installplan -n {{ cluster_namespace }}`
+- `oc get sub -n {{ cluster_namespace }}`
+
+**General event timeline:**
+- `oc get events -n {{ cluster_namespace }} --sort-by='.lastTimestamp' | tail -50`
+- `oc get events -A --sort-by='.lastTimestamp' --field-selector reason=Failed | tail -20`
+
+**Output processing:** Use `grep`, `awk`, `jq`, `sort`, `tail`, `head` to filter output.
+For JSON output: `oc get <resource> -o json | jq '<query>'`
+
+### Phase 3 -- Classify and recommend
+
+Based on your investigation, classify the failure into exactly ONE category:
+
+1. **product_bug** -- ODF/OCS/Ceph/Rook product code is broken. The test correctly detected a defect.
+   Recommend filing a Jira bug with the evidence you found.
+
+2. **test_bug** -- The test logic is wrong, not the product. The product is working correctly but
+   the test has a defect (wrong assertion, stale reference, missing wait, hardcoded value, etc.).
+   You MUST suggest specific code changes to fix the test (show the diff).
+
+3. **infra_issue** -- Cluster infrastructure problem unrelated to product or test code.
+   Examples: node down, network partition, DNS failure, resource exhaustion, cloud provider issue.
+
+4. **known_issue** -- Matches a known bug pattern you recognize. Reference the bug if possible.
+
+## Safety Rules
+
+You may ONLY run read-only commands. The following are PERMITTED:
+- oc get, oc describe, oc logs, oc adm top, oc exec (for ceph status/health/diagnostics only)
+- oc get events, oc whoami, oc version, oc api-resources
+- grep, awk, jq, sort, tail, head, cat, wc (for output processing)
+
+The following are STRICTLY FORBIDDEN -- never run these:
+- oc delete, oc apply, oc create, oc patch, oc edit, oc scale
+- oc drain, oc cordon, oc uncordon, oc adm (except top)
+- oc debug (it creates ephemeral pods)
+- Any command that modifies cluster state
+- rm, mv, or any file modification commands
+
+## Output Format
+
+After your investigation, provide your findings in this exact structure:
+
+**INVESTIGATION SUMMARY:**
+[2-3 paragraph narrative of what you found, linking the test intent to the cluster state]
+
+**CATEGORY:** [product_bug|test_bug|infra_issue|known_issue]
+
+**ROOT CAUSE:**
+[One clear sentence identifying the root cause]
+
+**EVIDENCE:**
+- [Evidence point 1]
+- [Evidence point 2]
+- [Evidence point 3]
+
+**RECOMMENDED ACTION:**
+[What should be done to fix this]
+
+{% if "test_bug" in "product_bug test_bug" %}
+**CODE FIX (if test_bug):**
+```python
+# Show the specific code changes needed
+```
+{% endif %}

--- a/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
+++ b/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
@@ -29,7 +29,13 @@ Follow these three phases in order. Be methodical and focused.
 1. Read the test source file at `{{ test_source_path }}` to understand what the test was trying to do.
    - What resources does it create? What operations does it perform? What does it assert?
 {% if test_log_path %}
-2. Read the test log file at `{{ test_log_path }}` to see the sequence of actions and where it broke.
+2. Inspect the test log file at `{{ test_log_path }}` to see the sequence of actions and where it broke.
+   - WARNING: Test logs can be very large (thousands of lines) because they contain full oc command output.
+     Do NOT Read the entire file. Instead, use Bash to inspect it efficiently:
+     - `wc -l {{ test_log_path }}` to check the size first
+     - `tail -200 {{ test_log_path }}` to see the end where the failure occurred
+     - `grep -n -i 'error\|failed\|exception\|traceback' {{ test_log_path }} | tail -30` to find error lines
+     - `grep -B5 -A5 '<specific_error_text>' {{ test_log_path }}` to get context around a specific error
    - What commands ran successfully before the failure?
    - What was the last successful operation?
 {% endif %}

--- a/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
+++ b/ocs_ci/utility/live_debugger/prompt_templates/investigate_failure.j2
@@ -2,6 +2,15 @@ You are an expert SRE and OpenShift Data Foundation (ODF/OCS) engineer performin
 A test has just failed and the cluster is still running. Your job is to investigate the failure,
 determine the root cause, and classify it.
 
+## CRITICAL: Speed Constraints
+
+Each API turn takes minutes. You MUST complete your entire investigation in 2-3 turns maximum.
+- Turn 1: Read the test source file AND run ALL relevant oc commands in parallel (batch them)
+- Turn 2: Based on results, run any follow-up commands AND write your final report
+- Do NOT read memory files, MEMORY.md, or any files under ~/.claude/
+- Do NOT explore the codebase beyond the test source file
+- Keep your text responses brief -- focus on commands and findings
+
 ## Test Information
 - Test name: {{ test_name }}
 - Node ID: {{ test_nodeid }}
@@ -20,126 +29,51 @@ determine the root cause, and classify it.
 {{ traceback_text }}
 ```
 
-## Investigation Instructions
+## Investigation Plan
 
-Follow these three phases in order. Be methodical and focused.
+### Turn 1 -- Read test + initial cluster check (run ALL these in parallel)
 
-### Phase 1 -- Understand the test and error
+Run all of the following simultaneously in your first response:
 
-1. Read the test source file at `{{ test_source_path }}` to understand what the test was trying to do.
-   - What resources does it create? What operations does it perform? What does it assert?
+1. Read the test source file at `{{ test_source_path }}`
 {% if test_log_path %}
-2. Inspect the test log file at `{{ test_log_path }}` to see the sequence of actions and where it broke.
-   - WARNING: Test logs can be very large (thousands of lines) because they contain full oc command output.
-     Do NOT Read the entire file. Instead, use Bash to inspect it efficiently:
-     - `wc -l {{ test_log_path }}` to check the size first
-     - `tail -200 {{ test_log_path }}` to see the end where the failure occurred
-     - `grep -n -i 'error\|failed\|exception\|traceback' {{ test_log_path }} | tail -30` to find error lines
-     - `grep -B5 -A5 '<specific_error_text>' {{ test_log_path }}` to get context around a specific error
-   - What commands ran successfully before the failure?
-   - What was the last successful operation?
+2. `tail -200 {{ test_log_path }}` (see where it failed)
+3. `grep -n -i 'error\|failed\|exception' {{ test_log_path }} | tail -20`
 {% endif %}
-3. Analyze the traceback above to identify the specific error.
+4. Based on the traceback, run the most relevant cluster commands. Pick from:
+   - `oc get pods -n {{ cluster_namespace }} | grep -v Running` (pod issues)
+   - `oc get events -n {{ cluster_namespace }} --sort-by='.lastTimestamp' | tail -30` (recent events)
+   - `oc exec $(oc get pods -n {{ cluster_namespace }} -l app=rook-ceph-tools -o name) -n {{ cluster_namespace }} -- ceph status` (Ceph health)
+   - `oc get pvc -A | grep -iv bound` (PVC issues)
+   - `oc get nodes -o wide` (node issues)
+   - `oc adm top nodes` (resource exhaustion)
 
-### Phase 2 -- Targeted cluster investigation
+### Turn 2 -- Follow-up + final report
 
-Based on the specific error from Phase 1, investigate the relevant cluster state.
-Do NOT check everything -- focus on the error area. Follow the evidence chain:
-each finding should guide your next command.
-
-Choose from these investigation approaches based on the error type:
-
-**Resource not found / wrong status:**
-- `oc get <resource-type> -n {{ cluster_namespace }}`
-- `oc describe <resource> -n {{ cluster_namespace }}`
-- `oc get events -n {{ cluster_namespace }} --sort-by='.lastTimestamp' | tail -30`
-
-**Pod failure / timeout / crash:**
-- `oc get pods -n {{ cluster_namespace }} | grep -v Running`
-- `oc describe pod <pod-name> -n {{ cluster_namespace }}`
-- `oc logs <pod-name> -n {{ cluster_namespace }} --tail=100`
-- `oc logs <pod-name> -n {{ cluster_namespace }} --previous` (for crash loops)
-
-**Ceph health issues:**
-- Find the tools pod: `oc get pods -n {{ cluster_namespace }} | grep rook-ceph-tools`
-- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph status`
-- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph health detail`
-- `oc exec <tools-pod> -n {{ cluster_namespace }} -- ceph osd tree`
-- `oc exec <tools-pod> -n {{ cluster_namespace }} -- rados df`
-
-**PVC / StorageClass issues:**
-- `oc get pvc -n {{ cluster_namespace }}`
-- `oc get pvc -A | grep -i pending`
-- `oc describe pvc <pvc-name> -n {{ cluster_namespace }}`
-- `oc get sc`
-- Check provisioner pods
-
-**Node issues:**
-- `oc get nodes -o wide`
-- `oc describe node <node-name>` (look at Conditions and Taints)
-- `oc adm top nodes`
-
-**Resource exhaustion:**
-- `oc adm top nodes`
-- `oc adm top pods -n {{ cluster_namespace }} --sort-by=memory | head -20`
-
-**Networking / DNS:**
-- `oc exec <pod> -n {{ cluster_namespace }} -- nslookup <hostname>`
-- `oc exec <pod> -n {{ cluster_namespace }} -- curl -s -o /dev/null -w '%{http_code}' <url>`
-
-**Operator issues:**
-- `oc get csv -n {{ cluster_namespace }}`
-- `oc get installplan -n {{ cluster_namespace }}`
-- `oc get sub -n {{ cluster_namespace }}`
-
-**General event timeline:**
-- `oc get events -n {{ cluster_namespace }} --sort-by='.lastTimestamp' | tail -50`
-- `oc get events -A --sort-by='.lastTimestamp' --field-selector reason=Failed | tail -20`
-
-**Output processing:** Use `grep`, `awk`, `jq`, `sort`, `tail`, `head` to filter output.
-For JSON output: `oc get <resource> -o json | jq '<query>'`
-
-### Phase 3 -- Classify and recommend
-
-Based on your investigation, classify the failure into exactly ONE category:
-
-1. **product_bug** -- ODF/OCS/Ceph/Rook product code is broken. The test correctly detected a defect.
-   Recommend filing a Jira bug with the evidence you found.
-
-2. **test_bug** -- The test logic is wrong, not the product. The product is working correctly but
-   the test has a defect (wrong assertion, stale reference, missing wait, hardcoded value, etc.).
-   You MUST suggest specific code changes to fix the test (show the diff).
-
-3. **infra_issue** -- Cluster infrastructure problem unrelated to product or test code.
-   Examples: node down, network partition, DNS failure, resource exhaustion, cloud provider issue.
-
-4. **known_issue** -- Matches a known bug pattern you recognize. Reference the bug if possible.
+Based on Turn 1 findings, run any targeted follow-up commands AND produce your final report in the same response.
 
 ## Safety Rules
 
-You may ONLY run read-only commands. The following are PERMITTED:
-- oc get, oc describe, oc logs, oc adm top, oc exec (for ceph status/health/diagnostics only)
-- oc get events, oc whoami, oc version, oc api-resources
-- grep, awk, jq, sort, tail, head, cat, wc (for output processing)
+ONLY read-only commands. PERMITTED: oc get, oc describe, oc logs, oc adm top, oc exec (ceph diagnostics), grep, awk, jq, tail, head, cat, wc.
+FORBIDDEN: oc delete/apply/create/patch/edit/scale/drain/cordon/debug, rm, mv, any state modification.
 
-The following are STRICTLY FORBIDDEN -- never run these:
-- oc delete, oc apply, oc create, oc patch, oc edit, oc scale
-- oc drain, oc cordon, oc uncordon, oc adm (except top)
-- oc debug (it creates ephemeral pods)
-- Any command that modifies cluster state
-- rm, mv, or any file modification commands
+## Classification
+
+Classify the failure as exactly ONE of:
+1. **product_bug** -- ODF/OCS/Ceph/Rook product defect
+2. **test_bug** -- test logic is wrong (suggest specific code fix)
+3. **infra_issue** -- cluster infrastructure problem (node, network, resources)
+4. **known_issue** -- matches a known bug pattern
 
 ## Output Format
 
-After your investigation, provide your findings in this exact structure:
-
 **INVESTIGATION SUMMARY:**
-[2-3 paragraph narrative of what you found, linking the test intent to the cluster state]
+[2-3 paragraph narrative]
 
 **CATEGORY:** [product_bug|test_bug|infra_issue|known_issue]
 
 **ROOT CAUSE:**
-[One clear sentence identifying the root cause]
+[One clear sentence]
 
 **EVIDENCE:**
 - [Evidence point 1]
@@ -148,10 +82,3 @@ After your investigation, provide your findings in this exact structure:
 
 **RECOMMENDED ACTION:**
 [What should be done to fix this]
-
-{% if "test_bug" in "product_bug test_bug" %}
-**CODE FIX (if test_bug):**
-```python
-# Show the specific code changes needed
-```
-{% endif %}

--- a/ocs_ci/utility/live_debugger/report_builder.py
+++ b/ocs_ci/utility/live_debugger/report_builder.py
@@ -1,0 +1,416 @@
+"""
+HTML report generation for live cluster debugging results.
+
+Generates per-test reports and a session-level aggregated report
+with expandable sections for each investigated test failure.
+"""
+
+import html
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+# Category colors for the report
+CATEGORY_COLORS = {
+    "product_bug": "#dc3545",
+    "test_bug": "#fd7e14",
+    "infra_issue": "#6f42c1",
+    "known_issue": "#17a2b8",
+    "unknown": "#6c757d",
+}
+
+CATEGORY_LABELS = {
+    "product_bug": "Product Bug",
+    "test_bug": "Test Bug",
+    "infra_issue": "Infra Issue",
+    "known_issue": "Known Issue",
+    "unknown": "Unknown",
+}
+
+
+class DebugReportBuilder:
+    """Generates HTML reports from live debugging investigation results."""
+
+    def build_single_report(self, result):
+        """
+        Generate HTML report for a single test investigation.
+
+        Args:
+            result: Investigation result dict from LiveClusterDebugger.investigate()
+
+        Returns:
+            str: HTML content
+        """
+        category = result.get("category", "unknown")
+        color = CATEGORY_COLORS.get(category, CATEGORY_COLORS["unknown"])
+        label = CATEGORY_LABELS.get(category, "Unknown")
+
+        investigation_html = self._markdown_to_html(
+            result.get("investigation", "No investigation data")
+        )
+        evidence_items = result.get("evidence", [])
+        evidence_html = "\n".join(
+            f"<li>{html.escape(e)}</li>" for e in evidence_items
+        ) if evidence_items else "<li>No evidence recorded</li>"
+
+        safety_violations = result.get("safety_violations", [])
+        safety_html = ""
+        if safety_violations:
+            items = "\n".join(
+                f'<li class="violation">{html.escape(v)}</li>'
+                for v in safety_violations
+            )
+            safety_html = f"""
+            <div class="safety-warning">
+                <h3>Safety Violations Detected</h3>
+                <ul>{items}</ul>
+            </div>
+            """
+
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Live Debug: {html.escape(result.get('test_name', 'Unknown'))}</title>
+{self._css()}
+</head>
+<body>
+<div class="container">
+    <h1>Live Cluster Debug Report</h1>
+    <div class="test-header">
+        <h2>{html.escape(result.get('test_name', 'Unknown'))}</h2>
+        <span class="badge" style="background:{color}">{label}</span>
+        <span class="phase-badge">{html.escape(result.get('failure_phase', 'call'))}</span>
+    </div>
+    <div class="meta">
+        <span>Node ID: <code>{html.escape(result.get('test_nodeid', ''))}</code></span>
+        <span>Cost: ${result.get('cost_usd', 0):.4f}</span>
+        <span>Turns: {result.get('num_turns', 0)}</span>
+        <span>Duration: {result.get('duration_seconds', 0):.1f}s</span>
+    </div>
+
+    {safety_html}
+
+    <h3>Root Cause</h3>
+    <p class="root-cause">{html.escape(result.get('root_cause', 'Not determined'))}</p>
+
+    <h3>Evidence</h3>
+    <ul class="evidence">{evidence_html}</ul>
+
+    <h3>Recommended Action</h3>
+    <p>{html.escape(result.get('recommended_action', 'None'))}</p>
+
+    <details>
+        <summary>Full Investigation Narrative</summary>
+        <div class="investigation">{investigation_html}</div>
+    </details>
+
+    {self._render_error(result)}
+</div>
+</body>
+</html>"""
+
+    def build_session_report(self, all_results, log_dir):
+        """
+        Generate aggregated HTML report for all investigated tests in the session.
+
+        Args:
+            all_results: List of investigation result dicts
+            log_dir: Directory to write the report to
+
+        Returns:
+            str: Path to the generated report file
+        """
+        if not all_results:
+            logger.info("No live debug results to report")
+            return None
+
+        # Compute summary stats
+        total_cost = sum(r.get("cost_usd", 0) for r in all_results)
+        total_duration = sum(r.get("duration_seconds", 0) for r in all_results)
+        category_counts = {}
+        for r in all_results:
+            cat = r.get("category", "unknown")
+            category_counts[cat] = category_counts.get(cat, 0) + 1
+
+        # Build summary table rows
+        summary_rows = []
+        for r in all_results:
+            cat = r.get("category", "unknown")
+            color = CATEGORY_COLORS.get(cat, CATEGORY_COLORS["unknown"])
+            label = CATEGORY_LABELS.get(cat, "Unknown")
+            test_name = html.escape(r.get("test_name", "Unknown"))
+            root_cause = html.escape(
+                self._truncate_text(r.get("root_cause", ""), 120)
+            )
+            summary_rows.append(f"""
+                <tr>
+                    <td><code>{test_name}</code></td>
+                    <td><span class="badge" style="background:{color}">{label}</span></td>
+                    <td class="phase">{html.escape(r.get('failure_phase', 'call'))}</td>
+                    <td>{root_cause}</td>
+                    <td>${r.get('cost_usd', 0):.4f}</td>
+                    <td>{r.get('duration_seconds', 0):.0f}s</td>
+                </tr>
+            """)
+
+        # Build per-test expandable sections
+        detail_sections = []
+        for i, r in enumerate(all_results):
+            cat = r.get("category", "unknown")
+            color = CATEGORY_COLORS.get(cat, CATEGORY_COLORS["unknown"])
+            label = CATEGORY_LABELS.get(cat, "Unknown")
+            test_name = html.escape(r.get("test_name", "Unknown"))
+            investigation_html = self._markdown_to_html(
+                r.get("investigation", "No investigation data")
+            )
+            evidence_items = r.get("evidence", [])
+            evidence_html = "\n".join(
+                f"<li>{html.escape(e)}</li>" for e in evidence_items
+            ) if evidence_items else "<li>No evidence</li>"
+
+            safety_violations = r.get("safety_violations", [])
+            safety_html = ""
+            if safety_violations:
+                items = "\n".join(
+                    f'<li class="violation">{html.escape(v)}</li>'
+                    for v in safety_violations
+                )
+                safety_html = f"""
+                <div class="safety-warning">
+                    <h4>Safety Violations</h4>
+                    <ul>{items}</ul>
+                </div>
+                """
+
+            detail_sections.append(f"""
+            <details class="test-detail" {"open" if i == 0 else ""}>
+                <summary>
+                    <span class="badge" style="background:{color}">{label}</span>
+                    <code>{test_name}</code>
+                    <span class="phase-badge">{html.escape(r.get('failure_phase', 'call'))}</span>
+                </summary>
+                <div class="detail-body">
+                    {safety_html}
+                    <h4>Root Cause</h4>
+                    <p class="root-cause">{html.escape(r.get('root_cause', 'Not determined'))}</p>
+
+                    <h4>Evidence</h4>
+                    <ul class="evidence">{evidence_html}</ul>
+
+                    <h4>Recommended Action</h4>
+                    <p>{html.escape(r.get('recommended_action', 'None'))}</p>
+
+                    <details>
+                        <summary>Full Investigation ({r.get('num_turns', 0)} turns, ${r.get('cost_usd', 0):.4f})</summary>
+                        <div class="investigation">{investigation_html}</div>
+                    </details>
+
+                    {self._render_error(r)}
+                </div>
+            </details>
+            """)
+
+        # Category summary badges
+        category_badges = " ".join(
+            f'<span class="badge" style="background:{CATEGORY_COLORS.get(cat, "#6c757d")}">'
+            f'{CATEGORY_LABELS.get(cat, cat)}: {count}</span>'
+            for cat, count in sorted(category_counts.items())
+        )
+
+        report_html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Live Debug Session Report</title>
+{self._css()}
+</head>
+<body>
+<div class="container">
+    <h1>Live Cluster Debug Report</h1>
+
+    <div class="session-summary">
+        <h2>Session Summary</h2>
+        <div class="stats">
+            <div class="stat">
+                <span class="stat-value">{len(all_results)}</span>
+                <span class="stat-label">Tests Investigated</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value">${total_cost:.4f}</span>
+                <span class="stat-label">Total Cost</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value">{total_duration:.0f}s</span>
+                <span class="stat-label">Total Duration</span>
+            </div>
+        </div>
+        <div class="category-summary">{category_badges}</div>
+    </div>
+
+    <h2>Summary Table</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Test</th>
+                <th>Category</th>
+                <th>Phase</th>
+                <th>Root Cause</th>
+                <th>Cost</th>
+                <th>Duration</th>
+            </tr>
+        </thead>
+        <tbody>
+            {"".join(summary_rows)}
+        </tbody>
+    </table>
+
+    <h2>Detailed Investigations</h2>
+    {"".join(detail_sections)}
+</div>
+</body>
+</html>"""
+
+        # Write the report
+        os.makedirs(log_dir, exist_ok=True)
+        report_path = os.path.join(log_dir, "live_debug_report.html")
+        try:
+            with open(report_path, "w") as f:
+                f.write(report_html)
+            logger.info(f"Live debug session report saved: {report_path}")
+        except OSError as e:
+            logger.error(f"Failed to save session report: {e}")
+            return None
+
+        return report_path
+
+    def _render_error(self, result):
+        """Render an error section if the investigation had errors."""
+        error = result.get("error")
+        if not error:
+            return ""
+        return f"""
+        <div class="error-box">
+            <h3>Investigation Error</h3>
+            <p>{html.escape(error)}</p>
+        </div>
+        """
+
+    def _markdown_to_html(self, text):
+        """Simple markdown-to-HTML conversion for the investigation narrative."""
+        if not text:
+            return "<p>No data</p>"
+
+        text = html.escape(text)
+
+        # Code blocks
+        text = re.sub(
+            r"```(\w*)\n(.*?)```",
+            r'<pre><code class="language-\1">\2</code></pre>',
+            text,
+            flags=re.DOTALL,
+        )
+
+        # Inline code
+        text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+
+        # Bold
+        text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+
+        # Headers
+        text = re.sub(r"^### (.+)$", r"<h4>\1</h4>", text, flags=re.MULTILINE)
+        text = re.sub(r"^## (.+)$", r"<h3>\1</h3>", text, flags=re.MULTILINE)
+
+        # Bullet lists
+        text = re.sub(r"^- (.+)$", r"<li>\1</li>", text, flags=re.MULTILINE)
+        text = re.sub(
+            r"(<li>.*?</li>\n?)+",
+            lambda m: f"<ul>{m.group(0)}</ul>",
+            text,
+        )
+
+        # Paragraphs (double newlines)
+        paragraphs = text.split("\n\n")
+        processed = []
+        for p in paragraphs:
+            p = p.strip()
+            if p and not p.startswith("<"):
+                p = f"<p>{p}</p>"
+            processed.append(p)
+        text = "\n".join(processed)
+
+        return text
+
+    @staticmethod
+    def _truncate_text(text, max_len):
+        """Truncate text for display in summary table."""
+        if not text or len(text) <= max_len:
+            return text or ""
+        return text[:max_len] + "..."
+
+    @staticmethod
+    def _css():
+        """Return the CSS styles for reports."""
+        return """<style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+           background: #f5f5f5; color: #333; line-height: 1.6; }
+    .container { max-width: 1200px; margin: 0 auto; padding: 20px; }
+    h1 { color: #1a1a2e; margin-bottom: 20px; border-bottom: 2px solid #e94560; padding-bottom: 10px; }
+    h2 { color: #16213e; margin: 20px 0 10px; }
+    h3 { color: #0f3460; margin: 15px 0 8px; }
+    h4 { color: #0f3460; margin: 12px 0 6px; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px;
+             color: white; font-size: 0.85em; font-weight: 600; margin-right: 6px; }
+    .phase-badge { display: inline-block; padding: 2px 8px; border-radius: 4px;
+                   background: #e9ecef; color: #495057; font-size: 0.8em; margin-left: 6px; }
+    .test-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+    .test-header h2 { margin: 0; }
+    .meta { display: flex; gap: 20px; color: #666; font-size: 0.9em; margin-bottom: 15px;
+            flex-wrap: wrap; }
+    .meta code { background: #e9ecef; padding: 2px 6px; border-radius: 3px; font-size: 0.85em; }
+    .root-cause { background: #fff3cd; padding: 10px 15px; border-radius: 5px;
+                  border-left: 4px solid #ffc107; margin: 5px 0 15px; }
+    .evidence { margin: 5px 0 15px; padding-left: 20px; }
+    .evidence li { margin: 4px 0; }
+    table { width: 100%; border-collapse: collapse; margin: 10px 0 20px; background: white;
+            border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    th { background: #1a1a2e; color: white; padding: 10px 12px; text-align: left;
+         font-size: 0.9em; }
+    td { padding: 8px 12px; border-bottom: 1px solid #eee; font-size: 0.9em; }
+    td code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; font-size: 0.85em;
+              word-break: break-all; }
+    td.phase { text-align: center; }
+    tr:hover { background: #f8f9fa; }
+    details { margin: 10px 0; }
+    summary { cursor: pointer; padding: 8px 12px; background: #e9ecef; border-radius: 5px;
+              font-weight: 600; }
+    summary:hover { background: #dee2e6; }
+    .test-detail { background: white; border-radius: 8px; margin: 10px 0;
+                   box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }
+    .test-detail > summary { background: #f8f9fa; padding: 12px 16px; border-radius: 0;
+                              display: flex; align-items: center; gap: 8px; }
+    .detail-body { padding: 16px; }
+    .investigation { background: #f8f9fa; padding: 15px; border-radius: 5px; margin-top: 10px;
+                     max-height: 600px; overflow-y: auto; font-size: 0.9em; }
+    .investigation pre { background: #1a1a2e; color: #e9ecef; padding: 12px; border-radius: 5px;
+                         overflow-x: auto; margin: 8px 0; }
+    .investigation code { font-family: "SF Mono", "Fira Code", monospace; font-size: 0.9em; }
+    .session-summary { background: white; padding: 20px; border-radius: 8px; margin-bottom: 20px;
+                       box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    .stats { display: flex; gap: 30px; margin: 15px 0; }
+    .stat { text-align: center; }
+    .stat-value { display: block; font-size: 1.8em; font-weight: 700; color: #1a1a2e; }
+    .stat-label { font-size: 0.85em; color: #666; }
+    .category-summary { margin-top: 10px; }
+    .error-box { background: #f8d7da; border: 1px solid #f5c6cb; padding: 12px 16px;
+                 border-radius: 5px; margin-top: 10px; }
+    .error-box h3 { color: #721c24; margin-bottom: 5px; }
+    .error-box p { color: #721c24; }
+    .safety-warning { background: #fff3cd; border: 1px solid #ffc107; padding: 12px 16px;
+                      border-radius: 5px; margin-bottom: 15px; }
+    .safety-warning h3, .safety-warning h4 { color: #856404; margin-bottom: 5px; }
+    .violation { color: #856404; }
+</style>"""

--- a/ocs_ci/utility/live_debugger/safety.py
+++ b/ocs_ci/utility/live_debugger/safety.py
@@ -1,0 +1,209 @@
+"""
+Post-hoc safety audit for commands executed during live debugging.
+
+Defense-in-depth layer: even though the prompt instructs Claude to use
+read-only commands, this module verifies that no destructive commands
+were actually executed.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# oc subcommands that are read-only and safe
+ALLOWED_OC_SUBCOMMANDS = frozenset({
+    "get",
+    "describe",
+    "logs",
+    "events",
+    "version",
+    "whoami",
+    "api-resources",
+    "api-versions",
+    "status",
+    "project",
+    "projects",
+    "auth",
+    "config",
+    "explain",
+    "plugin",
+})
+
+# oc adm subcommands that are read-only
+ALLOWED_OC_ADM_SUBCOMMANDS = frozenset({
+    "top",
+    "inspect",
+})
+
+# oc exec is allowed only for known diagnostic commands
+ALLOWED_EXEC_COMMANDS = frozenset({
+    "ceph",
+    "rados",
+    "rbd",
+    "ceph-volume",
+    "df",
+    "cat",
+    "ls",
+    "ps",
+    "env",
+    "mount",
+    "lsblk",
+    "free",
+    "uptime",
+    "hostname",
+    "nslookup",
+    "dig",
+    "curl",
+    "ping",
+    "ip",
+    "ss",
+    "netstat",
+    "top",
+})
+
+# Commands that are always forbidden
+FORBIDDEN_COMMANDS = frozenset({
+    "rm",
+    "rmdir",
+    "mv",
+    "dd",
+    "mkfs",
+    "fdisk",
+    "parted",
+    "shutdown",
+    "reboot",
+    "halt",
+    "init",
+    "systemctl",
+    "kubectl",  # should use oc instead
+})
+
+# oc subcommands that mutate cluster state
+DESTRUCTIVE_OC_SUBCOMMANDS = frozenset({
+    "delete",
+    "apply",
+    "create",
+    "patch",
+    "edit",
+    "scale",
+    "drain",
+    "cordon",
+    "uncordon",
+    "taint",
+    "label",
+    "annotate",
+    "replace",
+    "set",
+    "rollout",
+    "debug",
+    "run",
+    "expose",
+    "new-app",
+    "new-project",
+    "start-build",
+    "cancel-build",
+    "import-image",
+    "tag",
+    "process",
+})
+
+
+def audit_commands(commands):
+    """
+    Audit a list of shell commands for safety violations.
+
+    Args:
+        commands: List of command strings that were executed.
+
+    Returns:
+        List of violation description strings. Empty list means all safe.
+    """
+    violations = []
+
+    for cmd in commands:
+        cmd_stripped = cmd.strip()
+        if not cmd_stripped:
+            continue
+
+        # Split into tokens for analysis
+        tokens = cmd_stripped.split()
+        if not tokens:
+            continue
+
+        base_cmd = tokens[0]
+
+        # Check for piped commands -- audit each segment
+        if "|" in cmd_stripped:
+            segments = cmd_stripped.split("|")
+            for segment in segments:
+                segment_violations = audit_commands([segment.strip()])
+                violations.extend(segment_violations)
+            continue
+
+        # Check forbidden base commands
+        if base_cmd in FORBIDDEN_COMMANDS:
+            violations.append(f"Forbidden command: {cmd_stripped}")
+            continue
+
+        # Check oc commands
+        if base_cmd == "oc" and len(tokens) > 1:
+            subcmd = tokens[1]
+
+            # oc adm <subcmd>
+            if subcmd == "adm" and len(tokens) > 2:
+                adm_subcmd = tokens[2]
+                if adm_subcmd not in ALLOWED_OC_ADM_SUBCOMMANDS:
+                    violations.append(
+                        f"Forbidden oc adm subcommand: {cmd_stripped}"
+                    )
+                continue
+
+            # oc exec -- check the command being executed
+            if subcmd == "exec":
+                violation = _audit_oc_exec(cmd_stripped, tokens)
+                if violation:
+                    violations.append(violation)
+                continue
+
+            # Check for destructive oc subcommands
+            if subcmd in DESTRUCTIVE_OC_SUBCOMMANDS:
+                violations.append(
+                    f"Destructive oc command: {cmd_stripped}"
+                )
+                continue
+
+            # Check that the subcommand is in the allow list
+            if subcmd not in ALLOWED_OC_SUBCOMMANDS:
+                # Not in allow list but also not destructive -- log a warning
+                logger.warning(
+                    f"Unknown oc subcommand (not in allow list): {subcmd}"
+                )
+
+    return violations
+
+
+def _audit_oc_exec(full_cmd, tokens):
+    """
+    Audit an ``oc exec`` command to ensure it only runs diagnostic commands.
+
+    Returns:
+        A violation string if unsafe, or None if safe.
+    """
+    # Find the command after "--"
+    try:
+        dash_idx = tokens.index("--")
+        exec_tokens = tokens[dash_idx + 1:]
+    except ValueError:
+        # No "--" separator; the command may be inline
+        # This is unusual but not necessarily dangerous
+        return None
+
+    if not exec_tokens:
+        return None
+
+    exec_cmd = exec_tokens[0]
+    if exec_cmd not in ALLOWED_EXEC_COMMANDS:
+        return f"Forbidden exec command '{exec_cmd}' in: {full_cmd}"
+
+    return None


### PR DESCRIPTION
Introduces a --live-debug pytest flag that spawns a Claude Code session to investigate the live cluster when a test fails. The debugger reads the test source code and logs, runs read-only oc commands, and classifies failures as product_bug, test_bug, infra_issue, or known_issue. It runs in parallel with must-gather to avoid adding wall-clock time and triggers on all failure phases (setup, call, teardown).