### PR TITLE
add idempotency for aws HCP infra deployment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6947,
+        "line_number": 7027,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -934,9 +934,9 @@ class HyperShiftBase:
 
         """
 
-        timeout_pods_wait_min = 40
-        timeout_hosted_cluster_completed_min = 40
-        timeout_worker_nodes_ready_min = 60
+        timeout_pods_wait_min = 30
+        timeout_hosted_cluster_completed_min = 20
+        timeout_worker_nodes_ready_min = 30
 
         namespace = f"clusters-{name}"
         logger.info(

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -831,20 +831,26 @@ def deploy_hosted_ocp_clusters(cluster_names_list=None):
             deploy_hypershift_oidc = False
             create_deployer_iam_role = False
 
-        hosted_ocp_cluster.deploy_dependencies(
-            deploy_acm_hub=deploy_acm_hub,
-            deploy_cnv=deploy_cnv,
-            deploy_metallb=first_ocp_deployment,
-            download_hcp_binary=first_ocp_deployment,
-            deploy_hyperconverged=deploy_hyperconverged,
-            deploy_mce=deploy_mce,
-            deploy_hypershift_oidc=deploy_hypershift_oidc,
-            create_deployer_iam_role=create_deployer_iam_role,
-        )
+        try:
+            hosted_ocp_cluster.deploy_dependencies(
+                deploy_acm_hub=deploy_acm_hub,
+                deploy_cnv=deploy_cnv,
+                deploy_metallb=first_ocp_deployment,
+                download_hcp_binary=first_ocp_deployment,
+                deploy_hyperconverged=deploy_hyperconverged,
+                deploy_mce=deploy_mce,
+                deploy_hypershift_oidc=deploy_hypershift_oidc,
+                create_deployer_iam_role=create_deployer_iam_role,
+            )
 
-        cluster_name = hosted_ocp_cluster.deploy_ocp()
-        if cluster_name:
-            cluster_names.append(cluster_name)
+            cluster_name = hosted_ocp_cluster.deploy_ocp()
+            if cluster_name:
+                cluster_names.append(cluster_name)
+        except (RuntimeError, CommandFailed, ClientError) as e:
+            logger.error(
+                f"Failed to deploy hosted OCP cluster '{cluster_name}': {e}. "
+                "Skipping and continuing with remaining clusters."
+            )
 
     cluster_names_existing = get_hosted_cluster_names()
     cluster_names_desired_left = [
@@ -1191,16 +1197,39 @@ class HostedClients(HyperShiftBase):
                         f"oc patch -n clusters {constants.HOSTED_CLUSTERS}/{cluster_name} --type=merge "
                         f"--patch='{patch}'"
                     )
-                    exec_cmd(cmd)
+                    try:
+                        exec_cmd(cmd)
+                    except CommandFailed as e:
+                        logger.error(
+                            f"Failed to patch proxy trusted CA for cluster '{cluster_name}': {e}. "
+                            "Skipping and continuing with remaining clusters."
+                        )
 
         # Need to create networkpolicy as mentioned in bug 2281536,
         # https://bugzilla.redhat.com/show_bug.cgi?id=2281536#c21
 
         # Create Network Policy
         storage_client = StorageClient()
+        failed_network_policy = []
         for cluster_name in cluster_names:
-            storage_client.create_network_policy(
-                namespace_to_create_storage_client=f"clusters-{cluster_name}"
+            try:
+                storage_client.create_network_policy(
+                    namespace_to_create_storage_client=f"clusters-{cluster_name}"
+                )
+            except (CommandFailed, AssertionError) as e:
+                logger.error(
+                    f"Failed to create network policy for cluster '{cluster_name}': {e}. "
+                    "Dropping cluster from further deployment stages."
+                )
+                failed_network_policy.append(cluster_name)
+
+        if failed_network_policy:
+            cluster_names = [
+                name for name in cluster_names if name not in failed_network_policy
+            ]
+            logger.warning(
+                f"Clusters dropped due to network policy failure: {failed_network_policy}. "
+                f"Remaining clusters: {cluster_names}"
             )
 
         check_odf_prerequisites()
@@ -2823,8 +2852,9 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
                 else:
                     logger.warning(
                         f"Infrastructure exists but output file not found: {self.output_infra_file}. "
-                        "Infrastructure may have been created outside this tool."
+                        "Reconstructing output file from existing AWS resources."
                     )
+                    self._reconstruct_infra_output(existing_vpcs)
                     return self.output_infra_file
         except ClientError as e:
             logger.error(
@@ -2899,6 +2929,90 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
             logger.warning(f"Could not read/parse infra output file: {e}")
 
         return self.output_infra_file
+
+    def _reconstruct_infra_output(self, existing_vpcs):
+        """
+        Reconstruct the infrastructure output JSON file from existing AWS resources.
+
+        Queries Route53 for public/private/local hosted zones by cluster name and
+        base domain, and reads the VPC CIDR from the existing VPC. Writes the
+        reconstructed data to self.output_infra_file and populates instance attributes.
+
+        If Route53 zones are missing the infrastructure is considered incomplete
+        (partial creation from a prior failed run) and a RuntimeError is raised
+        with instructions to clean up before retrying.
+
+        Args:
+            existing_vpcs (list): List of VPC dicts returned by describe_vpcs.
+
+        Raises:
+            RuntimeError: If Route53 zones are missing (partial infra state).
+        """
+        zone_name = f"{self.name}.{self.base_domain}."
+        logger.info(f"Querying Route53 for hosted zones with name '{zone_name}'")
+
+        r53 = self.route53_client
+        paginator = r53.get_paginator("list_hosted_zones")
+        public_zone_id = None
+        private_zone_id = None
+        local_zone_id = None
+
+        for page in paginator.paginate():
+            for zone in page["HostedZones"]:
+                if zone["Name"] != zone_name:
+                    continue
+                zone_id = zone["Id"].split("/")[-1]
+                if zone["Config"]["PrivateZone"]:
+                    tags_resp = r53.list_tags_for_resource(
+                        ResourceType="hostedzone", ResourceId=zone_id
+                    )
+                    tags = {
+                        t["Key"]: t["Value"]
+                        for t in tags_resp["ResourceTagSet"]["Tags"]
+                    }
+                    if tags.get("Name", "").endswith("-local"):
+                        local_zone_id = zone_id
+                    else:
+                        private_zone_id = zone_id
+                else:
+                    public_zone_id = zone_id
+
+        if not public_zone_id or not private_zone_id:
+            vpc_id = (
+                existing_vpcs[0].get("VpcId", "unknown") if existing_vpcs else "unknown"
+            )
+            raise RuntimeError(
+                f"Partial infrastructure detected for cluster '{self.name}': "
+                f"VPC '{vpc_id}' (tag: kubernetes.io/cluster/{self.infra_id}=owned) exists "
+                f"but Route53 hosted zones for '{zone_name}' are missing. "
+                f"This is a leftover from a previous failed run. "
+                f"Delete the VPC and its associated resources, then retry."
+            )
+
+        vpc_cidr = existing_vpcs[0].get("CidrBlock") if existing_vpcs else None
+
+        logger.info(
+            f"Reconstructed infra data: infraID={self.infra_id}, "
+            f"publicZoneID={public_zone_id}, privateZoneID={private_zone_id}, "
+            f"localZoneID={local_zone_id}, machineCIDR={vpc_cidr}"
+        )
+
+        infra_data = {
+            "infraID": self.infra_id,
+            "publicZoneID": public_zone_id,
+            "privateZoneID": private_zone_id,
+            "localZoneID": local_zone_id,
+            "machineCIDR": vpc_cidr,
+        }
+
+        os.makedirs(os.path.dirname(self.output_infra_file), exist_ok=True)
+        with open(self.output_infra_file, "w") as f:
+            json.dump(infra_data, f, indent=2)
+        logger.info(
+            f"Reconstructed infrastructure output written to {self.output_infra_file}"
+        )
+
+        self.read_infra_output()
 
     def get_vpc_from_existing_infra(self, infra_id=None):
         """


