### PR TITLE
Fix OBC UI locators for PF5/PF6 compatibility

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -485,7 +485,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
 
                 try:
                     dialog = self.driver.find_element(
-                        By.CSS_SELECTOR, ".pf-v5-c-modal-box"
+                        By.CSS_SELECTOR, "[class*='c-modal-box']"
                     )
                     dialog.click()
                     time.sleep(0.5)
@@ -538,6 +538,8 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
                 # locator of three_dots btn aligned with the specific resource name
                 locator = (
                     f"//tr[contains(., '{resource_name}')]//button[@data-test='kebab-button'] | "
+                    f"//td[@data-label='Name' and normalize-space()='{resource_name}']"
+                    "/following-sibling::td//button[@aria-label='Dropdown toggle'] | "
                     f"//td[@data-label='Name' and normalize-space()='{resource_name}']"
                     "/following-sibling::td//button[@aria-label='Kebab toggle']",
                     By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -386,14 +386,22 @@ generic_locators = {
         By.XPATH,
     ),
     "actions": (
-        '//button[@aria-label="Actions"]| //div[@data-test-id="details-actions"]//button[normalize-space()="Actions"]| '
+        '//div[@data-test-id="details-actions"]//button[normalize-space()="Actions"]| '
+        '//button[@aria-label="Actions"]| '
+        '//span[contains(@class,"c-menu-toggle__text") and text()="Actions"]/.. | '
         '//span[contains(@class,"c-dropdown__toggle-text") and text()="Actions"]/..',
         By.XPATH,
     ),
-    "three_dots": ('//button[@aria-label="Actions"]', By.XPATH),
+    "three_dots": (
+        '//button[@aria-label="Actions"] | '
+        '//button[@aria-label="Dropdown toggle"]',
+        By.XPATH,
+    ),
     "three_dots_specific_resource": (
-        "//td[@id='name']//a[contains(text(), '{}')]/../../..//button[@aria-label='Actions'] | "
-        "//tr[contains(., '{}')]//button[contains(@data-test, 'kebab-button')]",
+        "//tr[contains(., '{}')]//button[contains(@data-test, 'kebab-button')] | "
+        "//td[@data-label='Name']//a[contains(text(), '{}')]/../../..//button[@aria-label='Dropdown toggle'] | "
+        "//td[@data-label='name']//a[contains(text(), '{}')]/../../..//button[@aria-label='Dropdown toggle'] | "
+        "//td[@id='name']//a[contains(text(), '{}')]/../../..//button[@aria-label='Actions']",
         By.XPATH,
     ),
     "resource_link": (
@@ -2619,10 +2627,14 @@ bucket_tab = {
         By.XPATH,
     ),
     "bucket_action_button": (
+        "//button[@data-test='kebab-button'] | "
+        "//button[@aria-label='Dropdown toggle'] | "
         "//button[@aria-label='Kebab toggle']",
         By.XPATH,
     ),
     "bucket_delete_option": (
+        "//button[@role='menuitem'][normalize-space()='Delete Bucket'] | "
+        "//button[@role='menuitem'][normalize-space()='Delete'] | "
         "//button[@tabindex='-1']",
         By.XPATH,
     ),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2633,9 +2633,8 @@ bucket_tab = {
         By.XPATH,
     ),
     "bucket_delete_option": (
-        "//button[@role='menuitem'][normalize-space()='Delete Bucket'] | "
-        "//button[@role='menuitem'][normalize-space()='Delete'] | "
-        "//button[@tabindex='-1']",
+        "//button[@role='menuitem'][@id='Delete'] | "
+        "//button[@role='menuitem'][contains(normalize-space(),'Delete')]",
         By.XPATH,
     ),
     "bucket_confirm_button": (


### PR DESCRIPTION
- actions: reorder alternatives, put data-test-id first, add c-menu-toggle__text
- three_dots: add Dropdown toggle aria-label alternative
- three_dots_specific_resource: prioritize data-test kebab-button, fix td[@id='name'] to td[@data-label='Name'], use Dropdown toggle
- bucket_action_button: add data-test='kebab-button' and Dropdown toggle
- bucket_delete_option: add role=menuitem text match before fragile tabindex
- buckets_tab.py modal dialog: use version-agnostic [class*='c-modal-box']
- buckets_tab.py _check_three_dots_disabled: add Dropdown toggle fallback