### PR TITLE
Fixes #12886: Skip a test on external mode setup.

### DIFF
--- a/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
+++ b/tests/functional/pod_and_daemons/test_cephtoolbox_pod_nodeaffinity.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     tier4b,
     polarion_id,
     runs_on_provider,
+    skipif_external_mode,
 )
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.ocs.node import (
@@ -66,6 +67,7 @@ class TestCephtoolboxPod:
         request.addfinalizer(finalizer)
 
     @tier1
+    @skipif_external_mode
     @polarion_id("OCS-6086")
     def test_node_affinity_to_ceph_toolbox_pod(self):
         """


### PR DESCRIPTION
Fixes: #12886
In external mode, the Ceph layer runs on a separate cluster that is not managed by ODF. Therefore, the Ceph Toolbox is not supported in this mode, nor is it meaningful to use it. Although the ocs‑ci test framework creates a toolbox deployment manually to simplify testing,
 this deployment is not reconciled or managed by the OCS Operator.
Hence skiping this test on external mode