### PR TITLE
RHSTOR-7671:Add runbook link verification for ODFOperatorNotUpgradeable alert

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1996,
+        "line_number": 2000,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +649,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2103,
+        "line_number": 2107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +657,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2108,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +665,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2105,
+        "line_number": 2109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +673,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2106,
+        "line_number": 2110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +681,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2111,
+        "line_number": 2115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +689,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2126,
+        "line_number": 2130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +697,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2127,
+        "line_number": 2131,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +705,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2139,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +713,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2136,
+        "line_number": 2140,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +721,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2137,
+        "line_number": 2141,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +729,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2138,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +737,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2139,
+        "line_number": 2143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +745,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2876,
+        "line_number": 2880,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +753,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2877,
+        "line_number": 2881,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +761,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3598,
+        "line_number": 3602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +769,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3599,
+        "line_number": 3603,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1602,6 +1602,10 @@ ALERT_OBC_QUOTA_BYTES_ALERT = "ObcQuotaBytesAlert"
 ALERT_MDSCACHEUSAGEHIGH = "MDSCacheUsageHigh"
 ALERT_MDSCPUUSAGEHIGH = "MDSCPUUsageHigh"
 ALERT_ODFOPERATORNOTUPGRADABLE = "ODFOperatorNotUpgradeable"
+RUNBOOK_URL_ODFOPERATORNOTUPGRADABLE = (
+    "https://github.com/openshift/runbooks/blob/master/alerts/"
+    "openshift-container-storage-operator/ODFOperatorNotUpgradeable.md"
+)
 # ODF 4.21 new alerts
 ALERT_ODF_CORE_POD_RESTART = "ODFCorePodRestarted"
 ALERT_ODF_DISK_UTILIZATION_HIGH = "ODFDiskUtilizationHigh"

--- a/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
+++ b/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
@@ -28,13 +28,14 @@ log = logging.getLogger(__name__)
 
 def verify_odf_not_upgradeable(threading_lock):
     """
-    This Function Verifies ODFOperatorNotUpgradeable alert using PrometheusAPI
+    Verify ODFOperatorNotUpgradeable alert using PrometheusAPI.
 
     Args:
         threading_lock: Threading lock for Prometheus API calls
 
     Returns:
-        bool: True if ODFOperatorNotUpgradeable alert found otherwise False
+        tuple: (bool, list) - True and list of alerts if alert found,
+            False and empty list otherwise.
 
     """
     log.info("Verifying ODFOperatorNotUpgradeable alert is shown")
@@ -53,7 +54,7 @@ def verify_odf_not_upgradeable(threading_lock):
         if alerts:
             log.info(f"✓ Alert {alert_name} is firing as expected")
             log.info(f"Alert details: {alerts}")
-            return True
+            return True, alerts
         else:
             # Also check if alert exists in any state
             alerts_response = prometheus.get(
@@ -68,11 +69,48 @@ def verify_odf_not_upgradeable(threading_lock):
                             f"(state: {alert.get('state')})"
                         )
                         log.info(f"Alert details: {alert}")
-                        return True
-            return False
+                        return True, [alert]
+        return False, []
     except Exception as e:
         log.warning(f"Could not check for {alert_name} alert: {e}. ")
+        return False, []
+
+
+def verify_odf_not_upgradeable_runbook_link(alerts):
+    """
+    Verify ODFOperatorNotUpgradeable alert has the correct runbook link.
+
+    Args:
+        alerts (list): List of alert records from Prometheus API (e.g. from
+            verify_odf_not_upgradeable). Must contain at least one
+            ODFOperatorNotUpgradeable alert.
+
+    Returns:
+        bool: True if runbook_url annotation matches the expected runbook
+            URL for ODFOperatorNotUpgradeable, False otherwise.
+
+    """
+    if not alerts:
+        log.warning("No alerts provided for runbook link verification")
         return False
+    expected_runbook = constants.RUNBOOK_URL_ODFOPERATORNOTUPGRADABLE
+    for alert in alerts:
+        runbook_url = alert.get("annotations", {}).get("runbook_url", "")
+        if runbook_url == expected_runbook:
+            log.info(
+                "✓ ODFOperatorNotUpgradeable alert runbook link is correct: %s",
+                expected_runbook,
+            )
+            return True
+        if runbook_url:
+            log.warning(
+                "ODFOperatorNotUpgradeable runbook_url mismatch: expected %s, "
+                "got %s",
+                expected_runbook,
+                runbook_url,
+            )
+    log.warning("ODFOperatorNotUpgradeable alert has no or incorrect runbook_url")
+    return False
 
 
 @brown_squad
