### PR TITLE
Fixes 14614: fix for fstring attributeError issue of assertion failure Path

### DIFF
--- a/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
+++ b/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
@@ -143,7 +143,7 @@ class TestCSIADDonDaemonset(ManageTest):
             for container_status in container_status_list:
                 assert container_status[
                     "ready"
-                ], f"container {container_status['name']} in pod {pod.name} is not ready"
+                ], f"container {container_status['name']} in pod {pod['metadata']['name']} is not ready"
         logger.info("All containers in CSI-addon DaemonSet pods are ready")
 
     @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ class TestCSIADDonDaemonset(ManageTest):
             host_network = pod.get("spec").get("hostNetwork", False)
             assert (
                 not host_network
-            ), f" CSI-addon pod {pod.name} is using host network instead of pod network"
+            ), f" CSI-addon pod {pod['metadata']['name']} is using host network instead of pod network"
         logger.info(
             "CSI-addon DaemonSet pods using pod network instead of host-network"
         )


### PR DESCRIPTION
-Fixes issues #14614
- get_pods_having_label() returns raw dicts, not OCS pod objects, so .name raises AttributeError. The fix uses dict access, consistent with how other tests in the same file access pod names