### PR TITLE
fix acm submariner validation using ops ci framework

### DIFF
--- a/conf/ocsci/acm_hub_released_deploy.yaml
+++ b/conf/ocsci/acm_hub_released_deploy.yaml
@@ -1,0 +1,5 @@
+---
+ENV_DATA:
+  deploy_acm_hub_cluster: true
+  skip_ocs_deployment: true
+  acm_hub_unreleased: false

--- a/conf/ocsci/submariner_downstream_released.yaml
+++ b/conf/ocsci/submariner_downstream_released.yaml
@@ -1,0 +1,5 @@
+ENV_DATA:
+  submariner_source: "downstream"
+  submariner_release_type: "released"
+  submariner_channel: ""
+  subctl_version: "subctl-rhel9:v0.23"

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2592,8 +2592,9 @@ class Deployment(object):
 
     def deploy_acm_hub(self):
         """
-        Handle ACM HUB deployment
+        Deploy ACM hub cluster
         """
+
         if self.acm_operator_installed():
             logger.info("ACM Operator is already installed")
             self.deploy_multicluster_hub()
@@ -2610,6 +2611,7 @@ class Deployment(object):
         else:
             self.deploy_acm_hub_released()
             self.deploy_multicluster_hub()
+
         if config.ENV_DATA.get("configure_acm_to_import_mce"):
             self.configure_acm_to_import_mce_clusters()
         from ocs_ci.ocs.acm.acm import verify_running_acm

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.21-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.21-config.yaml
@@ -15,5 +15,4 @@ ENV_DATA:
   mce_version: "2.11"
   submariner_version: "0.23.1"
   # Below values needs to be changed when acm and submariner are GAed
-  submariner_source: "downstream"
   oadp_version: "1.5"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
@@ -22,7 +22,4 @@ ENV_DATA:
   submariner_version: "0.23.1"
   submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
   # Below values needs to be changed when acm and submariner are GAed
-  submariner_source: "downstream"
-  submariner_release_type: "released"
-  acm_hub_unreleased: true
   oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
@@ -17,7 +17,4 @@ ENV_DATA:
   submariner_version: "0.23.1"
   submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
   # Below values needs to be changed when acm and submariner are GAed
-  submariner_source: "downstream"
-  submariner_release_type: "released"
-  acm_hub_unreleased: true
   oadp_version: "1.6"

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -407,6 +407,7 @@ def pytest_configure(config):
     set_log_record_factory()
     # Ensure custom log levels are registered
     from ocs_ci.framework.custom_logger import TEST_STEP, ASSERTION, AI_DATA
+    from ocs_ci.utility.utils import auto_configure_acm, auto_configure_submariner
 
     logging.addLevelName(TEST_STEP, "TEST_STEP")
     logging.addLevelName(ASSERTION, "ASSERTION")
@@ -422,6 +423,8 @@ def pytest_configure(config):
 
         if not (config.getoption("--help") or config.getoption("collectonly")):
             process_cluster_cli_params(config)
+            auto_configure_acm()
+            auto_configure_submariner()
             config_file = os.path.expanduser(
                 os.path.join(
                     ocsci_config.RUN["log_dir"],

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -195,5 +195,31 @@ API_SSL_CERT = os.path.join(constants.DATA_DIR, "api-cert.crt")
 API_SSL_KEY = os.path.join(constants.DATA_DIR, "api-cert.key")
 API_SSL_CA_CERT = os.path.join(constants.DATA_DIR, "ca.crt")
 
+ocp_to_acm_unreleased_mapping = {
+    "4.14": False,
+    "4.15": False,
+    "4.16": False,
+    "4.17": False,
+    "4.18": False,
+    "4.19": False,
+    "4.20": False,
+    "4.21": False,
+    "4.22": True,
+    "4.23": True,
+}
+
+ocp_to_submariner_unreleased_mapping = {
+    "4.14": False,
+    "4.15": False,
+    "4.16": False,
+    "4.17": False,
+    "4.18": False,
+    "4.19": False,
+    "4.20": False,
+    "4.21": False,
+    "4.22": False,
+    "4.23": True,
+}
+
 # Storage cluster related defaults
 DEVICE_TYPE = "SSD"

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -7613,3 +7613,65 @@ def genereate_cred_file_rack():
     )
 
     return rack_dict
+
+
+def auto_configure_acm():
+    """
+    Auto-configure ACM as released or unreleased based on OCP version
+    If explicitly configured by user, skips auto-configuration.
+    Uses OCP version mappings with safe defaults (unreleased) for unknown versions.
+    """
+    # If explicitly configured by user, skip auto-configuration
+    if config.ENV_DATA.get("acm_hub_unreleased") is not None:
+        log.info(
+            f"ACM explicitly configured: acm_hub_unreleased={config.ENV_DATA['acm_hub_unreleased']}"
+        )
+        return
+    # Get OCP version
+    ocp_version = version_module.get_semantic_ocp_version_from_config()
+    # Look up in mapping, default to True (unreleased) for unknown versions
+    acm_unreleased = defaults.ocp_to_acm_unreleased_mapping.get(f"{ocp_version}", True)
+    config.ENV_DATA["acm_hub_unreleased"] = acm_unreleased
+    if f"{ocp_version}" in defaults.ocp_to_acm_unreleased_mapping:
+        log.info(
+            f"OCP {ocp_version} → ACM: {'UNRELEASED' if acm_unreleased else 'RELEASED'}"
+        )
+    else:
+        log.info(f"OCP {ocp_version} not in mapping → ACM: UNRELEASED (safe default)")
+
+
+def auto_configure_submariner():
+    """
+    Auto-configure Submariner as released or unreleased based on OCP version.
+    If explicitly configured by user, skips auto-configuration.
+    Uses OCP version mappings with safe defaults (unreleased) for unknown versions.
+    """
+    # Set submariner_source default if not provided by user
+    if config.ENV_DATA.get("submariner_source") is None:
+        config.ENV_DATA["submariner_source"] = "downstream"
+        log.info("Submariner source not specified, defaulting to: downstream")
+
+    # If explicitly configured by user, skip auto-configuration
+    if config.ENV_DATA.get("submariner_release_type") is not None:
+        log.info(
+            f"Submariner explicitly configured: release_type={config.ENV_DATA['submariner_release_type']}"
+        )
+        return
+    # Get OCP version
+    ocp_version = version_module.get_semantic_ocp_version_from_config()
+    # Look up in mapping, default to True (unreleased) for unknown versions
+    submariner_unreleased = defaults.ocp_to_submariner_unreleased_mapping.get(
+        f"{ocp_version}", True
+    )
+    config.ENV_DATA["submariner_release_type"] = (
+        "unreleased" if submariner_unreleased else "released"
+    )
+
+    if f"{ocp_version}" in defaults.ocp_to_submariner_unreleased_mapping:
+        log.info(
+            f"OCP {ocp_version} → Submariner: {'UNRELEASED' if submariner_unreleased else 'RELEASED'}"
+        )
+    else:
+        log.info(
+            f"OCP {ocp_version} not in mapping → Submariner: UNRELEASED (safe default)"
+        )


### PR DESCRIPTION
fix acm submariner validation using ops ci framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic configuration of Advanced Cluster Management (ACM) and Submariner during initialization and test setup, reducing manual steps
  * Automatic detection of ACM/Submariner release type based on OpenShift version for smoother deployments

* **Chores**
  * Updated component versions and environment defaults for OpenShift 4.22 support and related tooling configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/14733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->