### PR TITLE
WIP: Add VLAN-based multus networking support for baremetal deployments

### DIFF
--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan.yaml
@@ -1,0 +1,47 @@
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  is_multus_enabled: true
+
+  # VLAN Configuration
+  # Set to true to use VLAN-based multus instead of shim interfaces
+  multus_use_vlan: true
+
+  # Public Network Configuration
+  multus_create_public_net: true
+  multus_public_net_interface: 'enp1s0f1'  # Base physical interface
+  multus_public_net_namespace: 'openshift-storage'
+  multus_public_net_type: 'macvlan'
+  multus_public_net_mode: 'bridge'
+
+  # Public Network VLAN Settings
+  multus_public_net_vlan_id: 201  # VLAN ID for public network
+  multus_public_net_ip_range: '192.168.20.0/24'
+
+  # Public Network Shim Settings (for host-to-pod communication)
+  multus_public_net_shim_name: 'odf-pub-shim'
+  multus_public_net_shim_network: '192.168.252.0/24'   # Shim network
+  # Note: Shim IPs are auto-assigned: .5 for first node, .6 for second, .7 for third
+
+  # Cluster Network Configuration
+  multus_create_cluster_net: true
+  multus_cluster_net_interface: 'enp1s0f1'  # Base physical interface
+  multus_cluster_net_namespace: 'openshift-storage'
+  multus_cluster_net_type: 'macvlan'
+  multus_cluster_net_mode: 'bridge'
+
+  # Cluster Network VLAN Settings
+  multus_cluster_net_vlan_id: 202  # VLAN ID for cluster network
+  multus_cluster_net_ip_range: '192.168.30.0/24'
+
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2510'

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_cluster_only.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_cluster_only.yaml
@@ -1,0 +1,33 @@
+---
+# VLAN-based Multus Configuration - Cluster Network Only
+# Configuration with just cluster network (private network for Ceph traffic)
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  is_multus_enabled: true
+
+  # VLAN Configuration
+  multus_use_vlan: true
+
+  # Public Network - Disabled
+  multus_create_public_net: false
+
+  # Cluster Network Configuration with VLAN
+  multus_create_cluster_net: true
+  multus_cluster_net_interface: 'enp1s0f1'  # Base physical interface
+  multus_cluster_net_namespace: 'openshift-storage'
+  multus_cluster_net_type: 'macvlan'
+  multus_cluster_net_mode: 'bridge'
+  multus_cluster_net_vlan_id: 202
+  multus_cluster_net_ip_range: '192.168.30.0/24'
+
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2510'

--- a/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_public_only.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_public_only.yaml
@@ -1,0 +1,38 @@
+---
+# VLAN-based Multus Configuration - Public Network Only
+# This is a simpler configuration for initial testing with just public network
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  is_multus_enabled: true
+
+  # VLAN Configuration
+  multus_use_vlan: true
+
+  # Public Network Configuration with VLAN
+  multus_create_public_net: true
+  multus_public_net_interface: 'enp1s0f1'  # Base physical interface
+  multus_public_net_namespace: 'openshift-storage'
+  multus_public_net_type: 'macvlan'
+  multus_public_net_mode: 'bridge'
+  multus_public_net_vlan_id: 201
+  multus_public_net_ip_range: '192.168.20.0/24'
+
+  # Public Network Shim Settings (for host-to-pod communication)
+  multus_public_net_shim_name: 'odf-pub-shim'
+  multus_public_net_shim_network: '192.168.252.0/24'   # Shim network (IPs .0-.15 reserved)
+  # Note: Shim IPs are auto-assigned: .5 for first node, .6 for second, .7 for third
+
+  # Cluster Network - Disabled
+  multus_create_cluster_net: false
+
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2510'

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -799,7 +799,7 @@ class Deployment(object):
 
         Args:
             subscription_name (str): Subscription name pattern
