### PR TITLE
Added Krknctl random scenario execution

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -602,6 +602,16 @@
         "verified_result": null
       }
     ],
+    "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
+      {
+        "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "ocs_ci/ocs/clients.py": [
       {
         "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",

--- a/conf/ocsci/krkn_chaos_config.yaml
+++ b/conf/ocsci/krkn_chaos_config.yaml
@@ -33,6 +33,8 @@ ENV_DATA:
       # NOTE: Only RBD (Ceph Block) PVCs support encryption via storage class
       #       CephFS PVCs do NOT support per-PVC encryption (cluster-wide only)
       use_encrypted_pvc: false  # Set to true to use encrypted RBD PVCs with encrypted storage class
+      # Cron schedule for keyrotation.csiaddons.openshift.io/schedule on encrypted RBD StorageClass
+      PV_ENCRYPTION_KEYROTATION_SCHEDULE: "*/3 * * * *"
 
       # Common workload parameters
       threads: 16

--- a/ocs_ci/krkn_chaos/background_cluster_operations.py
+++ b/ocs_ci/krkn_chaos/background_cluster_operations.py
@@ -31,6 +31,8 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.ocs.resources import pvc as pvc_helpers
 from ocs_ci.ocs.resources import job as job_helpers
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs import node as node_helpers
 from ocs_ci.ocs.exceptions import (
     UnexpectedBehaviour,
@@ -908,7 +910,7 @@ class BackgroundClusterOperations:
             num_pvcs = min(3, len(self.workloads))
             log.info(f"Will check up to {num_pvcs} workloads for PVCs")
 
-            # Collect PVCs from workloads
+            # Collect PVCs from workloads (coerce OCS → PVC for snapshot APIs)
             workload_pvcs = []
             for idx, workload in enumerate(self.workloads[:num_pvcs]):
                 log.debug(
@@ -919,18 +921,23 @@ class BackgroundClusterOperations:
                     f"has_pvc={hasattr(workload, 'pvc')}"
                 )
 
+                raw_list = []
                 if hasattr(workload, "pvc_objs"):
-                    pvc_list = workload.pvc_objs[:1]  # Take first PVC
-                    workload_pvcs.extend(pvc_list)
-                    log.debug(f"  → Found {len(pvc_list)} PVCs in pvc_objs")
+                    raw_list = workload.pvc_objs[:1]  # Take first PVC
+                    log.debug(f"  → Found {len(raw_list)} raw refs in pvc_objs")
                 elif hasattr(workload, "pvc_obj"):
-                    workload_pvcs.append(workload.pvc_obj)
-                    log.debug("  → Found 1 PVC in pvc_obj")
+                    raw_list = [workload.pvc_obj]
+                    log.debug("  → Found 1 raw ref in pvc_obj")
                 elif hasattr(workload, "pvc"):
-                    workload_pvcs.append(workload.pvc)
-                    log.debug("  → Found 1 PVC in pvc")
+                    raw_list = [workload.pvc]
+                    log.debug("  → Found 1 raw ref in pvc")
                 else:
                     log.debug("  → No PVC attributes found")
+
+                for raw in raw_list:
+                    coerced = self._coerce_workload_pvc_to_pvc_instance(raw)
+                    if coerced is not None:
+                        workload_pvcs.append(coerced)
 
             if not workload_pvcs:
                 log.warning(
@@ -954,7 +961,10 @@ class BackgroundClusterOperations:
                         f"Created snapshot {snapshot_obj.name} from PVC {pvc_obj.name}"
                     )
                 except Exception as e:
-                    log.error(f"Failed to create snapshot from PVC {pvc_obj.name}: {e}")
+                    pvc_name = getattr(pvc_obj, "name", None) if pvc_obj else None
+                    log.error(
+                        f"Failed to create snapshot from PVC {pvc_name or '(unknown)'}: {e}"
+                    )
                     continue
 
             if not snapshots:
@@ -1069,6 +1079,39 @@ class BackgroundClusterOperations:
     # Helper Methods
     # ==========================================================================
 
+    def _coerce_workload_pvc_to_pvc_instance(self, pvc_obj):
+        """
+        Normalize a workload PVC reference to :class:`~ocs_ci.ocs.resources.pvc.PVC`.
+
+        Some paths hand back plain :class:`~ocs_ci.ocs.resources.ocs.OCS` objects for
+        ``kind=PersistentVolumeClaim``; snapshot/clone helpers require the ``PVC``
+        subclass (``create_snapshot``, ``resize_pvc``, etc.).
+        """
+        if pvc_obj is None:
+            return None
+        if isinstance(pvc_obj, PVC):
+            return pvc_obj
+        if isinstance(pvc_obj, OCS) and getattr(pvc_obj, "kind", None) == (
+            "PersistentVolumeClaim"
+        ):
+            try:
+                if hasattr(pvc_obj, "reload"):
+                    pvc_obj.reload()
+                return PVC(**pvc_obj.data)
+            except Exception as err:
+                log.warning(
+                    "Could not coerce OCS to PVC (name=%s): %s",
+                    getattr(pvc_obj, "name", "?"),
+                    err,
+                )
+                return None
+        log.debug(
+            "Skipping non-PVC workload reference: type=%s kind=%s",
+            type(pvc_obj).__name__,
+            getattr(pvc_obj, "kind", None),
+        )
+        return None
+
     def _get_random_workload_pvc(self, provisioner_type: Optional[str] = None):
         """
         Get a random workload PVC.
@@ -1093,11 +1136,14 @@ class BackgroundClusterOperations:
                 continue
 
             for pvc_obj in workload_pvcs:
+                coerced = self._coerce_workload_pvc_to_pvc_instance(pvc_obj)
+                if coerced is None:
+                    continue
                 if provisioner_type:
-                    if provisioner_type in pvc_obj.provisioner:
-                        pvcs.append(pvc_obj)
+                    if provisioner_type in coerced.provisioner:
+                        pvcs.append(coerced)
                 else:
-                    pvcs.append(pvc_obj)
+                    pvcs.append(coerced)
 
         return random.choice(pvcs) if pvcs else None
 

--- a/ocs_ci/krkn_chaos/config/chaos_scenarios_list.yaml
+++ b/ocs_ci/krkn_chaos/config/chaos_scenarios_list.yaml
@@ -89,11 +89,6 @@ chaos_scenarios:
   #         jinja_template: scenarios/openshift/ibmcloud_node_scenarios.yml
   #         description: "Simulates node failures on IBM Cloud clusters"
 
-  # - time_scenarios:
-  #     - time-scenarios-example:
-  #         jinja_template: scenarios/openshift/time_scenarios_example.yml
-  #         description: "Manipulates system time to test time drift effects"
-
   # - cluster_shut_down_scenarios:
   #     - cluster-shut-down-scenario:
   #         jinja_template: scenarios/openshift/cluster_shut_down_scenario.yml
@@ -122,11 +117,6 @@ chaos_scenarios:
           jinja_template: scenarios/openshift/network_chaos.yml.j2
           description: "General network chaos simulation at cluster level"
 
-  # - service_hijacking_scenarios:
-  #     - service-hijacking:
-  #         jinja_template: scenarios/kube/service_hijacking.yaml
-  #         description: "Intercepts service traffic to simulate hijacking"
-
   # - syn_flood_scenarios:
   #     - syn-flood:
   #         jinja_template: scenarios/kube/syn_flood.yaml
@@ -139,8 +129,3 @@ chaos_scenarios:
   #     - node-network-filter:
   #         jinja_template: scenarios/kube/node-network-filter.yml
   #         description: "Applies network filters at node level using eBPF"
-
-  # - kubevirt_vm_outage:
-  #     - kubevirt-vm-outage:
-  #         jinja_template: scenarios/kubevirt/kubevirt-vm-outage.yaml
-  #         description: "Simulates unavailability of KubeVirt-based VMs"

--- a/ocs_ci/krkn_chaos/krkn_chaos.py
+++ b/ocs_ci/krkn_chaos/krkn_chaos.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import shlex
 import threading
 import subprocess
 import time
@@ -7,11 +8,12 @@ import json
 import re
 import yaml
 
-from ocs_ci.ocs.constants import KRKN_OUTPUT_DIR, KRKN_RUN_CMD
+from ocs_ci.ocs.constants import KRKN_OUTPUT_DIR, KRKN_RUN_CMD, KRKNCTL
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.krkn_chaos.krkn_port_manager import KrknPortManager
 from ocs_ci.framework import config
 from ocs_ci.utility.ibmcloud import get_ibmcloud_cluster_region
+from ocs_ci.utility.utils import exec_cmd
 
 log = logging.getLogger(__name__)
 
@@ -880,3 +882,647 @@ class KrKnRunner:
             if k != "telemetry":
                 normalized[k] = v
         return normalized
+
+
+class KrKnctlRunner:
+    """
+    Class to run krknctl CLI commands (run, random, list, describe, clean, attach,
+    graph, query-status, etc.) with a consistent environment and optional
+    global flags (e.g. private registry).
+    """
+
+    # Subcommands supported by krknctl
+    SUBCOMMANDS = (
+        "attach",
+        "clean",
+        "completion",
+        "describe",
+        "graph",
+        "help",
+        "list",
+        "query-status",
+        "random",
+        "run",
+    )
+
+    # Global flags (before subcommand) from `krknctl --help`
+    GLOBAL_FLAGS = (
+        "private_registry",
+        "private_registry_insecure",
+        "private_registry_password",
+        "private_registry_scenarios",
+        "private_registry_skip_tls",
+        "private_registry_token",
+        "private_registry_username",
+    )
+
+    def __init__(
+        self,
+        krknctl_binary=None,
+        kubeconfig=None,
+        use_sudo=True,
+        **global_flags,
+    ):
+        """
+        Args:
+            krknctl_binary (str): Path to krknctl binary. Defaults to
+                {KRKNCTL}/krknctl.
+            kubeconfig (str): Path to kubeconfig. If None, uses KUBECONFIG env
+                or cluster path from config.
+            use_sudo (bool): If True, run krknctl via sudo so it can use the
+                rootful podman socket (e.g. /run/podman/podman.sock). Default True.
+            **global_flags: Optional global flags for krknctl (e.g.
+                private_registry="quay.io",
+                private_registry_username="user",
+                private_registry_password="secret").
+                Names use underscores; they are converted to --kebab-case.
+        """
+        if krknctl_binary is None:
+            krknctl_binary = os.path.join(KRKNCTL, "krknctl")
+        self.krknctl_binary = krknctl_binary
+        self.kubeconfig = kubeconfig
+        self.use_sudo = use_sudo
+        self.global_flags = {
+            k: v for k, v in global_flags.items() if k in self.GLOBAL_FLAGS
+        }
+
+    def _env(self):
+        """Build environment dict for subprocess (e.g. KUBECONFIG)."""
+        env = os.environ.copy()
+        if self.kubeconfig is not None:
+            env["KUBECONFIG"] = self.kubeconfig
+        else:
+            kubeconfig_path = config.RUN.get("kubeconfig")
+            if kubeconfig_path:
+                env["KUBECONFIG"] = kubeconfig_path
+            else:
+                cluster_path = config.ENV_DATA.get("cluster_path")
+                if cluster_path:
+                    kubeconfig_path = os.path.join(
+                        cluster_path,
+                        config.RUN.get("kubeconfig_location", "auth/kubeconfig"),
+                    )
+                    if os.path.exists(kubeconfig_path):
+                        env["KUBECONFIG"] = kubeconfig_path
+        return env
+
+    def _flag_to_arg(self, key, value):
+        """Convert a Python kwarg to krknctl flag (--kebab-case)."""
+        flag = "--" + key.replace("_", "-")
+        if value is True:
+            return [flag]
+        if value is False or value is None:
+            return []
+        return [flag, str(value)]
+
+    def _build_cmd(self, subcommand, *args, **flags):
+        """
+        Build the full krknctl command as a list for exec_cmd.
+
+        Args:
+            subcommand (str): One of SUBCOMMANDS (run, random, list, ...).
+            *args: Positional arguments (e.g. scenario name, plan path).
+            **flags: Subcommand-specific flags (e.g. plan=path, wait_duration=60).
+                    Converted to --flag=value or --flag value.
+
+        Returns:
+            list: Command list [binary, ...global_flags, subcommand, ...args, ...flags].
+        """
+        if subcommand not in self.SUBCOMMANDS:
+            raise ValueError(
+                f"Unknown subcommand '{subcommand}'. Must be one of {self.SUBCOMMANDS}"
+            )
+        cmd = []
+        if self.use_sudo:
+            cmd.extend(["sudo", "-E", self.krknctl_binary])
+        else:
+            cmd.append(self.krknctl_binary)
+
+        if self.kubeconfig is not None:
+            cmd.extend(["--kubeconfig", self.kubeconfig])
+
+        for key, value in self.global_flags.items():
+            cmd.extend(self._flag_to_arg(key, value))
+
+        cmd.append(subcommand)
+
+        for a in args:
+            cmd.append(str(a))
+
+        for key, value in sorted(flags.items()):
+            if key in self.GLOBAL_FLAGS:
+                continue
+            cmd.extend(self._flag_to_arg(key, value))
+
+        return cmd
+
+    def run_subcommand(
+        self,
+        subcommand,
+        *args,
+        timeout=600,
+        ignore_error=False,
+        **flags,
+    ):
+        """
+        Run a krknctl subcommand and return the completed process.
+
+        Args:
+            subcommand (str): One of run, random, list, describe, clean, etc.
+            *args: Positional arguments for the subcommand.
+            timeout (int): Command timeout in seconds.
+            ignore_error (bool): If True, do not raise CommandFailed on non-zero exit.
+            **flags: Subcommand-specific flags.
+
+        Returns:
+            CompletedProcess: stdout, stderr, returncode (from exec_cmd).
+
+        Raises:
+            CommandFailed: If ignore_error is False and the command fails.
+        """
+        cmd = self._build_cmd(subcommand, *args, **flags)
+        log.info("Executing krknctl: %s", shlex.join(cmd))
+        try:
+            completed = exec_cmd(
+                cmd,
+                timeout=timeout,
+                ignore_error=ignore_error,
+                env=self._env(),
+            )
+        except CommandFailed as e:
+            log.error("krknctl %s failed: %s", subcommand, e)
+            raise
+        return completed
+
+    def run(self, scenario_name, *args, timeout=600, ignore_error=False, **flags):
+        """
+        Run a single scenario: krknctl run <scenario_name> [flags].
+
+        Equivalent to: krknctl run node-memory-hog --kubeconfig /path/to/kubeconfig
+
+        Args:
+            scenario_name (str): Scenario name (e.g. "node-memory-hog", "pod-scenarios",
+                from plan or krknctl list).
+            *args: Extra positional args for run.
+            timeout (int): Command timeout.
+            ignore_error (bool): If True, do not raise on non-zero exit.
+            **flags: Flags for run (e.g. wait_duration=120).
+
+        Returns:
+            CompletedProcess.
+
+        Example:
+            runner = KrKnctlRunner(kubeconfig="/path/to/kubeconfig")
+            runner.run("node-memory-hog")
+        """
+        return self.run_subcommand(
+            "run",
+            scenario_name,
+            *args,
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def run_node_memory_hog(
+        self,
+        chaos_duration=None,
+        memory_workers=None,
+        memory_consumption=None,
+        namespace=None,
+        node_selector=None,
+        timeout=600,
+        ignore_error=False,
+        **extra_flags,
+    ):
+        """
+        Run the node-memory-hog scenario with configurable parameters.
+
+        Equivalent to: krknctl run node-memory-hog --chaos-duration 60 ...
+
+        Args:
+            chaos_duration (int): Chaos duration in seconds. Default 60.
+            memory_workers (int): Number of memory workers. Default 1.
+            memory_consumption (str): Memory consumption (e.g. "90%", "95%").
+                Default "90%".
+            namespace (str): Target namespace. Default "default".
+            node_selector (str): Node selector (e.g. "node-role.kubernetes.io/worker").
+            timeout (int): Command timeout in seconds.
+            ignore_error (bool): If True, do not raise on non-zero exit.
+            **extra_flags: Any other flags for the scenario.
+
+        Returns:
+            CompletedProcess.
+
+        Example:
+            runner = KrKnctlRunner(kubeconfig="/path/to/kubeconfig")
+            runner.run_node_memory_hog(
+                chaos_duration=80,
+                memory_workers=2,
+                memory_consumption="95%",
+                namespace="openshift-storage",
+                node_selector="node-role.kubernetes.io/worker",
+            )
+        """
+        flags = dict(extra_flags)
+        if chaos_duration is not None:
+            flags["chaos_duration"] = chaos_duration
+        if memory_workers is not None:
+            flags["memory_workers"] = memory_workers
+        if memory_consumption is not None:
+            flags["memory_consumption"] = memory_consumption
+        if namespace is not None:
+            flags["namespace"] = namespace
+        if node_selector is not None:
+            flags["node_selector"] = node_selector
+        return self.run(
+            "node-memory-hog",
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def run_node_io_hog(
+        self,
+        chaos_duration=None,
+        io_block_size=None,
+        io_workers=None,
+        io_write_bytes=None,
+        node_mount_path=None,
+        namespace=None,
+        node_selector=None,
+        taints=None,
+        number_of_nodes=None,
+        timeout=600,
+        ignore_error=False,
+        **extra_flags,
+    ):
+        """
+        Run the node-io-hog scenario (disk pressure on a node).
+
+        Parameters map to: krknctl run node-io-hog --chaos-duration 60 --io-block-size 1m ...
+
+        Args:
+            chaos_duration (int): Chaos duration in seconds. Default 60.
+            io_block_size (str): I/O block size (e.g. "1m"). Default "1m".
+            io_workers (int): I/O workers. Default 5.
+            io_write_bytes (str): I/O write bytes (e.g. "10m"). Default "10m".
+            node_mount_path (str): Node mount path. Default "/root".
+            namespace (str): Target namespace. Default "default".
+            node_selector (str): Node selector (e.g. "node-role.kubernetes.io/worker").
+            taints (str): Node taints (e.g. "[]").
+            number_of_nodes (int): Number of nodes to target.
+            timeout (int): Command timeout in seconds.
+            ignore_error (bool): If True, do not raise on non-zero exit.
+            **extra_flags: Any other flags for the scenario.
+
+        Returns:
+            CompletedProcess.
+        """
+        flags = dict(extra_flags)
+        if chaos_duration is not None:
+            flags["chaos_duration"] = chaos_duration
+        if io_block_size is not None:
+            flags["io_block_size"] = io_block_size
+        if io_workers is not None:
+            flags["io_workers"] = io_workers
+        if io_write_bytes is not None:
+            flags["io_write_bytes"] = io_write_bytes
+        if node_mount_path is not None:
+            flags["node_mount_path"] = node_mount_path
+        if namespace is not None:
+            flags["namespace"] = namespace
+        if node_selector is not None:
+            flags["node_selector"] = node_selector
+        if taints is not None:
+            flags["taints"] = taints
+        if number_of_nodes is not None:
+            flags["number_of_nodes"] = number_of_nodes
+        return self.run(
+            "node-io-hog",
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def run_node_cpu_hog(
+        self,
+        chaos_duration=None,
+        cores=None,
+        cpu_percentage=None,
+        namespace=None,
+        node_selector=None,
+        taints=None,
+        number_of_nodes=None,
+        timeout=600,
+        ignore_error=False,
+        **extra_flags,
+    ):
+        """
+        Run the node-cpu-hog scenario (CPU pressure on a node).
+
+        Parameters map to: krknctl run node-cpu-hog --chaos-duration 60 --cpu-percentage 50 ...
+
+        Args:
+            chaos_duration (int): Chaos duration in seconds. Default 60.
+            cores (int): Number of CPU cores to stress.
+            cpu_percentage (int): CPU percentage (e.g. 50, 95). Default 50.
+            namespace (str): Target namespace. Default "default".
+            node_selector (str): Node selector (e.g. "node-role.kubernetes.io/worker").
+            taints (str): Node taints (e.g. "[]").
+            number_of_nodes (int): Number of nodes to target.
+            timeout (int): Command timeout in seconds.
+            ignore_error (bool): If True, do not raise on non-zero exit.
+            **extra_flags: Any other flags for the scenario.
+
+        Returns:
+            CompletedProcess.
+        """
+        flags = dict(extra_flags)
+        if chaos_duration is not None:
+            flags["chaos_duration"] = chaos_duration
+        if cores is not None:
+            flags["cores"] = cores
+        if cpu_percentage is not None:
+            flags["cpu_percentage"] = cpu_percentage
+        if namespace is not None:
+            flags["namespace"] = namespace
+        if node_selector is not None:
+            flags["node_selector"] = node_selector
+        if taints is not None:
+            flags["taints"] = taints
+        if number_of_nodes is not None:
+            flags["number_of_nodes"] = number_of_nodes
+        return self.run(
+            "node-cpu-hog",
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def random(
+        self,
+        plan_path,
+        *args,
+        alerts_profile=None,
+        exit_on_error=False,
+        graph_dump=None,
+        max_parallel=None,
+        metrics_profile=None,
+        number_of_scenarios=None,
+        timeout=3600,
+        ignore_error=False,
+        **extra_flags,
+    ):
+        """
+        Run a random chaos run from a plan file: krknctl random run <plan_path> [flags].
+
+        Only non-empty options are passed to the command; omit a parameter to leave it unset.
+
+        Args:
+            plan_path (str): Path to the plan JSON file (e.g. from generate_random_plan_file).
+            *args: Extra positional args for random (after plan_path).
+            alerts_profile (str): Custom alerts profile file path (--alerts-profile).
+            exit_on_error (bool): If True, interrupt workflow and exit non-zero on error
+                (--exit-on-error).
+            graph_dump (str): File path to persist the generated dependency graph
+                (--graph-dump).
+            max_parallel (int): Maximum number of parallel scenarios (--max-parallel).
+            metrics_profile (str): Custom metrics profile file path (--metrics-profile).
+            number_of_scenarios (int): Number of elements to select from the execution plan
+                (--number-of-scenarios).
+            timeout (int): Command timeout (default 1 hour for chaos run).
+            ignore_error (bool): If True, do not raise on non-zero exit.
+            **extra_flags: Any other flags for random run (only non-empty values are passed).
+
+        Returns:
+            CompletedProcess.
+        """
+        flags = dict(extra_flags)
+        if alerts_profile is not None and str(alerts_profile).strip():
+            flags["alerts_profile"] = alerts_profile
+        if exit_on_error:
+            flags["exit_on_error"] = True
+        if graph_dump is not None and str(graph_dump).strip():
+            flags["graph_dump"] = graph_dump
+        if max_parallel is not None:
+            flags["max_parallel"] = max_parallel
+        if metrics_profile is not None and str(metrics_profile).strip():
+            flags["metrics_profile"] = metrics_profile
+        if number_of_scenarios is not None:
+            flags["number_of_scenarios"] = number_of_scenarios
+        return self.run_subcommand(
+            "random",
+            "run",
+            plan_path,
+            *args,
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def random_background(
+        self,
+        plan_path,
+        log_path=None,
+        alerts_profile=None,
+        exit_on_error=False,
+        graph_dump=None,
+        max_parallel=None,
+        metrics_profile=None,
+        number_of_scenarios=None,
+        echo_to_log=True,
+        **extra_flags,
+    ):
+        """
+        Start krknctl random run in a background process. Stdout/stderr are
+        streamed to a log file and optionally echoed to the test log in real
+        time so long-running runs are easy to monitor. Caller polls the
+        returned process and runs cleanup when it exits.
+
+        Args:
+            plan_path (str): Path to the plan JSON file.
+            log_path (str): Path to the log file. If None, uses
+                <dirname(plan_path)>/krknctl.log.
+            alerts_profile: Optional --alerts-profile.
+            exit_on_error: Optional --exit-on-error.
+            graph_dump: Optional --graph-dump.
+            max_parallel: Optional --max-parallel.
+            metrics_profile: Optional --metrics-profile.
+            number_of_scenarios: Optional --number-of-scenarios.
+            echo_to_log (bool): If True (default), stream each line to log.info
+                so test output shows krknctl progress in real time.
+            **extra_flags: Any other flags for random run.
+
+        Returns:
+            tuple: (process, log_path). process is subprocess.Popen; poll with
+                process.poll() (None = still running). log_path is the log file path.
+        """
+        if log_path is None:
+            log_path = os.path.join(os.path.dirname(plan_path), "krknctl.log")
+        flags = dict(extra_flags)
+        if alerts_profile is not None and str(alerts_profile).strip():
+            flags["alerts_profile"] = alerts_profile
+        if exit_on_error:
+            flags["exit_on_error"] = True
+        if graph_dump is not None and str(graph_dump).strip():
+            flags["graph_dump"] = graph_dump
+        if max_parallel is not None:
+            flags["max_parallel"] = max_parallel
+        if metrics_profile is not None and str(metrics_profile).strip():
+            flags["metrics_profile"] = metrics_profile
+        if number_of_scenarios is not None:
+            flags["number_of_scenarios"] = number_of_scenarios
+        cmd = self._build_cmd("random", "run", plan_path, **flags)
+        log.info(
+            "Starting krknctl in background (output -> %s): %s",
+            log_path,
+            shlex.join(cmd),
+        )
+        os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=self._env(),
+            bufsize=1,
+        )
+
+        def _stream_stdout(proc, path, echo):
+            """Read process stdout line by line; write to file and optionally to log."""
+            with open(path, "w") as f:
+                try:
+                    for line in iter(proc.stdout.readline, b""):
+                        text = line.decode("utf-8", errors="replace").rstrip()
+                        f.write(text + "\n")
+                        f.flush()
+                        if echo and text:
+                            log.info("[krknctl] %s", text)
+                except (ValueError, OSError):
+                    pass
+                finally:
+                    proc.stdout.close()
+
+        def _heartbeat(proc, path, interval=60):
+            """Log periodically while krknctl is still running so monitoring is visible."""
+            while proc.poll() is None:
+                time.sleep(interval)
+                if proc.poll() is None:
+                    log.info(
+                        "krknctl is still running (monitoring; log file: %s)",
+                        path,
+                    )
+
+        reader = threading.Thread(
+            target=_stream_stdout,
+            args=(process, log_path, echo_to_log),
+            name="krknctl-log-reader",
+            daemon=True,
+        )
+        reader.start()
+        heartbeat = threading.Thread(
+            target=_heartbeat,
+            args=(process, log_path),
+            name="krknctl-heartbeat",
+            daemon=True,
+        )
+        heartbeat.start()
+        return process, log_path
+
+    def list_scenarios(self, *args, timeout=60, ignore_error=False, **flags):
+        """
+        List available or running scenarios: krknctl list [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "list", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def describe(self, scenario_name, *args, timeout=30, ignore_error=False, **flags):
+        """
+        Describe a scenario: krknctl describe <scenario_name> [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "describe",
+            scenario_name,
+            *args,
+            timeout=timeout,
+            ignore_error=ignore_error,
+            **flags,
+        )
+
+    def clean(self, *args, timeout=120, ignore_error=False, **flags):
+        """
+        Clean already run scenario files and containers: krknctl clean [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "clean", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def attach(self, *args, timeout=30, ignore_error=False, **flags):
+        """
+        Connect to running scenario logs: krknctl attach [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "attach", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def graph(self, *args, timeout=300, ignore_error=False, **flags):
+        """
+        Run or scaffold a dependency-graph run: krknctl graph [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "graph", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def query_status(self, *args, timeout=30, ignore_error=False, **flags):
+        """
+        Check status of container(s): krknctl query-status [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "query-status", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def completion(self, *args, timeout=10, ignore_error=False, **flags):
+        """
+        Generate shell completion script: krknctl completion [flags].
+
+        Returns:
+            CompletedProcess.
+        """
+        return self.run_subcommand(
+            "completion", *args, timeout=timeout, ignore_error=ignore_error, **flags
+        )
+
+    def help_cmd(self, subcommand=None, *args, timeout=10, ignore_error=False):
+        """
+        Help for krknctl or a subcommand: krknctl help [command].
+
+        Args:
+            subcommand (str): Optional subcommand name (e.g. "random", "run").
+
+        Returns:
+            CompletedProcess.
+        """
+        if subcommand is not None:
+            args = (subcommand,) + args
+        return self.run_subcommand(
+            "help", *args, timeout=timeout, ignore_error=ignore_error
+        )

--- a/ocs_ci/krkn_chaos/krkn_helpers.py
+++ b/ocs_ci/krkn_chaos/krkn_helpers.py
@@ -3,6 +3,7 @@ import os
 import re
 import pytest
 from ocs_ci.ocs.constants import (
+    CEPH_HEALTH_ERROR,
     KRKN_CHAOS_DIR,
     OPENSHIFT_STORAGE_NAMESPACE,
     # Component label constants
@@ -39,8 +40,12 @@ from ocs_ci.ocs.constants import (
     KRKN_CLOUD_IBM,
     KRKN_CLOUD_VMWARE,
     KRKN_CLOUD_BAREMETAL,
+    FUSIONAAS_PLATFORM,
+    MANAGED_SERVICE_PLATFORMS,
 )
 from ocs_ci.ocs import ocp
+from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.exceptions import NoobaaHealthException
 from ocs_ci.ocs.node import get_worker_nodes, get_master_nodes
 from ocs_ci.krkn_chaos.krkn_scenario_generator import (
     ApplicationOutageScenarios,
@@ -51,6 +56,7 @@ from ocs_ci.krkn_chaos.krkn_scenario_generator import (
 )
 from ocs_ci.resiliency.resiliency_tools import CephStatusTool
 from ocs_ci.framework import config
+from ocs_ci.utility.utils import ceph_crash_info_display
 
 log = logging.getLogger(__name__)
 
@@ -88,7 +94,7 @@ def get_krkn_cloud_type():
     Get the Krkn cloud type based on the current platform.
 
     Returns:
-        str: Krkn cloud type (aws, azure, ibm, vmware, bm)
+        str: Krkn cloud type (aws, azure, ibmcloud, vmware, bm)
 
     Raises:
         pytest.skip: If platform is not supported for node chaos testing
@@ -2095,6 +2101,17 @@ class CephHealthHelper(BaseScenarioHelper):
                 return True, ""
             else:
                 self.log.error("❌ Ceph crashes detected")
+                # Same as resiliency: log each crash ID and `ceph crash info <id>` output
+                try:
+                    self.log.error(
+                        "Ceph crash details (ceph crash info <crash_id>), "
+                        "same as resiliency ceph_crash_info_display:"
+                    )
+                    ceph_crash_info_display(ceph_status.toolbox)
+                except Exception as disp_ex:
+                    self.log.warning(
+                        "Could not run ceph_crash_info_display on toolbox: %s", disp_ex
+                    )
                 # Get detailed crash information for logging and error message
                 error_msg = (
                     f"Ceph crashes detected after {component_label} {chaos_type}. "
@@ -2120,7 +2137,10 @@ class CephHealthHelper(BaseScenarioHelper):
                             self.log.error(f"   ... and {remaining} more crashes")
                             error_msg += f"  ... and {remaining} more crash(es)\n"
 
-                        error_msg += "\nRun 'ceph crash ls' and 'ceph crash info <crash_id>' for more details."
+                        error_msg += (
+                            "\nFull `ceph crash info <crash_id>` output was logged above "
+                            "(same as resiliency ceph_crash_info_display)."
+                        )
                     else:
                         error_msg += "Unable to retrieve crash details."
                 except Exception as detail_ex:
@@ -2133,6 +2153,99 @@ class CephHealthHelper(BaseScenarioHelper):
             self.log.error(f"Failed to check Ceph crashes: {e}")
             # In case of check failure, assume no crashes (conservative approach)
             return True, ""
+
+
+def _krkn_should_run_noobaa_health_check():
+    """
+    Whether to assert Noobaa health, aligned with
+    :meth:`ocs_ci.ocs.cluster.CephCluster.cluster_health_check` (Noobaa block).
+
+    Krkn chaos jobs run on OCP > 4.10 only, so the BZ 2075422 live-deployment
+    Noobaa skip from ``cluster_health_check`` is not replicated here.
+
+    Skips when ``CephCluster`` is not fully applicable (mcg-only / Fusion
+    consumer), on managed-service platforms, or when Noobaa is disabled in
+    config.
+    """
+    if config.ENV_DATA.get("mcg_only_deployment"):
+        return False
+    if (
+        config.ENV_DATA.get("platform") == FUSIONAAS_PLATFORM
+        and str(config.ENV_DATA.get("cluster_type", "")).lower() == "consumer"
+    ):
+        return False
+    if config.ENV_DATA["platform"] in MANAGED_SERVICE_PLATFORMS:
+        return False
+    if config.COMPONENTS["disable_noobaa"]:
+        return False
+    return True
+
+
+def krkn_exit_criteria(chaos_context="krkn chaos", namespace=None):
+    """
+    Generic exit criteria: assert no Ceph crash, cluster not in HEALTH_ERR, and
+    Noobaa healthy when applicable.
+
+    Call at the end of any krkn/krknctl chaos test to fail if the cluster has
+    crashes or is in HEALTH_ERR state after chaos. Noobaa health uses
+    :meth:`ocs_ci.ocs.cluster.CephCluster.wait_for_noobaa_health_ok` when
+    :func:`_krkn_should_run_noobaa_health_check` returns true (same gating as
+    ``cluster_health_check`` except the BZ 2075422 skip, omitted for OCP > 4.10
+    Krkn jobs).
+
+    Args:
+        chaos_context (str): Short description for log/assert messages
+            (e.g. "krknctl random chaos", "krknctl service disruption").
+        namespace (str): OpenShift namespace for the cluster. Defaults to
+            OPENSHIFT_STORAGE_NAMESPACE.
+
+    Raises:
+        AssertionError: If Ceph crash(es) were generated, cluster is in
+            HEALTH_ERR, or Noobaa is not healthy (when checks run).
+    """
+    if namespace is None:
+        namespace = OPENSHIFT_STORAGE_NAMESPACE
+    health_helper = CephHealthHelper(namespace=namespace)
+    no_crashes, crash_details = health_helper.check_ceph_crashes(None, chaos_context)
+    assert no_crashes, f"Ceph crash(es) generated during test: {crash_details}"
+
+    ceph_status = CephStatusTool()
+    health_status = ceph_status.get_ceph_health()
+    assert health_status != CEPH_HEALTH_ERROR, (
+        f"Ceph cluster is in {CEPH_HEALTH_ERROR} state after test "
+        f"(status: {health_status})"
+    )
+
+    if _krkn_should_run_noobaa_health_check():
+        log.info("Checking Noobaa health after %s", chaos_context)
+        try:
+            CephCluster().wait_for_noobaa_health_ok()
+        except NoobaaHealthException as exc:
+            raise AssertionError(
+                f"Noobaa is not healthy after {chaos_context}: {exc}"
+            ) from exc
+
+
+def krknctl_random_test_exit_criteria(
+    chaos_context="krknctl random chaos", namespace=None
+):
+    """
+    Exit criteria for krknctl random chaos tests.
+
+    Calls krkn_exit_criteria() with the given context. Use at the end of
+    krknctl random / service disruption tests to assert no Ceph crash and
+    cluster not in HEALTH_ERR.
+
+    Args:
+        chaos_context (str): Short description for log/assert messages
+            (e.g. "krknctl random chaos", "krknctl service disruption").
+        namespace (str): OpenShift namespace for the cluster. Defaults to
+            OPENSHIFT_STORAGE_NAMESPACE.
+
+    Raises:
+        AssertionError: If Ceph crash(es) were generated or cluster is in HEALTH_ERR.
+    """
+    krkn_exit_criteria(chaos_context=chaos_context, namespace=namespace)
 
 
 # ============================================================================

--- a/ocs_ci/krkn_chaos/krkn_scenario_generator.py
+++ b/ocs_ci/krkn_chaos/krkn_scenario_generator.py
@@ -918,7 +918,7 @@ class NodeScenarios:
     Supported cloud types:
         - aws: Amazon Web Services
         - azure: Microsoft Azure
-        - ibm: IBM Cloud
+        - ibmcloud: IBM Cloud
         - bm: BareMetal
         - vmware: VMware vSphere
 
@@ -938,7 +938,7 @@ class NodeScenarios:
     # Cloud type constants
     CLOUD_AWS = "aws"
     CLOUD_AZURE = "azure"
-    CLOUD_IBM = "ibm"
+    CLOUD_IBM = "ibmcloud"
     CLOUD_BAREMETAL = "bm"
     CLOUD_VMWARE = "vmware"
 
@@ -1001,7 +1001,7 @@ class NodeScenarios:
 
         Args:
             scenario_dir (str): Directory to write the YAML file.
-            cloud_type (str): Cloud provider type (aws, azure, ibm, bm, vmware).
+            cloud_type (str): Cloud provider type (aws, azure, ibmcloud, bm, vmware).
             scenarios (list, optional): List of scenario dicts for multiple scenarios.
                 Each dict can have all the parameters below.
             actions (list, optional): List of actions for single scenario mode

--- a/ocs_ci/krkn_chaos/krkn_workload_config.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_config.py
@@ -236,6 +236,19 @@ class KrknWorkloadConfig:
         vdbench_config = self.get_vdbench_config()
         return vdbench_config.get("use_encrypted_pvc", False)
 
+    def get_pv_encryption_keyrotation_schedule(self) -> str:
+        """
+        Cron schedule for PV encryption key rotation annotation on encrypted RBD StorageClass.
+
+        Applied as ``keyrotation.csiaddons.openshift.io/schedule`` when encrypted
+        RBD storage classes are created for Krkn VDBENCH workloads.
+
+        Returns:
+            str: Cron expression (default: every 3 minutes, matching prior hardcoded behavior)
+        """
+        vdbench_config = self.get_vdbench_config()
+        return vdbench_config.get("PV_ENCRYPTION_KEYROTATION_SCHEDULE", "*/3 * * * *")
+
     def get_block_workload_config(self) -> Dict[str, Any]:
         """
         Get block workload configuration.

--- a/ocs_ci/krkn_chaos/krkn_workload_factory.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_factory.py
@@ -3,10 +3,48 @@ import subprocess
 import tempfile
 import time
 from contextlib import suppress
+from ocs_ci.helpers.keyrotation_helper import PVKeyrotation
 from ocs_ci.ocs import constants
 from ocs_ci.krkn_chaos.krkn_workload_config import KrknWorkloadConfig
 
 log = logging.getLogger(__name__)
+
+
+def _ensure_tenant_kms_for_encrypted_rbd(proj_obj, pv_encryption_kms_setup_factory):
+    """
+    Configure KMS for encrypted RBD workloads: resolve encryptionKMSID and, for
+    Vault token mode, create ceph-csi-kms-token in the tenant namespace.
+
+    Mirrors the flow in test_rbd_pv_encryption and multi_cnv_workload_factory.
+
+    Args:
+        proj_obj: Project / namespace object for tenant resources.
+        pv_encryption_kms_setup_factory: pytest fixture callable from conftest.
+
+    Returns:
+        tuple: (encryption_kms_id str or None, kms client object or None)
+    """
+    from ocs_ci.framework import config as ocsci_config
+
+    if not pv_encryption_kms_setup_factory:
+        return None, None
+
+    kms_provider = ocsci_config.ENV_DATA.get("KMS_PROVIDER", "")
+
+    if kms_provider.lower() == constants.HPCS_KMS_PROVIDER:
+        kms = pv_encryption_kms_setup_factory("v1")
+        return kms.kmsid, kms
+
+    if kms_provider == constants.AZURE_KV_PROVIDER_NAME:
+        kms = pv_encryption_kms_setup_factory()
+        return kms.azure_kms_connection_name, kms
+
+    # Vault (default): tenant must have Secret ceph-csi-kms-token for CSI.
+    use_vault_namespace = ocsci_config.ENV_DATA.get("vault_hcp", False)
+    kms = pv_encryption_kms_setup_factory("v2", use_vault_namespace)
+    kms.vault_path_token = kms.generate_vault_token()
+    kms.create_vault_csi_kms_token(namespace=proj_obj.namespace)
+    return kms.kmsid, kms
 
 
 class WorkloadOps:
@@ -213,6 +251,15 @@ class WorkloadOps:
                 with suppress(Exception):
                     workload.cleanup_workload()
 
+    def stop_background_operations_on_chaos_failure(self):
+        """
+        Stop background cluster operations when chaos aborts early (e.g. Ceph crash).
+
+        Safe to call multiple times. Does not validate or tear down workloads; use
+        validate_and_cleanup() for normal post-chaos teardown.
+        """
+        self._stop_background_cluster_operations()
+
     def _stop_background_cluster_operations(self):
         """Stop background cluster operations."""
         if not self.background_cluster_ops:
@@ -343,6 +390,7 @@ class KrknWorkloadFactory:
         loaded_fixtures=None,
         timeout=360,
         storageclass_factory=None,
+        pv_encryption_kms_setup_factory=None,
         # Backward compatibility - old signature
         resiliency_workload=None,
         vdbench_block_config=None,
@@ -362,6 +410,7 @@ class KrknWorkloadFactory:
             loaded_fixtures: Dict of loaded fixtures (preferred, registry-based)
             timeout: Timeout for operations
             storageclass_factory: Storage class factory fixture (for encrypted PVCs)
+            pv_encryption_kms_setup_factory: KMS setup fixture (tenant Vault token, etc.)
 
             # Backward compatibility (deprecated - use loaded_fixtures)
             resiliency_workload: VDBENCH fixture (optional)
@@ -436,9 +485,10 @@ class KrknWorkloadFactory:
             for param in fixture_params:
                 args.append(loaded_fixtures.get(param))
 
-            # Add storageclass_factory for VDBENCH workloads (for encrypted PVC support)
-            if workload_type == "VDBENCH" and storageclass_factory is not None:
+            # Add storageclass_factory and KMS factory for VDBENCH (encrypted PVC support)
+            if workload_type == "VDBENCH":
                 args.append(storageclass_factory)
+                args.append(pv_encryption_kms_setup_factory)
 
             # Create workloads using factory method
             try:
@@ -468,6 +518,7 @@ class KrknWorkloadFactory:
                         loaded_fixtures.get("vdbench_block_config"),
                         loaded_fixtures.get("vdbench_filesystem_config"),
                         storageclass_factory,
+                        pv_encryption_kms_setup_factory,
                     )
                     workloads_by_type[KrknWorkloadConfig.VDBENCH] = vdbench_workloads
                     all_workloads.extend(vdbench_workloads)
@@ -514,6 +565,8 @@ class KrknWorkloadFactory:
             resiliency_workload,
             vdbench_block_config,
             vdbench_filesystem_config,
+            None,
+            None,
         )
         return WorkloadOps(proj_obj, workloads, [KrknWorkloadConfig.VDBENCH])
 
@@ -525,6 +578,7 @@ class KrknWorkloadFactory:
         vdbench_block_config,
         vdbench_filesystem_config,
         storageclass_factory=None,
+        pv_encryption_kms_setup_factory=None,
     ):
         """Create VDBENCH workloads for a given project.
 
@@ -535,6 +589,7 @@ class KrknWorkloadFactory:
             vdbench_block_config: VDBENCH block config fixture
             vdbench_filesystem_config: VDBENCH filesystem config fixture
             storageclass_factory: Storage class factory fixture (optional, for encrypted PVCs)
+            pv_encryption_kms_setup_factory: KMS setup fixture (optional; required for Vault-encrypted RBD)
 
         Returns:
             list: List of created workload objects
@@ -700,13 +755,24 @@ class KrknWorkloadFactory:
         # NOTE: Only RBD (CEPHBLOCKPOOL) supports per-PVC encryption via storage class
         # CephFS does NOT support per-PVC encryption via storage class parameters
         encrypted_storage_classes = {}
+        encryption_kms_id = None
         if use_encrypted and storageclass_factory is not None:
             log.info("Creating encrypted storage classes for VDBENCH workloads")
             try:
+                encryption_kms_id, _kms = _ensure_tenant_kms_for_encrypted_rbd(
+                    proj_obj, pv_encryption_kms_setup_factory
+                )
+                if not encryption_kms_id:
+                    log.warning(
+                        "Encrypted PVCs requested but pv_encryption_kms_setup_factory "
+                        "was not provided or KMS setup returned no encryption_kms_id; "
+                        "RBD provisioning may fail (e.g. missing ceph-csi-kms-token)."
+                    )
                 # Create encrypted RBD storage class ONLY (CephFS not supported)
                 encrypted_rbd_sc = storageclass_factory(
                     interface=constants.CEPHBLOCKPOOL,
                     encrypted=True,
+                    encryption_kms_id=encryption_kms_id,
                 )
             except Exception as e:
                 log.error(f"Failed to create encrypted storage class: {e}")
@@ -718,6 +784,10 @@ class KrknWorkloadFactory:
                 log.info(
                     f"✓ Created encrypted RBD storage class: {encrypted_rbd_sc.name}"
                 )
+
+                kr_schedule = self.config.get_pv_encryption_keyrotation_schedule()
+                pvk_obj = PVKeyrotation(encrypted_rbd_sc)
+                pvk_obj.annotate_storageclass_key_rotation(schedule=kr_schedule)
 
                 # IMPORTANT: CephFS encryption is NOT supported via storage class parameters
                 # CephFS can only use cluster-wide encryption (configured at StorageCluster level)

--- a/ocs_ci/krkn_chaos/krknclt_helper.py
+++ b/ocs_ci/krkn_chaos/krknclt_helper.py
@@ -1,0 +1,996 @@
+"""
+Krkctl plan generation for chaos testing.
+
+The plan template (plan.json.j2) matches the workable krknctl plan format: each
+scenario key is "scenario_name_{{ suffix }}" and depends_on is "root_{{ suffix }}".
+PlanGenerator parses the Jinja template, fills parameters, and writes the plan file;
+the instance holds the plan file path after generation.
+"""
+
+import json
+import logging
+import os
+import random
+import string
+import copy
+import subprocess
+import time
+
+from jinja2 import Template
+
+from ocs_ci.ocs.constants import (
+    KRKN_CLOUD_IBM,
+    KRKN_CLOUD_VMWARE,
+    KRKN_OUTPUT_DIR,
+    KRKNCTL_PLAN_TEMPLATE,
+    OPENSHIFT_STORAGE_NAMESPACE,
+    OSD_APP_LABEL,
+    MON_APP_LABEL,
+    MGR_APP_LABEL,
+    MDS_APP_LABEL,
+    RGW_APP_LABEL,
+    OPERATOR_LABEL,
+    NOOBAA_APP_LABEL,
+)
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
+from ocs_ci.krkn_chaos.krkn_chaos import KrKnctlRunner
+from ocs_ci.krkn_chaos.krkn_helpers import (
+    CephHealthHelper,
+    ValidationHelper,
+    krknctl_random_test_exit_criteria,
+)
+
+log = logging.getLogger(__name__)
+
+# Default interval (seconds) for polling krknctl process and running Ceph crash check.
+POLL_INTERVAL = 180
+
+
+def _normalize_krknctl_cloud_type(cloud_type):
+    """
+    Map legacy krkn names to values accepted by krknctl ``random run`` validation.
+
+    krknctl allows ``aws,azure,gcp,vmware,ibmcloud,ibmcloudpower,bm`` (not ``ibm``).
+    """
+    if cloud_type is None:
+        return cloud_type
+    s = str(cloud_type).strip()
+    if not s:
+        return cloud_type
+    if s.lower() == "ibm":
+        return "ibmcloud"
+    return s
+
+
+KRKN_APP_LABEL_CONSTANTS = (
+    OSD_APP_LABEL,
+    MON_APP_LABEL,
+    MGR_APP_LABEL,
+    MDS_APP_LABEL,
+    RGW_APP_LABEL,
+    OPERATOR_LABEL,
+    NOOBAA_APP_LABEL,
+)
+CEPH_APP_SELECTORS = [label.split("=", 1)[1] for label in KRKN_APP_LABEL_CONSTANTS]
+
+# Base scenario names in plan.json.j2 (JSON keys are "<base>_{{ suffix }}"; variants
+# use hyphenated bases e.g. network-chaos-ingress-latency_<suffix>). Keep in sync with
+# the template when adding scenarios. Used for documentation and PlanGenerator.SCENARIO_NAMES.
+KRKNCTL_PLAN_SCENARIO_KEYS = (
+    "root",
+    "application-outages",
+    "application-outages-egress-only",
+    "application-outages-ingress-only",
+    "application-outages-osd",
+    "application-outages-rgw",
+    "container-scenarios",
+    "container-scenarios-mds",
+    "container-scenarios-mon",
+    "container-scenarios-osd",
+    "kubevirt-outage",
+    "network-chaos",
+    "network-chaos-egress-loss",
+    "network-chaos-egress-latency",
+    "network-chaos-egress-serial",
+    "network-chaos-ingress-latency",
+    "node-cpu-hog",
+    "node-cpu-hog-mild",
+    "node-io-hog",
+    "node-io-hog-heavy",
+    "node-memory-hog",
+    "node-memory-hog-moderate",
+    "node-network-filter",
+    "node-scenarios",
+    "pod-network-chaos",
+    "pod-network-chaos-egress-only",
+    "pod-network-chaos-ingress-only",
+    "pod-network-filter",
+    "pod-scenarios",
+    "pod-scenarios-mgr",
+    "pod-scenarios-mon",
+    "pod-scenarios-multi-disruption",
+    "pod-scenarios-noobaa",
+    "pod-scenarios-rbd-plugin",
+    "service-disruption-scenarios",
+    "service-disruption-scenarios-rook",
+    "syn-flood",
+    "syn-flood-mgr",
+    "time-scenarios",
+    "time-scenarios-osd",
+)
+
+ROOT_SCENARIO_KEY = "root"
+
+# Plan with only root + service-disruption-scenarios (for test_random_service_disruption).
+SERVICE_DISRUPTION_INCLUDE_SCENARIOS = (
+    ROOT_SCENARIO_KEY,
+    "service-disruption-scenarios",
+)
+
+# Plan with only root + application-outages (expanded per label).
+APPLICATION_OUTAGES_INCLUDE_SCENARIOS = (
+    ROOT_SCENARIO_KEY,
+    "application-outages",
+)
+
+# Comprehensive service disruption: root + application-outages, pod-scenarios,
+# container-scenarios (expanded per label), plus a single service-disruption-scenarios
+# node (namespace targeting only — not expanded per pod label).
+COMPREHENSIVE_SERVICE_DISRUPTION_INCLUDE_SCENARIOS = (
+    ROOT_SCENARIO_KEY,
+    "application-outages",
+    "pod-scenarios",
+    "container-scenarios",
+    "service-disruption-scenarios",
+)
+
+# App labels used when expanding application-outages (one node per label).
+# Use KRKN_APP_LABEL_CONSTANTS so application-outage covers OSD, MON, MGR, MDS, RGW, operator, Noobaa.
+APPLICATION_OUTAGES_APP_LABELS = KRKN_APP_LABEL_CONSTANTS
+
+# krknctl random: base scenario names for a minimal plan (dummy root + node-scenarios only).
+KRKNCTL_RANDOM_NODE_SCENARIO_BASES = (
+    ROOT_SCENARIO_KEY,
+    "node-scenarios",
+)
+
+# krknctl random: base scenario names for kubevirt-outage (dummy root + krkn-hub kubevirt-outage).
+KRKNCTL_RANDOM_KUBEVIRT_OUTAGE_SCENARIO_BASES = (
+    ROOT_SCENARIO_KEY,
+    "kubevirt-outage",
+)
+
+# krknctl random: base scenario names for time-scenarios (dummy root + krkn-hub time-scenarios).
+KRKNCTL_RANDOM_TIME_SCENARIO_BASES = (
+    ROOT_SCENARIO_KEY,
+    "time-scenarios",
+)
+
+
+def _apply_ibmcloud_node_scenario_auth_from_config(template_vars):
+    """
+    Populate ``ibm_url``, ``ibm_apikey``, ``ibm_power_url``, ``ibm_power_crn`` for
+    ``plan.json.j2`` from ``config.AUTH['ibmcloud']`` (loaded from ``data/auth.yaml``),
+    matching :meth:`ocs_ci.krkn_chaos.krkn_chaos.KrKnRunner._run_krkn_command`.
+
+    Only runs when ``cloud_type`` is IBM (``KRKN_CLOUD_IBM``). Does not overwrite keys
+    already set (caller should apply env overrides after this).
+
+    Recognized optional keys under ``ibmcloud`` besides ``api_key`` / ``api_endpoint``:
+    ``ibm_power_url`` or ``power_url``, ``ibm_power_crn`` or ``power_crn``.
+    """
+    from ocs_ci.framework import config
+    from ocs_ci.utility.ibmcloud import get_ibmcloud_cluster_region
+
+    if template_vars.get("cloud_type") != KRKN_CLOUD_IBM:
+        return
+
+    ibmcloud_auth = config.AUTH.get("ibmcloud") or {}
+    if not ibmcloud_auth:
+        return
+
+    api_key = ibmcloud_auth.get("api_key")
+    if api_key:
+        template_vars.setdefault("ibm_apikey", api_key)
+
+    api_endpoint = ibmcloud_auth.get("api_endpoint")
+    if api_endpoint:
+        template_vars.setdefault("ibm_url", api_endpoint)
+    elif "ibm_url" not in template_vars:
+        try:
+            region = get_ibmcloud_cluster_region()
+            template_vars["ibm_url"] = f"https://{region}.iaas.cloud.ibm.com/v1"
+            log.info(
+                "Set krknctl node-scenarios ibm_url from cluster region (no api_endpoint in AUTH)"
+            )
+        except (CommandFailed, Exception) as e:
+            log.warning(
+                "Could not derive ibm_url from IBM Cloud region (%s); "
+                "set api_endpoint in AUTH['ibmcloud'] or IBMC_URL in the environment",
+                e,
+            )
+
+    power_url = ibmcloud_auth.get("ibm_power_url") or ibmcloud_auth.get("power_url")
+    if power_url:
+        template_vars.setdefault("ibm_power_url", power_url)
+
+    power_crn = ibmcloud_auth.get("ibm_power_crn") or ibmcloud_auth.get("power_crn")
+    if power_crn:
+        template_vars.setdefault("ibm_power_crn", power_crn)
+
+
+def _apply_vsphere_node_scenario_auth_from_config(template_vars):
+    """
+    Populate ``vsphere_ip``, ``vsphere_user``, ``vsphere_pass`` for ``plan.json.j2``
+    from ``config.AUTH['vmware']`` / ``config.AUTH['vsphere']`` (merged from
+    ``data/auth.yaml`` under the ``AUTH`` section), with fallback to ``ENV_DATA``
+    keys ``vsphere_server``, ``vsphere_user``, ``vsphere_password`` — same sources as
+    :class:`~ocs_ci.ocs.platform_nodes.VMWare` / ``deployment/vmware.py``.
+
+    Only runs when ``cloud_type`` is VMware (``KRKN_CLOUD_VMWARE``). Does not overwrite
+    keys already set (caller applies env overrides after this).
+    """
+    from ocs_ci.framework import config
+
+    if template_vars.get("cloud_type") != KRKN_CLOUD_VMWARE:
+        return
+
+    vm_auth = {}
+    for key in ("vmware", "vsphere"):
+        block = config.AUTH.get(key)
+        if isinstance(block, dict):
+            vm_auth.update(block)
+
+    env_data = config.ENV_DATA or {}
+
+    server = (
+        vm_auth.get("vsphere_server")
+        or vm_auth.get("vsphere_ip")
+        or vm_auth.get("server")
+        or env_data.get("vsphere_server")
+    )
+    user = (
+        vm_auth.get("vsphere_user")
+        or vm_auth.get("username")
+        or env_data.get("vsphere_user")
+    )
+    password = (
+        vm_auth.get("vsphere_password")
+        or vm_auth.get("password")
+        or env_data.get("vsphere_password")
+    )
+
+    if server:
+        template_vars.setdefault("vsphere_ip", server)
+    if user:
+        template_vars.setdefault("vsphere_user", user)
+    if password:
+        template_vars.setdefault("vsphere_pass", password)
+
+
+def build_krknctl_node_scenario_template_vars():
+    """
+    Build Jinja context for ``plan.json.j2`` when the plan includes ``node-scenarios``.
+
+    Sets ``cloud_type`` from :func:`~ocs_ci.krkn_chaos.krkn_helpers.get_krkn_cloud_type`
+    (calls ``pytest.skip`` on unsupported platforms). For IBM Cloud, fills ``IBMC_*``
+    template fields from ``config.AUTH['ibmcloud']`` (``data/auth.yaml``), same as
+    :class:`~ocs_ci.krkn_chaos.krkn_chaos.KrKnRunner`. For VMware, fills ``VSPHERE_*``
+    template fields from ``config.AUTH['vmware']`` / ``['vsphere']`` when present, else
+    from ``ENV_DATA`` (``vsphere_server``, ``vsphere_user``, ``vsphere_password``).
+    Environment variables override config for the same keys. Other optional tuning knobs
+    come from the process environment (same names as krkn-hub ``node-scenarios`` env keys).
+
+    **Do not** read generic ``NODE_NAME`` for targeting nodes: Jenkins sets ``NODE_NAME``
+    to the **agent** hostname, which is not a Kubernetes node name and makes krknctl
+    validation fail. Use ``KRKN_NODE_NAME`` to pin cluster node(s) (comma-separated);
+    it is mapped to the plan's ``NODE_NAME`` field for krkn-hub.
+
+    Returns:
+        dict: Template variables passed to :class:`PlanGenerator`.
+    """
+    import os
+
+    from ocs_ci.krkn_chaos.krkn_helpers import get_krkn_cloud_type
+
+    cloud_override = os.environ.get("CLOUD_TYPE")
+    raw_cloud = cloud_override if cloud_override else get_krkn_cloud_type()
+    template_vars = {"cloud_type": _normalize_krknctl_cloud_type(raw_cloud)}
+    _apply_ibmcloud_node_scenario_auth_from_config(template_vars)
+    _apply_vsphere_node_scenario_auth_from_config(template_vars)
+    # Optional: env vars map to Jinja names in plan.json.j2 ``node-scenarios`` block
+    env_map = (
+        ("ACTION", "node_scenario_action"),
+        ("LABEL_SELECTOR", "node_scenario_label"),
+        ("EXCLUDE_LABEL", "exclude_label"),
+        ("INSTANCE_COUNT", "node_instance_count"),
+        ("RUNS", "node_scenario_runs"),
+        ("KUBE_CHECK", "kube_check"),
+        ("PARALLEL", "parallel"),
+        ("TIMEOUT", "node_scenario_timeout"),
+        ("DURATION", "node_scenario_duration"),
+        ("DISABLE_SSL_VERIFICATION", "disable_ssl_verification"),
+        ("VSPHERE_IP", "vsphere_ip"),
+        ("VSPHERE_USERNAME", "vsphere_user"),
+        ("VSPHERE_PASSWORD", "vsphere_pass"),
+        ("AWS_ACCESS_KEY_ID", "aws_access_key_id"),
+        ("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key"),
+        ("AWS_DEFAULT_REGION", "aws_region"),
+        ("BMC_USER", "bmc_user"),
+        ("BMC_PASSWORD", "bmc_password"),
+        ("BMC_ADDR", "bmc_addr"),
+        ("DISKS", "disks"),
+        ("IBMC_URL", "ibm_url"),
+        ("IBMC_POWER_URL", "ibm_power_url"),
+        ("IBMC_POWER_CRN", "ibm_power_crn"),
+        ("IBMC_APIKEY", "ibm_apikey"),
+        ("AZURE_TENANT_ID", "azure_tenant_id"),
+        ("AZURE_CLIENT_ID", "azure_client_id"),
+        ("AZURE_CLIENT_SECRET", "azure_client_secret"),
+        ("AZURE_SUBSCRIPTION_ID", "azure_subscription_id"),
+    )
+    for env_key, tmpl_key in env_map:
+        val = os.environ.get(env_key)
+        if val:
+            template_vars[tmpl_key] = val
+    # Pin cluster node(s) in the plan (krkn-hub env NODE_NAME). Use KRKN_NODE_NAME only —
+    # do not use process env NODE_NAME (Jenkins sets that to the agent hostname).
+    krkn_node = os.environ.get("KRKN_NODE_NAME", "").strip()
+    if krkn_node:
+        template_vars["node_name"] = krkn_node
+    return template_vars
+
+
+def build_krknctl_kubevirt_outage_template_vars():
+    """
+    Build Jinja context for ``plan.json.j2`` when the plan includes ``kubevirt-outage``.
+
+    Target VM is read from ``krkn_config.kubevirt_outage`` in merged ocsci config, or from
+    environment variables ``KRKN_KUBEVIRT_NAMESPACE`` / ``KRKN_KUBEVIRT_VM_NAME`` (env wins).
+    Calls ``pytest.skip`` if ``vm_name`` is unset (scenario needs a concrete VM).
+
+    Returns:
+        dict: Template variables passed to :class:`PlanGenerator`.
+    """
+    import os
+
+    import pytest
+
+    from ocs_ci.framework import config
+
+    krkn_config = config.ENV_DATA.get("krkn_config", {})
+    ko = krkn_config.get("kubevirt_outage", {}) or {}
+
+    namespace = (
+        os.environ.get("KRKN_KUBEVIRT_NAMESPACE") or ko.get("namespace") or "default"
+    )
+    vm_name = (
+        os.environ.get("KRKN_KUBEVIRT_VM_NAME") or ko.get("vm_name") or ""
+    ).strip()
+    if not vm_name:
+        pytest.skip(
+            "kubevirt-outage requires a target VM: set krkn_config.kubevirt_outage.vm_name "
+            "in ocsci config or export KRKN_KUBEVIRT_VM_NAME"
+        )
+
+    timeout = ko.get("timeout", 60)
+    kill_count = ko.get("kill_count", 1)
+
+    return {
+        "kubevirt_namespace": namespace,
+        "kubevirt_vm_name": vm_name,
+        "kubevirt_timeout": str(timeout),
+        "kubevirt_kill_count": str(kill_count),
+    }
+
+
+def build_krknctl_time_scenario_template_vars():
+    """
+    Build Jinja context for ``plan.json.j2`` when the plan includes ``time-scenarios``.
+
+    Values come from ``krkn_config.time_scenarios`` in merged ocsci config, with optional
+    environment overrides (``KRKN_TIME_ACTION``, ``KRKN_TIME_CONTAINER``,
+    ``KRKN_TIME_LABEL_SELECTOR``, ``KRKN_TIME_OBJECT_NAME``, ``KRKN_TIME_OBJECT_TYPE``).
+    Storage namespace for the scenario comes from :class:`PlanGenerator` ``namespace``.
+
+    Returns:
+        dict: Template variables passed to :class:`PlanGenerator`.
+    """
+    import os
+
+    from ocs_ci.framework import config
+
+    krkn_config = config.ENV_DATA.get("krkn_config", {})
+    ts = krkn_config.get("time_scenarios", {}) or {}
+
+    def _pick(cfg_key: str, env_key: str, default: str) -> str:
+        v = os.environ.get(env_key)
+        if v is not None and v != "":
+            return v
+        v = ts.get(cfg_key)
+        if v is not None and v != "":
+            return str(v)
+        return default
+
+    return {
+        "time_action": _pick("action", "KRKN_TIME_ACTION", "skew_date"),
+        "time_container": _pick("container_name", "KRKN_TIME_CONTAINER", ""),
+        "time_label_selector": _pick(
+            "label_selector", "KRKN_TIME_LABEL_SELECTOR", "app=rook-ceph-mon"
+        ),
+        "time_object_name": _pick("object_name", "KRKN_TIME_OBJECT_NAME", "[]"),
+        "time_object_type": _pick("object_type", "KRKN_TIME_OBJECT_TYPE", "pod"),
+    }
+
+
+def run_krknctl_chaos_and_validate(
+    plan_path,
+    workload_ops,
+    max_parallel,
+    run_name,
+    failure_context,
+    validation_failure_context,
+    poll_interval=None,
+    namespace=None,
+):
+    """
+    Shared flow: start krknctl in background, poll until exit (with Ceph crash check),
+    handle returncode, validate/cleanup workloads, run exit criteria.
+
+    Use this from tests that run krknctl random chaos or service disruption so
+    the run, poll, cleanup, and exit-criteria logic stay in one place.
+
+    Args:
+        plan_path: Path to the krknctl plan file.
+        workload_ops: WorkloadOps fixture instance (or any object with
+            setup_workloads(), validate_and_cleanup()).
+        max_parallel: Max parallel scenarios for krknctl.
+        run_name: Name for poll logs and exit criteria (e.g. "krknctl", "krknctl service disruption").
+        failure_context: Short name for CommandFailed message (e.g. "krknctl random run", "krknctl service disruption").
+        validation_failure_context: Context for ValidationHelper (e.g. "krknctl-random", "krknctl-service-disruption").
+        poll_interval (int, optional): Seconds between polls; default POLL_INTERVAL.
+        namespace (str, optional): OpenShift namespace for Ceph check; default OPENSHIFT_STORAGE_NAMESPACE.
+
+    Raises:
+        CommandFailed: If krknctl exits with non-zero returncode.
+        AssertionError: From exit criteria or ValidationHelper as appropriate.
+    """
+    if poll_interval is None:
+        poll_interval = POLL_INTERVAL
+    if namespace is None:
+        namespace = OPENSHIFT_STORAGE_NAMESPACE
+
+    log_path = os.path.join(os.path.dirname(plan_path), "krknctl.log")
+    runner = KrKnctlRunner()
+    process, _ = runner.random_background(
+        plan_path,
+        log_path=log_path,
+        max_parallel=max_parallel,
+    )
+    log.info(
+        "krknctl started in background; log file: %s",
+        log_path,
+    )
+
+    returncode = poll_krknctl_until_exit(
+        process,
+        log_path=log_path,
+        poll_interval=poll_interval,
+        namespace=namespace,
+        run_name=run_name,
+        workload_ops=workload_ops,
+    )
+    log.info("krknctl process ended with returncode=%s", returncode)
+
+    if returncode != 0:
+        log.error(
+            "%s failed (returncode=%s). Check log: %s",
+            failure_context,
+            returncode,
+            log_path,
+        )
+        try:
+            workload_ops.validate_and_cleanup()
+        except (UnexpectedBehaviour, CommandFailed) as cleanup_ex:
+            log.warning("Workload cleanup after chaos failure: %s", cleanup_ex)
+        raise CommandFailed(
+            f"{failure_context} failed with returncode={returncode}. Log: {log_path}"
+        )
+
+    try:
+        workload_ops.validate_and_cleanup()
+        log.info("Workloads validated and cleaned up successfully")
+    except (UnexpectedBehaviour, CommandFailed) as e:
+        ValidationHelper().handle_workload_validation_failure(
+            e,
+            validation_failure_context,
+            run_name,
+        )
+
+    krknctl_random_test_exit_criteria(run_name)
+
+
+def _terminate_krknctl_process(process):
+    """
+    Stop the krknctl subprocess (SIGTERM, then SIGKILL on timeout).
+
+    Called when aborting early so heartbeat / poll loops do not see a live process.
+    """
+    if process is None or process.poll() is not None:
+        return
+    log.warning("Terminating krknctl subprocess after Ceph crash detection")
+    try:
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            log.warning("krknctl did not exit after SIGTERM; sending SIGKILL")
+            process.kill()
+            process.wait(timeout=15)
+    except Exception as ex:
+        log.warning("Error terminating krknctl process: %s", ex)
+
+
+def _shutdown_chaos_on_ceph_crash(process, workload_ops):
+    """
+    Best-effort shutdown when periodic Ceph crash check fails: stop bg cluster ops,
+    then terminate krknctl so child and heartbeat threads wind down before pytest
+    failure hooks (e.g. must-gather) run.
+    """
+    if workload_ops is not None:
+        stop_fn = getattr(
+            workload_ops, "stop_background_operations_on_chaos_failure", None
+        )
+        if callable(stop_fn):
+            try:
+                stop_fn()
+            except Exception as ex:
+                log.warning(
+                    "Could not stop background cluster operations after Ceph crash: %s",
+                    ex,
+                )
+    _terminate_krknctl_process(process)
+
+
+def poll_krknctl_until_exit(
+    process,
+    log_path=None,
+    poll_interval=180,
+    namespace=None,
+    run_name="krknctl",
+    workload_ops=None,
+):
+    """
+    Poll a krknctl subprocess until it exits, checking for Ceph crashes every
+    poll_interval seconds. Use this in tests that run krknctl in the background
+    so that any Ceph crash during the run fails the test immediately and
+    generates evidence.
+
+    Args:
+        process: Subprocess with .poll() and .returncode (e.g. subprocess.Popen).
+        log_path (str, optional): Path to krknctl log file for log messages.
+        poll_interval (int): Seconds between polls and Ceph crash checks (default 180).
+        namespace (str, optional): OpenShift namespace for Ceph check.
+            Defaults to OPENSHIFT_STORAGE_NAMESPACE.
+        run_name (str): Short name for log messages (e.g. "krknctl", "krknctl service disruption").
+        workload_ops: Optional workload ops object with stop_background_operations_on_chaos_failure();
+            used to stop BgOp threads when failing fast on Ceph crash.
+
+    Returns:
+        int: Process return code when the process has exited.
+
+    Raises:
+        AssertionError: If Ceph crash(es) are detected during the poll loop.
+    """
+    if namespace is None:
+        namespace = OPENSHIFT_STORAGE_NAMESPACE
+    health_helper = CephHealthHelper(namespace=namespace)
+    while process.poll() is None:
+        no_crashes, crash_details = health_helper.check_ceph_crashes(
+            None, f"chaos (periodic check every {poll_interval} s)"
+        )
+        if not no_crashes and crash_details:
+            _shutdown_chaos_on_ceph_crash(process, workload_ops)
+            raise AssertionError(
+                f"Periodic Ceph crash check failed (every {poll_interval} s). "
+                f"Ceph crash detected during chaos; failing test to generate evidence.\n{crash_details}"
+            )
+        log_msg = f"{run_name} still running"
+        if log_path:
+            log_msg += f" (log: {log_path})"
+        log_msg += f"; next check in {poll_interval} s"
+        log.info(log_msg)
+        time.sleep(poll_interval)
+    return process.returncode
+
+
+def _full_key(base_name, suffix):
+    """Plan key for a scenario: base_name_suffix (e.g. application-outages_5j6t5)."""
+    return f"{base_name}_{suffix}"
+
+
+def _label_to_slug(label_selector):
+    """Convert label_selector like 'app=rook-ceph-osd' to a slug 'rook-ceph-osd'."""
+    if "=" in label_selector:
+        return label_selector.split("=", 1)[1].replace(".", "-")
+    return label_selector.replace(".", "-")
+
+
+def _label_to_short_slug(label_selector):
+    """Convert label_selector to short slug for plan keys: 'app=rook-ceph-osd' -> 'osd'."""
+    app_value = _label_to_slug(label_selector)
+    if app_value.startswith("rook-ceph-"):
+        return app_value.split("rook-ceph-", 1)[1]
+    return app_value
+
+
+def _label_to_pod_selector(label_selector):
+    """Convert label_selector 'app=rook-ceph-osd' to POD_SELECTOR value '{app: rook-ceph-osd}'."""
+    app_value = _label_to_slug(label_selector)
+    return f"{{app: {app_value}}}"
+
+
+def get_worker_instance_count_for_krknctl_plan():
+    """
+    String worker-node count for ``INSTANCE_COUNT`` defaults in ``plan.json.j2``.
+
+    Uses :func:`~ocs_ci.ocs.node.get_worker_nodes`. Returns ``"1"`` if the list is
+    empty or the cluster cannot be queried (e.g. missing kubeconfig).
+
+    Returns:
+        str: Number of workers as a decimal string, at least ``"1"``.
+    """
+    try:
+        from ocs_ci.ocs.node import get_worker_nodes
+
+        n = len(get_worker_nodes())
+        return str(n) if n > 0 else "1"
+    except Exception as e:
+        log.warning(
+            "Could not get worker node count for krknctl plan; defaulting INSTANCE_COUNT to 1: %s",
+            e,
+        )
+        return "1"
+
+
+class PlanGenerator:
+    """
+    Generates krknctl plan JSON files from the Jinja template.
+
+    Holds scenario names and exposes one method that parses the template,
+    fills parameters, applies exclusions/overrides, and writes the plan file.
+    After generate() is called, plan_path is set to the written file location.
+    """
+
+    # Scenario names defined in the plan template (same as KRKNCTL_PLAN_SCENARIO_KEYS).
+    SCENARIO_NAMES = KRKNCTL_PLAN_SCENARIO_KEYS
+
+    def __init__(
+        self,
+        namespace="openshift-storage",
+        include_scenarios=None,
+        exclude_scenarios=None,
+        scenario_overrides=None,
+        use_random_selectors=True,
+        label_selectors=None,
+        **template_vars,
+    ):
+        self.namespace = namespace
+        self.include_scenarios = (
+            include_scenarios  # None or list; takes precedence over exclude
+        )
+        self.exclude_scenarios = exclude_scenarios or []
+        self.scenario_overrides = scenario_overrides or {}
+        self.use_random_selectors = use_random_selectors
+        self.label_selectors = label_selectors  # list of pod label strings; expands app-outage/pod/container only
+        self.template_vars = template_vars
+        self.plan_path = None
+        self._suffix = None
+
+    def generate(self):
+        """
+        Parse the Jinja template, fill parameters, apply exclusions and overrides,
+        write the plan file, and set self.plan_path to the written path.
+
+        Injects ``worker_instance_count`` (cluster worker count via
+        :func:`get_worker_instance_count_for_krknctl_plan`) unless overridden in
+        ``template_vars``.
+
+        Returns:
+            str: Absolute path to the generated plan JSON file.
+        """
+        if not os.path.isfile(KRKNCTL_PLAN_TEMPLATE):
+            raise FileNotFoundError(
+                f"krknctl plan template not found at {KRKNCTL_PLAN_TEMPLATE}"
+            )
+
+        self._suffix = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=5)
+        )
+
+        worker_instance_count = (
+            self.template_vars.get("worker_instance_count")
+            or get_worker_instance_count_for_krknctl_plan()
+        )
+
+        if self.use_random_selectors:
+            pod_app = random.choice(CEPH_APP_SELECTORS)
+            label_app = random.choice(CEPH_APP_SELECTORS)
+            pod_selector = f"{{app: {pod_app}}}"
+            label_selector = f"app={label_app}"
+            workers = str(random.randint(1, 6))
+        else:
+            pod_selector = self.template_vars.get("pod_selector", "")
+            label_selector = self.template_vars.get("label_selector", "")
+            workers = self.template_vars.get("workers", "1")
+
+        context = {
+            "suffix": self._suffix,
+            "namespace": self.namespace,
+            "pod_selector": pod_selector,
+            "label_selector": label_selector,
+            "pod_label": label_selector,
+            "workers": workers,
+            "worker_instance_count": worker_instance_count,
+        }
+        context.update(self.template_vars)
+
+        with open(KRKNCTL_PLAN_TEMPLATE, "r") as f:
+            template = Template(f.read())
+        rendered = template.render(**context)
+        rendered_stripped = rendered.strip() if rendered else ""
+        if not rendered_stripped:
+            raise ValueError(
+                f"Plan template rendered to empty. Path: {KRKNCTL_PLAN_TEMPLATE}"
+            )
+        plan_data = json.loads(rendered)
+
+        if self.include_scenarios:
+            self._keep_only_included(plan_data)
+            if self.label_selectors:
+                if "application-outages" in self.include_scenarios:
+                    self._expand_application_outages_by_labels(plan_data)
+                if "pod-scenarios" in self.include_scenarios:
+                    self._expand_pod_scenarios_by_labels(plan_data)
+                if "container-scenarios" in self.include_scenarios:
+                    self._expand_container_scenarios_by_labels(plan_data)
+            if "service-disruption-scenarios" in self.include_scenarios:
+                self._normalize_service_disruption_scenario(plan_data)
+        else:
+            self._remove_excluded(plan_data)
+            self._warn_if_root_excluded(plan_data)
+        self._apply_overrides(plan_data)
+
+        os.makedirs(KRKN_OUTPUT_DIR, exist_ok=True)
+        dir_suffix = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=8)
+        )
+        plan_dir = os.path.join(KRKN_OUTPUT_DIR, dir_suffix)
+        os.makedirs(plan_dir, exist_ok=True)
+        file_suffix = "".join(
+            random.choices(string.ascii_lowercase + string.digits, k=8)
+        )
+        self.plan_path = os.path.join(plan_dir, f"plan_{file_suffix}.json")
+        with open(self.plan_path, "w") as f:
+            json.dump(plan_data, f, indent=2)
+
+        log.info(
+            "Generated krknctl plan: %s (namespace=%s, suffix=%s, include=%s, exclude=%s)",
+            self.plan_path,
+            self.namespace,
+            self._suffix,
+            self.include_scenarios,
+            self.exclude_scenarios,
+        )
+        return os.path.abspath(self.plan_path)
+
+    def _keep_only_included(self, plan_data):
+        """Keep only scenarios in include_scenarios (and _comment keys). Root must be in include_scenarios if needed."""
+        include_set = set(self.include_scenarios)
+        for k in list(plan_data.keys()):
+            if k.startswith("_"):
+                continue
+            base = k.rsplit("_", 1)[0] if "_" in k else k
+            if base not in include_set:
+                del plan_data[k]
+                log.debug("Removed scenario (not in include list): %s", base)
+
+    def _expand_application_outages_by_labels(self, plan_data):
+        """
+        Replace the single application-outages node with one node per label in
+        label_selectors, each with its own POD_SELECTOR. Keys become
+        application-outages_<short_slug>_<suffix> (e.g. application-outages_osd_xxyyzz).
+        """
+        base_key = _full_key("application-outages", self._suffix)
+        if base_key not in plan_data:
+            log.warning(
+                "application-outages key %s not in plan; skip expand by labels",
+                base_key,
+            )
+            return
+        template_node = plan_data.pop(base_key)
+        root_key = _full_key(ROOT_SCENARIO_KEY, self._suffix)
+        for label in self.label_selectors:
+            node = copy.deepcopy(template_node)
+            node.setdefault("env", {})["POD_SELECTOR"] = _label_to_pod_selector(label)
+            if "depends_on" in node:
+                node["depends_on"] = root_key
+            short_slug = _label_to_short_slug(label)
+            new_key = f"application-outages_{short_slug}_{self._suffix}"
+            plan_data[new_key] = node
+            log.debug("Added application-outages node for label: %s", label)
+
+    def _expand_pod_scenarios_by_labels(self, plan_data):
+        """
+        Replace the single pod-scenarios node with one node per label in
+        label_selectors, each with its own POD_LABEL. Keys become
+        pod-scenarios_<short_slug>_<suffix>.
+        """
+        base_key = _full_key("pod-scenarios", self._suffix)
+        if base_key not in plan_data:
+            log.warning(
+                "pod-scenarios key %s not in plan; skip expand by labels",
+                base_key,
+            )
+            return
+        template_node = plan_data.pop(base_key)
+        root_key = _full_key(ROOT_SCENARIO_KEY, self._suffix)
+        for label in self.label_selectors:
+            node = copy.deepcopy(template_node)
+            node.setdefault("env", {})["POD_LABEL"] = label
+            if "depends_on" in node:
+                node["depends_on"] = root_key
+            short_slug = _label_to_short_slug(label)
+            new_key = f"pod-scenarios_{short_slug}_{self._suffix}"
+            plan_data[new_key] = node
+            log.debug("Added pod-scenarios node for label: %s", label)
+
+    def _expand_container_scenarios_by_labels(self, plan_data):
+        """
+        Replace the single container-scenarios node with one node per label in
+        label_selectors, each with its own LABEL_SELECTOR. Keys become
+        container-scenarios_<short_slug>_<suffix>.
+        """
+        base_key = _full_key("container-scenarios", self._suffix)
+        if base_key not in plan_data:
+            log.warning(
+                "container-scenarios key %s not in plan; skip expand by labels",
+                base_key,
+            )
+            return
+        template_node = plan_data.pop(base_key)
+        root_key = _full_key(ROOT_SCENARIO_KEY, self._suffix)
+        for label in self.label_selectors:
+            node = copy.deepcopy(template_node)
+            node.setdefault("env", {})["LABEL_SELECTOR"] = label
+            if "depends_on" in node:
+                node["depends_on"] = root_key
+            short_slug = _label_to_short_slug(label)
+            new_key = f"container-scenarios_{short_slug}_{self._suffix}"
+            plan_data[new_key] = node
+            log.debug("Added container-scenarios node for label: %s", label)
+
+    def _normalize_service_disruption_scenario(self, plan_data):
+        """
+        Ensure service-disruption-scenarios targets a namespace only.
+
+        Krkn-hub's service-disruption plugin disrupts namespaces (not pods).
+        LABEL_SELECTOR selects namespace labels when NAMESPACE is unset; it is not
+        a pod label. Mutually exclusive with NAMESPACE — use storage namespace name
+        and empty LABEL_SELECTOR. Do not expand per pod label (unlike pod/container
+        scenarios).
+        """
+        base_key = _full_key("service-disruption-scenarios", self._suffix)
+        if base_key not in plan_data:
+            log.warning(
+                "service-disruption-scenarios key %s not in plan; skip normalize",
+                base_key,
+            )
+            return
+        node = plan_data[base_key]
+        env = node.setdefault("env", {})
+        env["NAMESPACE"] = self.namespace
+        env["LABEL_SELECTOR"] = ""
+        log.debug(
+            "service-disruption-scenarios: namespace=%s, LABEL_SELECTOR cleared (namespace-only)",
+            self.namespace,
+        )
+
+    def _remove_excluded(self, plan_data):
+        """
+        Drop excluded scenario nodes. A template base name like ``network-chaos`` also
+        removes hyphenated variants (``network-chaos-ingress-latency``, etc.) so exclude
+        lists match krkn-hub scenario families in plan.json.j2.
+        """
+        excluded_set = set(self.exclude_scenarios)
+        for k in list(plan_data.keys()):
+            if k.startswith("_"):
+                continue
+            base = k.rsplit("_", 1)[0] if "_" in k else k
+            for ex in excluded_set:
+                if base == ex or base.startswith(ex + "-"):
+                    del plan_data[k]
+                    log.debug(
+                        "Excluded scenario from plan: %s (matched exclude %s)",
+                        base,
+                        ex,
+                    )
+                    break
+
+    def _warn_if_root_excluded(self, plan_data):
+        if ROOT_SCENARIO_KEY not in self.exclude_scenarios:
+            return
+        root_key = _full_key(ROOT_SCENARIO_KEY, self._suffix)
+        remaining = [k for k in plan_data if not k.startswith("_") and k != root_key]
+        if remaining:
+            log.warning(
+                "Root scenario is excluded but %s remain; DAG may be invalid (depends_on root).",
+                remaining,
+            )
+
+    def _apply_overrides(self, plan_data):
+        if not self.scenario_overrides:
+            return
+        for base_name, overrides in self.scenario_overrides.items():
+            key = _full_key(base_name, self._suffix)
+            if key not in plan_data or not isinstance(plan_data[key], dict):
+                log.warning(
+                    "scenario_overrides key %s not in plan, skipping", base_name
+                )
+                continue
+            scenario = plan_data[key]
+            if "env" in overrides and isinstance(overrides["env"], dict):
+                env = scenario.setdefault("env", {})
+                for k, v in overrides["env"].items():
+                    env[k] = str(v)
+                    log.debug("Override %s env %s = %s", base_name, k, v)
+
+
+def generate_plan_file(
+    namespace="openshift-storage",
+    include_scenarios=None,
+    exclude_scenarios=None,
+    scenario_overrides=None,
+    use_random_selectors=True,
+    **template_vars,
+):
+    """
+    Generate a krknctl plan JSON file from the Jinja template.
+
+    Uses PlanGenerator: parses template, fills parameters, writes file.
+    When include_scenarios is set, only those scenarios (plus root if listed) are kept;
+    otherwise exclude_scenarios is used to remove scenarios.
+    Returns the plan file path.
+    """
+    generator = PlanGenerator(
+        namespace=namespace,
+        include_scenarios=include_scenarios,
+        exclude_scenarios=exclude_scenarios,
+        scenario_overrides=scenario_overrides,
+        use_random_selectors=use_random_selectors,
+        **template_vars,
+    )
+    return generator.generate()
+
+
+def generate_random_plan_file(
+    namespace="openshift-storage",
+    include_scenarios=None,
+    exclude_scenarios=None,
+    scenario_overrides=None,
+    **kwargs,
+):
+    """
+    Generate a plan file with random pod/label selectors.
+
+    Convenience wrapper: creates PlanGenerator with use_random_selectors=True
+    and returns the plan path.
+    """
+    return generate_plan_file(
+        namespace=namespace,
+        include_scenarios=include_scenarios,
+        exclude_scenarios=exclude_scenarios,
+        scenario_overrides=scenario_overrides,
+        use_random_selectors=True,
+        **kwargs,
+    )

--- a/ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2
+++ b/ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2
@@ -1,0 +1,556 @@
+{
+  "_comment": {
+    "_comment": "Jinja catalog for krknctl plans (OCS-oriented defaults). Covers all named krkn-hub tags on quay.io/krkn-chaos/krkn-hub except chaos-recommender (separate workflow; see krkn-chaos.dev docs). dummy-scenario is for CI/local and may not exist as a public Quay tag. Cerberus is quay.io/krkn-chaos/cerberus, not a krkn-hub scenario. Cloud scenarios need creds from Jenkins."
+  },
+  "root_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:dummy-scenario",
+    "name": "dummy-scenario",
+    "env": {
+      "END": "10",
+      "EXIT_STATUS": "0"
+    }
+  },
+  "application-outages_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "600",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mgr}') }}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-ingress-only_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mgr}') }}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-egress-only_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-mon}') }}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-osd_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-osd}') }}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "application-outages-rgw_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:application-outages",
+    "name": "application-outages",
+    "env": {
+      "BLOCK_TRAFFIC_TYPE": "[Ingress, Egress]",
+      "DURATION": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ pod_selector | default('{app: rook-ceph-rgw}') }}",
+      "WAIT_DURATION": "60",
+      "KRKN_DEBUG": "False"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "60",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios-osd_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios-mds_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "{{ ceph_mds_container | default('mds') }}",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-mds') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "container-scenarios-mon_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:container-scenarios",
+    "name": "container-scenarios",
+    "env": {
+      "ACTION": "1",
+      "CONTAINER_NAME": "{{ ceph_mon_container | default('mon') }}",
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-mon') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "network-chaos-egress-latency_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:network-chaos",
+    "name": "network-chaos",
+    "env": {
+      "DURATION": "240",
+      "EGRESS": "{latency: 100ms}",
+      "EXECUTION": "parallel",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TRAFFIC_TYPE": "egress",
+      "WAIT_DURATION": "240"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "network-chaos-egress-serial_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:network-chaos",
+    "name": "network-chaos",
+    "env": {
+      "DURATION": "300",
+      "EGRESS": "{bandwidth: 100mbit}",
+      "EXECUTION": "serial",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TRAFFIC_TYPE": "egress",
+      "WAIT_DURATION": "300"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "network-chaos_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:network-chaos",
+    "name": "network-chaos",
+    "env": {
+      "DURATION": "300",
+      "EGRESS": "{bandwidth: 100mbit}",
+      "EXECUTION": "parallel",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TRAFFIC_TYPE": "egress",
+      "WAIT_DURATION": "300"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "network-chaos-ingress-latency_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:network-chaos",
+    "name": "network-chaos",
+    "env": {
+      "DURATION": "240",
+      "NETWORK_PARAMS": "{latency: 80ms,loss: 40%}",
+      "EXECUTION": "parallel",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TRAFFIC_TYPE": "ingress",
+      "WAIT_DURATION": "240"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "network-chaos-egress-loss_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:network-chaos",
+    "name": "network-chaos",
+    "env": {
+      "DURATION": "240",
+      "NETWORK_PARAMS": "{bandwidth: 80mbit,loss: 0.02,latency: 25ms}",
+      "EXECUTION": "parallel",
+      "INSTANCE_COUNT": "{{ net_instance_count | default(worker_instance_count) }}",
+      "INTERFACES": "{{ net_interfaces | default('[]') }}",
+      "LABEL_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TRAFFIC_TYPE": "egress",
+      "WAIT_DURATION": "240"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-cpu-hog_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-cpu-hog",
+    "name": "node-cpu-hog",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_CPU_CORE": "2",
+      "NODE_CPU_PERCENTAGE": "95",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TOTAL_CHAOS_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-cpu-hog-mild_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-cpu-hog",
+    "name": "node-cpu-hog",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_CPU_CORE": "1",
+      "NODE_CPU_PERCENTAGE": "85",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TOTAL_CHAOS_DURATION": "120"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-io-hog_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-io-hog",
+    "name": "node-io-hog",
+    "env": {
+      "IO_BLOCK_SIZE": "1m",
+      "IO_WORKERS": "5",
+      "IO_WRITE_BYTES": "10m",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TOTAL_CHAOS_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-io-hog-heavy_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-io-hog",
+    "name": "node-io-hog",
+    "env": {
+      "IO_BLOCK_SIZE": "4m",
+      "IO_WORKERS": "{{ io_workers | default('8') }}",
+      "IO_WRITE_BYTES": "50m",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "TOTAL_CHAOS_DURATION": "240"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-memory-hog_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-memory-hog",
+    "name": "node-memory-hog",
+    "env": {
+      "MEMORY_CONSUMPTION_PERCENTAGE": "90%",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "NUMBER_OF_WORKERS": "{{ workers | default('4') }}",
+      "TOTAL_CHAOS_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-memory-hog-moderate_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-memory-hog",
+    "name": "node-memory-hog",
+    "env": {
+      "MEMORY_CONSUMPTION_PERCENTAGE": "70%",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "NUMBER_OF_WORKERS": "{{ workers | default('2') }}",
+      "TOTAL_CHAOS_DURATION": "120"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-network-filter_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-network-filter",
+    "name": "node-network-filter",
+    "env": {
+      "NODE_SELECTOR": "{{ node_selector | default('node-role.kubernetes.io/worker=') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "EXECUTION": "parallel",
+      "INGRESS": "true",
+      "EGRESS": "true",
+      "PORTS": "8080,8443",
+      "PROTOCOLS": "tcp",
+      "TOTAL_CHAOS_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-network-chaos-egress-only_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-network-chaos",
+    "name": "pod-network-chaos",
+    "env": {
+      "EGRESS_PORTS": "[]",
+      "INGRESS_PORTS": "[]",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TEST_DURATION": "120",
+      "TRAFFIC_TYPE": "[egress]",
+      "WAIT_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-network-chaos_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-network-chaos",
+    "name": "pod-network-chaos",
+    "env": {
+      "EGRESS_PORTS": "[]",
+      "INGRESS_PORTS": "[]",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TEST_DURATION": "180",
+      "TRAFFIC_TYPE": "[ingress,egress]",
+      "WAIT_DURATION": "300"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-network-chaos-ingress-only_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-network-chaos",
+    "name": "pod-network-chaos",
+    "env": {
+      "EGRESS_PORTS": "[]",
+      "INGRESS_PORTS": "[]",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "LABEL_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TEST_DURATION": "120",
+      "TRAFFIC_TYPE": "[ingress]",
+      "WAIT_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-network-filter_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-network-filter",
+    "name": "pod-network-filter",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "POD_SELECTOR": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "INSTANCE_COUNT": "{{ worker_instance_count }}",
+      "EXECUTION": "parallel",
+      "INGRESS": "true",
+      "EGRESS": "true",
+      "PORTS": "8080,8443",
+      "PROTOCOLS": "tcp",
+      "TOTAL_CHAOS_DURATION": "180"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-mon_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "180",
+      "KILL_TIMEOUT": "240",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-mon') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-mgr_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "KILL_TIMEOUT": "180",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-mgr') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-noobaa_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "180",
+      "KILL_TIMEOUT": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ pod_label | default('app=noobaa') }}",
+      "WAIT_DURATION": "30"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "KILL_TIMEOUT": "180",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-osd') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-multi-disruption_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "{{ pod_disruption_count | default('3') }}",
+      "EXPECTED_RECOVERY_TIME": "180",
+      "KILL_TIMEOUT": "300",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": "{{ pod_name_pattern | default('.*') }}",
+      "POD_LABEL": "{{ pod_label | default('app=rook-ceph-osd') }}",
+      "WAIT_DURATION": "30"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "pod-scenarios-rbd-plugin_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:pod-scenarios",
+    "name": "pod-scenarios",
+    "env": {
+      "DISRUPTION_COUNT": "1",
+      "EXPECTED_RECOVERY_TIME": "120",
+      "KILL_TIMEOUT": "180",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "NAME_PATTERN": ".*",
+      "POD_LABEL": "{{ pod_label | default('app=csi-rbdplugin') }}",
+      "WAIT_DURATION": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "service-disruption-scenarios_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:service-disruption-scenarios",
+    "name": "service-disruption-scenarios",
+    "env": {
+      "DELETE_COUNT": "1",
+      "LABEL_SELECTOR": "",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "RUNS": "1"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "service-disruption-scenarios-rook_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:service-disruption-scenarios",
+    "name": "service-disruption-scenarios",
+    "env": {
+      "DELETE_COUNT": "1",
+      "LABEL_SELECTOR": "{{ svc_label_selector | default('') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "RUNS": "{{ svc_disruption_runs | default('1') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "syn-flood_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:syn-flood",
+    "name": "syn-flood",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TARGET_SERVICE_LABEL": "{{ label_selector | default('app=rook-ceph-osd') }}",
+      "TARGET_PORT": "8080",
+      "TOTAL_CHAOS_DURATION": "180",
+      "NUMBER_OF_PODS": "2"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "syn-flood-mgr_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:syn-flood",
+    "name": "syn-flood",
+    "env": {
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "TARGET_SERVICE_LABEL": "{{ label_selector | default('app=rook-ceph-mgr') }}",
+      "TARGET_PORT": "8080",
+      "TOTAL_CHAOS_DURATION": "120",
+      "NUMBER_OF_PODS": "2"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-mon') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "time-scenarios-osd_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:time-scenarios",
+    "name": "time-scenarios",
+    "env": {
+      "ACTION": "{{ time_action | default('skew_date') }}",
+      "CONTAINER_NAME": "{{ time_container | default('') }}",
+      "LABEL_SELECTOR": "{{ time_label_selector | default('app=rook-ceph-osd') }}",
+      "NAMESPACE": "{{ namespace | default('openshift-storage') }}",
+      "OBJECT_NAME": "{{ time_object_name | default('[]') }}",
+      "OBJECT_TYPE": "{{ time_object_type | default('pod') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "kubevirt-outage_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:kubevirt-outage",
+    "name": "kubevirt-outage",
+    "env": {
+      "NAMESPACE": "{{ kubevirt_namespace | default('default') }}",
+      "VM_NAME": "{{ kubevirt_vm_name | default('') }}",
+      "TIMEOUT": "{{ kubevirt_timeout | default('60') }}",
+      "KILL_COUNT": "{{ kubevirt_kill_count | default('1') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  },
+  "node-scenarios_{{ suffix }}": {
+    "image": "quay.io/krkn-chaos/krkn-hub:node-scenarios",
+    "name": "node-scenarios",
+    "env": {
+      "ACTION": "{{ node_scenario_action | default('stop_start_kubelet_scenario') }}",
+      "LABEL_SELECTOR": "{{ node_scenario_label | default('node-role.kubernetes.io/worker') }}",
+      "EXCLUDE_LABEL": "{{ exclude_label | default('') }}",
+      "NODE_NAME": "{{ node_name | default('') }}",
+      "INSTANCE_COUNT": "{{ node_instance_count | default(worker_instance_count) }}",
+      "RUNS": "{{ node_scenario_runs | default('1') }}",
+      "KUBE_CHECK": "{{ kube_check | default('true') }}",
+      "PARALLEL": "{{ parallel | default('false') }}",
+      "CLOUD_TYPE": "{{ cloud_type | default('aws') }}",
+      "TIMEOUT": "{{ node_scenario_timeout | default('180') }}",
+      "DURATION": "{{ node_scenario_duration | default('120') }}",
+      "DISABLE_SSL_VERIFICATION": "{{ disable_ssl_verification | default('false') }}",
+      "VSPHERE_IP": "{{ vsphere_ip | default('') }}",
+      "VSPHERE_USERNAME": "{{ vsphere_user | default('') }}",
+      "VSPHERE_PASSWORD": "{{ vsphere_pass | default('') }}",{# pragma: allowlist secret #}
+      "AWS_ACCESS_KEY_ID": "{{ aws_access_key_id | default('') }}",
+      "AWS_SECRET_ACCESS_KEY": "{{ aws_secret_access_key | default('') }}",{# pragma: allowlist secret #}
+      "AWS_DEFAULT_REGION": "{{ aws_region | default('') }}",
+      "BMC_USER": "{{ bmc_user | default('') }}",
+      "BMC_PASSWORD": "{{ bmc_password | default('') }}",{# pragma: allowlist secret #}
+      "BMC_ADDR": "{{ bmc_addr | default('') }}",
+      "DISKS": "{{ disks | default('') }}",
+      "IBMC_URL": "{{ ibm_url | default('') }}",
+      "IBMC_POWER_URL": "{{ ibm_power_url | default('') }}",
+      "IBMC_POWER_CRN": "{{ ibm_power_crn | default('') }}",
+      "IBMC_APIKEY": "{{ ibm_apikey | default('') }}",{# pragma: allowlist secret #}
+      "AZURE_TENANT_ID": "{{ azure_tenant_id | default('') }}",
+      "AZURE_CLIENT_ID": "{{ azure_client_id | default('') }}",
+      "AZURE_CLIENT_SECRET": "{{ azure_client_secret | default('') }}",{# pragma: allowlist secret #}
+      "AZURE_SUBSCRIPTION_ID": "{{ azure_subscription_id | default('') }}"
+    },
+    "depends_on": "root_{{ suffix }}"
+  }
+}

--- a/ocs_ci/krkn_chaos/template/scenarios/openshift/node_scenarios.yml.j2
+++ b/ocs_ci/krkn_chaos/template/scenarios/openshift/node_scenarios.yml.j2
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../plugin.schema.json
 # Node Scenarios - Simulates node failures on various cloud platforms
-# Supported cloud_types: aws, azure, openstack, ibm, alibaba, bm (baremetal), vmware
+# Supported cloud_types: aws, azure, openstack, ibmcloud, alibaba, bm (baremetal), vmware
 # Supported actions: node_stop_start_scenario, node_reboot_scenario, node_termination_scenario,
 #                    node_disk_detach_attach_scenario, stop_kubelet_scenario, restart_kubelet_scenario
 node_scenarios:

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3800,7 +3800,8 @@ KRKN_SCENARIO_TEMPLATE = os.path.join(KRKN_SCENARIO_TEMPLATE_DIR, "scenarios")
 # Krkn supported cloud types for node scenarios
 KRKN_CLOUD_AWS = "aws"
 KRKN_CLOUD_AZURE = "azure"
-KRKN_CLOUD_IBM = "ibm"
+# krknctl / krkn-hub node-scenarios validate CLOUD_TYPE against ibmcloud (not "ibm")
+KRKN_CLOUD_IBM = "ibmcloud"
 KRKN_CLOUD_BAREMETAL = "bm"
 KRKN_CLOUD_VMWARE = "vmware"
 
@@ -3815,6 +3816,15 @@ KRKN_STOP_KUBELET = "stop_kubelet_scenario"
 KRKN_STOP_START_KUBELET = "stop_start_kubelet_scenario"
 KRKN_RESTART_KUBELET = "restart_kubelet_scenario"
 KRKN_NODE_CRASH = "node_crash_scenario"
+
+# krknclt chaos constants
+KRKNCTL_BINARY_TAR = (
+    "https://krkn-chaos.gateway.scarf.sh/krknctl-v0.10.20-beta-linux-amd64.tar.gz"
+)
+KRKNCTL = os.path.join(DATA_DIR, "krknctl")
+KRKNCTL_PLAN_TEMPLATE = os.path.join(
+    KRKN_SCENARIO_TEMPLATE_DIR, "scenarios", "keknctl", "plan.json.j2"
+)
 
 CSI_ADDONS_CONFIGMAP_NAME = "csi-addons-config"
 RBD_CSI_ADDONS_PLUGIN_DIR = (

--- a/tests/cross_functional/krkn_chaos/conftest.py
+++ b/tests/cross_functional/krkn_chaos/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 import os
+import subprocess
+import tarfile
+import time
 import fauxfactory
 import yaml
 import logging
@@ -7,9 +10,11 @@ from ocs_ci.ocs.constants import (
     KRKN_DIR,
     KRKN_CHAOS_DIR,
     KRKN_CHAOS_SCENARIO_DIR,
+    KRKNCTL_BINARY_TAR,
+    KRKNCTL,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.utility.utils import run_cmd
+from ocs_ci.utility.utils import run_cmd, download_with_retries
 from ocs_ci.resiliency.resiliency_tools import CephStatusTool
 from ocs_ci.krkn_chaos.krkn_helpers import CephHealthHelper
 from ocs_ci.ocs import constants
@@ -176,6 +181,125 @@ def krkn_setup():
 
 
 @pytest.fixture(scope="session")
+def krknctl_setup():
+    """
+    Set up krknctl binary and podman for krknctl chaos testing.
+
+    1. Download the krknctl tar from KRKNCTL_BINARY_TAR and extract it into
+       the ocs_ci data directory (KRKNCTL). The tar contains only the
+       krknctl binary, so it can be run from data/krknctl/krknctl.
+    2. Make the krknctl binary executable.
+    3. Enable and start the podman service so it is running.
+
+    This fixture does not return anything.
+    """
+    os.makedirs(KRKNCTL, exist_ok=True)
+
+    tar_filename = os.path.basename(KRKNCTL_BINARY_TAR)
+    tar_path = os.path.join(KRKNCTL, tar_filename)
+    krknctl_binary = os.path.join(KRKNCTL, "krknctl")
+
+    if os.path.exists(krknctl_binary):
+        log.info("Removing existing krknctl binary at %s", krknctl_binary)
+        os.remove(krknctl_binary)
+
+    if not os.path.exists(tar_path):
+        log.info("Downloading krknctl binary from %s", KRKNCTL_BINARY_TAR)
+        downloaded = download_with_retries(KRKNCTL_BINARY_TAR, tar_path)
+        if not downloaded:
+            raise CommandFailed(
+                f"Failed to download krknctl tar from {KRKNCTL_BINARY_TAR}"
+            )
+    else:
+        log.info("Using existing krknctl tar at %s", tar_path)
+
+    log.info("Extracting krknctl tar into %s", KRKNCTL)
+    with tarfile.open(tar_path, "r:gz") as tf:
+        tf.extractall(path=KRKNCTL)
+
+    if not os.path.isfile(krknctl_binary):
+        raise CommandFailed(
+            f"krknctl binary not found at {krknctl_binary} after extracting {tar_path}"
+        )
+
+    log.info("Making krknctl binary executable: %s", krknctl_binary)
+    os.chmod(krknctl_binary, 0o755)
+
+    # Enable and start podman so krknctl can run scenarios in containers.
+    # Use sudo so this works when the test runs as a non-root user (e.g. jenkins).
+    # Enable both podman.socket and podman.service so the API is available to krknctl.
+    log.info("Enabling and starting podman (socket and service) via sudo")
+    podman_ok = False
+    for service_name in ("podman.socket", "podman"):
+        try:
+            run_cmd(f"sudo systemctl enable --now {service_name}", timeout=30)
+            run_cmd(f"sudo systemctl is-active --quiet {service_name}", timeout=5)
+            log.info("Podman '%s' is enabled and running", service_name)
+            podman_ok = True
+        except (CommandFailed, Exception) as e:
+            log.debug("Could not enable/start %s: %s", service_name, e)
+    if not podman_ok:
+        log.warning(
+            "Could not enable/start podman.socket or podman; "
+            "krknctl may require podman to be running."
+        )
+
+    # krknctl runs scenarios in containers; require podman or docker to be usable.
+    container_runtime_ok = False
+    for runtime, check_cmd in (("podman", "podman info"), ("docker", "docker info")):
+        if runtime == "podman":
+            for service_name in ("podman.socket", "podman"):
+                try:
+                    run_cmd(f"sudo systemctl start {service_name}", timeout=15)
+                    log.info("Started podman: %s", service_name)
+                except (CommandFailed, Exception) as e:
+                    log.debug("Could not start %s: %s", service_name, e)
+        try:
+            run_cmd(check_cmd, timeout=15, ignore_error=False)
+            log.info("Container runtime '%s' is available for krknctl", runtime)
+            container_runtime_ok = True
+            break
+        except (CommandFailed, Exception) as e:
+            log.debug("Container runtime '%s' not available: %s", runtime, e)
+            continue
+    if not container_runtime_ok:
+        pytest.skip(
+            "Neither podman nor docker is available or usable. "
+            "krknctl requires a container runtime to run chaos scenarios. "
+            "Install podman or docker and ensure the service is running (e.g. systemctl start podman)."
+        )
+
+    # krknctl expects a container API socket (DOCKER_HOST). For rootless podman, start the
+    # user's podman API service so the socket exists and set DOCKER_HOST for krknctl subprocesses.
+    if os.geteuid() != 0:
+        xdg_runtime = os.environ.get("XDG_RUNTIME_DIR") or os.path.join(
+            "/run", "user", str(os.getuid())
+        )
+        rootless_socket = os.path.join(xdg_runtime, "podman", "podman.sock")
+        if not os.path.exists(rootless_socket):
+            try:
+                log.info("Starting rootless podman system service for krknctl")
+                _proc = subprocess.Popen(
+                    ["podman", "system", "service", "--time=3600"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=os.environ.copy(),
+                )
+                for _ in range(10):
+                    time.sleep(0.5)
+                    if os.path.exists(rootless_socket):
+                        break
+                if not os.path.exists(rootless_socket):
+                    _proc.terminate()
+                    log.warning("Rootless podman socket did not appear")
+            except Exception as e:
+                log.debug("Could not start rootless podman service: %s", e)
+        if os.path.exists(rootless_socket):
+            os.environ["DOCKER_HOST"] = f"unix://{rootless_socket}"
+            log.info("Set DOCKER_HOST=%s for krknctl", os.environ["DOCKER_HOST"])
+
+
+@pytest.fixture(scope="session")
 def krkn_scenarios_list():
     """
     Load the hog_scenarios YAML configuration into a Python dictionary.
@@ -329,6 +453,48 @@ def workload_ops(request, project_factory, multi_pvc_factory, storageclass_facto
                 log.error(f"  ✗ Failed to load fixture '{fixture_name}': {e}")
                 # Don't fail immediately - let factory handle missing fixtures
 
+    # If workloads are exclusively non-VDBENCH (e.g. CNV_ONLY), pre-load VDBENCH
+    # fixtures so KrknWorkloadFactory.create_workload_ops can fall back when the
+    # primary type yields no workloads (CNV optional / empty VMs, etc.).
+    if KrknWorkloadConfig.VDBENCH not in workload_types:
+        vdbench_required = KrknWorkloadRegistry.get_required_fixtures(
+            KrknWorkloadConfig.VDBENCH
+        )
+        log.info(
+            "Pre-loading VDBENCH fixtures for factory fallback: %s",
+            vdbench_required,
+        )
+        for fixture_name in vdbench_required:
+            if fixture_name in fixtures:
+                continue
+            try:
+                fixtures[fixture_name] = request.getfixturevalue(fixture_name)
+                log.debug("  ✓ Loaded fallback fixture: %s", fixture_name)
+            except Exception as e:
+                log.warning(
+                    "Could not load VDBENCH fallback fixture '%s': %s",
+                    fixture_name,
+                    e,
+                )
+
+    # Load KMS factory when encrypted RBD is configured (tenant Vault token, etc.)
+    pv_encryption_kms_setup_factory = None
+    if config.use_encrypted_pvc():
+        try:
+            pv_encryption_kms_setup_factory = request.getfixturevalue(
+                "pv_encryption_kms_setup_factory"
+            )
+            log.info(
+                "Loaded pv_encryption_kms_setup_factory for encrypted VDBENCH PVCs"
+            )
+        except Exception as e:
+            log.warning(
+                "Encrypted PVCs are enabled in Krkn config but "
+                "pv_encryption_kms_setup_factory could not be loaded: %s. "
+                "Encrypted RBD provisioning may fail without tenant KMS resources.",
+                e,
+            )
+
     # Create workload factory and workloads using registry-based approach
     factory = KrknWorkloadFactory()
     ops = factory.create_workload_ops(
@@ -336,6 +502,7 @@ def workload_ops(request, project_factory, multi_pvc_factory, storageclass_facto
         multi_pvc_factory,
         loaded_fixtures=fixtures,  # Pass all loaded fixtures
         storageclass_factory=storageclass_factory,  # Pass storageclass factory for encrypted PVCs
+        pv_encryption_kms_setup_factory=pv_encryption_kms_setup_factory,
     )
 
     try:

--- a/tests/cross_functional/krkn_chaos/test_random_chaos.py
+++ b/tests/cross_functional/krkn_chaos/test_random_chaos.py
@@ -1,0 +1,383 @@
+"""
+Test suite for krknctl random chaos scenarios.
+
+Flow: generate plan -> start workload and background cluster ops -> run krknctl
+random chaos in background (output to log file) -> poll every 3 min until exit
+(with periodic Ceph crash check at each poll; fail immediately if crash detected) ->
+stop workload and background ops, cleanup. Ceph crash check also via fixture.
+"""
+
+import logging
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import green_squad, chaos, polarion_id
+from ocs_ci.ocs import constants
+from ocs_ci.krkn_chaos.krknclt_helper import (
+    APPLICATION_OUTAGES_APP_LABELS,
+    COMPREHENSIVE_SERVICE_DISRUPTION_INCLUDE_SCENARIOS,
+    KRKNCTL_RANDOM_KUBEVIRT_OUTAGE_SCENARIO_BASES,
+    KRKNCTL_RANDOM_NODE_SCENARIO_BASES,
+    KRKNCTL_RANDOM_TIME_SCENARIO_BASES,
+    PlanGenerator,
+    build_krknctl_kubevirt_outage_template_vars,
+    build_krknctl_node_scenario_template_vars,
+    build_krknctl_time_scenario_template_vars,
+    run_krknctl_chaos_and_validate,
+)
+from ocs_ci.krkn_chaos.logging_helpers import log_test_start
+
+log = logging.getLogger(__name__)
+
+DEFAULT_EXCLUDE_SCENARIOS = []
+
+
+@green_squad
+@chaos
+class TestKrKnctlRandomChaos:
+    """
+    Test suite for krknctl random chaos runs.
+
+    Uses a generated plan file (from the jinja template) and runs
+    krknctl random run with configurable max-parallel. Workloads and
+    background cluster operations are started before chaos and validated after.
+    """
+
+    @pytest.mark.parametrize(
+        "max_parallel",
+        [2, 3, 4],
+        ids=[
+            "krknctl-random-max-parallel-2",
+            "krknctl-random-max-parallel-3",
+            "krknctl-random-max-parallel-4",
+        ],
+    )
+    @polarion_id("OCS-7789")
+    def test_krknctl_random_chaos_run(
+        self,
+        krknctl_setup,
+        workload_ops,
+        max_parallel,
+    ):
+        """
+        Run krknctl random chaos with a generated plan and workload validation.
+
+        Flow:
+        1. Generate random plan file (before workload).
+        2. Start workload and background cluster operations.
+        3. run_krknctl_chaos_and_validate: run krknctl random in background
+            (output to krknctl.log), poll every 3 min until exit; at each poll
+            check for Ceph crashes and raise AssertionError if any are found
+            (test fails, evidence is generated). Once krknctl ends: validate
+            and cleanup workloads, run exit criteria.
+        4. Ceph crash check is also done by krkn_chaos_test_lifecycle fixture
+            (autouse: archive at start, finalizer at end).
+
+        Args:
+            krknctl_setup: Session fixture for krknctl binary and podman.
+            workload_ops: WorkloadOps fixture for workload setup/validation.
+            max_parallel: Maximum number of parallel scenarios (2, 3, or 4).
+        """
+        log_test_start(
+            "krknctl random chaos",
+            f"max_parallel={max_parallel}",
+            max_parallel=max_parallel,
+        )
+
+        # Generate random plan file (before workload)
+        log.info("Generating random plan file (exclude=%s)", DEFAULT_EXCLUDE_SCENARIOS)
+        generator = PlanGenerator(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            exclude_scenarios=DEFAULT_EXCLUDE_SCENARIOS,
+            use_random_selectors=True,
+        )
+        generator.generate()
+        plan_path = generator.plan_path
+        log.info("Using plan file: %s", plan_path)
+
+        # WORKLOAD SETUP - Start workloads and background cluster operations
+        log.info("Setting up workloads for krknctl random chaos")
+        workload_ops.setup_workloads()
+
+        run_krknctl_chaos_and_validate(
+            plan_path,
+            workload_ops,
+            max_parallel,
+            run_name="krknctl",
+            failure_context="krknctl random run",
+            validation_failure_context="krknctl-random",
+        )
+        log.info(
+            "krknctl random chaos test completed successfully (max_parallel=%s)",
+            max_parallel,
+        )
+
+    @pytest.mark.parametrize(
+        "max_parallel",
+        [2, 3, 4],
+        ids=[
+            "krknctl-random-node-max-parallel-2",
+            "krknctl-random-node-max-parallel-3",
+            "krknctl-random-node-max-parallel-4",
+        ],
+    )
+    @polarion_id("OCS-7790")
+    def test_krknctl_random_chaos_node_scenarios(
+        self,
+        krknctl_setup,
+        workload_ops,
+        max_parallel,
+    ):
+        """
+        Run krknctl ``random`` with a plan containing only root + node-scenarios.
+
+        ``cloud_type`` is set from the cluster platform (see
+        ``get_krkn_cloud_type``), or from ``CLOUD_TYPE`` if set; unsupported
+        platforms skip. Optional env vars matching krkn-hub ``node-scenarios``
+        (e.g. ``AWS_*``, ``VSPHERE_*``, ``ACTION``, ``KUBE_CHECK``) are forwarded
+        into the plan when present. To target specific cluster nodes, set
+        ``KRKN_NODE_NAME`` (not ``NODE_NAME``, which Jenkins sets to the agent).
+
+        Flow matches ``test_krknctl_random_chaos_run`` (workload, background ops,
+        krknctl in background, poll, validate).
+        """
+        log_test_start(
+            "krknctl random chaos (node-scenarios)",
+            f"max_parallel={max_parallel}",
+            max_parallel=max_parallel,
+        )
+
+        node_template_vars = build_krknctl_node_scenario_template_vars()
+        log.info(
+            f"Generating krknctl plan (include={KRKNCTL_RANDOM_NODE_SCENARIO_BASES}, "
+            f"cloud_type={node_template_vars.get('cloud_type')})"
+        )
+        generator = PlanGenerator(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            include_scenarios=KRKNCTL_RANDOM_NODE_SCENARIO_BASES,
+            use_random_selectors=False,
+            **node_template_vars,
+        )
+        generator.generate()
+        plan_path = generator.plan_path
+        log.info(f"Using plan file: {plan_path}")
+
+        log.info("Setting up workloads for krknctl random node-scenarios chaos")
+        workload_ops.setup_workloads()
+
+        run_krknctl_chaos_and_validate(
+            plan_path,
+            workload_ops,
+            max_parallel,
+            run_name="krknctl node-scenarios",
+            failure_context="krknctl random node-scenarios run",
+            validation_failure_context="krknctl-random-node-scenarios",
+        )
+        log.info(
+            f"krknctl random node-scenarios test completed (max_parallel={max_parallel})"
+        )
+
+    @pytest.mark.parametrize(
+        "max_parallel",
+        [2, 3, 4],
+        ids=[
+            "krknctl-random-kubevirt-max-parallel-2",
+            "krknctl-random-kubevirt-max-parallel-3",
+            "krknctl-random-kubevirt-max-parallel-4",
+        ],
+    )
+    @polarion_id("OCS-7791")
+    def test_krknctl_random_chaos_kubevirt_outage(
+        self,
+        krknctl_setup,
+        workload_ops,
+        max_parallel,
+    ):
+        """
+        Run krknctl ``random`` with a plan containing only root + kubevirt-outage.
+
+        Requires a VirtualMachine name (``krkn_config.kubevirt_outage`` or
+        ``KRKN_KUBEVIRT_VM_NAME``); otherwise the test skips. Namespace defaults
+        to ``default`` or ``kubevirt_outage.namespace`` / ``KRKN_KUBEVIRT_NAMESPACE``.
+        """
+        log_test_start(
+            "krknctl random chaos (kubevirt-outage)",
+            f"max_parallel={max_parallel}",
+            max_parallel=max_parallel,
+        )
+
+        kv_template_vars = build_krknctl_kubevirt_outage_template_vars()
+        log.info(
+            "Generating krknctl plan (include=%s, namespace=%s, vm=%s)",
+            KRKNCTL_RANDOM_KUBEVIRT_OUTAGE_SCENARIO_BASES,
+            kv_template_vars.get("kubevirt_namespace"),
+            kv_template_vars.get("kubevirt_vm_name"),
+        )
+        generator = PlanGenerator(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            include_scenarios=KRKNCTL_RANDOM_KUBEVIRT_OUTAGE_SCENARIO_BASES,
+            use_random_selectors=False,
+            **kv_template_vars,
+        )
+        generator.generate()
+        plan_path = generator.plan_path
+        log.info("Using plan file: %s", plan_path)
+
+        log.info("Setting up workloads for krknctl random kubevirt-outage chaos")
+        workload_ops.setup_workloads()
+
+        run_krknctl_chaos_and_validate(
+            plan_path,
+            workload_ops,
+            max_parallel,
+            run_name="krknctl kubevirt-outage",
+            failure_context="krknctl random kubevirt-outage run",
+            validation_failure_context="krknctl-random-kubevirt-outage",
+        )
+        log.info(
+            "krknctl random kubevirt-outage test completed (max_parallel=%s)",
+            max_parallel,
+        )
+
+    @pytest.mark.parametrize(
+        "max_parallel",
+        [2, 3, 4],
+        ids=[
+            "krknctl-random-time-max-parallel-2",
+            "krknctl-random-time-max-parallel-3",
+            "krknctl-random-time-max-parallel-4",
+        ],
+    )
+    @polarion_id("OCS-7792")
+    def test_krknctl_random_chaos_time_scenarios(
+        self,
+        krknctl_setup,
+        workload_ops,
+        max_parallel,
+    ):
+        """
+        Run krknctl ``random`` with a plan containing only root + time-scenarios.
+
+        Targets and action come from ``krkn_config.time_scenarios`` or ``KRKN_TIME_*``
+        env vars; see ``build_krknctl_time_scenario_template_vars``.
+        """
+        log_test_start(
+            "krknctl random chaos (time-scenarios)",
+            f"max_parallel={max_parallel}",
+            max_parallel=max_parallel,
+        )
+
+        time_template_vars = build_krknctl_time_scenario_template_vars()
+        log.info(
+            f"Generating krknctl plan (include={KRKNCTL_RANDOM_TIME_SCENARIO_BASES}, "
+            f"action={time_template_vars.get('time_action')}, "
+            f"label={time_template_vars.get('time_label_selector')})"
+        )
+        generator = PlanGenerator(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            include_scenarios=KRKNCTL_RANDOM_TIME_SCENARIO_BASES,
+            use_random_selectors=False,
+            **time_template_vars,
+        )
+        generator.generate()
+        plan_path = generator.plan_path
+        log.info(f"Using plan file: {plan_path}")
+
+        log.info("Setting up workloads for krknctl random time-scenarios chaos")
+        workload_ops.setup_workloads()
+
+        run_krknctl_chaos_and_validate(
+            plan_path,
+            workload_ops,
+            max_parallel,
+            run_name="krknctl time-scenarios",
+            failure_context="krknctl random time-scenarios run",
+            validation_failure_context="krknctl-random-time-scenarios",
+        )
+        log.info(
+            f"krknctl random time-scenarios test completed (max_parallel={max_parallel})"
+        )
+
+
+@green_squad
+@chaos
+class TestKrKnctlServiceDisruption:
+    """
+    Test suite for comprehensive krknctl chaos including namespace service disruption.
+
+    Generates a plan with root + application-outages, pod-scenarios, and
+    container-scenarios expanded per label in APPLICATION_OUTAGES_APP_LABELS, plus
+    a single service-disruption-scenarios node targeting openshift-storage by name
+    (krkn-hub disrupts namespaces, not per-pod labels). Same flow as random chaos:
+    workload setup, krknctl random run in background, poll, cleanup.
+    """
+
+    @pytest.mark.parametrize(
+        "max_parallel",
+        [2, 3, 4],
+        ids=["max-parallel-2", "max-parallel-3", "max-parallel-4"],
+    )
+    @polarion_id("OCS-7793")
+    def test_random_service_disruption(
+        self,
+        krknctl_setup,
+        workload_ops,
+        max_parallel,
+    ):
+        """
+        Run comprehensive chaos (application-outages, pod-scenarios,
+        container-scenarios per label, plus one namespace-level service-disruption).
+
+        Flow:
+        1. Generate plan with root + all four scenario types; first three expanded
+            per label (APPLICATION_OUTAGES_APP_LABELS); service-disruption once
+            for openshift-storage namespace.
+        2. Start workload and background cluster operations.
+        3. run_krknctl_chaos_and_validate: run krknctl random in background
+            (output to krknctl.log), poll every 3 min until exit; at each poll
+            check for Ceph crashes and raise AssertionError if any are found
+            (test fails, evidence is generated). Once krknctl ends: validate
+            and cleanup workloads, run exit criteria.
+        4. Ceph crash check is also done by krkn_chaos_test_lifecycle fixture
+            (autouse: archive at start, finalizer at end).
+
+        Args:
+            krknctl_setup: Session fixture for krknctl binary and podman.
+            workload_ops: WorkloadOps fixture for workload setup/validation.
+            max_parallel: Maximum number of parallel scenarios (2, 3, or 4).
+        """
+        log_test_start(
+            "service disruption",
+            f"all_labels max_parallel={max_parallel}",
+        )
+
+        # Generate plan: root + application-outages, pod-scenarios, container-scenarios
+        # expanded per label; service-disruption-scenarios is a single namespace target
+        generator = PlanGenerator(
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            include_scenarios=COMPREHENSIVE_SERVICE_DISRUPTION_INCLUDE_SCENARIOS,
+            use_random_selectors=False,
+            label_selectors=list(APPLICATION_OUTAGES_APP_LABELS),
+        )
+        generator.generate()
+        plan_path = generator.plan_path
+        log.info(
+            "Using plan file: %s (labels=%s)",
+            plan_path,
+            [label.split("=", 1)[1] for label in APPLICATION_OUTAGES_APP_LABELS],
+        )
+
+        log.info("Setting up workloads for service disruption test")
+        workload_ops.setup_workloads()
+
+        run_krknctl_chaos_and_validate(
+            plan_path,
+            workload_ops,
+            max_parallel,
+            run_name="krknctl service disruption",
+            failure_context="krknctl service disruption",
+            validation_failure_context="krknctl-service-disruption",
+        )
+        log.info(
+            "service disruption test completed successfully (all labels, max_parallel=%s)",
+            max_parallel,
+        )


### PR DESCRIPTION
PR: Add test automation for krknctl chaos scenarios

- Krknctl random chaos (test_krknctl_random_chaos_run): Runs krknctl random chaos with a generated plan and workload validation; parametrized over max_parallel 2, 3, and 4.
- Krknctl service disruption (test_random_service_disruption): Runs comprehensive service disruption (application-outages, pod-scenarios, container-scenarios, service-disruption-scenarios) for all app labels in a single plan; parametrized over max_parallel 2, 3, and 4.

Both tests assert exit criteria: no Ceph crash and cluster not in HEALTH_ERR after chaos.