### PR TITLE
RHSTOR7671:Add runbook content checks and override test for ODFOperatorNotUpgradeable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2000,
+        "line_number": 2002,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +649,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2107,
+        "line_number": 2109,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +657,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2108,
+        "line_number": 2110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +665,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2109,
+        "line_number": 2111,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +673,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2110,
+        "line_number": 2112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +681,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2115,
+        "line_number": 2117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +689,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2130,
+        "line_number": 2132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +697,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2131,
+        "line_number": 2133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +705,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2139,
+        "line_number": 2141,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +713,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2140,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +721,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2141,
+        "line_number": 2143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +729,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +737,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2143,
+        "line_number": 2145,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +745,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2880,
+        "line_number": 2882,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +753,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2881,
+        "line_number": 2883,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +761,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3602,
+        "line_number": 3604,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +769,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3603,
+        "line_number": 3605,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1606,6 +1606,8 @@ RUNBOOK_URL_ODFOPERATORNOTUPGRADABLE = (
     "https://github.com/openshift/runbooks/blob/master/alerts/"
     "openshift-container-storage-operator/ODFOperatorNotUpgradeable.md"
 )
+# Mandatory section headers for OpenShift runbook content (Meaning, Impact, etc.)
+RUNBOOK_MANDATORY_HEADERS = ["Meaning", "Impact", "Diagnosis", "Mitigation"]
 # ODF 4.21 new alerts
 ALERT_ODF_CORE_POD_RESTART = "ODFCorePodRestarted"
 ALERT_ODF_DISK_UTILIZATION_HIGH = "ODFDiskUtilizationHigh"

--- a/ocs_ci/ocs/resources/csv.py
+++ b/ocs_ci/ocs/resources/csv.py
@@ -2,6 +2,7 @@
 CSV related functionalities
 """
 
+import json
 import logging
 
 from ocs_ci.ocs import constants
@@ -134,26 +135,30 @@ def get_operator_csv_names(namespace=None):
     return ocs_csv_name, odf_csv_name
 
 
-def check_operatorcondition_upgradeable_false(
+def check_operatorcondition_upgradeable(
     operator_name,
     csv_name,
     namespace,
+    upgradeable_expected,
     timeout=300,
     reason=None,
     message_pattern=None,
 ):
     """
-    Check if OperatorCondition shows Upgradeable=False with specified reason.
+    Check if OperatorCondition shows Upgradeable with the expected status
+    (True or False), optionally matching reason and message.
 
     Args:
         operator_name (str): Name of the operator (for logging)
         csv_name (str): CSV name of the operator
         namespace (str): Namespace where OperatorCondition is located
+        upgradeable_expected (bool): If True, expect Upgradeable=True (e.g. after
+            override). If False, expect Upgradeable=False.
         timeout (int): Timeout in seconds to wait for condition
-        reason (str): Expected reason in OperatorCondition. If None, checks
-            for any reason when Upgradeable=False
-        message_pattern (str): Expected message pattern in OperatorCondition.
-            If None, only reason is checked
+        reason (str): Expected reason in OperatorCondition. If None, only
+            status is checked (any reason for False; any reason for True).
+        message_pattern (str): Expected message pattern. If None, only reason
+            (or status) is checked.
 
     Returns:
         bool: True if condition is met, False otherwise
