### PR TITLE
Refactor IngressNodeFirewall deployment to use Operator base class

### DIFF
--- a/ocs_ci/deployment/ingress_node_firewall.py
+++ b/ocs_ci/deployment/ingress_node_firewall.py
@@ -1,13 +1,10 @@
 import logging
 
-from ocs_ci.deployment.qe_app_registry import QeAppRegistry
 from ocs_ci.framework import config
-from ocs_ci.ocs import constants, exceptions
-from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.ocs.resources.packagemanifest import PackageManifest
 from ocs_ci.utility import templating
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.operators import IngressNodeFirewallOperator
 
 
 logger = logging.getLogger(__name__)
@@ -80,149 +77,38 @@ def deploy_ingress_node_firewall(rules):
         rules (dict): dictionary of IngressNodeFirewall Rules (content of `spec.ingress`)
 
     """
-    inf = IngressNodeFirewallInstaller()
+    # Create and deploy the Ingress Node Firewall Operator
+    inf_operator = IngressNodeFirewallOperator(create_catalog=True)
+    inf_operator.deploy()
 
-    # check if Ingress Node Firewall Operator is available
-    if not inf.check_existing_packagemanifests():
-        # Ingress Node Firewall Operator is not available, we have to create QE App Registry Catalog Source
-        # and related Image content source policy
-        qe_app_registry = QeAppRegistry()
-        qe_app_registry.icsp()
-        qe_app_registry.catalog_source()
-        inf.source = constants.QE_APP_REGISTRY_CATALOG_SOURCE_NAME
-    # create openshift-ingress-node-firewall namespace
-    inf.create_namespace()
-
-    # create operator group
-    inf.create_operatorgroup()
-
-    # subscribe to the Ingress Node Firewall Operator
-    inf.create_subscription()
-
-    # verify installation
-    inf.verify_csv_status()
-
-    # create config
-    inf.create_config()
-
-    # add firewall rules
-    inf.create_rules(rules=rules)
+    # Create firewall configuration and rules
+    create_config()
+    create_rules(rules=rules)
 
 
-class IngressNodeFirewallInstaller(object):
+def create_config():
     """
-    IngressNodeFirewall Installer class for Ingress Node Firewall deployment
+    Creates configuration for IngressNodeFirewall
 
     """
+    logger.info("Creating IngressNodeFirewallConfig")
+    config_yaml_file = templating.load_yaml(constants.INF_CONFIG_YAML)
+    config_yaml = OCS(**config_yaml_file)
+    config_yaml.create()
+    logger.info("IngressNodeFirewallConfig created successfully")
 
-    def __init__(self):
-        self.namespace = constants.INGRESS_NODE_FIREWALL_NAMESPACE
-        self.source = constants.OPERATOR_CATALOG_SOURCE_NAME
 
-    def check_existing_packagemanifests(self):
-        """
-        Check if Ingress Node Firewall Operator is available or not.
+def create_rules(rules):
+    """
+    Create IngressNodeFirewall Rules
 
-        Returns:
-            bool: True if Ingress Node Operator is available, False otherwise
-        """
-        try:
-            pm = PackageManifest(constants.INGRESS_NODE_FIREWALL_OPERATOR_NAME)
-            pm.get(silent=True)
-            return True
-        except (exceptions.CommandFailed, exceptions.ResourceNotFoundError):
-            return False
+    Args:
+        rules (dict): dictionary of IngressNodeFirewall Rules (content of `spec.ingress`)
 
