### PR TITLE
RHSTOR-8248-Happypath

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6679,79 +6679,26 @@ def change_reclaimspacecronjob_state_for_pvc(pvc_objs, suspend=True):
 
 def set_schedule_precedence(precedence):
     """
-    Create or update the 'csi-addons-config' ConfigMap with the given
-    schedule-precedence ('storageclass' or 'pvc') and restart the CSI Addons
-    controller manager so the change is picked up.
+    Set the schedule-precedence key in the 'csi-addons-config' ConfigMap
+    and restart the CSI Addons controller manager.
 
-    Handles both cases: ConfigMap exists / does not exist.
-    Uses valid JSON for merge patch to avoid decoding errors.
+    Delegates to the generic update_csi_addons_config() helper.
+
+    Args:
+        precedence (str): Must be 'storageclass' or 'pvc'.
+
+    Raises:
+        ValueError: If precedence is not 'storageclass' or 'pvc'.
+
     """
-    import yaml
+    from ocs_ci.ocs.resources.csi_addons import update_csi_addons_config
 
     if precedence not in ("storageclass", "pvc"):
         raise ValueError(
             f"Invalid precedence value: {precedence}. Must be 'storageclass' or 'pvc'."
         )
 
-    configmap_name = getattr(
-        constants, "CSI_ADDONS_CONFIGMAP_NAME", "csi-addons-config"
-    )
-    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
-
-    cm_ocp = OCP(kind=constants.CONFIGMAP, namespace=namespace)
-
-    # Manifest used when CM does not exist
-    cm_manifest = {
-        "apiVersion": "v1",
-        "kind": "ConfigMap",
-        "metadata": {"name": configmap_name, "namespace": namespace},
-        "data": {"schedule-precedence": precedence},
-    }
-
-    if cm_ocp.is_exist(configmap_name):
-        # UPDATE PATH: use valid JSON for merge patch (K8s expects JSON here)
-        patch_payload = json.dumps({"data": {"schedule-precedence": precedence}})
-        logger.info(
-            "Patching ConfigMap '%s' in ns '%s' to schedule-precedence=%s",
-            configmap_name,
-            namespace,
-            precedence,
-        )
-        # NOTE: wrap JSON in single quotes so shlex keeps it as one arg
-        cm_ocp.exec_oc_cmd(
-            f"patch configmap {configmap_name} -p '{patch_payload}' --type=merge",
-            out_yaml_format=False,
-        )
-    else:
-        # CREATE PATH: write manifest to temp file and apply
-        logger.info(
-            "Creating ConfigMap '%s' in ns '%s' with schedule-precedence=%s",
-            configmap_name,
-            namespace,
-            precedence,
-        )
-        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".yaml") as fp:
-            yaml.safe_dump(cm_manifest, fp, sort_keys=False)
-            tmp_path = fp.name
-        try:
-            cm_ocp.exec_oc_cmd(f"apply -f {tmp_path}", out_yaml_format=False)
-        finally:
-            try:
-                os.remove(tmp_path)
-            except OSError:
-                pass
-
-    logger.info(
-        "ConfigMap '%s' set to schedule-precedence=%s", configmap_name, precedence
-    )
-
-    # Restart CSI Addons controller manager pods so the new value is read
-    logger.info("Restarting CSI Addons controller manager pods...")
-    pod.restart_pods_having_label(
-        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
-        namespace=namespace,
-    )
-    logger.info("CSI Addons controller manager pods restarted.")
+    update_csi_addons_config("schedule-precedence", precedence)
 
 
 def verify_reclaimspacecronjob_suspend_state_for_pvc(pvc_obj):
