### PR TITLE
Consolidate duplicate craft_s3_command into bucket_utils

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -587,7 +587,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2831,
+        "line_number": 2796,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -2381,41 +2381,6 @@ def remove_scc_policy(sa_name, namespace):
         logger.info(out)
 
 
-def craft_s3_command(cmd, mcg_obj=None, api=False, max_attempts=8):
-    """
-    Crafts the AWS CLI S3 command including the
-    login credentials and command to be ran
-
-    Args:
-        mcg_obj: An MCG object containing the MCG S3 connection credentials
-        cmd: The AWSCLI command to run
-        api: True if the call is for s3api, false if s3
-        max_attempts: The maximum number of AWSCLI retry attempts
-                     max_attempts=8 means a maximum of one minute
-                     additional waiting time in case of failure
-
-    Returns:
-        str: The crafted command, ready to be executed on the pod
-
-    """
-    api = "api" if api else ""
-    if mcg_obj:
-        base_command = (
-            f'sh -c "AWS_CA_BUNDLE={constants.SERVICE_CA_CRT_AWSCLI_PATH} '
-            f"AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} "
-            f"AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} "
-            f"AWS_MAX_ATTEMPTS={max_attempts} "
-            f"AWS_DEFAULT_REGION={mcg_obj.region} "
-            f"aws s3{api} "
-            f"--endpoint={mcg_obj.s3_internal_endpoint} "
-        )
-        string_wrapper = '"'
-    else:
-        base_command = f"aws s3{api} --no-sign-request "
-        string_wrapper = ""
-    return f"{base_command}{cmd}{string_wrapper}"
-
-
 def get_current_test_name():
     """
     A function to return the current test name in a parsed manner

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -40,7 +40,9 @@ from ocs_ci.utility.prometheus import PrometheusAPI
 logger = logging.getLogger(__name__)
 
 
-def craft_s3_command(cmd, mcg_obj=None, api=False, signed_request_creds=None):
+def craft_s3_command(
+    cmd, mcg_obj=None, api=False, signed_request_creds=None, max_attempts=8
+):
     """
     Crafts the AWS CLI S3 command including the
     login credentials and command to be ran
@@ -50,6 +52,9 @@ def craft_s3_command(cmd, mcg_obj=None, api=False, signed_request_creds=None):
         cmd: The AWSCLI command to run
         api: True if the call is for s3api, false if s3
         signed_request_creds: a dictionary containing AWS S3 creds for a signed request
+        max_attempts: The maximum number of AWSCLI retry attempts
+                     max_attempts=8 means a maximum of one minute
+                     additional waiting time in case of failure
 
     Returns:
         str: The crafted command, ready to be executed on the pod
@@ -77,6 +82,7 @@ def craft_s3_command(cmd, mcg_obj=None, api=False, signed_request_creds=None):
             f'sh -c "AWS_CA_BUNDLE={constants.AWSCLI_CA_BUNDLE_PATH} '
             f"AWS_ACCESS_KEY_ID={mcg_obj.access_key_id} "
             f"AWS_SECRET_ACCESS_KEY={mcg_obj.access_key} "
+            f"AWS_MAX_ATTEMPTS={max_attempts} "
             f"{region}"
             f"aws s3{api} "
             f"--endpoint={mcg_obj.s3_internal_endpoint} "
@@ -91,6 +97,7 @@ def craft_s3_command(cmd, mcg_obj=None, api=False, signed_request_creds=None):
         base_command = (
             f'sh -c "AWS_ACCESS_KEY_ID={signed_request_creds.get("access_key_id")} '
             f'AWS_SECRET_ACCESS_KEY={signed_request_creds.get("access_key")} '
+            f"AWS_MAX_ATTEMPTS={max_attempts} "
             f'region={signed_request_creds.get("region")} '
             f"aws s3{api} "
             f'--endpoint={signed_request_creds.get("endpoint")} '

--- a/ocs_ci/ocs/resources/bucket_logging_manager.py
+++ b/ocs_ci/ocs/resources/bucket_logging_manager.py
@@ -3,9 +3,8 @@ import json
 import time
 
 from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import craft_s3_command
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.ocs.bucket_utils import list_objects_from_bucket
+from ocs_ci.ocs.bucket_utils import craft_s3_command, list_objects_from_bucket
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility.utils import TimeoutSampler
 

--- a/ocs_ci/ocs/resources/bucket_notifications_manager.py
+++ b/ocs_ci/ocs/resources/bucket_notifications_manager.py
@@ -6,10 +6,10 @@ from time import sleep
 
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import (
-    craft_s3_command,
     create_unique_resource_name,
     default_storage_class,
 )
+from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.amq import AMQ
 from ocs_ci.ocs.exceptions import CommandFailed

--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -17,11 +17,9 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_noobaa_external_pgsql,
 )
 from ocs_ci.framework.testlib import MCGTest
-from ocs_ci.helpers.helpers import (
-    craft_s3_command,
-)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
+    craft_s3_command,
     change_versions_creation_date_in_noobaa_db,
     craft_s3cmd_command,
     create_multipart_upload,


### PR DESCRIPTION
Remove the duplicate craft_s3_command from ocs_ci/helpers/helpers.py and update all consumers to use the version in ocs_ci/ocs/bucket_utils.py, which has proper SSL handling and multicluster support.

Port the max_attempts (AWS_MAX_ATTEMPTS) retry logic from the helpers version into bucket_utils, preserving the default of 8 attempts.