@@ -103,6 +141,7 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         2. ODF OperatorCondition CR: Upgradeable=False, Reason: "CephClusterHealthNotOK"
         3. The operator being not Upgradeable should be shown as an Alert
            ODFOperatorNotUpgradeable
+        4. ODFOperatorNotUpgradeable alert has correct runbook_url link
 
         Args:
             mon_pod_down: Fixture that scales down one MON deployment
@@ -167,7 +206,8 @@ class TestODFUpgradePrecheckConditions(ManageTest):
             log.warning("⚠ ODF OperatorCondition check did not pass ")
 
         # Verify ODFOperatorNotUpgradeable alert is shown
-        alert_found = verify_odf_not_upgradeable(threading_lock)
+        alert_found, odf_alerts = verify_odf_not_upgradeable(threading_lock)
+        runbook_ok = verify_odf_not_upgradeable_runbook_link(odf_alerts)
 
         # Test Summary
         log.info("=" * 80)
@@ -183,6 +223,10 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         log.info(
             f"  ODFOperatorNotUpgradeable Alert: " f"{'✓' if alert_found else '⚠'}"
         )
+        log.info(
+            f"  ODFOperatorNotUpgradeable Runbook Link: "
+            f"{'✓' if runbook_ok else '⚠'}"
+        )
         log.info("=" * 80)
 
         # Assertions for test validation
@@ -195,6 +239,9 @@ class TestODFUpgradePrecheckConditions(ManageTest):
             "'CephClusterHealthNotOK'"
         )
         assert alert_found, "ODFOperatorNotUpgradeable alert not found."
+        assert runbook_ok, (
+            "ODFOperatorNotUpgradeable alert runbook link is missing or " "incorrect."
+        )
 
         log.info(
             "Test completed: Upgrade should be blocked when Ceph health "
@@ -222,6 +269,7 @@ class TestODFUpgradePrecheckConditions(ManageTest):
            Reason: "StorageClusterNotReady"
         2. The operator being not Upgradeable should be shown as an Alert
            ODFOperatorNotUpgradeable
+        3. ODFOperatorNotUpgradeable alert has correct runbook_url link
 
         Args:
             storagecluster_to_progressing: Fixture that patches StorageCluster
@@ -274,7 +322,8 @@ class TestODFUpgradePrecheckConditions(ManageTest):
             log.warning("⚠ ODF OperatorCondition check did not pass ")
 
         # Verify ODFOperatorNotUpgradeable alert is shown
-        alert_found = verify_odf_not_upgradeable(threading_lock)
+        alert_found, odf_alerts = verify_odf_not_upgradeable(threading_lock)
+        runbook_ok = verify_odf_not_upgradeable_runbook_link(odf_alerts)
 
         # Summary
         log.info("=" * 80)
@@ -286,6 +335,10 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         log.info(
             f"  ODFOperatorNotUpgradeable Alert: " f"{'✓' if alert_found else '⚠'}"
         )
+        log.info(
+            f"  ODFOperatorNotUpgradeable Runbook Link: "
+            f"{'✓' if runbook_ok else '⚠'}"
+        )
         log.info("=" * 80)
 
         # Assertions for test validation
@@ -294,6 +347,9 @@ class TestODFUpgradePrecheckConditions(ManageTest):
             "'StorageClusterNotReady'"
         )
         assert alert_found, "ODFOperatorNotUpgradeable alert not found."
+        assert runbook_ok, (
+            "ODFOperatorNotUpgradeable alert runbook link is missing or " "incorrect."
+        )
 
         log.info(
             "Test completed: Upgrade should be blocked when StorageCluster "


### PR DESCRIPTION
Code chnages:
- Add RUNBOOK_URL_ODFOPERATORNOTUPGRADABLE in constants for the
  openshift/runbooks ODFOperatorNotUpgradeable.md URL
- Extend verify_odf_not_upgradeable to return (bool, alerts) so
  the same alert list can be reused for runbook checks
- Add verify_odf_not_upgradeable_runbook_link(alerts) to assert
  annotations.runbook_url matches the expected runbook
- In test_ceph_health_warning_blocks_upgrade and
  test_storagecluster_not_ready_blocks_upgrade: verify runbook link
  after alert check and assert with a clear failure message