### PR TITLE
Fix odf_console_plugin_check to navigate to local cluster first 4.18

### DIFF
--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -11,6 +11,7 @@ from ocs_ci.ocs.cluster import (
 )
 from ocs_ci.ocs.exceptions import UnexpectedODFAccessException, CephHealthException
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
+from ocs_ci.ocs.ui.base_ui import navigate_to_local_cluster
 from ocs_ci.ocs.ui.block_pool import BlockPoolUI
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
@@ -205,6 +206,8 @@ class ValidationUI(PageNavigator):
         if not, this function will enable it so as to see ODF tab under Storage section
 
         """
+        logger.info("Ensure we are in local cluster view, not Fleet Management")
+        navigate_to_local_cluster()
 
         self.navigate_installed_operators_page()
         logger.info("Click on project dropdown")


### PR DESCRIPTION
Navigate to local cluster before going to the Installed Operators page to ensure we are in the Administrator perspective of the local cluster rather than the Fleet Management / All Clusters view, where the Operators navigation menu is not present.

Resolve problem when UI is showing the Fleet instead of a local cluster: 

```
self = ValidationUI Web Page
locator = ("//button[text()='Operators'] | //button[text()='Ecosystem']", 'xpath')
timeout = 180


def is_expanded(self, locator, timeout=30):
    """
    Check whether an element is in an expanded or collapsed state

    Args:
        locator (tuple): (GUI element needs to operate on (str), type (By))
        timeout (int): Looks for a web element repeatedly until timeout (sec) happens.

    return:
        bool: True if element expanded, False otherwise

    """
    wait = WebDriverWait(self.driver, timeout)
    try:

      element = wait.until(ec.element_to_be_clickable((locator[1], locator[0])))

ocs_ci/ocs/ui/base_ui.py:362: 

```

