### PR TITLE
stop using full path in a log line

### DIFF
--- a/ocs_ci/deployment/fusion_aas.py
+++ b/ocs_ci/deployment/fusion_aas.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs.fusion import create_fusion_monitoring_resources, deploy_odf
 from ocs_ci.ocs.managedservice import update_pull_secret
 from ocs_ci.ocs.resources import pvc
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class FUSIONAASOCP(rosa_deployment.ROSAOCP):

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -47,7 +47,7 @@ from ocs_ci.ocs.managedservice import (
 )
 from ocs_ci.ocs.resources import pvc
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class ROSAOCP(BaseOCPDeployment):

--- a/ocs_ci/ocs/fusion.py
+++ b/ocs_ci/ocs/fusion.py
@@ -22,7 +22,7 @@ from ocs_ci.ocs.resources.csv import (
     get_csvs_start_with_prefix,
 )
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 FUSION_TEMPLATE_DIR = os.path.join(constants.TEMPLATE_DIR, "fusion-aas")
 

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -33,7 +33,7 @@ from ocs_ci.utility.utils import (
     get_role_arn_from_sub,
 )
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class CloudManager(ABC):

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -52,7 +52,7 @@ from ocs_ci.helpers.helpers import (
 )
 import subprocess
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class MCG:

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -33,7 +33,7 @@ from ocs_ci.utility import templating, version
 from ocs_ci.utility.utils import TimeoutSampler, mask_secrets
 from time import sleep
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class OBC(object):

--- a/ocs_ci/ocs/resources/objectconfigfile.py
+++ b/ocs_ci/ocs/resources/objectconfigfile.py
@@ -26,7 +26,7 @@ from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs.exceptions import CommandFailed, NotFoundError
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 def link_spec_volume(spec_dict, volume_name, pvc_name):

--- a/ocs_ci/tests/test_pytest_sanity.py
+++ b/ocs_ci/tests/test_pytest_sanity.py
@@ -3,7 +3,7 @@
 import os
 import logging
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 def test_nontest_code_unexpected_in_tests_dir():

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -23,7 +23,7 @@ from ocs_ci.ocs.parallel import parallel
 from ocs_ci.utility.templating import load_yaml
 from tempfile import NamedTemporaryFile
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 TIMEOUT = 90
 SLEEP = 3

--- a/ocs_ci/utility/gcp.py
+++ b/ocs_ci/utility/gcp.py
@@ -35,7 +35,7 @@ from ocs_ci.ocs.constants import (
 )
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 # default location of files with necessary GCP cluster details

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -37,7 +37,7 @@ from ocs_ci.utility.utils import get_infra_id, get_ocp_version, run_cmd, Timeout
 from ocs_ci.ocs.node import get_nodes
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 def login(region=None, resource_group=None):

--- a/ocs_ci/utility/ibmcloud_bm.py
+++ b/ocs_ci/utility/ibmcloud_bm.py
@@ -14,7 +14,7 @@ from ocs_ci.utility.utils import run_cmd
 from ocs_ci.utility.retry import retry
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class IBMCloudBM(object):

--- a/ocs_ci/utility/kubevirt_vm.py
+++ b/ocs_ci/utility/kubevirt_vm.py
@@ -15,7 +15,7 @@ from ocs_ci.utility.decorators import switch_to_provider_for_function
 from ocs_ci.ocs import constants
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 def get_vm_name(vm):

--- a/ocs_ci/utility/openshift_dedicated.py
+++ b/ocs_ci/utility/openshift_dedicated.py
@@ -14,7 +14,7 @@ from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import run_cmd, exec_cmd
 from ocs_ci.utility import utils
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 openshift_dedicated = config.AUTH.get("openshiftdedicated", {})
 _credentials_cache = {}
 

--- a/ocs_ci/utility/pagerduty.py
+++ b/ocs_ci/utility/pagerduty.py
@@ -10,7 +10,7 @@ from ocs_ci.ocs import constants, managedservice
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.utility.utils import exec_cmd
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 def set_pagerduty_integration_secret(integration_key):

--- a/ocs_ci/utility/pgsql.py
+++ b/ocs_ci/utility/pgsql.py
@@ -8,7 +8,7 @@ import functools
 from psycopg2 import connect, OperationalError
 
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 class PgsqlManager:

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.ssl_certs import get_root_ca_cert
 from ocs_ci.utility.utils import TimeoutIterator
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 # TODO(fbalak): if ignore_more_occurences is set to False then tests are flaky.

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -37,7 +37,7 @@ from ocs_ci.utility.retry import catch_exceptions
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 from ocs_ci.utility import version
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 rosa = config.AUTH.get("rosa", {})
 rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
 # to trace the leftovers of aws resources - use the date + letters for every role, config, etc.

--- a/tests/functional/object/mcg/test_nb_mgmt_endpoint.py
+++ b/tests/functional/object/mcg/test_nb_mgmt_endpoint.py
@@ -10,7 +10,7 @@ from ocs_ci.framework.testlib import skipif_ocs_version
 
 from ocs_ci.ocs.bucket_utils import retrieve_verification_mode
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 @mcg

--- a/tests/functional/upgrade/test_ms_upgrade.py
+++ b/tests/functional/upgrade/test_ms_upgrade.py
@@ -10,7 +10,7 @@ from ocs_ci.framework.testlib import (
     ms_provider_required,
 )
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 @yellow_squad

--- a/tests/libtest/test_multicluster.py
+++ b/tests/libtest/test_multicluster.py
@@ -10,7 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.utility.utils import get_primary_nb_db_pod
 
-logger = logging.getLogger(name=__file__)
+logger = logging.getLogger(__name__)
 
 
 @libtest


### PR DESCRIPTION
In some cases the prefix to a log message contains a full path path, starting from `/home`

```
2026-02-25 20:20:26  13:20:26 - MainThread - /home/jenkins/workspace/qe-odf-provider-client-multicluster/ocs-ci/ocs_ci/utility/aws.py - INFO - C[dnd-dosypenk-232a] - Waiting for instance ip-10-0-55-102.us-west-2.compute.internal to reach status stopped
```

In most cases we instantiate `loggin.getLogger` like this: `logger = logging.getLogger(__name__) `and in this case with full path, like this: `logging.getLogger(name=__file__)`
There are 21 matches total.

- [ ] To backport to older supported release branches

