### PR TITLE
Add grpcPodConfig to CatalogSource to prevent TRANSIENT_FAILURE

### DIFF
--- a/ocs_ci/templates/ocs-deployment/catalog-source.yaml
+++ b/ocs_ci/templates/ocs-deployment/catalog-source.yaml
@@ -15,6 +15,11 @@ spec:
   publisher: Red Hat
   sourceType: grpc
   priority: 100
+  grpcPodConfig:
+    memoryTarget: 512Mi
+    extractContent:
+      cacheDir: /tmp/cache
+      catalogDir: /configs
   # If the registry image still have the same tag (latest-stable-4.6, or for stage testing)
   # we need to have this updateStrategy, otherwise we will not see new pushed content.
   updateStrategy:


### PR DESCRIPTION
The catalog pod crash-loops because it only gets 50Mi memory by default, which is insufficient for the 78MB configs + 260MB cache. The startup probe kills it before the gRPC server becomes ready.

Adding memoryTarget (512Mi) and extractContent config allows the catalog to load via init containers and gives the process enough memory.