### PR TITLE
Fix test_node_drain_and_fault_tolerance_for_multiple_mds that caused cascading test failures on IBM Cloud 3-worker clusters.

### DIFF
--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -14,7 +14,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_client,
 )
 from ocs_ci.framework import config
-from ocs_ci.helpers import helpers
 from ocs_ci.ocs.cluster import (
     adjust_active_mds_count_storagecluster,
     get_active_mds_count_cephfilesystem,
@@ -24,7 +23,7 @@ from ocs_ci.ocs.cluster import (
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs import node, constants
-from ocs_ci.ocs.resources.pod import get_mds_pods
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
     delete_and_create_osd_node,
@@ -74,11 +73,18 @@ class TestMultipleMds:
             ), "Failed to set active mds count to 1"
 
             log.info("Validate mds pods are up and running")
-            mds_pods = get_mds_pods()
-            for mds_pod in mds_pods:
-                helpers.wait_for_resource_state(
-                    resource=mds_pod, state=constants.STATUS_RUNNING
-                )
+            # Wait by selector rather than by pod name to avoid stale references
+            # after a ReplicaSet rollover triggered by the scale adjustment.
+            ocp_pod = OCP(
+                kind=constants.POD,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            )
+            ocp_pod.wait_for_resource(
+                condition=constants.STATUS_RUNNING,
+                selector="app=rook-ceph-mds",
+                resource_count=2,
+                timeout=300,
+            )
 
             log.info("Checking for Ceph Health OK")
             ceph_health_check()
@@ -147,9 +153,12 @@ class TestMultipleMds:
         active_mds_node_name = selected_pod_obj.data["spec"].get("nodeName")
 
         log.info("Drain active mds pod running node")
-        node.drain_nodes([active_mds_node_name])
-        # Make the node schedulable again
-        node.schedule_nodes([active_mds_node_name])
+        try:
+            node.drain_nodes([active_mds_node_name])
+        finally:
+            # Always uncordon, even if drain fails or times out, to prevent
+            # the node remaining unschedulable and affecting subsequent tests.
+            node.schedule_nodes([active_mds_node_name])
 
         log.info("Performing cluster and Ceph health checks")
         self.sanity_helpers.health_check(tries=120)


### PR DESCRIPTION
Fix test_node_drain_and_fault_tolerance_for_multiple_mds that caused cascading test failures on IBM Cloud 3-worker clusters.

 Root Cause (from log analysis)

  - Item 2042165: oc adm drain timed out after 1800s because a pre-existing unschedulable node + the drain-cordoned node left only 1 CPU-constrained node. PDB requirements for noobaa-endpoint,
  ocs-client-operator-console, etc. could not be satisfied. The node stayed cordoned.
  - Item 2042166: Auto-retried run inherited the cordoned node. Drain succeeded (2 schedulable nodes now), but teardown's adjust_active_mds_count(1) rolled the MDS-a ReplicaSet. Teardown then described the deleted
  pod by name → NotFound.

Fix: 
Wrap drain_nodes in try/finally to guarantee schedule_nodes always runs, even if drain fails or times out.
Replace the stale pod-object iteration with OCP.wait_for_resource(selector="app=rook-ceph-mds", resource_count=2). This waits for 2 Running MDS pods (1 active + 1 standby-replay) by label selector, so it automatically picks up newly created pods regardless of RS rollover.