### PR TITLE
merge test_workload_with_checksum and test_workload_with_checksum_verify into test_workload_with_checksum_rbd

### DIFF
--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -367,6 +367,7 @@ def workload_fio_storageutilization(
     target_percentage=None,
     target_size=None,
     with_checksum=False,
+    retain_pv=False,
     keep_fio_data=False,
     minimal_time=480,
     throw_skip=True,
@@ -408,9 +409,11 @@ def workload_fio_storageutilization(
         target_size (int): target size of the PVC for fio to use, eg. 10 means
             a request for fio to write 10GiB of data
         with_checksum (bool): if true, sha1 checksum of the data written by
-            fio is stored on the volume, and reclaim policy of the volume is
-            changed to ``Retain`` so that the volume is not removed during test
-            teardown for later verification runs
+            fio is stored on the volume
+        retain_pv (bool): if true, reclaim policy of the volume is changed to
+            ``Retain`` and the volume is labeled so that it is not removed
+            during test teardown for later verification runs. Only effective
+            when with_checksum is True.
         keep_fio_data (bool): If true, keep the fio data after the fio
             storage utilization is completed. Else if false, deletes the fio data.
         minimal_time (int): Minimal number of seconds to monitor a system.
@@ -593,7 +596,7 @@ def workload_fio_storageutilization(
             logger.info("Storage for the PVC was not yet reclaimed enough.")
         return result
 
-    if with_checksum:
+    if with_checksum and retain_pv:
         # Let's get the name of the PV via the PVC.
         ocp_pvc = ocp.OCP(kind=constants.PVC, namespace=project.namespace)
         pvc_data = ocp_pvc.get()
@@ -625,9 +628,9 @@ def workload_fio_storageutilization(
         label = f"fixture={fixture_name}"
         ocp_pv.add_label(pv_name, label)
     else:
-        # Without checksum, we just need to make sure that data were deleted
-        # and wait for this to happen to avoid conflicts with tests executed
-        # right after this one.
+        # Without checksum or when not retaining PV, we just need to make
+        # sure that data were deleted and wait for this to happen to avoid
+        # conflicts with tests executed right after this one.
         if not keep_fio_data:
             delete_fio_data(fio_job_file, is_storage_reclaimed)
         else:

--- a/ocs_ci/ocs/fiojob.py
+++ b/ocs_ci/ocs/fiojob.py
@@ -452,31 +452,33 @@ def workload_fio_storageutilization(
     # ceph cluster during high utilization levels (for expected values, consult
     # BZ 1775432 and check that there is no more recent BZ or JIRA in this
     # area)
-    ceph_full_ratios = [
-        "full_ratio",
-        "backfillfull_ratio",
-        "nearfull_ratio",
-    ]
-    ct_pod = pod.get_ceph_tools_pod()
-    # As noted in ceph docs:
-    # https://docs.ceph.com/docs/nautilus/rados/configuration/mon-config-ref/
-    # we need to look for full ratio values in OSDMap of the cluster:
-    # > These settings only apply during cluster creation. Afterwards they need
-    # > to be changed in the OSDMap using ceph osd set-nearfull-ratio and ceph
-    # > osd set-full-ratio
-    logger.info("inspecting values of ceph *full ratios in osd map")
-    osd_dump_dict = ct_pod.exec_ceph_cmd("ceph osd dump")
-    for ceph_ratio in ceph_full_ratios:
-        ratio_value = osd_dump_dict.get(ceph_ratio)
-        if ratio_value is not None:
-            logger.info(f"{ceph_ratio} is {ratio_value}")
-        else:
-            logger.warning(f"{ceph_ratio} not found in osd map")
+    # These operations need to run on the provider cluster
+    with config.RunWithProviderConfigContextIfAvailable():
+        ceph_full_ratios = [
+            "full_ratio",
+            "backfillfull_ratio",
+            "nearfull_ratio",
+        ]
+        ct_pod = pod.get_ceph_tools_pod()
+        # As noted in ceph docs:
+        # https://docs.ceph.com/docs/nautilus/rados/configuration/mon-config-ref/
+        # we need to look for full ratio values in OSDMap of the cluster:
+        # > These settings only apply during cluster creation. Afterwards they need
+        # > to be changed in the OSDMap using ceph osd set-nearfull-ratio and ceph
+        # > osd set-full-ratio
+        logger.info("inspecting values of ceph *full ratios in osd map")
+        osd_dump_dict = ct_pod.exec_ceph_cmd("ceph osd dump")
+        for ceph_ratio in ceph_full_ratios:
+            ratio_value = osd_dump_dict.get(ceph_ratio)
+            if ratio_value is not None:
+                logger.info(f"{ceph_ratio} is {ratio_value}")
+            else:
+                logger.warning(f"{ceph_ratio} not found in osd map")
 
-    if target_size is not None:
-        pvc_size = target_size
-    else:
-        pvc_size = get_storageutilization_size(target_percentage, ceph_pool_name)
+        if target_size is not None:
+            pvc_size = target_size
+        else:
+            pvc_size = get_storageutilization_size(target_percentage, ceph_pool_name)
 
     # If we are trying to utilize particular percentage of total OCS capacity
     # and current usage is already higher, the test will be skipped, because
@@ -576,13 +578,17 @@ def workload_fio_storageutilization(
         return measured_op
 
     # measure MAX AVAIL value just before reclamaion of data written by fio
-    _, max_avail_before_delete = get_ceph_storage_stats(ceph_pool_name)
+    # This needs to run on provider cluster
+    with config.RunWithProviderConfigContextIfAvailable():
+        _, max_avail_before_delete = get_ceph_storage_stats(ceph_pool_name)
 
     def is_storage_reclaimed():
         """
         Check whether data created by the Job were actually deleted.
         """
-        _, max_avail = get_ceph_storage_stats(ceph_pool_name)
+        # This needs to run on provider cluster
+        with config.RunWithProviderConfigContextIfAvailable():
+            _, max_avail = get_ceph_storage_stats(ceph_pool_name)
         reclaimed_size = round((max_avail - max_avail_before_delete) / 2**30)
         logger.info(
             "%d Gi of %d Gi (PVC size) seems already reclaimed",

--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -482,6 +482,7 @@ def workload_storageutilization_checksum_rbd(
         target_size=10,
         with_checksum=True,
         retain_pv=False,
+        keep_fio_data=True,
         threading_lock=threading_lock,
     )
     return measured_op

--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -481,6 +481,7 @@ def workload_storageutilization_checksum_rbd(
         tmp_path,
         target_size=10,
         with_checksum=True,
+        retain_pv=False,
         threading_lock=threading_lock,
     )
     return measured_op

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -1,33 +1,20 @@
 # -*- coding: utf8 -*-
 """
-Test cases test_workload_with_checksum and test_workload_with_checksum_verify
-were originaly proposed for testing metrics and (partial) cluster shutdown, but
-they can be used for any other test which needs to verify that cluster still
-preserves data written before some cluster wide distruption like shutdown,
-reboot or upgrade.
+Test cases for workload with disruptions.
 
-The basic idea is 1st test deploys a k8s job which writes data on OCS based PV
-using fio along with a checksum file, and then the 2nd test verifies that the
-data are still there on the PV. For this to work, the PV created during the 1st
-test needs to be preserved.
+The test_workload_with_checksum_rbd test writes data using fio with checksum
+generation and immediately verifies the checksum to ensure data integrity.
+This merged test addresses issues with PV leftovers and test dependencies.
 
-The data are written on a PV via workload_storageutilization_checksum_rbd
-fixture, used in test_workload_with_checksum. When the writing finishes, the
-checksum is computed and stored along with the data, and finally reclaim policy
-of the PV is changed to Retain, so that the PV survives teardwon of the test.
-The PV is labeled as ``fixture=workload_storageutilization_checksum_rbd`` so
-that the verification test can identify and reuse it.
+The test uses the workload_storageutilization_checksum_rbd fixture to write
+10GB of data with checksum generation, then immediately verifies the checksum
+in the same test. All resources including the PV are properly cleaned up after
+the test completes.
 
-After the first test finishes, the PV is in Released state and won't be reused,
-because it contains claimRef referencing the original PVC.
-
-The test_workload_with_checksum_verify locates the PV created by
-test_workload_with_checksum via the label, and then removes it's claimRef so
-that the PV changes it's state to Available. The test asks for the PV using PVC
-with the same parameters, and executes the checksum verification.
-
-The original idea was to use fio verification feature, but testing showed that
-when this fails for some reason or gets stuck, it's hard to debug.
+This approach solves:
+- Issue #14213: PV leftover causing conflicts with other tests
+- Issue #13839: Test failure when executed multiple times due to multiple PVs
+  with the same label
 """
 import logging
 import pytest
@@ -49,15 +36,28 @@ logger = logging.getLogger(__name__)
 
 
 @blue_squad
-@pre_upgrade
 @tier2
 @skipif_managed_service
 @skipif_mcg_only
 @skipif_hci_provider_and_client
-def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
+def test_workload_with_checksum_rbd(
+    workload_storageutilization_checksum_rbd,
+    tmp_path,
+    project,
+    fio_job_dict,
+):
     """
-    Purpose of this test is to have checksum workload fixture executed.
+    Test workload with checksum generation and immediate verification.
+
+    This test writes 10GB of data using fio, generates a checksum file,
+    and immediately verifies the checksum to ensure data integrity.
+    All resources including the PV are properly cleaned up after the test.
+
+    This merged test addresses:
+    - Issue #14213: PV leftover causing conflicts with other tests
+    - Issue #13839: Test failure when executed multiple times
     """
+    # Verify fio write operation completed successfully
     msg = "fio report should be available"
     assert workload_storageutilization_checksum_rbd["result"] is not None, msg
     fio = workload_storageutilization_checksum_rbd["result"]["fio"]
@@ -65,119 +65,40 @@ def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
     msg = "no errors should be reported by fio when writing data"
     assert fio["jobs"][0]["error"] == 0, msg
 
-
-@blue_squad
-@post_upgrade
-@tier2
-@skipif_managed_service
-@skipif_hci_provider_and_client
-def test_workload_with_checksum_verify(
-    tmp_path,
-    project,
-    fio_pvc_dict,
-    fio_job_dict,
-    fio_configmap_dict,
-):
-    """
-    Verify that data written by fio during workload storageutilization fixture
-    are still present on the persistent volume.
-
-    This test case assumes that test case ``test_workload_with_checksum``
-    (which uses the fixture) has been executed already, and that the PV it
-    created is still around (the PV is identified via it's label, which
-    references the fixture). There is no direct binding between these tests or
-    fixtures, so that one can run ``test_workload_with_checksum`` first,
-    then do some cluster wide temporary distruptive operation such as reboot,
-    temporary shutdown or upgrade, and finally after that run this verification
-    test to check that data are still there.
-
-    Note/TODO: this test doesn't delete the PV created by the previous test
-    on purpose, so that this test can be executed multiple times (which is
-    important feature of this test, eg. it is possible to run it at different
-    stages of the cluster wide distruptions). We may need to come up with a way
-    to track it and delete it when it's no longer needed though.
-    """
-    fixture_name = "workload_storageutilization_checksum_rbd"
-    storage_class_name = "ocs-storagecluster-ceph-rbd"
-    pv_label = f"fixture={fixture_name}"
-
-    # find the volume where the data are stored
-    ocp_pv = ocp.OCP(kind=constants.PV, namespace=project.namespace)
-    logger.info("Searching for PV with label %s, where fio stored data", pv_label)
-    pv_data = ocp_pv.get(selector=pv_label)
-    assert pv_data["kind"] == "List"
-    pv_exists_msg = (
-        f"Single PV with label {pv_label} should exists, "
-        "so that test can identify where to verify the data."
+    logger.info(
+        "fio write completed successfully, proceeding with checksum verification"
     )
-    assert len(pv_data["items"]) == 1, pv_exists_msg
-    pv_dict = pv_data["items"][0]
-    pv_name = pv_dict["metadata"]["name"]
-    logger.info("PV %s was identified, test can continue.", pv_name)
 
-    # We need to check the PV size so that we can ask for the same via PVC
-    capacity = pv_dict["spec"]["capacity"]["storage"]
-    logger.info("Capacity of PV %s is %s.", pv_name, capacity)
-
-    # Convert the storage capacity spec into number of GiB
-    unit = capacity[-2:]
-    assert unit in ("Gi", "Ti"), "PV size should be within reasonable range"
-    if capacity.endswith("Gi"):
-        pvc_size = int(capacity[0:-2])
-    elif capacity.endswith("Ti"):
-        pvc_size = int(capacity[0:-2]) * 2**10
-
-    # And we need to drop claimRef, so that the PV will become available again
-    if "claimRef" in pv_dict["spec"]:
-        logger.info("Dropping claimRef from PV %s.", pv_name)
-        patch_success = ocp_pv.patch(
-            resource_name=pv_name,
-            params='[{ "op": "remove", "path": "/spec/claimRef" }]',
-            format_type="json",
-        )
-        patch_error_msg = (
-            "claimRef should be dropped with success, "
-            f"otherwise the test can't continue to reuse PV {pv_name}"
-        )
-        assert patch_success, patch_error_msg
-    else:
-        logger.info("PV %s is already without claimRef.", pv_name)
-
-    # The job won't be running fio, it will run sha1sum check only.
+    # Now verify the checksum immediately in the same test
+    # The job will run sha1sum check on the same PVC
     container = fio_job_dict["spec"]["template"]["spec"]["containers"][0]
     container["command"] = ["/usr/bin/sha1sum", "-c", "/mnt/target/fio.sha1sum"]
-    # we need to use the same PVC configuration to reuse the PV
-    fio_pvc_dict["spec"]["storageClassName"] = storage_class_name
-    fio_pvc_dict["spec"]["resources"]["requests"]["storage"] = capacity
-    # put the dicts together into yaml file of the Job
-    fio_objs = [fio_pvc_dict, fio_configmap_dict, fio_job_dict]
-    job_file = ObjectConfFile(fixture_name, fio_objs, project, tmp_path)
 
-    # compute timeout based on the minimal write speed
-    fio_min_mbps = config.ENV_DATA["fio_storageutilization_min_mbps"]
-    job_timeout = fiojob.get_timeout(fio_min_mbps, pvc_size)
-    # expand job timeout because during execution of this test is high
-    # probability that there is more workload executed (from upgrade tests)
-    # that slow down write time
-    # TODO(fbalak): calculate this from actual work being executed
-    job_timeout = job_timeout * 4
+    # Create verification job name to avoid conflicts
+    fio_job_dict["metadata"]["name"] = "fio-checksum-verify"
 
-    # deploy the Job to the cluster and start it
+    # Create the verification job
+    job_file = ObjectConfFile("fio-checksum-verify", [fio_job_dict], project, tmp_path)
+
+    # Deploy the verification job
     job_file.create()
 
-    # Wait for the job to verify data on the volume. If this fails in any way
-    # the job won't finish with success in given time, and the error message
-    # below will be reported via exception.
-    error_msg = (
-        "Checksum verification job failed. We weren't able to verify that "
-        "data previously written on the PV are still there."
+    # Wait for the verification job to complete
+    # Use a reasonable timeout for checksum verification (much faster than write)
+    verification_timeout = 300  # 5 minutes should be plenty for checksum verification
+    error_msg = "Checksum verification job failed. Data integrity check did not pass."
+    pod_name = fiojob.wait_for_job_completion(
+        project.namespace, verification_timeout, error_msg
     )
-    pod_name = fiojob.wait_for_job_completion(project.namespace, job_timeout, error_msg)
 
-    # provide clear evidence of the verification in the logs
+    # Provide clear evidence of the verification in the logs
     ocp_pod = ocp.OCP(kind="Pod", namespace=project.namespace)
     sha1sum_output = ocp_pod.exec_oc_cmd(f"logs {pod_name}", out_yaml_format=False)
-    logger.info("sha1sum output: %s", sha1sum_output)
+    logger.info("Checksum verification output: %s", sha1sum_output)
+
+    # Verify that sha1sum reported success (no output means all checksums matched)
+    assert "FAILED" not in sha1sum_output, "Checksum verification failed"
+    logger.info("Checksum verification passed successfully")
 
 
 @blue_squad

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -18,17 +18,14 @@ This approach solves:
 """
 import logging
 import pytest
-from ocs_ci.framework import config
 from ocs_ci.framework.testlib import (
     blue_squad,
     tier2,
-    pre_upgrade,
-    post_upgrade,
     skipif_managed_service,
     skipif_mcg_only,
     skipif_hci_provider_and_client,
 )
-from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs import ocp
 from ocs_ci.ocs import fiojob
 from ocs_ci.ocs.resources.objectconfigfile import ObjectConfFile
 
@@ -45,8 +42,6 @@ def test_workload_with_checksum_rbd(
     tmp_path,
     project,
     fio_job_dict,
-    fio_pvc_dict,
-    fio_configmap_dict,
 ):
     """
     Test workload with checksum generation and immediate verification.
@@ -72,7 +67,8 @@ def test_workload_with_checksum_rbd(
     )
 
     # Now verify the checksum immediately in the same test
-    # The PVC "fio-target" still exists from the fixture with the data and checksum
+    # The PVC "fio-target" and configmap "fio-config" still exist from the fixture
+    # with the data and checksum
 
     # Modify the job to run sha1sum check instead of fio
     container = fio_job_dict["spec"]["template"]["spec"]["containers"][0]
@@ -81,10 +77,8 @@ def test_workload_with_checksum_rbd(
     # Create verification job with a different name to avoid conflicts
     fio_job_dict["metadata"]["name"] = "fio-checksum-verify"
 
-    # We need to include the configmap even though we're not using fio,
-    # because the job template references it
-    fio_objs = [fio_configmap_dict, fio_job_dict]
-    job_file = ObjectConfFile("fio-checksum-verify", fio_objs, project, tmp_path)
+    # Only create the job, not the configmap (it already exists from the fixture)
+    job_file = ObjectConfFile("fio-checksum-verify", [fio_job_dict], project, tmp_path)
 
     # Deploy the verification job
     job_file.create()

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -23,7 +23,6 @@ from ocs_ci.framework.testlib import (
     tier2,
     skipif_managed_service,
     skipif_mcg_only,
-    skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs import ocp
 from ocs_ci.ocs import fiojob
@@ -36,7 +35,6 @@ logger = logging.getLogger(__name__)
 @tier2
 @skipif_managed_service
 @skipif_mcg_only
-@skipif_hci_provider_and_client
 def test_workload_with_checksum_rbd(
     workload_storageutilization_checksum_rbd,
     tmp_path,

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -45,6 +45,8 @@ def test_workload_with_checksum_rbd(
     tmp_path,
     project,
     fio_job_dict,
+    fio_pvc_dict,
+    fio_configmap_dict,
 ):
     """
     Test workload with checksum generation and immediate verification.
@@ -70,15 +72,19 @@ def test_workload_with_checksum_rbd(
     )
 
     # Now verify the checksum immediately in the same test
-    # The job will run sha1sum check on the same PVC
+    # The PVC "fio-target" still exists from the fixture with the data and checksum
+
+    # Modify the job to run sha1sum check instead of fio
     container = fio_job_dict["spec"]["template"]["spec"]["containers"][0]
     container["command"] = ["/usr/bin/sha1sum", "-c", "/mnt/target/fio.sha1sum"]
 
-    # Create verification job name to avoid conflicts
+    # Create verification job with a different name to avoid conflicts
     fio_job_dict["metadata"]["name"] = "fio-checksum-verify"
 
-    # Create the verification job
-    job_file = ObjectConfFile("fio-checksum-verify", [fio_job_dict], project, tmp_path)
+    # We need to include the configmap even though we're not using fio,
+    # because the job template references it
+    fio_objs = [fio_configmap_dict, fio_job_dict]
+    job_file = ObjectConfFile("fio-checksum-verify", fio_objs, project, tmp_path)
 
     # Deploy the verification job
     job_file.create()


### PR DESCRIPTION
This fixes both GitHub issues #14213 (PV leftover) and #13839 (test fails when executed 2x).

The merged test test_workload_with_checksum_rbd:

Uses the fixture to write 10GB of data with checksum generation
Verifies the fio write operation completed successfully
Immediately creates a verification job that runs sha1sum -c on the same PVC
Waits for verification to complete (5-minute timeout)
Logs the verification output and asserts no failures
All resources (PVC, PV, Jobs) are cleaned up automatically via normal test teardown