### PR TITLE
storage monitoring for FDF

### DIFF
--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -241,6 +241,14 @@ class FusionDataFoundationDeployment:
         Setup storage
         """
         logger.info("Configuring storage.")
+        storage_namespace = config.ENV_DATA.get(
+            "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        logger.info(f"Adding cluster-monitoring label to namespace {storage_namespace}")
+        OCP(kind="namespace").add_label(
+            resource_name=storage_namespace,
+            label="openshift.io/cluster-monitoring=true",
+        )
         if self.lso_enabled:
             self.ensure_lso_installed()
         self.patch_catalogsource()


### PR DESCRIPTION
Add `openshift.io/cluster-monitoring=true` label to storage namespace in FDF deployment                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                 
  In the FDF deployment flow, the openshift-storage namespace (or custom cluster_namespace) is created implicitly by the Fusion operator — unlike the standard ODF flow where it is created from deploy-with-olm.yaml which already carries the monitoring label.                
                                                                                                                                                                                                                                                                                 
  This change applies the `openshift.io/cluster-monitoring=true` label at the start of setup_storage(), after FDF installation is verified and the namespace exists, but before the StorageCluster CR is created. This ensures Prometheus picks up ServiceMonitor and  PrometheusRule objects in the storage namespace from the moment they appear.    