### PR TITLE
UI llm Fallback enhancement * Stack trace, prompts and cache per session [AI hackatone]

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -4,6 +4,7 @@ import logging
 import os
 import gc
 import time
+import traceback
 import zipfile
 from functools import reduce
 
@@ -243,7 +244,9 @@ class BaseUI:
                 self.take_screenshot(f"{type(self).__name__}-{date_time}")
                 self.copy_dom(f"{type(self).__name__}-{date_time}")
                 logger.error(e)
-                new_locator = self.locator_fallback.attempt_fallback(locator, "click")
+                new_locator = self.locator_fallback.attempt_fallback(
+                    locator, "click", stack_trace=traceback.format_exc()
+                )
                 if new_locator:
                     element = WebDriverWait(self.driver, timeout).until(
                         ec.element_to_be_clickable((new_locator[1], new_locator[0]))
@@ -333,7 +336,9 @@ class BaseUI:
             self.take_screenshot()
             self.copy_dom()
             logger.error(e)
-            new_locator = self.locator_fallback.attempt_fallback(locator, "send_keys")
+            new_locator = self.locator_fallback.attempt_fallback(
+                locator, "send_keys", stack_trace=traceback.format_exc()
+            )
             if new_locator:
                 element = WebDriverWait(self.driver, timeout).until(
                     ec.visibility_of_element_located((new_locator[1], new_locator[0]))
@@ -477,7 +482,9 @@ class BaseUI:
             return self.driver.find_element(by=locator[1], value=locator[0]).text
         except NoSuchElementException as e:
             logger.error(e)
-            new_locator = self.locator_fallback.attempt_fallback(locator, "get_text")
+            new_locator = self.locator_fallback.attempt_fallback(
+                locator, "get_text", stack_trace=traceback.format_exc()
+            )
             if new_locator:
                 return self.driver.find_element(
                     by=new_locator[1], value=new_locator[0]
@@ -519,7 +526,7 @@ class BaseUI:
         except TimeoutException as e:
             logger.error(e)
             new_locator = self.locator_fallback.attempt_fallback(
-                locator, "wait_visible"
+                locator, "wait_visible", stack_trace=traceback.format_exc()
             )
             if new_locator:
                 return WebDriverWait(self.driver, min(timeout, 10)).until(
@@ -549,7 +556,7 @@ class BaseUI:
         except TimeoutException as e:
             logger.error(e)
             new_locator = self.locator_fallback.attempt_fallback(
-                locator, "wait_present"
+                locator, "wait_present", stack_trace=traceback.format_exc()
             )
             if new_locator:
                 return WebDriverWait(self.driver, min(timeout, 10)).until(
@@ -696,7 +703,9 @@ class BaseUI:
             element.clear()
         except TimeoutException as e:
             logger.error(e)
-            new_locator = self.locator_fallback.attempt_fallback(locator, "clear")
+            new_locator = self.locator_fallback.attempt_fallback(
+                locator, "clear", stack_trace=traceback.format_exc()
+            )
             if new_locator:
                 element = WebDriverWait(self.driver, timeout).until(
                     ec.element_to_be_clickable((new_locator[1], new_locator[0]))
@@ -748,7 +757,9 @@ class BaseUI:
             logger.warning(
                 f"Locator {locator[1]} {locator[0]} did not find text {expected_text}"
             )
-            new_locator = self.locator_fallback.attempt_fallback(locator, "wait_text")
+            new_locator = self.locator_fallback.attempt_fallback(
+                locator, "wait_text", stack_trace=traceback.format_exc()
+            )
             if new_locator:
                 try:
                     WebDriverWait(self.driver, min(timeout, 10)).until(
@@ -791,7 +802,9 @@ class BaseUI:
             self.take_screenshot()
             # locator here is (By, value) — reverse for fallback which expects (value, By)
             new_locator = self.locator_fallback.attempt_fallback(
-                (locator[1], locator[0]), "check_presence"
+                (locator[1], locator[0]),
+                "check_presence",
+                stack_trace=traceback.format_exc(),
             )
             if new_locator:
                 try:
@@ -807,7 +820,9 @@ class BaseUI:
             self.take_screenshot()
             # locator here is (By, value) — reverse for fallback which expects (value, By)
             new_locator = self.locator_fallback.attempt_fallback(
-                (locator[1], locator[0]), "check_presence"
+                (locator[1], locator[0]),
+                "check_presence",
+                stack_trace=traceback.format_exc(),
             )
             if new_locator:
                 try:

--- a/ocs_ci/ocs/ui/llm_tools/locator_fallback.py
+++ b/ocs_ci/ocs/ui/llm_tools/locator_fallback.py
@@ -12,21 +12,38 @@ from ocs_ci.helpers.helpers import get_current_test_name
 logger = logging.getLogger(__name__)
 
 STAGE_1_PROMPT = """\
-You are a Selenium UI test engineer. A UI test failed because this locator \
-could not find an element:
-  Selector: {selector}
-  Type: {by_type}
-  Action: {action}
-  URL: {url}
+You are a Selenium UI test engineer debugging a locator failure.
 
-Analyze the DOM below and find the target element. Return a replacement locator.
+FAILED LOCATOR (treat as a hint about intent, not the answer):
+  Selector : {selector}
+  Type     : {by_type}
+  Action   : {action}
+  URL      : {url}
+
+CALL CHAIN — read this to understand what the test was doing when it failed:
+{stack_trace}
+
+BEFORE searching the DOM, reason through these three questions:
+1. INTENT   — What is the test trying to accomplish? \
+(infer from test name, page-object method names, and helper names in the call chain)
+2. ELEMENT  — What kind of element is this? \
+(e.g. button, input, checkbox, link, list item, table row, dropdown option) \
+Use the action ("{action}"), the method names in the trace, and the failed \
+locator name as clues. Do not assume the element type from the selector alone.
+3. IDENTITY — What stable attributes would this element carry? \
+(data-test, aria-label, role, id, type, name — prefer these over class names)
+
+Then search the DOM for an element that matches the inferred intent, kind, and \
+identity — even if it looks nothing like the original locator.
+
 Rules:
 1. Prefer XPath over CSS selectors
-2. Prefer data-test, aria-label, id attributes
+2. Prefer data-test, aria-label, id, role, type attributes
 3. Avoid auto-generated class names
-4. NEVER use PatternFly prefixes (pf-, pf-v5-, pf-v6-, etc.) in selectors — \
+4. NEVER use PatternFly prefixes (pf-, pf-v5-, pf-v6-, etc.) — \
 these change across PF versions and break tests
 5. Must match exactly one element
+6. Prefer semantic/structural attributes over position-based selectors
 
 Respond with ONLY JSON: {{"selector": "...", "by_type": "xpath"}}
 
@@ -35,21 +52,46 @@ DOM:
 """
 
 STAGE_2_PROMPT = """\
-You are a Selenium UI test engineer. A UI test failed because this locator \
-could not find an element:
-  Selector: {selector}
-  Type: {by_type}
-  Action: {action}
-  URL: {url}
+You are a Selenium UI test engineer debugging a locator failure.
 
-A screenshot of the page is attached. Cross-reference the visual layout with \
-the DOM below to identify the target element. Return a replacement locator.
+FAILED LOCATOR (treat as a hint about intent, not the answer):
+  Selector : {selector}
+  Type     : {by_type}
+  Action   : {action}
+  URL      : {url}
+
+CALL CHAIN — read this to understand what the test was doing when it failed:
+{stack_trace}
+
+BEFORE searching the DOM, reason through these three questions:
+1. INTENT   — What is the test trying to accomplish? \
+(infer from test name, page-object method names, and helper names in the call chain)
+2. ELEMENT  — What kind of element is this? \
+(e.g. button, input, checkbox, link, list item, table row, dropdown option) \
+Use the action ("{action}"), the method names in the trace, and the failed \
+locator name as clues. Do not assume the element type from the selector alone.
+3. IDENTITY — What stable attributes would this element carry? \
+(data-test, aria-label, role, id, type, name — prefer these over class names)
+
+A screenshot of the page is attached. Use it together with the DOM — \
+neither source alone is sufficient:
+- Screenshot → tells you WHICH page you are on, WHERE the target element \
+appears visually, what its visible label/text/icon is, and what kind of \
+control it looks like (button, dropdown, text field, list item, etc.)
+- DOM       → tells you the actual HTML structure, attributes, and hierarchy \
+needed to write a precise XPath
+The screenshot shows the full page — it contains many other elements that are \
+NOT the target. Use it only to identify the region and visual appearance of \
+the one element the test was trying to interact with, then locate that specific \
+node in the DOM and build the XPath from its attributes.
+
 Rules:
 1. Prefer XPath over CSS selectors
-2. Prefer data-test, aria-label, id attributes
+2. Prefer data-test, aria-label, id, role, type attributes
 3. Avoid auto-generated class names
-4. NEVER use PatternFly prefixes (pf-, pf-v5-, pf-v6-, etc.) in selectors
+4. NEVER use PatternFly prefixes (pf-, pf-v5-, pf-v6-, etc.)
 5. Must match exactly one element
+6. Prefer semantic/structural attributes over position-based selectors
 
 Respond with ONLY JSON: {{"selector": "...", "by_type": "xpath"}}
 
@@ -71,12 +113,27 @@ STRIP_SELF_CLOSING_RE = re.compile(
 WHITESPACE_RE = re.compile(r"\s{2,}")
 
 
+def _locator_cache_dir():
+    """Returns the locator_cache/ directory path for the current run."""
+    base_ui_logs_dir = os.path.join(
+        os.path.expanduser(ocsci_config.RUN["log_dir"]),
+        f"ui_logs_dir_{ocsci_config.RUN['run_id']}",
+    )
+    return os.path.join(base_ui_logs_dir, "locator_cache")
+
+
+def get_session_cache_path():
+    """Returns the path to the session-wide locator cache file."""
+    return os.path.join(_locator_cache_dir(), "session_locators_cache.json")
+
+
 class LocatorFallback:
     """
     AI-powered locator fallback for Selenium UI tests.
 
     When a locator fails, the DOM (and optionally a screenshot) is sent to an
-    LLM which generates a replacement locator. Results are cached per-test.
+    LLM which generates a replacement locator. Results are cached per-test and
+    accumulated in a session-wide cache for reuse across tests.
     """
 
     def __init__(self, driver):
@@ -98,36 +155,44 @@ class LocatorFallback:
 
     def _get_cache_path(self):
         if self._cache_path is None:
-            base_ui_logs_dir = os.path.join(
-                os.path.expanduser(ocsci_config.RUN["log_dir"]),
-                f"ui_logs_dir_{ocsci_config.RUN['run_id']}",
-            )
             test_name = get_current_test_name()
             self._cache_path = os.path.join(
-                base_ui_logs_dir,
-                f"ai_locator_cache_{test_name}.json",
+                _locator_cache_dir(),
+                f"{test_name}.json",
             )
         return self._cache_path
+
+    @staticmethod
+    def _read_json_file(path):
+        """Reads a JSON file and returns its contents as a dict, or {} on any error."""
+        if not os.path.isfile(path):
+            return {}
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
 
     def _load_cache(self):
         if self._cache is not None:
             return self._cache
-        cache_path = self._get_cache_path()
-        if os.path.isfile(cache_path):
-            try:
-                with open(cache_path, "r") as f:
-                    self._cache = json.load(f)
-            except (json.JSONDecodeError, OSError):
-                self._cache = {}
-        else:
-            self._cache = {}
+        session_data = self._read_json_file(get_session_cache_path())
+        per_test_data = self._read_json_file(self._get_cache_path())
+        self._cache = {**session_data, **per_test_data}
         return self._cache
 
     def _save_cache(self):
-        cache_path = self._get_cache_path()
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-        with open(cache_path, "w") as f:
+        cache_dir = _locator_cache_dir()
+        os.makedirs(cache_dir, exist_ok=True)
+
+        with open(self._get_cache_path(), "w") as f:
             json.dump(self._cache, f, indent=2)
+
+        session_cache_path = get_session_cache_path()
+        session_data = self._read_json_file(session_cache_path)
+        session_data.update(self._cache)
+        with open(session_cache_path, "w") as f:
+            json.dump(session_data, f, indent=2)
 
     @staticmethod
     def _cache_key(locator):
@@ -193,13 +258,14 @@ class LocatorFallback:
 
         return (selector, by_type)
 
-    def attempt_fallback(self, locator, action="interact"):
+    def attempt_fallback(self, locator, action="interact", stack_trace=None):
         """
         Attempts to find a replacement locator using LLM analysis.
 
         Args:
             locator (tuple): Original (selector, By) tuple that failed.
             action (str): The action that was being performed (click, send_keys, etc.).
+            stack_trace (str): Full Python traceback captured at the point of failure.
 
         Returns:
             tuple: (selector, by_type) replacement locator, or None if fallback fails.
@@ -252,13 +318,17 @@ class LocatorFallback:
 
         cost_before = self.client.total_cost_usd
 
-        result = self._try_stage_1(selector, by_type, action, url, raw_html)
+        result = self._try_stage_1(
+            selector, by_type, action, url, raw_html, stack_trace=stack_trace
+        )
         if result:
             self._cache_result(cache_key, selector, by_type, result, url)
             self._log_cost(cost_before)
             return result
 
-        result = self._try_stage_2(selector, by_type, action, url, raw_html)
+        result = self._try_stage_2(
+            selector, by_type, action, url, raw_html, stack_trace=stack_trace
+        )
         if result:
             self._cache_result(cache_key, selector, by_type, result, url)
             self._log_cost(cost_before)
@@ -270,7 +340,7 @@ class LocatorFallback:
         )
         return None
 
-    def _try_stage_1(self, selector, by_type, action, url, raw_html):
+    def _try_stage_1(self, selector, by_type, action, url, raw_html, stack_trace=None):
         """Stage 1: DOM-only LLM query."""
         logger.info("[AI_FALLBACK] stage=1 (DOM-only) selector=%s", selector)
         cleaned_html = self._strip_dom(raw_html, DOM_MAX_CHARS_STAGE_1)
@@ -280,6 +350,7 @@ class LocatorFallback:
             by_type=by_type,
             action=action,
             url=url,
+            stack_trace=stack_trace or "(not available)",
             cleaned_html=cleaned_html,
         )
 
@@ -310,7 +381,7 @@ class LocatorFallback:
         )
         return None
 
-    def _try_stage_2(self, selector, by_type, action, url, raw_html):
+    def _try_stage_2(self, selector, by_type, action, url, raw_html, stack_trace=None):
         """Stage 2: DOM + screenshot LLM query."""
         logger.info("[AI_FALLBACK] stage=2 (DOM+screenshot) selector=%s", selector)
         cleaned_html = self._strip_dom(raw_html, DOM_MAX_CHARS_STAGE_2)
@@ -325,6 +396,7 @@ class LocatorFallback:
             by_type=by_type,
             action=action,
             url=url,
+            stack_trace=stack_trace or "(not available)",
             cleaned_html=cleaned_html,
         )
 
@@ -429,6 +501,7 @@ class LocatorFallback:
             "new_by_type": new_locator[1],
             "timestamp": datetime.datetime.now().isoformat(),
             "page_url": url,
+            "test_name": get_current_test_name(),
         }
         self._cache = cache
         self._save_cache()


### PR DESCRIPTION
UI locator fallback: stack trace context, session cache, improved prompts

  - Pass full Python traceback to LLM at each fallback trigger so it can infer intent and element type from the test call chain, not just the failing selector
  - Restructure cache: locator_cache/{test_name}.json + session_locators_cache.json (shared across all tests in a run, loaded at fallback init for immediate reuse)
  - Cache entries now include test_name for future tooling
  - Rework prompts: INTENT→ELEMENT→IDENTITY reasoning before DOM search; screenshot stage explains DOM+screenshot must be used together

New cache structure, e.g.: 

```
{
  "//button[text()='3-way Replication']|xpath": {
    "old_selector": "//button[text()='3-way Replication']",
    "old_by_type": "xpath",
    "new_selector": "//button[@role='menuitem' and contains(.,'3-way Replication')]",
    "new_by_type": "xpath",
    "timestamp": "2026-04-05T06:32:22.634279",
    "page_url": "https://console-openshift-console.apps.dosypenk-44s.ibmcloud2.qe.rh-ocs.com/odf/system/ns/openshift-storage/ocs.openshift.io~v1~StorageCluster/ocs-storagecluster/storage-pools/create/~new",
    "test_name": "test_blocking_pool_creation_rules"
  },
  "#tags-input|tag name": {
    "old_selector": "#tags-input",
    "old_by_type": "tag name",
    "new_selector": "//input[@data-test='tags-input']",
    "new_by_type": "xpath",
    "timestamp": "2026-04-05T06:34:28.121454",
    "page_url": "https://console-openshift-console.apps.dosypenk-44s.ibmcloud2.qe.rh-ocs.com/odf/storage-cluster/storage-pools?name=rbd-pool-test-cc0f9ffc5a8641d7bba8553c56",
    "test_name": "test_blocking_pool_creation_rules"
  },
  "//button[@aria-label='Validation']/child::*[contains(@class, 'c-icon')]|xpath": {
    "old_selector": "//button[@aria-label='Validation']/child::*[contains(@class, 'c-icon')]",
    "old_by_type": "xpath",
    "new_selector": "//button[@aria-label='Validation']",
    "new_by_type": "xpath",
    "timestamp": "2026-04-05T06:37:51.018184",
    "page_url": "https://console-openshift-console.apps.dosypenk-44s.ibmcloud2.qe.rh-ocs.com/odf/system/ns/openshift-storage/ocs.openshift.io~v1~StorageCluster/ocs-storagecluster/storage-pools/create/~new",
    "test_name": "test_blocking_pool_creation_rules"
  },
  "//div[contains(@class, 'toolbar__item')]//span[contains(@class, 'dropdown__toggle-text')] | //div[contains(@class, 'input-group') and contains(@class, 'co-filter-group')]//button/span|xpath": {
    "old_selector": "//div[contains(@class, 'toolbar__item')]//span[contains(@class, 'dropdown__toggle-text')] | //div[contains(@class, 'input-group') and contains(@class, 'co-filter-group')]//button/span",
    "old_by_type": "xpath",
    "new_selector": "//button[@data-test='console-select-menu-toggle']",
    "new_by_type": "xpath",
    "timestamp": "2026-04-05T07:29:03.687590",
    "page_url": "https://console-openshift-console.apps.dosypenk-44s.ibmcloud2.qe.rh-ocs.com/odf/storage-cluster/storage-pools",
    "test_name": "test_blocking_pool_creation_rules"
  }
}
```