### PR TITLE
Add disk cleanup to FDF deployment with LSO

### DIFF
--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -10,7 +10,10 @@ import tempfile
 import yaml
 
 from ocs_ci.deployment.helpers import storage_class
-from ocs_ci.deployment.helpers.lso_helpers import add_disks_lso
+from ocs_ci.deployment.helpers.lso_helpers import (
+    add_disks_lso,
+    cleanup_nodes_for_lso_install,
+)
 from ocs_ci.deployment.helpers.storage_class import get_storageclass
 from ocs_ci.framework import config
 
@@ -251,6 +254,12 @@ class FusionDataFoundationDeployment:
         )
         if self.lso_enabled:
             self.ensure_lso_installed()
+            # Perform disk cleanup after LSO is installed but before any disk operations
+            if config.ENV_DATA.get("skip_disks_cleanup", False):
+                logger.info("Skipping disks cleanup")
+            else:
+                logger.info("Performing disk cleanup for LSO")
+                cleanup_nodes_for_lso_install()
         self.patch_catalogsource()
 
         fusion_version = config.ENV_DATA["fusion_version"].replace("v", "")


### PR DESCRIPTION
FDF deployment with LSO was missing the disk cleanup step that ODF deployment includes. This caused issues when disks had any remnants from previous use (partition tables, filesystem signatures, or Ceph bluestore metadata), as LSO is very strict about disk state and rejects unclean disks.

This adds cleanup_nodes_for_lso_install() call to FDF setup_storage(), which performs:
- wipefs -a -f to remove filesystem signatures
- sgdisk --zap-all to clear partition tables
- dd commands to zero Ceph bluestore metadata at multiple offsets
- removal of /var/lib/rook and /mnt/local-storage directories

The cleanup runs after LSO install but before any disk operations, and can be disabled with skip_disks_cleanup: true in ENV_DATA.
