### PR TITLE
Re-try for fips check

### DIFF
--- a/ocs_ci/ocs/resources/fips.py
+++ b/ocs_ci/ocs/resources/fips.py
@@ -1,7 +1,8 @@
 import logging
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.exceptions import FipsNotInstalledException
+from ocs_ci.ocs.exceptions import FipsNotInstalledException, CommandFailed
 from ocs_ci.ocs import constants
+from ocs_ci.utility.retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ def check_fips_enabled(fips_location=constants.FIPS_LOCATION):
         ignore_selector=["rook-ceph-detect-version"]
     )
     for running_pod in running_pods_object:
-        fips_value = running_pod.exec_sh_cmd_on_pod(f"cat {fips_location}")
+        fips_value = _get_fips_value_from_pod(running_pod, fips_location)
         if str(fips_value).strip() != "1":
             raise FipsNotInstalledException(
                 "Error in the installation of FIPS on the cluster!"
@@ -33,3 +34,27 @@ def check_fips_enabled(fips_location=constants.FIPS_LOCATION):
             )
         else:
             log.info(f"Pod {running_pod.name} is FIPS enabled!")
+
+
+@retry(
+    CommandFailed,
+    tries=3,
+    delay=30,
+    backoff=1,
+    text_in_exception="container not found",
+)
+def _get_fips_value_from_pod(running_pod, fips_location):
+    """
+    Get FIPS value from a pod with retry logic for transient container issues.
+
+    This function retries when encountering "container not found" errors which can
+    occur due to etcd timeouts or temporary pod state issues during leader election.
+
+    Args:
+        running_pod: Pod object to query
+        fips_location: Path to the FIPS enabled file
+
+    Returns:
+        str: FIPS value from the pod
+    """
+    return running_pod.exec_sh_cmd_on_pod(f"cat {fips_location}")


### PR DESCRIPTION
Seen here:
 https://url.corp.redhat.com/d7643e6
 
  ```
  2026-03-04 04:11:07  >                       ocs_install_verification(ocs_registry_image=ocs_registry_image)
  2026-03-04 04:11:07
  2026-03-04 04:11:07  tests/functional/deployment/test_deployment.py:68:
  2026-03-04 04:11:07  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  2026-03-04 04:11:07  ocs_ci/ocs/resources/storage_cluster.py:711: in ocs_install_verification
  2026-03-04 04:11:07      check_fips_enabled()
  2026-03-04 04:11:07  ocs_ci/ocs/resources/fips.py:27: in check_fips_enabled
  2026-03-04 04:11:07      fips_value = running_pod.exec_sh_cmd_on_pod(f"cat {fips_location}")
  2026-03-04 04:11:07  ocs_ci/ocs/resources/pod.py:309: in exec_sh_cmd_on_pod
  2026-03-04 04:11:07      return self.ocp.exec_oc_cmd(
  2026-03-04 04:11:07  ocs_ci/ocs/ocp.py:189: in exec_oc_cmd
  2026-03-04 04:11:07      out = run_cmd(
  2026-03-04 04:11:07  ocs_ci/utility/utils.py:488: in run_cmd
  2026-03-04 04:11:07      completed_process = exec_cmd(
  .....
  2026-03-04 04:11:07              ):
  2026-03-04 04:11:07                  log.info(f"No results found for grep command: {masked_cmd}")
  2026-03-04 04:11:07              else:
  2026-03-04 04:11:07  >               raise CommandFailed(
  2026-03-04 04:11:07                      f"Error during execution of command: {masked_cmd}."
  2026-03-04 04:11:07                      f"\nError is {masked_stderr}"
  2026-03-04 04:11:07                  )
  2026-03-04 04:11:07  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc -n openshift-storage exec odf-operator-controller-manager-5f78d7f8bf-7275k -- bash -c "cat
  /proc/sys/crypto/fips_enabled".
  2026-03-04 04:11:07  E               Error is error: unable to upgrade connection: container not found ("manager")
  2026-03-04 04:11:07
  2026-03-04 04:11:07  ocs_ci/utility/utils.py:706: CommandFailed
```

  So I it possible to do some re-try logic when this will happen? Or what can lead this is seen?

  we probably wnt to re-try in this case we see such "container not found" in  mg logs in that pod I see last line:
  ```
  2026-03-04T03:04:04.565450140Z E0304 03:04:04.565399       1 leaderelection.go:369] Failed to update lock: etcdserver: request timed out
  ```