### PR TITLE
Fix lifecycle UI locators for PF5/PF6 compatibility

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/bucket_lifecycle_ui.py
+++ b/ocs_ci/ocs/ui/page_objects/bucket_lifecycle_ui.py
@@ -125,6 +125,7 @@ class BucketLifecycleUI(ObjectStorage, ConfirmDialog):
 
         self.do_click((f"//tr//a[contains(text(), '{bucket_name}')]", By.XPATH))
 
+        self.page_has_loaded()
         self.do_click(self.bucket_tab["management_tab"])
 
         logger.info("Navigated to lifecycle rules page")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -408,8 +408,8 @@ generic_locators = {
         By.CSS_SELECTOR,
     ),
     "confirm_dilog_input": ("//input[@placeholder='{}']", By.XPATH),
-    "confirm_delete_resource": ("//button[contains(text(), 'Delete')]", By.XPATH),
-    "cancel_delete_resource": ("//button[contains(text(), 'Cancel')]", By.XPATH),
+    "confirm_delete_resource": ("//button[contains(normalize-space(), 'Delete')]", By.XPATH),
+    "cancel_delete_resource": ("//button[contains(normalize-space(), 'Cancel')]", By.XPATH),
     "close_dialog": ("button[aria-label='Close']", By.XPATH),
     "submit_form": ('button[type="submit"]', By.CSS_SELECTOR),
     "ocs_operator": ('//h1[text()="OpenShift Container Storage"]', By.XPATH),
@@ -2854,7 +2854,7 @@ bucket_tab = {
         By.XPATH,
     ),
     "create_lifecycle_rule_button": (
-        "//button[text()='Create lifecycle rule']",
+        "//button[normalize-space()='Create lifecycle rule']",
         By.XPATH,
     ),
     "lifecycle_rules_list": (
@@ -2866,7 +2866,7 @@ bucket_tab = {
         By.XPATH,
     ),
     "rule_kebab_menu": (
-        "//tr[contains(., '{}')]//button[@data-ouia-component-type='PF5/MenuToggle']",
+        "//tr[contains(., '{}')]//button[contains(@data-ouia-component-type, 'MenuToggle')]",
         By.XPATH,
     ),
     "edit_rule_option": (
@@ -2928,15 +2928,15 @@ bucket_tab = {
         By.XPATH,
     ),
     "lifecycle_create_button": (
-        "//button[text()='Create' and contains(@class, 'pf-m-primary') and @aria-disabled='false']",
+        "//button[normalize-space()='Create' and contains(@class, 'pf-m-primary') and @aria-disabled='false']",
         By.XPATH,
     ),
     "lifecycle_save_button": (
-        "//button[text()='Save' and contains(@class, 'pf-m-primary')]",
+        "//button[normalize-space()='Save' and contains(@class, 'pf-m-primary')]",
         By.XPATH,
     ),
     "lifecycle_cancel_button": (
-        "//button[text()='Cancel']",
+        "//button[normalize-space()='Cancel']",
         By.XPATH,
     ),
     # Current objects (Expiration) section

--- a/tests/functional/object/mcg/ui/test_bucket_lifecycle_ui.py
+++ b/tests/functional/object/mcg/ui/test_bucket_lifecycle_ui.py
@@ -380,16 +380,9 @@ class TestBucketLifecycleUI:
             log_step("No buckets from previous tests, creating a new one")
             lifecycle_ui, bucket_name = self._setup_bucket_and_navigate_to_lifecycle()
         else:
-            # Validate list is not empty before accessing first element
-            if len(self.created_buckets) == 0:
-                log_step("Created buckets list is empty, creating a new bucket")
-                lifecycle_ui, bucket_name = (
-                    self._setup_bucket_and_navigate_to_lifecycle()
-                )
-            else:
-                bucket_name = self.created_buckets[0]
-                log_step(f"Using existing bucket from previous tests: {bucket_name}")
-                lifecycle_ui.navigate_to_bucket_lifecycle(bucket_name)
+            bucket_name = self.created_buckets[0]
+            log_step(f"Using existing bucket from previous tests: {bucket_name}")
+            lifecycle_ui.navigate_to_bucket_lifecycle(bucket_name)
 
         rules = lifecycle_ui.get_lifecycle_rules_list()
 


### PR DESCRIPTION
OCP 4.21 uses a mix of PatternFly 5 and 6 components. PF6 wraps button text in <span class="pf-v6-c-button__text">, which breaks XPath text() matching since text() only matches direct text nodes.

- Replace text()= with normalize-space()= in button locators so they match both PF5 (direct text) and PF6 (span-wrapped text)
- Use contains(@data-ouia-component-type, 'MenuToggle') instead of hardcoding PF5/MenuToggle for the kebab menu selector
- Add page_has_loaded() wait in navigate_to_bucket_lifecycle between clicking the bucket link and the Management tab
- Remove redundant empty-list guard in test_delete_lifecycle_rule