### PR TITLE
Improve must-gather directory naming with version and test information

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1269,7 +1269,18 @@ def _collect_ocs_logs(
                 cluster_config.DEPLOYMENT["default_latest_tag"],
             ),
         )
-        ocs_log_dir_path = os.path.join(log_dir_path, "ocs_must_gather")
+        # Get ODF version for directory naming
+        try:
+            ocs_version_obj = version.get_ocs_version_from_csv(only_major_minor=True)
+            ocs_version_str = f"_ODF-{ocs_version_obj}"
+        except Exception:
+            # Omit version if not available
+            ocs_version_str = ""
+        # Include test name for failed test cases
+        test_name_str = f"_{dir_name}" if status_failure else ""
+        ocs_log_dir_path = os.path.join(
+            log_dir_path, f"ocs_must_gather{ocs_version_str}{test_name_str}"
+        )
         ocs_must_gather_image = cluster_config.REPORTING.get(
             "ocs_must_gather_image",
             cluster_config.REPORTING["default_ocs_must_gather_image"],
@@ -1308,9 +1319,21 @@ def _collect_ocs_logs(
             )
             collect_ceph_external(path=external_ceph_log_dir_path)
     if ocp:
-        ocp_log_dir_path = os.path.join(log_dir_path, "ocp_must_gather")
+        # Get OCP version for directory naming
+        try:
+            ocp_version_obj = version.get_semantic_ocp_running_version()
+            ocp_version_str = f"_OCP-{ocp_version_obj.major}.{ocp_version_obj.minor}"
+        except Exception:
+            # Omit version if not available
+            ocp_version_str = ""
+        # Include test name for failed test cases
+        test_name_str = f"_{dir_name}" if status_failure else ""
+        ocp_log_dir_path = os.path.join(
+            log_dir_path, f"ocp_must_gather{ocp_version_str}{test_name_str}"
+        )
         ocp_service_log_dir_path = os.path.join(
-            log_dir_path, "ocp_service_logs_must_gather"
+            log_dir_path,
+            f"ocp_service_logs_must_gather{ocp_version_str}{test_name_str}",
         )
         ocp_must_gather_image = cluster_config.REPORTING["ocp_must_gather_image"]
         if cluster_config.DEPLOYMENT.get("disconnected"):

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1276,10 +1276,11 @@ def _collect_ocs_logs(
         except Exception:
             # Omit version if not available
             ocs_version_str = ""
-        # Include test name for failed test cases
+        # Include run_id and test name for better identification
+        run_id_str = f"_{cluster_config.RUN['run_id']}"
         test_name_str = f"_{dir_name}" if status_failure else ""
         ocs_log_dir_path = os.path.join(
-            log_dir_path, f"ocs_must_gather{ocs_version_str}{test_name_str}"
+            log_dir_path, f"ocs_must_gather{run_id_str}{ocs_version_str}{test_name_str}"
         )
         ocs_must_gather_image = cluster_config.REPORTING.get(
             "ocs_must_gather_image",
@@ -1326,14 +1327,15 @@ def _collect_ocs_logs(
         except Exception:
             # Omit version if not available
             ocp_version_str = ""
-        # Include test name for failed test cases
+        # Include run_id and test name for better identification
+        run_id_str = f"_{cluster_config.RUN['run_id']}"
         test_name_str = f"_{dir_name}" if status_failure else ""
         ocp_log_dir_path = os.path.join(
-            log_dir_path, f"ocp_must_gather{ocp_version_str}{test_name_str}"
+            log_dir_path, f"ocp_must_gather{run_id_str}{ocp_version_str}{test_name_str}"
         )
         ocp_service_log_dir_path = os.path.join(
             log_dir_path,
-            f"ocp_service_logs_must_gather{ocp_version_str}{test_name_str}",
+            f"ocp_service_logs_must_gather{run_id_str}{ocp_version_str}{test_name_str}",
         )
         ocp_must_gather_image = cluster_config.REPORTING["ocp_must_gather_image"]
         if cluster_config.DEPLOYMENT.get("disconnected"):


### PR DESCRIPTION
Update must-gather directory names to include ODF and OCP versions for better clarity and easier log identification. For failed test cases, also include the test name in the directory name.

Directory naming examples:
- Success: ocs_must_gather_ODF-4.21, ocp_must_gather_OCP-4.15
- Failure: ocs_must_gather_ODF-4.21_test_name, ocp_must_gather_OCP-4.15_test_name

This makes it immediately clear which versions the logs are from and which test failed, improving log organization and debugging workflow.