### PR TITLE
14629:test_negative_custom_taint need adjustment for provider/multiclient setup

### DIFF
--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -79,6 +79,14 @@ class TestNonOCSTaintAndTolerations(E2ETest):
         Initialize Sanity instance
 
         """
+        if (
+            config.ENV_DATA.get("platform", "").lower()
+            in constants.HCI_PROVIDER_CLIENT_PLATFORMS
+            and config.ENV_DATA.get("cluster_type", "").lower() == constants.HCI_CLIENT
+        ):
+            pytest.skip(
+                "Test not supported on HCI client cluster - CephCluster CRD not available"
+            )
         self.sanity_helpers = Sanity()
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
-Fixes: #14629
- The fix adds a runtime check in init_sanity that skips the test when running on an HCI client cluster. This is needed because:
  - The existing @skipif_hci_provider_and_client class-level marker is static, evaluated at import time when the multi-cluster config may not be fully populated
  - The runtime check uses config.ENV_DATA which reflects the current cluster context at test execution time
  - It checks specifically for HCI_CLIENT cluster type, since that's the cluster where CephCluster CRD doesn't exist