### PR TITLE
Fix storageclass_factory teardown when ownerReferences are injected

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1277,25 +1277,48 @@ def storageclass_factory_fixture(
 
     def finalizer():
         for instance in instances:
+            _delete_storageclass(instance)
+
+    def _delete_storageclass(instance, max_attempts=3, wait_timeout=20):
+        for attempt in range(max_attempts):
             try:
                 sc_data = instance.ocp.get(resource_name=instance.name)
-                if sc_data.get("metadata", {}).get("ownerReferences"):
-                    log.info(
-                        f"Removing ownerReferences from StorageClass "
-                        f"{instance.name} before deletion"
-                    )
+            except CommandFailed as ex:
+                if "NotFound" in str(ex):
+                    return
+                raise
+
+            if sc_data.get("metadata", {}).get("ownerReferences"):
+                try:
                     instance.ocp.patch(
                         resource_name=instance.name,
                         params='{"metadata": {"ownerReferences": null}}',
                         format_type="merge",
                     )
-            except CommandFailed:
-                log.warning(
-                    f"Failed to remove ownerReferences from StorageClass "
-                    f"{instance.name}, proceeding with deletion anyway"
+                except CommandFailed:
+                    log.warning(
+                        f"Failed to clear ownerReferences from "
+                        f"StorageClass {instance.name}"
+                    )
+
+            instance.ocp.delete(resource_name=instance.name)
+            try:
+                instance.ocp.wait_for_delete(
+                    instance.name, timeout=wait_timeout
                 )
-            instance.delete()
-            instance.ocp.wait_for_delete(instance.name, timeout=120)
+                return
+            except TimeoutError:
+                if attempt < max_attempts - 1:
+                    log.warning(
+                        f"StorageClass {instance.name} was recreated by "
+                        f"a controller after deletion "
+                        f"(attempt {attempt + 1}/{max_attempts}), retrying"
+                    )
+
+        log.warning(
+            f"StorageClass {instance.name} could not be permanently "
+            f"deleted after {max_attempts} attempts"
+        )
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
## Summary

The StorageClient controller in OCS 4.20+ adopts test-created StorageClasses by injecting `ownerReferences` and recreates them within milliseconds of deletion. This causes:

1. **`TimeoutError` (120s)** in `storageclass_factory` finalizer
2. **Cascading `ResourceLeftoversException`** in `environment_check` for subsequent tests

### Changes

| File | Change |
|------|--------|
| `tests/conftest.py` | `storageclass_factory` finalizer: clear `ownerReferences` via merge patch, retry delete up to 3 times (20s timeout each), log warning if controller persists |
| `ocs_ci/utility/environment_check.py` | Skip StorageClasses with `ownerReferences` pointing to `StorageClient` from leftover detection |

### Why both files need changes

The v1 and v2 fixes (conftest.py only) were validated via rehearsal in [openshift/release#75559](https://github.com/openshift/release/pull/75559). Results:

- **v2 conftest.py fix works**: no `TimeoutError`, all 4 test SCs deleted successfully on first attempt
- **`ResourceLeftoversException` still occurs**: the controller recreates deleted SCs between the finalizer completing and `environment_check` running its diff
- **2 test errors** from recreated SCs: `test_rwx_dynamic_pvc[CephFileSystem-Delete]`, `test_raw_block_pv[Retain]`

The `environment_check.py` change closes this gap by excluding controller-owned SCs from leftover detection.

## Test plan

- [ ] Run `interop-tests-ocs-tests` step via pj-rehearse to confirm:
  - No `TimeoutError` in `storageclass_factory` finalizer
  - No `ResourceLeftoversException` from recreated StorageClasses
  - No regressions in other `storageclass_factory` consumers

## Rehearsal history

| Version | PR | Result | Issue |
|---------|-----|--------|-------|
| v1 (patch only) | [openshift/release#75408](https://github.com/openshift/release/pull/75408) | Failed | Single delete insufficient, controller recreates SC immediately |
| v2 (retry loop) | [openshift/release#75559](https://github.com/openshift/release/pull/75559) | Partial | No TimeoutError, but 2 ResourceLeftoversException from env check |
| v3 (this PR) | -- | Pending | Adds environment_check.py filtering |

Ref: [OCSQE-4285](https://issues.redhat.com/browse/OCSQE-4285)