@@ -161,23 +166,26 @@ def check_operatorcondition_upgradeable_false(
     """
     if not csv_name:
         log.warning(
-            f"Skipping {operator_name} OperatorCondition check - " "CSV name not found"
+            f"Skipping {operator_name} OperatorCondition check - CSV name not found"
         )
         return False
 
-    log.info(f"Checking {operator_name} OperatorCondition: {csv_name}")
+    expected_status = "True" if upgradeable_expected else "False"
+    log.info(
+        f"Checking {operator_name} OperatorCondition (Upgradeable={expected_status}): {csv_name}"
+    )
     operatorcondition = OCP(
         kind="OperatorCondition",
         namespace=namespace,
     )
 
     def _check_condition():
-        """Check if OperatorCondition shows Upgradeable=False"""
+        """Read OperatorCondition and verify Upgradeable matches expected."""
         oc_data = operatorcondition.get(resource_name=csv_name, dont_raise=True)
         if not oc_data:
             return False
 
-        # OperatorCondition can be a single item or list
+        # OperatorCondition API can return a list or a single resource
         items = (
             oc_data.get("items", [])
             if isinstance(oc_data, dict) and "items" in oc_data
@@ -199,19 +207,23 @@ def check_operatorcondition_upgradeable_false(
                         f"status: {status}, reason: {condition_reason}, "
                         f"message: {message}"
                     )
-                    if status == "False":
-                        # If reason is specified, check for it
-                        if reason:
-                            if reason in condition_reason:
-                                # If message_pattern is also specified, check it
-                                if message_pattern:
-                                    if message_pattern in message:
-                                        return True
-                                else:
-                                    return True
-                        else:
-                            # No specific reason expected, just check status
-                            return True
+                    # Validate status and optional reason/message
+                    if upgradeable_expected:
+                        if status != "True":
+                            return False
+                        if reason and reason not in condition_reason:
+                            return False
+                        if message_pattern and message_pattern not in message:
+                            return False
+                        return True
+                    else:
+                        if status != "False":
+                            return False
+                        if reason and reason not in condition_reason:
+                            return False
+                        if message_pattern and message_pattern not in message:
+                            return False
+                        return True
         return False
 
     sample = TimeoutSampler(
@@ -219,23 +231,77 @@ def check_operatorcondition_upgradeable_false(
         sleep=10,
         func=_check_condition,
     )
-
     try:
         if sample.wait_for_func_status(result=True):
             log.info(
-                f"{operator_name} OperatorCondition shows "
-                f"Upgradeable=False with reason '{reason}'"
+                f"{operator_name} OperatorCondition shows Upgradeable={expected_status} (reason={reason})"
             )
             return True
-        else:
-            log.warning(
-                f"{operator_name} OperatorCondition did not show "
-                "Upgradeable=False within timeout."
-            )
-            return False
+        log.warning(
+            f"{operator_name} OperatorCondition did not show Upgradeable={expected_status} within timeout"
+        )
+        return False
     except Exception as e:
+        # OperatorCondition may be missing or API may be temporarily unavailable
         log.warning(
             f"{operator_name} OperatorCondition may not be updated yet "
-            f"or not found: {e}."
+            f"or not found: {e}. Continuing with test."
         )
+        return False
+
+
+def apply_operatorcondition_upgrade_override(
+    csv_name,
+    namespace,
+    reason="ManualOverride",
+    message="Manually overriding upgradeable condition",
+):
+    """
+    Apply an override to OperatorCondition so Upgradeable is reported as True.
+    Used when cluster admin wants to allow upgrade despite operator reporting
+    Upgradeable=False (e.g. per runbook "Option 2: Override the condition").
+
+    Args:
+        csv_name (str): CSV name (OperatorCondition resource has same name)
+        namespace (str): Namespace where OperatorCondition is located
+        reason (str): Reason for the override (default: ManualOverride)
+        message (str): Message for the override condition
+
+    Returns:
+        bool: True if patch succeeded, False otherwise
+
+    """
+    if not csv_name:
+        log.warning("Cannot apply override: CSV name not found")
+        return False
+    operatorcondition = OCP(
+        kind="OperatorCondition",
+        namespace=namespace,
+    )
+    # OLM allows cluster admin to override Upgradeable via spec.overrides
+    # (see runbook "Option 2: Override the condition")
+    patch = {
+        "spec": {
+            "overrides": [
+                {
+                    "type": "Upgradeable",
+                    "status": "True",
+                    "reason": reason,
+                    "message": message,
+                }
+            ]
+        }
+    }
+    patch_str = json.dumps(patch)
+    try:
+        operatorcondition.exec_oc_cmd(
+            f"patch operatorcondition {csv_name} --type=merge -p '{patch_str}'",
+            out_yaml_format=False,
+        )
+        log.info(
+            f"Applied OperatorCondition upgrade override for {csv_name}: reason={reason}"
+        )
+        return True
+    except Exception as e:
+        log.warning(f"Failed to apply OperatorCondition override: {e}")
         return False

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1046,6 +1046,35 @@ def get_url_content(url, **kwargs):
     return r.content
 
 
+def convert_github_blob_url_to_raw(link):
+    """
+    Convert a GitHub blob URL to raw content URL (for any owner/repo/branch).
+
+    Args:
+        link (str): GitHub URL like
+            https://github.com/owner/repo/blob/branch/path/to/file.md
+
+    Returns:
+        str: Raw URL like
+            https://raw.githubusercontent.com/owner/repo/branch/path/to/file.md
+            If the link does not match the GitHub blob pattern, returns the
+            original link unchanged (e.g. already raw or non-GitHub).
+
+    """
+    pattern = (
+        r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
+        r"blob/(?P<branch>[^/]+)/(?P<path>.+)"
+    )
+    match = re.match(pattern, link)
+    if match:
+        owner = match.group("owner")
+        repo = match.group("repo")
+        branch = match.group("branch")
+        path = match.group("path")
+        return f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
+    return link
+
+
 def expose_ocp_version(version):
     """
     This helper function exposes latest nightly version or GA version of OCP.

--- a/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
+++ b/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
@@ -3,6 +3,7 @@ Test cases for ODF upgrade pre-check conditions.
 """
 
 import logging
+import re
 
 import pytest
 
@@ -14,11 +15,16 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
 )
 from ocs_ci.framework.testlib import ManageTest
-from ocs_ci.utility.utils import run_ceph_health_cmd
+from ocs_ci.utility.utils import (
+    run_ceph_health_cmd,
+    get_url_content,
+    convert_github_blob_url_to_raw,
+)
 from ocs_ci.utility.prometheus import PrometheusAPI
 from ocs_ci.ocs.resources.csv import (
     get_operator_csv_names,
-    check_operatorcondition_upgradeable_false,
+    check_operatorcondition_upgradeable,
+    apply_operatorcondition_upgrade_override,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.storage_cluster import StorageCluster
@@ -98,19 +104,58 @@ def verify_odf_not_upgradeable_runbook_link(alerts):
         runbook_url = alert.get("annotations", {}).get("runbook_url", "")
         if runbook_url == expected_runbook:
             log.info(
-                "✓ ODFOperatorNotUpgradeable alert runbook link is correct: %s",
-                expected_runbook,
+                f"✓ ODFOperatorNotUpgradeable alert runbook link is correct: "
+                f"{expected_runbook}"
             )
             return True
         if runbook_url:
             log.warning(
-                "ODFOperatorNotUpgradeable runbook_url mismatch: expected %s, "
-                "got %s",
-                expected_runbook,
-                runbook_url,
+                f"ODFOperatorNotUpgradeable runbook_url mismatch: expected "
+                f"{expected_runbook}, got {runbook_url}"
             )
     log.warning("ODFOperatorNotUpgradeable alert has no or incorrect runbook_url")
     return False
+
+
+def verify_runbook_content(blob_url, alert_name, mandatory_headers=None):
+    """
+    Fetch runbook from URL and verify it contains alert name and mandatory
+    section headers (Meaning, Impact, Diagnosis, Mitigation).
+
+    Args:
+        blob_url (str): Runbook URL (blob or raw)
+        alert_name (str): Expected alert name in runbook (e.g. in title)
+        mandatory_headers (list): Section headers that must appear as "## X".
+            Defaults to constants.RUNBOOK_MANDATORY_HEADERS.
+
+    Returns:
+        bool: True if runbook content is valid, False otherwise.
+
+    """
+    if mandatory_headers is None:
+        mandatory_headers = constants.RUNBOOK_MANDATORY_HEADERS
+    raw_url = convert_github_blob_url_to_raw(blob_url)
+    try:
+        content = get_url_content(raw_url, timeout=30)
+    except Exception as e:
+        log.warning(f"Failed to fetch runbook from {raw_url}: {e}")
+        return False
+    # get_url_content returns bytes; decode for string checks
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    if not content or alert_name not in content:
+        log.warning(f"Runbook does not contain alert name {alert_name}")
+        return False
+    # Require OpenShift runbook sections (## Meaning, ## Impact, etc.)
+    for header in mandatory_headers:
+        if not re.search(rf"##\s+{re.escape(header)}\s", content):
+            log.warning(f"Runbook missing mandatory section: ## {header}")
+            return False
+    log.info(
+        f"Runbook content valid: alert {alert_name} and headers "
+        f"{mandatory_headers} present"
+    )
+    return True
 
 
 @brown_squad
@@ -177,19 +222,21 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         log.info(f"ODF CSV name: {odf_csv_name}")
 
         # Check OCS OperatorCondition with specific reason
-        ocs_condition_met = check_operatorcondition_upgradeable_false(
+        ocs_condition_met = check_operatorcondition_upgradeable(
             operator_name="OCS",
             csv_name=ocs_csv_name,
             namespace=namespace,
+            upgradeable_expected=False,
             reason="CephClusterHealthNotOK",
             message_pattern="CephCluster health is HEALTH_WARN.",
         )
 
         # Check ODF OperatorCondition with specific reason
-        odf_condition_met = check_operatorcondition_upgradeable_false(
+        odf_condition_met = check_operatorcondition_upgradeable(
             operator_name="ODF",
             csv_name=odf_csv_name,
             namespace=namespace,
+            upgradeable_expected=False,
             reason="CephClusterHealthNotOK",
             message_pattern="CephCluster health is HEALTH_WARN.",
         )
@@ -308,10 +355,11 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         log.info(f"ODF CSV name: {odf_csv_name}")
 
         # Check ODF OperatorCondition with specific reason
-        odf_condition_met = check_operatorcondition_upgradeable_false(
+        odf_condition_met = check_operatorcondition_upgradeable(
             operator_name="ODF",
             csv_name=odf_csv_name,
             namespace=namespace,
+            upgradeable_expected=False,
             reason="StorageClusterNotReady",
         )
 
@@ -354,4 +402,106 @@ class TestODFUpgradePrecheckConditions(ManageTest):
         log.info(
             "Test completed: Upgrade should be blocked when StorageCluster "
             "is not in Ready state"
+        )
+
+    @pytest.mark.polarion_id("OCS-7423")
+    def test_runbook_validity_and_override_restores_upgradeable(
+        self, mon_pod_down, threading_lock
+    ):
+        """
+        Verify ODFOperatorNotUpgradeable runbook validity and that applying
+        the override (instruct patch) makes ODF OperatorCondition report
+        Upgradeable=True. Ceph WARN state is cleaned up in teardown via
+        mon_pod_down fixture.
+
+        Steps:
+        1. Cause Ceph HEALTH_WARN (mon_pod_down fixture scales down one MON).
+        2. Verify ODFOperatorNotUpgradeable alert and runbook link.
+        3. Verify runbook content (mandatory sections and alert name).
+        4. Apply OperatorCondition upgrade override (runbook Option 2).
+        5. Verify ODF OperatorCondition shows Upgradeable=True with override
+           reason/message.
+
+        Expected Result:
+        1. Alert and runbook link are correct.
+        2. Runbook contains alert name and sections: Meaning, Impact,
+           Diagnosis, Mitigation.
+        3. After override, OperatorCondition shows Upgradeable=True with
+           reason/message related to override.
+        4. Teardown: MON is scaled back up (mon_pod_down fixture) so Ceph
+           returns to healthy state.
+
+        Args:
+            mon_pod_down: Fixture that scales down one MON and restores it
+                in teardown (cleans up Ceph WARN state).
+            threading_lock: Threading lock for Prometheus API calls.
+
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # Step 1: Ceph HEALTH_WARN (handled by mon_pod_down fixture)
+        log.info("Step 1: MON scaled down to cause HEALTH_WARN (handled by fixture)")
+        health_status = run_ceph_health_cmd(namespace=namespace, detail=True)
+        log.info("Ceph health status: %s", health_status)
+        assert (
+            "WARN" in health_status or "HEALTH_WARN" in health_status
+        ), "Expected HEALTH_WARN from mon_pod_down setup"
+
+        # Step 2: Verify alert and runbook link
+        log.info("Step 2: Verifying ODFOperatorNotUpgradeable alert and runbook link")
+        alert_found, odf_alerts = verify_odf_not_upgradeable(threading_lock)
+        assert alert_found, "ODFOperatorNotUpgradeable alert not found."
+        runbook_link_ok = verify_odf_not_upgradeable_runbook_link(odf_alerts)
+        assert (
+            runbook_link_ok
+        ), "ODFOperatorNotUpgradeable alert runbook link is missing or incorrect."
+
+        # Step 3: Verify runbook content (validity)
+        log.info(
+            "Step 3: Verifying runbook content (mandatory sections and alert name)"
+        )
+        runbook_content_ok = verify_runbook_content(
+            blob_url=constants.RUNBOOK_URL_ODFOPERATORNOTUPGRADABLE,
+            alert_name=constants.ALERT_ODFOPERATORNOTUPGRADABLE,
+        )
+        assert runbook_content_ok, (
+            "ODFOperatorNotUpgradeable runbook content invalid: missing alert "
+            "name or mandatory sections (Meaning, Impact, Diagnosis, Mitigation)."
+        )
+
+        # Step 4: Apply OperatorCondition upgrade override (runbook instruct)
+        _, odf_csv_name = get_operator_csv_names(namespace=namespace)
+        assert odf_csv_name, "ODF CSV name not found"
+        override_reason = "ManualOverride"
+        override_message = "Manually overriding upgradeable condition"
+        override_ok = apply_operatorcondition_upgrade_override(
+            csv_name=odf_csv_name,
+            namespace=namespace,
+            reason=override_reason,
+            message=override_message,
+        )
+        assert override_ok, "Failed to apply OperatorCondition upgrade override"
+
+        # Step 5: Verify ODF OperatorCondition shows Upgradeable=True
+        log.info(
+            "Step 5: Verifying ODF OperatorCondition shows Upgradeable=True "
+            "after override"
+        )
+        upgradeable_true_ok = check_operatorcondition_upgradeable(
+            operator_name="ODF",
+            csv_name=odf_csv_name,
+            namespace=namespace,
+            upgradeable_expected=True,
+            timeout=600,
+            reason=override_reason,
+            message_pattern=override_message,
+        )
+        assert upgradeable_true_ok, (
+            f"ODF OperatorCondition should show Upgradeable=True with reason "
+            f"{override_reason} and message related to override after override."
+        )
+
+        log.info(
+            "Test completed: Runbook validity and override behavior verified; "
+            "teardown will restore MON and clear Ceph WARN state."
         )


### PR DESCRIPTION
Code Changes:
- Add test_runbook_validity_and_override_restores_upgradeable
  - Assert runbook content (alert name + Meaning, Impact, Diagnosis, Mitigation)
  - Apply OperatorCondition upgrade override (runbook Option 2)
  - Assert ODF OperatorCondition shows Upgradeable=True with override reason

- CSV/OperatorCondition helpers
  - Add apply_operatorcondition_upgrade_override() and check_operatorcondition_upgradeable(..., upgradeable_expected=bool)
  - Remove check_operatorcondition_upgradeable_false/true; callers use check_operatorcondition_upgradeable with upgradeable_expected=False or True