### PR TITLE
Add vSphere LSO config with extra disk for replica-1 testing

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_extra_disk_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_extra_disk_3m_3w.yaml
@@ -5,7 +5,7 @@ DEPLOYMENT:
   allow_lower_instance_requirements: false
   local_storage: true
   type: 'VMDK'
-  provision_type: 'thick'
+  provision_type: 'thin'
 ENV_DATA:
   platform: 'vsphere'
   deployment_type: 'upi'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_extra_disk_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_extra_disk_3m_3w.yaml
@@ -1,0 +1,19 @@
+---
+# Based on upi_1az_rhcos_vsan_lso_vmdk_3m_3w.yaml with extra disk per worker
+# for replica-1 (non-resilient pools) testing (DFBUGS-6355).
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  extra_disks: 2
+  fio_storageutilization_min_mbps: 10.0


### PR DESCRIPTION
Based on upi_1az_rhcos_vsan_lso_vmdk_3m_3w.yaml with extra_disks: 2 to provide available PVs for non-resilient pool OSDs ([DFBUGS-6355](https://redhat.atlassian.net/browse/DFBUGS-6355)).



