### PR TITLE
Fix mon pod selection on LSO deployments in test_mon_data_avail_warn

### DIFF
--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -113,6 +113,7 @@ class TestMonDataAvailWarn(E2ETest):
             self.oc_cmd.exec_oc_debug_cmd(
                 node=self.worker_node,
                 cmd_list=[write_cmd],
+                timeout=600,
             )
         else:
             self.mon_pod.exec_sh_cmd_on_pod(command=write_cmd, sh="sh")

--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -16,7 +16,6 @@ from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
 )
-from ocs_ci.ocs import node
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.cluster import CephCluster
 from ocs_ci.utility import utils
@@ -55,29 +54,15 @@ class TestMonDataAvailWarn(E2ETest):
         Setting up the environment for the test
 
         """
-        if config.DEPLOYMENT.get("local_storage"):
-            self.worker_node = node.get_worker_nodes()[0]
-            self.oc_cmd = OCP(namespace=config.ENV_DATA["cluster_namespace"])
-            mon_pod_name = self.oc_cmd.exec_oc_debug_cmd(
-                node=self.worker_node,
-                cmd_list=["ls /var/lib/rook/ | grep mon"],
-            )
-            mon_pod_id = mon_pod_name.split("-")[1].replace("\n", "")
-
-            mon_pods_info = pod.get_pods_having_label(
-                label=f"ceph_daemon_id={mon_pod_id}",
-                namespace=config.ENV_DATA["cluster_namespace"],
-            )
-            self.mon_pod = pod.get_pod_obj(
-                name=mon_pods_info[0]["metadata"]["name"],
-                namespace=config.ENV_DATA["cluster_namespace"],
-            )
-        else:
-            self.mon_pod = random.choice(pod.get_mon_pods())
+        self.mon_pod = random.choice(pod.get_mon_pods())
         self.mon_suffix = self.mon_pod.get().get("metadata").get("labels").get("mon")
 
         self.workloads_dir = f"/var/lib/ceph/mon/ceph-{self.mon_suffix}/workloads"
         log.info(f"Selected mon '{self.mon_pod.name}'")
+
+        if config.DEPLOYMENT.get("local_storage"):
+            self.worker_node = self.mon_pod.get()["spec"]["nodeName"]
+            self.oc_cmd = OCP(namespace=config.ENV_DATA["cluster_namespace"])
         self.mon_pod.exec_cmd_on_pod(f"mkdir {self.workloads_dir}")
         self.mon_pod.exec_cmd_on_pod(f"touch {self.workloads_dir}/{TEMP_FILE}")
 

--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -81,11 +81,18 @@ class TestMonDataAvailWarn(E2ETest):
             int: Used space percentage
 
         """
-        path = f"/var/lib/ceph/mon/ceph-{self.mon_suffix}"
         if config.DEPLOYMENT.get("local_storage"):
-            path = "/etc/hosts"
-        cmd = f"df -Th | grep {path}"
-        mount_details = self.mon_pod.exec_sh_cmd_on_pod(command=cmd, sh="sh")
+            path = f"/var/lib/rook/mon-{self.mon_suffix}/data"
+            cmd = f"df -Th {path}"
+            result = self.oc_cmd.exec_oc_debug_cmd(
+                node=self.worker_node,
+                cmd_list=[cmd],
+            )
+            mount_details = result.strip().splitlines()[-1]
+        else:
+            path = f"/var/lib/ceph/mon/ceph-{self.mon_suffix}"
+            cmd = f"df -Th {path}"
+            mount_details = self.mon_pod.exec_sh_cmd_on_pod(command=cmd, sh="sh")
         used_percent = mount_details.split()[5].replace("%", "")
         return int(used_percent)
 


### PR DESCRIPTION
## Summary
  - The LSO code path in `workloads_dir_setup` used `ceph_daemon_id` label to find the mon pod, but this label is shared between mon and mgr pods (e.g., both `rook-ceph-mon-a` and `rook-ceph-mgr-a` have
  `ceph_daemon_id=a`)
  - When the mgr pod was returned first by the API, the test selected it instead of the mon pod, causing `mon_suffix=None` and `mkdir /var/lib/ceph/mon/ceph-None/workloads` failure
  - Replace the LSO-specific pod lookup with `get_mon_pods()` which uses the unambiguous `app=rook-ceph-mon` label
  - The worker node for the LSO dd path is now derived from the selected mon pod's `spec.nodeName`

## Root Cause
ReportPortal: https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/44404/2024569/2024879/log

Platform: vSphere UPI LSO