### PR TITLE
Fix mon pod validation failure during IBM ROKS deployment

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -37,6 +37,7 @@ from ocs_ci.ocs.exceptions import (
     ResourceWrongStatusException,
     CephHealthException,
     ActiveMdsValueNotMatch,
+    TemporaryPodsDuringDeployment,
 )
 from ocs_ci.ocs.resources import ocs, storage_cluster
 import ocs_ci.ocs.constants as constant
@@ -1155,6 +1156,7 @@ def validate_ocs_pods_on_pvc(pods, pvc_names, pvc_label=None):
 
     Raises:
          AssertionError: If no PVC found for one of the pod
+         TemporaryPodsDuringDeployment: If pod is not found (may have been deleted/replaced)
 
     """
     logger.info(f"Validating if each pod from: {pods} has PVC from {pvc_names}.")
@@ -1169,20 +1171,33 @@ def validate_ocs_pods_on_pvc(pods, pvc_names, pvc_label=None):
                 continue
             assert found_pvc, f"No PVC found for pod: {pod_name}!"
         else:
-            pod_obj = ocp.OCP(
-                kind="Pod",
-                namespace=config.ENV_DATA["cluster_namespace"],
-                resource_name=pod_name,
-            )
-            pod_data = pod_obj.get()
-            pod_labels = pod_data["metadata"].get("labels", {})
-            pvc_name = pod_labels[pvc_label]
-            assert (
-                pvc_name in pvc_names
-            ), f"No PVC {pvc_name} found for pod: {pod_name} in PVCs: {pvc_names}!"
+            try:
+                pod_obj = ocp.OCP(
+                    kind="Pod",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    resource_name=pod_name,
+                )
+                pod_data = pod_obj.get()
+                pod_labels = pod_data["metadata"].get("labels", {})
+                pvc_name = pod_labels[pvc_label]
+                assert (
+                    pvc_name in pvc_names
+                ), f"No PVC {pvc_name} found for pod: {pod_name} in PVCs: {pvc_names}!"
+                logger.info(f"PVC {pvc_name} found for pod {pod_name}")
+            except CommandFailed as e:
+                if "NotFound" in str(e):
+                    logger.warning(
+                        f"Pod {pod_name} not found - may have been replaced during "
+                        "deployment. Triggering retry to refresh both PVC and pod lists."
+                    )
+                    raise TemporaryPodsDuringDeployment(
+                        f"Pod {pod_name} disappeared - likely being replaced"
+                    )
+                else:
+                    raise
 
 
-@retry(CommandFailed, tries=3, delay=10, backoff=1)
+@retry(CommandFailed, tries=3, delay=30, backoff=1)
 def validate_claim_name_match_pvc(pvc_names, validated_pods=None):
     """
     Validate if OCS pods have mathching PVC and Claim name
@@ -1213,13 +1228,15 @@ def validate_claim_name_match_pvc(pvc_names, validated_pods=None):
         validated_pods.add(ceph_pod)
 
 
+@retry((TemporaryPodsDuringDeployment, AssertionError), tries=3, delay=60, backoff=1)
 def validate_cluster_on_pvc():
     """
     Validate creation of PVCs for MON and OSD pods.
     Also validate that those PVCs are attached to the OCS pods
 
     Raises:
-         AssertionError: If PVC is not mounted on one or more OCS pods
+         AssertionError: If PVC is not mounted on one or more OCS pods or some of the PVCs are not bound
+         TemporaryPodsDuringDeployment: If canary or temporary pods detected (triggers retry)
 
     """
     # Get the PVCs for selected label (MON/OSD)
@@ -1233,18 +1250,36 @@ def validate_cluster_on_pvc():
         if pvc_obj.name.startswith(
             constants.DEFAULT_DEVICESET_PVC_NAME
         ) or pvc_obj.name.startswith(constants.DEFAULT_MON_PVC_NAME):
+            if pvc_obj.status != constants.STATUS_BOUND:
+                logger.warning(
+                    f"PVC {pvc_obj.name} is in {pvc_obj.status} state, not Bound. "
+                    "This may be due to mon replacement in progress. Will retry."
+                )
             assert (
                 pvc_obj.status == constants.STATUS_BOUND
             ), f"PVC {pvc_obj.name} is not Bound"
             logger.info(f"PVC {pvc_obj.name} is in Bound state")
             pvc_names.append(pvc_obj.name)
 
-    mon_pods = get_pod_name_by_pattern("rook-ceph-mon", ns)
     if not config.DEPLOYMENT.get("local_storage"):
         logger.info("Validating all mon pods have PVC")
         mon_pvc_label = constants.ROOK_CEPH_MON_PVC_LABEL
         if Version.coerce(config.ENV_DATA["ocs_version"]) < Version.coerce("4.6"):
             mon_pvc_label = None
+
+        mon_pods = get_pod_name_by_pattern("rook-ceph-mon", ns)
+
+        # Check for canary pods - these are temporary during mon replacement
+        # Raise exception to trigger retry with fresh PVC and pod lists
+        canary_pods = [pod for pod in mon_pods if "canary" in pod]
+        if canary_pods:
+            logger.warning(
+                f"Detected canary pods {canary_pods} - mon replacement in progress. "
+                "Will retry validation to allow deployment to stabilize."
+            )
+            raise TemporaryPodsDuringDeployment(f"Canary pods detected: {canary_pods}")
+
+        logger.info(f"Validating mon pods: {mon_pods}")
         validate_ocs_pods_on_pvc(
             mon_pods,
             pvc_names,

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -774,3 +774,12 @@ class FloatingIPAssignException(Exception):
 
 class SubctlDownloadFailed(Exception):
     pass
+
+
+class TemporaryPodsDuringDeployment(Exception):
+    """
+    Raised when temporary pods (like canary pods) are detected during deployment.
+    This triggers a retry to allow the deployment to stabilize.
+    """
+
+    pass


### PR DESCRIPTION
Handles temporary canary pods that appear during mon replacement on IBM ROKS clusters. Adds retry logic at validate_cluster_on_pvc level to refresh both PVC and pod lists when canary pods are detected or pods disappear during validation.

Changes:
 - Add TemporaryPodsDuringDeployment exception for retry signaling
 - Detect canary pods early and trigger retry before validation
 - Handle pod NotFound errors when pods are replaced mid-validation
 - Retry entire validate_cluster_on_pvc to refresh PVCs and pod lists