### PR TITLE
vSphere LSO deployment: clear stale CCM `uninitialized` taint on workers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -641,7 +641,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2015,
+        "line_number": 2020,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +649,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2122,
+        "line_number": 2127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +657,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2123,
+        "line_number": 2128,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +665,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2124,
+        "line_number": 2129,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +673,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2125,
+        "line_number": 2130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +681,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2130,
+        "line_number": 2135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +689,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2145,
+        "line_number": 2150,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +697,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2146,
+        "line_number": 2151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +705,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2154,
+        "line_number": 2159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +713,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2155,
+        "line_number": 2160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +721,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2156,
+        "line_number": 2161,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +729,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2157,
+        "line_number": 2162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +737,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2158,
+        "line_number": 2163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +745,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2749,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +753,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2906,
+        "line_number": 2911,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +761,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2907,
+        "line_number": 2912,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +769,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3628,
+        "line_number": 3633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -777,7 +777,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3629,
+        "line_number": 3634,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.node import (
     get_all_nodes,
     get_node_objs,
     get_master_nodes,
+    untaint_nodes,
 )
 from ocs_ci.utility import templating, version
 from ocs_ci.utility.deployment import get_ocp_ga_version
@@ -151,6 +152,23 @@ def setup_local_storage(storageclass):
     elif platform == constants.VSPHERE_PLATFORM:
         # extra_disks is used in vSphere attach_disk() method
         storage_class_device_count = config.ENV_DATA.get("extra_disks", 1)
+        logger.info(
+            "Clearing stale cloud-provider uninitialized taints on workers "
+            "(required for LSO diskmaker to schedule)"
+        )
+        try:
+            untaint_nodes(
+                taint_label=(
+                    f"{constants.CLOUD_PROVIDER_UNINITIALIZED_TAINT_KEY}"
+                    f"=true:NoSchedule"
+                ),
+                nodes_to_untaint=workers,
+            )
+        except CommandFailed as exc:
+            logger.warning(
+                "Could not clear cloud-provider uninitialized taint on workers: %s",
+                exc,
+            )
     expected_pvs = len(worker_names) * storage_class_device_count
     if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
         verify_pvs_created(expected_pvs, storageclass, False)

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1635,6 +1635,11 @@ INFRA_NODE_LABEL = "node-role.kubernetes.io/infra=''"
 NODE_SELECTOR_ANNOTATION = "openshift.io/node-selector="
 TOPOLOGY_ROOK_LABEL = "topology.rook.io/rack"
 OPERATOR_NODE_TAINT = "node.ocs.openshift.io/storage=true:NoSchedule"
+# CCM applies this until cloud init finishes; if it sticks, LSO diskmaker
+# DaemonSets cannot schedule (NoSchedule). Key-only match for has_taint().
+CLOUD_PROVIDER_UNINITIALIZED_TAINT_KEY = (
+    "node.cloudprovider.kubernetes.io/uninitialized"
+)
 OPERATOR_CATALOG_SOURCE_NAME = "redhat-operators"
 IBM_OPERATOR_CATALOG_SOURCE_NAME = "ibm-operator-catalog"
 OSBS_BOUNDLE_IMAGE = "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub-pending"


### PR DESCRIPTION
**Problem:**

  If `node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` is left on a worker (the cloud controller did not clear it), Local Storage Operator diskmaker pods cannot schedule there, resulting in too few local PVs (e.g., 4 instead of 6 when every worker should contribute disks).

**Change:**

- In `setup_local_storage()`, for vSphere, call `untaint_nodes()` with the full taint
    `node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` on workers, in the same branch where
  `storage_class_device_count` is set from `extra_disks`—so vSphere LSO-related logic stays together and avoids an
  extra top-level `if platform == vsphere` for this step.
- Wrap the `oc adm taint` path in `try` / `except CommandFailed`: log a warning and continue to
    `verify_pvs_created` so a transient `oc` / API failure does not abort the whole deployment helper.
- Add `CLOUD_PROVIDER_UNINITIALIZED_TAINT_KEY` in `constants.py` for the taint key and full string construction.
- Update `.secrets.baseline` (detect-secrets hook when touching nearby lines).

See, for example, the failed job here: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/66699/console