### PR DESCRIPTION
add idempotency for aws HCP infra deployment to avoid failures like: 

```
2026-03-24 12:23:53  ERROR
2026-03-24 12:23:53  ______________________ ERROR at setup of test_deployment _______________________
2026-03-24 12:23:53  
2026-03-24 12:23:53  request = <SubRequest 'cluster' for <Function test_deployment>>
2026-03-24 12:23:53  log_cli_level = 'INFO'
2026-03-24 12:23:53  record_testsuite_property = <bound method LogXML.add_global_property of <_pytest.junitxml.LogXML object at 0x7f728340bfd0>>
2026-03-24 12:23:53  set_live_must_gather_images = None
2026-03-24 12:23:53  
2026-03-24 12:23:53      @pytest.fixture(scope="session", autouse=True)
2026-03-24 12:23:53      def cluster(
2026-03-24 12:23:53          request, log_cli_level, record_testsuite_property, set_live_must_gather_images
2026-03-24 12:23:53      ):
2026-03-24 12:23:53          """
2026-03-24 12:23:53          This fixture initiates deployment for both OCP and OCS clusters.
2026-03-24 12:23:53          Specific platform deployment classes will handle the fine details
2026-03-24 12:23:53          of action
2026-03-24 12:23:53          """
2026-03-24 12:23:53          log.info(f"All logs located at {ocsci_log_path()}")
2026-03-24 12:23:53      
2026-03-24 12:23:53          teardown = ocsci_config.RUN["cli_params"]["teardown"]
2026-03-24 12:23:53          deploy = ocsci_config.RUN["cli_params"]["deploy"]
2026-03-24 12:23:53          if teardown or deploy:
2026-03-24 12:23:53              for index in range(ocsci_config.nclusters):
2026-03-24 12:23:53                  with config.RunWithConfigContext(index):
2026-03-24 12:23:53                      # Let get initiated deployer for each cluster here to be sure all necesary
2026-03-24 12:23:53                      # values are propagated to all clusters configs
2026-03-24 12:23:53                      DEPLOYERS[config.ENV_DATA["cluster_name"]] = (
2026-03-24 12:23:53                          dep_factory.DeploymentFactory().get_deployment()
2026-03-24 12:23:53                      )
2026-03-24 12:23:53              deployer = DEPLOYERS[config.ENV_DATA["cluster_name"]]
2026-03-24 12:23:53      
2026-03-24 12:23:53          # Add a finalizer to teardown the cluster after test execution is finished
2026-03-24 12:23:53          if teardown:
2026-03-24 12:23:53      
2026-03-24 12:23:53              def cluster_teardown_finalizer():
2026-03-24 12:23:53                  # If KMS is configured, clean up the backend resources
2026-03-24 12:23:53                  # we are doing it before OCP cleanup
2026-03-24 12:23:53                  if ocsci_config.DEPLOYMENT.get("kms_deployment"):
2026-03-24 12:23:53                      try:
2026-03-24 12:23:53                          kms = KMS.get_kms_deployment()
2026-03-24 12:23:53                          kms.cleanup()
2026-03-24 12:23:53                      except Exception as ex:
2026-03-24 12:23:53                          log.error(f"Failed to cleanup KMS. Exception is: {ex}")
2026-03-24 12:23:53                  if ocsci_config.MULTICLUSTER.get("acm_cluster"):
2026-03-24 12:23:53                      try:
2026-03-24 12:23:53                          from ocs_ci.utility.aws import AWS
2026-03-24 12:23:53      
2026-03-24 12:23:53                          thanos_bucket_name = (
2026-03-24 12:23:53                              f"dr-thanos-bucket-{config.ENV_DATA['cluster_name']}"
2026-03-24 12:23:53                          )
2026-03-24 12:23:53                          AWS().delete_bucket(thanos_bucket_name)
2026-03-24 12:23:53                      except Exception as ex:
2026-03-24 12:23:53                          log.error(
2026-03-24 12:23:53                              f"Either failed to delete bucket or bucket doesn't exist {ex}"
2026-03-24 12:23:53                          )
2026-03-24 12:23:53                  if ocsci_config.ENV_DATA.get("iscsi_setup", False):
2026-03-24 12:23:53                      try:
2026-03-24 12:23:53                          iscsi_teardown()
2026-03-24 12:23:53                      except Exception as ex:
2026-03-24 12:23:53                          log.error(f"Failed to teardown iSCSI: {ex}")
2026-03-24 12:23:53                  # Destroy AWS HCP hosted clusters before the management cluster.
2026-03-24 12:23:53                  # This terminates EC2 worker instances, cleans up VPCs, IAM roles,
2026-03-24 12:23:53                  # peering connections, and HostedCluster CRs.
2026-03-24 12:23:53                  try:
2026-03-24 12:23:53                      if ocsci_config.ENV_DATA["cluster_type"] == constants.HCI_PROVIDER:
2026-03-24 12:23:53                          if not destroy_aws_hcp_clusters():
2026-03-24 12:23:53                              log.error(
2026-03-24 12:23:53                                  "!!!!! Cluster teardown failed. Delete manually !!!!!"
2026-03-24 12:23:53                              )
2026-03-24 12:23:53                  except Exception as ex:
2026-03-24 12:23:53                      log.error(f"Failed to destroy AWS HCP clusters: {ex}")
2026-03-24 12:23:53                  deployer.destroy_cluster(log_cli_level)
2026-03-24 12:23:53      
2026-03-24 12:23:53              request.addfinalizer(cluster_teardown_finalizer)
2026-03-24 12:23:53              log.info("Will teardown cluster because --teardown was provided")
2026-03-24 12:23:53      
2026-03-24 12:23:53          # Download client
2026-03-24 12:23:53          if ocsci_config.DEPLOYMENT["skip_download_client"]:
2026-03-24 12:23:53              log.info("Skipping client download")
2026-03-24 12:23:53          else:
2026-03-24 12:23:53              force_download = (
2026-03-24 12:23:53                  ocsci_config.RUN["cli_params"].get("deploy")
2026-03-24 12:23:53                  and ocsci_config.DEPLOYMENT["force_download_client"]
2026-03-24 12:23:53              )
2026-03-24 12:23:53              get_openshift_client(force_download=force_download)
2026-03-24 12:23:53      
2026-03-24 12:23:53          multi_arch = ocsci_config.ENV_DATA.get("multi_arch")
2026-03-24 12:23:53          if ocsci_config.ENV_DATA.get("early_testing") or multi_arch:
2026-03-24 12:23:54              release_img = ocsci_config.ENV_DATA.get("release_img")
2026-03-24 12:23:54              if not release_img and ocsci_config.ENV_DATA.get("multi_arch"):
2026-03-24 12:23:54                  release_img = get_latest_ocp_multi_image()
2026-03-24 12:23:54              if not release_img:
2026-03-24 12:23:54                  raise ValueError(
2026-03-24 12:23:54                      "No release_img provided in config under ENV_DATA section!"
2026-03-24 12:23:54                  )
2026-03-24 12:23:54              log.info(
2026-03-24 12:23:54                  f"Running early testing of RHCOS or multi-arch testing with release image: {release_img}"
2026-03-24 12:23:54              )
2026-03-24 12:23:54              # set environment variables for early testing of RHCOS or multi-arch
2026-03-24 12:23:54              os.environ["RELEASE_IMG"] = release_img
2026-03-24 12:23:54              os.environ["OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"] = release_img
2026-03-24 12:23:54      
2026-03-24 12:23:54          if deploy:
2026-03-24 12:23:54              # Deploy cluster
2026-03-24 12:23:54  >           deployer.deploy_cluster(log_cli_level)
2026-03-24 12:23:54  
2026-03-24 12:23:54  tests/conftest.py:2277: 
2026-03-24 12:23:54  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-03-24 12:23:54  ocs_ci/deployment/deployment.py:938: in deploy_cluster
2026-03-24 12:23:54      self.do_deploy_hosted_spoke_clusters()
2026-03-24 12:23:54  ocs_ci/deployment/deployment.py:824: in do_deploy_hosted_spoke_clusters
2026-03-24 12:23:54      HostedClients().do_deploy()
2026-03-24 12:23:54  ocs_ci/deployment/hub_spoke.py:1126: in do_deploy
2026-03-24 12:23:54      deploy_hosted_ocp_clusters(clusters_to_deploy)
2026-03-24 12:23:54  ocs_ci/deployment/hub_spoke.py:804: in deploy_hosted_ocp_clusters
2026-03-24 12:23:54      hosted_ocp_cluster.deploy_dependencies(
2026-03-24 12:23:54  ocs_ci/deployment/hub_spoke.py:3479: in deploy_dependencies
2026-03-24 12:23:54      self.read_infra_output()
2026-03-24 12:23:54  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-03-24 12:23:54  
2026-03-24 12:23:54  self = <ocs_ci.deployment.hub_spoke.HypershiftAWSHostedOCP object at 0x7f7280440ed0>
2026-03-24 12:23:54  
2026-03-24 12:23:54      def read_infra_output(self):
2026-03-24 12:23:54          """
2026-03-24 12:23:54          Read the infrastructure output file and extract zone IDs and machine CIDR.
2026-03-24 12:23:54      
2026-03-24 12:23:54          Reads the JSON output file created by 'hypershift create infra aws' and
2026-03-24 12:23:54          assigns the relevant values to instance attributes:
2026-03-24 12:23:54          - self.infra_id from 'infraID'
2026-03-24 12:23:54          - self.public_zone_id from 'publicZoneID'
2026-03-24 12:23:54          - self.private_zone_id from 'privateZoneID'
2026-03-24 12:23:54          - self.local_zone_id from 'localZoneID'
2026-03-24 12:23:54          - self.infra_machine_cidr from 'machineCIDR'
2026-03-24 12:23:54      
2026-03-24 12:23:54          Returns:
2026-03-24 12:23:54              dict: The parsed infrastructure output data
2026-03-24 12:23:54      
2026-03-24 12:23:54          Raises:
2026-03-24 12:23:54              FileNotFoundError: If output_infra_file does not exist
2026-03-24 12:23:54              ValueError: If output_infra_file is not set
2026-03-24 12:23:54              json.JSONDecodeError: If the file is not valid JSON
2026-03-24 12:23:54          """
2026-03-24 12:23:54          if not self.output_infra_file:
2026-03-24 12:23:54              raise ValueError(
2026-03-24 12:23:54                  "output_infra_file not set. Call create_aws_infra() first."
2026-03-24 12:23:54              )
2026-03-24 12:23:54      
2026-03-24 12:23:54          if not os.path.exists(self.output_infra_file):
2026-03-24 12:23:54  >           raise FileNotFoundError(
2026-03-24 12:23:54                  f"Infrastructure output file not found: {self.output_infra_file}"
2026-03-24 12:23:54              )
2026-03-24 12:23:54  E           FileNotFoundError: Infrastructure output file not found: /home/jenkins/clusters/cl-ag223a/openshift-cluster-dir/aws_hcp_files/cl-ag223a-infra-output.json
2026-03-24 12:23:54  
2026-03-24 12:23:54  ocs_ci/deployment/hub_spoke.py:2918: FileNotFoundError
2026-03-24 12:23:54  
```