### PR TITLE
Update the managed cluster list to identify clusterset name in MDR test

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2568,6 +2568,11 @@ def get_cluster_set_name(switch_ctx=None):
             for item in dr_cluster_relations[0]
         ]
 
+    # The list current_managed_clusters_list is required for RDR, not mandatory for MDR
+    current_managed_clusters_list = current_managed_clusters_list or [
+        mng_cluster["metadata"]["name"] for mng_cluster in managed_clusters
+    ]
+
     # ignore local-cluster here
     for i in managed_clusters:
         if (


### PR DESCRIPTION
In the function get_cluster_set_name the managedclusters under test is identified by ENV_DATA.rbd_dr_scenario. This value is not preset in MDR case so the list will be empty. Update the list with the actual managedclusters name if it is empty.