### PR TITLE
Skip replica-1 test on LSO clusters without extra disks

### DIFF
--- a/ocs_ci/ocs/replica_one.py
+++ b/ocs_ci/ocs/replica_one.py
@@ -30,12 +30,13 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = getLogger(__name__)
 
 
-def _get_failure_domains_from_storagecluster() -> list[str]:
+def get_failure_domains_from_storagecluster() -> dict:
     """
-    Get failure domains from StorageCluster status.failureDomainValues.
+    Get failure domain info from StorageCluster status.
 
     Returns:
-        list[str]: Failure domain names, or empty list if not available.
+        dict: {"values": list[str], "type": str} where type is
+              "host", "rack", or "zone". Empty dict if unavailable.
     """
     try:
         storage_cluster = OCP(
@@ -46,22 +47,23 @@ def _get_failure_domains_from_storagecluster() -> list[str]:
         items = sc_data.get("items", [])
         if not items:
             log.debug("No StorageCluster items found")
-            return []
+            return {}
 
-        failure_domain_values = (
-            items[0].get("status", {}).get("failureDomainValues", [])
-        )
+        status = items[0].get("status", {})
+        failure_domain_values = status.get("failureDomainValues", [])
+        failure_domain_type = status.get("failureDomain")
+
         if failure_domain_values:
             log.info(
                 f"Got failure domains from StorageCluster status: {failure_domain_values}"
             )
-            return failure_domain_values
-
-        log.debug("failureDomainValues not found in StorageCluster status")
-        return []
+        return {
+            "values": failure_domain_values,
+            "type": failure_domain_type,
+        }
     except (CommandFailed, KeyError, IndexError) as e:
         log.debug(f"Failed to get failure domains from StorageCluster: {e}")
-        return []
+        return {}
 
 
 def get_failure_domains() -> list[str]:
@@ -83,7 +85,7 @@ def get_failure_domains() -> list[str]:
         return config_zones
 
     # Priority 2: StorageCluster status (source of truth, available immediately)
-    sc_domains = _get_failure_domains_from_storagecluster()
+    sc_domains = get_failure_domains_from_storagecluster().get("values", [])
     if sc_domains:
         return sc_domains
 

--- a/tests/functional/storageclass/test_replica1.py
+++ b/tests/functional/storageclass/test_replica1.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
 from ocs_ci.ocs.constants import (
     CEPHBLOCKPOOL,
     ACCESS_MODE_RWO,
+    HOSTNAME_LABEL,
     LOCALSTORAGE_SC,
     POD,
     STATUS_READY,
@@ -26,7 +27,6 @@ from ocs_ci.ocs.constants import (
     STATUS_RUNNING,
     VOLUME_MODE_BLOCK,
     DEFALUT_DEVICE_CLASS,
-    VSPHERE_PLATFORM,
     RACK_LABEL,
     ZONE_LABEL,
 )
@@ -47,6 +47,7 @@ from ocs_ci.ocs.replica_one import (
     get_device_class_from_ceph,
     get_all_osd_names_by_device_class,
     get_failure_domains,
+    get_failure_domains_from_storagecluster,
     get_failures_domain_name,
 )
 from ocs_ci.ocs.resources.pvc import get_pvcs_using_storageclass
@@ -68,10 +69,19 @@ def _get_node_selector_for_failure_domain(
     Returns:
         dict[str, str] | None: Hard node selector if workers found, None otherwise.
     """
-    if config.ENV_DATA["platform"].lower() == VSPHERE_PLATFORM:
-        label_key = RACK_LABEL
-    else:
-        label_key = ZONE_LABEL
+    fd_type_to_label = {
+        "host": HOSTNAME_LABEL,
+        "rack": RACK_LABEL,
+        "zone": ZONE_LABEL,
+    }
+    sc_info = get_failure_domains_from_storagecluster()
+    fd_type = sc_info.get("type")
+    label_key = fd_type_to_label.get(fd_type)
+    if label_key is None:
+        pytest.fail(
+            f"Unknown failure domain type '{fd_type}' — "
+            f"expected one of: {list(fd_type_to_label.keys())}"
+        )
 
     worker_names = get_worker_nodes()
     workers = get_node_objs(worker_names)

--- a/tests/functional/storageclass/test_replica1.py
+++ b/tests/functional/storageclass/test_replica1.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
 from ocs_ci.ocs.constants import (
     CEPHBLOCKPOOL,
     ACCESS_MODE_RWO,
+    LOCALSTORAGE_SC,
     POD,
     STATUS_READY,
     REPLICA1_STORAGECLASS,
@@ -157,6 +158,28 @@ class TestReplicaOne:
         self.created_pods = []
 
         log.info("Setup function called")
+
+        if config.DEPLOYMENT.get("local_storage"):
+            failure_domains = get_failure_domains()
+            pv_obj = OCP(kind="PersistentVolume")
+            available_pvs = [
+                pv
+                for pv in pv_obj.get()["items"]
+                if pv["status"]["phase"] == "Available"
+                and pv["spec"].get("storageClassName") == LOCALSTORAGE_SC
+            ]
+            log.info(
+                f"LSO cluster: {len(available_pvs)} available PVs in "
+                f"{LOCALSTORAGE_SC}, need {len(failure_domains)} for replica-1"
+            )
+            if len(available_pvs) < len(failure_domains):
+                pytest.skip(
+                    f"Replica-1 requires {len(failure_domains)} extra PVs "
+                    f"(one per failure domain) but only "
+                    f"{len(available_pvs)} available in {LOCALSTORAGE_SC} "
+                    f"(DFBUGS-6355)"
+                )
+
         storage_cluster = StorageCluster(
             resource_name=config.ENV_DATA["storage_cluster_name"],
             namespace=config.ENV_DATA["cluster_namespace"],


### PR DESCRIPTION
- Add PV availability check before enabling non-resilient pools on LSO clusters
- Skip test when available localblock PVs < number of failure domains
- Check runs before any cluster mutations (before set_non_resilient_pool)
- Non-LSO clusters (vSphere, AWS) are unaffected
- Ref: [DFBUGS-6355](https://redhat.atlassian.net/browse/DFBUGS-6355)

fixes #https://github.com/red-hat-storage/ocs-ci/issues/14961
