### PR TITLE
Update ACM/MCE UI locators for Fleet Management / Core platform

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -973,30 +973,44 @@ acm_configuration_4_11 = {
 
 acm_configuration_4_12 = {
     "click-local-cluster": ("//a[text()='local-cluster']", By.XPATH),
-    # works for OCP 4.12 to 4.15
     "all-clusters_dropdown": (
+        # ACM (OCP 4.12-4.16)
         "//a[normalize-space()='All Clusters'] | "
         "//span[(@class='pf-c-menu-toggle__text' or @class='pf-v5-c-menu-toggle__text') "
-        "and normalize-space()='All Clusters']/..",
+        "and normalize-space()='All Clusters']/.. | "
+        # MCE Fleet Management (OCP 4.17+)
+        "//span[contains(@class, 'c-menu-toggle__text')]"
+        "//h2[normalize-space()='Fleet Management']/../..",
         By.XPATH,
     ),
-    # works for OCP 4.12 to 4.15
     "all-clusters_dropdown_item": (
+        # ACM (OCP 4.12-4.16)
         "//span[(@class='pf-c-menu__item-text' or @class='pf-v5-c-menu__item-text') "
-        "and text()='All Clusters']/..",
+        "and text()='All Clusters']/.. | "
+        # MCE Fleet Management (OCP 4.17+)
+        "//h2[@data-test-id='perspective-switcher-menu-option' "
+        "and normalize-space()='Fleet Management']",
         By.XPATH,
     ),
-    # works for OCP 4.12 to 4.15
     "local-cluster_dropdown": (
+        # ACM (OCP 4.12-4.16)
         "//h2[text()='local-cluster'] | "
         "//span[(@class='pf-c-menu-toggle__text' or @class='pf-v5-c-menu-toggle__text') "
-        "and text()='local-cluster']/..",
+        "and text()='local-cluster']/.. | "
+        # MCE Core platform (OCP 4.17+)
+        "//span[contains(@class, 'c-menu-toggle__text')]"
+        "//h2[normalize-space()='Core platform']/../.. | "
+        # Fallback: OCP console Overview page loaded
+        "//h1[normalize-space()='Overview']",
         By.XPATH,
     ),
-    # works for OCP 4.12 to 4.15
     "local-cluster_dropdown_item": (
+        # ACM (OCP 4.12-4.16)
         "//span[(@class='pf-c-menu__item-text' or @class='pf-v5-c-menu__item-text') "
-        "and text()='local-cluster']/..",
+        "and text()='local-cluster']/.. | "
+        # MCE Core platform (OCP 4.17+)
+        "//h2[@data-test-id='perspective-switcher-menu-option' "
+        "and normalize-space()='Core platform']",
         By.XPATH,
     ),
     "cluster_status_check": ('//button[normalize-space()="{}"]', By.XPATH),


### PR DESCRIPTION
## Summary

Update ACM cluster switcher locators to handle the new MCE UI terminology introduced in OCP 4.17+.

## Problem

UI tests on HCI provider-client clusters fail during `login_ui()` → `navigate_to_local_cluster()` because the ACM "All Clusters" dropdown was replaced by a "Fleet Management" / "Core platform" perspective switcher in the MCE console plugin. The Selenium locators only looked for the old text, causing 3x 180-second timeouts.

## Changes

Updated all four ACM locators in `acm_configuration_4_12` (`views.py`):

| Locator | Old text | New text added |
|---------|----------|----------------|
| `all-clusters_dropdown` | "All Clusters" | "Fleet Management" (h2 in menu-toggle) |
| `all-clusters_dropdown_item` | "All Clusters" | "Fleet Management" (perspective-switcher-menu-option) |
| `local-cluster_dropdown` | "local-cluster" | "Core platform" (h2 in menu-toggle) + `<h1>Overview</h1>` fallback |
| `local-cluster_dropdown_item` | "local-cluster" | "Core platform" (perspective-switcher-menu-option) |

Also switched from exact class matching (`@class='pf-v5-c-menu-toggle__text'`) to `contains(@class, 'c-menu-toggle__text')` to support pf-v5 and pf-v6.

## Validation

Locators tested against 4 DOM snapshots (CorePlatform closed/opened, FleetManager open, broken MCE fallback) using lxml xpath evaluation.

## Test plan
- [ ] Verify UI tests pass on HCI provider-client clusters with MCE
- [ ] Verify backward compatibility with older ACM UI (All Clusters / local-cluster text)