### PR TITLE
Match the name of catalogsource in client cluster with provider cluster

### DIFF
--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -7004,6 +7004,7 @@ class SpokeODF(SpokeOCP, ABC):
         Returns:
             bool: True if the catalog source exists, False otherwise
         """
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
         ocp_obj = OCP(
             kind=constants.CATSRC,
             namespace=constants.MARKETPLACE_NAMESPACE,
@@ -7011,7 +7012,7 @@ class SpokeODF(SpokeOCP, ABC):
         )
         return ocp_obj.check_resource_existence(
             timeout=self.timeout_check_resources_exist_sec,
-            resource_name="ocs-catalogsource",
+            resource_name=catalog_source_data["metadata"]["name"],
             should_exist=True,
         )
 
@@ -7033,9 +7034,7 @@ class SpokeODF(SpokeOCP, ABC):
             if not reapply:
                 return True
 
-        catalog_source_data = templating.load_yaml(
-            constants.PROVIDER_MODE_CATALOGSOURCE
-        )
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
 
         if not config.ENV_DATA.get("clusters").get(self.name).get("hosted_odf_version"):
             if not reapply:

--- a/ocs_ci/ocs/resources/storage_client.py
+++ b/ocs_ci/ocs/resources/storage_client.py
@@ -81,9 +81,7 @@ class StorageClient:
         if not is_available:
             if catalog_yaml:
 
-                catalog_data = templating.load_yaml(
-                    constants.PROVIDER_MODE_CATALOGSOURCE
-                )
+                catalog_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
                 log.info(
                     f"Updating image details for client subscription: {client_subcription_image}"
                 )
@@ -95,7 +93,7 @@ class StorageClient:
                 self.ocp_obj.exec_oc_cmd(f"apply -f {catalog_data_yaml.name}")
 
                 catalog_source = CatalogSource(
-                    resource_name=constants.OCS_CATALOG_SOURCE_NAME,
+                    resource_name=catalog_data["metadata"]["name"],
                     namespace=constants.MARKETPLACE_NAMESPACE,
                 )
                 # Wait for catalog source is ready

--- a/ocs_ci/templates/ocs-deployment/provider-mode/ocs_client_operator_subscription.yaml
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/ocs_client_operator_subscription.yaml
@@ -7,5 +7,5 @@ spec:
     channel: {}
     installPlanApproval: Automatic
     name: ocs-client-operator
-    source: ocs-catalogsource
+    source: redhat-operators
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Use the catalogsource name "redhat-operators" in the client cluster. This is to use the same catalogsource name for hub(provider) and client cluster. Moreover, the operator `DR Cluster Operator` expects catalogsource name (redhat-operators) that matches the Df catalogsource name in the ACM hub cluster.