### PR TITLE
Fix craft_s3_command to check mcg_obj.ssl for disabling SSL verification

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -60,7 +60,8 @@ def craft_s3_command(cmd, mcg_obj=None, api=False, signed_request_creds=None):
     no_ssl = (
         "--no-verify-ssl"
         if (
-            (signed_request_creds and signed_request_creds.get("ssl")) is False
+            (signed_request_creds and signed_request_creds.get("ssl") is False)
+            or (mcg_obj and getattr(mcg_obj, "ssl", None) is False)
             or (
                 config.multicluster
                 and not config.DEPLOYMENT.get("use_custom_ingress_ssl_cert")


### PR DESCRIPTION
craft_s3_command only checked signed_request_creds for the ssl flag, ignoring mcg_obj.ssl. This caused NSFS tests to fail with "SSL: CERTIFICATE_VERIFY_FAILED" because --no-verify-ssl was never added to the AWS CLI command when ssl=False was set on mcg_obj.

Also clarifies the operator precedence in the existing signed_request_creds check for readability — the original logic was functionally correct but relied on subtle Python `and` short-circuit behavior.