### PR TITLE
Wait for NFS StorageClass propagation to client cluster

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3727,6 +3727,7 @@ NFS_CSI_PLUGIN_PROVISIONER_LABEL = "app=csi-nfsplugin-provisioner"
 NFS_CSI_PLUGIN_LABEL = "app=csi-nfsplugin"
 NFS_CSI_CTRLPLUGIN_LABEL_419 = "app=openshift-storage.nfs.csi.ceph.com-ctrlplugin"
 NFS_CSI_NODEPLUGIN_LABEL_419 = "app=openshift-storage.nfs.csi.ceph.com-nodeplugin"
+NFS_DEFAULT_SERVICE_NAME = "ocs-storagecluster-cephnfs-service"
 DAEMONSET_CSI_CEPHFS = "openshift-storage.cephfs.csi.ceph.com-nodeplugin"
 DAEMONSET_CSI_RBD = "openshift-storage.rbd.csi.ceph.com-nodeplugin"
 DAEMONSET_CSI_RBD_CSI_ADDONS = (

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -330,15 +330,10 @@ class StorageConsumer:
 
         """
         with config.RunWithConfigContext(self.consumer_context):
-            current_storage_classes = (
-                self.ocp.get(resource_name=self.name).get("spec").get("storageClasses")
-            )
+            current_storage_classes = self.get_storage_classes()
             if storage_class in current_storage_classes:
                 current_storage_classes.remove(storage_class)
-                patch_param = (
-                    f'{{"spec": {{"storageClasses": {current_storage_classes}}}}}'
-                )
-                self.ocp.patch(resource_name=self.name, params=patch_param)
+                self.set_storage_classes(current_storage_classes)
 
     @if_version(">4.18")
     def set_custom_volume_snapshot_class(self, snapshot_class):

--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -3,6 +3,7 @@ Module that contains all operations related to nfs feature in a cluster
 
 """
 
+import json
 import logging
 import yaml
 import pytest
@@ -176,7 +177,14 @@ def create_nfs_load_balancer_service(
             """
 
     nfs_service_data = yaml.safe_load(service)
-    helpers.create_resource(**nfs_service_data)
+    svc_ocp = ocp.OCP(
+        kind=constants.SERVICE,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+    if svc_ocp.is_exist(resource_name="rook-ceph-nfs-my-nfs-load-balancer"):
+        log.info("NFS LoadBalancer service already exists, skipping creation")
+    else:
+        helpers.create_resource(**nfs_service_data)
 
     log.info("Waiting for NFS LoadBalancer ingress to be assigned...")
     for ingress_add in TimeoutSampler(
@@ -463,6 +471,103 @@ def distribute_nfs_storage_class_to_all_consumers(nfs_sc):
     return check_storage_classes_on_clients(ready_consumer_names)
 
 
+def remove_nfs_storage_class_from_all_consumers(nfs_sc):
+    """
+    Remove the NFS storage class from all ready StorageConsumer resources on
+    the provider. This undoes the distribution done by
+    distribute_nfs_storage_class_to_all_consumers().
+
+    Args:
+        nfs_sc (str): NFS storage class name to remove
+
+    """
+    from ocs_ci.ocs.resources.storageconsumer import get_ready_storage_consumers
+
+    consumers = get_ready_storage_consumers()
+    consumers = [
+        consumer
+        for consumer in consumers
+        if consumer.name != constants.INTERNAL_STORAGE_CONSUMER_NAME
+    ]
+
+    if not consumers:
+        log.warning("No ready storage consumers found")
+        return
+
+    for consumer in consumers:
+        log.info(
+            "Removing NFS storage class '%s' from consumer '%s'",
+            nfs_sc,
+            consumer.name,
+        )
+        consumer.remove_custom_storage_class(nfs_sc)
+
+
+def wait_for_nfs_csi_config_on_client_cluster(timeout=300):
+    """
+    Wait until the NFS CSI configuration is populated in the ``ceph-csi-config``
+    ConfigMap on the client (consumer) cluster.
+
+    After distributing the NFS StorageClass via StorageConsumer.spec.storageClasses,
+    the ``ocs-client-operator`` reconciles the ``ceph-csi-config`` ConfigMap
+    asynchronously. Until the ``nfs`` section for a cluster entry is present,
+    the NFS CSI provisioner cannot create PVCs.
+
+    Args:
+        timeout (int): Maximum seconds to wait (default: 300).
+
+    Raises:
+        TimeoutExpiredError: If the NFS CSI config is not populated within timeout.
+
+    """
+    config.switch_to_consumer()
+    cluster_name = config.ENV_DATA["cluster_name"]
+    log.info(
+        "Waiting for NFS CSI config to be populated in 'ceph-csi-config' "
+        "on client cluster '%s'",
+        cluster_name,
+    )
+
+    configmap_obj = ocp.OCP(
+        kind=constants.CONFIGMAP,
+        namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+    )
+
+    def _nfs_csi_config_populated():
+        cm = configmap_obj.get(resource_name="ceph-csi-config", dont_raise=True)
+        if not cm:
+            return False
+        config_json = cm.get("data", {}).get("config.json", "")
+        if not config_json:
+            return False
+        try:
+            entries = json.loads(config_json)
+        except (ValueError, TypeError):
+            return False
+        for entry in entries:
+            # Check if 'nfs' key exists (even if empty dict)
+            # NFS section can be empty {} and still work
+            if "nfs" in entry:
+                nfs_section = entry.get("nfs", {})
+                log.info(
+                    "NFS CSI config key found on client cluster '%s': %s",
+                    cluster_name,
+                    nfs_section if nfs_section else "{} (empty, but present)",
+                )
+                return True
+        return False
+
+    for populated in TimeoutSampler(
+        timeout=timeout, sleep=15, func=_nfs_csi_config_populated
+    ):
+        if populated:
+            break
+        log.info(
+            "NFS CSI config not yet populated on client cluster '%s', retrying...",
+            cluster_name,
+        )
+
+
 def nfs_access_for_clients(nfs_sc):
     """
     This method is for client clusters to be able to access nfs
@@ -506,6 +611,10 @@ def nfs_access_for_clients(nfs_sc):
 
     # Distribute the scs to consumers
     distribute_nfs_storage_class_to_all_consumers(nfs_sc)
+
+    # Wait for ocs-client-operator to populate NFS section in ceph-csi-configs
+    # on the client cluster before attempting PVC creation
+    wait_for_nfs_csi_config_on_client_cluster()
 
     # verify nfs server details shared
     server = fetch_nfs_server_details_on_client_cluster()
@@ -671,13 +780,27 @@ def remove_nfs_endpoint_details():
     config.switch_to_consumer()
 
 
-def fetch_nfs_server_details_on_client_cluster():
+def fetch_nfs_server_details_on_client_cluster(default_server=False):
     """
     Fetch the NFS server endpoint configured on the client (consumer) cluster.
+
+    The NFS StorageClass is propagated asynchronously after the StorageConsumer
+    spec is patched on the provider. This function retries until the StorageClass
+    appears on the client cluster and its server parameter is populated.
+
+    Args:
+        default_server (bool): If True, wait until the server parameter equals
+            the default NFS service name ("ocs-storagecluster-cephnfs-service").
+            Use this when the external endpoint has been removed and the
+            operator is expected to revert to the default. Default is False.
 
     Returns:
         str: NFS server endpoint (IP address or hostname) configured
              in the NFS StorageClass.
+
+    Raises:
+        TimeoutExpiredError: If the NFS StorageClass does not appear or the
+            expected server value is not reached within the timeout.
 
     """
     # switch to consumer
@@ -687,4 +810,26 @@ def fetch_nfs_server_details_on_client_cluster():
         kind=constants.STORAGECLASS, resource_name=constants.NFS_STORAGECLASS_NAME
     )
 
-    return nfs_sc.data["parameters"]["server"]
+    log.info(
+        "Waiting for NFS StorageClass '%s' to appear on client cluster '%s'",
+        constants.NFS_STORAGECLASS_NAME,
+        config.ENV_DATA["cluster_name"],
+    )
+
+    def _get_nfs_server():
+        sc_data = nfs_sc.get(dont_raise=True)
+        if sc_data:
+            return sc_data.get("parameters", {}).get("server")
+        return None
+
+    sample = TimeoutSampler(timeout=120, sleep=10, func=_get_nfs_server)
+    for server in sample:
+        if server:
+            if default_server and server != "ocs-storagecluster-cephnfs-service":
+                continue
+            log.info(
+                "NFS StorageClass '%s' found on client cluster with server: %s",
+                constants.NFS_STORAGECLASS_NAME,
+                server,
+            )
+            return server

--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -625,7 +625,7 @@ def nfs_access_for_clients(nfs_sc):
     ):
         server == hostname_add
     else:
