### PR TITLE
A fix to test_bucket_replication_and_its_metrics test 

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3558,13 +3558,12 @@ def get_noobaa_bucket_replication_metrics_in_prometheus(
     """
     query = f"{metric_name} {{bucket_name='{bucket_name}'}}"
     api = PrometheusAPI(threading_lock=threading_lock)
-    resp = api.get("query", payload={"query": query}, timeout=1800)
+    logger.info(f"Prometheus query: {query}")
+    resp = api.get("query", payload={"query": query}, timeout=1200)
 
     if resp.ok:
-        logger.info(f"******* PROMETHEUS QUERY {query}")
+        logger.info(f"Prometheus response: {resp.text}")
         metrics_output = json.loads(resp.text)
-        logger.info(f"******* PROMETHEUS RESULT STR {resp.text}")
-        logger.info(f"******* PROMETHEUS RESULT JSON {metrics_output}")
         got_metrics_value = int(metrics_output["data"]["result"][0]["value"][1])
         logger.info(f"Metrics {metric_name} : {got_metrics_value}")
         return got_metrics_value


### PR DESCRIPTION
This PR is a fix to test_bucket_replication_and_its_metrics test , solution to https://github.com/red-hat-storage/ocs-ci/issues/14699 . 
Please note that 3 timeouts were tested: 600s, 1200s and 1800s, 600s was consistently failing, 1800 and 1200 worked, therefore 1200 was chosen. 
Also some prints to the logs were added for clarity.