### PR TITLE
apply w/a for cert issue on hypershift cluster creation

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -821,7 +821,19 @@ class HyperShiftBase:
             create_hcp_cluster_cmd += " --olm-disable-default-sources"
 
         logger.info("Creating HyperShift hosted cluster")
-        exec_cmd(create_hcp_cluster_cmd)
+        try:
+            exec_cmd(create_hcp_cluster_cmd)
+        except CommandFailed as e:
+            if "x509: certificate signed by unknown authority" in str(
+                e
+            ) and "hostedclusters.hypershift.openshift.io" in str(e):
+                logger.warning(
+                    "HyperShift webhook TLS error detected — applying CA bundle fix and retrying"
+                )
+                fix_hypershift_webhook_ca_bundle()
+                exec_cmd(create_hcp_cluster_cmd)
+            else:
+                raise
 
         return name
 
@@ -918,7 +930,19 @@ class HyperShiftBase:
             create_hcp_cluster_cmd += " --olm-disable-default-sources"
 
         logger.info("Creating HyperShift hosted cluster")
-        exec_cmd(create_hcp_cluster_cmd)
+        try:
+            exec_cmd(create_hcp_cluster_cmd)
+        except CommandFailed as e:
+            if "x509: certificate signed by unknown authority" in str(
+                e
+            ) and "hostedclusters.hypershift.openshift.io" in str(e):
+                logger.warning(
+                    "HyperShift webhook TLS error detected — applying CA bundle fix and retrying"
+                )
+                fix_hypershift_webhook_ca_bundle()
+                exec_cmd(create_hcp_cluster_cmd)
+            else:
+                raise
 
         return name
 
@@ -1291,6 +1315,60 @@ class HyperShiftBase:
             return False
         logger.info(cmd_res.stdout.decode("utf-8").splitlines())
         return True
+
+
+def fix_hypershift_webhook_ca_bundle():
+    """
+    Fix HyperShift webhook configurations when the CA bundle is missing or mismatched,
+    causing 'x509: certificate signed by unknown authority' errors during hosted cluster
+    creation.
+
+    Patches both MutatingWebhookConfiguration and ValidatingWebhookConfiguration named
+    'hypershift.openshift.io' with the CA bundle from the 'webhook-serving-ca' secret
+    in the 'hypershift' namespace.
+
+    This workaround addresses a known race condition where the HyperShift operator
+    creates or rotates its webhook-serving-ca after the webhook configurations are
+    registered, leaving the caBundle field stale or empty.
+    """
+    logger.info(
+        "Fixing HyperShift webhook CA bundle mismatch — patching MutatingWebhookConfiguration "
+        "and ValidatingWebhookConfiguration with CA from 'webhook-serving-ca' secret"
+    )
+    secret_obj = OCP(kind="Secret", namespace=constants.HYPERSHIFT_NAMESPACE)
+    secret_data = secret_obj.get(resource_name="webhook-serving-ca")
+    ca_bundle = secret_data["data"]["ca.crt"]
+
+    for webhook_kind in (
+        "mutatingwebhookconfiguration",
+        "validatingwebhookconfiguration",
+    ):
+        webhook_obj = OCP(kind=webhook_kind)
+        try:
+            wh_data = webhook_obj.get(resource_name="hypershift.openshift.io")
+        except Exception:
+            logger.warning(
+                f"No {webhook_kind} named 'hypershift.openshift.io' found, skipping"
+            )
+            continue
+        num_webhooks = len(wh_data.get("webhooks", []))
+        patch = [
+            {
+                "op": "replace",
+                "path": f"/webhooks/{i}/clientConfig/caBundle",
+                "value": ca_bundle,
+            }
+            for i in range(num_webhooks)
+        ]
+        webhook_obj.patch(
+            resource_name="hypershift.openshift.io",
+            params=patch,
+            format_type="json",
+        )
+        logger.info(
+            f"Patched {num_webhooks} webhook(s) in {webhook_kind}/hypershift.openshift.io"
+        )
+    logger.info("HyperShift webhook CA bundle fix applied successfully")
 
 
 def create_cluster_dir(cluster_name):


### PR DESCRIPTION
Following the AI debugging w/a that helped to resolve issue, this PR automates the steps.