@@ -7317,12 +7264,8 @@ def get_schedule_precedance_value_from_csi_addons_configmap(
     """
     Return the schedule precedence from the 'csi-addons-config' ConfigMap.
 
-    If the ConfigMap (or key) doesn't exist, return the default ('storageclass').
-
-    The ConfigMap has the following structure:
-    - name: csi-addons-config
-    - namespace: openshift-storage (or cluster_namespace)
-    - data.schedule-precedence: 'storageclass' or 'pvc'
+    Delegates to the generic get_csi_addons_config_value() helper,
+    then validates the returned value is 'storageclass' or 'pvc'.
 
     Args:
         default (str): Default value to return if ConfigMap doesn't exist.
@@ -7330,46 +7273,22 @@ def get_schedule_precedance_value_from_csi_addons_configmap(
 
     Returns:
         str: The schedule precedence value ('storageclass' or 'pvc').
+
     """
-    cm_name = getattr(constants, "CSI_ADDONS_CONFIGMAP_NAME", "csi-addons-config")
-    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+    from ocs_ci.ocs.resources.csi_addons import get_csi_addons_config_value
 
-    cm_ocp = OCP(kind=constants.CONFIGMAP, namespace=namespace)
+    value = get_csi_addons_config_value("schedule-precedence", default=default)
+    value = value.strip().lower()
 
-    try:
-        if not cm_ocp.is_exist(cm_name):
-            logger.info(
-                "ConfigMap '%s' not found in namespace '%s'; using default '%s'.",
-                cm_name,
-                namespace,
-                default,
-            )
-            return default
+    if value in ("storageclass", "pvc"):
+        return value
 
-        cm = cm_ocp.get(resource_name=cm_name)
-        value = cm.get("data", {}).get("schedule-precedence", "").strip().lower()
-
-        if value in ("storageclass", "pvc"):
-            logger.info("Schedule precedence from ConfigMap: %s", value)
-            return value
-
-        logger.warning(
-            "ConfigMap '%s' has missing/invalid 'schedule-precedence' (got '%s'); using default '%s'.",
-            cm_name,
-            value,
-            default,
-        )
-        return default
-
-    except CommandFailed as e:
-        logger.warning(
-            "Failed to read ConfigMap '%s' in ns '%s' (%s); using default '%s'.",
-            cm_name,
-            namespace,
-            e,
-            default,
-        )
-        return default
+    logger.warning(
+        "Invalid 'schedule-precedence' value '%s'; using default '%s'.",
+        value,
+        default,
+    )
+    return default
 
 
 def verify_socket_on_node(node_name, host_path, socket_name):

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -1,0 +1,162 @@
+"""
+Helpers for interacting with the csi-addons-config ConfigMap.
+
+Provides generic get/set operations for any key in the ConfigMap.
+Used by set_schedule_precedence() in helpers.py and by stagger tests.
+"""
+
+import json
+import logging
+import os
+import tempfile
+
+import yaml
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+
+def update_csi_addons_config(key: str, value: str) -> None:
+    """
+    Create or update a key in the 'csi-addons-config' ConfigMap and restart
+    the CSI Addons controller manager so the change is picked up.
+
+    Handles both cases: ConfigMap exists / does not exist.
+    Uses JSON merge patch to preserve existing keys.
+
+    Args:
+        key (str): The ConfigMap data key to set (e.g. 'cronjob-stagger-window').
+        value (str): The value to assign to the key.
+
+    Raises:
+        CommandFailed: If the ConfigMap patch or create operation fails.
+
+    """
+    configmap_name = constants.CSI_ADDONS_CONFIGMAP_NAME
+    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+
+    cm_ocp = OCP(kind=constants.CONFIGMAP, namespace=namespace)
+
+    if cm_ocp.is_exist(configmap_name):
+        patch_payload = json.dumps({"data": {key: value}})
+        logger.info(
+            "Patching ConfigMap '%s' in ns '%s': %s=%s",
+            configmap_name,
+            namespace,
+            key,
+            value,
+        )
+        cm_ocp.exec_oc_cmd(
+            f"patch configmap {configmap_name} -p '{patch_payload}' --type=merge",
+            out_yaml_format=False,
+        )
+    else:
+        logger.info(
+            "Creating ConfigMap '%s' in ns '%s' with %s=%s",
+            configmap_name,
+            namespace,
+            key,
+            value,
+        )
+        cm_manifest = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": configmap_name, "namespace": namespace},
+            "data": {key: value},
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".yaml"
+        ) as fp:
+            yaml.safe_dump(cm_manifest, fp, sort_keys=False)
+            tmp_path = fp.name
+        try:
+            cm_ocp.exec_oc_cmd(f"apply -f {tmp_path}", out_yaml_format=False)
+        finally:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+    logger.info("ConfigMap '%s' updated: %s=%s", configmap_name, key, value)
+
+    logger.info("Restarting CSI Addons controller manager pods...")
+    pod.restart_pods_having_label(
+        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+        namespace=namespace,
+    )
+
+    logger.info("Waiting for CSI Addons controller manager pod to be Ready...")
+    for pods_data in TimeoutSampler(
+        timeout=120,
+        sleep=10,
+        func=pod.get_pods_having_label,
+        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+        namespace=namespace,
+        statuses=[constants.STATUS_RUNNING],
+    ):
+        if pods_data:
+            logger.info("CSI Addons controller manager pod is Ready.")
+            break
+
+
+def get_csi_addons_config_value(key: str, default: str = "") -> str:
+    """
+    Read a value from the 'csi-addons-config' ConfigMap.
+
+    Returns the default if the ConfigMap does not exist, the key is missing,
+    or the read operation fails.
+
+    Args:
+        key (str): The ConfigMap data key to read (e.g. 'cronjob-stagger-window').
+        default (str): Fallback value when the key is absent. Defaults to "".
+
+    Returns:
+        str: The value from the ConfigMap, or *default* if unavailable.
+
+    """
+    configmap_name = constants.CSI_ADDONS_CONFIGMAP_NAME
+    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+
+    cm_ocp = OCP(kind=constants.CONFIGMAP, namespace=namespace)
+
+    try:
+        if not cm_ocp.is_exist(configmap_name):
+            logger.info(
+                "ConfigMap '%s' not found in ns '%s'; returning default '%s' for key '%s'.",
+                configmap_name,
+                namespace,
+                default,
+                key,
+            )
+            return default
+
+        cm = cm_ocp.get(resource_name=configmap_name)
+        value = cm.get("data", {}).get(key, "").strip()
+
+        if not value:
+            logger.info(
+                "Key '%s' missing or empty in ConfigMap '%s'; returning default '%s'.",
+                key,
+                configmap_name,
+                default,
+            )
+            return default
+
+        logger.info("ConfigMap '%s' key '%s' = '%s'", configmap_name, key, value)
+        return value
+
+    except CommandFailed as e:
+        logger.warning(
+            "Failed to read ConfigMap '%s' in ns '%s' (%s); returning default '%s'.",
+            configmap_name,
+            namespace,
+            e,
+            default,
+        )
+        return default

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -70,9 +70,7 @@ def update_csi_addons_config(key: str, value: str) -> None:
             "metadata": {"name": configmap_name, "namespace": namespace},
             "data": {key: value},
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", delete=False, suffix=".yaml"
-        ) as fp:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".yaml") as fp:
             yaml.safe_dump(cm_manifest, fp, sort_keys=False)
             tmp_path = fp.name
         try:

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -22,6 +22,34 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
+def _restart_csi_addons_controller(namespace: str) -> None:
+    """
+    Restart the CSI Addons controller manager and wait for it to be Ready.
+
+    Args:
+        namespace (str): The namespace where the controller runs.
+
+    """
+    logger.info("Restarting CSI Addons controller manager pods...")
+    pod.restart_pods_having_label(
+        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+        namespace=namespace,
+    )
+
+    logger.info("Waiting for CSI Addons controller manager pod to be Ready...")
+    for pods_data in TimeoutSampler(
+        timeout=120,
+        sleep=10,
+        func=pod.get_pods_having_label,
+        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+        namespace=namespace,
+        statuses=[constants.STATUS_RUNNING],
+    ):
+        if pods_data:
+            logger.info("CSI Addons controller manager pod is Ready.")
+            break
+
+
 def update_csi_addons_config(key: str, value: str) -> None:
     """
     Create or update a key in the 'csi-addons-config' ConfigMap and restart
@@ -82,25 +110,60 @@ def update_csi_addons_config(key: str, value: str) -> None:
                 pass
 
     logger.info("ConfigMap '%s' updated: %s=%s", configmap_name, key, value)
+    _restart_csi_addons_controller(namespace)
 
-    logger.info("Restarting CSI Addons controller manager pods...")
-    pod.restart_pods_having_label(
-        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
-        namespace=namespace,
+
+def remove_csi_addons_config_key(key: str) -> None:
+    """
+    Remove a key from the 'csi-addons-config' ConfigMap and restart
+    the CSI Addons controller manager so the change is picked up.
+
+    No-op if the ConfigMap does not exist or the key is already absent.
+
+    Args:
+        key (str): The ConfigMap data key to remove.
+
+    Raises:
+        CommandFailed: If the patch operation fails for a reason other
+            than the key already being absent.
+
+    """
+    configmap_name = constants.CSI_ADDONS_CONFIGMAP_NAME
+    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+
+    cm_ocp = OCP(kind=constants.CONFIGMAP, namespace=namespace)
+
+    if not cm_ocp.is_exist(configmap_name):
+        logger.info(
+            "ConfigMap '%s' not found in ns '%s'; nothing to remove.",
+            configmap_name,
+            namespace,
+        )
+        return
+
+    cm = cm_ocp.get(resource_name=configmap_name)
+    if key not in cm.get("data", {}):
+        logger.info(
+            "Key '%s' not present in ConfigMap '%s'; nothing to remove.",
+            key,
+            configmap_name,
+        )
+        return
+
+    patch_payload = json.dumps([{"op": "remove", "path": f"/data/{key}"}])
+    logger.info(
+        "Removing key '%s' from ConfigMap '%s' in ns '%s'",
+        key,
+        configmap_name,
+        namespace,
+    )
+    cm_ocp.exec_oc_cmd(
+        f"patch configmap {configmap_name} -p '{patch_payload}' --type=json",
+        out_yaml_format=False,
     )
 
-    logger.info("Waiting for CSI Addons controller manager pod to be Ready...")
-    for pods_data in TimeoutSampler(
-        timeout=120,
-        sleep=10,
-        func=pod.get_pods_having_label,
-        label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
-        namespace=namespace,
-        statuses=[constants.STATUS_RUNNING],
-    ):
-        if pods_data:
-            logger.info("CSI Addons controller manager pod is Ready.")
-            break
+    logger.info("Key '%s' removed from ConfigMap '%s'", key, configmap_name)
+    _restart_csi_addons_controller(namespace)
 
 
 def get_csi_addons_config_value(key: str, default: str = "") -> str:

--- a/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
+++ b/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
@@ -68,9 +68,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
         )
 
         def finalizer():
-            logger.info(
-                "Restoring stagger window to: %s", self.original_stagger_window
-            )
+            logger.info("Restoring stagger window to: %s", self.original_stagger_window)
             update_csi_addons_config(
                 CRONJOB_STAGGER_WINDOW_KEY, self.original_stagger_window
             )
@@ -162,11 +160,16 @@ class TestStaggeredCronjobScheduling(ManageTest):
                 f"expected '{SHORT_SCHEDULE}'"
             )
             uid = cj_data["metadata"]["uid"]
-            logger.info("CronJob for PVC '%s': schedule=%s, UID=%s", pvc_name, actual_schedule, uid)
+            logger.info(
+                "CronJob for PVC '%s': schedule=%s, UID=%s",
+                pvc_name,
+                actual_schedule,
+                uid,
+            )
             uids.add(uid)
-        assert len(uids) == NUM_PVCS, (
-            f"Expected {NUM_PVCS} unique CronJob UIDs, got {len(uids)}: {uids}"
-        )
+        assert (
+            len(uids) == NUM_PVCS
+        ), f"Expected {NUM_PVCS} unique CronJob UIDs, got {len(uids)}: {uids}"
 
         # Step 7: Wait for ReclaimSpaceJobs and compare timestamps
         logger.info("Step 7: Waiting for ReclaimSpaceJobs to appear")
@@ -183,16 +186,16 @@ class TestStaggeredCronjobScheduling(ManageTest):
         readback = get_csi_addons_config_value(
             CRONJOB_STAGGER_WINDOW_KEY, default=CRONJOB_STAGGER_WINDOW_DEFAULT
         )
-        assert readback == "0", (
-            f"Expected stagger window '0' after disable, got '{readback}'"
-        )
+        assert (
+            readback == "0"
+        ), f"Expected stagger window '0' after disable, got '{readback}'"
 
         logger.info("Step 8: Verifying CronJobs survive stagger disable")
         for pvc_name, cj_obj in cronjob_map.items():
             cj_data = cj_obj.get()
-            assert cj_data["spec"]["schedule"] == SHORT_SCHEDULE, (
-                f"CronJob for PVC '{pvc_name}' schedule changed after stagger disable"
-            )
+            assert (
+                cj_data["spec"]["schedule"] == SHORT_SCHEDULE
+            ), f"CronJob for PVC '{pvc_name}' schedule changed after stagger disable"
         logger.info("All CronJobs intact after stagger disable")
 
     def _wait_for_cronjob(self, pvc_obj) -> OCP:
@@ -252,14 +255,10 @@ class TestStaggeredCronjobScheduling(ManageTest):
         timestamps = {}
         for cj_name in cronjob_names:
             prefix = f"{cj_name}-"
-            matching = [
-                j for j in all_jobs if j["metadata"]["name"].startswith(prefix)
-            ]
+            matching = [j for j in all_jobs if j["metadata"]["name"].startswith(prefix)]
             if not matching:
                 return None
-            earliest = min(
-                matching, key=lambda j: j["metadata"]["creationTimestamp"]
-            )
+            earliest = min(matching, key=lambda j: j["metadata"]["creationTimestamp"])
             ts_str = earliest["metadata"]["creationTimestamp"]
             timestamps[cj_name] = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
         return timestamps
@@ -312,7 +311,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
         max_spread = max(
             abs((a - b).total_seconds())
             for i, a in enumerate(ts_values)
-            for b in ts_values[i + 1:]
+            for b in ts_values[i + 1 :]
         )
         logger.info("Maximum timestamp spread: %.1f seconds", max_spread)
         logger.info("Timestamps: %s", timestamps)

--- a/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
+++ b/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
@@ -1,0 +1,323 @@
+"""
+Tests for staggered CronJob scheduling in csi-addons.
+
+Verifies that the csi-addons controller applies a deterministic, UID-based
+offset to ReclaimSpaceCronJob execution times to prevent thundering herd.
+
+Upstream PR: https://github.com/csi-addons/kubernetes-csi-addons/pull/949
+"""
+
+import logging
+from datetime import datetime
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_ocs_version
+from ocs_ci.framework.testlib import ManageTest, tier2
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.csi_addons import (
+    get_csi_addons_config_value,
+    update_csi_addons_config,
+)
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+# --- Test-local constants (no magic numbers) ---
+CRONJOB_STAGGER_WINDOW_KEY = "cronjob-stagger-window"
+CRONJOB_STAGGER_WINDOW_DEFAULT = "2"
+SCHEDULE_PRECEDENCE_KEY = "schedule-precedence"
+SCHEDULE_PRECEDENCE_STORAGECLASS = "storageclass"
+NUM_PVCS = 3
+PVC_SIZE_GIB = 5
+SHORT_SCHEDULE = "*/3 * * * *"
+CRONJOB_CREATION_TIMEOUT = 180
+JOB_CREATION_TIMEOUT = 360
+MIN_STAGGER_SPREAD_SECONDS = 5
+
+
+@green_squad
+@skipif_ocs_version("<4.22")
+class TestStaggeredCronjobScheduling(ManageTest):
+    """
+    Test staggered CronJob scheduling for ReclaimSpace operations.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self, request):
+        """
+        Record initial csi-addons-config values, set schedule-precedence
+        to 'storageclass' so the controller reads StorageClass annotations,
+        and restore original values after the test completes.
+        """
+        self.original_stagger_window = get_csi_addons_config_value(
+            CRONJOB_STAGGER_WINDOW_KEY, default=CRONJOB_STAGGER_WINDOW_DEFAULT
+        )
+        self.original_precedence = get_csi_addons_config_value(
+            SCHEDULE_PRECEDENCE_KEY, default=""
+        )
+        logger.info(
+            "Recorded original values: stagger_window=%s, schedule_precedence=%s",
+            self.original_stagger_window,
+            self.original_precedence or "(not set)",
+        )
+
+        update_csi_addons_config(
+            SCHEDULE_PRECEDENCE_KEY, SCHEDULE_PRECEDENCE_STORAGECLASS
+        )
+
+        def finalizer():
+            logger.info(
+                "Restoring stagger window to: %s", self.original_stagger_window
+            )
+            update_csi_addons_config(
+                CRONJOB_STAGGER_WINDOW_KEY, self.original_stagger_window
+            )
+            if self.original_precedence:
+                logger.info(
+                    "Restoring schedule-precedence to: %s", self.original_precedence
+                )
+                update_csi_addons_config(
+                    SCHEDULE_PRECEDENCE_KEY, self.original_precedence
+                )
+
+        request.addfinalizer(finalizer)
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_staggered_cronjob_scheduling_happy_path(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify staggered CronJob scheduling for ReclaimSpace operations.
+
+        Steps:
+            1. Verify the default stagger window (2h) in the ConfigMap.
+            2. Create a StorageClass with a short-interval ReclaimSpace schedule.
+            3. Create RBD PVCs and attach pods.
+            4. Wait for ReclaimSpaceCronJob creation for each PVC.
+            5. Verify spec.schedule is unchanged (stagger is controller-internal).
+            6. Verify CronJobs have distinct UIDs for unique stagger offsets.
+            7. Wait for ReclaimSpaceJobs and compare creation timestamps.
+            8. Disable stagger (window=0) and verify CronJobs survive.
+
+        """
+        # Step 1: Verify default stagger window
+        logger.info("Step 1: Verifying default stagger window value")
+        current_window = get_csi_addons_config_value(
+            CRONJOB_STAGGER_WINDOW_KEY, default=CRONJOB_STAGGER_WINDOW_DEFAULT
+        )
+        assert current_window == CRONJOB_STAGGER_WINDOW_DEFAULT, (
+            f"Expected default stagger window '{CRONJOB_STAGGER_WINDOW_DEFAULT}', "
+            f"got '{current_window}'"
+        )
+
+        # Step 2: Create StorageClass with short-interval schedule
+        logger.info("Step 2: Creating StorageClass with schedule: %s", SHORT_SCHEDULE)
+        sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            annotations={
+                constants.RECLAIMSPACE_SCHEDULE_ANNOTATION: SHORT_SCHEDULE,
+            },
+        )
+
+        # Step 3: Create PVCs and pods
+        logger.info("Step 3: Creating %d RBD PVCs (size=%dGiB)", NUM_PVCS, PVC_SIZE_GIB)
+        pvc_objs = multi_pvc_factory(
+            size=PVC_SIZE_GIB,
+            num_of_pvc=NUM_PVCS,
+            storageclass=sc_obj,
+            access_modes=[f"{constants.ACCESS_MODE_RWO}-Block"],
+            wait_each=True,
+        )
+
+        logger.info("Step 3: Creating pods for PVCs")
+        for pvc_obj in pvc_objs:
+            pod_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                pvc=pvc_obj,
+                status=constants.STATUS_RUNNING,
+                raw_block_pv=True,
+            )
+
+        # Step 4: Wait for ReclaimSpaceCronJob creation per PVC
+        logger.info("Step 4: Waiting for ReclaimSpaceCronJob creation")
+        cronjob_map = {}
+        for pvc_obj in pvc_objs:
+            cronjob_obj = self._wait_for_cronjob(pvc_obj)
+            cronjob_map[pvc_obj.name] = cronjob_obj
+
+        # Steps 5-6: Verify spec.schedule unchanged and collect unique UIDs
+        logger.info("Steps 5-6: Verifying schedule and collecting CronJob UIDs")
+        uids = set()
+        for pvc_name, cj_obj in cronjob_map.items():
+            cj_data = cj_obj.get()
+            actual_schedule = cj_data["spec"]["schedule"]
+            assert actual_schedule == SHORT_SCHEDULE, (
+                f"CronJob for PVC '{pvc_name}' has schedule '{actual_schedule}', "
+                f"expected '{SHORT_SCHEDULE}'"
+            )
+            uid = cj_data["metadata"]["uid"]
+            logger.info("CronJob for PVC '%s': schedule=%s, UID=%s", pvc_name, actual_schedule, uid)
+            uids.add(uid)
+        assert len(uids) == NUM_PVCS, (
+            f"Expected {NUM_PVCS} unique CronJob UIDs, got {len(uids)}: {uids}"
+        )
+
+        # Step 7: Wait for ReclaimSpaceJobs and compare timestamps
+        logger.info("Step 7: Waiting for ReclaimSpaceJobs to appear")
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj_obj.resource_name for cj_obj in cronjob_map.values()]
+
+        timestamps = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        self._assert_stagger_spread(timestamps)
+
+        # Step 8: Disable stagger and verify CronJobs survive
+        logger.info("Step 8: Disabling stagger (window=0)")
+        update_csi_addons_config(CRONJOB_STAGGER_WINDOW_KEY, "0")
+
+        readback = get_csi_addons_config_value(
+            CRONJOB_STAGGER_WINDOW_KEY, default=CRONJOB_STAGGER_WINDOW_DEFAULT
+        )
+        assert readback == "0", (
+            f"Expected stagger window '0' after disable, got '{readback}'"
+        )
+
+        logger.info("Step 8: Verifying CronJobs survive stagger disable")
+        for pvc_name, cj_obj in cronjob_map.items():
+            cj_data = cj_obj.get()
+            assert cj_data["spec"]["schedule"] == SHORT_SCHEDULE, (
+                f"CronJob for PVC '{pvc_name}' schedule changed after stagger disable"
+            )
+        logger.info("All CronJobs intact after stagger disable")
+
+    def _wait_for_cronjob(self, pvc_obj) -> OCP:
+        """
+        Wait for a ReclaimSpaceCronJob to be created for the given PVC.
+
+        Uses the deterministic naming convention: {pvc-name}-reclaimspace.
+        ODF 4.22+ no longer annotates PVCs with the CronJob name.
+
+        Args:
+            pvc_obj: PVC object to look up the CronJob for.
+
+        Returns:
+            OCP: The CronJob OCP object.
+
+        Raises:
+            TimeoutExpiredError: If the CronJob is not created within timeout.
+
+        """
+        expected_name = f"{pvc_obj.name}-reclaimspace"
+        cronjob_ocp = OCP(
+            kind=constants.RECLAIMSPACECRONJOB,
+            namespace=pvc_obj.namespace,
+            resource_name=expected_name,
+        )
+
+        for result in TimeoutSampler(
+            timeout=CRONJOB_CREATION_TIMEOUT,
+            sleep=10,
+            func=cronjob_ocp.check_resource_existence,
+            should_exist=True,
+        ):
+            if result:
+                logger.info(
+                    "CronJob '%s' found for PVC '%s'",
+                    expected_name,
+                    pvc_obj.name,
+                )
+                return cronjob_ocp
+
+    def _get_earliest_job_timestamps(
+        self, ocp_jobs: OCP, cronjob_names: list[str]
+    ) -> dict[str, datetime] | None:
+        """
+        Check whether at least one ReclaimSpaceJob exists per CronJob and
+        return their earliest creation timestamps.
+
+        Args:
+            ocp_jobs (OCP): OCP client for ReclaimSpaceJobs in the target namespace.
+            cronjob_names (list[str]): CronJob names to match Jobs against.
+
+        Returns:
+            dict[str, datetime] | None: Timestamps if all CronJobs have Jobs, else None.
+
+        """
+        all_jobs = ocp_jobs.get().get("items", [])
+        timestamps = {}
+        for cj_name in cronjob_names:
+            prefix = f"{cj_name}-"
+            matching = [
+                j for j in all_jobs if j["metadata"]["name"].startswith(prefix)
+            ]
+            if not matching:
+                return None
+            earliest = min(
+                matching, key=lambda j: j["metadata"]["creationTimestamp"]
+            )
+            ts_str = earliest["metadata"]["creationTimestamp"]
+            timestamps[cj_name] = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+        return timestamps
+
+    def _collect_job_timestamps(
+        self, namespace: str, cronjob_names: list[str]
+    ) -> dict[str, datetime]:
+        """
+        Wait for at least one ReclaimSpaceJob per CronJob and return their
+        earliest creation timestamps.
+
+        Args:
+            namespace (str): Namespace where Jobs are created.
+            cronjob_names (list[str]): CronJob names to match Jobs against.
+
+        Returns:
+            dict[str, datetime]: Mapping of CronJob name to earliest Job creation datetime.
+
+        Raises:
+            TimeoutExpiredError: If Jobs don't appear for all CronJobs.
+
+        """
+        ocp_jobs = OCP(kind=constants.RECLAIMSPACEJOBS, namespace=namespace)
+
+        for timestamps in TimeoutSampler(
+            timeout=JOB_CREATION_TIMEOUT,
+            sleep=15,
+            func=self._get_earliest_job_timestamps,
+            ocp_jobs=ocp_jobs,
+            cronjob_names=cronjob_names,
+        ):
+            if timestamps:
+                for cj_name, ts in timestamps.items():
+                    logger.info("Job timestamp for CronJob '%s': %s", cj_name, ts)
+                return timestamps
+
+    def _assert_stagger_spread(self, timestamps: dict) -> None:
+        """
+        Assert that Job creation timestamps are NOT all clustered within
+        MIN_STAGGER_SPREAD_SECONDS of each other, confirming stagger is active.
+
+        Args:
+            timestamps (dict): Mapping of CronJob name to creation datetime.
+
+        Raises:
+            AssertionError: If all timestamps are within the spread threshold.
+
+        """
+        ts_values = list(timestamps.values())
+        max_spread = max(
+            abs((a - b).total_seconds())
+            for i, a in enumerate(ts_values)
+            for b in ts_values[i + 1:]
+        )
+        logger.info("Maximum timestamp spread: %.1f seconds", max_spread)
+        logger.info("Timestamps: %s", timestamps)
+        assert max_spread > MIN_STAGGER_SPREAD_SECONDS, (
+            f"All Job timestamps within {MIN_STAGGER_SPREAD_SECONDS}s of each other "
+            f"(spread={max_spread:.1f}s). Stagger may not be active. "
+            f"Timestamps: {timestamps}"
+        )

--- a/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
+++ b/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
@@ -83,7 +83,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
         request.addfinalizer(finalizer)
 
     @tier2
-    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.polarion_id("OCS-7800")
     def test_staggered_cronjob_scheduling_happy_path(
         self,
         storageclass_factory,

--- a/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
+++ b/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
@@ -15,9 +15,11 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_ocs_version
 from ocs_ci.framework.testlib import ManageTest, tier2
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.csi_addons import (
     get_csi_addons_config_value,
+    remove_csi_addons_config_key,
     update_csi_addons_config,
 )
 from ocs_ci.utility.utils import TimeoutSampler
@@ -79,6 +81,11 @@ class TestStaggeredCronjobScheduling(ManageTest):
                 update_csi_addons_config(
                     SCHEDULE_PRECEDENCE_KEY, self.original_precedence
                 )
+            else:
+                logger.info(
+                    "Removing schedule-precedence key (was not set before test)"
+                )
+                remove_csi_addons_config_key(SCHEDULE_PRECEDENCE_KEY)
 
         request.addfinalizer(finalizer)
 
@@ -222,19 +229,20 @@ class TestStaggeredCronjobScheduling(ManageTest):
             resource_name=expected_name,
         )
 
-        for result in TimeoutSampler(
-            timeout=CRONJOB_CREATION_TIMEOUT,
-            sleep=10,
-            func=cronjob_ocp.check_resource_existence,
-            should_exist=True,
-        ):
-            if result:
-                logger.info(
-                    "CronJob '%s' found for PVC '%s'",
-                    expected_name,
-                    pvc_obj.name,
-                )
-                return cronjob_ocp
+        found = cronjob_ocp.check_resource_existence(
+            should_exist=True, timeout=CRONJOB_CREATION_TIMEOUT
+        )
+        if not found:
+            raise TimeoutExpiredError(
+                f"CronJob '{expected_name}' not created within "
+                f"{CRONJOB_CREATION_TIMEOUT}s"
+            )
+        logger.info(
+            "CronJob '%s' found for PVC '%s'",
+            expected_name,
+            pvc_obj.name,
+        )
+        return cronjob_ocp
 
     def _get_earliest_job_timestamps(
         self, ocp_jobs: OCP, cronjob_names: list[str]


### PR DESCRIPTION
- [x] Add generic csi-addons-config ConfigMap helpers (get/set any key, wait-for-ready after controller restart)
- [x] Add happy path test verifying UID-based stagger offsets for ReclaimSpaceCronJobs (8 steps: create PVCs, verify CronJob   schedule unchanged, compare Job timestamps for spread, disable stagger and verify survival)
- [x] Set `schedule-precedence: storageclass` in fixture setup so the controller reads SC annotations
- [x] Refactor `set_schedule_precedence` and get_schedule_precedance_value_from_csi_addons_configmap` in helpers.py to thin wrappers delegating to the new generic helpers 

Callers to validate (refactored helpers.py functions):
  - [ ] tests/functional/storageclass/test_enforce_storageclass_precedance_for_KRRS.py (set_schedule_precedence)
  - [ ] tests/functional/pv/pv_encryption/test_disable_pv_keyrotation.py (both functions)
