### PR TITLE
Add CNV DR tests for mixed/shared protection types and removal

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -298,6 +298,30 @@ ENV_DATA:
       dr_workload_app_placement_name: "cnv-dict-1",
       vm_name: "vm-workload-2",
       vm_secret: "vm-secret-1", vm_username: "cirros",
+    },
+    {
+      name: "vm-discovered-3", workload_dir: "rdr/cnv-workload/vm-pvc/vm-resources/vm-workload-3",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "cnv-dict-1",
+      dr_workload_app_placement_name: "cnv-dict-1",
+      vm_name: "vm-workload-3",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
+    },
+    {
+      name: "vm-discovered-4", workload_dir: "rdr/cnv-workload/vm-pvc/vm-resources/vm-workload-4",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "cnv-dict-1",
+      dr_workload_app_placement_name: "cnv-dict-1",
+      vm_name: "vm-workload-4",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
     }
   ]
 

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1865,19 +1865,27 @@ def validate_vgrc_count():
     return True
 
 
-def validate_vgr_vgrc_binding(namespace, drpc_names):
+def validate_vgr_vgrc_binding(namespace, drpc_names, timeout=120, sleep=30):
     """
     Validate that each DRPC's VolumeGroupReplication has a bound
     VolumeGroupReplicationContent and that the VGRC references back
     to the same VGR (bidirectional check).
 
+    The VGR may take time to appear after a DRPC is created, so
+    this polls until all expected VGRs are found and bound or the
+    timeout is reached.
+
     Args:
         namespace (str): Namespace where the VGRs are created
         drpc_names (list): List of DRPC resource names to validate
+        timeout (int): Timeout in seconds (default: 120)
+        sleep (int): Polling interval in seconds (default: 30)
 
     Raises:
-        AssertionError: If a VGR is missing, has no bound VGRC,
-            or the VGRC references a different VGR (stale binding)
+        TimeoutExpiredError: If VGR-VGRC binding is not established
+            within the timeout
+        AssertionError: If a VGRC references the wrong VGR
+            (stale binding)
 
     """
     vgr_ocp = ocp.OCP(
@@ -1885,25 +1893,57 @@ def validate_vgr_vgrc_binding(namespace, drpc_names):
         namespace=namespace,
     )
     vgrc_ocp = ocp.OCP(kind="VolumeGroupReplicationContent")
+
+    def _match_vgr(vgr_items, drpc_name):
+        # VGR names are truncated by the operator and may be
+        # identical for different DRPCs. Match using the
+        # k8s-resource-selector value in the VGR spec which
+        # contains the full un-truncated DRPC base name.
+        base = drpc_name.replace("-drpc", "")
+        matched = []
+        for v in vgr_items:
+            selector = v.get("spec", {}).get("source", {}).get("selector", {})
+            match_exprs = selector.get("matchExpressions", [])
+            for expr in match_exprs:
+                if base in expr.get("values", []):
+                    matched.append(v)
+                    break
+        return matched
+
+    def _check_bindings():
+        vgr_items = vgr_ocp.get().get("items", [])
+        vgrc_items = vgrc_ocp.get().get("items", [])
+
+        for drpc_name in drpc_names:
+            matched = _match_vgr(vgr_items, drpc_name)
+            if not matched:
+                return False
+            vgr = matched[0]
+            vgrc_name = vgr["spec"].get("volumeGroupReplicationContentName", "")
+            if not vgrc_name:
+                return False
+            vgrc_match = [v for v in vgrc_items if v["metadata"]["name"] == vgrc_name]
+            if not vgrc_match:
+                return False
+        return True
+
+    for sample in TimeoutSampler(timeout=timeout, sleep=sleep, func=_check_bindings):
+        if sample:
+            break
+        logger.info(
+            "VGR-VGRC binding not yet ready for %s. Retrying",
+            drpc_names,
+        )
+
     vgr_items = vgr_ocp.get().get("items", [])
     vgrc_items = vgrc_ocp.get().get("items", [])
 
     for drpc_name in drpc_names:
-        matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
-        assert matched, (
-            f"No VGR found for DRPC {drpc_name} in " f"namespace {namespace}"
-        )
+        matched = _match_vgr(vgr_items, drpc_name)
         vgr = matched[0]
         vgr_name = vgr["metadata"]["name"]
         vgrc_name = vgr["spec"].get("volumeGroupReplicationContentName", "")
-        assert vgrc_name, (
-            f"VGR {vgr_name} has no bound " f"VolumeGroupReplicationContent"
-        )
-
         vgrc_match = [v for v in vgrc_items if v["metadata"]["name"] == vgrc_name]
-        assert vgrc_match, (
-            f"VGRC {vgrc_name} referenced by VGR " f"{vgr_name} does not exist"
-        )
         vgrc_ref = (
             vgrc_match[0]
             .get("spec", {})
@@ -1915,12 +1955,16 @@ def validate_vgr_vgrc_binding(namespace, drpc_names):
             f"{vgrc_ref!r} instead of {vgr_name!r} "
             f"(stale binding)"
         )
-        logger.info(f"VGR {vgr_name} <-> VGRC {vgrc_name} " f"binding verified")
+        logger.info(
+            "VGR %s <-> VGRC %s binding verified",
+            vgr_name,
+            vgrc_name,
+        )
     logger.info("VGR-VGRC binding validation completed")
 
 
 def validate_vgr_pvc_refs(
-    namespace, drpc_name, expected_pvc_names, timeout=120, sleep=30
+    namespace, drpc_name, expected_pvc_names, timeout=180, sleep=30
 ):
     """
     Validate that a DRPC's VolumeGroupReplication contains exactly
@@ -1950,9 +1994,21 @@ def validate_vgr_pvc_refs(
         namespace=namespace,
     )
 
+    def _match_vgr(vgr_items):
+        base = drpc_name.replace("-drpc", "")
+        matched = []
+        for v in vgr_items:
+            selector = v.get("spec", {}).get("source", {}).get("selector", {})
+            match_exprs = selector.get("matchExpressions", [])
+            for expr in match_exprs:
+                if base in expr.get("values", []):
+                    matched.append(v)
+                    break
+        return matched
+
     def _check_pvc_refs():
         vgr_items = vgr_ocp.get().get("items", [])
-        matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
+        matched = _match_vgr(vgr_items)
         assert matched, (
             f"No VGR found for DRPC {drpc_name} in " f"namespace {namespace}"
         )
@@ -1970,7 +2026,7 @@ def validate_vgr_pvc_refs(
         )
 
     vgr_items = vgr_ocp.get().get("items", [])
-    matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
+    matched = _match_vgr(vgr_items)
     vgr_name = matched[0]["metadata"]["name"]
     logger.info("VGR %s PVC refs validated: %s", vgr_name, expected)
 

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1919,6 +1919,62 @@ def validate_vgr_vgrc_binding(namespace, drpc_names):
     logger.info("VGR-VGRC binding validation completed")
 
 
+def validate_vgr_pvc_refs(
+    namespace, drpc_name, expected_pvc_names, timeout=120, sleep=30
+):
+    """
+    Validate that a DRPC's VolumeGroupReplication contains exactly
+    the expected PVCs in status.persistentVolumeClaimsRefList.
+
+    The VGR PVC ref list may take a sync cycle to update after
+    a shared VM is enrolled, so this polls until the expected
+    PVCs appear or the timeout is reached.
+
+    Args:
+        namespace (str): Namespace where VGRs are created
+        drpc_name (str): DRPC resource name to match in VGR name
+        expected_pvc_names (list): Expected PVC names
+        timeout (int): Timeout in seconds (default: 120)
+        sleep (int): Polling interval in seconds (default: 30)
+
+    Raises:
+        TimeoutExpiredError: If VGR PVC refs do not match within
+            the timeout
+        AssertionError: If no VGR is found for the DRPC
+
+    """
+    expected = sorted(expected_pvc_names)
+
+    vgr_ocp = ocp.OCP(
+        kind=constants.VOLUME_GROUP_REPLICATION,
+        namespace=namespace,
+    )
+
+    def _check_pvc_refs():
+        vgr_items = vgr_ocp.get().get("items", [])
+        matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
+        assert matched, (
+            f"No VGR found for DRPC {drpc_name} in " f"namespace {namespace}"
+        )
+        vgr = matched[0]
+        pvc_refs = vgr.get("status", {}).get("persistentVolumeClaimsRefList", [])
+        return sorted([p["name"] for p in pvc_refs])
+
+    for sample in TimeoutSampler(timeout=timeout, sleep=sleep, func=_check_pvc_refs):
+        if sample == expected:
+            break
+        logger.info(
+            "VGR PVC refs not yet matching: expected %s, " "got %s. Retrying",
+            expected,
+            sample,
+        )
+
+    vgr_items = vgr_ocp.get().get("items", [])
+    matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
+    vgr_name = matched[0]["metadata"]["name"]
+    logger.info("VGR %s PVC refs validated: %s", vgr_name, expected)
+
+
 def verify_last_group_sync_time(
     drpc_obj,
     scheduling_interval,

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1189,10 +1189,9 @@ def wait_for_replication_resources_deletion(
                 timeout=timeout,
             )
 
-    if (
+    if not skip_vrg_check and (
         not check_state
         or (ocs_version <= version.VERSION_4_17 and "cephfs" not in namespace)
-        and not skip_vrg_check
     ):
         wait_for_resource_existence(
             kind=constants.VOLUME_REPLICATION_GROUP,
@@ -2612,16 +2611,33 @@ def do_discovered_apps_cleanup(
     config.switch_to_cluster_by_name(old_primary)
     workload_path = constants.DR_WORKLOAD_REPO_BASE_DIR + "/" + workload_dir
     if not ignore_resource_not_found:
-
         # --ignore-not-found is needed to avoid https://issues.redhat.com/browse/DFBUGS-3706
         logger.info("Using '--ignore-not-found' during workload deletion")
-        run_cmd(
-            f"oc delete -k {workload_path} -n {workload_namespace} --wait=false --ignore-not-found --force "
+        delete_cmd = (
+            f"oc delete -k {workload_path} -n {workload_namespace} "
+            f"--wait=false --ignore-not-found --force "
         )
     else:
-        run_cmd(
-            f"oc delete -k {workload_path} -n {workload_namespace} --wait=false --force "
+        delete_cmd = (
+            f"oc delete -k {workload_path} -n {workload_namespace} "
+            f"--wait=false --force "
         )
+    retryable_errors = ("etcdserver", "Timeout", "context deadline exceeded")
+    for attempt in range(3):
+        try:
+            run_cmd(delete_cmd)
+            break
+        except CommandFailed as e:
+            err_msg = str(e)
+            if any(err in err_msg for err in retryable_errors) and attempt < 2:
+                logger.warning(
+                    "Server error during workload deletion (attempt %d/3), "
+                    "retrying in 60s",
+                    attempt + 1,
+                )
+                time.sleep(60)
+            else:
+                raise
     if not skip_resource_deletion_verification:
         wait_for_all_resources_deletion(
             namespace=workload_namespace, discovered_apps=True, vrg_name=vrg_name
@@ -3526,3 +3542,60 @@ def extract_images_from_yaml(obj, images=None):
             extract_images_from_yaml(item, images)
 
     return images
+
+
+def wait_for_managed_cluster_unreachable(cluster_name, timeout=600, sleep=15):
+    """
+    Wait until the ACM hub reports a managed cluster as unreachable (AVAILABLE=Unknown).
+
+    After stopping cluster nodes, the ACM hub detects the loss of connectivity
+    and sets the ManagedCluster AVAILABLE condition to ``Unknown``. Ramen requires
+    this state before it will complete a failover operation. Using a fixed sleep
+    is unreliable — this function polls the actual cluster status instead.
+
+    Args:
+        cluster_name (str): Name of the managed cluster to wait for.
+        timeout (int): Maximum seconds to wait (default: 600).
+        sleep (int): Seconds between polling attempts (default: 15).
+
+    Raises:
+        TimeoutExpiredError: If the cluster does not become unreachable within timeout.
+
+    """
+    restore_index = config.cur_index
+    config.switch_acm_ctx()
+    mc_obj = OCP(kind=constants.ACM_MANAGEDCLUSTER)
+    logger.info(
+        "Waiting for managed cluster '%s' to become unreachable on ACM hub",
+        cluster_name,
+    )
+
+    def _is_unreachable():
+        try:
+            conditions = (
+                mc_obj.get(resource_name=cluster_name)
+                .get("status", {})
+                .get("conditions", [])
+            )
+        except Exception:
+            return False
+        for condition in conditions:
+            if condition.get("type") == "ManagedClusterConditionAvailable":
+                status = condition.get("status", "True")
+                if status in ("False", "Unknown"):
+                    logger.info(
+                        "Managed cluster '%s' is unreachable (AVAILABLE=%s)",
+                        cluster_name,
+                        status,
+                    )
+                    return True
+        return False
+
+    from ocs_ci.utility.utils import TimeoutSampler
+
+    for reachable in TimeoutSampler(timeout=timeout, sleep=sleep, func=_is_unreachable):
+        if reachable:
+            break
+        logger.info("Managed cluster '%s' still reachable, retrying...", cluster_name)
+
+    config.switch_ctx(restore_index)

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1626,6 +1626,23 @@ def get_all_drpolicy():
     return return_drpolicy_list
 
 
+def delete_drpolicy(drpolicy_name):
+    """
+    Delete a DRPolicy resource from the hub cluster.
+
+    Args:
+        drpolicy_name (str): Name of the DRPolicy to delete
+
+    """
+    config.switch_acm_ctx()
+    drpolicy_obj = ocp.OCP(kind=constants.DRPOLICY)
+    try:
+        drpolicy_obj.delete(resource_name=drpolicy_name)
+        logger.info(f"DRPolicy {drpolicy_name} deleted")
+    except Exception as ex:
+        logger.warning(f"Failed to delete DRPolicy {drpolicy_name}: {ex}")
+
+
 @retry(UnexpectedBehaviour, tries=5, delay=10, backoff=2)
 def validate_drpolicy_grouping(drpolicy_name=None):
     """
@@ -1846,6 +1863,60 @@ def validate_vgrc_count():
 
     logger.info("VGRC count validation completed successfully")
     return True
