### PR TITLE
Fix upgrade blocking logic to allow lower CSV versions

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -917,19 +917,37 @@ def run_ocs_upgrade(
                     channel=current_channel
                 )
                 if csv_name_pre_upgrade != csv_after_catalog_update:
-                    error_msg = (
-                        "UPGRADE BLOCKED: Detected unexpected build in catalog. "
-                        f"Current channel '{current_channel}' had CSV '{csv_name_pre_upgrade}' "
-                        f"before catalog update, but now shows '{csv_after_catalog_update}'. "
-                        f"This would cause OLM to upgrade to '{csv_after_catalog_update}' before "
-                        "the channel change, creating conflicting upgrade paths."
+                    version_pre = version.get_semantic_version(
+                        version.extract_version_from_csv_name(csv_name_pre_upgrade)
                     )
-                    log.error(error_msg)
-                    raise UnexpectedCatalogBuildException(error_msg)
-                log.info(
-                    f"Catalog build check passed. CSV in channel '{current_channel}' "
-                    f"remains '{csv_name_pre_upgrade}'."
-                )
+                    version_after = version.get_semantic_version(
+                        version.extract_version_from_csv_name(csv_after_catalog_update)
+                    )
+
+                    # Only block if the new version is HIGHER (which would cause unwanted upgrade)
+                    # Allow if version is lower or same (downgrade scenario is OK)
+                    if version_after > version_pre:
+                        error_msg = (
+                            "UPGRADE BLOCKED: Detected unexpected build in catalog. "
+                            f"Current channel '{current_channel}' had CSV '{csv_name_pre_upgrade}' "
+                            f"before catalog update, but now shows '{csv_after_catalog_update}'. "
+                            f"This would cause OLM to upgrade to '{csv_after_catalog_update}' before "
+                            "the channel change, creating conflicting upgrade paths."
+                        )
+                        log.error(error_msg)
+                        raise UnexpectedCatalogBuildException(error_msg)
+                    else:
+                        log.info(
+                            f"CSV changed in channel '{current_channel}' from "
+                            f"'{csv_name_pre_upgrade}' to '{csv_after_catalog_update}', "
+                            f"but version decreased ({version_pre} -> {version_after}). "
+                            "This is acceptable and won't cause conflicting upgrade paths."
+                        )
+                else:
+                    log.info(
+                        f"Catalog build check passed. CSV in channel '{current_channel}' "
+                        f"remains '{csv_name_pre_upgrade}'."
+                    )
             except ChannelNotFound:
                 log.info(
                     f"Channel '{current_channel}' not found in updated catalog. "

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -573,3 +573,26 @@ def get_semantic_running_odf_version():
     odf_full_version = get_running_odf_version()
     odf_version = get_semantic_version(version=odf_full_version)
     return odf_version
+
+
+def extract_version_from_csv_name(csv_name):
+    """
+    Extract version string from CSV name.
+
+    Args:
+        csv_name (str): CSV name in the format 'ocs-operator.v<version>-<suffix>'
+                       or 'odf-operator.v<version>-<suffix>'
+                       Example: 'ocs-operator.v4.21.2-rhodf' or 'odf-operator.v4.22.0-rhodf'
+
+    Returns:
+        str: Version string (e.g., '4.21.2')
+
+    Raises:
+        IndexError: If CSV name format doesn't match expected pattern
+        ValueError: If version cannot be extracted from CSV name
+
+    """
+    # CSV format: ocs-operator.v<version>-<suffix> or odf-operator.v<version>-<suffix>
+    # Extract the version part between 'v' and the last '-'
+    version_part = csv_name.split(".v")[1].rsplit("-", 1)[0]
+    return version_part


### PR DESCRIPTION
The upgrade blocker was failing when a newer z-stream was released in the current channel after the upgrade build was created. For example, when upgrading 4.21 -> 4.22 with a build based on 4.21.1, if 4.21.2 was released, the upgrade would fail even though this doesn't cause conflicting upgrade paths.

Now only blocks when the catalog shows a HIGHER version (which would cause an unwanted intermediate upgrade). Allows lower versions since they don't trigger automatic upgrades.

Changes:
- Add extract_version_from_csv_name() to ocs_ci/utility/version.py
- Update upgrade logic to compare semantic versions
- Only raise UnexpectedCatalogBuildException when version_after > version_pre