```
HyperShift Cluster Creation Issue - Summary
Problem
Error:


failed calling webhook "hostedclusters.hypershift.openshift.io": 
failed to call webhook: Post "[https://operator.hypershift.svc:443/](https://operator.hypershift.svc/)...": 
tls: failed to verify certificate: x509: certificate signed by unknown authority
Impact: HyperShift hosted cluster creation failed because the webhook endpoint couldn't be reached due to TLS certificate verification failure.

Root Cause
The MutatingWebhookConfiguration and ValidatingWebhookConfiguration for HyperShift were missing the CA bundle needed to verify the HyperShift operator's webhook certificate.

Certificate Chain:
✅ HyperShift operator serves webhook with certificate: manager-serving-cert
✅ Certificate issued by: CN=hypershift-webhook-ca
✅ CA certificate stored in secret: webhook-serving-ca
❌ Webhook configurations missing the CA bundle → couldn't verify the operator's certificate
Investigation Steps
Checked webhook existence:

Found webhooks named hypershift.openshift.io (not the expected name)
Verified certificate secrets:

manager-serving-cert - valid certificate (expires Apr 2027)
webhook-serving-ca - contains the CA certificate
Identified the gap:

CA bundle was missing from webhook configurations' caBundle field
Without it, Kubernetes couldn't verify the operator's TLS certificate
Solution
Patched both webhook configurations with the correct CA bundle:


CA_BUNDLE=$(oc get secret -n hypershift webhook-serving-ca -o jsonpath='{.data.ca\.crt}')

# Updated mutating webhook
oc patch mutatingwebhookconfiguration hypershift.openshift.io --type='json' \
  -p="[{\"op\":\"replace\",\"path\":\"/webhooks/0/clientConfig/caBundle\",\"value\":\"$CA_BUNDLE\"}]"

# Updated validating webhook  
oc patch validatingwebhookconfiguration hypershift.openshift.io --type='json' \
  -p="[{\"op\":\"replace\",\"path\":\"/webhooks/0/clientConfig/caBundle\",\"value\":\"$CA_BUNDLE\"}]"
Result
✅ Webhook configurations now have the correct CA bundle

✅ Certificate verification succeeds

✅ HyperShift cluster creation can proceed

Why This Happened
Most likely causes:

HyperShift operator didn't inject the CA bundle during webhook creation
Webhook configurations were created before certificates were ready
Operator restart or certificate rotation occurred without updating webhooks

Prevention
This issue shouldn't recur, but if it does:

Restart HyperShift operator: oc delete pod -n hypershift -l name=operator
Or manually patch webhooks with CA bundle
```

----

Issue: 
```
{"level":"info","ts":"2026-04-13T06:21:50-04:00","msg":"Applied Kube resource","kind":"Namespace","namespace":"","name":"clusters"}
{"level":"info","ts":"2026-04-13T06:21:50-04:00","msg":"Applied Kube resource","kind":"Secret","namespace":"clusters","name":"j058-c1baie-t4-pull-secret"}
{"level":"info","ts":"2026-04-13T06:21:50-04:00","msg":"Applied Kube resource","kind":"Secret","namespace":"clusters","name":"j058-c1baie-t4-etcd-encryption-key"}
{"level":"error","ts":"2026-04-13T06:21:50-04:00","msg":"Failed to create cluster","error":"failed to apply object \"clusters/j058-c1baie-t4\": Internal error occurred: failed calling webhook \"hostedclusters.hypershift.openshift.io\": failed to call webhook: Post \"[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)\": tls: failed to verify certificate: x509: certificate signed by unknown authority","stacktrace":"github.com/openshift/hypershift/cmd/cluster/kubevirt.NewCreateCommand.func1\n\t/tmp/tmpqexxjepg/cmd/cluster/kubevirt/create.go:344\ngithub.com/spf13/cobra.(*Command).execute\n\t/tmp/tmpqexxjepg/vendor/github.com/spf13/cobra/command.go:1015\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/tmp/tmpqexxjepg/vendor/github.com/spf13/cobra/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/tmp/tmpqexxjepg/vendor/github.com/spf13/cobra/command.go:1071\ngithub.com/spf13/cobra.(*Command).ExecuteContext\n\t/tmp/tmpqexxjepg/vendor/github.com/spf13/cobra/command.go:1064\nmain.main\n\t/tmp/tmpqexxjepg/main.go:80\nruntime.main\n\t/home/jenkins/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.linux-amd64/src/runtime/proc.go:285"}
Error: failed to apply object "clusters/j058-c1baie-t4": Internal error occurred: failed calling webhook "hostedclusters.hypershift.openshift.io": failed to call webhook: Post "[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)": tls: failed to verify certificate: x509: certificate signed by unknown authority
failed to apply object "clusters/j058-c1baie-t4": Internal error occurred: failed calling webhook "hostedclusters.hypershift.openshift.io": failed to call webhook: Post "[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)": tls: failed to verify certificate: x509: certificate signed by unknown authority
```