### PR TITLE
node ip extract for vsphere Agents

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -44,6 +44,7 @@ from ocs_ci.ocs.exceptions import (
     UnexpectedDeploymentConfiguration,
 )
 from ocs_ci.ocs.node import (
+    get_node_internal_ips,
     get_node_ips,
     get_typed_worker_nodes,
     remove_nodes,
@@ -2190,6 +2191,11 @@ class VSPHEREAgentAI(VSPHEREBASE):
 
             with config.RunWithProviderConfigContextIfAvailable():
                 master_node_ips = get_node_ips(constants.MASTER_MACHINE)
+                if not master_node_ips:
+                    logger.info(
+                        "No ExternalIP found on master nodes, falling back to InternalIP"
+                    )
+                    master_node_ips = get_node_internal_ips(constants.MASTER_MACHINE)
 
             create_dns_records_api_int(master_node_ips)
 

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -356,6 +356,32 @@ def get_node_ips(node_type="worker"):
         raise NotImplementedError
 
 
+def get_node_internal_ips(node_type="worker"):
+    """
+    Gets the node InternalIP addresses. Useful on platforms like vSphere
+    where ExternalIP is not set by the cloud provider.
+
+    Args:
+        node_type (str): The node type (e.g. worker, master)
+
+    Returns:
+        list: Node InternalIP addresses
+
+    """
+    ocp = OCP(kind=constants.NODE)
+    if node_type == "worker":
+        nodes = ocp.get(selector=constants.WORKER_LABEL).get("items")
+    if node_type == "master":
+        nodes = ocp.get(selector=constants.MASTER_LABEL).get("items")
+
+    return [
+        each["address"]
+        for node in nodes
+        for each in node["status"]["addresses"]
+        if each["type"] == "InternalIP"
+    ]
+
+
 def get_node_ip_addresses(ipkind):
     """
     Gets a dictionary of required IP addresses for all nodes


### PR DESCRIPTION
Bypass this problem: 

```
2026-03-14 17:09:43  ocs_ci/deployment/deployment.py:833: in deploy_cluster
2026-03-14 17:09:43      self.do_deploy_ocp(log_cli_level)
2026-03-14 17:09:43  ocs_ci/deployment/deployment.py:306: in do_deploy_ocp
2026-03-14 17:09:43      self.deploy_ocp(log_cli_level)
2026-03-14 17:09:43  ocs_ci/deployment/vmware.py:2379: in deploy_ocp
2026-03-14 17:09:43      super(VSPHEREAgentAI, self).deploy_ocp(log_cli_level)
2026-03-14 17:09:43  ocs_ci/deployment/deployment.py:948: in deploy_ocp
2026-03-14 17:09:43      self.ocp_deployment.deploy(log_cli_level)
2026-03-14 17:09:43  ocs_ci/deployment/vmware.py:2200: in deploy
2026-03-14 17:09:43      create_dns_records_api_int(master_node_ips)
2026-03-14 17:09:43  ocs_ci/deployment/vmware.py:3057: in create_dns_records_api_int
2026-03-14 17:09:43      _create_dns_records_helper([dns_record_name], ip_list)
2026-03-14 17:09:43  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-03-14 17:09:43  
2026-03-14 17:09:43  dns_record_names = ['api-int.dnddosypenk-14a3'], ips = []
2026-03-14 17:09:43  
2026-03-14 17:09:43      def _create_dns_records_helper(dns_record_names: list[str], ips: list):
2026-03-14 17:09:43          """
2026-03-14 17:09:43          Helper function to create DNS records. Not supposed to be called directly.
2026-03-14 17:09:43          """
2026-03-14 17:09:43          aws = AWS()
2026-03-14 17:09:43          responses = []
2026-03-14 17:09:43          dns_record_mapping = {}
2026-03-14 17:09:43          for index, record in enumerate(dns_record_names):
2026-03-14 17:09:43  >           dns_record_mapping[record] = ips[index]
2026-03-14 17:09:43  E           IndexError: list index out of range
2026-03-14 17:09:43  
2026-03-14 17:09:43  ocs_ci/deployment/vmware.py:3068: IndexError
```