### PR TITLE
WIP_Fix test_automated_recovery_from_failed_nodes_reactive failures

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -895,7 +895,7 @@ class OCP(object):
 
         while (time.time() - start_time) < timeout:
             try:
-                res = self.exec_oc_cmd(command)
+                res = self.exec_oc_cmd(command, timeout=timeout + 60)
             except CommandFailed as ex:
                 res = ex.args[0] if ex.args else str(ex)
                 elapsed_time = time.time() - start_time

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -594,10 +594,15 @@ class Pod(OCS):
         if isinstance(packages, list):
             packages = " ".join(packages)
 
-        # Detect OS inside pod
-        os_release = self.exec_cmd_on_pod(
-            "cat /etc/os-release || true", out_yaml_format=False
-        )
+        # Detect OS inside pod. Use try/except instead of shell '|| true' so
+        # the command works on any container image regardless of shell availability
+        # (oc rsh does not invoke a shell, so || would be passed as a literal arg).
+        try:
+            os_release = self.exec_cmd_on_pod(
+                "cat /etc/os-release", out_yaml_format=False
+            )
+        except CommandFailed:
+            os_release = ""
 
         os_release_lower = os_release.lower() if os_release else ""
 

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -212,6 +212,14 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
         if failure == "shutdown":
             nodes.stop_nodes(failure_node_obj, wait=True)
             log.info(f"Successfully powered off node: " f"{failure_node_obj[0].name}")
+            log.info(
+                f"Waiting for node {failure_node_obj[0].name} to reach NotReady state"
+            )
+            wait_for_nodes_status(
+                node_names=[failure_node_obj[0].name],
+                status=constants.NODE_NOT_READY,
+                timeout=300,
+            )
         elif failure == "terminate":
             nodes.terminate_nodes(failure_node_obj, wait=True)
             log.info(
@@ -219,10 +227,13 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 f"{failure_node_obj[0].name} instance"
             )
 
+        dc_pod_timeout = 900 if failure == "shutdown" else 720
         try:
             # DC app pods on the failed node will get automatically created on other
             # running node. Waiting for all dc app pod to reach running state
-            pod.wait_for_dc_app_pods_to_reach_running_state(dc_pod_obj, timeout=720)
+            pod.wait_for_dc_app_pods_to_reach_running_state(
+                dc_pod_obj, timeout=dc_pod_timeout
+            )
             log.info("All the dc pods reached running state")
             pod.wait_for_storage_pods(timeout=300)
 

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -58,10 +58,10 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
     Knip-678 Automated recovery from failed nodes - Reactive
     """
 
-    threads = []
-
     @pytest.fixture(autouse=True)
     def teardown(self, request):
+        self.threads = []
+
         def finalizer():
             worker_nodes = get_worker_nodes()
             # Removing created label on all worker nodes
@@ -183,12 +183,18 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 else:
                     node_type = constants.RHCOS
                 node_conf = {"stack_name": common_nodes[0]}
-                print(f"node_conf: {node_conf}")
+                log.info(f"node_conf: {node_conf}")
                 new_ocs_node_names = add_new_node_and_label_upi(
-                    node_type, 1, mark_for_ocs_label=True
+                    node_type, 1, mark_for_ocs_label=True, node_conf=node_conf
                 )
-        except ValueError as e:
-            log.error(f"Unsupported deployment type: {e}")
+            else:
+                raise ValueError(
+                    f"Unsupported deployment type: {deployment_type}. "
+                    "Expected 'ipi' or 'upi'."
+                )
+        except (ValueError, IndexError) as e:
+            log.error(f"Failed to add new node: {e}")
+            raise
 
         failure_domain = get_failure_domain()
         log.info("Wait for the nodes racks or zones to appear...")

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -265,6 +265,18 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 )
             raise
 
+        # For shutdown, the stopped node is permanently replaced by the new
+        # node added before the failure. Terminate it now so the node object
+        # is removed from the cluster before health_check calls
+        # wait_for_nodes_status for all nodes (the stopped node would never
+        # return to Ready and would cause health_check to time out).
+        if failure == "shutdown":
+            nodes.terminate_nodes(failure_node_obj, wait=True)
+            log.info(
+                f"Successfully terminated stopped node : "
+                f"{failure_node_obj[0].name} instance"
+            )
+
         # Check basic cluster functionality by creating resources
         # (pools, storageclasses, PVCs, pods - both CephFS and RBD),
         # run IO and delete the resources

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -220,6 +220,25 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
                 status=constants.NODE_NOT_READY,
                 timeout=300,
             )
+            # Force-delete DC app pods on the failed node to immediately
+            # release RBD/CephFS VolumeAttachments. For stopped (not
+            # terminated) nodes the CSI external-attacher waits for kubelet
+            # confirmation of unmount which never comes, leaving the
+            # VolumeAttachment permanently stuck and blocking the replacement
+            # pod with a Multi-Attach error. Force-deleting the old pod
+            # removes the VolumeAttachment without CSI confirmation.
+            log.info(
+                f"Force-deleting DC app pods on failed node "
+                f"{failure_node_obj[0].name} to release VolumeAttachments"
+            )
+            for dc_pod in dc_pod_obj:
+                try:
+                    dc_pod_node = get_pod_node(dc_pod)
+                    if dc_pod_node.name == failure_node_obj[0].name:
+                        log.info(f"Force-deleting pod {dc_pod.name} on failed node")
+                        dc_pod.delete(force=True, wait=False)
+                except Exception as ex:
+                    log.warning(f"Could not force-delete DC pod {dc_pod.name}: {ex}")
         elif failure == "terminate":
             nodes.terminate_nodes(failure_node_obj, wait=True)
             log.info(


### PR DESCRIPTION
Multiple bugs caused consistent test failures on both IPI and UPI:

1. pod.py - install_packages: 'cat /etc/os-release || true' was passed to exec_cmd_on_pod which uses oc rsh without a shell wrapper. shlex.split() treated '||' as a literal filename arg to cat, causing CommandFailed on every call. check_file_existence() triggered install_packages() when the fedora DC pod had no 'which' in PATH, causing all IO-start checks to fail with TimeoutExpiredError before any node was disrupted. Fixed by using try/except CommandFailed instead of shell operators.

2. test file - threads class-level list: threads = [] was defined at class level and shared across all parametrized instances, accumulating thread handles from previous runs. Moved initialization to teardown fixture so each test gets a fresh list.

3. test file - node_conf not passed to add_new_node_and_label_upi: the UPI path built node_conf with the correct stack_name but never passed it to add_new_node_and_label_upi. Fixed by passing node_conf=node_conf.

4. test file - print() replaced with log.info() to follow framework logging guidelines.

5. test file - unsupported deployment type now raises ValueError explicitly and except clause broadened to also catch IndexError (empty common_nodes).