### PR TITLE
A fix to test_bucket_used_bytes_metric test case

### DIFF
--- a/tests/functional/object/mcg/test_noobaa_prometheus.py
+++ b/tests/functional/object/mcg/test_noobaa_prometheus.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 def get_bucket_used_bytes_metric(bucket_name, threading_lock):
     response = json.loads(
         PrometheusAPI(threading_lock=threading_lock)
-        .get(f'query?query=NooBaa_bucket_used_bytes{{bucket_name="{bucket_name}"}}')
+        .get(
+            f'query?query=NooBaa_bucket_used_bytes{{bucket_name="{bucket_name}"}}',
+            timeout=600,
+        )
         .content.decode("utf-8")
     )
     if len(response.get("data").get("result")) == 0:


### PR DESCRIPTION
This PR is a fix for https://github.com/red-hat-storage/ocs-ci/issues/11409 ( test_bucket_used_bytes_metric test case).

The solution is to increase timeout for prometheus query, since sometimes ( at least in 50% of the runs) a timeout of 300 secs is not enough.