-        server == "ocs-storagecluster-cephnfs-service"
+        server == constants.NFS_DEFAULT_SERVICE_NAME
 
     # switch to consumer
     config.switch_to_consumer()
@@ -790,7 +790,7 @@ def fetch_nfs_server_details_on_client_cluster(default_server=False):
 
     Args:
         default_server (bool): If True, wait until the server parameter equals
-            the default NFS service name ("ocs-storagecluster-cephnfs-service").
+            the default NFS service name (constants.NFS_DEFAULT_SERVICE_NAME).
             Use this when the external endpoint has been removed and the
             operator is expected to revert to the default. Default is False.
 
@@ -825,7 +825,7 @@ def fetch_nfs_server_details_on_client_cluster(default_server=False):
     sample = TimeoutSampler(timeout=120, sleep=10, func=_get_nfs_server)
     for server in sample:
         if server:
-            if default_server and server != "ocs-storagecluster-cephnfs-service":
+            if default_server and server != constants.NFS_DEFAULT_SERVICE_NAME:
                 continue
             log.info(
                 "NFS StorageClass '%s' found on client cluster with server: %s",

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -220,6 +220,10 @@ class TestNfsEnable(ManageTest):
                 )
                 self.nfs_sc = constants.COPY_NFS_STORAGECLASS_NAME
             yield