-            namespace (str): Namespace name for checking subscription if None then default from ENV_data
+            namespace (str): Namespace name for checking subscription if None then default from ENV_DATA
 
         """
         if not namespace:
@@ -945,8 +945,17 @@ class Deployment(object):
                         node_obj.exec_oc_debug_cmd(node=node, cmd_list=[ip_link_cmd])
 
             if create_public_net:
+                use_vlan = config.ENV_DATA.get("multus_use_vlan", False)
                 logger.info("Creating Multus public network")
-                public_net_data = templating.load_yaml(constants.MULTUS_PUBLIC_NET_YAML)
+
+                # Determine which template to use
+                if use_vlan:
+                    nad_to_load = constants.MULTUS_PUBLIC_NET_VLAN_YAML
+                    logger.info("Using VLAN-based public network template")
+                else:
+                    nad_to_load = constants.MULTUS_PUBLIC_NET_YAML
+
+                public_net_data = templating.load_yaml(nad_to_load)
                 public_net_data["metadata"]["name"] = config.ENV_DATA.get(
                     "multus_public_net_name"
                 )
@@ -955,12 +964,52 @@ class Deployment(object):
                 )
                 public_net_config_str = public_net_data["spec"]["config"]
                 public_net_config_dict = json.loads(public_net_config_str)
-                public_net_config_dict["master"] = config.ENV_DATA.get(
-                    "multus_public_net_interface"
-                )
-                public_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
-                    "multus_public_net_range"
-                )
+
+                # Configure master interface
+                if use_vlan:
+                    # For VLAN mode, master is the VLAN interface
+                    vlan_id = config.ENV_DATA.get("multus_public_net_vlan_id", 201)
+                    base_interface = config.ENV_DATA.get("multus_public_net_interface")
+                    vlan_interface = f"{base_interface}.{vlan_id}"
+                    public_net_config_dict["master"] = vlan_interface
+                    logger.info(
+                        f"Public network using VLAN interface: {vlan_interface}"
+                    )
+                else:
+                    # For non-VLAN mode, master is the base interface
+                    public_net_config_dict["master"] = config.ENV_DATA.get(
+                        "multus_public_net_interface"
+                    )
+
+                # Configure IP range
+                if use_vlan and config.ENV_DATA.get("multus_public_net_ip_range"):
+                    public_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
+                        "multus_public_net_ip_range"
+                    )
+                else:
+                    public_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
+                        "multus_public_net_range"
+                    )
+
+                # Configure IP range limits for VLAN mode
+                if use_vlan:
+                    # Add routes to shim network (critical for host-to-pod communication)
+                    # Default shim network is 192.168.252.0/24 (shim IPs assigned starting at .5)
+                    shim_network = config.ENV_DATA.get(
+                        "multus_public_net_shim_network", "192.168.252.0/24"
+                    )
+                    if "routes" not in public_net_config_dict["ipam"]:
+                        public_net_config_dict["ipam"]["routes"] = []
+                    # Ensure route to shim network exists
+                    if not any(
+                        r.get("dst") == shim_network
+                        for r in public_net_config_dict["ipam"]["routes"]
+                    ):
+                        public_net_config_dict["ipam"]["routes"].append(
+                            {"dst": shim_network}
+                        )
+                    logger.info(f"Added route to shim network: {shim_network}")
+
                 public_net_config_dict["type"] = config.ENV_DATA.get(
                     "multus_public_net_type"
                 )
@@ -975,10 +1024,17 @@ class Deployment(object):
                 run_cmd(f"oc create -f {public_net_yaml.name}")
 
             if create_cluster_net:
+                use_vlan = config.ENV_DATA.get("multus_use_vlan", False)
                 logger.info("Creating Multus cluster network")
-                cluster_net_data = templating.load_yaml(
-                    constants.MULTUS_CLUSTER_NET_YAML
-                )
+
+                # Determine which template to use
+                if use_vlan:
+                    nad_to_load = constants.MULTUS_CLUSTER_NET_VLAN_YAML
+                    logger.info("Using VLAN-based cluster network template")
+                else:
+                    nad_to_load = constants.MULTUS_CLUSTER_NET_YAML
+
+                cluster_net_data = templating.load_yaml(nad_to_load)
                 cluster_net_data["metadata"]["name"] = config.ENV_DATA.get(
                     "multus_cluster_net_name"
                 )
@@ -987,21 +1043,52 @@ class Deployment(object):
                 )
                 cluster_net_config_str = cluster_net_data["spec"]["config"]
                 cluster_net_config_dict = json.loads(cluster_net_config_str)
-                cluster_net_config_dict["master"] = config.ENV_DATA.get(
-                    "multus_cluster_net_interface"
-                )
-                cluster_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
-                    "multus_cluster_net_range"
-                )
-                cluster_net_config_dict["type"] = config.ENV_DATA.get(
-                    "multus_cluster_net_type"
-                )
+
+                # Configure master interface
+                if use_vlan:
+                    # For VLAN mode, master is the VLAN interface
+                    vlan_id = config.ENV_DATA.get("multus_cluster_net_vlan_id", 202)
+                    base_interface = config.ENV_DATA.get("multus_cluster_net_interface")
+                    vlan_interface = f"{base_interface}.{vlan_id}"
+                    cluster_net_config_dict["master"] = vlan_interface
+                    logger.info(
+                        f"Cluster network using VLAN interface: {vlan_interface}"
+                    )
+                else:
+                    # For non-VLAN mode, master is the base interface
+                    cluster_net_config_dict["master"] = config.ENV_DATA.get(
+                        "multus_cluster_net_interface"
+                    )
+
+                # Configure IP range
+                if use_vlan and config.ENV_DATA.get("multus_cluster_net_ip_range"):
+                    cluster_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
+                        "multus_cluster_net_ip_range"
+                    )
+                else:
+                    cluster_net_config_dict["ipam"]["range"] = config.ENV_DATA.get(
+                        "multus_cluster_net_range"
+                    )
+
+                # Configure IP range limits for VLAN mode
+                if use_vlan:
+                    if config.ENV_DATA.get("multus_cluster_net_ip_range_start"):
+                        cluster_net_config_dict["ipam"][
+                            "range_start"
+                        ] = config.ENV_DATA.get("multus_cluster_net_ip_range_start")
+                    if config.ENV_DATA.get("multus_cluster_net_ip_range_end"):
+                        cluster_net_config_dict["ipam"][
+                            "range_end"
+                        ] = config.ENV_DATA.get("multus_cluster_net_ip_range_end")
+                    # Remove routes for VLAN mode (not needed)
+                    cluster_net_config_dict["ipam"].pop("routes", None)
+
                 cluster_net_config_dict["mode"] = config.ENV_DATA.get(
                     "multus_cluster_net_mode"
                 )
                 cluster_net_data["spec"]["config"] = json.dumps(cluster_net_config_dict)
                 cluster_net_yaml = tempfile.NamedTemporaryFile(
-                    mode="w+", prefix="multus_public", delete=False
+                    mode="w+", prefix="multus_cluster", delete=False
                 )
                 templating.dump_data_to_temp_yaml(
                     cluster_net_data, cluster_net_yaml.name

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -750,6 +750,23 @@ MULTUS_PUBLIC_NET_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "multus-public-ne
 MULTUS_CLUSTER_NET_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "multus-cluster-net.yaml"
 )
+NODE_NETWORK_CONFIGURATION_POLICY = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "node_network_configuration_policy.yaml"
+)
+
+# VLAN-based Multus Networks (without shim interfaces)
+NODE_NETWORK_CONFIGURATION_POLICY_VLAN = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "node_network_configuration_policy_vlan.yaml"
+)
+NODE_NETWORK_CONFIGURATION_POLICY_VLAN_DUAL = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "node_network_configuration_policy_vlan_dual.yaml"
+)
+MULTUS_PUBLIC_NET_VLAN_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "multus-public-net-vlan.yaml"
+)
+MULTUS_CLUSTER_NET_VLAN_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "multus-cluster-net-vlan.yaml"
+)
 
 OPERATOR_SOURCE_NAME = "ocs-operatorsource"
 

--- a/ocs_ci/templates/ocs-deployment/multus-cluster-net-vlan.yaml
+++ b/ocs_ci/templates/ocs-deployment/multus-cluster-net-vlan.yaml
@@ -1,0 +1,18 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: cluster-net
+  namespace: openshift-storage
+  labels: {}
+  annotations: {}
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "type": "macvlan",
+      "master": "enp1s0f1.202",
+      "mode": "bridge",
+      "ipam": {
+            "type": "whereabouts",
+            "range": "192.168.30.0/24"
+      }
+  }'

--- a/ocs_ci/templates/ocs-deployment/multus-public-net-vlan.yaml
+++ b/ocs_ci/templates/ocs-deployment/multus-public-net-vlan.yaml
@@ -1,0 +1,21 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: public-net
+  namespace: openshift-storage
+  labels: {}
+  annotations: {}
+spec:
+  config: '{
+      "cniVersion": "0.3.1",
+      "type": "macvlan",
+      "master": "enp1s0f1.201",
+      "mode": "bridge",
+      "ipam": {
+            "type": "whereabouts",
+            "range": "192.168.20.0/24",
+            "routes": [
+                {"dst": "192.168.252.0/24"}
+            ]
+      }
+  }'

--- a/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_vlan.yaml
+++ b/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_vlan.yaml
@@ -1,0 +1,41 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ceph-public-net-vlan-worker-node
+  namespace: openshift-storage
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-node
+  desiredState:
+    interfaces:
+      # VLAN interface - NO IP (just for VLAN tagging)
+      - name: enp1s0f1.201  # VLAN interface - will be templated
+        description: VLAN interface for OpenShift Data Foundation public Multus network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: enp1s0f1  # Base physical interface - will be templated
+          id: 201  # VLAN ID - will be templated
+        ipv4:
+          enabled: false  # Critical: No IP on base VLAN interface
+          dhcp: false
+      # Shim interface - HAS IP (for host-to-pod communication)
+      - name: odf-pub-shim  # Shim interface name - will be templated
+        description: Shim interface for host connectivity to ODF pods (solves macvlan hairpin problem)
+        type: mac-vlan
+        state: up
+        mac-vlan:
+          base-iface: enp1s0f1.201  # Built on top of VLAN interface - will be templated
+          mode: bridge
+          promiscuous: true
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 192.168.252.5  # Static IP for shim - will be templated per node
+              prefix-length: 24  # /24 subnet to reach all Multus pod IPs
+    routes:
+      config:
+        - destination: 192.168.20.0/24  # Route to entire pod network - will be templated
+          next-hop-interface: odf-pub-shim  # Via shim interface - will be templated

--- a/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_vlan_dual.yaml
+++ b/ocs_ci/templates/ocs-deployment/node_network_configuration_policy_vlan_dual.yaml
@@ -1,0 +1,54 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ceph-networks-vlan-worker-node
+  namespace: openshift-storage
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+    kubernetes.io/hostname: worker-node
+  desiredState:
+    interfaces:
+      # Public network VLAN - NO IP
+      - name: enp1s0f1.201  # VLAN interface for public network - will be templated
+        description: VLAN interface for OpenShift Data Foundation public Multus network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: enp1s0f1  # Base physical interface - will be templated
+          id: 201  # Public VLAN ID - will be templated
+        ipv4:
+          enabled: false
+          dhcp: false
+      # Public network Shim - HAS IP (for host-to-pod communication)
+      - name: odf-pub-shim  # Public shim interface - will be templated
+        description: Shim interface for host connectivity to ODF public network pods
+        type: mac-vlan
+        state: up
+        mac-vlan:
+          base-iface: enp1s0f1.201  # Built on public VLAN - will be templated
+          mode: bridge
+          promiscuous: true
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 192.168.252.5  # Static IP for public shim - will be templated per node
+              prefix-length: 24  # /24 subnet to reach all Multus pod IPs
+      # Cluster network VLAN - NO IP
+      - name: enp1s0f1.202  # VLAN interface for cluster network - will be templated
+        description: VLAN interface for OpenShift Data Foundation cluster Multus network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: enp1s0f1  # Base physical interface - will be templated
+          id: 202  # Cluster VLAN ID - will be templated
+        ipv4:
+          enabled: false
+          dhcp: false
+      # Cluster network does NOT need shim (per Red Hat docs - pod-to-pod only)
+    routes:
+      config:
+        # Route to public network via shim
+        - destination: 192.168.20.0/24  # Route to public pod network - will be templated
+          next-hop-interface: odf-pub-shim  # Via public shim - will be templated


### PR DESCRIPTION
  Implement VLAN-based multus networking as an alternative to the existing
  one network approach for baremetal ODF deployments. This addresses network
  performance issues (high retransmits).

  Changes:
  - Add VLAN mode support to NodeNetworkConfigurationPolicy creation
  - Add VLAN interface configuration (e.g., enp1s0f1.201, enp1s0f1.202)
  - Update NetworkAttachmentDefinition to use VLAN interfaces as master
  - Remove unnecessary routes for VLAN-based deployments
  - Add new configuration parameter: multus_use_vlan

  New template files:
  - node_network_configuration_policy_vlan.yaml (single VLAN)
  - node_network_configuration_policy_vlan_dual.yaml (dual VLAN)
  - multus-public-net-vlan.yaml (public network NAD)
  - multus-cluster-net-vlan.yaml (cluster network NAD)

  New configuration files:
  - upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan.yaml (dual network)
  - upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_public_only.yaml (public only)
  - upi_1az_rhcos_multus_nvme_intel_3m_3w_vlan_cluster_only.yaml (cluster only)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>