### PR TITLE
Exclude mon pod leftover from the teardown environment check.

### DIFF
--- a/tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
@@ -11,7 +11,11 @@ from ocs_ci.helpers.helpers import (
     check_osd_log_exist_on_rook_ceph_operator_pod,
 )
 from ocs_ci.helpers.odf_cli import ODFCLIRetriever, ODFCliRunner
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.ocs import constants
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    ignore_leftover_label,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -28,6 +32,7 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_ocs_version("<4.8")
 @skipif_external_mode
+@ignore_leftover_label(constants.MON_APP_LABEL)
 @pytest.mark.polarion_id("OCS-2581")
 class TestRookCephOperatorLogType(ManageTest):
     """


### PR DESCRIPTION
- Fixes: #13696
- The test test_rook_ceph_operator_log_type[odf_cli] fails with ResourceLeftoversException because changing ROOK_LOG_LEVEL in the rook operator configmap triggers rook operator reconciliation, which rolls daemon deployments (creating new ReplicaSet The environment_check fixture detects the mon-a pod replacement as a "leftover" because compare_dicts() uses generateName to identify pods. The test itself passes the failure is solely in the environment_check teardown.