### PR TITLE
Fix PVC issue contains still emptyDir as well as PVC

### DIFF
--- a/ocs_ci/ocs/registry.py
+++ b/ocs_ci/ocs/registry.py
@@ -35,7 +35,7 @@ def change_registry_backend_to_ocs():
         access_mode=constants.ACCESS_MODE_RWX,
     )
     helpers.wait_for_resource_state(pv_obj, "Bound", timeout=300)
-    param_cmd = f'[{{"op": "add", "path": "/spec/storage", "value": {{"pvc": {{"claim": "{pv_obj.name}"}}}}}}]'
+    param_cmd = f'[{{"op": "replace", "path": "/spec/storage", "value": {{"pvc": {{"claim": "{pv_obj.name}"}}}}}}]'
 
     run_cmd(
         f"oc patch {constants.IMAGE_REGISTRY_CONFIG} -p " f"'{param_cmd}' --type json"


### PR DESCRIPTION
Avoid OCP upgrade issue:
```
message: 'Unable to apply resources: unable to sync storage configuration: exactly
        one storage type should be configured at the same time, got 2: [EmptyDir PVC]'
```
In image-registry cluster operator