### PR TITLE
Fix IO write overload in "test_resize_osd" on vSphere

### DIFF
--- a/ocs_ci/helpers/pod_helpers.py
+++ b/ocs_ci/helpers/pod_helpers.py
@@ -1,4 +1,9 @@
 import logging
+import random
+import time
+
+from ocs_ci.ocs.constants import VOLUME_MODE_BLOCK
+from ocs_ci.ocs.resources.pod import calculate_md5sum_of_pod_files
 
 logger = logging.getLogger(__name__)
 
@@ -143,3 +148,93 @@ def validate_all_pods_container_resources(pods_resources_details_dict):
                 invalid_values[pod_name] = res["invalid_values"]
 
     return {"result": all_ok, "invalid_values": invalid_values}
+
+
+def run_io_on_pods(pods, pod_file_name, size="1G", runtime=30):
+    """
+    Helper function to run IO on the pods
+
+    Args:
+        pods (list): The list of pods for running the IO
+        pod_file_name (str): The pod file name for fio
+        size (str): Size in MB or Gi, e.g. '200M'.
+            Default value is '1G'
+        runtime (int): The number of seconds IO should run for
+
+    """
+    logger.info("Starting IO on all pods")
+    for pod_obj in pods:
+        storage_type = "block" if pod_obj.pvc.volume_mode == VOLUME_MODE_BLOCK else "fs"
+        rate = f"{random.randint(1, 5)}M"
+        pod_obj.run_io(
+            storage_type=storage_type,
+            size=size,
+            runtime=runtime,
+            rate=rate,
+            fio_filename=pod_file_name,
+            end_fsync=1,
+        )
+        logger.info("IO started on pod %s", pod_obj.name)
+    logger.info("Started IO on all pods")
+
+
+def run_io_on_small_groups_of_pods(
+    pods,
+    pod_file_name,
+    size="1G",
+    runtime=30,
+    num_of_groups=3,
+    do_md5sum=False,
+    wait_between_groups=30,
+):
+    """
+    Run IO on pods in smaller groups to avoid overwhelming
+    the Ceph cluster with simultaneous writes.
+
+    After each group starts, the function waits
+    'wait_between_groups' seconds before starting the next
+    group. If do_md5sum is True, it also waits for IO to
+    complete and calculates md5sum per group.
+
+    Args:
+        pods (list): The list of pods for running the IO
+        pod_file_name (str): The pod file name for fio
+        size (str): Size in MB or Gi, e.g. '200M'.
+            Default value is '1G'
+        runtime (int): The number of seconds IO should
+            run for
+        num_of_groups (int): The number of groups to
+            divide the pods into for running IO
+        do_md5sum (bool): If True, wait for IO to
+            complete and calculate md5sum per group
+        wait_between_groups (int): Seconds to wait
+            between starting each group
+
+    """
+    total_pods = len(pods)
+    group_size = max(1, total_pods // num_of_groups)
+    num_groups = (total_pods + group_size - 1) // group_size
+    logger.info(
+        "Dividing %d pods into %d groups of ~%d for running IO",
+        total_pods,
+        num_groups,
+        group_size,
+    )
+
+    for i in range(0, total_pods, group_size):
+        group_num = i // group_size + 1
+        pod_group = pods[i : i + group_size]
+        logger.info(
+            "Running IO on pod group %d/%d (%d pods)",
+            group_num,
+            num_groups,
+            len(pod_group),
+        )
+        run_io_on_pods(pod_group, pod_file_name, size=size, runtime=runtime)
+        if do_md5sum:
+            calculate_md5sum_of_pod_files(pod_group, pod_file_name)
+        logger.info(
+            "Waiting %d seconds between groups",
+            wait_between_groups,
+        )
+        time.sleep(wait_between_groups)

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -27,7 +27,7 @@ from ocs_ci.framework.testlib import (
     tier4c,
     tier4a,
 )
-from ocs_ci.ocs.constants import VOLUME_MODE_BLOCK, OSD, ROOK_OPERATOR, MON_DAEMON
+from ocs_ci.ocs.constants import OSD, ROOK_OPERATOR, MON_DAEMON
 from ocs_ci.helpers.osd_resize import (
     ceph_verification_steps_post_resize_osd,
     check_ceph_health_after_resize_osd,
@@ -36,9 +36,9 @@ from ocs_ci.helpers.osd_resize import (
     basic_resize_osd,
     check_storage_size_is_reflected_in_ui,
 )
+from ocs_ci.helpers.pod_helpers import run_io_on_small_groups_of_pods
 from ocs_ci.ocs.resources.pod import (
     get_osd_pods,
-    calculate_md5sum_of_pod_files,
     verify_md5sum_on_pod_files,
 )
 from ocs_ci.ocs.resources.pvc import get_deviceset_pvcs, get_deviceset_pvs
@@ -137,33 +137,6 @@ class TestResizeOSD(ManageTest):
 
         request.addfinalizer(finalizer)
 
-    def run_io_on_pods(self, pods, size="1G", runtime=30):
-        """
-        Run IO on the pods
-
-        Args:
-            pods (list): The list of pods for running the IO
-            size (str): Size in MB or Gi, e.g. '200M'. Default value is '1G'
-            runtime (int): The number of seconds IO should run for
-
-        """
-        logger.info("Starting IO on all pods")
-        for pod_obj in pods:
-            storage_type = (
-                "block" if pod_obj.pvc.volume_mode == VOLUME_MODE_BLOCK else "fs"
-            )
-            rate = f"{random.randint(1, 5)}M"
-            pod_obj.run_io(
-                storage_type=storage_type,
-                size=size,
-                runtime=runtime,
-                rate=rate,
-                fio_filename=self.pod_file_name,
-                end_fsync=1,
-            )
-            logger.info(f"IO started on pod {pod_obj.name}")
-        logger.info("Started IO on all pods")
-
     def prepare_data_before_resize_osd(self):
         """
         Prepare the data before resizing the osd
@@ -178,12 +151,19 @@ class TestResizeOSD(ManageTest):
             pvc_size=pvc_size, num_of_rbd_pvc=5, num_of_cephfs_pvc=5
         )
         logger.info("Run IO on the pods for integrity check")
-        self.run_io_on_pods(self.pods_for_integrity_check)
-        logger.info("Calculate the md5sum of the pods for integrity check")
-        calculate_md5sum_of_pod_files(self.pods_for_integrity_check, self.pod_file_name)
+        run_io_on_small_groups_of_pods(
+            self.pods_for_integrity_check,
+            self.pod_file_name,
+            do_md5sum=True,
+        )
         runtime = 180
         logger.info(f"Run IO on the pods in the test background for {runtime} seconds")
-        self.run_io_on_pods(self.pods_for_run_io, size="2G", runtime=runtime)
+        run_io_on_small_groups_of_pods(
+            self.pods_for_run_io,
+            self.pod_file_name,
+            size="2G",
+            runtime=runtime,
+        )
 
     def verification_steps_post_resize_osd(self):
         ceph_verification_steps_post_resize_osd(
@@ -206,7 +186,11 @@ class TestResizeOSD(ManageTest):
         self.pvcs3, self.pods_for_run_io = self.create_pvcs_and_pods(
             pvc_size=pvc_size, num_of_rbd_pvc=6, num_of_cephfs_pvc=6
         )
-        self.run_io_on_pods(self.pods_for_run_io, size="2G")
+        run_io_on_small_groups_of_pods(
+            self.pods_for_run_io,
+            self.pod_file_name,
+            size="2G",
+        )
         logger.info("Check the cluster health")
         self.sanity_helpers.health_check()
 


### PR DESCRIPTION
fix https://github.com/red-hat-storage/ocs-ci/issues/14283

Run fio on pods in smaller staggered groups instead of all at once, to avoid overwhelming Ceph OSDs with simultaneous writes (mainly affects vSphere)
- Extract `run_io_on_pods` and `run_io_on_small_groups_of_pods` into `ocs_ci/helpers/pod_helpers.py` for reuse.
- Apply grouped pods IO to both `prepare_data_before_resize_osd` and `verification_steps_post_resize_osd`.


The OSD resize test was launching fio writes on all pods (10-12) simultaneously, which could overload the Ceph cluster and cause slow operations or health warnings. This issue mainly occurs on vSphere, where disk throughput is more limited. This update adds a helper that divides pods into smaller groups and staggers IO starts with a configurable delay between groups (default 30s), preventing the initial write burst from hitting all OSDs at once. The IO helper functions were moved from the `TestResizeOSD` class to `ocs_ci/helpers/pod_helpers.py` for reuse by other tests.