-    def create_namespace(self):
-        """
-        Creates the namespace for IngressNodeFirewall resources
-
-        Raises:
-            CommandFailed: If the 'oc create' command fails.
-
-        """
-        try:
-            logger.info(
-                f"Creating namespace {self.namespace} for IngressNodeFirewall resources"
-            )
-            namespace_yaml_file = templating.load_yaml(constants.INF_NAMESPACE_YAML)
-            namespace_yaml = OCS(**namespace_yaml_file)
-            namespace_yaml.create()
-            logger.info(
-                f"IngressNodeFirewall namespace {self.namespace} was created successfully"
-            )
-        except exceptions.CommandFailed as err:
-            if (
-                f'project.project.openshift.io "{self.namespace}" already exists'
-                in str(err)
-            ):
-                logger.info(f"Namespace {self.namespace} already exists")
-            else:
-                raise err
-
-    def create_operatorgroup(self):
-        """
-        Creates an OperatorGroup for IngressNodeFirewall
-
-        """
-        logger.info("Creating OperatorGroup for IngressNodeFirewall")
-        operatorgroup_yaml_file = templating.load_yaml(constants.INF_OPERATORGROUP_YAML)
-        operatorgroup_yaml = OCS(**operatorgroup_yaml_file)
-        operatorgroup_yaml.create()
-        logger.info("IngressNodeFirewall OperatorGroup created successfully")
-
-    def create_subscription(self):
-        """
-        Creates subscription for IngressNodeFirewall operator
-
-        """
-        logger.info("Creating Subscription for IngressNodeFirewall")
-        subscription_yaml_file = templating.load_yaml(constants.INF_SUBSCRIPTION_YAML)
-        subscription_yaml_file["spec"]["source"] = self.source
-        subscription_yaml = OCS(**subscription_yaml_file)
-        subscription_yaml.create()
-        logger.info("IngressNodeFirewall Subscription created successfully")
-
-    def verify_csv_status(self):
-        """
-        Verify the CSV status for the IngressNodeFirewall Operator deployment equals Succeeded
-
-        """
-        for csv in TimeoutSampler(
-            timeout=900,
-            sleep=15,
-            func=get_csvs_start_with_prefix,
-            csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,
-            namespace=self.namespace,
-        ):
-            if csv:
-                break
-        csv_name = csv[0]["metadata"]["name"]
-        csv_obj = CSV(resource_name=csv_name, namespace=self.namespace)
-        csv_obj.wait_for_phase(phase="Succeeded", timeout=720)
-
-    def create_config(self):
-        """
-        Creates configuration for IngressNodeFirewall
-
-        """
-        logger.info("Creating IngressNodeFirewallConfig")
-        config_yaml_file = templating.load_yaml(constants.INF_CONFIG_YAML)
-        config_yaml = OCS(**config_yaml_file)
-        config_yaml.create()
-        logger.info("IngressNodeFirewallConfig created successfully")
-
-    def create_rules(self, rules):
-        """
-        Create IngressNodeFirewall Rules
-
-        Args:
-            rules (dict): dictionary of IngressNodeFirewall Rules (content of `spec.ingress`)
-
-        """
-        logger.info("Creating IngressNodeFirewall Rules")
-        rules_yaml_file = templating.load_yaml(constants.INF_RULES_YAML)
-        rules_yaml_file["spec"]["ingress"] = rules
-        rules_yaml = OCS(**rules_yaml_file)
-        rules_yaml.create()
-        logger.info("IngressNodeFirewall Rules created successfully")
+    """
+    logger.info("Creating IngressNodeFirewall Rules")
+    rules_yaml_file = templating.load_yaml(constants.INF_RULES_YAML)
+    rules_yaml_file["spec"]["ingress"] = rules
+    rules_yaml = OCS(**rules_yaml_file)
+    rules_yaml.create()
+    logger.info("IngressNodeFirewall Rules created successfully")

--- a/ocs_ci/utility/operators.py
+++ b/ocs_ci/utility/operators.py
@@ -648,3 +648,66 @@ class OADPOperator(Operator):
             selector=constants.MANAGED_CONTROLLER_LABEL,
             timeout=600,
         ), "OADP operator did not reach running phase"
+
+
+class IngressNodeFirewallOperator(Operator):
+    def __init__(self, create_catalog: bool = False):
+        self.name = constants.INGRESS_NODE_FIREWALL_OPERATOR_NAME
+        ocp_version = get_semantic_ocp_version_from_config()
+        self.unreleased_catalog_image_tag: str = (
+            f"ocp__{ocp_version}__ingress-node-firewall-rhel9-operator"
+        )
+        self.unreleased_images = [
+            "registry.redhat.io/openshift4/ingress-node-firewall-operator-bundle",
+            "registry.redhat.io/openshift4/ingress-node-firewall-rhel9-operator",
+            "registry.redhat.io/openshift4/ingress-node-firewall-rhel9",
+            "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9",
+        ]
+        self.disconnected_required_packages = [
+            "ingress-node-firewall",
+        ]
+        self.namespace = constants.INGRESS_NODE_FIREWALL_NAMESPACE
+        super().__init__(create_catalog)
+
+    def _customize_operatorgroup(self, operatorgroup_data: dict):
+        """
+        Hook for Ingress Node Firewall to customize OperatorGroup YAML
+
+        Args:
+            operatorgroup_data (dict): the OperatorGroup YAML data
+        """
+        operatorgroup_data["spec"]["targetNamespaces"] = []
+
+    def verify_csv_status(self):
+        """
+        Verify the CSV status for the IngressNodeFirewall Operator deployment equals Succeeded
+        """
+        for csv in TimeoutSampler(
+            timeout=900,
+            sleep=15,
+            func=get_csvs_start_with_prefix,
+            csv_prefix=constants.INGRESS_NODE_FIREWALL_CSV_NAME,
+            namespace=self.namespace,
+        ):
+            if csv:
+                break
+        csv_name = csv[0]["metadata"]["name"]
+        csv_obj = CSV(resource_name=csv_name, namespace=self.namespace)
+        csv_obj.wait_for_phase(phase="Succeeded", timeout=720)
+
+    def _customize_post_deployment_steps(self):
+        """
+        Customize post deployment steps for IngressNodeFirewallOperator
+        """
+        self.verify_csv_status()
+
+    def _deployment_verification(self):
+        """
+        Verify the deployment of the Ingress Node Firewall operator
+        """
+        inf_operator = OCP(kind=constants.POD, namespace=self.namespace)
+        assert inf_operator.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector=constants.MANAGED_CONTROLLER_LABEL,
+            timeout=600,
+        ), "Ingress Node Operator operator did not reach running phase"


### PR DESCRIPTION
Eliminates code duplication by replacing IngressNodeFirewallInstaller class with IngressNodeFirewallOperator that extends the Operator base class. This aligns the implementation with other operators (NMStateOperator, LocalStorageOperator, etc.) and automatically handles unreleased operator catalogs.

This change should also fix the deployment of un-released version (e.g. on OCP 4.22).