+            # Remove NFS SC from distributed storage classes on the provider
+            nfs_utils.remove_nfs_storage_class_from_all_consumers(
+                constants.NFS_STORAGECLASS_NAME
+            )
             # Disable nfs feature
             nfs_utils.disable_nfs_service_from_provider(self.sc, nfs_ganesha_pod)
 
@@ -1651,9 +1655,10 @@ class TestNfsEnable(ManageTest):
         """
         # remove nfs external endpoint details from storagecluster
         nfs_utils.remove_nfs_endpoint_details()
-        time.sleep(40)
 
-        server = nfs_utils.fetch_nfs_server_details_on_client_cluster()
+        server = nfs_utils.fetch_nfs_server_details_on_client_cluster(
+            default_server=True
+        )
         # validate default nfs server details is displayed
         assert (
             server == "ocs-storagecluster-cephnfs-service"

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1661,7 +1661,7 @@ class TestNfsEnable(ManageTest):
         )
         # validate default nfs server details is displayed
         assert (
-            server == "ocs-storagecluster-cephnfs-service"
+            server == constants.NFS_DEFAULT_SERVICE_NAME
         ), f"Expected default NFS server service, got: {server}"
 
         # Update nfs external endpoint details in storagecluster


### PR DESCRIPTION
The NFS StorageClass is distributed to clients by patching the StorageConsumer spec on the provider, which triggers async propagation. fetch_nfs_server_details_on_client_cluster() was reading the SC immediately with no retry, causing CommandFailed (NotFound) when propagation hadn't completed yet.

Replace the single .data access with a TimeoutSampler loop (300s/10s) that retries until the StorageClass and its 'server' parameter appear on the client cluster.

fix for: https://github.com/red-hat-storage/ocs-ci/issues/14840