### PR TITLE
update-2.12-fusion-image

### DIFF
--- a/ocs_ci/framework/conf/fusion_version/fusion-2.12.yaml
+++ b/ocs_ci/framework/conf/fusion_version/fusion-2.12.yaml
@@ -2,5 +2,5 @@
 DEPLOYMENT:
   fusion_channel: v2.0
   fusion_pre_release_sds_version: 2.12.0
-  fusion_pre_release_image: 2.12.0-20251216170624
+  fusion_pre_release_image: 2.12.1-20260219223110
   fusion_pre_release: true

--- a/ocs_ci/templates/fusion/catalog-source.yaml.j2
+++ b/ocs_ci/templates/fusion/catalog-source.yaml.j2
@@ -7,7 +7,7 @@ spec:
   displayName: isf-catalog
   publisher: IBM
   sourceType: grpc
-  image: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/sds-{{ sds_version }}/isf-operator-software-catalog:{{ image_tag }}
+  image: docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-mint-docker-local/sds-{{ sds_version }}/isf-operator-software-catalog:{{ image_tag }}
   updateStrategy:
     registryPoll:
       interval: 15m


### PR DESCRIPTION
 The dev-docker-local Artifactory repository for sds-2.12.0 does not exist — only mint-docker-local has v2.12 catalog images. This caused the isf-catalog CatalogSource pod to fail with ImagePullBackOff on every deployment attempt.                                          
                                                            
  Additionally, the pinned build tag 2.12.0-20251216170624 was never published to any registry (manifest unknown on both Artifactory and icr.io).                                                                                                                                
                                                                                                                                                                                                                                                                                 
  Changes:
  - Switch template from dev-docker-local → mint-docker-local for the catalog image repo
  - Update pinned tag to 2.12.1-20260219223110 (latest available and verified working build)
<img width="1720" height="829" alt="image" src="https://github.com/user-attachments/assets/af89a997-862f-4246-ad0c-abe0c85b1532" />
