### PR TITLE
Fix NFS mount failure on IBM Cloud when client VM is in a different V…

### DIFF
--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -5,16 +5,15 @@ Module that contains all operations related to nfs feature in a cluster
 
 import logging
 import yaml
-import time
 import pytest
-from ocs_ci.ocs import constants, resources
+from ocs_ci.ocs import constants, resources, ocp
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.retry import retry
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.framework import config
 from ocs_ci.utility import version as version_module
-from ocs_ci.utility.utils import convert_device_size
+from ocs_ci.utility.utils import convert_device_size, exec_cmd, TimeoutSampler
 
 log = logging.getLogger(__name__)
 
@@ -172,38 +171,131 @@ def create_nfs_load_balancer_service(
 
     nfs_service_data = yaml.safe_load(service)
     helpers.create_resource(**nfs_service_data)
-    time.sleep(30)
-    ingress_add = storage_cluster_obj.exec_oc_cmd(
-        "get service rook-ceph-nfs-my-nfs-load-balancer"
-        + " --output jsonpath='{.status.loadBalancer.ingress}'"
-    )
+
+    log.info("Waiting for NFS LoadBalancer ingress to be assigned...")
+    for ingress_add in TimeoutSampler(
+        timeout=300,
+        sleep=15,
+        func=storage_cluster_obj.exec_oc_cmd,
+        command=(
+            "get service rook-ceph-nfs-my-nfs-load-balancer"
+            " --output jsonpath='{.status.loadBalancer.ingress}'"
+        ),
+    ):
+        if ingress_add:
+            break
+        log.info("NFS LoadBalancer ingress not yet assigned, retrying...")
 
     host_details = ingress_add[0]
     if "hostname" in host_details:
         hostname_add = host_details["hostname"]
-        log.info(f"ingress hostname, {hostname_add}")
+        log.info("ingress hostname, %s", hostname_add)
         return hostname_add
     elif "ip" in host_details:
         host_ip = host_details["ip"]
-        log.info(f"ingress host ip, {host_ip}")
+        log.info("ingress host ip, %s", host_ip)
         return host_ip
     else:
         log.error("host details unavailable")
+
+
+def update_etc_hosts_on_nfs_client(con, hostname):
+    """
+    Resolve an NFS LB hostname from within the cluster and update /etc/hosts
+    on the NFS client VM.
+
+    IBM Cloud VPC Load Balancer hostnames (``*.lb.appdomain.cloud``) are only
+    resolvable from within the same VPC. When the NFS client VM is in a
+    different VPC, DNS resolution fails and mounts hang. This function resolves
+    the hostname by exec-ing on the node where the NFS pod runs, then writes
+    the result into /etc/hosts on the client VM so mounts succeed.
+
+    This must be called after the LB service is created and after establishing
+    the SSH connection to the NFS client VM. It is safe to call on every
+    reconnect since it removes stale entries before writing new ones.
+
+    Args:
+        con (Connection): SSH connection to the NFS client VM
+        hostname (str): NFS LB hostname to resolve and add to /etc/hosts
+
+    """
+    nfs_pods = pod.get_all_pods(
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        selector=["rook-ceph-nfs"],
+    )
+    if not nfs_pods:
+        log.warning("No NFS pods found, skipping /etc/hosts update on NFS client VM")
+        return
+
+    nfs_node = nfs_pods[0].get()["spec"]["nodeName"]
+    log.info("Resolving %s from cluster node %s", hostname, nfs_node)
+
+    lb_ips = []
+    try:
+        for sample in TimeoutSampler(
+            timeout=300,
+            sleep=15,
+            func=exec_cmd,
+            cmd=(
+                f"oc debug node/{nfs_node} --to-namespace=default "
+                f"-- chroot /host getent hosts {hostname}"
+            ),
+            ignore_error=True,
+        ):
+            if sample and sample.stdout:
+                try:
+                    lb_ips = [
+                        line.split()[0]
+                        for line in sample.stdout.decode().strip().splitlines()
+                        if line.strip()
+                    ]
+                except (UnicodeDecodeError, AttributeError) as e:
+                    log.warning("Failed to decode getent output: %s", e)
+            if lb_ips:
+                break
+            log.info("Could not resolve %s yet, retrying in 15s...", hostname)
+    except TimeoutExpiredError:
+        log.warning(
+            "Could not resolve %s from within the cluster after waiting, "
+            "skipping /etc/hosts update",
+            hostname,
+        )
+        return
+
+    log.info("Resolved %s to %s", hostname, lb_ips)
+
+    # Escape dots so sed treats them as literals, not regex wildcards
+    escaped_hostname = hostname.replace(".", r"\.")
+    con.exec_cmd(f"sed -i '/{escaped_hostname}/d' /etc/hosts")
+    con.exec_cmd(f"echo '{lb_ips[0]} {hostname}' >> /etc/hosts")
+    log.info("Updated /etc/hosts on NFS client VM: %s %s", lb_ips[0], hostname)
 
 
 def delete_nfs_load_balancer_service(
     storage_cluster_obj,
 ):
     """
-    Delete the nfs loadbalancer service
+    Delete the nfs loadbalancer service and wait for it to be removed.
 
     Args:
         storage_cluster_obj (obj): storage cluster object
 
     """
-    # Delete ocs nfs Service
-    cmd_delete_nfs_service = "delete service rook-ceph-nfs-my-nfs-load-balancer"
-    storage_cluster_obj.exec_oc_cmd(cmd_delete_nfs_service)
+    svc_name = "rook-ceph-nfs-my-nfs-load-balancer"
+    namespace = storage_cluster_obj.namespace
+
+    svc_obj = ocp.OCP(kind=constants.SERVICE, namespace=namespace)
+    if not svc_obj.is_exist(resource_name=svc_name):
+        log.info(
+            "NFS LoadBalancer service %s does not exist, skipping delete", svc_name
+        )
+        return
+
+    log.info("Deleting NFS LoadBalancer service %s", svc_name)
+    storage_cluster_obj.exec_oc_cmd(f"delete service {svc_name}")
+
+    log.info("Waiting for NFS LoadBalancer service %s to be deleted...", svc_name)
+    svc_obj.wait_for_delete(resource_name=svc_name, timeout=300)
 
 
 def skip_test_if_nfs_client_unavailable(nfs_client_ip):

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1,3 +1,4 @@
+import ipaddress
 import pytest
 import logging
 import time
@@ -35,7 +36,6 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs.resources import pod, ocs
 from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.exceptions import CommandFailed, ConfigurationError
-
 
 log = logging.getLogger(__name__)
 # Error message to look in a command output
@@ -254,6 +254,12 @@ class TestNfsEnable(ManageTest):
     def get_nfs_client_connection(self, re_try=True):
         """
         Create connection to NFS Client VM.
+
+        After establishing the SSH connection, if the NFS LB endpoint is a
+        hostname (not a raw IP), the hostname is resolved from within the
+        cluster and /etc/hosts on the client VM is updated. This is required
+        when the NFS client VM is in a different VPC from the OpenShift cluster
+        and cannot resolve IBM Cloud VPC LB hostnames via its DNS servers.
         """
         log.info("Connecting to nfs client test VM")
         tries = 3 if re_try else 1
@@ -266,7 +272,23 @@ class TestNfsEnable(ManageTest):
                 private_key=self.nfs_client_private_key,
             )
 
