### PR TITLE
resolve default storage class AWS / gp3-csi

### DIFF
--- a/ocs_ci/deployment/helpers/storage_class.py
+++ b/ocs_ci/deployment/helpers/storage_class.py
@@ -12,7 +12,7 @@ from ocs_ci.ocs.ocp import OCP
 logger = logging.getLogger(__name__)
 
 DEFAULT_STORAGE_CLASS_MAP = {
-    constants.AWS_PLATFORM: "gp2-csi",
+    constants.AWS_PLATFORM: "gp3-csi",
     constants.IBMCLOUD_PLATFORM: "ibmc-vpc-block-10iops-tier",
     constants.VSPHERE_PLATFORM: "thin-csi-odf",
     constants.AZURE_PLATFORM: "managed-csi",


### PR DESCRIPTION
Resolve issue on FDF installations with AWS:

```
 The StorageCluster CR's storageDeviceSets[0].dataPVCTemplate does not specify a storageClassName. The operator can't determine which StorageClass to use for provisioning OSD PVCs,
  so it rejects the spec and enters Error phase.

  The cluster has two available StorageClasses: gp2-csi and gp3-csi (default). No Ceph resources, PVCs, or data pods have been created yet — the reconciliation fails before it gets
  that far.

```

Storageclass name should be set via StorageCluster with this manner: 

```
 {
    "spec": {
      "storageDeviceSets": [{
        "name": "ocs-deviceset",
        "count": 1,
        "replica": 3,
        "portable": true,
        "dataPVCTemplate": {
          "spec": {
            "storageClassName": "gp3-csi",
            "accessModes": ["ReadWriteOnce"],
            "volumeMode": "Block",
            "resources": {
              "requests": {
                "storage": "100Gi"
              }
            }
          }
        }
      }]
    }
  }'
```