### PR TITLE
Avoid check for the service ocs-provider-server in client cluster during RDR deployment

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2600,8 +2600,8 @@ def create_service_exporter(annotate=True):
         index = cluster.MULTICLUSTER["multicluster_index"]
         config.switch_ctx(index)
         if (
-            get_provider_service_type() == "NodePort"
-            or cluster.ENV_DATA.get("cluster_type").lower() == constants.HCI_CLIENT
+            cluster.ENV_DATA.get("cluster_type").lower() == constants.HCI_CLIENT
+            or get_provider_service_type() == "NodePort"
         ):
             logger.info("Skipping ServiceExport creation for multiclient cluster")
             continue


### PR DESCRIPTION
Fixes #14626 