### PR TITLE
correct the markers

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -5,8 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework.pytest_customization.marks import (
     blue_squad,
     skipif_ocs_version,
-    aws_platform_required,
-    baremetal_deployment_required,
+    skipif_vsphere_platform,
+    skipif_disconnected_cluster,
 )
 from ocs_ci.framework.testlib import E2ETest, tier2
 from ocs_ci.helpers import helpers
@@ -90,8 +90,8 @@ def active_mds_alert_values(threading_lock):
 @tier2
 @blue_squad
 @skipif_ocs_version("<4.15")
-@aws_platform_required
-@baremetal_deployment_required
+@skipif_vsphere_platform
+@skipif_disconnected_cluster
 class TestMdsCpuAlerts(E2ETest):
     @pytest.fixture(scope="function", autouse=True)
     def teardown(self, request):


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/12677

The markers are causing the test to be skipped every time by forcing it to look for both aws and bm platforms simultaneously.