### PR TITLE
Prevent upgrade conflicts from unexpected catalog builds

### DIFF
--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -833,3 +833,12 @@ class TemporaryPodsDuringDeployment(Exception):
     """
 
     pass
+
+
+class UnexpectedCatalogBuildException(Exception):
+    """
+    Raised when catalog source contains an unexpected build version that
+    would cause OLM to initiate an upgrade to a different version than intended.
+    """
+
+    pass

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -80,6 +80,8 @@ from ocs_ci.ocs.exceptions import (
     TimeoutException,
     ExternalClusterRGWAdminOpsUserException,
     CSVNotFound,
+    UnexpectedCatalogBuildException,
+    ChannelNotFound,
 )
 from ocs_ci.ocs.ui.base_ui import logger, login_ui
 from ocs_ci.ocs.ui.views import locators, ODF_OPERATOR
@@ -621,10 +623,7 @@ class OCSUpgrade(object):
             channel: (str): OCS subscription channel
 
         """
-        if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_9:
-            subscription_name = constants.ODF_SUBSCRIPTION
-        else:
-            subscription_name = constants.OCS_SUBSCRIPTION
+        subscription_name = constants.ODF_SUBSCRIPTION
         kind_name = "subscription.operators.coreos.com"
         subscription = OCP(
             resource_name=subscription_name,
@@ -787,6 +786,11 @@ class OCSUpgrade(object):
                     get_and_apply_idms_from_catalog(f"{image_url}:{new_image_tag}")
                     prune_old_df_repo_idms()
 
+                # Wait for catalog source to be ready
+                log.info("Waiting for catalog source to be ready after update.")
+                ocs_catalog.wait_for_state("READY", timeout=480)
+                log.info("Catalog source is ready.")
+
 
 def run_ocs_upgrade(
     operation=None,
@@ -879,6 +883,63 @@ def run_ocs_upgrade(
     with CephHealthMonitor(ceph_cluster):
         channel = upgrade_ocs.set_upgrade_channel()
         upgrade_ocs.set_upgrade_images()
+
+        # Check for unexpected catalog builds during y-stream upgrades only
+        # Y-stream: 4.21 -> 4.22 (version changes), Z-stream: 4.21 -> 4.21 (same version, different patch)
+        parsed_versions = upgrade_ocs.get_parsed_versions()
+        version_change = (
+            parsed_versions[1].major != parsed_versions[0].major
+            or parsed_versions[1].minor != parsed_versions[0].minor
+        )
+
+        if version_change and not upgrade_in_current_source:
+            # Y-stream upgrade: check for unexpected builds in current channel
+            log.info(
+                f"Y-stream upgrade ({original_ocs_version} -> {upgrade_version}). "
+                "Checking for unexpected builds in current channel."
+            )
+
+            subscription_name = constants.ODF_SUBSCRIPTION
+            subscription_obj = OCP(
+                resource_name=subscription_name,
+                kind="subscription.operators.coreos.com",
+                namespace=namespace,
+            )
+            current_channel = subscription_obj.data["spec"]["channel"]
+
+            operator_selector = get_selector_for_ocs_operator()
+            package_manifest = PackageManifest(
+                resource_name=OCS_OPERATOR_NAME,
+                selector=operator_selector,
+            )
+            try:
+                csv_after_catalog_update = package_manifest.get_current_csv(
+                    channel=current_channel
+                )
+                if csv_name_pre_upgrade != csv_after_catalog_update:
+                    error_msg = (
+                        "UPGRADE BLOCKED: Detected unexpected build in catalog. "
+                        f"Current channel '{current_channel}' had CSV '{csv_name_pre_upgrade}' "
+                        f"before catalog update, but now shows '{csv_after_catalog_update}'. "
+                        f"This would cause OLM to upgrade to '{csv_after_catalog_update}' before "
+                        "the channel change, creating conflicting upgrade paths."
+                    )
+                    log.error(error_msg)
+                    raise UnexpectedCatalogBuildException(error_msg)
+                log.info(
+                    f"Catalog build check passed. CSV in channel '{current_channel}' "
+                    f"remains '{csv_name_pre_upgrade}'."
+                )
+            except ChannelNotFound:
+                log.info(
+                    f"Channel '{current_channel}' not found in updated catalog. "
+                    "Skipping build check."
+                )
+        else:
+            log.info(
+                f"Z-stream or same-source upgrade ({original_ocs_version} -> {upgrade_version}). "
+                "Skipping catalog build check."
+            )
 
         if platform in constants.HCI_PROVIDER_CLIENT_PLATFORMS:
             HostedClients().apply_idms_to_hosted_clusters()


### PR DESCRIPTION
During y-stream upgrades (e.g., 4.21 to 4.22), if the upgrade catalog contains an unreleased build of the current version (e.g., 4.21.2 when upgrading from 4.21.1), OLM detects it immediately after the catalog update and starts upgrading before the channel change occurs. This creates conflicting upgrade paths that are hard to debug.

This change adds validation to detect such scenarios:
- Before catalog update: capture current CSV from current channel
- After catalog update: wait for catalog ready, then re-check CSV
- If CSV changed: fail with clear error message identifying the issue

This prevents the race condition and provides clear diagnostics when the catalog contains unexpected builds.