### PR TITLE
Fix to creation of duplicate bucket negative test case

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -489,8 +489,7 @@ class MCGS3Bucket(ObjectBucket):
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
                 logger.info(f"Bucket {self.name} already exists")
-            else:
-                raise e
+            raise e
 
     def internal_delete(self):
         """

--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -205,8 +205,11 @@ class TestBucketCreationAndDeletion(MCGTest):
         )
         for bucket_name in bucket_set:
             try:
+                logger.info(f"Trying to create a bucket with name {bucket_name}")
                 bucket = BUCKET_MAP[interface.lower()](bucket_name, mcg=mcg_obj)
-                assert not bucket, "Unexpected: Duplicate creation hasn't failed."
+                assert (
+                    not bucket
+                ), f"Unexpected: Duplicate creation of {bucket_name} hasn't failed."
             except (CommandFailed, botocore.exceptions.ClientError) as err:
                 assert re.search(expected_err, str(err)), (
                     "Couldn't verify OBC creation. Unexpected error " f"{str(err)}"


### PR DESCRIPTION
This PR contains a fix to creation of duplicate bucket negative test case (https://github.com/red-hat-storage/ocs-ci/issues/14686) 
When bucket creation failed because bucket with such name already existed , the exception was not propagated, and now it is. 