+
+
+def validate_vgr_vgrc_binding(namespace, drpc_names):
+    """
+    Validate that each DRPC's VolumeGroupReplication has a bound
+    VolumeGroupReplicationContent and that the VGRC references back
+    to the same VGR (bidirectional check).
+
+    Args:
+        namespace (str): Namespace where the VGRs are created
+        drpc_names (list): List of DRPC resource names to validate
+
+    Raises:
+        AssertionError: If a VGR is missing, has no bound VGRC,
+            or the VGRC references a different VGR (stale binding)
+
+    """
+    vgr_ocp = ocp.OCP(
+        kind=constants.VOLUME_GROUP_REPLICATION,
+        namespace=namespace,
+    )
+    vgrc_ocp = ocp.OCP(kind="VolumeGroupReplicationContent")
+    vgr_items = vgr_ocp.get().get("items", [])
+    vgrc_items = vgrc_ocp.get().get("items", [])
+
+    for drpc_name in drpc_names:
+        matched = [v for v in vgr_items if drpc_name in v["metadata"]["name"]]
+        assert matched, (
+            f"No VGR found for DRPC {drpc_name} in " f"namespace {namespace}"
+        )
+        vgr = matched[0]
+        vgr_name = vgr["metadata"]["name"]
+        vgrc_name = vgr["spec"].get("volumeGroupReplicationContentName", "")
+        assert vgrc_name, (
+            f"VGR {vgr_name} has no bound " f"VolumeGroupReplicationContent"
+        )
+
+        vgrc_match = [v for v in vgrc_items if v["metadata"]["name"] == vgrc_name]
+        assert vgrc_match, (
+            f"VGRC {vgrc_name} referenced by VGR " f"{vgr_name} does not exist"
+        )
+        vgrc_ref = (
+            vgrc_match[0]
+            .get("spec", {})
+            .get("volumeGroupReplicationRef", {})
+            .get("name", "")
+        )
+        assert vgrc_ref == vgr_name, (
+            f"VGRC {vgrc_name} references VGR "
+            f"{vgrc_ref!r} instead of {vgr_name!r} "
+            f"(stale binding)"
+        )
+        logger.info(f"VGR {vgr_name} <-> VGRC {vgrc_name} " f"binding verified")
+    logger.info("VGR-VGRC binding validation completed")
 
 
 def verify_last_group_sync_time(

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -3596,6 +3596,6 @@ def wait_for_managed_cluster_unreachable(cluster_name, timeout=600, sleep=15):
     for reachable in TimeoutSampler(timeout=timeout, sleep=sleep, func=_is_unreachable):
         if reachable:
             break
-        logger.info("Managed cluster '%s' still reachable, retrying...", cluster_name)
+        logger.info(f"Managed cluster '{cluster_name}' still reachable, retrying...")
 
     config.switch_ctx(restore_index)

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -3100,6 +3100,7 @@ def do_discovered_apps_cleanup(
     vrg_name,
     skip_resource_deletion_verification=False,
     ignore_resource_not_found=False,
+    wait_for_cleanup_timeout=300,
 ):
     """
     Function to clean up Resources
@@ -3116,12 +3117,16 @@ def do_discovered_apps_cleanup(
 
         ignore_resource_not_found (bool): False by default, resource not found is ignored when the workload which was
                                         DR protected via ACM UI is deleted, refer DFBUGS-3706
+        wait_for_cleanup_timeout (int): Timeout in seconds for waiting for DRPC WaitOnUserToCleanUp
+                                        progression status (default: 300)
 
     """
     restore_index = config.cur_index
     config.switch_acm_ctx()
     drpc_obj = DRPC(namespace=constants.DR_OPS_NAMESPACE, resource_name=drpc_name)
-    drpc_obj.wait_for_progression_status(status=constants.STATUS_WAITFORUSERTOCLEANUP)
+    drpc_obj.wait_for_progression_status(
+        status=constants.STATUS_WAITFORUSERTOCLEANUP, timeout=wait_for_cleanup_timeout
+    )
     time.sleep(90)
     assert drpc_obj.get_progression_status(
         status_to_check=constants.STATUS_WAITFORUSERTOCLEANUP

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1229,10 +1229,9 @@ def wait_for_replication_resources_deletion(
                 timeout=timeout,
             )
 
-    if (
+    if not skip_vrg_check and (
         not check_state
         or (ocs_version <= version.VERSION_4_17 and "cephfs" not in namespace)
-        and not skip_vrg_check
     ):
         wait_for_resource_existence(
             kind=constants.VOLUME_REPLICATION_GROUP,
@@ -1430,13 +1429,28 @@ def wait_for_cnv_workload(
 
     """
     logger.info(f"Wait for VM: {vm_name} to reach {phase} state")
-    vm_obj = ocp.OCP(
+    vmi_obj = ocp.OCP(
         kind=constants.VIRTUAL_MACHINE_INSTANCES,
         resource_name=vm_name,
         namespace=namespace,
     )
-    vm_obj._has_phase = True
-    vm_obj.wait_for_phase(phase=constants.STATUS_RUNNING, timeout=timeout)
+    vmi_obj._has_phase = True
+    vmi_obj.wait_for_phase(phase=constants.STATUS_RUNNING, timeout=timeout)
+
+    # A paused VMI still reports phase=Running — also wait for the VM's
+    # printableStatus to confirm the VM is not paused before returning.
+    if phase == constants.STATUS_RUNNING:
+        logger.info(f"Verifying VM: {vm_name} is not paused (printableStatus=Running)")
+        vm_ocp_obj = ocp.OCP(
+            kind=constants.VIRTUAL_MACHINE,
+            resource_name=vm_name,
+            namespace=namespace,
+        )
+        vm_ocp_obj.wait_for_resource(
+            resource_name=vm_name,
+            condition=constants.VM_RUNNING,
+            timeout=timeout,
+        )
 
 
 def wait_for_replication_destinations_creation(rep_dest_count, namespace, timeout=900):
@@ -1692,6 +1706,23 @@ def get_all_drpolicy():
 # Guard flag: bounce the ramen-hub-operator pod at most once per process
 # across all retry attempts of validate_drpolicy_grouping.
 _ramen_hub_pod_bounced = False
+
+
+def delete_drpolicy(drpolicy_name):
+    """
+    Delete a DRPolicy resource from the hub cluster.
+
+    Args:
+        drpolicy_name (str): Name of the DRPolicy to delete
+
+    """
+    config.switch_acm_ctx()
+    drpolicy_obj = ocp.OCP(kind=constants.DRPOLICY)
+    try:
+        drpolicy_obj.delete(resource_name=drpolicy_name)
+        logger.info(f"DRPolicy {drpolicy_name} deleted")
+    except Exception as ex:
+        logger.warning(f"Failed to delete DRPolicy {drpolicy_name}: {ex}")
 
 
 @retry(UnexpectedBehaviour, tries=10, delay=30, backoff=2, max_delay=120)
@@ -2042,6 +2073,172 @@ def validate_vgrc_count():
 
     logger.info("VGRC count validation completed successfully")
     return True
+
+
+def validate_vgr_vgrc_binding(namespace, drpc_names, timeout=120, sleep=30):
+    """
+    Validate that each DRPC's VolumeGroupReplication has a bound
+    VolumeGroupReplicationContent and that the VGRC references back
+    to the same VGR (bidirectional check).
+
+    The VGR may take time to appear after a DRPC is created, so
+    this polls until all expected VGRs are found and bound or the
+    timeout is reached.
+
+    Args:
+        namespace (str): Namespace where the VGRs are created
+        drpc_names (list): List of DRPC resource names to validate
+        timeout (int): Timeout in seconds (default: 120)
+        sleep (int): Polling interval in seconds (default: 30)
+
+    Raises:
+        TimeoutExpiredError: If VGR-VGRC binding is not established
+            within the timeout
+        AssertionError: If a VGRC references the wrong VGR
+            (stale binding)
+
+    """
+    vgr_ocp = ocp.OCP(
+        kind=constants.VOLUME_GROUP_REPLICATION,
+        namespace=namespace,
+    )
+    vgrc_ocp = ocp.OCP(kind="VolumeGroupReplicationContent")
+
+    def _match_vgr(vgr_items, drpc_name):
+        # VGR names are truncated by the operator and may be
+        # identical for different DRPCs. Match using the
+        # k8s-resource-selector value in the VGR spec which
+        # contains the full un-truncated DRPC base name.
+        base = drpc_name.replace("-drpc", "")
+        matched = []
+        for v in vgr_items:
+            selector = v.get("spec", {}).get("source", {}).get("selector", {})
+            match_exprs = selector.get("matchExpressions", [])
+            for expr in match_exprs:
+                if base in expr.get("values", []):
+                    matched.append(v)
+                    break
+        return matched
+
+    def _check_bindings():
+        vgr_items = vgr_ocp.get().get("items", [])
+        vgrc_items = vgrc_ocp.get().get("items", [])
+
+        for drpc_name in drpc_names:
+            matched = _match_vgr(vgr_items, drpc_name)
+            if not matched:
+                return False
+            vgr = matched[0]
+            vgrc_name = vgr["spec"].get("volumeGroupReplicationContentName", "")
+            if not vgrc_name:
+                return False
+            vgrc_match = [v for v in vgrc_items if v["metadata"]["name"] == vgrc_name]
+            if not vgrc_match:
+                return False
+        return True
+
+    for sample in TimeoutSampler(timeout=timeout, sleep=sleep, func=_check_bindings):
+        if sample:
+            break
+        logger.info(
+            "VGR-VGRC binding not yet ready for %s. Retrying",
+            drpc_names,
+        )
+
+    vgr_items = vgr_ocp.get().get("items", [])
+    vgrc_items = vgrc_ocp.get().get("items", [])
+
+    for drpc_name in drpc_names:
+        matched = _match_vgr(vgr_items, drpc_name)
+        vgr = matched[0]
+        vgr_name = vgr["metadata"]["name"]
+        vgrc_name = vgr["spec"].get("volumeGroupReplicationContentName", "")
+        vgrc_match = [v for v in vgrc_items if v["metadata"]["name"] == vgrc_name]
+        vgrc_ref = (
+            vgrc_match[0]
+            .get("spec", {})
+            .get("volumeGroupReplicationRef", {})
+            .get("name", "")
+        )
+        assert vgrc_ref == vgr_name, (
+            f"VGRC {vgrc_name} references VGR "
+            f"{vgrc_ref!r} instead of {vgr_name!r} "
+            f"(stale binding)"
+        )
+        logger.info(
+            "VGR %s <-> VGRC %s binding verified",
+            vgr_name,
+            vgrc_name,
+        )
+    logger.info("VGR-VGRC binding validation completed")
+
+
+def validate_vgr_pvc_refs(
+    namespace, drpc_name, expected_pvc_names, timeout=180, sleep=30
+):
+    """
+    Validate that a DRPC's VolumeGroupReplication contains exactly
+    the expected PVCs in status.persistentVolumeClaimsRefList.
+
+    The VGR PVC ref list may take a sync cycle to update after
+    a shared VM is enrolled, so this polls until the expected
+    PVCs appear or the timeout is reached.
+
+    Args:
+        namespace (str): Namespace where VGRs are created
+        drpc_name (str): DRPC resource name to match in VGR name
+        expected_pvc_names (list): Expected PVC names
+        timeout (int): Timeout in seconds (default: 120)
+        sleep (int): Polling interval in seconds (default: 30)
+
+    Raises:
+        TimeoutExpiredError: If VGR PVC refs do not match within
+            the timeout
+        AssertionError: If no VGR is found for the DRPC
+
+    """
+    expected = sorted(expected_pvc_names)
+
+    vgr_ocp = ocp.OCP(
+        kind=constants.VOLUME_GROUP_REPLICATION,
+        namespace=namespace,
+    )
+
+    def _match_vgr(vgr_items):
+        base = drpc_name.replace("-drpc", "")
+        matched = []
+        for v in vgr_items:
+            selector = v.get("spec", {}).get("source", {}).get("selector", {})
+            match_exprs = selector.get("matchExpressions", [])
+            for expr in match_exprs:
+                if base in expr.get("values", []):
+                    matched.append(v)
+                    break
+        return matched
+
+    def _check_pvc_refs():
+        vgr_items = vgr_ocp.get().get("items", [])
+        matched = _match_vgr(vgr_items)
+        assert matched, (
+            f"No VGR found for DRPC {drpc_name} in " f"namespace {namespace}"
+        )
+        vgr = matched[0]
+        pvc_refs = vgr.get("status", {}).get("persistentVolumeClaimsRefList", [])
+        return sorted([p["name"] for p in pvc_refs])
+
+    for sample in TimeoutSampler(timeout=timeout, sleep=sleep, func=_check_pvc_refs):
+        if sample == expected:
+            break
+        logger.info(
+            "VGR PVC refs not yet matching: expected %s, " "got %s. Retrying",
+            expected,
+            sample,
+        )
+
+    vgr_items = vgr_ocp.get().get("items", [])
+    matched = _match_vgr(vgr_items)
+    vgr_name = matched[0]["metadata"]["name"]
+    logger.info("VGR %s PVC refs validated: %s", vgr_name, expected)
 
 
 def verify_last_group_sync_time(
@@ -2935,16 +3132,33 @@ def do_discovered_apps_cleanup(
     config.switch_to_cluster_by_name(old_primary)
     workload_path = constants.DR_WORKLOAD_REPO_BASE_DIR + "/" + workload_dir
     if not ignore_resource_not_found:
-
         # --ignore-not-found is needed to avoid https://issues.redhat.com/browse/DFBUGS-3706
         logger.info("Using '--ignore-not-found' during workload deletion")
-        run_cmd(
-            f"oc delete -k {workload_path} -n {workload_namespace} --wait=false --ignore-not-found --force "
+        delete_cmd = (
+            f"oc delete -k {workload_path} -n {workload_namespace} "
+            f"--wait=false --ignore-not-found --force "
         )
     else:
-        run_cmd(
-            f"oc delete -k {workload_path} -n {workload_namespace} --wait=false --force "
+        delete_cmd = (
+            f"oc delete -k {workload_path} -n {workload_namespace} "
+            f"--wait=false --force "
         )
+    retryable_errors = ("etcdserver", "Timeout", "context deadline exceeded")
+    for attempt in range(3):
+        try:
+            exec_cmd(delete_cmd)
+            break
+        except CommandFailed as e:
+            err_msg = str(e)
+            if any(err in err_msg for err in retryable_errors) and attempt < 2:
+                logger.warning(
+                    "Server error during workload deletion (attempt %d/3), "
+                    "retrying in 60s",
+                    attempt + 1,
+                )
+                time.sleep(60)
+            else:
+                raise
     if not skip_resource_deletion_verification:
         wait_for_all_resources_deletion(
             namespace=workload_namespace, discovered_apps=True, vrg_name=vrg_name
@@ -4766,3 +4980,60 @@ def validate_cluster_odf_cli(retries=5, retry_interval=60):
         f"ODF DR validate clusters did not report success after {retries} attempts. "
         f"Output:\n{last_stdout}"
     )
+
+
+def wait_for_managed_cluster_unreachable(cluster_name, timeout=600, sleep=15):
+    """
+    Wait until the ACM hub reports a managed cluster as unreachable (AVAILABLE=Unknown).
+
+    After stopping cluster nodes, the ACM hub detects the loss of connectivity
+    and sets the ManagedCluster AVAILABLE condition to ``Unknown``. Ramen requires
+    this state before it will complete a failover operation. Using a fixed sleep
+    is unreliable — this function polls the actual cluster status instead.
+
+    Args:
+        cluster_name (str): Name of the managed cluster to wait for.
+        timeout (int): Maximum seconds to wait (default: 600).
+        sleep (int): Seconds between polling attempts (default: 15).
+
+    Raises:
+        TimeoutExpiredError: If the cluster does not become unreachable within timeout.
+
+    """
+    restore_index = config.cur_index
+    config.switch_acm_ctx()
+    mc_obj = OCP(kind=constants.ACM_MANAGEDCLUSTER)
+    logger.info(
+        "Waiting for managed cluster '%s' to become unreachable on ACM hub",
+        cluster_name,
+    )
+
+    def _is_unreachable():
+        try:
+            conditions = (
+                mc_obj.get(resource_name=cluster_name)
+                .get("status", {})
+                .get("conditions", [])
+            )
+        except Exception:
+            return False
+        for condition in conditions:
+            if condition.get("type") == "ManagedClusterConditionAvailable":
+                status = condition.get("status", "True")
+                if status in ("False", "Unknown"):
+                    logger.info(
+                        "Managed cluster '%s' is unreachable (AVAILABLE=%s)",
+                        cluster_name,
+                        status,
+                    )
+                    return True
+        return False
+
+    from ocs_ci.utility.utils import TimeoutSampler
+
+    for reachable in TimeoutSampler(timeout=timeout, sleep=sleep, func=_is_unreachable):
+        if reachable:
+            break
+        logger.info(f"Managed cluster '{cluster_name}' still reachable, retrying...")
+
+    config.switch_ctx(restore_index)

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -11,7 +11,10 @@ from ocs_ci.utility.version import compare_versions
 from selenium.common.exceptions import (
     NoSuchElementException,
     StaleElementReferenceException,
+    TimeoutException as SeleniumTimeoutException,
 )
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -821,53 +824,72 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
 
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    if acm_obj.check_element_presence(
-        (
-            acm_loc["modal_dialog_close_button"][1],
-            acm_loc["modal_dialog_close_button"][0],
-        ),
-        timeout=10,
-    ):
-        log.info("Modal dialog box found, closing it..")
-        acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
-    log.info("Look for 'All Clusters'")
-    all_clusters = acm_obj.wait_until_expected_text_is_found(
-        acm_loc["all-clusters"], expected_text="All clusters"
-    )
-    if all_clusters:
-        log.info("All Clusters option found")
-    else:
-        log.warning("'All Clusters' not found on the VMs page")
-        return False
     for vm in vms:
-        log.info("Select the cluster where VM workload is running")
-        acm_obj.do_click(
-            format_locator(acm_loc["managed-cluster-name"], managed_cluster_name)
+        vm_locator = format_locator(acm_loc["cnv-vm-name"], vm.vm_name)
+        # The visibility shortcut (skip tree navigation when the VM is already
+        # on-screen) is safe for enrollment calls because only one instance of
+        # the VM exists at that point. For status-check-only calls
+        # (assign_policy=False) we must navigate through the cluster tree to
+        # guarantee we reach the correct cluster's VM; otherwise the XPath may
+        # match a stale ACM-cached entry from a different cluster (e.g. the
+        # old primary after failover cleanup) and produce a non-Running status.
+        vm_already_visible = assign_policy and acm_obj.check_element_presence(
+            (vm_locator[1], vm_locator[0]), timeout=10
         )
-        log.info(f"Managed cluster {managed_cluster_name} found ")
-        log.info("Select the namespace where VM workload is running")
-        acm_obj.do_click(
-            format_locator(acm_loc["cnv-workload-namespace"], namespace),
-            enable_screenshot=True,
-        )
-        log.info(f"Namespace {namespace} found on cluster {managed_cluster_name}")
-        log.info("Click on the VM")
-        acm_obj.do_click(
-            format_locator(acm_loc["cnv-vm-name"], vm.vm_name), enable_screenshot=True
-        )
-        log.info("Check the status of the VM")
-        vm_current_status = acm_obj.get_element_text(acm_loc["vm-status"])
-        if vm_current_status != "Running":
-            wait_for_status = acm_obj.wait_until_expected_text_is_found(
-                acm_loc["vm-status"], expected_text="Running", timeout=300
-            )
-            assert (
-                wait_for_status
-            ), f"Expected VM status is 'Running', but got '{vm_current_status}'"
-        else:
+        if vm_already_visible:
             log.info(
-                f"VM status is running on the managed cluster {managed_cluster_name}"
+                f"VM {vm.vm_name} already visible on the page, "
+                "skipping tree navigation"
             )
+        else:
+            if acm_obj.check_element_presence(
+                (
+                    acm_loc["modal_dialog_close_button"][1],
+                    acm_loc["modal_dialog_close_button"][0],
+                ),
+                timeout=10,
+            ):
+                log.info("Modal dialog box found, closing it..")
+                acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            log.info("Look for 'All Clusters'")
+            all_clusters = acm_obj.wait_until_expected_text_is_found(
+                acm_loc["all-clusters"], expected_text="All clusters"
+            )
+            if all_clusters:
+                log.info("All Clusters option found")
+            else:
+                log.warning("'All Clusters' not found on the VMs page")
+                return False
+            ns_locator = format_locator(acm_loc["cnv-workload-namespace"], namespace)
+            ns_already_visible = acm_obj.check_element_presence(
+                (ns_locator[1], ns_locator[0]), timeout=10
+            )
+            if not ns_already_visible:
+                log.info("Select the cluster where VM workload is running")
+                acm_obj.do_click(
+                    format_locator(
+                        acm_loc["managed-cluster-name"],
+                        managed_cluster_name,
+                    )
+                )
+                log.info(f"Managed cluster {managed_cluster_name} found ")
+            else:
+                log.info("Namespace already visible, " "skipping managed cluster click")
+            log.info("Select the namespace where VM workload is running")
+            acm_obj.do_click(ns_locator, enable_screenshot=True)
+            log.info(
+                f"Namespace {namespace} found on " f"cluster {managed_cluster_name}"
+            )
+        log.info("Click on the VM")
+        acm_obj.do_click(vm_locator, enable_screenshot=True)
+        log.info("Check the status of the VM")
+        vm_running = acm_obj.wait_until_expected_text_is_found(
+            acm_loc["vm-status"], expected_text="Running", timeout=300
+        )
+        assert vm_running, (
+            "Expected VM status is 'Running' but the status element "
+            "was not found or did not reach Running state"
+        )
         if assign_policy:
             log.info("Click on the Actions button")
             acm_obj.do_click(acm_loc["vm-actions"], enable_screenshot=True)
@@ -884,12 +906,29 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 log.info("Protecting VM with Shared Protection type")
                 acm_obj.do_click(acm_loc["select-shared"], enable_screenshot=True)
                 radio_buttons = acm_obj.get_elements(acm_loc["select-drpc"])
-                # Assert that exactly one element is found
                 assert (
-                    len(radio_buttons) == 1
-                ), f"Expected 1 radio button but found {len(radio_buttons)}"
-                log.info("Expected 1 radio button found, select existing DRPC")
-                acm_obj.do_click(acm_loc["select-drpc"], enable_screenshot=True)
+                    len(radio_buttons) >= 1
+                ), f"Expected at least 1 radio button but found {len(radio_buttons)}"
+                if len(radio_buttons) == 1:
+                    log.info("Only 1 radio button found, selecting existing DRPC")
+                    acm_obj.do_click(acm_loc["select-drpc"], enable_screenshot=True)
+                else:
+                    log.info(
+                        "%d radio buttons found, selecting DRPC matching "
+                        "protection name '%s'",
+                        len(radio_buttons),
+                        protection_name,
+                    )
+                    # The radio button value is the DRPC resource name.
+                    # Standalone enrollment creates a DRPC named
+                    # '{protection_name}-drpc'; try both forms.
+                    drpc_radio_locator = (
+                        f"//input[@name='radioGroup']"
+                        f"[@value='{protection_name}' or "
+                        f"@value='{protection_name}-drpc']",
+                        By.XPATH,
+                    )
+                    acm_obj.do_click(drpc_radio_locator, enable_screenshot=True)
             log.info("Click next")
             acm_obj.do_click(acm_loc["vm-page-next-btn"], enable_screenshot=True)
             if standalone:
@@ -915,10 +954,146 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
             conf_msg = acm_obj.get_element_text(acm_loc["conf-msg"])
             log.info(f"Confirmation message is {conf_msg}")
             acm_obj.take_screenshot()
-            expected_conf_msg = conf_msg.split("\n", 1)[1].strip()
-            assert expected_conf_msg == "New policy assigned to application"
+            assert (
+                "New policy assigned to application" in conf_msg
+            ), f"Unexpected confirmation message: '{conf_msg}'"
             log.info("Close page")
             acm_obj.do_click(acm_loc["close-page"], enable_screenshot=True)
+    return True
+
+
+def remove_drprotection_for_discovered_vm_via_ui(
+    acm_obj,
+    vm,
+    managed_cluster_name,
+    namespace,
+):
+    """
+    Remove DR protection from a single discovered VM via the ACM Fleet Virtualization UI.
+
+    Works for both Standalone and Shared protection types.
+    Standalone removes the VM's protection and its associated DRPC entirely.
+    Shared removes only this VM from its shared DRPC group; the DRPC and
+    other VMs enrolled in the same group remain protected.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        vm (object): The VM workload object whose DR protection should be removed
+        managed_cluster_name (str): Name of the managed cluster where the VM runs
+        namespace (str): Namespace of the VM workload
+
+    Returns:
+        True if the removal completed successfully
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    if acm_obj.check_element_presence(
+        (
+            acm_loc["modal_dialog_close_button"][1],
+            acm_loc["modal_dialog_close_button"][0],
+        ),
+        timeout=10,
+    ):
+        log.info("Modal dialog box found, closing it..")
+        try:
+            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+        except SeleniumTimeoutException:
+            log.warning(
+                "Modal dialog close button not clickable, "
+                "sending Escape key to dismiss the dialog"
+            )
+            try:
+                acm_obj.driver.find_element("tag name", "body").send_keys(Keys.ESCAPE)
+                log.info("Sent Escape key to dismiss modal dialog")
+            except Exception as esc_err:
+                log.warning("Failed to send Escape key: %s", esc_err)
+
+    vm_locator = format_locator(acm_loc["cnv-vm-name"], vm.vm_name)
+    vm_already_visible = acm_obj.check_element_presence(
+        (vm_locator[1], vm_locator[0]), timeout=10
+    )
+    if vm_already_visible:
+        log.info(
+            f"VM {vm.vm_name} already visible on the page, " "skipping tree navigation"
+        )
+    else:
+        log.info("Look for 'All Clusters'")
+        all_clusters = acm_obj.wait_until_expected_text_is_found(
+            acm_loc["all-clusters"], expected_text="All clusters"
+        )
+        assert all_clusters, "'All Clusters' not found on the VMs page"
+
+        ns_locator = format_locator(acm_loc["cnv-workload-namespace"], namespace)
+        ns_already_visible = acm_obj.check_element_presence(
+            (ns_locator[1], ns_locator[0]), timeout=10
+        )
+        if not ns_already_visible:
+            log.info(f"Select cluster '{managed_cluster_name}'")
+            acm_obj.do_click(
+                format_locator(acm_loc["managed-cluster-name"], managed_cluster_name)
+            )
+        else:
+            log.info("Namespace already visible, skipping managed cluster click")
+        log.info(f"Select namespace '{namespace}'")
+        acm_obj.do_click(
+            format_locator(acm_loc["cnv-workload-namespace"], namespace),
+            enable_screenshot=True,
+        )
+        # Guard: the namespace sidebar button occasionally triggers a navigation to
+        # the ACM Search page instead of filtering the Fleet Virtualization VM list.
+        # Detect this by checking for the Fleet Virtualization nav and re-navigate
+        # if we've been taken to the wrong page.
+        fleet_nav_present = acm_obj.check_element_presence(
+            (
+                By.XPATH,
+                "//nav[@data-test-id="
+                "'fleet-virtualization-perspective-perspective-nav']",
+            ),
+            timeout=5,
+        )
+        if not fleet_nav_present:
+            log.warning(
+                "Namespace button click navigated away from Fleet "
+                "Virtualization page. Re-navigating."
+            )
+            navigate_using_fleet_virtualization(acm_obj)
+    log.info(f"Click on VM '{vm.vm_name}'")
+    acm_obj.do_click(
+        vm_locator,
+        enable_screenshot=True,
+    )
+
+    log.info("Click Actions -> Manage disaster recovery")
+    acm_obj.do_click(acm_loc["vm-actions"], enable_screenshot=True)
+    acm_obj.do_click(acm_loc["manage-dr"], enable_screenshot=True)
+
+    log.info("Click 'Remove protection'")
+    acm_obj.do_click(acm_loc["remove-vm-protection"], enable_screenshot=True)
+
+    log.info("Confirm removal")
+    acm_obj.do_click(acm_loc["confirm-remove-protection"], enable_screenshot=True)
+
+    log.info("Verify removal confirmation message")
+    removal_confirmed = acm_obj.wait_until_expected_text_is_found(
+        acm_loc["remove-protection-conf-msg"],
+        expected_text="removed",
+        timeout=60,
+    )
+    if not removal_confirmed:
+        log.warning(
+            "Protection removal confirmation message not found on UI. "
+            "Will rely on backend DRPC verification."
+        )
+        acm_obj.take_screenshot()
+
+    log.info("Close the dialog")
+    acm_obj.do_click(acm_loc["close-page"], enable_screenshot=True)
+
+    log.info(
+        f"DR protection successfully removed from VM '{vm.vm_name}' "
+        f"in namespace '{namespace}'"
+    )
     return True
 
 
@@ -943,9 +1118,27 @@ def navigate_using_fleet_virtualization(acm_obj):
     acm_version_str = ".".join(get_running_acm_version().split(".")[:2])
     acm_loc = locators_for_current_ocp_version()["acm_page"]
     log.info("Navigate to VMs console using Fleet Virtulization dropdown")
-    acm_obj.do_click(acm_loc["switch-perspective"])
-    acm_obj.do_click(acm_loc["fleet-virtual"])
     acm_obj.page_has_loaded(retries=10, sleep_time=5)
+    # Check for the Fleet Virtualization perspective-specific nav container.
+    # Using the nav data-test-id avoids false positives from the AI locator
+    # fallback, which can match the Clusters nav link as the VMs nav item.
+    fleet_virt_nav_visible = acm_obj.check_element_presence(
+        (
+            By.XPATH,
+            "//nav[@data-test-id="
+            "'fleet-virtualization-perspective-perspective-nav']",
+        ),
+        timeout=5,
+    )
+    if fleet_virt_nav_visible:
+        log.info(
+            "Already in Fleet Virtualization with sidebar visible, "
+            "skipping perspective switch"
+        )
+    else:
+        acm_obj.do_click(acm_loc["switch-perspective"])
+        acm_obj.do_click(acm_loc["fleet-virtual"])
+        acm_obj.page_has_loaded(retries=10, sleep_time=5)
     if compare_versions(f"{acm_version_str} >= 2.16"):
         if acm_obj.check_element_presence(
             (
@@ -955,9 +1148,48 @@ def navigate_using_fleet_virtualization(acm_obj):
             timeout=10,
         ):
             log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            try:
+                acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            except SeleniumTimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "sending Escape key to dismiss the dialog"
+                )
+                try:
+                    acm_obj.driver.find_element("tag name", "body").send_keys(
+                        Keys.ESCAPE
+                    )
+                    log.info("Sent Escape key to dismiss modal dialog")
+                except Exception as esc_err:
+                    log.warning("Failed to send Escape key: %s", esc_err)
+            acm_obj.page_has_loaded(retries=10, sleep_time=5)
     log.info("From side nav bar, navigate to VirtualMachines page")
-    acm_obj.do_click(acm_loc["nav-bar-vms-page"])
+    nav_clicked = False
+    if acm_obj.check_element_presence(
+        (acm_loc["nav-bar-vms-page"][1], acm_loc["nav-bar-vms-page"][0]),
+        timeout=10,
+    ):
+        try:
+            acm_obj.do_click(acm_loc["nav-bar-vms-page"])
+            nav_clicked = True
+        except SeleniumTimeoutException:
+            log.warning(
+                "VMs nav item found in DOM but not clickable, "
+                "falling back to direct URL navigation"
+            )
+    if not nav_clicked:
+        # Fleet Virtualization perspective may have been renamed or its sidebar
+        # nav items reorganised; fall back to direct URL navigation.
+        log.info("VMs nav item not in sidebar, navigating to VMs page via URL")
+        current_url = acm_obj.driver.current_url
+        base_url = current_url.split("/k8s")[0].split("/multicloud")[0]
+        vms_url = (
+            f"{base_url}/k8s/all-clusters"
+            "/all-namespaces/kubevirt.io~v1~VirtualMachine"
+        )
+        log.info("Navigating to VMs URL: %s", vms_url)
+        acm_obj.driver.get(vms_url)
+        acm_obj.page_has_loaded(retries=10, sleep_time=5)
     log.info(
         "Successfully navigate to the VirtualMachines page under Fleet Virtualization"
     )
@@ -970,6 +1202,12 @@ def navigate_using_fleet_virtualization(acm_obj):
             timeout=10,
         ):
             log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            try:
+                acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            except SeleniumTimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "dialog may have already closed"
+                )
 
     return True

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -861,7 +861,12 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 log.warning("'All Clusters' not found on the VMs page")
                 return False
             ns_locator = format_locator(acm_loc["cnv-workload-namespace"], namespace)
-            ns_already_visible = acm_obj.check_element_presence(
+            # Gate this shortcut on assign_policy for the same reason as
+            # vm_already_visible: when assign_policy=False (status-check) we
+            # must navigate the full cluster tree to guarantee we land on the
+            # correct cluster's namespace (e.g. secondary after failover), not
+            # a stale tree state left over from the previous iteration.
+            ns_already_visible = assign_policy and acm_obj.check_element_presence(
                 (ns_locator[1], ns_locator[0]), timeout=10
             )
             if not ns_already_visible:

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1012,7 +1012,7 @@ def remove_drprotection_for_discovered_vm_via_ui(
                 acm_obj.driver.find_element("tag name", "body").send_keys(Keys.ESCAPE)
                 log.info("Sent Escape key to dismiss modal dialog")
             except Exception as esc_err:
-                log.warning("Failed to send Escape key: %s", esc_err)
+                log.warning(f"Failed to send Escape key: {esc_err}")
 
     vm_locator = format_locator(acm_loc["cnv-vm-name"], vm.vm_name)
     vm_already_visible = acm_obj.check_element_presence(
@@ -1166,7 +1166,7 @@ def navigate_using_fleet_virtualization(acm_obj):
                     )
                     log.info("Sent Escape key to dismiss modal dialog")
                 except Exception as esc_err:
-                    log.warning("Failed to send Escape key: %s", esc_err)
+                    log.warning(f"Failed to send Escape key: {esc_err}")
             acm_obj.page_has_loaded(retries=10, sleep_time=5)
     log.info("From side nav bar, navigate to VirtualMachines page")
     nav_clicked = False
@@ -1192,7 +1192,7 @@ def navigate_using_fleet_virtualization(acm_obj):
             f"{base_url}/k8s/all-clusters"
             "/all-namespaces/kubevirt.io~v1~VirtualMachine"
         )
-        log.info("Navigating to VMs URL: %s", vms_url)
+        log.info(f"Navigating to VMs URL: {vms_url}")
         acm_obj.driver.get(vms_url)
         acm_obj.page_has_loaded(retries=10, sleep_time=5)
     log.info(

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1047,17 +1047,31 @@ def remove_drprotection_for_discovered_vm_via_ui(
         )
         # Guard: the namespace sidebar button occasionally triggers a navigation to
         # the ACM Search page instead of filtering the Fleet Virtualization VM list.
-        # Detect this by checking for the Fleet Virtualization nav and re-navigate
-        # if we've been taken to the wrong page.
-        fleet_nav_present = acm_obj.check_element_presence(
-            (
+        # Detect this by checking the perspective switcher text or the Fleet
+        # Virtualization nav and re-navigate if we've been taken to the wrong page.
+        still_in_fleet_virt = False
+        switcher_found = False
+        try:
+            switcher_el = acm_obj.driver.find_element(
                 By.XPATH,
-                "//nav[@data-test-id="
-                "'fleet-virtualization-perspective-perspective-nav']",
-            ),
-            timeout=5,
-        )
-        if not fleet_nav_present:
+                "//button[@data-test-id='perspective-switcher-toggle']"
+                " | //*[contains(@class, 'perspective-switcher')]//button",
+            )
+            switcher_found = True
+            if "fleet virtualization" in switcher_el.text.strip().lower():
+                still_in_fleet_virt = True
+        except Exception:
+            pass
+        if not switcher_found and not still_in_fleet_virt:
+            still_in_fleet_virt = acm_obj.check_element_presence(
+                (
+                    By.XPATH,
+                    "//nav[@data-test-id="
+                    "'fleet-virtualization-perspective-perspective-nav']",
+                ),
+                timeout=5,
+            )
+        if not still_in_fleet_virt:
             log.warning(
                 "Namespace button click navigated away from Fleet "
                 "Virtualization page. Re-navigating."
@@ -1122,20 +1136,43 @@ def navigate_using_fleet_virtualization(acm_obj):
     """
     acm_version_str = ".".join(get_running_acm_version().split(".")[:2])
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    log.info("Navigate to VMs console using Fleet Virtulization dropdown")
+    log.info("Navigate to VMs console using Fleet Virtualization dropdown")
     acm_obj.page_has_loaded(retries=10, sleep_time=5)
-    # Check for the Fleet Virtualization perspective-specific nav container.
-    # Using the nav data-test-id avoids false positives from the AI locator
-    # fallback, which can match the Clusters nav link as the VMs nav item.
-    fleet_virt_nav_visible = acm_obj.check_element_presence(
-        (
+    # Check whether we are already in the Fleet Virtualization perspective
+    # by looking at the perspective switcher text. In OCP 4.22 (PF6) the
+    # nav data-test-id changed, so the old nav-based check triggers AI
+    # fallback false positives that match the Fleet Management nav instead.
+    already_in_fleet_virt = False
+    switcher_found = False
+    try:
+        switcher_el = acm_obj.driver.find_element(
             By.XPATH,
-            "//nav[@data-test-id="
-            "'fleet-virtualization-perspective-perspective-nav']",
-        ),
-        timeout=5,
-    )
-    if fleet_virt_nav_visible:
+            "//button[@data-test-id='perspective-switcher-toggle']"
+            " | //*[contains(@class, 'perspective-switcher')]//button",
+        )
+        switcher_text = switcher_el.text.strip().lower()
+        switcher_found = True
+        if "fleet virtualization" in switcher_text:
+            already_in_fleet_virt = True
+        else:
+            log.info(
+                f"Perspective switcher shows '{switcher_el.text.strip()}', "
+                "need to switch to Fleet Virtualization"
+            )
+    except Exception:
+        pass
+    if not switcher_found and not already_in_fleet_virt:
+        fleet_virt_nav_visible = acm_obj.check_element_presence(
+            (
+                By.XPATH,
+                "//nav[@data-test-id="
+                "'fleet-virtualization-perspective-perspective-nav']",
+            ),
+            timeout=5,
+        )
+        if fleet_virt_nav_visible:
+            already_in_fleet_virt = True
+    if already_in_fleet_virt:
         log.info(
             "Already in Fleet Virtualization with sidebar visible, "
             "skipping perspective switch"
@@ -1172,7 +1209,7 @@ def navigate_using_fleet_virtualization(acm_obj):
     nav_clicked = False
     if acm_obj.check_element_presence(
         (acm_loc["nav-bar-vms-page"][1], acm_loc["nav-bar-vms-page"][0]),
-        timeout=10,
+        timeout=30,
     ):
         try:
             acm_obj.do_click(acm_loc["nav-bar-vms-page"])
@@ -1183,20 +1220,32 @@ def navigate_using_fleet_virtualization(acm_obj):
                 "falling back to direct URL navigation"
             )
     if not nav_clicked:
-        # Fleet Virtualization perspective may have been renamed or its sidebar
-        # nav items reorganised; fall back to direct URL navigation.
         log.info("VMs nav item not in sidebar, navigating to VMs page via URL")
         current_url = acm_obj.driver.current_url
         base_url = current_url.split("/k8s")[0].split("/multicloud")[0]
+        base_url = base_url.split("/fleet-virtualization")[0]
         vms_url = (
-            f"{base_url}/k8s/all-clusters"
-            "/all-namespaces/kubevirt.io~v1~VirtualMachine"
+            f"{base_url}/fleet-virtualization"
+            "/kubevirt.io~v1~VirtualMachine"
+            "/all-clusters/all-namespaces"
         )
         log.info(f"Navigating to VMs URL: {vms_url}")
         acm_obj.driver.get(vms_url)
         acm_obj.page_has_loaded(retries=10, sleep_time=5)
+    # In OCP 4.22 the Fleet Virtualization VMs page defaults to the Overview
+    # tab. Click the "Virtual machines" tab to show the actual VM list.
+    vm_tab_locator = (
+        "//a[normalize-space()='Virtual machines'] | "
+        "//button[normalize-space()='Virtual machines']",
+        By.XPATH,
+    )
+    if acm_obj.check_element_presence(
+        (vm_tab_locator[1], vm_tab_locator[0]), timeout=10
+    ):
+        acm_obj.do_click(vm_tab_locator)
+        acm_obj.page_has_loaded(retries=5, sleep_time=3)
     log.info(
-        "Successfully navigate to the VirtualMachines page under Fleet Virtualization"
+        "Successfully navigated to the VirtualMachines page under Fleet Virtualization"
     )
     if compare_versions(f"{acm_version_str} < 2.16"):
         if acm_obj.check_element_presence(

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1840,12 +1840,12 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
             policy_assigned = acm_obj.wait_until_expected_text_is_found(
                 acm_loc["conf-msg"],
                 expected_text="New policy assigned to application",
-                timeout=60,
+                timeout=120,
             )
             acm_obj.take_screenshot()
             assert policy_assigned, (
                 "Expected confirmation 'New policy assigned to application' "
-                "not found within 60s after clicking Assign"
+                "not found within 120s after clicking Assign"
             )
             log.info("Close page")
             acm_obj.do_click(acm_loc["close-page"], enable_screenshot=True)

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -801,6 +801,7 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
     standalone=True,
     protection_name=None,
     namespace=None,
+    dr_policy_name=None,
 ):
     """
     This function can be used to check the VM status and assign Data Policy using UI to Discovered VMs
@@ -817,6 +818,8 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
         protection_name (str): Protection name used to DR protect the workload using which
                                 DRPC and Placement would be created
         namespace (str): None by default, namespace of the workload
+        dr_policy_name (str): Name of the DRPolicy to select. When None,
+            the first available policy is selected.
 
 
      Returns:
@@ -939,7 +942,17 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
             if standalone:
                 log.info("Select policy")
                 acm_obj.do_click(acm_loc["dr-policy"], enable_screenshot=True)
-                acm_obj.do_click(acm_loc["select-policy"], enable_screenshot=True)
+                if dr_policy_name:
+                    policy_locator = (
+                        f'//*[text()="{dr_policy_name}"]',
+                        By.XPATH,
+                    )
+                    acm_obj.do_click(policy_locator, enable_screenshot=True)
+                else:
+                    acm_obj.do_click(
+                        acm_loc["select-policy"],
+                        enable_screenshot=True,
+                    )
             log.info("Click next")
             acm_obj.do_click(acm_loc["vm-page-next-btn"], enable_screenshot=True)
             log.info("Verify selected protection type")

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -14,6 +14,8 @@ from selenium.common.exceptions import (
     StaleElementReferenceException,
     TimeoutException as SeleniumTimeoutException,
 )
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
 from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers
@@ -1663,6 +1665,7 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
     standalone=True,
     protection_name=None,
     namespace=None,
+    dr_policy_name=None,
 ):
     """
     This function can be used to check the VM status and assign Data Policy using UI to Discovered VMs
@@ -1679,6 +1682,8 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
         protection_name (str): Protection name used to DR protect the workload using which
                                 DRPC and Placement would be created
         namespace (str): None by default, namespace of the workload
+        dr_policy_name (str): Name of the DRPolicy to select. When None,
+            the first available policy is selected.
 
 
      Returns:
@@ -1686,53 +1691,82 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
 
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    if acm_obj.check_element_presence(
-        (
-            acm_loc["modal_dialog_close_button"][1],
-            acm_loc["modal_dialog_close_button"][0],
-        ),
-        timeout=10,
-    ):
-        log.info("Modal dialog box found, closing it..")
-        acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
-    log.info("Look for 'All Clusters'")
-    all_clusters = acm_obj.wait_until_expected_text_is_found(
-        acm_loc["all-clusters"], expected_text="All clusters"
-    )
-    if all_clusters:
-        log.info("All Clusters option found")
-    else:
-        log.warning("'All Clusters' not found on the VMs page")
-        return False
     for vm in vms:
-        log.info("Select the cluster where VM workload is running")
-        acm_obj.do_click(
-            format_locator(acm_loc["managed-cluster-name"], managed_cluster_name)
+        vm_locator = format_locator(acm_loc["cnv-vm-name"], vm.vm_name)
+        # The visibility shortcut (skip tree navigation when the VM is already
+        # on-screen) is safe for enrollment calls because only one instance of
+        # the VM exists at that point. For status-check-only calls
+        # (assign_policy=False) we must navigate through the cluster tree to
+        # guarantee we reach the correct cluster's VM; otherwise the XPath may
+        # match a stale ACM-cached entry from a different cluster (e.g. the
+        # old primary after failover cleanup) and produce a non-Running status.
+        vm_already_visible = assign_policy and acm_obj.check_element_presence(
+            (vm_locator[1], vm_locator[0]), timeout=10
         )
-        log.info(f"Managed cluster {managed_cluster_name} found ")
-        log.info("Select the namespace where VM workload is running")
-        acm_obj.do_click(
-            format_locator(acm_loc["cnv-workload-namespace"], namespace),
-            enable_screenshot=True,
-        )
-        log.info(f"Namespace {namespace} found on cluster {managed_cluster_name}")
-        log.info("Click on the VM")
-        acm_obj.do_click(
-            format_locator(acm_loc["cnv-vm-name"], vm.vm_name), enable_screenshot=True
-        )
-        log.info("Check the status of the VM")
-        vm_current_status = acm_obj.get_element_text(acm_loc["vm-status"])
-        if vm_current_status != "Running":
-            wait_for_status = acm_obj.wait_until_expected_text_is_found(
-                acm_loc["vm-status"], expected_text="Running", timeout=300
-            )
-            assert (
-                wait_for_status
-            ), f"Expected VM status is 'Running', but got '{vm_current_status}'"
-        else:
+        if vm_already_visible:
             log.info(
-                f"VM status is running on the managed cluster {managed_cluster_name}"
+                f"VM {vm.vm_name} already visible on the page, "
+                "skipping tree navigation"
             )
+        else:
+            if acm_obj.check_element_presence(
+                (
+                    acm_loc["modal_dialog_close_button"][1],
+                    acm_loc["modal_dialog_close_button"][0],
+                ),
+                timeout=10,
+            ):
+                log.info("Modal dialog box found, closing it..")
+                try:
+                    acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+                except Exception:
+                    log.warning(
+                        "Modal dialog close button not clickable (dialog may have closed itself), proceeding"
+                    )
+            log.info("Look for 'All Clusters'")
+            all_clusters = acm_obj.wait_until_expected_text_is_found(
+                acm_loc["all-clusters"], expected_text="All clusters"
+            )
+            if all_clusters:
+                log.info("All Clusters option found")
+            else:
+                log.warning("'All Clusters' not found on the VMs page")
+                return False
+            ns_locator = format_locator(acm_loc["cnv-workload-namespace"], namespace)
+            # Gate this shortcut on assign_policy for the same reason as
+            # vm_already_visible: when assign_policy=False (status-check) we
+            # must navigate the full cluster tree to guarantee we land on the
+            # correct cluster's namespace (e.g. secondary after failover), not
+            # a stale tree state left over from the previous iteration.
+            ns_already_visible = assign_policy and acm_obj.check_element_presence(
+                (ns_locator[1], ns_locator[0]), timeout=10
+            )
+            if not ns_already_visible:
+                log.info("Select the cluster where VM workload is running")
+                acm_obj.do_click(
+                    format_locator(
+                        acm_loc["managed-cluster-name"],
+                        managed_cluster_name,
+                    )
+                )
+                log.info(f"Managed cluster {managed_cluster_name} found ")
+            else:
+                log.info("Namespace already visible, " "skipping managed cluster click")
+            log.info("Select the namespace where VM workload is running")
+            acm_obj.do_click(ns_locator, enable_screenshot=True)
+            log.info(
+                f"Namespace {namespace} found on " f"cluster {managed_cluster_name}"
+            )
+        log.info("Click on the VM")
+        acm_obj.do_click(vm_locator, enable_screenshot=True)
+        log.info("Check the status of the VM")
+        vm_running = acm_obj.wait_until_expected_text_is_found(
+            acm_loc["vm-status"], expected_text="Running", timeout=300
+        )
+        assert vm_running, (
+            "Expected VM status is 'Running' but the status element "
+            "was not found or did not reach Running state"
+        )
         if assign_policy:
             log.info("Click on the Actions button")
             acm_obj.do_click(acm_loc["vm-actions"], enable_screenshot=True)
@@ -1749,18 +1783,45 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 log.info("Protecting VM with Shared Protection type")
                 acm_obj.do_click(acm_loc["select-shared"], enable_screenshot=True)
                 radio_buttons = acm_obj.get_elements(acm_loc["select-drpc"])
-                # Assert that exactly one element is found
                 assert (
-                    len(radio_buttons) == 1
-                ), f"Expected 1 radio button but found {len(radio_buttons)}"
-                log.info("Expected 1 radio button found, select existing DRPC")
-                acm_obj.do_click(acm_loc["select-drpc"], enable_screenshot=True)
+                    len(radio_buttons) >= 1
+                ), f"Expected at least 1 radio button but found {len(radio_buttons)}"
+                if len(radio_buttons) == 1:
+                    log.info("Only 1 radio button found, selecting existing DRPC")
+                    acm_obj.do_click(acm_loc["select-drpc"], enable_screenshot=True)
+                else:
+                    log.info(
+                        "%d radio buttons found, selecting DRPC matching "
+                        "protection name '%s'",
+                        len(radio_buttons),
+                        protection_name,
+                    )
+                    # The radio button value is the DRPC resource name.
+                    # Standalone enrollment creates a DRPC named
+                    # '{protection_name}-drpc'; try both forms.
+                    drpc_radio_locator = (
+                        f"//input[@name='radioGroup']"
+                        f"[@value='{protection_name}' or "
+                        f"@value='{protection_name}-drpc']",
+                        By.XPATH,
+                    )
+                    acm_obj.do_click(drpc_radio_locator, enable_screenshot=True)
             log.info("Click next")
             acm_obj.do_click(acm_loc["vm-page-next-btn"], enable_screenshot=True)
             if standalone:
                 log.info("Select policy")
                 acm_obj.do_click(acm_loc["dr-policy"], enable_screenshot=True)
-                acm_obj.do_click(acm_loc["select-policy"], enable_screenshot=True)
+                if dr_policy_name:
+                    policy_locator = (
+                        f'//*[text()="{dr_policy_name}"]',
+                        By.XPATH,
+                    )
+                    acm_obj.do_click(policy_locator, enable_screenshot=True)
+                else:
+                    acm_obj.do_click(
+                        acm_loc["select-policy"],
+                        enable_screenshot=True,
+                    )
             log.info("Click next")
             acm_obj.do_click(acm_loc["vm-page-next-btn"], enable_screenshot=True)
             log.info("Verify selected protection type")
@@ -1775,15 +1836,168 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
             ), f"Expected {'Standalone' if standalone else 'Shared'}, but got '{protection_type}'"
             log.info("Assign DRPolicy")
             acm_obj.do_click(acm_loc["assign"], enable_screenshot=True)
-            time.sleep(2)
             log.info("Policy confirmation")
-            conf_msg = acm_obj.get_element_text(acm_loc["conf-msg"])
-            log.info(f"Confirmation message is {conf_msg}")
+            policy_assigned = acm_obj.wait_until_expected_text_is_found(
+                acm_loc["conf-msg"],
+                expected_text="New policy assigned to application",
+                timeout=60,
+            )
             acm_obj.take_screenshot()
-            expected_conf_msg = conf_msg.split("\n", 1)[1].strip()
-            assert expected_conf_msg == "New policy assigned to application"
+            assert policy_assigned, (
+                "Expected confirmation 'New policy assigned to application' "
+                "not found within 60s after clicking Assign"
+            )
             log.info("Close page")
             acm_obj.do_click(acm_loc["close-page"], enable_screenshot=True)
+    return True
+
+
+def remove_drprotection_for_discovered_vm_via_ui(
+    acm_obj,
+    vm,
+    managed_cluster_name,
+    namespace,
+):
+    """
+    Remove DR protection from a single discovered VM via the ACM Fleet Virtualization UI.
+
+    Works for both Standalone and Shared protection types.
+    Standalone removes the VM's protection and its associated DRPC entirely.
+    Shared removes only this VM from its shared DRPC group; the DRPC and
+    other VMs enrolled in the same group remain protected.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        vm (object): The VM workload object whose DR protection should be removed
+        managed_cluster_name (str): Name of the managed cluster where the VM runs
+        namespace (str): Namespace of the VM workload
+
+    Returns:
+        True if the removal completed successfully
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+
+    if acm_obj.check_element_presence(
+        (
+            acm_loc["modal_dialog_close_button"][1],
+            acm_loc["modal_dialog_close_button"][0],
+        ),
+        timeout=10,
+    ):
+        log.info("Modal dialog box found, closing it..")
+        try:
+            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+        except SeleniumTimeoutException:
+            log.warning(
+                "Modal dialog close button not clickable, "
+                "sending Escape key to dismiss the dialog"
+            )
+            try:
+                acm_obj.driver.find_element("tag name", "body").send_keys(Keys.ESCAPE)
+                log.info("Sent Escape key to dismiss modal dialog")
+            except Exception as esc_err:
+                log.warning(f"Failed to send Escape key: {esc_err}")
+
+    vm_locator = format_locator(acm_loc["cnv-vm-name"], vm.vm_name)
+    vm_already_visible = acm_obj.check_element_presence(
+        (vm_locator[1], vm_locator[0]), timeout=10
+    )
+    if vm_already_visible:
+        log.info(
+            f"VM {vm.vm_name} already visible on the page, " "skipping tree navigation"
+        )
+    else:
+        log.info("Look for 'All Clusters'")
+        all_clusters = acm_obj.wait_until_expected_text_is_found(
+            acm_loc["all-clusters"], expected_text="All clusters"
+        )
+        assert all_clusters, "'All Clusters' not found on the VMs page"
+
+        ns_locator = format_locator(acm_loc["cnv-workload-namespace"], namespace)
+        ns_already_visible = acm_obj.check_element_presence(
+            (ns_locator[1], ns_locator[0]), timeout=10
+        )
+        if not ns_already_visible:
+            log.info(f"Select cluster '{managed_cluster_name}'")
+            acm_obj.do_click(
+                format_locator(acm_loc["managed-cluster-name"], managed_cluster_name)
+            )
+        else:
+            log.info("Namespace already visible, skipping managed cluster click")
+        log.info(f"Select namespace '{namespace}'")
+        acm_obj.do_click(
+            format_locator(acm_loc["cnv-workload-namespace"], namespace),
+            enable_screenshot=True,
+        )
+        # Guard: the namespace sidebar button occasionally triggers a navigation to
+        # the ACM Search page instead of filtering the Fleet Virtualization VM list.
+        # Detect this by checking the perspective switcher text or the Fleet
+        # Virtualization nav and re-navigate if we've been taken to the wrong page.
+        still_in_fleet_virt = False
+        switcher_found = False
+        try:
+            switcher_el = acm_obj.driver.find_element(
+                By.XPATH,
+                "//button[@data-test-id='perspective-switcher-toggle']"
+                " | //*[contains(@class, 'perspective-switcher')]//button",
+            )
+            switcher_found = True
+            if "fleet virtualization" in switcher_el.text.strip().lower():
+                still_in_fleet_virt = True
+        except Exception:
+            pass
+        if not switcher_found and not still_in_fleet_virt:
+            still_in_fleet_virt = acm_obj.check_element_presence(
+                (
+                    By.XPATH,
+                    "//nav[@data-test-id="
+                    "'fleet-virtualization-perspective-perspective-nav']",
+                ),
+                timeout=5,
+            )
+        if not still_in_fleet_virt:
+            log.warning(
+                "Namespace button click navigated away from Fleet "
+                "Virtualization page. Re-navigating."
+            )
+            navigate_using_fleet_virtualization(acm_obj)
+    log.info(f"Click on VM '{vm.vm_name}'")
+    acm_obj.do_click(
+        vm_locator,
+        enable_screenshot=True,
+    )
+
+    log.info("Click Actions -> Manage disaster recovery")
+    acm_obj.do_click(acm_loc["vm-actions"], enable_screenshot=True)
+    acm_obj.do_click(acm_loc["manage-dr"], enable_screenshot=True)
+
+    log.info("Click 'Remove protection'")
+    acm_obj.do_click(acm_loc["remove-vm-protection"], enable_screenshot=True)
+
+    log.info("Confirm removal")
+    acm_obj.do_click(acm_loc["confirm-remove-protection"], enable_screenshot=True)
+
+    log.info("Verify removal confirmation message")
+    removal_confirmed = acm_obj.wait_until_expected_text_is_found(
+        acm_loc["remove-protection-conf-msg"],
+        expected_text="removed",
+        timeout=60,
+    )
+    if not removal_confirmed:
+        log.warning(
+            "Protection removal confirmation message not found on UI. "
+            "Will rely on backend DRPC verification."
+        )
+        acm_obj.take_screenshot()
+
+    log.info("Close the dialog")
+    acm_obj.do_click(acm_loc["close-page"], enable_screenshot=True)
+
+    log.info(
+        f"DR protection successfully removed from VM '{vm.vm_name}' "
+        f"in namespace '{namespace}'"
+    )
     return True
 
 
@@ -1807,10 +2021,56 @@ def navigate_using_fleet_virtualization(acm_obj):
     """
     acm_version_str = ".".join(get_running_acm_version().split(".")[:2])
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    log.info("Navigate to VMs console using Fleet Virtulization dropdown")
-    acm_obj.do_click(acm_loc["switch-perspective"])
-    acm_obj.do_click(acm_loc["fleet-virtual"])
+    log.info("Navigate to VMs console using Fleet Virtualization dropdown")
     acm_obj.page_has_loaded(retries=10, sleep_time=5)
+    # Check whether we are already in the Fleet Virtualization perspective
+    # by looking at the perspective switcher text. In OCP 4.22 (PF6) the
+    # nav data-test-id changed, so the old nav-based check triggers AI
+    # fallback false positives that match the Fleet Management nav instead.
+    already_in_fleet_virt = False
+    switcher_found = False
+    try:
+        switcher_el = acm_obj.driver.find_element(
+            By.XPATH,
+            "//button[@data-test-id='perspective-switcher-toggle']"
+            " | //*[contains(@class, 'perspective-switcher')]//button",
+        )
+        switcher_text = switcher_el.text.strip().lower()
+        switcher_found = True
+        if "fleet virtualization" in switcher_text:
+            already_in_fleet_virt = True
+        else:
+            log.info(
+                f"Perspective switcher shows '{switcher_el.text.strip()}', "
+                "need to switch to Fleet Virtualization"
+            )
+    except Exception:
+        pass
+    if not switcher_found and not already_in_fleet_virt:
+        fleet_virt_nav_visible = acm_obj.check_element_presence(
+            (
+                By.XPATH,
+                "//nav[@data-test-id="
+                "'fleet-virtualization-perspective-perspective-nav']",
+            ),
+            timeout=5,
+        )
+        if fleet_virt_nav_visible:
+            already_in_fleet_virt = True
+    if already_in_fleet_virt:
+        log.info(
+            "Already in Fleet Virtualization with sidebar visible, "
+            "skipping perspective switch"
+        )
+    else:
+        acm_obj.do_click(acm_loc["switch-perspective"])
+        # Wait for the dropdown to render before the next do_click call.
+        # Without this sleep, do_click(fleet-virtual) finds no matching
+        # element and calls page_has_loaded() internally, which scrolls the
+        # page and causes Chrome to close the dropdown immediately.
+        time.sleep(2)
+        acm_obj.do_click(acm_loc["fleet-virtual"])
+        acm_obj.page_has_loaded(retries=10, sleep_time=5)
     if compare_versions(f"{acm_version_str} >= 2.16"):
         if acm_obj.check_element_presence(
             (
@@ -1820,11 +2080,63 @@ def navigate_using_fleet_virtualization(acm_obj):
             timeout=10,
         ):
             log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            try:
+                acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            except SeleniumTimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "sending Escape key to dismiss the dialog"
+                )
+                try:
+                    acm_obj.driver.find_element("tag name", "body").send_keys(
+                        Keys.ESCAPE
+                    )
+                    log.info("Sent Escape key to dismiss modal dialog")
+                except Exception as esc_err:
+                    log.warning(f"Failed to send Escape key: {esc_err}")
+            acm_obj.page_has_loaded(retries=10, sleep_time=5)
     log.info("From side nav bar, navigate to VirtualMachines page")
-    acm_obj.do_click(acm_loc["nav-bar-vms-page"])
+    nav_clicked = False
+    if acm_obj.check_element_presence(
+        (acm_loc["nav-bar-vms-page"][1], acm_loc["nav-bar-vms-page"][0]),
+        timeout=30,
+    ):
+        try:
+            acm_obj.do_click(acm_loc["nav-bar-vms-page"])
+            nav_clicked = True
+        except SeleniumTimeoutException:
+            log.warning(
+                "VMs nav item found in DOM but not clickable, "
+                "falling back to direct URL navigation"
+            )
+    if not nav_clicked:
+        log.info("VMs nav item not in sidebar, navigating to VMs page via URL")
+        current_url = acm_obj.driver.current_url
+        base_url = current_url.split("/k8s")[0].split("/multicloud")[0]
+        base_url = base_url.split("/fleet-virtualization")[0]
+        vms_url = (
+            f"{base_url}/fleet-virtualization"
+            "/kubevirt.io~v1~VirtualMachine"
+            "/all-clusters/all-namespaces"
+        )
+        log.info(f"Navigating to VMs URL: {vms_url}")
+        acm_obj.driver.get(vms_url)
+        acm_obj.page_has_loaded(retries=10, sleep_time=5)
+
+    # In OCP 4.22 the Fleet Virtualization VMs page defaults to the Overview
+    # tab. Click the "Virtual machines" tab to show the actual VM list.
+    vm_tab_locator = (
+        "//a[normalize-space()='Virtual machines'] | "
+        "//button[normalize-space()='Virtual machines']",
+        By.XPATH,
+    )
+    if acm_obj.check_element_presence(
+        (vm_tab_locator[1], vm_tab_locator[0]), timeout=10
+    ):
+        acm_obj.do_click(vm_tab_locator)
+        acm_obj.page_has_loaded(retries=5, sleep_time=3)
     log.info(
-        "Successfully navigate to the VirtualMachines page under Fleet Virtualization"
+        "Successfully navigated to the VirtualMachines page under Fleet Virtualization"
     )
     if compare_versions(f"{acm_version_str} < 2.16"):
         if acm_obj.check_element_presence(
@@ -1835,6 +2147,12 @@ def navigate_using_fleet_virtualization(acm_obj):
             timeout=10,
         ):
             log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            try:
+                acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+            except SeleniumTimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "dialog may have already closed"
+                )
 
     return True

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -824,7 +824,7 @@ def validate_page_title(title):
     Args:
         title (str): required title
     """
-    WebDriverWait(SeleniumDriver(), 60).until(ec.title_is(title))
+    WebDriverWait(SeleniumDriver(), 60).until(ec.title_contains(title))
     log.info(f"page title: {title}")
 
 

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -2163,44 +2163,74 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
 
         config.switch_acm_ctx()
         if not shared_drpc_protection:
+            # Delete both possible DRPC names (CLI-created has no suffix, UI-created has -drpc suffix).
+            # --ignore-not-found handles cases where the DRPC was already cleaned up by the test flow.
+            # --wait=false avoids blocking on Ramen finalizer processing (which can exceed 600 s);
+            # Ramen will process the deletion asynchronously and release VRG/PV resources.
             log.info("Deleting DRPC")
-            try:
-                run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}"
-                )
-            except CommandFailed:
-                # This is needed when DRPolicy is applied via UI, where DRPC which is created has suffix -drpc
-                # hence deletion fails
-                run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-drpc"
-                )
-                log.info("DRPC deleted")
+            run_cmd(
+                f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} "
+                f"{self.discovered_apps_placement_name} "
+                f"{self.discovered_apps_placement_name}-drpc "
+                f"--ignore-not-found --wait=false"
+            )
+            log.info("DRPC deletion submitted")
+            # Delete both possible Placement names (CLI-created has -plmnt-1 suffix, UI-created has -placement-1).
+            # --wait=false avoids blocking on finalizer processing (same reason as DRPC above).
             log.info("Deleting Placement")
-            try:
-                run_cmd(
-                    f"oc delete placement -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-plmnt-1"
-                )
-            except CommandFailed:
-                # When the VMs are protected from UI, placement created does not contain suffix "-plmnt-1",
-                # hence this is needed for deletion
-                placement_name = f"{self.discovered_apps_placement_name}-placement-1"
-                run_cmd(
-                    f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
-                    f"{placement_name}"
-                )
+            run_cmd(
+                f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
+                f"{self.discovered_apps_placement_name}-plmnt-1 "
+                f"{self.discovered_apps_placement_name}-placement-1 "
+                f"--ignore-not-found --wait=false"
+            )
 
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
             log.info(f"Deleting workload from {cluster.ENV_DATA['cluster_name']}")
             run_cmd(
-                f"oc delete -k {self.workload_path} -n {self.workload_namespace}",
+                f"oc delete -k {self.workload_path} -n {self.workload_namespace}"
+                " --wait=false --ignore-not-found --force",
                 ignore_error=True,
             )
             if not skip_resource_deletion_verification:
+                # Determine the VRG name on this managed cluster before waiting
+                # for deletion. VRGs live on managed clusters (openshift-dr-ops),
+                # not on the hub, and may already be gone if the test's
+                # relocate/failover cleanup ran before delete_workload.
+                # CLI-created DRPCs have no suffix; UI-created have a -drpc suffix.
+                workload_vrg_name = ""
+                if not shared_drpc_protection:
+                    vrg_obj = ocp.OCP(
+                        kind=constants.VOLUME_REPLICATION_GROUP,
+                        namespace=constants.DR_OPS_NAMESPACE,
+                    )
+                    for candidate in [
+                        self.discovered_apps_placement_name,
+                        f"{self.discovered_apps_placement_name}-drpc",
+                    ]:
+                        if vrg_obj.is_exist(resource_name=candidate):
+                            workload_vrg_name = candidate
+                            log.info(
+                                "Found VRG '%s' in %s on cluster %s",
+                                workload_vrg_name,
+                                constants.DR_OPS_NAMESPACE,
+                                cluster.ENV_DATA["cluster_name"],
+                            )
+                            break
+                    if not workload_vrg_name:
+                        log.info(
+                            "VRG for workload '%s' not found on cluster %s "
+                            "(already cleaned up) — skipping VRG deletion wait",
+                            self.discovered_apps_placement_name,
+                            cluster.ENV_DATA["cluster_name"],
+                        )
                 dr_helpers.wait_for_all_resources_deletion(
                     namespace=self.workload_namespace,
                     discovered_apps=True,
                     workload_cleanup=True,
+                    vrg_name=workload_vrg_name,
+                    skip_vrg_check=not workload_vrg_name,
                 )
                 ocp_obj = ocp.OCP()
                 ocp_obj.delete_project(project_name=self.workload_namespace)

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -47,6 +47,7 @@ from ocs_ci.ocs.utils import (
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import (
     clone_repo,
+    exec_cmd,
     run_cmd,
     TimeoutSampler,
 )  # IgnoreDeprecation
@@ -2345,45 +2346,74 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
 
         config.switch_acm_ctx()
         if not shared_drpc_protection:
+            # Delete both possible DRPC names (CLI-created has no suffix, UI-created has -drpc suffix).
+            # --ignore-not-found handles cases where the DRPC was already cleaned up by the test flow.
+            # --wait=false avoids blocking on Ramen finalizer processing (which can exceed 600 s);
+            # Ramen will process the deletion asynchronously and release VRG/PV resources.
             log.info("Deleting DRPC")
-            try:
-                run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}"
-                )
-            except CommandFailed:
-                # This is needed when DRPolicy is applied via UI, where DRPC which is created has suffix -drpc
-                # hence deletion fails
-                run_cmd(
-                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-drpc"
-                )
-                log.info("DRPC deleted")
+            exec_cmd(
+                f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} "
+                f"{self.discovered_apps_placement_name} "
+                f"{self.discovered_apps_placement_name}-drpc "
+                f"--ignore-not-found --wait=false"
+            )
+            log.info("DRPC deletion submitted")
+            # Delete both possible Placement names (CLI-created has -plmnt-1 suffix, UI-created has -placement-1).
+            # --wait=false avoids blocking on finalizer processing (same reason as DRPC above).
             log.info("Deleting Placement")
