### PR TITLE
Use the context of cluster_name in the function is_hosted_cluster

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5609,16 +5609,10 @@ def get_client_type_by_name(cluster_name):
         get_hosted_cluster_type,
     )
 
-    # Store original context index to restore later
-    orig_index = config.cur_index
-    try:
-        config.switch_ctx(config.get_cluster_index_by_name(cluster_name))
-        if not is_hosted_cluster(cluster_name):
-            return constants.NON_HOSTED_CLUSTER
+    if not is_hosted_cluster(cluster_name):
+        return constants.NON_HOSTED_CLUSTER
 
-        return get_hosted_cluster_type(cluster_name)
-    finally:
-        config.switch_ctx(orig_index)
+    return get_hosted_cluster_type(cluster_name)
 
 
 def switch_to_correct_client_type(client_type):


### PR DESCRIPTION
The decorator `config.run_with_provider_context_if_available `of the function `is_hosted_cluster` is unaware of the current cluster context and also assumes that only one provider cluster is present. Without current context being the given cluster_name, the function cannot use the value of ENV_DATA.provider_cluster_name to use correct provider cluster context.
Added switch to cluster_name context to solve this.