### PR TITLE
Fixes: #14544:  Skip this test for ODF>4.17

### DIFF
--- a/tests/functional/pod_and_daemons/test_mgr_enable_rook_backend_module.py
+++ b/tests/functional/pod_and_daemons/test_mgr_enable_rook_backend_module.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @tier2
 @brown_squad
 @skipif_external_mode
-@skipif_ocs_version("<4.15")
+@skipif_ocs_version(["<4.15", ">4.17"])
 @jira("DFBUGS-1284")
 @pytest.mark.polarion_id("OCS-6240")
 class TestMgrRookModule(ManageTest):


### PR DESCRIPTION
Signed-off-by: suchita-g <sgatfane@redhat.com>

since 4.17, the rook mgr module has been explicitly disabled [1] https://github.com/red-hat-storage/ocs-operator/pull/2776