-            try:
-                run_cmd(
-                    f"oc delete placement -n {constants.DR_OPS_NAMESPACE} {self.discovered_apps_placement_name}-plmnt-1"
-                )
-            except CommandFailed:
-                # When the VMs are protected from UI, placement created does not contain suffix "-plmnt-1",
-                # hence this is needed for deletion
-                placement_name = f"{self.discovered_apps_placement_name}-placement-1"
-                run_cmd(
-                    f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
-                    f"{placement_name}"
-                )
+            exec_cmd(
+                f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
+                f"{self.discovered_apps_placement_name}-plmnt-1 "
+                f"{self.discovered_apps_placement_name}-placement-1 "
+                f"--ignore-not-found --wait=false"
+            )
 
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
             log.info(f"Deleting workload from {cluster.ENV_DATA['cluster_name']}")
             run_cmd(
-                f"oc delete -k {self.workload_path} -n {self.workload_namespace}",
+                f"oc delete -k {self.workload_path} -n {self.workload_namespace}"
+                " --wait=false --ignore-not-found --force",
                 ignore_error=True,
             )
             if not skip_resource_deletion_verification:
+                # Determine the VRG name on this managed cluster before waiting
+                # for deletion. VRGs live on managed clusters (openshift-dr-ops),
+                # not on the hub, and may already be gone if the test's
+                # relocate/failover cleanup ran before delete_workload.
+                # CLI-created DRPCs have no suffix; UI-created have a -drpc suffix.
+                workload_vrg_name = ""
+                if not shared_drpc_protection:
+                    vrg_obj = ocp.OCP(
+                        kind=constants.VOLUME_REPLICATION_GROUP,
+                        namespace=constants.DR_OPS_NAMESPACE,
+                    )
+                    for candidate in [
+                        self.discovered_apps_placement_name,
+                        f"{self.discovered_apps_placement_name}-drpc",
+                    ]:
+                        if vrg_obj.is_exist(resource_name=candidate):
+                            workload_vrg_name = candidate
+                            log.info(
+                                "Found VRG '%s' in %s on cluster %s",
+                                workload_vrg_name,
+                                constants.DR_OPS_NAMESPACE,
+                                cluster.ENV_DATA["cluster_name"],
+                            )
+                            break
+                    if not workload_vrg_name:
+                        log.info(
+                            "VRG for workload '%s' not found on cluster %s "
+                            "(already cleaned up) — skipping VRG deletion wait",
+                            self.discovered_apps_placement_name,
+                            cluster.ENV_DATA["cluster_name"],
+                        )
                 dr_helpers.wait_for_all_resources_deletion(
                     namespace=self.workload_namespace,
                     discovered_apps=True,
                     workload_cleanup=True,
-                    vrg_name=self.discovered_apps_placement_name,
+                    vrg_name=workload_vrg_name,
+                    skip_vrg_check=not workload_vrg_name,
                 )
                 ocp_obj = ocp.OCP()
                 ocp_obj.delete_project(project_name=self.workload_namespace)

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -259,7 +259,16 @@ class AcmPageNavigator(BaseUI):
             ),
             timeout=15,
         ):
-            self.do_click(self.acm_page_nav["modal_dialog_close_button"], timeout=15)
+            try:
+                self.do_click(
+                    self.acm_page_nav["modal_dialog_close_button"],
+                    timeout=15,
+                )
+            except TimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "dialog may not be present"
+                )
         log.info("Successfully navigated to ACM console")
         self.take_screenshot()
 

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -263,7 +263,16 @@ class AcmPageNavigator(BaseUI):
             timeout=15,
             use_fallback=False,
         ):
-            self.do_click(self.acm_page_nav["modal_dialog_close_button"], timeout=15)
+            try:
+                self.do_click(
+                    self.acm_page_nav["modal_dialog_close_button"],
+                    timeout=15,
+                )
+            except TimeoutException:
+                log.warning(
+                    "Modal dialog close button not clickable, "
+                    "dialog may not be present"
+                )
         log.info("Successfully navigated to ACM console")
         self.take_screenshot()
 

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1187,6 +1187,46 @@ acm_page_nav_420 = {
     ),
 }
 
