### PR TITLE
deployment/baremetal: fix clean_disks skipping virtio-blk on KVM/Fyre

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1453,28 +1453,29 @@ def clean_disks(worker, namespace=constants.DEFAULT_NAMESPACE):
 
     """
     ocp_obj = ocp.OCP()
-    disks_available_on_worker_nodes_for_cleanup = disks_available_to_cleanup(worker)
-
-    # Get the name and size in bytes of the disks
-    out = ocp_obj.exec_oc_debug_cmd(
-        node=worker.name,
-        cmd_list=["lsblk -nd -e252,7 --output NAME,SIZE -b --json"],
-        namespace=namespace,
+    disks_available_on_worker_nodes_for_cleanup = disks_available_to_cleanup(
+        worker, namespace
     )
-    lsblk_output = json.loads(str(out))
-    lsblk_devices = lsblk_output["blockdevices"]
 
-    for lsblk_device in lsblk_devices:
-        if lsblk_device["name"] not in disks_available_on_worker_nodes_for_cleanup:
-            logger.info(f'the disk cleanup is ignored for, {lsblk_device["name"]}')
-            pass
-        else:
-            clean_disk(
-                worker.name,
-                f"/dev/{lsblk_device['name']}",
-                int(lsblk_device["size"]),
-                ocp_obj=ocp_obj,
-            )
+    # Clean each eligible disk directly using the validated list from
+    # disks_available_to_cleanup. Avoids a global lsblk scan with major-number
+    # exclusions (e.g. -e252) that inadvertently skips virtio-blk devices on
+    # KVM/Fyre platforms where major 252 is assigned to virtio-blk instead of
+    # device-mapper.
+    for disk_name in disks_available_on_worker_nodes_for_cleanup:
+        out = ocp_obj.exec_oc_debug_cmd(
+            node=worker.name,
+            cmd_list=[f"lsblk -n --output SIZE -b --json /dev/{disk_name}"],
+            namespace=namespace,
+        )
+        size = int(json.loads(str(out))["blockdevices"][0]["size"])
+        clean_disk(
+            worker.name,
+            f"/dev/{disk_name}",
+            size,
+            ocp_obj=ocp_obj,
+            namespace=namespace,
+        )
 
     if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):
         root_disk_common_path = config.ENV_DATA["baremetal"]["root_disk_common_path"]

--- a/tests/libtest/test_disks_available_to_cleanup.py
+++ b/tests/libtest/test_disks_available_to_cleanup.py
@@ -1,0 +1,56 @@
+import json
+import logging
+
+from ocs_ci.framework.testlib import ManageTest, libtest, brown_squad, skipif_no_lso
+from ocs_ci.deployment.baremetal import disks_available_to_cleanup
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.node import get_nodes
+from ocs_ci.ocs.ocp import OCP
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@libtest
+@skipif_no_lso
+class TestDisksAvailableToCleanup(ManageTest):
+    """
+    Verify that disks_available_to_cleanup returns eligible disks and that the
+    new per-disk lsblk size lookup used in clean_disks works for each of them.
+    No actual disk wiping is performed.
+    """
+
+    def test_disks_available_to_cleanup(self):
+        """
+        For each worker node:
+          1. Confirm disks_available_to_cleanup returns a non-empty list.
+          2. For each disk, run the per-disk lsblk size lookup introduced in
+             the clean_disks fix and verify a valid size is returned.
+        """
+        ocp_obj = OCP()
+        worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
+        assert worker_nodes, "No worker nodes found"
+
+        for worker in worker_nodes:
+            disks = disks_available_to_cleanup(worker)
+            log.info("Node %s — disks available for cleanup: %s", worker.name, disks)
+            assert isinstance(
+                disks, list
+            ), f"Expected a list for node {worker.name}, got {type(disks)}"
+
+            for disk_name in disks:
+                out = ocp_obj.exec_oc_debug_cmd(
+                    node=worker.name,
+                    cmd_list=[f"lsblk -n --output SIZE -b --json /dev/{disk_name}"],
+                )
+                size = int(json.loads(str(out))["blockdevices"][0]["size"])
+                log.info(
+                    "Node %s — disk /dev/%s size: %d bytes",
+                    worker.name,
+                    disk_name,
+                    size,
+                )
+                assert size > 0, (
+                    f"Expected positive size for /dev/{disk_name} on "
+                    f"{worker.name}, got {size}"
+                )


### PR DESCRIPTION
The previous clean_disks used `lsblk -e252` to exclude device-mapper devices, but on KVM/Fyre platforms major 252 is assigned to virtio-blk, so OSD disks (vdb, vdc) were silently skipped during cleanup.

Fix: drop the global lsblk scan with the major-number exclusion. Instead, rely on `disks_available_to_cleanup` (which already filters by boot-disk detection and nbd/loop exclusion) to get the eligible disk list, then query each disk's size individually via a targeted `lsblk /dev/<disk>` call.

Also pass namespace through to `disks_available_to_cleanup` so both functions are consistent, and add a libtest
(`test_disks_available_to_cleanup`) that verifies the per-disk size lookup works correctly on a live cluster without wiping any disks.