-        return __make_connection()
+        con = __make_connection()
+        hostname_add = getattr(self, "hostname_add", None)
+        if hostname_add:
+            is_ip = False
+            try:
+                ipaddress.ip_address(hostname_add)
+                is_ip = True
+            except ValueError:
+                pass
+            if not is_ip:
+                log.info(
+                    "NFS LB endpoint %s is a hostname, resolving and "
+                    "updating /etc/hosts on NFS client VM",
+                    hostname_add,
+                )
+                nfs_utils.update_etc_hosts_on_nfs_client(con, hostname_add)
+        return con
 
     @tier1
     @polarion_id("OCS-4269")


### PR DESCRIPTION
…PC (#14676)

* Fix NFS mount failure on IBM Cloud when client VM is in a different VPC

When the NFS LoadBalancer service is recreated, IBM Cloud assigns a new VPC LB hostname (*.lb.appdomain.cloud) that is only resolvable from within the cluster VPC. NFS client VMs in a different VPC cannot resolve this hostname via their DNS servers, causing mounts to hang indefinitely.

Add update_etc_hosts_on_nfs_client() to nfs_utils.py that resolves the LB hostname by exec-ing getent on the node running the NFS pod, then updates /etc/hosts on the client VM with the fresh IP mapping. Call this from get_nfs_client_connection() whenever the NFS endpoint is a hostname (IBM Cloud) rather than a raw IP (AWS). Stale entries are removed before writing so repeated redeployments remain safe.




* Improve NFS LB service create/delete reliability on IBM Cloud

- Replace fixed time.sleep(30) with TimeoutSampler polling loop (15s interval, 5min timeout) when waiting for LB ingress to be assigned after service creation
- Add retry loop with ignore_error=True when resolving LB hostname via oc debug node, to handle DNS propagation delay within the cluster
- Add existence check and wait_for_delete after deleting the LB service to ensure IBM Cloud VPC LB is fully deprovisioned before teardown continues
- Remove unused time import




* Address PR review: improve IP validation and decode error handling

- Replace hostname_add[0].isdigit() check with ipaddress.ip_address() for proper IP validation, correctly handling IPv4, IPv6 and hostnames
- Add import ipaddress to test file
- Wrap sample.stdout.decode() in try-except for UnicodeDecodeError and AttributeError in update_etc_hosts_on_nfs_client




* Refactor IP check to avoid exception-based flow control

Separate the ipaddress.ip_address() check from the update_etc_hosts_on_nfs_client() call to prevent potential .pyc cache issues where the except ValueError handler may not be present in stale bytecode. Also adds a log message when hostname resolution is triggered.





* Fix exec_cmd parameter name in update_etc_hosts_on_nfs_client

The exec_cmd function expects 'cmd' not 'command' as the parameter name. Using the wrong name caused hostname resolution via getent to silently fail.





* Handle TimeoutExpiredError gracefully in hostname resolution

Catch TimeoutExpiredError from TimeoutSampler when hostname resolution fails instead of letting it crash the test. Log a warning and skip the /etc/hosts update, allowing the test to continue.





* Fix RST docstring warning for wildcard in hostname pattern




---------