+acm_page_nav_421 = {
+    "modal_dialog_close_button": (
+        "//div[@role='dialog']//button[@aria-label='Close']",
+        By.XPATH,
+    ),
+    "all-clusters": (
+        "//li[@role='treeitem']//button[text()='All clusters']",
+        By.XPATH,
+    ),
+    "managed-cluster-name": (
+        "//li[@role='treeitem']//button[text()='{}']",
+        By.XPATH,
+    ),
+    "cnv-workload-namespace": (
+        "//li[@role='treeitem']//button[text()='{}']",
+        By.XPATH,
+    ),
+    # ACM 2.16.1 removed the cluster-dropdown-toggle button; the All Clusters
+    # nav link is the direct replacement for both the toggle and the view.
+    "click-local-cluster": (
+        "//a[@data-test='nav' and @href='/multicloud/infrastructure/clusters']",
+        By.XPATH,
+    ),
+    "all-clusters-view": (
+        "//a[@data-test='nav' and @href='/multicloud/infrastructure/clusters']",
+        By.XPATH,
+    ),
+    # On OCP 4.21, perspective dropdown items render as <h2> elements with
+    # data-test-id="perspective-switcher-menu-option".  The dropdown shows
+    # perspectives in document order: Core platform → Fleet Management →
+    # Fleet Virtualization.  Do NOT include "Fleet Management" in this
+    # locator: the XPath | union returns elements in document order, so Fleet
+    # Management (position 2) would be found before Fleet Virtualization
+    # (position 3) and clicking it would be a no-op since it is already active.
+    "fleet-virtual": (
+        "//h2[normalize-space()='Fleet Virtualization']",
+        By.XPATH,
+    ),
+}
+
 acm_configuration = {
     "cluster-sets": (
         "//a[normalize-space()='Cluster sets'] | //button[.//span[normalize-space()='Cluster sets']]",
@@ -1801,10 +1841,26 @@ acm_configuration_4_19 = {
     ),
     "selected-protection-type": ("//div[normalize-space()='{}']", By.XPATH),
     "assign": ("button[type='submit']", By.CSS_SELECTOR),
-    "conf-msg": ('//h4[text()="New policy assigned to application"]', By.XPATH),
+    "conf-msg": (
+        '//h4[contains(text(),"New policy assigned to application")]',
+        By.XPATH,
+    ),
     "close-page": ("button[aria-label='Close']", By.CSS_SELECTOR),
     "select-shared": ("#shared-vm-protection", By.CSS_SELECTOR),
     "select-drpc": ("input[name='radioGroup']", By.CSS_SELECTOR),
+    # Locators for removing DR protection from an enrolled VM via UI
+    "remove-vm-protection": (
+        "//button[@id='disable-dr-action']",
+        By.XPATH,
+    ),
+    "confirm-remove-protection": (
+        "//button[@id='confirm-disable-dr-action']",
+        By.XPATH,
+    ),
+    "remove-protection-conf-msg": (
+        "//h4[contains(text(),'Protection removed')]",
+        By.XPATH,
+    ),
 }
 
 acm_configuration_4_20 = {
@@ -1825,7 +1881,7 @@ acm_configuration_4_20 = {
         "//button[@data-test-id='perspective-switcher-toggle']",
         By.XPATH,
     ),
-    "fleet-virtual": ("//h2[text()='Fleet Virtualization']", By.XPATH),
+    "fleet-virtual": ("//h2[normalize-space()='Fleet Virtualization']", By.XPATH),
     "nav-bar-vms-page": ("//a[@data-test-id='virtualmachines-nav-item']", By.XPATH),
     "all-clusters": ("//button[text()='All clusters']", By.XPATH),
     "managed-cluster-name": ("//button[text()='{}']", By.XPATH),
@@ -1848,6 +1904,7 @@ acm_configuration_4_20 = {
 
 acm_configuration_4_21 = {
     "vm-actions": ('//button[@data-test="actions-dropdown"]', By.XPATH),
+    "vm-status": ("//*[normalize-space()='Running']", By.XPATH),
     "dr-policy": (
         "//button[@aria-label='Typeahead single select']",
         By.XPATH,
@@ -1862,6 +1919,22 @@ acm_configuration_4_21 = {
     ),
     "assign": (
         "//button[contains(@class, 'c-button pf-m-primary pf-m-progress') and contains(text(), 'Assign')]",
+        By.XPATH,
+    ),
+    # OCP 4.21 ACM hub does not carry data-test-id on the perspective switcher
+    # button; match by button text to avoid AI-fallback misclicks.
+    "switch-perspective": (
+        "//button[@data-test-id='perspective-switcher-toggle']"
+        " | //*[contains(@class, 'perspective-switcher')]//button"
+        " | //button[.//*[normalize-space()='Fleet Management'"
+        " or normalize-space()='Fleet management']]"
+        " | //button[normalize-space()='Fleet Management'"
+        " or normalize-space()='Fleet management']",
+        By.XPATH,
+    ),
+    "fleet-virtual": (
+        "//*[normalize-space()='Fleet virtualization'"
+        " or normalize-space()='Fleet Virtualization']",
         By.XPATH,
     ),
 }
@@ -1962,6 +2035,35 @@ acm_configuration_4_22 = {
         "(//button[@type='button'][.//*[normalize-space()='Nodes labeled']])[2]",
         By.XPATH,
     ),
+    "switch-perspective": (
+        "//button[@data-test-id='perspective-switcher-toggle'] | "
+        "//*[contains(@class, 'perspective-switcher')]//button | "
+        "//*[normalize-space()='Fleet management']/parent::button | "
+        "//*[normalize-space()='Fleet management']/ancestor::button[1]",
+        By.XPATH,
+    ),
+    "fleet-virtual": (
+        "//*[normalize-space()='Fleet virtualization'"
+        " or normalize-space()='Fleet Virtualization']",
+        By.XPATH,
+    ),
+    "nav-bar-vms-page": (
+        "//a[@data-test-id='virtualmachines-nav-item'] | "
+        "//*[normalize-space()='VirtualMachines']",
+        By.XPATH,
+    ),
+    "vm-page-next-btn": (
+        "//button[normalize-space()='Next']",
+        By.XPATH,
+    ),
+    "assign": (
+        "//button[normalize-space()='Assign']",
+        By.XPATH,
+    ),
+    "all-clusters": ("//li[@role='treeitem']//*[text()='All clusters']", By.XPATH),
+    "managed-cluster-name": ("//li[@role='treeitem']//*[text()='{}']", By.XPATH),
+    "cnv-workload-namespace": ("//li[@role='treeitem']//*[text()='{}']", By.XPATH),
+    "vm-status": ("//*[normalize-space()='Running']", By.XPATH),
 }
 
 add_capacity = {
@@ -4201,6 +4303,7 @@ locators = {
             **acm_page_nav_420,
             **acm_configuration_4_20,
             **acm_configuration_4_21,
+            **acm_page_nav_421,
             **acm_configuration_4_22,
         },
         "validation": {
@@ -4280,6 +4383,7 @@ locators = {
             **acm_page_nav_420,
             **acm_configuration_4_20,
             **acm_configuration_4_21,
+            **acm_page_nav_421,
         },
         "validation": {
             **validation,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1089,6 +1089,42 @@ acm_page_nav_420 = {
     ),
 }
 
+acm_page_nav_421 = {
+    "modal_dialog_close_button": (
+        "//div[@role='dialog']//button[@aria-label='Close']",
+        By.XPATH,
+    ),
+    "all-clusters": (
+        "//li[@role='treeitem']//button[text()='All clusters']",
+        By.XPATH,
+    ),
+    "managed-cluster-name": (
+        "//li[@role='treeitem']//button[text()='{}']",
+        By.XPATH,
+    ),
+    "cnv-workload-namespace": (
+        "//li[@role='treeitem']//button[text()='{}']",
+        By.XPATH,
+    ),
+    # ACM 2.16.1 removed the cluster-dropdown-toggle button; the All Clusters
+    # nav link is the direct replacement for both the toggle and the view.
+    "click-local-cluster": (
+        "//a[@data-test='nav' and @href='/multicloud/infrastructure/clusters']",
+        By.XPATH,
+    ),
+    "all-clusters-view": (
+        "//a[@data-test='nav' and @href='/multicloud/infrastructure/clusters']",
+        By.XPATH,
+    ),
+    # ACM 2.16 nightly renamed the perspective from "Fleet Virtualization" to
+    # "Fleet Management". Match either to keep older nightlies working.
+    "fleet-virtual": (
+        "//h2[normalize-space()='Fleet Virtualization' "
+        "or normalize-space()='Fleet Management']",
+        By.XPATH,
+    ),
+}
+
 acm_configuration = {
     "cluster-sets": (
         "//a[normalize-space()='Cluster sets'] | //button[.//span[normalize-space()='Cluster sets']]",
@@ -1588,6 +1624,19 @@ acm_configuration_4_19 = {
     "close-page": ("button[aria-label='Close']", By.CSS_SELECTOR),
     "select-shared": ("#shared-vm-protection", By.CSS_SELECTOR),
     "select-drpc": ("input[name='radioGroup']", By.CSS_SELECTOR),
+    # Locators for removing DR protection from an enrolled VM via UI
+    "remove-vm-protection": (
+        "//button[@id='disable-dr-action']",
+        By.XPATH,
+    ),
+    "confirm-remove-protection": (
+        "//button[@id='confirm-disable-dr-action']",
+        By.XPATH,
+    ),
+    "remove-protection-conf-msg": (
+        "//h4[contains(text(),'Protection removed')]",
+        By.XPATH,
+    ),
 }
 
 acm_configuration_4_20 = {
@@ -1608,7 +1657,7 @@ acm_configuration_4_20 = {
         "//button[@data-test-id='perspective-switcher-toggle']",
         By.XPATH,
     ),
-    "fleet-virtual": ("//h2[text()='Fleet Virtualization']", By.XPATH),
+    "fleet-virtual": ("//h2[normalize-space()='Fleet Virtualization']", By.XPATH),
     "nav-bar-vms-page": ("//a[@data-test-id='virtualmachines-nav-item']", By.XPATH),
     "all-clusters": ("//button[text()='All clusters']", By.XPATH),
     "managed-cluster-name": ("//button[text()='{}']", By.XPATH),
@@ -3759,6 +3808,7 @@ locators = {
             **acm_page_nav_420,
             **acm_configuration_4_20,
             **acm_configuration_4_21,
+            **acm_page_nav_421,
         },
         "validation": {
             **validation,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1708,6 +1708,35 @@ acm_configuration_4_22 = {
         "//h2[normalize-space()='Core platform']",
         By.XPATH,
     ),
+    "switch-perspective": (
+        "//button[@data-test-id='perspective-switcher-toggle'] | "
+        "//*[contains(@class, 'perspective-switcher')]//button | "
+        "//*[normalize-space()='Fleet management']/parent::button | "
+        "//*[normalize-space()='Fleet management']/ancestor::button[1]",
+        By.XPATH,
+    ),
+    "fleet-virtual": (
+        "//*[normalize-space()='Fleet virtualization'"
+        " or normalize-space()='Fleet Virtualization']",
+        By.XPATH,
+    ),
+    "nav-bar-vms-page": (
+        "//a[@data-test-id='virtualmachines-nav-item'] | "
+        "//*[normalize-space()='VirtualMachines']",
+        By.XPATH,
+    ),
+    "vm-page-next-btn": (
+        "//button[normalize-space()='Next']",
+        By.XPATH,
+    ),
+    "assign": (
+        "//button[normalize-space()='Assign']",
+        By.XPATH,
+    ),
+    "all-clusters": ("//li[@role='treeitem']//*[text()='All clusters']", By.XPATH),
+    "managed-cluster-name": ("//li[@role='treeitem']//*[text()='{}']", By.XPATH),
+    "cnv-workload-namespace": ("//li[@role='treeitem']//*[text()='{}']", By.XPATH),
+    "vm-status": ("//*[normalize-space()='Running']", By.XPATH),
 }
 
 add_capacity = {
@@ -3735,6 +3764,7 @@ locators = {
             **acm_page_nav_420,
             **acm_configuration_4_20,
             **acm_configuration_4_21,
+            **acm_page_nav_421,
             **acm_configuration_4_22,
         },
         "validation": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8594,8 +8594,18 @@ def discovered_apps_dr_workload_cnv(request):
         if custom_sc:
             workload_key = "dr_cnv_discovered_apps_using_custom_pool_and_sc"
 
+        shared_already = (
+            sum(
+                1
+                for i in instances[1:]
+                if i.workload_namespace == instances[0].workload_namespace
+            )
+            if instances
+            else 0
+        )
         for index in range(pvc_vm):
-            workload_details = ocsci_config.ENV_DATA[workload_key][index]
+            config_index = shared_already + index if shared_drpc_protection else index
+            workload_details = ocsci_config.ENV_DATA[workload_key][config_index]
             workload_namespace = create_unique_resource_name("wrkld-vm", "dist")[:20]
             if shared_drpc_protection and instances:
                 workload_details["workload_namespace"] = instances[0].workload_namespace
@@ -8643,9 +8653,24 @@ def discovered_apps_dr_workload_cnv(request):
         return instances
 
     def teardown():
-        if "shared" in request.node.nodeid:
-            instances[0].delete_workload(skip_resource_deletion_verification=True)
-            instances[1].delete_workload(shared_drpc_protection=True)
+        # Detect whether all instances share the same namespace.
+        # When they do, we must delete all VMs before triggering
+        # wait_for_all_resources_deletion, otherwise pods from the
+        # remaining VMs block the wait.
+        same_namespace = len(instances) > 1 and (
+            len({i.workload_namespace for i in instances}) == 1
+        )
+        if same_namespace:
+            # Delete all but the last instance without waiting, skipping
+            # per-instance namespace/project cleanup.
+            # DRPC deletion uses --ignore-not-found so it is safe even if
+            # another instance already removed the shared DRPC.
+            for instance in instances[:-1]:
+                instance.delete_workload(skip_resource_deletion_verification=True)
+            # Last instance: delete its own DRPC (--ignore-not-found handles
+            # the case where it was already removed as a Shared DRPC), then
+            # wait for all pods in the namespace and remove the project.
+            instances[-1].delete_workload()
         else:
             for instance in instances:
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8455,8 +8455,18 @@ def discovered_apps_dr_workload_cnv(request):
         if custom_sc:
             workload_key = "dr_cnv_discovered_apps_using_custom_pool_and_sc"
 
+        shared_already = (
+            sum(
+                1
+                for i in instances[1:]
+                if i.workload_namespace == instances[0].workload_namespace
+            )
+            if instances
+            else 0
+        )
         for index in range(pvc_vm):
-            workload_details = ocsci_config.ENV_DATA[workload_key][index]
+            config_index = shared_already + index if shared_drpc_protection else index
+            workload_details = ocsci_config.ENV_DATA[workload_key][config_index]
             workload_namespace = create_unique_resource_name("wrkld-vm", "dist")[:20]
             if shared_drpc_protection and instances:
                 workload_details["workload_namespace"] = instances[0].workload_namespace
@@ -8499,9 +8509,24 @@ def discovered_apps_dr_workload_cnv(request):
         return instances
 
     def teardown():
-        if "shared" in request.node.nodeid:
-            instances[0].delete_workload(skip_resource_deletion_verification=True)
-            instances[1].delete_workload(shared_drpc_protection=True)
+        # Detect whether all instances share the same namespace.
+        # When they do, we must delete all VMs before triggering
+        # wait_for_all_resources_deletion, otherwise pods from the
+        # remaining VMs block the wait.
+        same_namespace = len(instances) > 1 and (
+            len({i.workload_namespace for i in instances}) == 1
+        )
+        if same_namespace:
+            # Delete all but the last instance without waiting, skipping
+            # per-instance namespace/project cleanup.
+            # DRPC deletion uses --ignore-not-found so it is safe even if
+            # another instance already removed the shared DRPC.
+            for instance in instances[:-1]:
+                instance.delete_workload(skip_resource_deletion_verification=True)
+            # Last instance: delete its own DRPC (--ignore-not-found handles
+            # the case where it was already removed as a Shared DRPC), then
+            # wait for all pods in the namespace and remove the project.
+            instances[-1].delete_workload()
         else:
             for instance in instances:
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8661,16 +8661,28 @@ def discovered_apps_dr_workload_cnv(request):
             len({i.workload_namespace for i in instances}) == 1
         )
         if same_namespace:
-            # Delete all but the last instance without waiting, skipping
-            # per-instance namespace/project cleanup.
-            # DRPC deletion uses --ignore-not-found so it is safe even if
-            # another instance already removed the shared DRPC.
-            for instance in instances[:-1]:
+            # Skip resource deletion verification for all instances.
+            # When the test fails mid-way (before DR unprotection), PVCs
+            # retain VGR finalizers that block deletion for 25+ minutes.
+            # Submitting all deletions without waiting and then deleting the
+            # project is more resilient — namespace deletion cascades and
+            # Ramen will release finalizers once it processes the DRPC removal.
+            for instance in instances:
                 instance.delete_workload(skip_resource_deletion_verification=True)
-            # Last instance: delete its own DRPC (--ignore-not-found handles
-            # the case where it was already removed as a Shared DRPC), then
-            # wait for all pods in the namespace and remove the project.
-            instances[-1].delete_workload()
+            namespace = instances[0].workload_namespace
+            for cluster in utils.get_non_acm_cluster_config():
+                config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+                try:
+                    OCP().delete_project(project_name=namespace)
+                    log.info(
+                        f"Project {namespace} deleted on"
+                        f" {cluster.ENV_DATA['cluster_name']}"
+                    )
+                except Exception:
+                    log.warning(
+                        f"Failed to delete project {namespace} on"
+                        f" {cluster.ENV_DATA['cluster_name']}"
+                    )
         else:
             for instance in instances:
                 try:

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1,5 +1,6 @@
 import logging
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import sleep
 
 import pytest
@@ -689,13 +690,23 @@ class TestACMKubevirtDRIntergration:
                 vrg_name=resource_name,
             )
 
-        # Wait for all VMs to be running
-        for cnv_wl in all_cnv_workloads:
-            dr_helpers.wait_for_cnv_workload(
-                vm_name=cnv_wl.vm_name,
-                namespace=workload_namespace,
-                phase=constants.STATUS_RUNNING,
-            )
+        # Wait for all VMs to be running concurrently to avoid sequential
+        # timeouts when DRPC failovers are staggered
+        logger.info("Waiting for all VMs to reach Running state concurrently")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
+                    vm_name=cnv_wl.vm_name,
+                    namespace=workload_namespace,
+                    phase=constants.STATUS_RUNNING,
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
+                logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
             workload_namespace,
@@ -765,13 +776,22 @@ class TestACMKubevirtDRIntergration:
                 vrg_name=resource_name,
             )
 
-        # Wait for all VMs to be running on secondary cluster
-        for cnv_wl in all_cnv_workloads:
-            dr_helpers.wait_for_cnv_workload(
-                vm_name=cnv_wl.vm_name,
-                namespace=workload_namespace,
-                phase=constants.STATUS_RUNNING,
-            )
+        # Wait for all VMs to be running on secondary cluster concurrently
+        logger.info("Waiting for all VMs to reach Running state on secondary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
+                    vm_name=cnv_wl.vm_name,
+                    namespace=workload_namespace,
+                    phase=constants.STATUS_RUNNING,
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
+                logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
         logger.info("Validating data integrity after failover")
@@ -908,13 +928,22 @@ class TestACMKubevirtDRIntergration:
                 vrg_name=resource_name,
             )
 
-        # Wait for all VMs to be running on primary cluster
-        for cnv_wl in all_cnv_workloads:
-            dr_helpers.wait_for_cnv_workload(
-                vm_name=cnv_wl.vm_name,
-                namespace=workload_namespace,
-                phase=constants.STATUS_RUNNING,
-            )
+        # Wait for all VMs to be running on primary cluster concurrently
+        logger.info("Waiting for all VMs to reach Running state on primary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
+                    vm_name=cnv_wl.vm_name,
+                    namespace=workload_namespace,
+                    phase=constants.STATUS_RUNNING,
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
+                logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         config.switch_acm_ctx()
         logger.info("On UI, check if all VMs are running after relocate")

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -122,8 +122,8 @@ class TestACMKubevirtDRIntergration:
                 # queries existing DRPCs when rendering the wizard; if the DRPC is
                 # not yet present the #shared-vm-protection radio button won't appear.
                 logger.info(
-                    "Waiting for DRPC %s-drpc to exist before Shared enrollment",
-                    protection_name,
+                    f"Waiting for DRPC {protection_name}-drpc to exist"
+                    " before Shared enrollment"
                 )
                 config.switch_acm_ctx()
                 wait_for_resource_existence(
@@ -565,8 +565,7 @@ class TestACMKubevirtDRIntergration:
         # wizard; if the DRPC has not yet been created the Shared option
         # (#shared-vm-protection) will not appear.
         logger.info(
-            "Waiting for DRPC %s to exist before enrolling VM 3 as Shared",
-            resource_name_1,
+            f"Waiting for DRPC {resource_name_1} to exist before enrolling VM 3 as Shared"
         )
         config.switch_acm_ctx()
         wait_for_resource_existence(
@@ -617,8 +616,7 @@ class TestACMKubevirtDRIntergration:
 
         # Wait for VM 2's DRPC to be present before enrolling VM 4 as Shared.
         logger.info(
-            "Waiting for DRPC %s to exist before enrolling VM 4 as Shared",
-            resource_name_2,
+            f"Waiting for DRPC {resource_name_2} to exist before enrolling VM 4 as Shared"
         )
         config.switch_acm_ctx()
         wait_for_resource_existence(
@@ -652,54 +650,33 @@ class TestACMKubevirtDRIntergration:
 
         config.switch_to_cluster_by_name(primary_cluster_name)
 
-        # Per-DRPC counts used during initial setup, post-failover, and post-relocate waits.
-        # DRPC1 covers VM 1 (index 0) and VM 3 (index 2);
-        # DRPC2 covers VM 2 (index 1) and VM 4 (index 3).
-        # Using namespace-wide totals (4) for each DRPC times out when one
-        # DRPC's VMs become healthy before the other DRPC's VMs are ready.
-        drpc1_pvc_count = (
-            all_cnv_workloads[0].workload_pvc_count
-            + all_cnv_workloads[2].workload_pvc_count
-        )
-        drpc1_pod_count = (
-            all_cnv_workloads[0].workload_pod_count
-            + all_cnv_workloads[2].workload_pod_count
-        )
-        drpc2_pvc_count = (
-            all_cnv_workloads[1].workload_pvc_count
-            + all_cnv_workloads[3].workload_pvc_count
-        )
-        drpc2_pod_count = (
-            all_cnv_workloads[1].workload_pod_count
-            + all_cnv_workloads[3].workload_pod_count
-        )
-        drpc_resource_counts = [
-            (resource_name_1, drpc1_pvc_count, drpc1_pod_count),
-            (resource_name_2, drpc2_pvc_count, drpc2_pod_count),
-        ]
-
-        # Wait for PVCs/pods per-DRPC but skip replication checks here
-        # because VolumeReplication count/state checks are namespace-wide
-        # and would fail when the other DRPC's VRs aren't ready yet.
-        for resource_name, pvc_count, pod_count in drpc_resource_counts:
-            dr_helpers.wait_for_all_resources_creation(
-                pvc_count,
-                pod_count,
-                workload_namespace,
-                discovered_apps=True,
-                vrg_name=resource_name,
-                skip_replication_resources=True,
-            )
-
-        # Single namespace-wide replication check using total PVC count
         total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
-        wait_for_replication_resources_creation(
+        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
+
+        # Wait for all PVCs and pods namespace-wide. The per-DRPC loop
+        # approach was incorrect: wait_for_all_resources_creation counts
+        # resources namespace-wide, so DRPC1's running pods would satisfy
+        # DRPC2's pod count check before DRPC2's own pods were ready.
+        dr_helpers.wait_for_all_resources_creation(
             total_pvc_count,
+            total_pod_count,
             workload_namespace,
-            timeout=900,
             discovered_apps=True,
             vrg_name=resource_name_1,
+            skip_replication_resources=True,
         )
+
+        # Verify both DRPCs' VRGs reach Primary state. A single call with
+        # vrg_name=resource_name_1 only verified DRPC1's VRG; DRPC2's volumes
+        # could still be unreplicated when the VMs tried to start.
+        for resource_name in drpc_resources:
+            wait_for_replication_resources_creation(
+                total_pvc_count,
+                workload_namespace,
+                timeout=900,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
 
         # Wait for all VMs to be running concurrently to avoid sequential
         # timeouts when DRPC failovers are staggered
@@ -773,28 +750,28 @@ class TestACMKubevirtDRIntergration:
                 old_primary=primary_cluster_name,
             )
 
-        # Verify resources creation on secondary cluster (failoverCluster).
-        # Use per-DRPC counts for PVC/pod waits, skip replication checks
-        # per-DRPC since they are namespace-wide.
         config.switch_to_cluster_by_name(secondary_cluster_name)
-        for resource_name, pvc_count, pod_count in drpc_resource_counts:
-            dr_helpers.wait_for_all_resources_creation(
-                pvc_count,
-                pod_count,
-                workload_namespace,
-                discovered_apps=True,
-                vrg_name=resource_name,
-                skip_replication_resources=True,
-            )
-
-        # Single namespace-wide replication check after both DRPCs
-        wait_for_replication_resources_creation(
+        # 1800s: two DRPCs fail over sequentially so DRPC2's VMs start up
+        # to 360s after DRPC1's, leaving too little of the default 900s
+        # window for all four pods to reach Running state.
+        dr_helpers.wait_for_all_resources_creation(
             total_pvc_count,
+            total_pod_count,
             workload_namespace,
-            timeout=900,
+            timeout=1800,
             discovered_apps=True,
             vrg_name=resource_name_1,
+            skip_replication_resources=True,
         )
+
+        for resource_name in drpc_resources:
+            wait_for_replication_resources_creation(
+                total_pvc_count,
+                workload_namespace,
+                timeout=900,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
 
         # Wait for all VMs to be running on secondary cluster concurrently
         logger.info("Waiting for all VMs to reach Running state on secondary cluster")
@@ -936,27 +913,25 @@ class TestACMKubevirtDRIntergration:
             )
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        # Verify resources creation on primary managed cluster.
-        # Skip replication checks per-DRPC since they are namespace-wide.
         config.switch_to_cluster_by_name(primary_cluster_name)
-        for resource_name, pvc_count, pod_count in drpc_resource_counts:
-            dr_helpers.wait_for_all_resources_creation(
-                pvc_count,
-                pod_count,
-                workload_namespace,
-                discovered_apps=True,
-                vrg_name=resource_name,
-                skip_replication_resources=True,
-            )
-
-        # Single namespace-wide replication check after both DRPCs
-        wait_for_replication_resources_creation(
+        dr_helpers.wait_for_all_resources_creation(
             total_pvc_count,
+            total_pod_count,
             workload_namespace,
-            timeout=900,
+            timeout=1800,
             discovered_apps=True,
             vrg_name=resource_name_1,
+            skip_replication_resources=True,
         )
+
+        for resource_name in drpc_resources:
+            wait_for_replication_resources_creation(
+                total_pvc_count,
+                workload_namespace,
+                timeout=900,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
 
         # Wait for all VMs to be running on primary cluster concurrently
         logger.info("Waiting for all VMs to reach Running state on primary cluster")
@@ -1170,8 +1145,7 @@ class TestACMKubevirtDRIntergration:
 
         # Wait for VM 1's DRPC to exist before enrolling VMs 2 and 3 as Shared.
         logger.info(
-            "Waiting for DRPC %s to exist before enrolling VMs 2/3 as Shared",
-            resource_name,
+            f"Waiting for DRPC {resource_name} to exist before enrolling VMs 2/3 as Shared"
         )
         config.switch_acm_ctx()
         wait_for_resource_existence(

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -18,6 +18,7 @@ from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.helpers.dr_helpers import (
     wait_for_all_resources_deletion,
     wait_for_managed_cluster_unreachable,
+    wait_for_replication_resources_creation,
     wait_for_resource_existence,
 )
 from ocs_ci.ocs import constants
@@ -651,11 +652,7 @@ class TestACMKubevirtDRIntergration:
 
         config.switch_to_cluster_by_name(primary_cluster_name)
 
-        # Wait for all resources to be created (4 VMs total)
-        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
-        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
-
-        # Per-DRPC counts used during post-failover / post-relocate waits.
+        # Per-DRPC counts used during initial setup, post-failover, and post-relocate waits.
         # DRPC1 covers VM 1 (index 0) and VM 3 (index 2);
         # DRPC2 covers VM 2 (index 1) and VM 4 (index 3).
         # Using namespace-wide totals (4) for each DRPC times out when one
@@ -681,14 +678,28 @@ class TestACMKubevirtDRIntergration:
             (resource_name_2, drpc2_pvc_count, drpc2_pod_count),
         ]
 
-        for resource_name in drpc_resources:
+        # Wait for PVCs/pods per-DRPC but skip replication checks here
+        # because VolumeReplication count/state checks are namespace-wide
+        # and would fail when the other DRPC's VRs aren't ready yet.
+        for resource_name, pvc_count, pod_count in drpc_resource_counts:
             dr_helpers.wait_for_all_resources_creation(
-                total_pvc_count,
-                total_pod_count,
+                pvc_count,
+                pod_count,
                 workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
+                skip_replication_resources=True,
             )
+
+        # Single namespace-wide replication check using total PVC count
+        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
+        wait_for_replication_resources_creation(
+            total_pvc_count,
+            workload_namespace,
+            timeout=900,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+        )
 
         # Wait for all VMs to be running concurrently to avoid sequential
         # timeouts when DRPC failovers are staggered
@@ -763,9 +774,8 @@ class TestACMKubevirtDRIntergration:
             )
 
         # Verify resources creation on secondary cluster (failoverCluster).
-        # Use per-DRPC counts to avoid a 900 s timeout: DRPC1's VMs may become
-        # healthy before DRPC2's VMs have started, so waiting for the full
-        # namespace count (4) on the first DRPC would time out.
+        # Use per-DRPC counts for PVC/pod waits, skip replication checks
+        # per-DRPC since they are namespace-wide.
         config.switch_to_cluster_by_name(secondary_cluster_name)
         for resource_name, pvc_count, pod_count in drpc_resource_counts:
             dr_helpers.wait_for_all_resources_creation(
@@ -774,7 +784,17 @@ class TestACMKubevirtDRIntergration:
                 workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
+                skip_replication_resources=True,
             )
+
+        # Single namespace-wide replication check after both DRPCs
+        wait_for_replication_resources_creation(
+            total_pvc_count,
+            workload_namespace,
+            timeout=900,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+        )
 
         # Wait for all VMs to be running on secondary cluster concurrently
         logger.info("Waiting for all VMs to reach Running state on secondary cluster")
@@ -916,8 +936,8 @@ class TestACMKubevirtDRIntergration:
             )
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        # Verify resources creation on primary managed cluster (per-DRPC counts
-        # for the same reason as post-failover — avoids 900 s timeout).
+        # Verify resources creation on primary managed cluster.
+        # Skip replication checks per-DRPC since they are namespace-wide.
         config.switch_to_cluster_by_name(primary_cluster_name)
         for resource_name, pvc_count, pod_count in drpc_resource_counts:
             dr_helpers.wait_for_all_resources_creation(
@@ -926,7 +946,17 @@ class TestACMKubevirtDRIntergration:
                 workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
+                skip_replication_resources=True,
             )
+
+        # Single namespace-wide replication check after both DRPCs
+        wait_for_replication_resources_creation(
+            total_pvc_count,
+            workload_namespace,
+            timeout=900,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+        )
 
         # Wait for all VMs to be running on primary cluster concurrently
         logger.info("Waiting for all VMs to reach Running state on primary cluster")

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -14,12 +14,17 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
-from ocs_ci.helpers.dr_helpers import wait_for_all_resources_deletion
+from ocs_ci.helpers.dr_helpers import (
+    wait_for_all_resources_deletion,
+    wait_for_managed_cluster_unreachable,
+    wait_for_resource_existence,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.helpers.dr_helpers_ui import (
     check_or_assign_drpolicy_for_discovered_vms_via_ui,
     navigate_using_fleet_virtualization,
+    remove_drprotection_for_discovered_vm_via_ui,
 )
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity_vm
 from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
@@ -107,9 +112,26 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             f"Primary managed cluster name is {cnv_workloads[0].preferred_primary_cluster}"
         )
-        assert navigate_using_fleet_virtualization(acm_obj)
         for i, vm in enumerate(cnv_workloads):
             standalone_flag = (not protection_type) or (i == 0)
+            if protection_type and i == 1:
+                # Wait for the standalone DRPC (created in iteration 0) to exist
+                # before opening the enrollment wizard in Shared mode. The ACM UI
+                # queries existing DRPCs when rendering the wizard; if the DRPC is
+                # not yet present the #shared-vm-protection radio button won't appear.
+                logger.info(
+                    "Waiting for DRPC %s-drpc to exist before Shared enrollment",
+                    protection_name,
+                )
+                config.switch_acm_ctx()
+                wait_for_resource_existence(
+                    kind=constants.DRPC,
+                    namespace=constants.DR_OPS_NAMESPACE,
+                    resource_name=f"{protection_name}-drpc",
+                    timeout=120,
+                    should_exist=True,
+                )
+            assert navigate_using_fleet_virtualization(acm_obj)
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[vm],
@@ -196,7 +218,7 @@ class TestACMKubevirtDRIntergration:
             f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
             "waiting for cluster to be unreachable.."
         )
-        sleep(300)
+        wait_for_managed_cluster_unreachable(primary_cluster_name)
 
         logger.info("FailingOver the workloads.....")
         dr_helpers.failover(
@@ -249,7 +271,9 @@ class TestACMKubevirtDRIntergration:
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
-        wait_for_nodes_status([node.name for node in active_primary_cluster_node_objs])
+        wait_for_nodes_status(
+            [node.name for node in active_primary_cluster_node_objs], timeout=900
+        )
         wait_for_pods_to_be_running(timeout=420, sleep=15)
         assert ceph_health_check(tries=10, delay=30)
 
@@ -276,14 +300,16 @@ class TestACMKubevirtDRIntergration:
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
         logger.info("On UI, check if VM is running after failover or not")
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=secondary_cluster_name,
-            assign_policy=False,
-        )
+        for cnv_wl in cnv_workloads:
+            assert navigate_using_fleet_virtualization(acm_obj)
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=secondary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(secondary_cluster_name)
 
         # Doing Relocate in below code
@@ -331,15 +357,16 @@ class TestACMKubevirtDRIntergration:
 
         config.switch_acm_ctx()
         logger.info("On UI, check if VM is running after relocate or not")
-        acm_obj.refresh_page()
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
+        for cnv_wl in cnv_workloads:
+            assert navigate_using_fleet_virtualization(acm_obj)
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=primary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster
@@ -360,4 +387,904 @@ class TestACMKubevirtDRIntergration:
                 username=cnv_wl.vm_username,
                 verify=True,
             )
-        logger.info(f"Test for {protection_name} protection type passed")
+
+        # ------------------------------------------------------------------ #
+        # Remove DR protection scenario                                        #
+        # Standalone run: remove protection from the single VM and verify     #
+        #   its DRPC is deleted.                                               #
+        # Shared run:     remove only the 2nd (Shared) VM from the DRPC and  #
+        #   verify the 1st VM is still protected with its DRPC intact.        #
+        # ------------------------------------------------------------------ #
+        config.switch_acm_ctx()
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        if protection_type:
+            # Shared run – cnv_workloads[1] is the Shared VM; remove it
+            logger.info(
+                "Removing DR protection from the Shared VM "
+                f"'{cnv_workloads[1].vm_name}'"
+            )
+            assert remove_drprotection_for_discovered_vm_via_ui(
+                acm_obj,
+                vm=cnv_workloads[1],
+                managed_cluster_name=primary_cluster_name,
+                namespace=cnv_workloads[0].workload_namespace,
+            )
+            # Validate: DRPC still exists (1st VM is still enrolled)
+            logger.info("Validating DRPC still exists for the remaining Standalone VM")
+            config.switch_acm_ctx()
+            wait_for_resource_existence(
+                kind=constants.DRPC,
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
+                timeout=120,
+                should_exist=True,
+            )
+            # Validate: 1st VM still shows Running and is still protected
+            logger.info("Validating 1st VM is still running and protected on UI")
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_workloads[0]],
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=primary_cluster_name,
+                assign_policy=False,
+            )
+            logger.info("Shared VM removed from DRPC; Standalone VM remains protected")
+        else:
+            # Standalone run – remove the single VM's protection entirely
+            logger.info(
+                "Removing DR protection from the Standalone VM "
+                f"'{cnv_workloads[0].vm_name}'"
+            )
+            assert remove_drprotection_for_discovered_vm_via_ui(
+                acm_obj,
+                vm=cnv_workloads[0],
+                managed_cluster_name=primary_cluster_name,
+                namespace=cnv_workloads[0].workload_namespace,
+            )
+            # Validate: DRPC is deleted
+            logger.info(
+                "Validating DRPC is deleted after Standalone protection removal"
+            )
+            config.switch_acm_ctx()
+            wait_for_resource_existence(
+                kind=constants.DRPC,
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
+                timeout=120,
+                should_exist=False,
+            )
+            logger.info("Standalone VM DR protection removed and DRPC deleted")
+
+    # TODO: Add Polarion ID when available
+    @pytest.mark.polarion_id("OCS-zzzz")
+    def test_acm_kubevirt_mixed_protection_types(
+        self,
+        setup_acm_ui,
+        discovered_apps_dr_workload_cnv,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        DR operation on multiple discovered VMs in the same namespace using mixed protection types
+        (some Standalone, some Shared). This test validates that VMs with different protection types
+        can coexist in the same namespace and perform DR operations successfully.
+
+        Test steps:
+
+        1. Deploy multiple CNV discovered workloads (4 VMs) in a single test namespace via CLI
+        2. Using ACM UI, DR protect the 1st and 2nd VMs from the VMs page using Standalone protection type
+        3. DR protect the 3rd VM using Shared protection type (tied to 1st VM's DRPC)
+        4. DR protect the 4th VM using Shared protection type (tied to 2nd VM's DRPC)
+        5. Write data to all VMs, take md5sum
+        6. Failover all workloads via CLI by shutting down the primary managed cluster
+        7. After successful failover, verify data integrity on all VMs
+        8. Write additional data post-failover
+        9. Recover the down managed cluster and perform cleanup
+        10. Perform Relocate operation back to the original cluster
+        11. Verify data integrity after relocate
+
+        """
+
+        md5sum_original = []
+        md5sum_failover = []
+        vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
+        all_cnv_workloads = []
+        drpc_resources = []
+
+        logger.info("Deploy 1st CNV workload (Standalone protection)")
+        cnv_workload_1 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+        )
+        all_cnv_workloads.append(cnv_workload_1[-1])
+
+        # VM 2 (index 1): will become 2nd Standalone; shared_drpc_protection=True means
+        # "deploy into the same namespace as the existing workload", not the DR protection type
+        logger.info(
+            "Deploy 2nd CNV workload in the same namespace (will use Standalone DR protection)"
+        )
+        cnv_workload_2 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_2[-1])
+
+        # VM 3 (index 2): will be enrolled as Shared with VM 1
+        logger.info(
+            "Deploy 3rd CNV workload in the same namespace (will be Shared with VM 1)"
+        )
+        cnv_workload_3 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_3[-1])
+
+        # VM 4 (index 3): will be enrolled as Shared with VM 2
+        logger.info(
+            "Deploy 4th CNV workload in the same namespace (will be Shared with VM 2)"
+        )
+        cnv_workload_4 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_4[-1])
+
+        assert all_cnv_workloads, "No discovered VMs found"
+        assert (
+            len(all_cnv_workloads) == 4
+        ), f"Expected 4 VMs, found {len(all_cnv_workloads)}"
+
+        config.switch_acm_ctx()
+        workload_namespace = all_cnv_workloads[0].workload_namespace
+        logger.info(f"All VMs deployed in namespace: {workload_namespace}")
+
+        acm_obj = AcmAddClusters()
+        primary_cluster_name = all_cnv_workloads[0].preferred_primary_cluster
+        logger.info(f"Primary managed cluster name is {primary_cluster_name}")
+
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        # DR protect VMs with mixed protection types
+        # VM 1: Standalone (creates new DRPC)
+        logger.info("DR protecting VM 1 with Standalone protection")
+        protection_name_1 = f"{workload_namespace}-standalone-1"
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=True,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+        )
+        # When DR protected via UI, the DRPC is named after the protection name entered
+        resource_name_1 = f"{protection_name_1}-drpc"
+        drpc_resources.append(resource_name_1)
+
+        # Wait for VM 1's DRPC to exist in Kubernetes before enrolling VM 3 as
+        # Shared. The ACM UI queries existing DRPCs when opening the enrollment
+        # wizard; if the DRPC has not yet been created the Shared option
+        # (#shared-vm-protection) will not appear.
+        logger.info(
+            "Waiting for DRPC %s to exist before enrolling VM 3 as Shared",
+            resource_name_1,
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_1,
+            timeout=120,
+            should_exist=True,
+        )
+
+        # VM 3: Shared with VM 1 (uses the single existing DRPC from VM 1)
+        # NOTE: the UI helper asserts exactly 1 radio button when selecting a Shared DRPC.
+        # VM 3 is enrolled immediately after VM 1 so only 1 DRPC exists at this point.
+        logger.info("DR protecting VM 3 with Shared protection (tied to VM 1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[2]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+        )
+
+        # VM 2: Standalone (creates a second independent DRPC)
+        logger.info("DR protecting VM 2 with Standalone protection")
+        protection_name_2 = f"{workload_namespace}-standalone-2"
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[1]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=True,
+            protection_name=protection_name_2,
+            namespace=workload_namespace,
+        )
+        resource_name_2 = f"{protection_name_2}-drpc"
+        drpc_resources.append(resource_name_2)
+
+        # Override discovered_apps_placement_name on the Standalone workload objects
+        # so delete_workload can find the custom UI-created DRPCs at teardown.
+        # delete_workload tries {name} and {name}-drpc — by setting the base name
+        # to protection_name_X (without -drpc), it resolves to resource_name_X.
+        # VM 3 and VM 4 use shared_drpc_protection=True so delete_workload skips
+        # DRPC deletion for them entirely.
+        all_cnv_workloads[0].discovered_apps_placement_name = protection_name_1
+        all_cnv_workloads[1].discovered_apps_placement_name = protection_name_2
+
+        # Wait for VM 2's DRPC to be present before enrolling VM 4 as Shared.
+        logger.info(
+            "Waiting for DRPC %s to exist before enrolling VM 4 as Shared",
+            resource_name_2,
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=120,
+            should_exist=True,
+        )
+
+        # VM 4: Shared with VM 2 (uses existing DRPC from VM 2)
+        logger.info("DR protecting VM 4 with Shared protection (tied to VM 2)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[3]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name_2,
+            namespace=workload_namespace,
+        )
+
+        logger.info(f"DRPC resources created: {drpc_resources}")
+
+        # Get scheduling interval from first DRPC
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            workload_namespace,
+            discovered_apps=True,
+            resource_name=resource_name_1,
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        # Wait for all resources to be created (4 VMs total)
+        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
+        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
+
+        # Per-DRPC counts used during post-failover / post-relocate waits.
+        # DRPC1 covers VM 1 (index 0) and VM 3 (index 2);
+        # DRPC2 covers VM 2 (index 1) and VM 4 (index 3).
+        # Using namespace-wide totals (4) for each DRPC times out when one
+        # DRPC's VMs become healthy before the other DRPC's VMs are ready.
+        drpc1_pvc_count = (
+            all_cnv_workloads[0].workload_pvc_count
+            + all_cnv_workloads[2].workload_pvc_count
+        )
+        drpc1_pod_count = (
+            all_cnv_workloads[0].workload_pod_count
+            + all_cnv_workloads[2].workload_pod_count
+        )
+        drpc2_pvc_count = (
+            all_cnv_workloads[1].workload_pvc_count
+            + all_cnv_workloads[3].workload_pvc_count
+        )
+        drpc2_pod_count = (
+            all_cnv_workloads[1].workload_pod_count
+            + all_cnv_workloads[3].workload_pod_count
+        )
+        drpc_resource_counts = [
+            (resource_name_1, drpc1_pvc_count, drpc1_pod_count),
+            (resource_name_2, drpc2_pvc_count, drpc2_pod_count),
+        ]
+
+        for resource_name in drpc_resources:
+            dr_helpers.wait_for_all_resources_creation(
+                total_pvc_count,
+                total_pod_count,
+                workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        # Wait for all VMs to be running
+        for cnv_wl in all_cnv_workloads:
+            dr_helpers.wait_for_cnv_workload(
+                vm_name=cnv_wl.vm_name,
+                namespace=workload_namespace,
+                phase=constants.STATUS_RUNNING,
+            )
+
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            workload_namespace,
+            discovered_apps=True,
+            resource_name=resource_name_1,
+        )
+
+        # Download and extract the virtctl binary to bin_dir. Skips if already present.
+        CNVInstaller().download_and_extract_virtctl_binary()
+
+        # Creating a file (file1) on all VMs and calculating MD5sum
+        logger.info("Writing data to all VMs and calculating MD5sum")
+        for cnv_wl in all_cnv_workloads:
+            md5sum_original.append(
+                run_dd_io(
+                    vm_obj=cnv_wl.vm_obj,
+                    file_path=vm_filepaths[0],
+                    username=cnv_wl.vm_username,
+                    verify=True,
+                )
+            )
+
+        for cnv_wl, md5sum in zip(all_cnv_workloads, md5sum_original):
+            logger.info(
+                f"Original checksum of file {vm_filepaths[0]} on VM {cnv_wl.workload_name}: {md5sum}"
+            )
+
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Shutdown primary managed cluster nodes
+        active_primary_index = config.cur_index
+        active_primary_cluster_node_objs = get_node_objs()
+        logger.info("Shutting down all the nodes of the primary managed cluster")
+        nodes_multicluster[active_primary_index].stop_nodes(
+            active_primary_cluster_node_objs
+        )
+        logger.info(
+            f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
+            "waiting for cluster to be unreachable.."
+        )
+        wait_for_managed_cluster_unreachable(primary_cluster_name)
+
+        # Failover all workloads (both DRPCs)
+        logger.info("Failing over all workloads...")
+        for resource_name in drpc_resources:
+            dr_helpers.failover(
+                failover_cluster=secondary_cluster_name,
+                namespace=workload_namespace,
+                discovered_apps=True,
+                workload_placement_name=resource_name,
+                old_primary=primary_cluster_name,
+            )
+
+        # Verify resources creation on secondary cluster (failoverCluster).
+        # Use per-DRPC counts to avoid a 900 s timeout: DRPC1's VMs may become
+        # healthy before DRPC2's VMs have started, so waiting for the full
+        # namespace count (4) on the first DRPC would time out.
+        config.switch_to_cluster_by_name(secondary_cluster_name)
+        for resource_name, pvc_count, pod_count in drpc_resource_counts:
+            dr_helpers.wait_for_all_resources_creation(
+                pvc_count,
+                pod_count,
+                workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        # Wait for all VMs to be running on secondary cluster
+        for cnv_wl in all_cnv_workloads:
+            dr_helpers.wait_for_cnv_workload(
+                vm_name=cnv_wl.vm_name,
+                namespace=workload_namespace,
+                phase=constants.STATUS_RUNNING,
+            )
+
+        # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
+        logger.info("Validating data integrity after failover")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[0], md5sum_original, "Failover"
+        )
+
+        # Creating a file (file2) post failover on all VMs
+        logger.info("Writing additional data post-failover")
+        for cnv_wl in all_cnv_workloads:
+            md5sum_failover.append(
+                run_dd_io(
+                    vm_obj=cnv_wl.vm_obj,
+                    file_path=vm_filepaths[1],
+                    username=cnv_wl.vm_username,
+                    verify=True,
+                )
+            )
+
+        for cnv_wl, md5sum in zip(all_cnv_workloads, md5sum_failover):
+            logger.info(
+                f"Checksum of files written after Failover: {vm_filepaths[1]} on VM {cnv_wl.workload_name}: {md5sum}"
+            )
+
+        # Recover the down managed cluster
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        logger.info("Recover the down managed cluster")
+        nodes_multicluster[active_primary_index].start_nodes(
+            active_primary_cluster_node_objs
+        )
+        wait_for_nodes_status(
+            [node.name for node in active_primary_cluster_node_objs], timeout=900
+        )
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+
+        # Cleanup operations after successful failover
+        logger.info("Doing Cleanup Operations after successful failover")
+        # VM 1 (index 0) and VM 3 (index 2) share DRPC1; VM 2 (index 1) and VM 4 (index 3) share DRPC2
+        drpc_per_vm = [
+            resource_name_1,  # VM 1
+            resource_name_2,  # VM 2
+            resource_name_1,  # VM 3
+            resource_name_2,  # VM 4
+        ]
+        for cnv_wl, drpc_name in zip(all_cnv_workloads, drpc_per_vm):
+            dr_helpers.do_discovered_apps_cleanup(
+                drpc_name=drpc_name,
+                old_primary=primary_cluster_name,
+                workload_namespace=workload_namespace,
+                workload_dir=cnv_wl.workload_dir,
+                vrg_name=drpc_name,
+                skip_resource_deletion_verification=True,
+            )
+
+        for resource_name in drpc_resources:
+            wait_for_all_resources_deletion(
+                namespace=workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        config.switch_acm_ctx()
+        for resource_name in drpc_resources:
+            drpc_obj = DRPC(
+                namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
+            )
+            drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
+
+        logger.info("On UI, check if all VMs are running after failover")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=all_cnv_workloads,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            managed_cluster_name=secondary_cluster_name,
+            assign_policy=False,
+        )
+
+        # Perform Relocate operation
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        logger.info("Relocating all workloads back to primary cluster...")
+        # Relocate workloads for first DRPC (VM 1 and VM 3)
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_1,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[0],
+            workload_instances_shared=[all_cnv_workloads[0], all_cnv_workloads[2]],
+        )
+
+        # Relocate workloads for second DRPC (VM 2 and VM 4)
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_2,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[1],
+            workload_instances_shared=[all_cnv_workloads[1], all_cnv_workloads[3]],
+        )
+
+        # Verify cleanup after relocate
+        for resource_name in drpc_resources:
+            wait_for_all_resources_deletion(
+                namespace=workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        config.switch_acm_ctx()
+        for resource_name in drpc_resources:
+            drpc_obj = DRPC(
+                namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
+            )
+            drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
+
+        # Verify resources creation on primary managed cluster (per-DRPC counts
+        # for the same reason as post-failover — avoids 900 s timeout).
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        for resource_name, pvc_count, pod_count in drpc_resource_counts:
+            dr_helpers.wait_for_all_resources_creation(
+                pvc_count,
+                pod_count,
+                workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        # Wait for all VMs to be running on primary cluster
+        for cnv_wl in all_cnv_workloads:
+            dr_helpers.wait_for_cnv_workload(
+                vm_name=cnv_wl.vm_name,
+                namespace=workload_namespace,
+                phase=constants.STATUS_RUNNING,
+            )
+
+        config.switch_acm_ctx()
+        logger.info("On UI, check if all VMs are running after relocate")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=all_cnv_workloads,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        # Validating data integrity (file1) after relocating VMs back to primary managed cluster
+        logger.info("Validating data integrity (file1) after relocate")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[0], md5sum_original, "Relocate"
+        )
+
+        # Validating data integrity (file2) after relocating VMs back to primary managed cluster
+        logger.info("Validating data integrity (file2) after relocate")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[1], md5sum_failover, "Relocate"
+        )
+
+        # Creating a file (file3) post relocate on all VMs
+        logger.info("Writing final data post-relocate")
+        for cnv_wl in all_cnv_workloads:
+            run_dd_io(
+                vm_obj=cnv_wl.vm_obj,
+                file_path=vm_filepaths[2],
+                username=cnv_wl.vm_username,
+                verify=True,
+            )
+
+        # ------------------------------------------------------------------ #
+        # Remove DR protection scenario                                        #
+        #                                                                      #
+        # Step A: Remove protection from VM 3 (Shared with VM 1 / DRPC1).    #
+        #   Validate: DRPC1 still exists, VM 1 is still protected.            #
+        #                                                                      #
+        # Step B: Remove protection from VM 2 (Standalone / DRPC2).          #
+        #   Validate: DRPC2 is deleted.                                        #
+        # ------------------------------------------------------------------ #
+        config.switch_acm_ctx()
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        # Step A: remove the Shared VM (VM 3, index 2) from DRPC1
+        logger.info(
+            "Removing DR protection from Shared VM 3 "
+            f"'{all_cnv_workloads[2].vm_name}' (tied to DRPC1)"
+        )
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[2],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        # Validate DRPC1 still exists and VM 1 is still protected
+        logger.info("Validating DRPC1 still exists after removing Shared VM 3")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_1,
+            timeout=120,
+            should_exist=True,
+        )
+        logger.info("Validating VM 1 is still running and protected (UI check)")
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0]],
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
+        logger.info("VM 3 removed from DRPC1; VM 1 remains protected under DRPC1")
+
+        # Step B: remove the Standalone VM (VM 2, index 1) → DRPC2 deleted
+        logger.info(
+            "Removing DR protection from Standalone VM 2 "
+            f"'{all_cnv_workloads[1].vm_name}' (DRPC2)"
+        )
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[1],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        # Validate DRPC2 is deleted
+        logger.info("Validating DRPC2 is deleted after removing Standalone VM 2")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=120,
+            should_exist=False,
+        )
+        logger.info("Standalone VM 2 DR protection removed and DRPC2 deleted")
+
+        logger.info(
+            f"Test for mixed protection types (Standalone and Shared) "
+            f"in namespace {workload_namespace} passed. "
+            f"DRPC groups: {protection_name_1}, {protection_name_2}"
+        )
+
+    # TODO: Add Polarion ID when available
+    @pytest.mark.polarion_id("OCS-wwww")
+    def test_acm_kubevirt_remove_all_shared_protection_vms(
+        self,
+        setup_acm_ui,
+        discovered_apps_dr_workload_cnv,
+    ):
+        """
+        Verify that the DRPC is deleted when DR protection is removed from
+        every VM enrolled under a shared protection group.
+
+        Three VMs are deployed in the same namespace.  One is DR-protected as
+        Standalone (this creates the DRPC), and the other two join the same
+        DRPC as Shared.  The test then removes protection from the Shared VMs
+        one at a time, asserting the DRPC is still present after each partial
+        removal, and finally removes the Standalone VM's protection, asserting
+        the DRPC is deleted once no VMs remain enrolled.
+
+        Test steps:
+
+        1. Deploy 3 CNV discovered workloads in a single namespace via CLI
+        2. DR protect VM 1 as Standalone (creates the DRPC)
+        3. DR protect VM 2 as Shared (joins VM 1's DRPC; only 1 DRPC exists)
+        4. DR protect VM 3 as Shared (joins VM 1's DRPC; still only 1 DRPC)
+        5. Verify all VMs are Running and replication resources are created
+        6. Write data to all VMs and record md5sums
+        7. Remove DR protection from VM 2 (Shared)
+           - Verify DRPC still exists and VM 1 / VM 3 are still protected
+        8. Remove DR protection from VM 3 (Shared)
+           - Verify DRPC still exists and VM 1 is still protected
+        9. Remove DR protection from VM 1 (Standalone – last enrolled VM)
+           - Verify DRPC is deleted
+        """
+
+        vm_filepaths = ["/dd_file1.txt"]
+        all_cnv_workloads = []
+
+        logger.info("Deploy VM 1 (will be Standalone)")
+        cnv_workload_1 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+        )
+        all_cnv_workloads.append(cnv_workload_1[-1])
+
+        logger.info("Deploy VM 2 in the same namespace (will be Shared)")
+        cnv_workload_2 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_2[-1])
+
+        logger.info("Deploy VM 3 in the same namespace (will be Shared)")
+        cnv_workload_3 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_3[-1])
+
+        assert all_cnv_workloads, "No discovered VMs found"
+        assert (
+            len(all_cnv_workloads) == 3
+        ), f"Expected 3 VMs, found {len(all_cnv_workloads)}"
+
+        config.switch_acm_ctx()
+        workload_namespace = all_cnv_workloads[0].workload_namespace
+        logger.info(f"All VMs deployed in namespace: {workload_namespace}")
+
+        acm_obj = AcmAddClusters()
+        primary_cluster_name = all_cnv_workloads[0].preferred_primary_cluster
+        logger.info(f"Primary cluster: {primary_cluster_name}")
+
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        # VM 1: Standalone – creates the DRPC
+        protection_name = workload_namespace
+        logger.info("DR protecting VM 1 with Standalone protection")
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=True,
+            protection_name=protection_name,
+            namespace=workload_namespace,
+        )
+        resource_name = f"{protection_name}-drpc"
+
+        # Wait for VM 1's DRPC to exist before enrolling VMs 2 and 3 as Shared.
+        logger.info(
+            "Waiting for DRPC %s to exist before enrolling VMs 2/3 as Shared",
+            resource_name,
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name,
+            timeout=120,
+            should_exist=True,
+        )
+
+        # VM 2: Shared – exactly 1 DRPC exists at this point
+        logger.info("DR protecting VM 2 with Shared protection (tied to VM 1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[1]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name,
+            namespace=workload_namespace,
+        )
+
+        # VM 3: Shared – still only 1 DRPC, radio-button assertion holds
+        logger.info("DR protecting VM 3 with Shared protection (tied to VM 1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[2]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info(f"All VMs enrolled under DRPC: {resource_name}")
+
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
+        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            discovered_apps=True,
+            vrg_name=resource_name,
+        )
+
+        for cnv_wl in all_cnv_workloads:
+            dr_helpers.wait_for_cnv_workload(
+                vm_name=cnv_wl.vm_name,
+                namespace=workload_namespace,
+                phase=constants.STATUS_RUNNING,
+            )
+
+        # Download virtctl if not already present
+        CNVInstaller().download_and_extract_virtctl_binary()
+
+        # Write data to all VMs
+        logger.info("Writing data to all VMs")
+        for cnv_wl in all_cnv_workloads:
+            run_dd_io(
+                vm_obj=cnv_wl.vm_obj,
+                file_path=vm_filepaths[0],
+                username=cnv_wl.vm_username,
+                verify=True,
+            )
+
+        # ------------------------------------------------------------------ #
+        # Step 7: Remove protection from VM 2 (Shared)                        #
+        # ------------------------------------------------------------------ #
+        config.switch_acm_ctx()
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        logger.info(
+            f"Removing DR protection from Shared VM 2 '{all_cnv_workloads[1].vm_name}'"
+        )
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[1],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info(
+            "Validating DRPC still exists after removing VM 2 (VM 1 and VM 3 remain)"
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name,
+            timeout=120,
+            should_exist=True,
+        )
+        logger.info(
+            "Validating VM 1 and VM 3 are still Running and protected (UI check)"
+        )
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0], all_cnv_workloads[2]],
+            protection_name=protection_name,
+            namespace=workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
+        logger.info("VM 2 removed; DRPC intact with VM 1 and VM 3 still enrolled")
+
+        # ------------------------------------------------------------------ #
+        # Step 8: Remove protection from VM 3 (Shared)                        #
+        # ------------------------------------------------------------------ #
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        logger.info(
+            f"Removing DR protection from Shared VM 3 '{all_cnv_workloads[2].vm_name}'"
+        )
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[2],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC still exists after removing VM 3 (VM 1 remains)")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name,
+            timeout=120,
+            should_exist=True,
+        )
+        logger.info("Validating VM 1 is still Running and protected (UI check)")
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0]],
+            protection_name=protection_name,
+            namespace=workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
+        logger.info("VM 3 removed; DRPC intact with VM 1 still enrolled")
+
+        # ------------------------------------------------------------------ #
+        # Step 9: Remove protection from VM 1 (Standalone – last enrollment)  #
+        # DRPC must be deleted once no VMs remain enrolled.                   #
+        # ------------------------------------------------------------------ #
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        logger.info(
+            f"Removing DR protection from Standalone VM 1 '{all_cnv_workloads[0].vm_name}'"
+            " (last VM in the group)"
+        )
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[0],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info(
+            "Validating DRPC is deleted now that all enrolled VMs have been removed"
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name,
+            timeout=300,
+            should_exist=False,
+        )
+        logger.info(
+            f"DRPC '{resource_name}' deleted as expected after removing "
+            "all VMs from the shared protection group"
+        )

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -22,7 +22,8 @@ from ocs_ci.helpers.dr_helpers import (
     wait_for_resource_existence,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.acm.acm import AcmAddClusters
+from ocs_ci.ocs.acm.acm import AcmAddClusters, login_to_acm
+from ocs_ci.ocs.ui.base_ui import close_browser
 from ocs_ci.helpers.dr_helpers_ui import (
     check_or_assign_drpolicy_for_discovered_vms_via_ui,
     navigate_using_fleet_virtualization,
@@ -67,21 +68,29 @@ class TestACMKubevirtDRIntergration:
         node_restart_teardown,
     ):
         """
-        DR operation on discovered VMs using Standalone and Shared Protection type. In shared protection, both VMs are
-        tied to a single DRPC in the same namespace where same DRPolicy is applied via UI to both the apps.
+        DR operation on discovered VMs using Standalone and Shared
+        Protection type. In shared protection, both VMs are tied to a
+        single DRPC in the same namespace where the same DRPolicy is
+        applied via UI to both the apps.
 
         Test steps:
 
         1. Deploy a CNV discovered workload in a test NS via CLI
-        2. Deploy another CNV discovered workload in the same namespace via CLI
-        3. Using ACM UI, DR protect the 1st workload from the VMs page using Standalone as Protection type
-        4. Then for shared protection, repeat the above steps and DR protect 2nd workload from the VMs page using
-            Shared option, which will use the existing DRPC of the 1st workload and gets tied to it.
-        5. Write data, take md5sum, failover this workload via CLI (both VMs) by shutting down the primary managed
-        cluster.
-        6. After successful failover, check md5sum, recover the down managed cluster and perform cleanup.
-        7. Let sync resume and then perform Relocate operation back to the original cluster.
-
+        2. (Shared only) Deploy a 2nd CNV workload in the same
+           namespace via CLI
+        3. DR protect workloads via ACM Fleet Virtualization UI
+           (Standalone for 1st VM, Shared for 2nd VM)
+        4. Write data to VMs, record md5sums
+        5. Shut down all nodes of the primary managed cluster
+        6. Failover workloads to the secondary cluster via CLI
+        7. Verify data integrity and VM status on the secondary
+           cluster
+        8. Recover the down managed cluster and perform cleanup
+        9. Verify VM status via ACM UI after failover
+        10. Relocate workloads back to the primary cluster
+        11. Verify VM status via ACM UI after relocate
+        12. Remove DR protection via ACM UI and verify DRPC
+            deletion
 
         """
 
@@ -89,14 +98,14 @@ class TestACMKubevirtDRIntergration:
         md5sum_failover = []
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
-        logger.info("Deploy 1st CNV workload")
+        logger.test_step("Deploy 1st CNV workload")
         cnv_workloads = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=False
         )
 
         if protection_type:
             # Deploy second workload for Shared protection (uses same namespace as first)
-            logger.info("Deploy 2nd CNV workload in the existing namespace")
+            logger.test_step("Deploy 2nd CNV workload in the existing namespace")
             cnv_workloads = discovered_apps_dr_workload_cnv(
                 pvc_vm=1, dr_protect=False, shared_drpc_protection=True
             )
@@ -109,11 +118,14 @@ class TestACMKubevirtDRIntergration:
 
         logger.info(f"CNV workloads instance is {cnv_workloads}")
 
+        config.switch_acm_ctx()
+        login_to_acm()
         acm_obj = AcmAddClusters()
         primary_cluster_name = cnv_workloads[0].preferred_primary_cluster
         logger.info(
             f"Primary managed cluster name is {cnv_workloads[0].preferred_primary_cluster}"
         )
+        logger.test_step("DR protect workloads via ACM UI")
         for i, vm in enumerate(cnv_workloads):
             standalone_flag = (not protection_type) or (i == 0)
             if protection_type and i == 1:
@@ -133,7 +145,12 @@ class TestACMKubevirtDRIntergration:
                     timeout=120,
                     should_exist=True,
                 )
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
             assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={vm.vm_name}, standalone={standalone_flag}, expected=True"
+            )
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[vm],
@@ -212,17 +229,17 @@ class TestACMKubevirtDRIntergration:
         # Shutdown primary managed cluster nodes
         active_primary_index = config.cur_index
         active_primary_cluster_node_objs = get_node_objs()
-        logger.info("Shutting down all the nodes of the primary managed cluster")
+        logger.test_step("Shut down all nodes of the primary managed cluster")
         nodes_multicluster[active_primary_index].stop_nodes(
             active_primary_cluster_node_objs
         )
         logger.info(
             f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
-            "waiting for cluster to be unreachable.."
+            "waiting for cluster to be unreachable"
         )
         wait_for_managed_cluster_unreachable(primary_cluster_name)
 
-        logger.info("FailingOver the workloads.....")
+        logger.test_step("Failover workloads to secondary cluster")
         dr_helpers.failover(
             failover_cluster=secondary_cluster_name,
             namespace=cnv_workloads[0].workload_namespace,
@@ -269,7 +286,7 @@ class TestACMKubevirtDRIntergration:
             )
 
         config.switch_to_cluster_by_name(primary_cluster_name)
-        logger.info("Recover the down managed cluster")
+        logger.test_step("Recover down managed cluster")
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
@@ -277,9 +294,10 @@ class TestACMKubevirtDRIntergration:
             [node.name for node in active_primary_cluster_node_objs], timeout=900
         )
         wait_for_pods_to_be_running(timeout=420, sleep=15)
+        logger.assertion("ceph_health_check: expected=True")
         assert ceph_health_check(tries=10, delay=30)
 
-        logger.info("Doing Cleanup Operations after successful failover")
+        logger.test_step("Cleanup after successful failover")
         for cnv_wl in cnv_workloads:
             dr_helpers.do_discovered_apps_cleanup(
                 drpc_name=resource_name,
@@ -301,9 +319,22 @@ class TestACMKubevirtDRIntergration:
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        logger.info("On UI, check if VM is running after failover or not")
+        logger.test_step("Verify VM status via ACM UI after failover")
+        logger.info("Refreshing browser session before UI verification")
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
+        config.switch_acm_ctx()
+        login_to_acm()
+        acm_obj = AcmAddClusters()
         for cnv_wl in cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
             assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={secondary_cluster_name}, expected=True"
+            )
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[cnv_wl],
@@ -320,7 +351,7 @@ class TestACMKubevirtDRIntergration:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        logger.info("Relocating the workloads.....")
+        logger.test_step("Relocate workloads back to primary cluster")
         dr_helpers.relocate(
             preferred_cluster=primary_cluster_name,
             namespace=cnv_workloads[0].workload_namespace,
@@ -357,10 +388,22 @@ class TestACMKubevirtDRIntergration:
             phase=constants.STATUS_RUNNING,
         )
 
+        logger.test_step("Verify VM status via ACM UI after relocate")
+        logger.info("Refreshing browser session before UI verification")
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
         config.switch_acm_ctx()
-        logger.info("On UI, check if VM is running after relocate or not")
+        login_to_acm()
+        acm_obj = AcmAddClusters()
         for cnv_wl in cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
             assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={primary_cluster_name}, expected=True"
+            )
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[cnv_wl],
@@ -398,6 +441,8 @@ class TestACMKubevirtDRIntergration:
         #   verify the 1st VM is still protected with its DRPC intact.        #
         # ------------------------------------------------------------------ #
         config.switch_acm_ctx()
+        logger.test_step("Remove DR protection via ACM UI")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
 
         if protection_type:
@@ -405,6 +450,10 @@ class TestACMKubevirtDRIntergration:
             logger.info(
                 "Removing DR protection from the Shared VM "
                 f"'{cnv_workloads[1].vm_name}'"
+            )
+            logger.assertion(
+                f"remove_drprotection_for_discovered_vm_via_ui:"
+                f" vm={cnv_workloads[1].vm_name}, expected=True"
             )
             assert remove_drprotection_for_discovered_vm_via_ui(
                 acm_obj,
@@ -424,6 +473,10 @@ class TestACMKubevirtDRIntergration:
             )
             # Validate: 1st VM still shows Running and is still protected
             logger.info("Validating 1st VM is still running and protected on UI")
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
+            )
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[cnv_workloads[0]],
@@ -438,6 +491,10 @@ class TestACMKubevirtDRIntergration:
             logger.info(
                 "Removing DR protection from the Standalone VM "
                 f"'{cnv_workloads[0].vm_name}'"
+            )
+            logger.assertion(
+                f"remove_drprotection_for_discovered_vm_via_ui:"
+                f" vm={cnv_workloads[0].vm_name}, expected=True"
             )
             assert remove_drprotection_for_discovered_vm_via_ui(
                 acm_obj,
@@ -459,6 +516,11 @@ class TestACMKubevirtDRIntergration:
             )
             logger.info("Standalone VM DR protection removed and DRPC deleted")
 
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
+
     # TODO: Add Polarion ID when available
     @pytest.mark.polarion_id("OCS-zzzz")
     def test_acm_kubevirt_mixed_protection_types(
@@ -469,23 +531,29 @@ class TestACMKubevirtDRIntergration:
         node_restart_teardown,
     ):
         """
-        DR operation on multiple discovered VMs in the same namespace using mixed protection types
-        (some Standalone, some Shared). This test validates that VMs with different protection types
-        can coexist in the same namespace and perform DR operations successfully.
+        DR operation on multiple discovered VMs in the same namespace
+        using mixed protection types (some Standalone, some Shared).
+        This test validates that VMs with different protection types
+        can coexist in the same namespace and perform DR operations
+        successfully.
 
         Test steps:
 
-        1. Deploy multiple CNV discovered workloads (4 VMs) in a single test namespace via CLI
-        2. Using ACM UI, DR protect the 1st and 2nd VMs from the VMs page using Standalone protection type
-        3. DR protect the 3rd VM using Shared protection type (tied to 1st VM's DRPC)
-        4. DR protect the 4th VM using Shared protection type (tied to 2nd VM's DRPC)
-        5. Write data to all VMs, take md5sum
-        6. Failover all workloads via CLI by shutting down the primary managed cluster
-        7. After successful failover, verify data integrity on all VMs
-        8. Write additional data post-failover
+        1. Deploy 4 CNV discovered workloads in a single namespace
+           via CLI
+        2. DR protect VMs 1 and 2 as Standalone via ACM UI
+        3. DR protect VM 3 as Shared (tied to VM 1's DRPC)
+        4. DR protect VM 4 as Shared (tied to VM 2's DRPC)
+        5. Write data to all VMs, record md5sums
+        6. Shut down all nodes of the primary managed cluster
+        7. Failover all workloads to the secondary cluster
+        8. Verify data integrity on all VMs after failover
         9. Recover the down managed cluster and perform cleanup
-        10. Perform Relocate operation back to the original cluster
-        11. Verify data integrity after relocate
+        10. Verify all VM statuses via ACM UI after failover
+        11. Relocate all workloads back to the primary cluster
+        12. Verify all VM statuses via ACM UI after relocate
+        13. Validate data integrity after relocate
+        14. Remove DR protection via ACM UI
 
         """
 
@@ -535,6 +603,7 @@ class TestACMKubevirtDRIntergration:
         ), f"Expected 4 VMs, found {len(all_cnv_workloads)}"
 
         config.switch_acm_ctx()
+        login_to_acm()
         workload_namespace = all_cnv_workloads[0].workload_namespace
         logger.info(f"All VMs deployed in namespace: {workload_namespace}")
 
@@ -729,18 +798,18 @@ class TestACMKubevirtDRIntergration:
         # Shutdown primary managed cluster nodes
         active_primary_index = config.cur_index
         active_primary_cluster_node_objs = get_node_objs()
-        logger.info("Shutting down all the nodes of the primary managed cluster")
+        logger.test_step("Shut down all nodes of the primary managed cluster")
         nodes_multicluster[active_primary_index].stop_nodes(
             active_primary_cluster_node_objs
         )
         logger.info(
             f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
-            "waiting for cluster to be unreachable.."
+            "waiting for cluster to be unreachable"
         )
         wait_for_managed_cluster_unreachable(primary_cluster_name)
 
         # Failover all workloads (both DRPCs)
-        logger.info("Failing over all workloads...")
+        logger.test_step("Failover all workloads to secondary cluster")
         for resource_name in drpc_resources:
             dr_helpers.failover(
                 failover_cluster=secondary_cluster_name,
@@ -815,7 +884,7 @@ class TestACMKubevirtDRIntergration:
 
         # Recover the down managed cluster
         config.switch_to_cluster_by_name(primary_cluster_name)
-        logger.info("Recover the down managed cluster")
+        logger.test_step("Recover down managed cluster")
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
@@ -823,10 +892,11 @@ class TestACMKubevirtDRIntergration:
             [node.name for node in active_primary_cluster_node_objs], timeout=900
         )
         wait_for_pods_to_be_running(timeout=420, sleep=15)
+        logger.assertion("ceph_health_check: expected=True")
         assert ceph_health_check(tries=10, delay=30)
 
         # Cleanup operations after successful failover
-        logger.info("Doing Cleanup Operations after successful failover")
+        logger.test_step("Cleanup after successful failover")
         # VM 1 (index 0) and VM 3 (index 2) share DRPC1; VM 2 (index 1) and VM 4 (index 3) share DRPC2
         drpc_per_vm = [
             resource_name_1,  # VM 1
@@ -858,8 +928,13 @@ class TestACMKubevirtDRIntergration:
             )
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        logger.info("On UI, check if all VMs are running after failover")
+        logger.test_step("Verify all VM statuses via ACM UI after failover")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" all_vms, cluster={secondary_cluster_name}, expected=True"
+        )
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=all_cnv_workloads,
@@ -875,7 +950,7 @@ class TestACMKubevirtDRIntergration:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        logger.info("Relocating all workloads back to primary cluster...")
+        logger.test_step("Relocate all workloads back to primary cluster")
         # Relocate workloads for first DRPC (VM 1 and VM 3)
         dr_helpers.relocate(
             preferred_cluster=primary_cluster_name,
@@ -951,8 +1026,13 @@ class TestACMKubevirtDRIntergration:
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         config.switch_acm_ctx()
-        logger.info("On UI, check if all VMs are running after relocate")
+        logger.test_step("Verify all VM statuses via ACM UI after relocate")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" all_vms, cluster={primary_cluster_name}, expected=True"
+        )
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=all_cnv_workloads,
@@ -964,7 +1044,7 @@ class TestACMKubevirtDRIntergration:
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster
-        logger.info("Validating data integrity (file1) after relocate")
+        logger.test_step("Validate data integrity after relocate")
         validate_data_integrity_vm(
             all_cnv_workloads, vm_filepaths[0], md5sum_original, "Relocate"
         )
@@ -995,12 +1075,18 @@ class TestACMKubevirtDRIntergration:
         #   Validate: DRPC2 is deleted.                                        #
         # ------------------------------------------------------------------ #
         config.switch_acm_ctx()
+        logger.test_step("Remove DR protection via ACM UI")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
 
         # Step A: remove the Shared VM (VM 3, index 2) from DRPC1
         logger.info(
             "Removing DR protection from Shared VM 3 "
             f"'{all_cnv_workloads[2].vm_name}' (tied to DRPC1)"
+        )
+        logger.assertion(
+            f"remove_drprotection_for_discovered_vm_via_ui:"
+            f" vm={all_cnv_workloads[2].vm_name}, expected=True"
         )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
@@ -1020,6 +1106,10 @@ class TestACMKubevirtDRIntergration:
             should_exist=True,
         )
         logger.info("Validating VM 1 is still running and protected (UI check)")
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" vm={all_cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
+        )
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=[all_cnv_workloads[0]],
@@ -1034,6 +1124,10 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             "Removing DR protection from Standalone VM 2 "
             f"'{all_cnv_workloads[1].vm_name}' (DRPC2)"
+        )
+        logger.assertion(
+            f"remove_drprotection_for_discovered_vm_via_ui:"
+            f" vm={all_cnv_workloads[1].vm_name}, expected=True"
         )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
@@ -1121,6 +1215,7 @@ class TestACMKubevirtDRIntergration:
         ), f"Expected 3 VMs, found {len(all_cnv_workloads)}"
 
         config.switch_acm_ctx()
+        login_to_acm()
         workload_namespace = all_cnv_workloads[0].workload_namespace
         logger.info(f"All VMs deployed in namespace: {workload_namespace}")
 
@@ -1218,10 +1313,16 @@ class TestACMKubevirtDRIntergration:
         # Step 7: Remove protection from VM 2 (Shared)                        #
         # ------------------------------------------------------------------ #
         config.switch_acm_ctx()
+        logger.test_step("Remove DR protection from VM 2 (Shared)")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
 
         logger.info(
             f"Removing DR protection from Shared VM 2 '{all_cnv_workloads[1].vm_name}'"
+        )
+        logger.assertion(
+            f"remove_drprotection_for_discovered_vm_via_ui:"
+            f" vm={all_cnv_workloads[1].vm_name}, expected=True"
         )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
@@ -1244,6 +1345,10 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             "Validating VM 1 and VM 3 are still Running and protected (UI check)"
         )
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" vms=[VM1, VM3], cluster={primary_cluster_name}, expected=True"
+        )
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=[all_cnv_workloads[0], all_cnv_workloads[2]],
@@ -1257,10 +1362,16 @@ class TestACMKubevirtDRIntergration:
         # ------------------------------------------------------------------ #
         # Step 8: Remove protection from VM 3 (Shared)                        #
         # ------------------------------------------------------------------ #
+        logger.test_step("Remove DR protection from VM 3 (Shared)")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
 
         logger.info(
             f"Removing DR protection from Shared VM 3 '{all_cnv_workloads[2].vm_name}'"
+        )
+        logger.assertion(
+            f"remove_drprotection_for_discovered_vm_via_ui:"
+            f" vm={all_cnv_workloads[2].vm_name}, expected=True"
         )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
@@ -1279,6 +1390,10 @@ class TestACMKubevirtDRIntergration:
             should_exist=True,
         )
         logger.info("Validating VM 1 is still Running and protected (UI check)")
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" vm={all_cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
+        )
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=[all_cnv_workloads[0]],
@@ -1293,11 +1408,17 @@ class TestACMKubevirtDRIntergration:
         # Step 9: Remove protection from VM 1 (Standalone – last enrollment)  #
         # DRPC must be deleted once no VMs remain enrolled.                   #
         # ------------------------------------------------------------------ #
+        logger.test_step("Remove DR protection from VM 1 (Standalone, last enrollment)")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
         assert navigate_using_fleet_virtualization(acm_obj)
 
         logger.info(
             f"Removing DR protection from Standalone VM 1 '{all_cnv_workloads[0].vm_name}'"
             " (last VM in the group)"
+        )
+        logger.assertion(
+            f"remove_drprotection_for_discovered_vm_via_ui:"
+            f" vm={all_cnv_workloads[0].vm_name}, expected=True"
         )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1057,20 +1057,21 @@ class TestACMKubevirtDRIntergration:
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
         logger.test_step("Verify all VM statuses via ACM UI after failover")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
-        logger.assertion(
-            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-            f" all_vms, cluster={secondary_cluster_name}, expected=True"
-        )
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=all_cnv_workloads,
-            protection_name=protection_name_1,
-            namespace=workload_namespace,
-            managed_cluster_name=secondary_cluster_name,
-            assign_policy=False,
-        )
+        for cnv_wl in all_cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
+            assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={secondary_cluster_name}, expected=True"
+            )
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name_1,
+                namespace=workload_namespace,
+                managed_cluster_name=secondary_cluster_name,
+                assign_policy=False,
+            )
 
         # Perform Relocate operation
         config.switch_to_cluster_by_name(primary_cluster_name)
@@ -1157,20 +1158,21 @@ class TestACMKubevirtDRIntergration:
 
         config.switch_acm_ctx()
         logger.test_step("Verify all VM statuses via ACM UI after relocate")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
-        logger.assertion(
-            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-            f" all_vms, cluster={primary_cluster_name}, expected=True"
-        )
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=all_cnv_workloads,
-            protection_name=protection_name_1,
-            namespace=workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
+        for cnv_wl in all_cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
+            assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={primary_cluster_name}, expected=True"
+            )
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name_1,
+                namespace=workload_namespace,
+                managed_cluster_name=primary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1090,6 +1090,7 @@ class TestACMKubevirtDRIntergration:
                 all_cnv_workloads[0],
                 all_cnv_workloads[2],
             ],
+            skip_odf_cli_validation=True,
         )
         dr_helpers.relocate(
             preferred_cluster=primary_cluster_name,
@@ -1102,6 +1103,7 @@ class TestACMKubevirtDRIntergration:
                 all_cnv_workloads[1],
                 all_cnv_workloads[3],
             ],
+            skip_odf_cli_validation=True,
         )
 
         for resource_name in drpc_resources:

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -38,6 +38,43 @@ from ocs_ci.utility.utils import ceph_health_check
 logger = logging.getLogger(__name__)
 
 
+def verify_drpc_protected_vms(resource_name, expected_vms, unexpected_vms=None):
+    """
+    Verify DRPC PROTECTED_VMS list via CLI.
+
+    Args:
+        resource_name (str): DRPC resource name.
+        expected_vms (list): VM names that must be in PROTECTED_VMS.
+        unexpected_vms (list): VM names that must NOT be in
+            PROTECTED_VMS (default None).
+
+    Raises:
+        AssertionError: if any expected VM is missing or unexpected
+            VM is present.
+    """
+    config.switch_acm_ctx()
+    drpc_obj = DRPC(
+        namespace=constants.DR_OPS_NAMESPACE,
+        resource_name=resource_name,
+    )
+    drpc_data = drpc_obj.get()
+    protected_vms = (
+        drpc_data.get("spec", {})
+        .get("kubeObjectProtection", {})
+        .get("recipeParameters", {})
+        .get("PROTECTED_VMS", [])
+    )
+    for vm_name in expected_vms:
+        assert (
+            vm_name in protected_vms
+        ), f"VM '{vm_name}' not found in PROTECTED_VMS: {protected_vms}"
+    for vm_name in unexpected_vms or []:
+        assert (
+            vm_name not in protected_vms
+        ), f"VM '{vm_name}' still in PROTECTED_VMS: {protected_vms}"
+    logger.info(f"DRPC PROTECTED_VMS verified: {protected_vms}")
+
+
 @rdr
 @tier2
 @turquoise_squad
@@ -163,6 +200,13 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             f'Placement name is "{cnv_workloads[0].discovered_apps_placement_name}"'
         )
+
+        if protection_type:
+            logger.test_step("Verify DRPC PROTECTED_VMS contains both VMs")
+            verify_drpc_protected_vms(
+                resource_name,
+                expected_vms=[wl.vm_name for wl in cnv_workloads],
+            )
 
         scheduling_interval = dr_helpers.get_scheduling_interval(
             cnv_workloads[0].workload_namespace,
@@ -471,19 +515,12 @@ class TestACMKubevirtDRIntergration:
                 timeout=120,
                 should_exist=True,
             )
-            # Validate: 1st VM still shows Running and is still protected
-            logger.info("Validating 1st VM is still running and protected on UI")
-            logger.assertion(
-                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-                f" vm={cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
-            )
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=[cnv_workloads[0]],
-                protection_name=protection_name,
-                namespace=cnv_workloads[0].workload_namespace,
-                managed_cluster_name=primary_cluster_name,
-                assign_policy=False,
+            # Validate: 1st VM still protected, 2nd VM removed from DRPC
+            logger.info("Validating DRPC PROTECTED_VMS contains only the 1st VM")
+            verify_drpc_protected_vms(
+                resource_name,
+                expected_vms=[cnv_workloads[0].vm_name],
+                unexpected_vms=[cnv_workloads[1].vm_name],
             )
             logger.info("Shared VM removed from DRPC; Standalone VM remains protected")
         else:
@@ -563,7 +600,7 @@ class TestACMKubevirtDRIntergration:
         all_cnv_workloads = []
         drpc_resources = []
 
-        logger.info("Deploy 1st CNV workload (Standalone protection)")
+        logger.test_step("Deploy 1st CNV workload (Standalone protection)")
         cnv_workload_1 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=False
         )
@@ -571,27 +608,21 @@ class TestACMKubevirtDRIntergration:
 
         # VM 2 (index 1): will become 2nd Standalone; shared_drpc_protection=True means
         # "deploy into the same namespace as the existing workload", not the DR protection type
-        logger.info(
-            "Deploy 2nd CNV workload in the same namespace (will use Standalone DR protection)"
-        )
+        logger.test_step("Deploy 2nd CNV workload (will use Standalone DR protection)")
         cnv_workload_2 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=True
         )
         all_cnv_workloads.append(cnv_workload_2[-1])
 
         # VM 3 (index 2): will be enrolled as Shared with VM 1
-        logger.info(
-            "Deploy 3rd CNV workload in the same namespace (will be Shared with VM 1)"
-        )
+        logger.test_step("Deploy 3rd CNV workload (will be Shared with VM 1)")
         cnv_workload_3 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=True
         )
         all_cnv_workloads.append(cnv_workload_3[-1])
 
         # VM 4 (index 3): will be enrolled as Shared with VM 2
-        logger.info(
-            "Deploy 4th CNV workload in the same namespace (will be Shared with VM 2)"
-        )
+        logger.test_step("Deploy 4th CNV workload (will be Shared with VM 2)")
         cnv_workload_4 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=True
         )
@@ -615,7 +646,7 @@ class TestACMKubevirtDRIntergration:
 
         # DR protect VMs with mixed protection types
         # VM 1: Standalone (creates new DRPC)
-        logger.info("DR protecting VM 1 with Standalone protection")
+        logger.test_step("DR protect VM 1 with Standalone protection")
         protection_name_1 = f"{workload_namespace}-standalone-1"
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
@@ -648,7 +679,7 @@ class TestACMKubevirtDRIntergration:
         # VM 3: Shared with VM 1 (uses the single existing DRPC from VM 1)
         # NOTE: the UI helper asserts exactly 1 radio button when selecting a Shared DRPC.
         # VM 3 is enrolled immediately after VM 1 so only 1 DRPC exists at this point.
-        logger.info("DR protecting VM 3 with Shared protection (tied to VM 1)")
+        logger.test_step("DR protect VM 3 with Shared protection (tied to VM 1)")
         assert navigate_using_fleet_virtualization(acm_obj)
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
@@ -660,18 +691,29 @@ class TestACMKubevirtDRIntergration:
         )
 
         # VM 2: Standalone (creates a second independent DRPC)
-        logger.info("DR protecting VM 2 with Standalone protection")
+        logger.test_step("DR protect VM 2 with Standalone protection")
         protection_name_2 = f"{workload_namespace}-standalone-2"
-        assert navigate_using_fleet_virtualization(acm_obj)
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[1]],
-            managed_cluster_name=primary_cluster_name,
-            standalone=True,
-            protection_name=protection_name_2,
-            namespace=workload_namespace,
-        )
         resource_name_2 = f"{protection_name_2}-drpc"
+        for attempt in range(3):
+            try:
+                assert navigate_using_fleet_virtualization(acm_obj)
+                assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                    acm_obj,
+                    vms=[all_cnv_workloads[1]],
+                    managed_cluster_name=primary_cluster_name,
+                    standalone=True,
+                    protection_name=protection_name_2,
+                    namespace=workload_namespace,
+                )
+                break
+            except (AssertionError, Exception) as e:
+                logger.warning(
+                    f"VM 2 Standalone enrollment attempt {attempt + 1}"
+                    f" failed: {e}. Retrying after 30s"
+                )
+                if attempt == 2:
+                    raise
+                sleep(30)
         drpc_resources.append(resource_name_2)
 
         # Override discovered_apps_placement_name on the Standalone workload objects
@@ -697,7 +739,7 @@ class TestACMKubevirtDRIntergration:
         )
 
         # VM 4: Shared with VM 2 (uses existing DRPC from VM 2)
-        logger.info("DR protecting VM 4 with Shared protection (tied to VM 2)")
+        logger.test_step("DR protect VM 4 with Shared protection (tied to VM 2)")
         assert navigate_using_fleet_virtualization(acm_obj)
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
@@ -749,7 +791,7 @@ class TestACMKubevirtDRIntergration:
 
         # Wait for all VMs to be running concurrently to avoid sequential
         # timeouts when DRPC failovers are staggered
-        logger.info("Waiting for all VMs to reach Running state concurrently")
+        logger.test_step("Wait for all VMs to reach Running state")
         with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
             futures = {
                 executor.submit(
@@ -775,7 +817,7 @@ class TestACMKubevirtDRIntergration:
         CNVInstaller().download_and_extract_virtctl_binary()
 
         # Creating a file (file1) on all VMs and calculating MD5sum
-        logger.info("Writing data to all VMs and calculating MD5sum")
+        logger.test_step("Write data to all VMs and calculating MD5sum")
         for cnv_wl in all_cnv_workloads:
             md5sum_original.append(
                 run_dd_io(
@@ -843,7 +885,7 @@ class TestACMKubevirtDRIntergration:
             )
 
         # Wait for all VMs to be running on secondary cluster concurrently
-        logger.info("Waiting for all VMs to reach Running state on secondary cluster")
+        logger.test_step("Verify all VMs running on secondary cluster")
         with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
             futures = {
                 executor.submit(
@@ -860,13 +902,13 @@ class TestACMKubevirtDRIntergration:
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
-        logger.info("Validating data integrity after failover")
+        logger.test_step("Validate data integrity after failover")
         validate_data_integrity_vm(
             all_cnv_workloads, vm_filepaths[0], md5sum_original, "Failover"
         )
 
         # Creating a file (file2) post failover on all VMs
-        logger.info("Writing additional data post-failover")
+        logger.test_step("Write additional data post-failover")
         for cnv_wl in all_cnv_workloads:
             md5sum_failover.append(
                 run_dd_io(
@@ -1050,7 +1092,7 @@ class TestACMKubevirtDRIntergration:
         )
 
         # Validating data integrity (file2) after relocating VMs back to primary managed cluster
-        logger.info("Validating data integrity (file2) after relocate")
+        logger.test_step("Validate data integrity (file2) after relocate")
         validate_data_integrity_vm(
             all_cnv_workloads, vm_filepaths[1], md5sum_failover, "Relocate"
         )
@@ -1105,18 +1147,11 @@ class TestACMKubevirtDRIntergration:
             timeout=120,
             should_exist=True,
         )
-        logger.info("Validating VM 1 is still running and protected (UI check)")
-        logger.assertion(
-            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-            f" vm={all_cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
-        )
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[0]],
-            protection_name=protection_name_1,
-            namespace=workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
+        logger.info("Validating DRPC1 PROTECTED_VMS contains only VM 1")
+        verify_drpc_protected_vms(
+            resource_name_1,
+            expected_vms=[all_cnv_workloads[0].vm_name],
+            unexpected_vms=[all_cnv_workloads[2].vm_name],
         )
         logger.info("VM 3 removed from DRPC1; VM 1 remains protected under DRPC1")
 
@@ -1191,19 +1226,19 @@ class TestACMKubevirtDRIntergration:
         vm_filepaths = ["/dd_file1.txt"]
         all_cnv_workloads = []
 
-        logger.info("Deploy VM 1 (will be Standalone)")
+        logger.test_step("Deploy VM 1 (will be Standalone)")
         cnv_workload_1 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=False
         )
         all_cnv_workloads.append(cnv_workload_1[-1])
 
-        logger.info("Deploy VM 2 in the same namespace (will be Shared)")
+        logger.test_step("Deploy VM 2 in the same namespace (will be Shared)")
         cnv_workload_2 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=True
         )
         all_cnv_workloads.append(cnv_workload_2[-1])
 
-        logger.info("Deploy VM 3 in the same namespace (will be Shared)")
+        logger.test_step("Deploy VM 3 in the same namespace (will be Shared)")
         cnv_workload_3 = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=True
         )
@@ -1227,7 +1262,7 @@ class TestACMKubevirtDRIntergration:
 
         # VM 1: Standalone – creates the DRPC
         protection_name = workload_namespace
-        logger.info("DR protecting VM 1 with Standalone protection")
+        logger.test_step("DR protect VM 1 with Standalone protection")
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=[all_cnv_workloads[0]],
@@ -1252,7 +1287,7 @@ class TestACMKubevirtDRIntergration:
         )
 
         # VM 2: Shared – exactly 1 DRPC exists at this point
-        logger.info("DR protecting VM 2 with Shared protection (tied to VM 1)")
+        logger.test_step("DR protect VM 2 with Shared protection (tied to VM 1)")
         assert navigate_using_fleet_virtualization(acm_obj)
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
@@ -1264,7 +1299,7 @@ class TestACMKubevirtDRIntergration:
         )
 
         # VM 3: Shared – still only 1 DRPC, radio-button assertion holds
-        logger.info("DR protecting VM 3 with Shared protection (tied to VM 1)")
+        logger.test_step("DR protect VM 3 with Shared protection (tied to VM 1)")
         assert navigate_using_fleet_virtualization(acm_obj)
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
@@ -1276,6 +1311,12 @@ class TestACMKubevirtDRIntergration:
         )
 
         logger.info(f"All VMs enrolled under DRPC: {resource_name}")
+
+        logger.test_step("Verify DRPC PROTECTED_VMS contains all 3 VMs")
+        verify_drpc_protected_vms(
+            resource_name,
+            expected_vms=[wl.vm_name for wl in all_cnv_workloads],
+        )
 
         config.switch_to_cluster_by_name(primary_cluster_name)
 
@@ -1300,7 +1341,7 @@ class TestACMKubevirtDRIntergration:
         CNVInstaller().download_and_extract_virtctl_binary()
 
         # Write data to all VMs
-        logger.info("Writing data to all VMs")
+        logger.test_step("Write data to all VMs")
         for cnv_wl in all_cnv_workloads:
             run_dd_io(
                 vm_obj=cnv_wl.vm_obj,
@@ -1342,22 +1383,16 @@ class TestACMKubevirtDRIntergration:
             timeout=120,
             should_exist=True,
         )
-        logger.info(
-            "Validating VM 1 and VM 3 are still Running and protected (UI check)"
+        logger.info("Validating DRPC PROTECTED_VMS contains VM 1 and VM 3 but not VM 2")
+        verify_drpc_protected_vms(
+            resource_name,
+            expected_vms=[
+                all_cnv_workloads[0].vm_name,
+                all_cnv_workloads[2].vm_name,
+            ],
+            unexpected_vms=[all_cnv_workloads[1].vm_name],
         )
-        logger.assertion(
-            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-            f" vms=[VM1, VM3], cluster={primary_cluster_name}, expected=True"
-        )
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[0], all_cnv_workloads[2]],
-            protection_name=protection_name,
-            namespace=workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
-        logger.info("VM 2 removed; DRPC intact with VM 1 and VM 3 still enrolled")
+        logger.info("VM 2 removed; DRPC intact with VM 1 and VM 3")
 
         # ------------------------------------------------------------------ #
         # Step 8: Remove protection from VM 3 (Shared)                        #
@@ -1389,20 +1424,13 @@ class TestACMKubevirtDRIntergration:
             timeout=120,
             should_exist=True,
         )
-        logger.info("Validating VM 1 is still Running and protected (UI check)")
-        logger.assertion(
-            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-            f" vm={all_cnv_workloads[0].vm_name}, cluster={primary_cluster_name}, expected=True"
+        logger.info("Validating DRPC PROTECTED_VMS contains only VM 1")
+        verify_drpc_protected_vms(
+            resource_name,
+            expected_vms=[all_cnv_workloads[0].vm_name],
+            unexpected_vms=[all_cnv_workloads[2].vm_name],
         )
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[0]],
-            protection_name=protection_name,
-            namespace=workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
-        logger.info("VM 3 removed; DRPC intact with VM 1 still enrolled")
+        logger.info("VM 3 removed; DRPC intact with VM 1")
 
         # ------------------------------------------------------------------ #
         # Step 9: Remove protection from VM 1 (Standalone – last enrollment)  #

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1291,7 +1291,7 @@ class TestACMKubevirtDRIntergration:
             kind=constants.DRPC,
             namespace=constants.DR_OPS_NAMESPACE,
             resource_name=resource_name_1,
-            timeout=300,
+            timeout=600,
             should_exist=False,
         )
 
@@ -1337,7 +1337,7 @@ class TestACMKubevirtDRIntergration:
             kind=constants.DRPC,
             namespace=constants.DR_OPS_NAMESPACE,
             resource_name=resource_name_2,
-            timeout=300,
+            timeout=600,
             should_exist=False,
         )
 

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1,4 +1,5 @@
 import logging
+import tempfile
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import sleep
@@ -21,7 +22,7 @@ from ocs_ci.helpers.dr_helpers import (
     wait_for_replication_resources_creation,
     wait_for_resource_existence,
 )
-from ocs_ci.ocs import constants
+from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.acm.acm import AcmAddClusters, login_to_acm
 from ocs_ci.ocs.ui.base_ui import close_browser
 from ocs_ci.helpers.dr_helpers_ui import (
@@ -33,7 +34,8 @@ from ocs_ci.ocs.dr.dr_workload import validate_data_integrity_vm
 from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
 from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
-from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.utility.templating import load_yaml, dump_data_to_temp_yaml
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check, exec_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -90,12 +92,11 @@ class TestACMKubevirtDRIntergration:
         argnames=["protection_type"],
         argvalues=[
             pytest.param(
-                False, id="standalone", marks=pytest.mark.polarion_id("OCS-xxxx")
+                False, id="standalone", marks=pytest.mark.polarion_id("OCS-8047")
             ),
-            pytest.param(True, id="shared", marks=pytest.mark.polarion_id("OCS-yyyy")),
+            pytest.param(True, id="shared", marks=pytest.mark.polarion_id("OCS-8048")),
         ],
     )
-    # TODO: Add Polarion ID when available
     def test_acm_kubevirt_using_different_protection_types(
         self,
         setup_acm_ui,
@@ -558,10 +559,10 @@ class TestACMKubevirtDRIntergration:
         except Exception:
             logger.warning("Browser already closed or crashed, proceeding")
 
-    # TODO: Add Polarion ID when available
-    @pytest.mark.polarion_id("OCS-zzzz")
+    @pytest.mark.polarion_id("OCS-8045")
     def test_acm_kubevirt_mixed_protection_types(
         self,
+        request,
         setup_acm_ui,
         discovered_apps_dr_workload_cnv,
         nodes_multicluster,
@@ -574,23 +575,34 @@ class TestACMKubevirtDRIntergration:
         can coexist in the same namespace and perform DR operations
         successfully.
 
+        Bug: Granular VM DR is broken
+        ref: https://redhat.atlassian.net/browse/DFBUGS-8039
+
         Test steps:
 
         1. Deploy 4 CNV discovered workloads in a single namespace
            via CLI
-        2. DR protect VMs 1 and 2 as Standalone via ACM UI
-        3. DR protect VM 3 as Shared (tied to VM 1's DRPC)
-        4. DR protect VM 4 as Shared (tied to VM 2's DRPC)
-        5. Write data to all VMs, record md5sums
-        6. Shut down all nodes of the primary managed cluster
-        7. Failover all workloads to the secondary cluster
-        8. Verify data integrity on all VMs after failover
-        9. Recover the down managed cluster and perform cleanup
-        10. Verify all VM statuses via ACM UI after failover
-        11. Relocate all workloads back to the primary cluster
-        12. Verify all VM statuses via ACM UI after relocate
-        13. Validate data integrity after relocate
-        14. Remove DR protection via ACM UI
+        2. Create a second DRPolicy (odr-policy-6m) with a different
+           scheduling interval
+        3. DR protect VM 1 as Standalone with default DRPolicy via
+           ACM UI
+        4. DR protect VM 3 as Shared (tied to VM 1's DRPC)
+        5. DR protect VM 2 as Standalone with odr-policy-6m via
+           ACM UI
+        6. DR protect VM 4 as Shared (tied to VM 2's DRPC)
+        7. Write data to all VMs, record md5sums
+        8. Shut down all nodes of the primary managed cluster
+        9. Failover all workloads to the secondary cluster
+        10. Verify VGR-VGRC binding on secondary cluster
+        11. Verify data integrity on all VMs after failover
+        12. Recover the down managed cluster and perform cleanup
+        13. Verify all VM statuses via ACM UI after failover
+        14. Relocate all workloads back to the primary cluster
+        15. Verify VGR-VGRC binding on primary cluster
+        16. Verify all VM statuses via ACM UI after relocate
+        17. Validate data integrity after relocate
+        18. Remove DR protection via ACM UI
+        19. Delete the second DRPolicy (odr-policy-6m)
 
         """
 
@@ -634,13 +646,46 @@ class TestACMKubevirtDRIntergration:
         ), f"Expected 4 VMs, found {len(all_cnv_workloads)}"
 
         config.switch_acm_ctx()
-        login_to_acm()
         workload_namespace = all_cnv_workloads[0].workload_namespace
         logger.info(f"All VMs deployed in namespace: {workload_namespace}")
-
-        acm_obj = AcmAddClusters()
         primary_cluster_name = all_cnv_workloads[0].preferred_primary_cluster
         logger.info(f"Primary managed cluster name is {primary_cluster_name}")
+
+        # Create a second DRPolicy with a different scheduling interval
+        # so each DRPC uses a distinct policy.
+        logger.test_step("Create second DRPolicy odr-policy-6m")
+        existing_policies = dr_helpers.get_all_drpolicy()
+        dr_clusters = existing_policies[0]["spec"]["drClusters"]
+        dr_policy_6m_name = "odr-policy-6m"
+        dr_policy_data = load_yaml(constants.DR_POLICY_ACM_HUB)
+        dr_policy_data["metadata"]["name"] = dr_policy_6m_name
+        dr_policy_data["spec"]["drClusters"] = dr_clusters
+        dr_policy_data["spec"]["schedulingInterval"] = "6m"
+        dr_policy_yaml = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="dr_policy_6m_", delete=False
+        )
+        dump_data_to_temp_yaml(dr_policy_data, dr_policy_yaml.name)
+        exec_cmd(f"oc create -f {dr_policy_yaml.name}")
+        drpolicy_ocp = ocp.OCP(
+            kind=constants.DRPOLICY,
+            resource_name=dr_policy_6m_name,
+        )
+        for sample in TimeoutSampler(
+            timeout=120,
+            sleep=5,
+            func=lambda: drpolicy_ocp.get()
+            .get("status", {})
+            .get("conditions", [{}])[0]
+            .get("reason", ""),
+        ):
+            if sample in constants.DRPOLICY_SUCCESS_REASONS:
+                break
+        logger.info(f"DRPolicy {dr_policy_6m_name} created and validated")
+
+        request.addfinalizer(lambda: dr_helpers.delete_drpolicy(dr_policy_6m_name))
+
+        login_to_acm()
+        acm_obj = AcmAddClusters()
 
         assert navigate_using_fleet_virtualization(acm_obj)
 
@@ -690,8 +735,10 @@ class TestACMKubevirtDRIntergration:
             namespace=workload_namespace,
         )
 
-        # VM 2: Standalone (creates a second independent DRPC)
-        logger.test_step("DR protect VM 2 with Standalone protection")
+        # VM 2: Standalone with odr-policy-6m (creates a second independent DRPC)
+        logger.test_step(
+            "DR protect VM 2 with Standalone protection " f"using {dr_policy_6m_name}"
+        )
         protection_name_2 = f"{workload_namespace}-standalone-2"
         resource_name_2 = f"{protection_name_2}-drpc"
         for attempt in range(3):
@@ -704,6 +751,7 @@ class TestACMKubevirtDRIntergration:
                     standalone=True,
                     protection_name=protection_name_2,
                     namespace=workload_namespace,
+                    dr_policy_name=dr_policy_6m_name,
                 )
                 break
             except (AssertionError, Exception) as e:
@@ -752,11 +800,19 @@ class TestACMKubevirtDRIntergration:
 
         logger.info(f"DRPC resources created: {drpc_resources}")
 
-        # Get scheduling interval from first DRPC
-        scheduling_interval = dr_helpers.get_scheduling_interval(
-            workload_namespace,
-            discovered_apps=True,
-            resource_name=resource_name_1,
+        # Use the larger scheduling interval (6m from DRPC2) to ensure
+        # both DRPCs have completed at least one sync cycle.
+        scheduling_interval = max(
+            dr_helpers.get_scheduling_interval(
+                workload_namespace,
+                discovered_apps=True,
+                resource_name=resource_name_1,
+            ),
+            dr_helpers.get_scheduling_interval(
+                workload_namespace,
+                discovered_apps=True,
+                resource_name=resource_name_2,
+            ),
         )
 
         config.switch_to_cluster_by_name(primary_cluster_name)
@@ -850,14 +906,9 @@ class TestACMKubevirtDRIntergration:
         )
         wait_for_managed_cluster_unreachable(primary_cluster_name)
 
-        # Failover DRPCs one at a time to avoid VGR/VGRC conflicts
-        # when both DRPCs share the same namespace.
-        drpc_vm_map = {
-            resource_name_1: [all_cnv_workloads[0], all_cnv_workloads[2]],
-            resource_name_2: [all_cnv_workloads[1], all_cnv_workloads[3]],
-        }
-        for resource_name, vms in drpc_vm_map.items():
-            logger.test_step(f"Failover {resource_name} to secondary cluster")
+        # Failover all workloads (both DRPCs)
+        logger.test_step("Failover all workloads to secondary cluster")
+        for resource_name in drpc_resources:
             dr_helpers.failover(
                 failover_cluster=secondary_cluster_name,
                 namespace=workload_namespace,
@@ -866,31 +917,45 @@ class TestACMKubevirtDRIntergration:
                 old_primary=primary_cluster_name,
             )
 
-            config.switch_to_cluster_by_name(secondary_cluster_name)
-            pvc_count = sum(wl.workload_pvc_count for wl in vms)
-            pod_count = sum(wl.workload_pod_count for wl in vms)
-            dr_helpers.wait_for_all_resources_creation(
-                pvc_count,
-                pod_count,
-                workload_namespace,
-                timeout=900,
-                discovered_apps=True,
-                vrg_name=resource_name,
-                skip_replication_resources=True,
-            )
+        config.switch_to_cluster_by_name(secondary_cluster_name)
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        for resource_name in drpc_resources:
             wait_for_replication_resources_creation(
-                pvc_count,
+                total_pvc_count,
                 workload_namespace,
                 timeout=900,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
-            for cnv_wl in vms:
-                dr_helpers.wait_for_cnv_workload(
+
+        # Verify each VGR has a bound VGRC after failover
+        logger.test_step("Verify VGR-VGRC binding on secondary cluster")
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, drpc_resources)
+
+        # Wait for all VMs to be running on secondary cluster
+        logger.test_step("Verify all VMs running on secondary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
                     vm_name=cnv_wl.vm_name,
                     namespace=workload_namespace,
                     phase=constants.STATUS_RUNNING,
-                )
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
@@ -984,75 +1049,86 @@ class TestACMKubevirtDRIntergration:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        # Relocate DRPCs one at a time to avoid VGR/VGRC conflicts
-        drpc_relocate_map = {
-            resource_name_1: {
-                "vms": [all_cnv_workloads[0], all_cnv_workloads[2]],
-                "workload_instance": all_cnv_workloads[0],
-                "workload_instances_shared": [
-                    all_cnv_workloads[0],
-                    all_cnv_workloads[2],
-                ],
-            },
-            resource_name_2: {
-                "vms": [all_cnv_workloads[1], all_cnv_workloads[3]],
-                "workload_instance": all_cnv_workloads[1],
-                "workload_instances_shared": [
-                    all_cnv_workloads[1],
-                    all_cnv_workloads[3],
-                ],
-            },
-        }
-        for resource_name, params in drpc_relocate_map.items():
-            logger.test_step(f"Relocate {resource_name} back to primary cluster")
-            dr_helpers.relocate(
-                preferred_cluster=primary_cluster_name,
-                namespace=workload_namespace,
-                workload_placement_name=resource_name,
-                discovered_apps=True,
-                old_primary=secondary_cluster_name,
-                workload_instance=params["workload_instance"],
-                workload_instances_shared=params["workload_instances_shared"],
-            )
+        logger.test_step("Relocate all workloads back to primary cluster")
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_1,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[0],
+            workload_instances_shared=[
+                all_cnv_workloads[0],
+                all_cnv_workloads[2],
+            ],
+        )
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_2,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[1],
+            workload_instances_shared=[
+                all_cnv_workloads[1],
+                all_cnv_workloads[3],
+            ],
+        )
 
+        for resource_name in drpc_resources:
             wait_for_all_resources_deletion(
                 namespace=workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
 
-            config.switch_acm_ctx()
+        config.switch_acm_ctx()
+        for resource_name in drpc_resources:
             drpc_obj = DRPC(
                 namespace=constants.DR_OPS_NAMESPACE,
                 resource_name=resource_name,
             )
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-            config.switch_to_cluster_by_name(primary_cluster_name)
-            pvc_count = sum(wl.workload_pvc_count for wl in params["vms"])
-            pod_count = sum(wl.workload_pod_count for wl in params["vms"])
-            dr_helpers.wait_for_all_resources_creation(
-                pvc_count,
-                pod_count,
-                workload_namespace,
-                timeout=900,
-                discovered_apps=True,
-                vrg_name=resource_name,
-                skip_replication_resources=True,
-            )
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        for resource_name in drpc_resources:
             wait_for_replication_resources_creation(
-                pvc_count,
+                total_pvc_count,
                 workload_namespace,
                 timeout=900,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
-            for cnv_wl in params["vms"]:
-                dr_helpers.wait_for_cnv_workload(
+
+        # Verify each VGR has a bound VGRC after relocate
+        logger.test_step("Verify VGR-VGRC binding on primary cluster")
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, drpc_resources)
+
+        # Wait for all VMs to be running on primary cluster
+        logger.info("Waiting for all VMs to reach Running state " "on primary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
                     vm_name=cnv_wl.vm_name,
                     namespace=workload_namespace,
                     phase=constants.STATUS_RUNNING,
-                )
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         config.switch_acm_ctx()
@@ -1177,8 +1253,7 @@ class TestACMKubevirtDRIntergration:
             f"DRPC groups: {protection_name_1}, {protection_name_2}"
         )
 
-    # TODO: Add Polarion ID when available
-    @pytest.mark.polarion_id("OCS-wwww")
+    @pytest.mark.polarion_id("OCS-8046")
     def test_acm_kubevirt_remove_all_shared_protection_vms(
         self,
         setup_acm_ui,

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -850,9 +850,14 @@ class TestACMKubevirtDRIntergration:
         )
         wait_for_managed_cluster_unreachable(primary_cluster_name)
 
-        # Failover all workloads (both DRPCs)
-        logger.test_step("Failover all workloads to secondary cluster")
-        for resource_name in drpc_resources:
+        # Failover DRPCs one at a time to avoid VGR/VGRC conflicts
+        # when both DRPCs share the same namespace.
+        drpc_vm_map = {
+            resource_name_1: [all_cnv_workloads[0], all_cnv_workloads[2]],
+            resource_name_2: [all_cnv_workloads[1], all_cnv_workloads[3]],
+        }
+        for resource_name, vms in drpc_vm_map.items():
+            logger.test_step(f"Failover {resource_name} to secondary cluster")
             dr_helpers.failover(
                 failover_cluster=secondary_cluster_name,
                 namespace=workload_namespace,
@@ -861,44 +866,31 @@ class TestACMKubevirtDRIntergration:
                 old_primary=primary_cluster_name,
             )
 
-        config.switch_to_cluster_by_name(secondary_cluster_name)
-        # 1800s: two DRPCs fail over sequentially so DRPC2's VMs start up
-        # to 360s after DRPC1's, leaving too little of the default 900s
-        # window for all four pods to reach Running state.
-        dr_helpers.wait_for_all_resources_creation(
-            total_pvc_count,
-            total_pod_count,
-            workload_namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name_1,
-            skip_replication_resources=True,
-        )
-
-        for resource_name in drpc_resources:
+            config.switch_to_cluster_by_name(secondary_cluster_name)
+            pvc_count = sum(wl.workload_pvc_count for wl in vms)
+            pod_count = sum(wl.workload_pod_count for wl in vms)
+            dr_helpers.wait_for_all_resources_creation(
+                pvc_count,
+                pod_count,
+                workload_namespace,
+                timeout=900,
+                discovered_apps=True,
+                vrg_name=resource_name,
+                skip_replication_resources=True,
+            )
             wait_for_replication_resources_creation(
-                total_pvc_count,
+                pvc_count,
                 workload_namespace,
                 timeout=900,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
-
-        # Wait for all VMs to be running on secondary cluster concurrently
-        logger.test_step("Verify all VMs running on secondary cluster")
-        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
-            futures = {
-                executor.submit(
-                    dr_helpers.wait_for_cnv_workload,
+            for cnv_wl in vms:
+                dr_helpers.wait_for_cnv_workload(
                     vm_name=cnv_wl.vm_name,
                     namespace=workload_namespace,
                     phase=constants.STATUS_RUNNING,
-                ): cnv_wl
-                for cnv_wl in all_cnv_workloads
-            }
-            for future in as_completed(futures):
-                cnv_wl = futures[future]
-                future.result()
+                )
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
@@ -992,79 +984,75 @@ class TestACMKubevirtDRIntergration:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        logger.test_step("Relocate all workloads back to primary cluster")
-        # Relocate workloads for first DRPC (VM 1 and VM 3)
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster_name,
-            namespace=workload_namespace,
-            workload_placement_name=resource_name_1,
-            discovered_apps=True,
-            old_primary=secondary_cluster_name,
-            workload_instance=all_cnv_workloads[0],
-            workload_instances_shared=[all_cnv_workloads[0], all_cnv_workloads[2]],
-        )
+        # Relocate DRPCs one at a time to avoid VGR/VGRC conflicts
+        drpc_relocate_map = {
+            resource_name_1: {
+                "vms": [all_cnv_workloads[0], all_cnv_workloads[2]],
+                "workload_instance": all_cnv_workloads[0],
+                "workload_instances_shared": [
+                    all_cnv_workloads[0],
+                    all_cnv_workloads[2],
+                ],
+            },
+            resource_name_2: {
+                "vms": [all_cnv_workloads[1], all_cnv_workloads[3]],
+                "workload_instance": all_cnv_workloads[1],
+                "workload_instances_shared": [
+                    all_cnv_workloads[1],
+                    all_cnv_workloads[3],
+                ],
+            },
+        }
+        for resource_name, params in drpc_relocate_map.items():
+            logger.test_step(f"Relocate {resource_name} back to primary cluster")
+            dr_helpers.relocate(
+                preferred_cluster=primary_cluster_name,
+                namespace=workload_namespace,
+                workload_placement_name=resource_name,
+                discovered_apps=True,
+                old_primary=secondary_cluster_name,
+                workload_instance=params["workload_instance"],
+                workload_instances_shared=params["workload_instances_shared"],
+            )
 
-        # Relocate workloads for second DRPC (VM 2 and VM 4)
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster_name,
-            namespace=workload_namespace,
-            workload_placement_name=resource_name_2,
-            discovered_apps=True,
-            old_primary=secondary_cluster_name,
-            workload_instance=all_cnv_workloads[1],
-            workload_instances_shared=[all_cnv_workloads[1], all_cnv_workloads[3]],
-        )
-
-        # Verify cleanup after relocate
-        for resource_name in drpc_resources:
             wait_for_all_resources_deletion(
                 namespace=workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
 
-        config.switch_acm_ctx()
-        for resource_name in drpc_resources:
+            config.switch_acm_ctx()
             drpc_obj = DRPC(
-                namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
             )
             drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        config.switch_to_cluster_by_name(primary_cluster_name)
-        dr_helpers.wait_for_all_resources_creation(
-            total_pvc_count,
-            total_pod_count,
-            workload_namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name_1,
-            skip_replication_resources=True,
-        )
-
-        for resource_name in drpc_resources:
+            config.switch_to_cluster_by_name(primary_cluster_name)
+            pvc_count = sum(wl.workload_pvc_count for wl in params["vms"])
+            pod_count = sum(wl.workload_pod_count for wl in params["vms"])
+            dr_helpers.wait_for_all_resources_creation(
+                pvc_count,
+                pod_count,
+                workload_namespace,
+                timeout=900,
+                discovered_apps=True,
+                vrg_name=resource_name,
+                skip_replication_resources=True,
+            )
             wait_for_replication_resources_creation(
-                total_pvc_count,
+                pvc_count,
                 workload_namespace,
                 timeout=900,
                 discovered_apps=True,
                 vrg_name=resource_name,
             )
-
-        # Wait for all VMs to be running on primary cluster concurrently
-        logger.info("Waiting for all VMs to reach Running state on primary cluster")
-        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
-            futures = {
-                executor.submit(
-                    dr_helpers.wait_for_cnv_workload,
+            for cnv_wl in params["vms"]:
+                dr_helpers.wait_for_cnv_workload(
                     vm_name=cnv_wl.vm_name,
                     namespace=workload_namespace,
                     phase=constants.STATUS_RUNNING,
-                ): cnv_wl
-                for cnv_wl in all_cnv_workloads
-            }
-            for future in as_completed(futures):
-                cnv_wl = futures[future]
-                future.result()
+                )
                 logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         config.switch_acm_ctx()

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -19,7 +19,6 @@ from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.helpers.dr_helpers import (
     wait_for_all_resources_deletion,
     wait_for_managed_cluster_unreachable,
-    wait_for_replication_resources_creation,
     wait_for_resource_existence,
 )
 from ocs_ci.ocs import constants, ocp
@@ -562,7 +561,6 @@ class TestACMKubevirtDRIntergration:
     @pytest.mark.polarion_id("OCS-8045")
     def test_acm_kubevirt_mixed_protection_types(
         self,
-        request,
         setup_acm_ui,
         discovered_apps_dr_workload_cnv,
         nodes_multicluster,
@@ -662,6 +660,7 @@ class TestACMKubevirtDRIntergration:
         # so each DRPC uses a distinct policy.
         logger.test_step("Create second DRPolicy odr-policy-6m")
         existing_policies = dr_helpers.get_all_drpolicy()
+        default_dr_policy_name = existing_policies[0]["metadata"]["name"]
         dr_clusters = existing_policies[0]["spec"]["drClusters"]
         run_id = config.RUN["run_id"]
         dr_policy_6m_name = f"odr-policy-6m-{str(run_id)[-4:]}"
@@ -690,8 +689,6 @@ class TestACMKubevirtDRIntergration:
                 break
         logger.info(f"DRPolicy {dr_policy_6m_name} created and validated")
 
-        request.addfinalizer(lambda: dr_helpers.delete_drpolicy(dr_policy_6m_name))
-
         login_to_acm()
         acm_obj = AcmAddClusters()
 
@@ -700,7 +697,7 @@ class TestACMKubevirtDRIntergration:
         # DR protect VMs with mixed protection types
         # VM 1: Standalone (creates new DRPC)
         logger.test_step("DR protect VM 1 with Standalone protection")
-        protection_name_1 = f"{workload_namespace}-standalone-1"
+        protection_name_1 = f"{workload_namespace}-s1"
         assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
             acm_obj,
             vms=[all_cnv_workloads[0]],
@@ -708,6 +705,7 @@ class TestACMKubevirtDRIntergration:
             standalone=True,
             protection_name=protection_name_1,
             namespace=workload_namespace,
+            dr_policy_name=default_dr_policy_name,
         )
         # When DR protected via UI, the DRPC is named after the protection name entered
         resource_name_1 = f"{protection_name_1}-drpc"
@@ -725,6 +723,7 @@ class TestACMKubevirtDRIntergration:
             resource_name_1,
             [_pvc_name(all_cnv_workloads[0].vm_name)],
         )
+        config.switch_acm_ctx()
 
         # Wait for VM 1's DRPC to exist in Kubernetes before enrolling VM 3 as
         # Shared. The ACM UI queries existing DRPCs when opening the enrollment
@@ -768,12 +767,13 @@ class TestACMKubevirtDRIntergration:
                 _pvc_name(all_cnv_workloads[2].vm_name),
             ],
         )
+        config.switch_acm_ctx()
 
         # VM 2: Standalone with odr-policy-6m (creates a second independent DRPC)
         logger.test_step(
             "DR protect VM 2 with Standalone protection " f"using {dr_policy_6m_name}"
         )
-        protection_name_2 = f"{workload_namespace}-standalone-2"
+        protection_name_2 = f"{workload_namespace}-s2"
         resource_name_2 = f"{protection_name_2}-drpc"
         for attempt in range(3):
             try:
@@ -810,6 +810,7 @@ class TestACMKubevirtDRIntergration:
             resource_name_2,
             [_pvc_name(all_cnv_workloads[1].vm_name)],
         )
+        config.switch_acm_ctx()
 
         # Override discovered_apps_placement_name on the Standalone workload objects
         # so delete_workload can find the custom UI-created DRPCs at teardown.
@@ -860,6 +861,7 @@ class TestACMKubevirtDRIntergration:
                 _pvc_name(all_cnv_workloads[3].vm_name),
             ],
         )
+        config.switch_acm_ctx()
 
         logger.info(f"DRPC resources created: {drpc_resources}")
 
@@ -895,36 +897,6 @@ class TestACMKubevirtDRIntergration:
             vrg_name=resource_name_1,
             skip_replication_resources=True,
         )
-
-        # Verify both DRPCs' VRGs reach Primary state. A single call with
-        # vrg_name=resource_name_1 only verified DRPC1's VRG; DRPC2's volumes
-        # could still be unreplicated when the VMs tried to start.
-        for resource_name in drpc_resources:
-            wait_for_replication_resources_creation(
-                total_pvc_count,
-                workload_namespace,
-                timeout=900,
-                discovered_apps=True,
-                vrg_name=resource_name,
-            )
-
-        # Wait for all VMs to be running concurrently to avoid sequential
-        # timeouts when DRPC failovers are staggered
-        logger.test_step("Wait for all VMs to reach Running state")
-        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
-            futures = {
-                executor.submit(
-                    dr_helpers.wait_for_cnv_workload,
-                    vm_name=cnv_wl.vm_name,
-                    namespace=workload_namespace,
-                    phase=constants.STATUS_RUNNING,
-                ): cnv_wl
-                for cnv_wl in all_cnv_workloads
-            }
-            for future in as_completed(futures):
-                cnv_wl = futures[future]
-                future.result()
-                logger.info(f"VM {cnv_wl.vm_name} is Running")
 
         secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
             workload_namespace,
@@ -990,15 +962,6 @@ class TestACMKubevirtDRIntergration:
             vrg_name=resource_name_1,
             skip_replication_resources=True,
         )
-
-        for resource_name in drpc_resources:
-            wait_for_replication_resources_creation(
-                total_pvc_count,
-                workload_namespace,
-                timeout=900,
-                discovered_apps=True,
-                vrg_name=resource_name,
-            )
 
         # Verify each VGR has a bound VGRC after failover
         logger.test_step("Verify VGR-VGRC binding on secondary cluster")
@@ -1163,15 +1126,6 @@ class TestACMKubevirtDRIntergration:
             vrg_name=resource_name_1,
             skip_replication_resources=True,
         )
-
-        for resource_name in drpc_resources:
-            wait_for_replication_resources_creation(
-                total_pvc_count,
-                workload_namespace,
-                timeout=900,
-                discovered_apps=True,
-                vrg_name=resource_name,
-            )
 
         # Verify each VGR has a bound VGRC after relocate
         logger.test_step("Verify VGR-VGRC binding on primary cluster")

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -582,14 +582,16 @@ class TestACMKubevirtDRIntergration:
 
         1. Deploy 4 CNV discovered workloads in a single namespace
            via CLI
-        2. Create a second DRPolicy (odr-policy-6m) with a different
-           scheduling interval
+        2. Create a second DRPolicy with a unique runtime name
+           and a different scheduling interval
         3. DR protect VM 1 as Standalone with default DRPolicy via
-           ACM UI
-        4. DR protect VM 3 as Shared (tied to VM 1's DRPC)
-        5. DR protect VM 2 as Standalone with odr-policy-6m via
-           ACM UI
-        6. DR protect VM 4 as Shared (tied to VM 2's DRPC)
+           ACM UI, validate VGR-VGRC binding and PVC refs
+        4. DR protect VM 3 as Shared (tied to VM 1's DRPC),
+           validate PVC refs updated
+        5. DR protect VM 2 as Standalone with the second DRPolicy
+           via ACM UI, validate 2 VGRs and PVC refs
+        6. DR protect VM 4 as Shared (tied to VM 2's DRPC),
+           validate PVC refs updated
         7. Write data to all VMs, record md5sums
         8. Shut down all nodes of the primary managed cluster
         9. Failover all workloads to the secondary cluster
@@ -601,8 +603,13 @@ class TestACMKubevirtDRIntergration:
         15. Verify VGR-VGRC binding on primary cluster
         16. Verify all VM statuses via ACM UI after relocate
         17. Validate data integrity after relocate
-        18. Remove DR protection via ACM UI
-        19. Delete the second DRPolicy (odr-policy-6m)
+        18. Remove VM 3 (Shared) from DRPC1, verify DRPC1 persists
+        19. Remove VM 1 (Standalone, last VM) from DRPC1, verify
+            DRPC1 is deleted
+        20. Remove VM 4 (Shared) from DRPC2, verify DRPC2 persists
+        21. Remove VM 2 (Standalone, last VM) from DRPC2, verify
+            DRPC2 is deleted
+        22. Delete the second DRPolicy
 
         """
 
@@ -656,7 +663,8 @@ class TestACMKubevirtDRIntergration:
         logger.test_step("Create second DRPolicy odr-policy-6m")
         existing_policies = dr_helpers.get_all_drpolicy()
         dr_clusters = existing_policies[0]["spec"]["drClusters"]
-        dr_policy_6m_name = "odr-policy-6m"
+        run_id = config.RUN["run_id"]
+        dr_policy_6m_name = f"odr-policy-6m-{str(run_id)[-4:]}"
         dr_policy_data = load_yaml(constants.DR_POLICY_ACM_HUB)
         dr_policy_data["metadata"]["name"] = dr_policy_6m_name
         dr_policy_data["spec"]["drClusters"] = dr_clusters
@@ -705,6 +713,19 @@ class TestACMKubevirtDRIntergration:
         resource_name_1 = f"{protection_name_1}-drpc"
         drpc_resources.append(resource_name_1)
 
+        def _pvc_name(vm_name):
+            return vm_name.replace("vm-workload-", "vm-") + "-pvc"
+
+        # Validate VGR/VGRC after VM 1 Standalone enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 1")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, [resource_name_1])
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_1,
+            [_pvc_name(all_cnv_workloads[0].vm_name)],
+        )
+
         # Wait for VM 1's DRPC to exist in Kubernetes before enrolling VM 3 as
         # Shared. The ACM UI queries existing DRPCs when opening the enrollment
         # wizard; if the DRPC has not yet been created the Shared option
@@ -735,6 +756,19 @@ class TestACMKubevirtDRIntergration:
             namespace=workload_namespace,
         )
 
+        # Validate VGR/VGRC after VM 3 Shared enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 3")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, [resource_name_1])
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_1,
+            [
+                _pvc_name(all_cnv_workloads[0].vm_name),
+                _pvc_name(all_cnv_workloads[2].vm_name),
+            ],
+        )
+
         # VM 2: Standalone with odr-policy-6m (creates a second independent DRPC)
         logger.test_step(
             "DR protect VM 2 with Standalone protection " f"using {dr_policy_6m_name}"
@@ -763,6 +797,19 @@ class TestACMKubevirtDRIntergration:
                     raise
                 sleep(30)
         drpc_resources.append(resource_name_2)
+
+        # Validate VGR/VGRC after VM 2 Standalone enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 2")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(
+            workload_namespace,
+            [resource_name_1, resource_name_2],
+        )
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_2,
+            [_pvc_name(all_cnv_workloads[1].vm_name)],
+        )
 
         # Override discovered_apps_placement_name on the Standalone workload objects
         # so delete_workload can find the custom UI-created DRPCs at teardown.
@@ -796,6 +843,22 @@ class TestACMKubevirtDRIntergration:
             standalone=False,
             protection_name=protection_name_2,
             namespace=workload_namespace,
+        )
+
+        # Validate VGR/VGRC after VM 4 Shared enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 4")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(
+            workload_namespace,
+            [resource_name_1, resource_name_2],
+        )
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_2,
+            [
+                _pvc_name(all_cnv_workloads[1].vm_name),
+                _pvc_name(all_cnv_workloads[3].vm_name),
+            ],
         )
 
         logger.info(f"DRPC resources created: {drpc_resources}")
@@ -1174,26 +1237,15 @@ class TestACMKubevirtDRIntergration:
         # ------------------------------------------------------------------ #
         # Remove DR protection scenario                                        #
         #                                                                      #
-        # Step A: Remove protection from VM 3 (Shared with VM 1 / DRPC1).    #
-        #   Validate: DRPC1 still exists, VM 1 is still protected.            #
-        #                                                                      #
-        # Step B: Remove protection from VM 2 (Standalone / DRPC2).          #
-        #   Validate: DRPC2 is deleted.                                        #
+        # Validates that a DRPC is NOT deleted until ALL VMs (standalone +      #
+        # shared) are removed from it.                                         #
         # ------------------------------------------------------------------ #
         config.switch_acm_ctx()
-        logger.test_step("Remove DR protection via ACM UI")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
+        acm_obj = AcmAddClusters()
 
-        # Step A: remove the Shared VM (VM 3, index 2) from DRPC1
-        logger.info(
-            "Removing DR protection from Shared VM 3 "
-            f"'{all_cnv_workloads[2].vm_name}' (tied to DRPC1)"
-        )
-        logger.assertion(
-            f"remove_drprotection_for_discovered_vm_via_ui:"
-            f" vm={all_cnv_workloads[2].vm_name}, expected=True"
-        )
+        # -- DRPC1: remove VM3 (Shared), then VM1 (Standalone) ------------- #
+        logger.test_step("Remove DR protection from VM 3 (Shared with DRPC1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
             vm=all_cnv_workloads[2],
@@ -1201,8 +1253,7 @@ class TestACMKubevirtDRIntergration:
             namespace=workload_namespace,
         )
 
-        # Validate DRPC1 still exists and VM 1 is still protected
-        logger.info("Validating DRPC1 still exists after removing Shared VM 3")
+        logger.info("Validating DRPC1 still exists after removing VM 3")
         config.switch_acm_ctx()
         wait_for_resource_existence(
             kind=constants.DRPC,
@@ -1211,306 +1262,16 @@ class TestACMKubevirtDRIntergration:
             timeout=120,
             should_exist=True,
         )
-        logger.info("Validating DRPC1 PROTECTED_VMS contains only VM 1")
         verify_drpc_protected_vms(
             resource_name_1,
             expected_vms=[all_cnv_workloads[0].vm_name],
             unexpected_vms=[all_cnv_workloads[2].vm_name],
         )
-        logger.info("VM 3 removed from DRPC1; VM 1 remains protected under DRPC1")
 
-        # Step B: remove the Standalone VM (VM 2, index 1) → DRPC2 deleted
-        logger.info(
-            "Removing DR protection from Standalone VM 2 "
-            f"'{all_cnv_workloads[1].vm_name}' (DRPC2)"
+        logger.test_step(
+            "Remove DR protection from VM 1 (Standalone, last VM in DRPC1)"
         )
-        logger.assertion(
-            f"remove_drprotection_for_discovered_vm_via_ui:"
-            f" vm={all_cnv_workloads[1].vm_name}, expected=True"
-        )
-        assert remove_drprotection_for_discovered_vm_via_ui(
-            acm_obj,
-            vm=all_cnv_workloads[1],
-            managed_cluster_name=primary_cluster_name,
-            namespace=workload_namespace,
-        )
-
-        # Validate DRPC2 is deleted
-        logger.info("Validating DRPC2 is deleted after removing Standalone VM 2")
-        config.switch_acm_ctx()
-        wait_for_resource_existence(
-            kind=constants.DRPC,
-            namespace=constants.DR_OPS_NAMESPACE,
-            resource_name=resource_name_2,
-            timeout=120,
-            should_exist=False,
-        )
-        logger.info("Standalone VM 2 DR protection removed and DRPC2 deleted")
-
-        logger.info(
-            f"Test for mixed protection types (Standalone and Shared) "
-            f"in namespace {workload_namespace} passed. "
-            f"DRPC groups: {protection_name_1}, {protection_name_2}"
-        )
-
-    @pytest.mark.polarion_id("OCS-8046")
-    def test_acm_kubevirt_remove_all_shared_protection_vms(
-        self,
-        setup_acm_ui,
-        discovered_apps_dr_workload_cnv,
-    ):
-        """
-        Verify that the DRPC is deleted when DR protection is removed from
-        every VM enrolled under a shared protection group.
-
-        Three VMs are deployed in the same namespace.  One is DR-protected as
-        Standalone (this creates the DRPC), and the other two join the same
-        DRPC as Shared.  The test then removes protection from the Shared VMs
-        one at a time, asserting the DRPC is still present after each partial
-        removal, and finally removes the Standalone VM's protection, asserting
-        the DRPC is deleted once no VMs remain enrolled.
-
-        Test steps:
-
-        1. Deploy 3 CNV discovered workloads in a single namespace via CLI
-        2. DR protect VM 1 as Standalone (creates the DRPC)
-        3. DR protect VM 2 as Shared (joins VM 1's DRPC; only 1 DRPC exists)
-        4. DR protect VM 3 as Shared (joins VM 1's DRPC; still only 1 DRPC)
-        5. Verify all VMs are Running and replication resources are created
-        6. Write data to all VMs and record md5sums
-        7. Remove DR protection from VM 2 (Shared)
-           - Verify DRPC still exists and VM 1 / VM 3 are still protected
-        8. Remove DR protection from VM 3 (Shared)
-           - Verify DRPC still exists and VM 1 is still protected
-        9. Remove DR protection from VM 1 (Standalone – last enrolled VM)
-           - Verify DRPC is deleted
-        """
-
-        vm_filepaths = ["/dd_file1.txt"]
-        all_cnv_workloads = []
-
-        logger.test_step("Deploy VM 1 (will be Standalone)")
-        cnv_workload_1 = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
-        )
-        all_cnv_workloads.append(cnv_workload_1[-1])
-
-        logger.test_step("Deploy VM 2 in the same namespace (will be Shared)")
-        cnv_workload_2 = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
-        )
-        all_cnv_workloads.append(cnv_workload_2[-1])
-
-        logger.test_step("Deploy VM 3 in the same namespace (will be Shared)")
-        cnv_workload_3 = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
-        )
-        all_cnv_workloads.append(cnv_workload_3[-1])
-
-        assert all_cnv_workloads, "No discovered VMs found"
-        assert (
-            len(all_cnv_workloads) == 3
-        ), f"Expected 3 VMs, found {len(all_cnv_workloads)}"
-
-        config.switch_acm_ctx()
-        login_to_acm()
-        workload_namespace = all_cnv_workloads[0].workload_namespace
-        logger.info(f"All VMs deployed in namespace: {workload_namespace}")
-
-        acm_obj = AcmAddClusters()
-        primary_cluster_name = all_cnv_workloads[0].preferred_primary_cluster
-        logger.info(f"Primary cluster: {primary_cluster_name}")
-
         assert navigate_using_fleet_virtualization(acm_obj)
-
-        # VM 1: Standalone – creates the DRPC
-        protection_name = workload_namespace
-        logger.test_step("DR protect VM 1 with Standalone protection")
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[0]],
-            managed_cluster_name=primary_cluster_name,
-            standalone=True,
-            protection_name=protection_name,
-            namespace=workload_namespace,
-        )
-        resource_name = f"{protection_name}-drpc"
-
-        # Wait for VM 1's DRPC to exist before enrolling VMs 2 and 3 as Shared.
-        logger.info(
-            f"Waiting for DRPC {resource_name} to exist before enrolling VMs 2/3 as Shared"
-        )
-        config.switch_acm_ctx()
-        wait_for_resource_existence(
-            kind=constants.DRPC,
-            namespace=constants.DR_OPS_NAMESPACE,
-            resource_name=resource_name,
-            timeout=120,
-            should_exist=True,
-        )
-
-        # VM 2: Shared – exactly 1 DRPC exists at this point
-        logger.test_step("DR protect VM 2 with Shared protection (tied to VM 1)")
-        assert navigate_using_fleet_virtualization(acm_obj)
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[1]],
-            managed_cluster_name=primary_cluster_name,
-            standalone=False,
-            protection_name=protection_name,
-            namespace=workload_namespace,
-        )
-
-        # VM 3: Shared – still only 1 DRPC, radio-button assertion holds
-        logger.test_step("DR protect VM 3 with Shared protection (tied to VM 1)")
-        assert navigate_using_fleet_virtualization(acm_obj)
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=[all_cnv_workloads[2]],
-            managed_cluster_name=primary_cluster_name,
-            standalone=False,
-            protection_name=protection_name,
-            namespace=workload_namespace,
-        )
-
-        logger.info(f"All VMs enrolled under DRPC: {resource_name}")
-
-        logger.test_step("Verify DRPC PROTECTED_VMS contains all 3 VMs")
-        verify_drpc_protected_vms(
-            resource_name,
-            expected_vms=[wl.vm_name for wl in all_cnv_workloads],
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster_name)
-
-        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
-        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
-        dr_helpers.wait_for_all_resources_creation(
-            total_pvc_count,
-            total_pod_count,
-            workload_namespace,
-            discovered_apps=True,
-            vrg_name=resource_name,
-        )
-
-        for cnv_wl in all_cnv_workloads:
-            dr_helpers.wait_for_cnv_workload(
-                vm_name=cnv_wl.vm_name,
-                namespace=workload_namespace,
-                phase=constants.STATUS_RUNNING,
-            )
-
-        # Download virtctl if not already present
-        CNVInstaller().download_and_extract_virtctl_binary()
-
-        # Write data to all VMs
-        logger.test_step("Write data to all VMs")
-        for cnv_wl in all_cnv_workloads:
-            run_dd_io(
-                vm_obj=cnv_wl.vm_obj,
-                file_path=vm_filepaths[0],
-                username=cnv_wl.vm_username,
-                verify=True,
-            )
-
-        # ------------------------------------------------------------------ #
-        # Step 7: Remove protection from VM 2 (Shared)                        #
-        # ------------------------------------------------------------------ #
-        config.switch_acm_ctx()
-        logger.test_step("Remove DR protection from VM 2 (Shared)")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
-
-        logger.info(
-            f"Removing DR protection from Shared VM 2 '{all_cnv_workloads[1].vm_name}'"
-        )
-        logger.assertion(
-            f"remove_drprotection_for_discovered_vm_via_ui:"
-            f" vm={all_cnv_workloads[1].vm_name}, expected=True"
-        )
-        assert remove_drprotection_for_discovered_vm_via_ui(
-            acm_obj,
-            vm=all_cnv_workloads[1],
-            managed_cluster_name=primary_cluster_name,
-            namespace=workload_namespace,
-        )
-
-        logger.info(
-            "Validating DRPC still exists after removing VM 2 (VM 1 and VM 3 remain)"
-        )
-        config.switch_acm_ctx()
-        wait_for_resource_existence(
-            kind=constants.DRPC,
-            namespace=constants.DR_OPS_NAMESPACE,
-            resource_name=resource_name,
-            timeout=120,
-            should_exist=True,
-        )
-        logger.info("Validating DRPC PROTECTED_VMS contains VM 1 and VM 3 but not VM 2")
-        verify_drpc_protected_vms(
-            resource_name,
-            expected_vms=[
-                all_cnv_workloads[0].vm_name,
-                all_cnv_workloads[2].vm_name,
-            ],
-            unexpected_vms=[all_cnv_workloads[1].vm_name],
-        )
-        logger.info("VM 2 removed; DRPC intact with VM 1 and VM 3")
-
-        # ------------------------------------------------------------------ #
-        # Step 8: Remove protection from VM 3 (Shared)                        #
-        # ------------------------------------------------------------------ #
-        logger.test_step("Remove DR protection from VM 3 (Shared)")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
-
-        logger.info(
-            f"Removing DR protection from Shared VM 3 '{all_cnv_workloads[2].vm_name}'"
-        )
-        logger.assertion(
-            f"remove_drprotection_for_discovered_vm_via_ui:"
-            f" vm={all_cnv_workloads[2].vm_name}, expected=True"
-        )
-        assert remove_drprotection_for_discovered_vm_via_ui(
-            acm_obj,
-            vm=all_cnv_workloads[2],
-            managed_cluster_name=primary_cluster_name,
-            namespace=workload_namespace,
-        )
-
-        logger.info("Validating DRPC still exists after removing VM 3 (VM 1 remains)")
-        config.switch_acm_ctx()
-        wait_for_resource_existence(
-            kind=constants.DRPC,
-            namespace=constants.DR_OPS_NAMESPACE,
-            resource_name=resource_name,
-            timeout=120,
-            should_exist=True,
-        )
-        logger.info("Validating DRPC PROTECTED_VMS contains only VM 1")
-        verify_drpc_protected_vms(
-            resource_name,
-            expected_vms=[all_cnv_workloads[0].vm_name],
-            unexpected_vms=[all_cnv_workloads[2].vm_name],
-        )
-        logger.info("VM 3 removed; DRPC intact with VM 1")
-
-        # ------------------------------------------------------------------ #
-        # Step 9: Remove protection from VM 1 (Standalone – last enrollment)  #
-        # DRPC must be deleted once no VMs remain enrolled.                   #
-        # ------------------------------------------------------------------ #
-        logger.test_step("Remove DR protection from VM 1 (Standalone, last enrollment)")
-        logger.assertion("navigate_using_fleet_virtualization: expected=True")
-        assert navigate_using_fleet_virtualization(acm_obj)
-
-        logger.info(
-            f"Removing DR protection from Standalone VM 1 '{all_cnv_workloads[0].vm_name}'"
-            " (last VM in the group)"
-        )
-        logger.assertion(
-            f"remove_drprotection_for_discovered_vm_via_ui:"
-            f" vm={all_cnv_workloads[0].vm_name}, expected=True"
-        )
         assert remove_drprotection_for_discovered_vm_via_ui(
             acm_obj,
             vm=all_cnv_workloads[0],
@@ -1518,18 +1279,68 @@ class TestACMKubevirtDRIntergration:
             namespace=workload_namespace,
         )
 
-        logger.info(
-            "Validating DRPC is deleted now that all enrolled VMs have been removed"
-        )
+        logger.info("Validating DRPC1 is deleted after removing last VM")
         config.switch_acm_ctx()
         wait_for_resource_existence(
             kind=constants.DRPC,
             namespace=constants.DR_OPS_NAMESPACE,
-            resource_name=resource_name,
+            resource_name=resource_name_1,
             timeout=300,
             should_exist=False,
         )
+
+        # -- DRPC2: remove VM4 (Shared), then VM2 (Standalone) ------------- #
+        logger.test_step("Remove DR protection from VM 4 (Shared with DRPC2)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[3],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC2 still exists after removing VM 4")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=120,
+            should_exist=True,
+        )
+        verify_drpc_protected_vms(
+            resource_name_2,
+            expected_vms=[all_cnv_workloads[1].vm_name],
+            unexpected_vms=[all_cnv_workloads[3].vm_name],
+        )
+
+        logger.test_step(
+            "Remove DR protection from VM 2 (Standalone, last VM in DRPC2)"
+        )
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[1],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC2 is deleted after removing last VM")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=300,
+            should_exist=False,
+        )
+
+        # Delete the second DRPolicy
+        logger.test_step("Delete the second DRPolicy")
+        dr_helpers.delete_drpolicy(dr_policy_6m_name)
+
         logger.info(
-            f"DRPC '{resource_name}' deleted as expected after removing "
-            "all VMs from the shared protection group"
+            f"Test for mixed protection types (Standalone and Shared) "
+            f"in namespace {workload_namespace} passed. "
+            f"DRPC groups: {protection_name_1}, {protection_name_2}"
         )

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1130,13 +1130,17 @@ class TestACMKubevirtDRIntergration:
             skip_odf_cli_validation=True,
         )
 
-        # Switch to old_primary (c2) where do_discovered_apps_cleanup ran with --wait=false
+        # Switch to old_primary (c2) where do_discovered_apps_cleanup ran with --wait=false.
+        # Use an extended timeout here: unlike failover (where VMs on the old primary are
+        # already stopped), the VMs on the secondary were actively running and require
+        # graceful termination before VRG/VR cascade cleanup can complete.
         config.switch_to_cluster_by_name(secondary_cluster_name)
         for resource_name in drpc_resources:
             wait_for_all_resources_deletion(
                 namespace=workload_namespace,
                 discovered_apps=True,
                 vrg_name=resource_name,
+                timeout=2100,
             )
 
         config.switch_acm_ctx()

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -233,6 +233,7 @@ class TestACMKubevirtDRIntergration:
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
             vrg_name=resource_name,
+            skip_replication_resources=True,
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,
@@ -300,6 +301,8 @@ class TestACMKubevirtDRIntergration:
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
             vrg_name=resource_name,
+            timeout=1800,
+            skip_replication_resources=True,
         )
         for cnv_wl in cnv_workloads:
             dr_helpers.wait_for_cnv_workload(
@@ -427,6 +430,8 @@ class TestACMKubevirtDRIntergration:
             cnv_workloads[0].workload_namespace,
             discovered_apps=True,
             vrg_name=resource_name,
+            timeout=1800,
+            skip_replication_resources=True,
         )
         dr_helpers.wait_for_cnv_workload(
             vm_name=cnv_workloads[0].vm_name,

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1106,6 +1106,8 @@ class TestACMKubevirtDRIntergration:
             skip_odf_cli_validation=True,
         )
 
+        # Switch to old_primary (c2) where do_discovered_apps_cleanup ran with --wait=false
+        config.switch_to_cluster_by_name(secondary_cluster_name)
         for resource_name in drpc_resources:
             wait_for_all_resources_deletion(
                 namespace=workload_namespace,

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -353,6 +353,7 @@ class TestACMKubevirtDRIntergration:
                 workload_dir=cnv_wl.workload_dir,
                 vrg_name=resource_name,
                 skip_resource_deletion_verification=True,
+                wait_for_cleanup_timeout=600,
             )
 
         wait_for_all_resources_deletion(

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1063,20 +1063,38 @@ class TestACMKubevirtDRIntergration:
 
         logger.test_step("Verify all VM statuses via ACM UI after failover")
         for cnv_wl in all_cnv_workloads:
-            logger.assertion("navigate_using_fleet_virtualization: expected=True")
-            assert navigate_using_fleet_virtualization(acm_obj)
-            logger.assertion(
-                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-                f" vm={cnv_wl.vm_name}, cluster={secondary_cluster_name}, expected=True"
-            )
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=[cnv_wl],
-                protection_name=protection_name_1,
-                namespace=workload_namespace,
-                managed_cluster_name=secondary_cluster_name,
-                assign_policy=False,
-            )
+            # The first UI interaction after failover, cleanup and cluster
+            # recovery can hit a drifted/not-yet-rendered ACM VMs page, so the
+            # status check may transiently fail to locate the tree. Retry with
+            # a fresh navigation instead of failing the whole DR test.
+            for attempt in range(3):
+                try:
+                    logger.assertion(
+                        "navigate_using_fleet_virtualization: expected=True"
+                    )
+                    assert navigate_using_fleet_virtualization(acm_obj)
+                    logger.assertion(
+                        f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                        f" vm={cnv_wl.vm_name}, cluster={secondary_cluster_name},"
+                        f" expected=True"
+                    )
+                    assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                        acm_obj,
+                        vms=[cnv_wl],
+                        protection_name=protection_name_1,
+                        namespace=workload_namespace,
+                        managed_cluster_name=secondary_cluster_name,
+                        assign_policy=False,
+                    )
+                    break
+                except (AssertionError, Exception) as e:
+                    logger.warning(
+                        f"VM {cnv_wl.vm_name} status check attempt {attempt + 1}"
+                        f" failed: {e}. Retrying after 30s"
+                    )
+                    if attempt == 2:
+                        raise
+                    sleep(30)
 
         # Perform Relocate operation
         config.switch_to_cluster_by_name(primary_cluster_name)
@@ -1164,20 +1182,36 @@ class TestACMKubevirtDRIntergration:
         config.switch_acm_ctx()
         logger.test_step("Verify all VM statuses via ACM UI after relocate")
         for cnv_wl in all_cnv_workloads:
-            logger.assertion("navigate_using_fleet_virtualization: expected=True")
-            assert navigate_using_fleet_virtualization(acm_obj)
-            logger.assertion(
-                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
-                f" vm={cnv_wl.vm_name}, cluster={primary_cluster_name}, expected=True"
-            )
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=[cnv_wl],
-                protection_name=protection_name_1,
-                namespace=workload_namespace,
-                managed_cluster_name=primary_cluster_name,
-                assign_policy=False,
-            )
+            # As with the post-failover check, the ACM VMs page can transiently
+            # fail to render right after relocate; retry with fresh navigation.
+            for attempt in range(3):
+                try:
+                    logger.assertion(
+                        "navigate_using_fleet_virtualization: expected=True"
+                    )
+                    assert navigate_using_fleet_virtualization(acm_obj)
+                    logger.assertion(
+                        f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                        f" vm={cnv_wl.vm_name}, cluster={primary_cluster_name},"
+                        f" expected=True"
+                    )
+                    assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                        acm_obj,
+                        vms=[cnv_wl],
+                        protection_name=protection_name_1,
+                        namespace=workload_namespace,
+                        managed_cluster_name=primary_cluster_name,
+                        assign_policy=False,
+                    )
+                    break
+                except (AssertionError, Exception) as e:
+                    logger.warning(
+                        f"VM {cnv_wl.vm_name} status check attempt {attempt + 1}"
+                        f" failed: {e}. Retrying after 30s"
+                    )
+                    if attempt == 2:
+                        raise
+                    sleep(30)
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -1,5 +1,7 @@
 import logging
+import tempfile
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import sleep
 
 import pytest
@@ -14,20 +16,64 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
-from ocs_ci.helpers.dr_helpers import wait_for_all_resources_deletion
-from ocs_ci.ocs import constants
-from ocs_ci.ocs.acm.acm import AcmAddClusters
+from ocs_ci.helpers.dr_helpers import (
+    wait_for_all_resources_deletion,
+    wait_for_managed_cluster_unreachable,
+    wait_for_resource_existence,
+)
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.acm.acm import AcmAddClusters, login_to_acm
+from ocs_ci.ocs.ui.base_ui import close_browser
 from ocs_ci.helpers.dr_helpers_ui import (
     check_or_assign_drpolicy_for_discovered_vms_via_ui,
     navigate_using_fleet_virtualization,
+    remove_drprotection_for_discovered_vm_via_ui,
 )
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity_vm
 from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
 from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
-from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.utility.templating import load_yaml, dump_data_to_temp_yaml
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check, exec_cmd
 
 logger = logging.getLogger(__name__)
+
+
+def verify_drpc_protected_vms(resource_name, expected_vms, unexpected_vms=None):
+    """
+    Verify DRPC PROTECTED_VMS list via CLI.
+
+    Args:
+        resource_name (str): DRPC resource name.
+        expected_vms (list): VM names that must be in PROTECTED_VMS.
+        unexpected_vms (list): VM names that must NOT be in
+            PROTECTED_VMS (default None).
+
+    Raises:
+        AssertionError: if any expected VM is missing or unexpected
+            VM is present.
+    """
+    config.switch_acm_ctx()
+    drpc_obj = DRPC(
+        namespace=constants.DR_OPS_NAMESPACE,
+        resource_name=resource_name,
+    )
+    drpc_data = drpc_obj.get()
+    protected_vms = (
+        drpc_data.get("spec", {})
+        .get("kubeObjectProtection", {})
+        .get("recipeParameters", {})
+        .get("PROTECTED_VMS", [])
+    )
+    for vm_name in expected_vms:
+        assert (
+            vm_name in protected_vms
+        ), f"VM '{vm_name}' not found in PROTECTED_VMS: {protected_vms}"
+    for vm_name in unexpected_vms or []:
+        assert (
+            vm_name not in protected_vms
+        ), f"VM '{vm_name}' still in PROTECTED_VMS: {protected_vms}"
+    logger.info(f"DRPC PROTECTED_VMS verified: {protected_vms}")
 
 
 @rdr
@@ -45,12 +91,11 @@ class TestACMKubevirtDRIntergration:
         argnames=["protection_type"],
         argvalues=[
             pytest.param(
-                False, id="standalone", marks=pytest.mark.polarion_id("OCS-xxxx")
+                False, id="standalone", marks=pytest.mark.polarion_id("OCS-8047")
             ),
-            pytest.param(True, id="shared", marks=pytest.mark.polarion_id("OCS-yyyy")),
+            pytest.param(True, id="shared", marks=pytest.mark.polarion_id("OCS-8048")),
         ],
     )
-    # TODO: Add Polarion ID when available
     def test_acm_kubevirt_using_different_protection_types(
         self,
         setup_acm_ui,
@@ -60,35 +105,43 @@ class TestACMKubevirtDRIntergration:
         node_restart_teardown,
     ):
         """
-        DR operation on discovered VMs using Standalone and Shared Protection type. In shared protection, both VMs are
-        tied to a single DRPC in the same namespace where same DRPolicy is applied via UI to both the apps.
+        DR operation on discovered VMs using Standalone and Shared
+        Protection type. In shared protection, both VMs are tied to a
+        single DRPC in the same namespace where the same DRPolicy is
+        applied via UI to both the apps.
 
         Test steps:
 
         1. Deploy a CNV discovered workload in a test NS via CLI
-        2. Deploy another CNV discovered workload in the same namespace via CLI
-        3. Using ACM UI, DR protect the 1st workload from the VMs page using Standalone as Protection type
-        4. Then for shared protection, repeat the above steps and DR protect 2nd workload from the VMs page using
-            Shared option, which will use the existing DRPC of the 1st workload and gets tied to it.
-        5. Write data, take md5sum, failover this workload via CLI (both VMs) by shutting down the primary managed
-        cluster.
-        6. After successful failover, check md5sum, recover the down managed cluster and perform cleanup.
-        7. Let sync resume and then perform Relocate operation back to the original cluster.
-
+        2. (Shared only) Deploy a 2nd CNV workload in the same
+           namespace via CLI
+        3. DR protect workloads via ACM Fleet Virtualization UI
+           (Standalone for 1st VM, Shared for 2nd VM)
+        4. Write data to VMs, record md5sums
+        5. Shut down all nodes of the primary managed cluster
+        6. Failover workloads to the secondary cluster via CLI
+        7. Verify data integrity and VM status on the secondary
+           cluster
+        8. Recover the down managed cluster and perform cleanup
+        9. Verify VM status via ACM UI after failover
+        10. Relocate workloads back to the primary cluster
+        11. Verify VM status via ACM UI after relocate
+        12. Remove DR protection via ACM UI and verify DRPC
+            deletion
 
         """
         md5sum_original = []
         md5sum_failover = []
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
-        logger.info("Deploy 1st CNV workload")
+        logger.test_step("Deploy 1st CNV workload")
         cnv_workloads = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=False, shared_drpc_protection=False
         )
 
         if protection_type:
             # Deploy second workload for Shared protection (uses same namespace as first)
-            logger.info("Deploy 2nd CNV workload in the existing namespace")
+            logger.test_step("Deploy 2nd CNV workload in the existing namespace")
             cnv_workloads = discovered_apps_dr_workload_cnv(
                 pvc_vm=1, dr_protect=False, shared_drpc_protection=True
             )
@@ -101,14 +154,39 @@ class TestACMKubevirtDRIntergration:
 
         logger.info(f"CNV workloads instance is {cnv_workloads}")
 
+        config.switch_acm_ctx()
+        login_to_acm()
         acm_obj = AcmAddClusters()
         primary_cluster_name = cnv_workloads[0].preferred_primary_cluster
         logger.info(
             f"Primary managed cluster name is {cnv_workloads[0].preferred_primary_cluster}"
         )
-        assert navigate_using_fleet_virtualization(acm_obj)
+        logger.test_step("DR protect workloads via ACM UI")
         for i, vm in enumerate(cnv_workloads):
             standalone_flag = (not protection_type) or (i == 0)
+            if protection_type and i == 1:
+                # Wait for the standalone DRPC (created in iteration 0) to exist
+                # before opening the enrollment wizard in Shared mode. The ACM UI
+                # queries existing DRPCs when rendering the wizard; if the DRPC is
+                # not yet present the #shared-vm-protection radio button won't appear.
+                logger.info(
+                    f"Waiting for DRPC {protection_name}-drpc to exist"
+                    " before Shared enrollment"
+                )
+                config.switch_acm_ctx()
+                wait_for_resource_existence(
+                    kind=constants.DRPC,
+                    namespace=constants.DR_OPS_NAMESPACE,
+                    resource_name=f"{protection_name}-drpc",
+                    timeout=120,
+                    should_exist=True,
+                )
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
+            assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={vm.vm_name}, standalone={standalone_flag}, expected=True"
+            )
             assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
                 acm_obj,
                 vms=[vm],
@@ -121,6 +199,13 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             f'Placement name is "{cnv_workloads[0].discovered_apps_placement_name}"'
         )
+
+        if protection_type:
+            logger.test_step("Verify DRPC PROTECTED_VMS contains both VMs")
+            verify_drpc_protected_vms(
+                resource_name,
+                expected_vms=[wl.vm_name for wl in cnv_workloads],
+            )
 
         scheduling_interval = dr_helpers.get_scheduling_interval(
             cnv_workloads[0].workload_namespace,
@@ -187,23 +272,24 @@ class TestACMKubevirtDRIntergration:
         # Shutdown primary managed cluster nodes
         active_primary_index = config.cur_index
         active_primary_cluster_node_objs = get_node_objs()
-        logger.info("Shutting down all the nodes of the primary managed cluster")
+        logger.test_step("Shut down all nodes of the primary managed cluster")
         nodes_multicluster[active_primary_index].stop_nodes(
             active_primary_cluster_node_objs
         )
         logger.info(
             f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
-            "waiting for cluster to be unreachable.."
+            "waiting for cluster to be unreachable"
         )
-        sleep(300)
+        wait_for_managed_cluster_unreachable(primary_cluster_name)
 
-        logger.info("FailingOver the workloads.....")
+        logger.test_step("Failover workloads to secondary cluster")
         dr_helpers.failover(
             failover_cluster=secondary_cluster_name,
             namespace=cnv_workloads[0].workload_namespace,
             discovered_apps=True,
             workload_placement_name=resource_name,
             old_primary=primary_cluster_name,
+            skip_odf_cli_validation=True,
         )
 
         # Verify resources creation on secondary cluster (failoverCluster)
@@ -244,15 +330,18 @@ class TestACMKubevirtDRIntergration:
             )
 
         config.switch_to_cluster_by_name(primary_cluster_name)
-        logger.info("Recover the down managed cluster")
+        logger.test_step("Recover down managed cluster")
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
-        wait_for_nodes_status([node.name for node in active_primary_cluster_node_objs])
+        wait_for_nodes_status(
+            [node.name for node in active_primary_cluster_node_objs], timeout=900
+        )
         wait_for_pods_to_be_running(timeout=420, sleep=15)
+        logger.assertion("ceph_health_check: expected=True")
         assert ceph_health_check(tries=10, delay=30)
 
-        logger.info("Doing Cleanup Operations after successful failover")
+        logger.test_step("Cleanup after successful failover")
         for cnv_wl in cnv_workloads:
             dr_helpers.do_discovered_apps_cleanup(
                 drpc_name=resource_name,
@@ -274,15 +363,30 @@ class TestACMKubevirtDRIntergration:
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        logger.info("On UI, check if VM is running after failover or not")
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=secondary_cluster_name,
-            assign_policy=False,
-        )
+        logger.test_step("Verify VM status via ACM UI after failover")
+        logger.info("Refreshing browser session before UI verification")
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
+        config.switch_acm_ctx()
+        login_to_acm()
+        acm_obj = AcmAddClusters()
+        for cnv_wl in cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
+            assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={secondary_cluster_name}, expected=True"
+            )
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=secondary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(secondary_cluster_name)
 
         # Doing Relocate in below code
@@ -291,7 +395,7 @@ class TestACMKubevirtDRIntergration:
         logger.info(f"Waiting for {wait_time} minutes to run IOs")
         sleep(wait_time * 60)
 
-        logger.info("Relocating the workloads.....")
+        logger.test_step("Relocate workloads back to primary cluster")
         dr_helpers.relocate(
             preferred_cluster=primary_cluster_name,
             namespace=cnv_workloads[0].workload_namespace,
@@ -302,6 +406,8 @@ class TestACMKubevirtDRIntergration:
             workload_instances_shared=cnv_workloads,
         )
         # Cleanup is handled as part of the Relocate function and checks are done below
+        # Switch to old_primary (c2) where do_discovered_apps_cleanup ran with --wait=false
+        config.switch_to_cluster_by_name(secondary_cluster_name)
         wait_for_all_resources_deletion(
             namespace=cnv_workloads[0].workload_namespace,
             discovered_apps=True,
@@ -328,17 +434,30 @@ class TestACMKubevirtDRIntergration:
             phase=constants.STATUS_RUNNING,
         )
 
+        logger.test_step("Verify VM status via ACM UI after relocate")
+        logger.info("Refreshing browser session before UI verification")
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
         config.switch_acm_ctx()
-        logger.info("On UI, check if VM is running after relocate or not")
-        acm_obj.refresh_page()
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
+        login_to_acm()
+        acm_obj = AcmAddClusters()
+        for cnv_wl in cnv_workloads:
+            logger.assertion("navigate_using_fleet_virtualization: expected=True")
+            assert navigate_using_fleet_virtualization(acm_obj)
+            logger.assertion(
+                f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+                f" vm={cnv_wl.vm_name}, cluster={primary_cluster_name}, expected=True"
+            )
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[cnv_wl],
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=primary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster
@@ -359,4 +478,826 @@ class TestACMKubevirtDRIntergration:
                 username=cnv_wl.vm_username,
                 verify=True,
             )
-        logger.info(f"Test for {protection_name} protection type passed")
+
+        # ------------------------------------------------------------------ #
+        # Remove DR protection scenario                                        #
+        # Standalone run: remove protection from the single VM and verify     #
+        #   its DRPC is deleted.                                               #
+        # Shared run:     remove only the 2nd (Shared) VM from the DRPC and  #
+        #   verify the 1st VM is still protected with its DRPC intact.        #
+        # ------------------------------------------------------------------ #
+        config.switch_acm_ctx()
+        logger.test_step("Remove DR protection via ACM UI")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        if protection_type:
+            # Shared run – cnv_workloads[1] is the Shared VM; remove it
+            logger.info(
+                "Removing DR protection from the Shared VM "
+                f"'{cnv_workloads[1].vm_name}'"
+            )
+            logger.assertion(
+                f"remove_drprotection_for_discovered_vm_via_ui:"
+                f" vm={cnv_workloads[1].vm_name}, expected=True"
+            )
+            assert remove_drprotection_for_discovered_vm_via_ui(
+                acm_obj,
+                vm=cnv_workloads[1],
+                managed_cluster_name=primary_cluster_name,
+                namespace=cnv_workloads[0].workload_namespace,
+            )
+            # Validate: DRPC still exists (1st VM is still enrolled)
+            logger.info("Validating DRPC still exists for the remaining Standalone VM")
+            config.switch_acm_ctx()
+            wait_for_resource_existence(
+                kind=constants.DRPC,
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
+                timeout=120,
+                should_exist=True,
+            )
+            # Validate: 1st VM still protected, 2nd VM removed from DRPC
+            logger.info("Validating DRPC PROTECTED_VMS contains only the 1st VM")
+            verify_drpc_protected_vms(
+                resource_name,
+                expected_vms=[cnv_workloads[0].vm_name],
+                unexpected_vms=[cnv_workloads[1].vm_name],
+            )
+            logger.info("Shared VM removed from DRPC; Standalone VM remains protected")
+        else:
+            # Standalone run – remove the single VM's protection entirely
+            logger.info(
+                "Removing DR protection from the Standalone VM "
+                f"'{cnv_workloads[0].vm_name}'"
+            )
+            logger.assertion(
+                f"remove_drprotection_for_discovered_vm_via_ui:"
+                f" vm={cnv_workloads[0].vm_name}, expected=True"
+            )
+            assert remove_drprotection_for_discovered_vm_via_ui(
+                acm_obj,
+                vm=cnv_workloads[0],
+                managed_cluster_name=primary_cluster_name,
+                namespace=cnv_workloads[0].workload_namespace,
+            )
+            # Validate: DRPC is deleted
+            logger.info(
+                "Validating DRPC is deleted after Standalone protection removal"
+            )
+            config.switch_acm_ctx()
+            wait_for_resource_existence(
+                kind=constants.DRPC,
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
+                timeout=120,
+                should_exist=False,
+            )
+            logger.info("Standalone VM DR protection removed and DRPC deleted")
+
+        try:
+            close_browser()
+        except Exception:
+            logger.warning("Browser already closed or crashed, proceeding")
+
+    @pytest.mark.polarion_id("OCS-8045")
+    def test_acm_kubevirt_mixed_protection_types(
+        self,
+        setup_acm_ui,
+        discovered_apps_dr_workload_cnv,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        DR operation on multiple discovered VMs in the same namespace
+        using mixed protection types (some Standalone, some Shared).
+        This test validates that VMs with different protection types
+        can coexist in the same namespace and perform DR operations
+        successfully.
+
+        Bug: Granular VM DR is broken
+        ref: https://redhat.atlassian.net/browse/DFBUGS-8039
+
+        Test steps:
+
+        1. Deploy 4 CNV discovered workloads in a single namespace
+           via CLI
+        2. Create a second DRPolicy with a unique runtime name
+           and a different scheduling interval
+        3. DR protect VM 1 as Standalone with default DRPolicy via
+           ACM UI, validate VGR-VGRC binding and PVC refs
+        4. DR protect VM 3 as Shared (tied to VM 1's DRPC),
+           validate PVC refs updated
+        5. DR protect VM 2 as Standalone with the second DRPolicy
+           via ACM UI, validate 2 VGRs and PVC refs
+        6. DR protect VM 4 as Shared (tied to VM 2's DRPC),
+           validate PVC refs updated
+        7. Write data to all VMs, record md5sums
+        8. Shut down all nodes of the primary managed cluster
+        9. Failover all workloads to the secondary cluster
+        10. Verify VGR-VGRC binding on secondary cluster
+        11. Verify data integrity on all VMs after failover
+        12. Recover the down managed cluster and perform cleanup
+        13. Verify all VM statuses via ACM UI after failover
+        14. Relocate all workloads back to the primary cluster
+        15. Verify VGR-VGRC binding on primary cluster
+        16. Verify all VM statuses via ACM UI after relocate
+        17. Validate data integrity after relocate
+        18. Remove VM 3 (Shared) from DRPC1, verify DRPC1 persists
+        19. Remove VM 1 (Standalone, last VM) from DRPC1, verify
+            DRPC1 is deleted
+        20. Remove VM 4 (Shared) from DRPC2, verify DRPC2 persists
+        21. Remove VM 2 (Standalone, last VM) from DRPC2, verify
+            DRPC2 is deleted
+        22. Delete the second DRPolicy
+
+        """
+
+        md5sum_original = []
+        md5sum_failover = []
+        vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
+        all_cnv_workloads = []
+        drpc_resources = []
+
+        logger.test_step("Deploy 1st CNV workload (Standalone protection)")
+        cnv_workload_1 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+        )
+        all_cnv_workloads.append(cnv_workload_1[-1])
+
+        # VM 2 (index 1): will become 2nd Standalone; shared_drpc_protection=True means
+        # "deploy into the same namespace as the existing workload", not the DR protection type
+        logger.test_step("Deploy 2nd CNV workload (will use Standalone DR protection)")
+        cnv_workload_2 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_2[-1])
+
+        # VM 3 (index 2): will be enrolled as Shared with VM 1
+        logger.test_step("Deploy 3rd CNV workload (will be Shared with VM 1)")
+        cnv_workload_3 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_3[-1])
+
+        # VM 4 (index 3): will be enrolled as Shared with VM 2
+        logger.test_step("Deploy 4th CNV workload (will be Shared with VM 2)")
+        cnv_workload_4 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+        )
+        all_cnv_workloads.append(cnv_workload_4[-1])
+
+        assert all_cnv_workloads, "No discovered VMs found"
+        assert (
+            len(all_cnv_workloads) == 4
+        ), f"Expected 4 VMs, found {len(all_cnv_workloads)}"
+
+        config.switch_acm_ctx()
+        workload_namespace = all_cnv_workloads[0].workload_namespace
+        logger.info(f"All VMs deployed in namespace: {workload_namespace}")
+        primary_cluster_name = all_cnv_workloads[0].preferred_primary_cluster
+        logger.info(f"Primary managed cluster name is {primary_cluster_name}")
+
+        # Create a second DRPolicy with a different scheduling interval
+        # so each DRPC uses a distinct policy.
+        logger.test_step("Create second DRPolicy odr-policy-6m")
+        existing_policies = dr_helpers.get_all_drpolicy()
+        default_dr_policy_name = existing_policies[0]["metadata"]["name"]
+        dr_clusters = existing_policies[0]["spec"]["drClusters"]
+        run_id = config.RUN["run_id"]
+        dr_policy_6m_name = f"odr-policy-6m-{str(run_id)[-4:]}"
+        dr_policy_data = load_yaml(constants.DR_POLICY_ACM_HUB)
+        dr_policy_data["metadata"]["name"] = dr_policy_6m_name
+        dr_policy_data["spec"]["drClusters"] = dr_clusters
+        dr_policy_data["spec"]["schedulingInterval"] = "6m"
+        dr_policy_yaml = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="dr_policy_6m_", delete=False
+        )
+        dump_data_to_temp_yaml(dr_policy_data, dr_policy_yaml.name)
+        exec_cmd(f"oc create -f {dr_policy_yaml.name}")
+        drpolicy_ocp = ocp.OCP(
+            kind=constants.DRPOLICY,
+            resource_name=dr_policy_6m_name,
+        )
+        for sample in TimeoutSampler(
+            timeout=120,
+            sleep=5,
+            func=lambda: drpolicy_ocp.get()
+            .get("status", {})
+            .get("conditions", [{}])[0]
+            .get("reason", ""),
+        ):
+            if sample in constants.DRPOLICY_SUCCESS_REASONS:
+                break
+        logger.info(f"DRPolicy {dr_policy_6m_name} created and validated")
+
+        login_to_acm()
+        acm_obj = AcmAddClusters()
+
+        assert navigate_using_fleet_virtualization(acm_obj)
+
+        # DR protect VMs with mixed protection types
+        # VM 1: Standalone (creates new DRPC)
+        logger.test_step("DR protect VM 1 with Standalone protection")
+        protection_name_1 = f"{workload_namespace}-s1"
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[0]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=True,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            dr_policy_name=default_dr_policy_name,
+        )
+        # When DR protected via UI, the DRPC is named after the protection name entered
+        resource_name_1 = f"{protection_name_1}-drpc"
+        drpc_resources.append(resource_name_1)
+
+        def _pvc_name(vm_name):
+            return vm_name.replace("vm-workload-", "vm-") + "-pvc"
+
+        # Validate VGR/VGRC after VM 1 Standalone enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 1")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, [resource_name_1])
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_1,
+            [_pvc_name(all_cnv_workloads[0].vm_name)],
+        )
+        config.switch_acm_ctx()
+
+        # Wait for VM 1's DRPC to exist in Kubernetes before enrolling VM 3 as
+        # Shared. The ACM UI queries existing DRPCs when opening the enrollment
+        # wizard; if the DRPC has not yet been created the Shared option
+        # (#shared-vm-protection) will not appear.
+        logger.info(
+            f"Waiting for DRPC {resource_name_1} to exist before enrolling VM 3 as Shared"
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_1,
+            timeout=120,
+            should_exist=True,
+        )
+
+        # VM 3: Shared with VM 1 (uses the single existing DRPC from VM 1)
+        # NOTE: the UI helper asserts exactly 1 radio button when selecting a Shared DRPC.
+        # VM 3 is enrolled immediately after VM 1 so only 1 DRPC exists at this point.
+        logger.test_step("DR protect VM 3 with Shared protection (tied to VM 1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[2]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+        )
+
+        # Validate VGR/VGRC after VM 3 Shared enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 3")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, [resource_name_1])
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_1,
+            [
+                _pvc_name(all_cnv_workloads[0].vm_name),
+                _pvc_name(all_cnv_workloads[2].vm_name),
+            ],
+        )
+        config.switch_acm_ctx()
+
+        # VM 2: Standalone with odr-policy-6m (creates a second independent DRPC)
+        logger.test_step(
+            "DR protect VM 2 with Standalone protection " f"using {dr_policy_6m_name}"
+        )
+        protection_name_2 = f"{workload_namespace}-s2"
+        resource_name_2 = f"{protection_name_2}-drpc"
+        for attempt in range(3):
+            try:
+                assert navigate_using_fleet_virtualization(acm_obj)
+                assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                    acm_obj,
+                    vms=[all_cnv_workloads[1]],
+                    managed_cluster_name=primary_cluster_name,
+                    standalone=True,
+                    protection_name=protection_name_2,
+                    namespace=workload_namespace,
+                    dr_policy_name=dr_policy_6m_name,
+                )
+                break
+            except (AssertionError, Exception) as e:
+                logger.warning(
+                    f"VM 2 Standalone enrollment attempt {attempt + 1}"
+                    f" failed: {e}. Retrying after 30s"
+                )
+                if attempt == 2:
+                    raise
+                sleep(30)
+        drpc_resources.append(resource_name_2)
+
+        # Validate VGR/VGRC after VM 2 Standalone enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 2")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(
+            workload_namespace,
+            [resource_name_1, resource_name_2],
+        )
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_2,
+            [_pvc_name(all_cnv_workloads[1].vm_name)],
+        )
+        config.switch_acm_ctx()
+
+        # Override discovered_apps_placement_name on the Standalone workload objects
+        # so delete_workload can find the custom UI-created DRPCs at teardown.
+        # delete_workload tries {name} and {name}-drpc — by setting the base name
+        # to protection_name_X (without -drpc), it resolves to resource_name_X.
+        # VM 3 and VM 4 use shared_drpc_protection=True so delete_workload skips
+        # DRPC deletion for them entirely.
+        all_cnv_workloads[0].discovered_apps_placement_name = protection_name_1
+        all_cnv_workloads[1].discovered_apps_placement_name = protection_name_2
+
+        # Wait for VM 2's DRPC to be present before enrolling VM 4 as Shared.
+        logger.info(
+            f"Waiting for DRPC {resource_name_2} to exist before enrolling VM 4 as Shared"
+        )
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=120,
+            should_exist=True,
+        )
+
+        # VM 4: Shared with VM 2 (uses existing DRPC from VM 2)
+        logger.test_step("DR protect VM 4 with Shared protection (tied to VM 2)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=[all_cnv_workloads[3]],
+            managed_cluster_name=primary_cluster_name,
+            standalone=False,
+            protection_name=protection_name_2,
+            namespace=workload_namespace,
+        )
+
+        # Validate VGR/VGRC after VM 4 Shared enrollment
+        logger.test_step("Validate VGR-VGRC binding and PVC refs after VM 4")
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.validate_vgr_vgrc_binding(
+            workload_namespace,
+            [resource_name_1, resource_name_2],
+        )
+        dr_helpers.validate_vgr_pvc_refs(
+            workload_namespace,
+            resource_name_2,
+            [
+                _pvc_name(all_cnv_workloads[1].vm_name),
+                _pvc_name(all_cnv_workloads[3].vm_name),
+            ],
+        )
+        config.switch_acm_ctx()
+
+        logger.info(f"DRPC resources created: {drpc_resources}")
+
+        # Use the larger scheduling interval (6m from DRPC2) to ensure
+        # both DRPCs have completed at least one sync cycle.
+        scheduling_interval = max(
+            dr_helpers.get_scheduling_interval(
+                workload_namespace,
+                discovered_apps=True,
+                resource_name=resource_name_1,
+            ),
+            dr_helpers.get_scheduling_interval(
+                workload_namespace,
+                discovered_apps=True,
+                resource_name=resource_name_2,
+            ),
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        total_pvc_count = sum(wl.workload_pvc_count for wl in all_cnv_workloads)
+        total_pod_count = sum(wl.workload_pod_count for wl in all_cnv_workloads)
+
+        # Wait for all PVCs and pods namespace-wide. The per-DRPC loop
+        # approach was incorrect: wait_for_all_resources_creation counts
+        # resources namespace-wide, so DRPC1's running pods would satisfy
+        # DRPC2's pod count check before DRPC2's own pods were ready.
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
+            workload_namespace,
+            discovered_apps=True,
+            resource_name=resource_name_1,
+        )
+
+        # Download and extract the virtctl binary to bin_dir. Skips if already present.
+        CNVInstaller().download_and_extract_virtctl_binary()
+
+        # Creating a file (file1) on all VMs and calculating MD5sum
+        logger.test_step("Write data to all VMs and calculating MD5sum")
+        for cnv_wl in all_cnv_workloads:
+            md5sum_original.append(
+                run_dd_io(
+                    vm_obj=cnv_wl.vm_obj,
+                    file_path=vm_filepaths[0],
+                    username=cnv_wl.vm_username,
+                    verify=True,
+                )
+            )
+
+        for cnv_wl, md5sum in zip(all_cnv_workloads, md5sum_original):
+            logger.info(
+                f"Original checksum of file {vm_filepaths[0]} on VM {cnv_wl.workload_name}: {md5sum}"
+            )
+
+        wait_time = 2 * scheduling_interval  # Time in minutes
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        # Shutdown primary managed cluster nodes
+        active_primary_index = config.cur_index
+        active_primary_cluster_node_objs = get_node_objs()
+        logger.test_step("Shut down all nodes of the primary managed cluster")
+        nodes_multicluster[active_primary_index].stop_nodes(
+            active_primary_cluster_node_objs
+        )
+        logger.info(
+            f"All nodes of the primary managed cluster {primary_cluster_name} are powered off, "
+            "waiting for cluster to be unreachable"
+        )
+        wait_for_managed_cluster_unreachable(primary_cluster_name)
+
+        # Failover all workloads (both DRPCs)
+        logger.test_step("Failover all workloads to secondary cluster")
+        for resource_name in drpc_resources:
+            dr_helpers.failover(
+                failover_cluster=secondary_cluster_name,
+                namespace=workload_namespace,
+                discovered_apps=True,
+                workload_placement_name=resource_name,
+                old_primary=primary_cluster_name,
+                skip_odf_cli_validation=True,
+            )
+
+        config.switch_to_cluster_by_name(secondary_cluster_name)
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        # Verify each VGR has a bound VGRC after failover
+        logger.test_step("Verify VGR-VGRC binding on secondary cluster")
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, drpc_resources)
+
+        # Wait for all VMs to be running on secondary cluster
+        logger.test_step("Verify all VMs running on secondary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
+                    vm_name=cnv_wl.vm_name,
+                    namespace=workload_namespace,
+                    phase=constants.STATUS_RUNNING,
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
+                logger.info(f"VM {cnv_wl.vm_name} is Running")
+
+        # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
+        logger.test_step("Validate data integrity after failover")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[0], md5sum_original, "Failover"
+        )
+
+        # Creating a file (file2) post failover on all VMs
+        logger.test_step("Write additional data post-failover")
+        for cnv_wl in all_cnv_workloads:
+            md5sum_failover.append(
+                run_dd_io(
+                    vm_obj=cnv_wl.vm_obj,
+                    file_path=vm_filepaths[1],
+                    username=cnv_wl.vm_username,
+                    verify=True,
+                )
+            )
+
+        for cnv_wl, md5sum in zip(all_cnv_workloads, md5sum_failover):
+            logger.info(
+                f"Checksum of files written after Failover: {vm_filepaths[1]} on VM {cnv_wl.workload_name}: {md5sum}"
+            )
+
+        # Recover the down managed cluster
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        logger.test_step("Recover down managed cluster")
+        nodes_multicluster[active_primary_index].start_nodes(
+            active_primary_cluster_node_objs
+        )
+        wait_for_nodes_status(
+            [node.name for node in active_primary_cluster_node_objs], timeout=900
+        )
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        logger.assertion("ceph_health_check: expected=True")
+        assert ceph_health_check(tries=10, delay=30)
+
+        # Cleanup operations after successful failover
+        logger.test_step("Cleanup after successful failover")
+        # VM 1 (index 0) and VM 3 (index 2) share DRPC1; VM 2 (index 1) and VM 4 (index 3) share DRPC2
+        drpc_per_vm = [
+            resource_name_1,  # VM 1
+            resource_name_2,  # VM 2
+            resource_name_1,  # VM 3
+            resource_name_2,  # VM 4
+        ]
+        for cnv_wl, drpc_name in zip(all_cnv_workloads, drpc_per_vm):
+            dr_helpers.do_discovered_apps_cleanup(
+                drpc_name=drpc_name,
+                old_primary=primary_cluster_name,
+                workload_namespace=workload_namespace,
+                workload_dir=cnv_wl.workload_dir,
+                vrg_name=drpc_name,
+                skip_resource_deletion_verification=True,
+            )
+
+        for resource_name in drpc_resources:
+            wait_for_all_resources_deletion(
+                namespace=workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        config.switch_acm_ctx()
+        for resource_name in drpc_resources:
+            drpc_obj = DRPC(
+                namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
+            )
+            drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
+
+        logger.test_step("Verify all VM statuses via ACM UI after failover")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" all_vms, cluster={secondary_cluster_name}, expected=True"
+        )
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=all_cnv_workloads,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            managed_cluster_name=secondary_cluster_name,
+            assign_policy=False,
+        )
+
+        # Perform Relocate operation
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        sleep(wait_time * 60)
+
+        logger.test_step("Relocate all workloads back to primary cluster")
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_1,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[0],
+            workload_instances_shared=[
+                all_cnv_workloads[0],
+                all_cnv_workloads[2],
+            ],
+        )
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster_name,
+            namespace=workload_namespace,
+            workload_placement_name=resource_name_2,
+            discovered_apps=True,
+            old_primary=secondary_cluster_name,
+            workload_instance=all_cnv_workloads[1],
+            workload_instances_shared=[
+                all_cnv_workloads[1],
+                all_cnv_workloads[3],
+            ],
+        )
+
+        for resource_name in drpc_resources:
+            wait_for_all_resources_deletion(
+                namespace=workload_namespace,
+                discovered_apps=True,
+                vrg_name=resource_name,
+            )
+
+        config.switch_acm_ctx()
+        for resource_name in drpc_resources:
+            drpc_obj = DRPC(
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=resource_name,
+            )
+            drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
+
+        config.switch_to_cluster_by_name(primary_cluster_name)
+        dr_helpers.wait_for_all_resources_creation(
+            total_pvc_count,
+            total_pod_count,
+            workload_namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        # Verify each VGR has a bound VGRC after relocate
+        logger.test_step("Verify VGR-VGRC binding on primary cluster")
+        dr_helpers.validate_vgr_vgrc_binding(workload_namespace, drpc_resources)
+
+        # Wait for all VMs to be running on primary cluster
+        logger.info("Waiting for all VMs to reach Running state " "on primary cluster")
+        with ThreadPoolExecutor(max_workers=len(all_cnv_workloads)) as executor:
+            futures = {
+                executor.submit(
+                    dr_helpers.wait_for_cnv_workload,
+                    vm_name=cnv_wl.vm_name,
+                    namespace=workload_namespace,
+                    phase=constants.STATUS_RUNNING,
+                ): cnv_wl
+                for cnv_wl in all_cnv_workloads
+            }
+            for future in as_completed(futures):
+                cnv_wl = futures[future]
+                future.result()
+                logger.info(f"VM {cnv_wl.vm_name} is Running")
+
+        config.switch_acm_ctx()
+        logger.test_step("Verify all VM statuses via ACM UI after relocate")
+        logger.assertion("navigate_using_fleet_virtualization: expected=True")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        logger.assertion(
+            f"check_or_assign_drpolicy_for_discovered_vms_via_ui:"
+            f" all_vms, cluster={primary_cluster_name}, expected=True"
+        )
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=all_cnv_workloads,
+            protection_name=protection_name_1,
+            namespace=workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
+        config.switch_to_cluster_by_name(primary_cluster_name)
+
+        # Validating data integrity (file1) after relocating VMs back to primary managed cluster
+        logger.test_step("Validate data integrity after relocate")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[0], md5sum_original, "Relocate"
+        )
+
+        # Validating data integrity (file2) after relocating VMs back to primary managed cluster
+        logger.test_step("Validate data integrity (file2) after relocate")
+        validate_data_integrity_vm(
+            all_cnv_workloads, vm_filepaths[1], md5sum_failover, "Relocate"
+        )
+
+        # Creating a file (file3) post relocate on all VMs
+        logger.info("Writing final data post-relocate")
+        for cnv_wl in all_cnv_workloads:
+            run_dd_io(
+                vm_obj=cnv_wl.vm_obj,
+                file_path=vm_filepaths[2],
+                username=cnv_wl.vm_username,
+                verify=True,
+            )
+
+        # ------------------------------------------------------------------ #
+        # Remove DR protection scenario                                        #
+        #                                                                      #
+        # Validates that a DRPC is NOT deleted until ALL VMs (standalone +      #
+        # shared) are removed from it.                                         #
+        # ------------------------------------------------------------------ #
+        config.switch_acm_ctx()
+        acm_obj = AcmAddClusters()
+
+        # -- DRPC1: remove VM3 (Shared), then VM1 (Standalone) ------------- #
+        logger.test_step("Remove DR protection from VM 3 (Shared with DRPC1)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[2],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC1 still exists after removing VM 3")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_1,
+            timeout=120,
+            should_exist=True,
+        )
+        verify_drpc_protected_vms(
+            resource_name_1,
+            expected_vms=[all_cnv_workloads[0].vm_name],
+            unexpected_vms=[all_cnv_workloads[2].vm_name],
+        )
+
+        logger.test_step(
+            "Remove DR protection from VM 1 (Standalone, last VM in DRPC1)"
+        )
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[0],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC1 is deleted after removing last VM")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_1,
+            timeout=300,
+            should_exist=False,
+        )
+
+        # -- DRPC2: remove VM4 (Shared), then VM2 (Standalone) ------------- #
+        logger.test_step("Remove DR protection from VM 4 (Shared with DRPC2)")
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[3],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC2 still exists after removing VM 4")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=120,
+            should_exist=True,
+        )
+        verify_drpc_protected_vms(
+            resource_name_2,
+            expected_vms=[all_cnv_workloads[1].vm_name],
+            unexpected_vms=[all_cnv_workloads[3].vm_name],
+        )
+
+        logger.test_step(
+            "Remove DR protection from VM 2 (Standalone, last VM in DRPC2)"
+        )
+        assert navigate_using_fleet_virtualization(acm_obj)
+        assert remove_drprotection_for_discovered_vm_via_ui(
+            acm_obj,
+            vm=all_cnv_workloads[1],
+            managed_cluster_name=primary_cluster_name,
+            namespace=workload_namespace,
+        )
+
+        logger.info("Validating DRPC2 is deleted after removing last VM")
+        config.switch_acm_ctx()
+        wait_for_resource_existence(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+            resource_name=resource_name_2,
+            timeout=300,
+            should_exist=False,
+        )
+
+        # Delete the second DRPolicy
+        logger.test_step("Delete the second DRPolicy")
+        dr_helpers.delete_drpolicy(dr_policy_6m_name)
+
+        logger.info(
+            f"Test for mixed protection types (Standalone and Shared) "
+            f"in namespace {workload_namespace} passed. "
+            f"DRPC groups: {protection_name_1}, {protection_name_2}"
+        )


### PR DESCRIPTION
- Add tests for Standalone/Shared DR protection with failover and relocate and removal of drprotection from UI for standalone and shared protections.
- Add mixed protection types test (4 VMs, 2 DRPCs) with DR lifecycle
- Add test verifying DRPC deletion when all shared VMs are unprotected
- Add remove_drprotection_for_discovered_vm_via_ui UI helper
- Add remove-protection locators to acm_configuration_4_19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended DR UI automation to better handle ACM UI variations and added a flow to remove DR protection for an individual discovered VM.
  * Expanded DR integration coverage for mixed protection types and incremental removal of shared-protection VMs.
* **Bug Fixes**
  * Made DR cleanup and failover readiness more reliable with safer delete gating, ignore-not-found handling, and targeted retries.
  * Improved UI navigation and modal/confirmation handling, and added more resilient page locator support across ACM versions.
* **Tests**
  * Updated DR test determinism and VM-scoped UI assertions across failover, recovery, and relocate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->