### PR TITLE
Add capacity via CLI for vSphere LSO with multiple device classes

### DIFF
--- a/ocs_ci/ocs/device_classes.py
+++ b/ocs_ci/ocs/device_classes.py
@@ -4,9 +4,16 @@ import random
 from ocs_ci.helpers.helpers import create_lvs_resource
 from ocs_ci.ocs.cluster import check_ceph_osd_tree
 from ocs_ci.ocs.exceptions import CephHealthException, ResourceNotFoundError
-from ocs_ci.ocs.node import add_disk_to_node, get_node_objs, get_osd_running_nodes
+from ocs_ci.ocs.node import (
+    add_disk_to_node,
+    add_new_disk_for_vsphere,
+    get_node_objs,
+    get_osd_running_nodes,
+)
 from ocs_ci.ocs.resources.pv import (
     get_pv_in_status,
+    get_pv_objs_in_sc,
+    wait_for_new_pvs_status,
     wait_for_pvs_in_lvs_to_reach_status,
 )
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
@@ -250,3 +257,57 @@ def verify_available_pvs_for_deviceclass(sc_name=None, wait=True, timeout=180):
         )
 
     return available_nodes_count
+
+
+def add_pvs_for_deviceset(sc_name, deviceset_name, timeout=300):
+    """
+    Add one new disk per OCS node and wait for the new PVs to be Available.
+
+    Takes a snapshot of existing PVs before adding disks so that only the
+    newly created PVs are counted. This is safe when multiple device sets
+    share the same StorageClass, because pre-existing available PVs
+    belonging to other device sets are never miscounted.
+
+    Args:
+        sc_name (str): StorageClass name for the target device set.
+        deviceset_name (str): Device set name, used for log messages.
+        timeout (int): Seconds to wait for new PVs to become Available.
+
+    Returns:
+        int: Number of new PVs added (one per OCS node).
+
+    Raises:
+        AssertionError: If the new PVs do not reach Available status
+            within the timeout.
+
+    """
+    osd_nodes = get_osd_running_nodes()
+    num_of_new_pvs = len(osd_nodes)
+
+    current_pvs = get_pv_objs_in_sc(sc_name)
+    log.info(
+        "Adding %d disk(s) for device set '%s' (SC: %s)",
+        num_of_new_pvs,
+        deviceset_name,
+        sc_name,
+    )
+    for _ in range(num_of_new_pvs):
+        add_new_disk_for_vsphere(sc_name=sc_name, ssd=True)
+
+    log.info(
+        "Waiting for %d new Available PV(s) in SC '%s'",
+        num_of_new_pvs,
+        sc_name,
+    )
+    assert wait_for_new_pvs_status(
+        current_pv_objs=current_pvs,
+        sc_name=sc_name,
+        expected_status=constants.STATUS_AVAILABLE,
+        num_of_new_pvs=num_of_new_pvs,
+        timeout=timeout,
+    ), (
+        f"Timed out waiting for {num_of_new_pvs} new Available"
+        f" PVs in SC '{sc_name}'"
+    )
+
+    return num_of_new_pvs

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1947,6 +1947,29 @@ def set_deviceset_count(count):
     )
 
 
+def set_deviceset_count_by_index(index, count):
+    """
+    Set the count for the StorageDeviceSet at the given index.
+
+    Args:
+        index (int): Index of the StorageDeviceSet in the
+            storageDeviceSets list.
+        count (int): New count value to set.
+
+    """
+    sc = get_storage_cluster()
+    params = (
+        f'[{{"op": "replace",'
+        f' "path": "/spec/storageDeviceSets/{index}/count",'
+        f' "value": {count}}}]'
+    )
+    sc.patch(
+        resource_name=sc.get()["items"][0]["metadata"]["name"],
+        params=params,
+        format_type="json",
+    )
+
+
 def get_storage_cluster(namespace=None):
     """
     Get storage cluster object

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -2089,32 +2089,14 @@ def add_capacity_lso(ui_flag=False):
     check_ceph_health_after_add_capacity(ceph_rebalance_timeout=3600)
 
 
-def set_deviceset_count(count):
+def set_deviceset_count(count, index=0):
     """
     Set osd count for Storage cluster.
 
     Args:
         count (int): the count param is storagecluster
-
-    """
-    sc = get_storage_cluster()
-    params = f"""[{{ "op": "replace", "path": "/spec/storageDeviceSets/0/count",
-                "value": {count}}}]"""
-    sc.patch(
-        resource_name=sc.get()["items"][0]["metadata"]["name"],
-        params=params.strip("\n"),
-        format_type="json",
-    )
-
-
-def set_deviceset_count_by_index(index, count):
-    """
-    Set the count for the StorageDeviceSet at the given index.
-
-    Args:
-        index (int): Index of the StorageDeviceSet in the
-            storageDeviceSets list.
-        count (int): New count value to set.
+        index (int): index of the StorageDeviceSet in the storageDeviceSets
+            list. Defaults to 0.
 
     """
     sc = get_storage_cluster()

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -2107,6 +2107,29 @@ def set_deviceset_count(count):
     )
 
 
+def set_deviceset_count_by_index(index, count):
+    """
+    Set the count for the StorageDeviceSet at the given index.
+
+    Args:
+        index (int): Index of the StorageDeviceSet in the
+            storageDeviceSets list.
+        count (int): New count value to set.
+
+    """
+    sc = get_storage_cluster()
+    params = (
+        f'[{{"op": "replace",'
+        f' "path": "/spec/storageDeviceSets/{index}/count",'
+        f' "value": {count}}}]'
+    )
+    sc.patch(
+        resource_name=sc.get()["items"][0]["metadata"]["name"],
+        params=params,
+        format_type="json",
+    )
+
+
 def get_storage_cluster(namespace=None):
     """
     Get storage cluster object

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
@@ -30,7 +30,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
     get_all_device_sets,
     get_storage_cluster,
     osd_encryption_verification,
-    set_deviceset_count_by_index,
+    set_deviceset_count,
 )
 from ocs_ci.utility.utils import ceph_health_check
 
@@ -136,6 +136,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
 
         request.addfinalizer(finalizer)
 
+    @pytest.mark.polarion_id("OCS-7795")
     def test_add_capacity_lso_multiple_device_classes_cli(
         self,
         reduce_and_resume_cluster_load,
@@ -174,7 +175,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
             target_ds["name"],
             new_count,
         )
-        set_deviceset_count_by_index(1, new_count)
+        set_deviceset_count(new_count, index=1)
 
         logger.info("Wait for the new deviceset PVCs to reach Bound status")
         wait_for_pvcs_in_deviceset_to_reach_status(

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
@@ -1,0 +1,186 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    skipif_external_mode,
+    skipif_hci_provider_and_client,
+    skipif_lean_deployment,
+    skipif_managed_service,
+    skipif_no_lso,
+    skipif_stretch_cluster,
+    vsphere_platform_required,
+)
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    ignore_leftovers,
+)
+from ocs_ci.helpers.sanity_helpers import Sanity
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import check_ceph_health_after_add_capacity
+from ocs_ci.ocs.device_classes import (
+    add_pvs_for_deviceset,
+    verify_deviceclasses_steps,
+)
+from ocs_ci.ocs.resources.pvc import wait_for_pvcs_in_deviceset_to_reach_status
+from ocs_ci.ocs.resources.storage_cluster import (
+    get_all_device_sets,
+    get_storage_cluster,
+    osd_encryption_verification,
+    set_deviceset_count_by_index,
+)
+from ocs_ci.utility.utils import ceph_health_check
+
+logger = logging.getLogger(__name__)
+
+
+@brown_squad
+@tier1
+@ignore_leftovers
+@pytest.mark.order("second_to_last")
+@vsphere_platform_required
+@skipif_no_lso
+@skipif_external_mode
+@skipif_managed_service
+@skipif_hci_provider_and_client
+@skipif_stretch_cluster
+@skipif_lean_deployment
+class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
+    """
+    Add capacity via CLI on a vSphere LSO ODF cluster with multiple
+    device classes.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_sanity(self, pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory):
+        """
+        Skip if fewer than two device sets exist and initialize test state.
+
+        Skips the test when the cluster has only one device class, since
+        the test specifically targets a second device set (index 1).
+        Stores factory fixtures as instance attributes for use in
+        post_verification_steps and initializes the Sanity helper.
+
+        Args:
+            pvc_factory: Fixture for creating PVCs.
+            pod_factory: Fixture for creating Pods.
+            bucket_factory: Fixture for creating object-store buckets.
+            rgw_bucket_factory: Fixture for creating RGW buckets.
+
+        """
+        device_sets = get_all_device_sets()
+        if len(device_sets) < 2:
+            pytest.skip(
+                "Test requires a cluster with multiple device classes "
+                f"(found only {len(device_sets)} device set)"
+            )
+
+        self.pvc_factory = pvc_factory
+        self.pod_factory = pod_factory
+        self.bucket_factory = bucket_factory
+        self.rgw_bucket_factory = rgw_bucket_factory
+        self.sanity_helpers = Sanity()
+
+    def post_verification_steps(
+        self, sc_timeout=300, ceph_health_tries=80, ceph_rebalance_timeout=3600
+    ):
+        """
+        Run standard post-capacity-addition verification steps.
+
+        Waits for the StorageCluster to reach Ready phase, verifies OSD
+        encryption if enabled, checks device class health and Ceph
+        rebalance, then confirms basic cluster functionality by creating
+        PVC/Pod/bucket resources.
+
+        Args:
+            sc_timeout (int): Seconds to wait for StorageCluster Ready phase.
+            ceph_health_tries (int): Number of retries for Ceph health check.
+            ceph_rebalance_timeout (int): Seconds to wait for Ceph rebalance.
+
+        """
+        sc_obj = get_storage_cluster()
+        sc_obj.wait_for_resource(
+            condition=constants.STATUS_READY,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            column="PHASE",
+            timeout=sc_timeout,
+            sleep=10,
+        )
+
+        if config.ENV_DATA.get("encryption_at_rest"):
+            osd_encryption_verification()
+
+        verify_deviceclasses_steps()
+        check_ceph_health_after_add_capacity(ceph_health_tries, ceph_rebalance_timeout)
+
+        logger.info("Check basic cluster functionality")
+        self.sanity_helpers.create_resources(
+            self.pvc_factory,
+            self.pod_factory,
+            self.bucket_factory,
+            self.rgw_bucket_factory,
+        )
+
+    @pytest.fixture(autouse=True)
+    def teardown(self, request):
+        """
+        Check that the ceph health is OK after the test.
+        """
+
+        def finalizer():
+            logger.info("Wait for the ceph health to be OK")
+            ceph_health_check(tries=20)
+
+        request.addfinalizer(finalizer)
+
+    def test_add_capacity_lso_multiple_device_classes_cli(
+        self,
+        reduce_and_resume_cluster_load,
+    ):
+        """
+        Test adding capacity via CLI on an LSO cluster that has more than
+        one device class.
+
+        The test adds one new disk per OCS node for the second device class,
+        waits for the new PVs, increments the device set count accordingly,
+        then runs the standard post-add-capacity verification steps.
+
+        Steps:
+            1. Read all StorageDeviceSets from the StorageCluster (setup
+               fixture skips if fewer than 2).
+            2. Select the second device set (index 1) as the target.
+            3. Snapshot current PVs in the target storage class, then add
+               one new disk per OCS node. Waiting only for the new PVs
+               avoids miscounting pre-existing available PVs that may
+               belong to a different device set sharing the same SC.
+            4. Increment the second device set's count so that one new OSD
+               is created per OCS node.
+            5. Wait for the new device set PVCs to reach Bound status.
+            6. Wait for the StorageCluster to reach Ready phase.
+            7. Verify OSD encryption if encryption-at-rest is enabled.
+            8. Verify device classes and Ceph health after capacity addition.
+            9. Check basic cluster functionality by creating resources.
+        """
+        device_sets = get_all_device_sets()
+        target_ds = device_sets[1]
+        sc_name = target_ds["dataPVCTemplate"]["spec"]["storageClassName"]
+        num_of_new_pvs = add_pvs_for_deviceset(sc_name, target_ds["name"])
+        new_count = target_ds["count"] + num_of_new_pvs
+        logger.info(
+            "Setting count for device set '%s' (index 1) to %d",
+            target_ds["name"],
+            new_count,
+        )
+        set_deviceset_count_by_index(1, new_count)
+
+        logger.info("Wait for the new deviceset PVCs to reach Bound status")
+        wait_for_pvcs_in_deviceset_to_reach_status(
+            target_ds["name"],
+            new_count,
+            constants.STATUS_BOUND,
+        )
+
+        self.post_verification_steps()

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
@@ -74,7 +74,8 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         device_sets = get_all_device_sets()
         if len(device_sets) < 2:
             logger.warning(
-                "Skipping: requires multiple device classes " "(found %d device set)",
+                "Skipping: requires multiple device classes "
+                "(found %d device set(s))",
                 len(device_sets),
             )
             pytest.skip(

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_lso_multiple_device_classes.py
@@ -73,6 +73,10 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         """
         device_sets = get_all_device_sets()
         if len(device_sets) < 2:
+            logger.warning(
+                "Skipping: requires multiple device classes " "(found %d device set)",
+                len(device_sets),
+            )
             pytest.skip(
                 "Test requires a cluster with multiple device classes "
                 f"(found only {len(device_sets)} device set)"
@@ -83,6 +87,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         self.bucket_factory = bucket_factory
         self.rgw_bucket_factory = rgw_bucket_factory
         self.sanity_helpers = Sanity()
+        logger.info("Test state initialized with %d device sets", len(device_sets))
 
     def post_verification_steps(
         self, sc_timeout=300, ceph_health_tries=80, ceph_rebalance_timeout=3600
@@ -101,6 +106,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
             ceph_rebalance_timeout (int): Seconds to wait for Ceph rebalance.
 
         """
+        logger.test_step("Wait for StorageCluster to reach Ready phase")
         sc_obj = get_storage_cluster()
         sc_obj.wait_for_resource(
             condition=constants.STATUS_READY,
@@ -111,12 +117,14 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         )
 
         if config.ENV_DATA.get("encryption_at_rest"):
+            logger.test_step("Verify OSD encryption")
             osd_encryption_verification()
 
+        logger.test_step("Verify device classes and Ceph health")
         verify_deviceclasses_steps()
         check_ceph_health_after_add_capacity(ceph_health_tries, ceph_rebalance_timeout)
 
-        logger.info("Check basic cluster functionality")
+        logger.test_step("Check basic cluster functionality")
         self.sanity_helpers.create_resources(
             self.pvc_factory,
             self.pod_factory,
@@ -131,7 +139,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         """
 
         def finalizer():
-            logger.info("Wait for the ceph health to be OK")
+            logger.test_step("Wait for ceph health to be OK")
             ceph_health_check(tries=20)
 
         request.addfinalizer(finalizer)
@@ -165,10 +173,20 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
             8. Verify device classes and Ceph health after capacity addition.
             9. Check basic cluster functionality by creating resources.
         """
+        logger.test_step("Select the second device set as the capacity target")
         device_sets = get_all_device_sets()
         target_ds = device_sets[1]
         sc_name = target_ds["dataPVCTemplate"]["spec"]["storageClassName"]
+        logger.info(
+            "Target device set: '%s' (storage class: '%s')",
+            target_ds["name"],
+            sc_name,
+        )
+
+        logger.test_step("Add one new disk per OCS node for the second device class")
         num_of_new_pvs = add_pvs_for_deviceset(sc_name, target_ds["name"])
+
+        logger.test_step("Increment device set count to add new OSDs")
         new_count = target_ds["count"] + num_of_new_pvs
         logger.info(
             "Setting count for device set '%s' (index 1) to %d",
@@ -177,7 +195,7 @@ class TestAddCapacityLSOMultipleDeviceClasses(ManageTest):
         )
         set_deviceset_count(new_count, index=1)
 
-        logger.info("Wait for the new deviceset PVCs to reach Bound status")
+        logger.test_step("Wait for new device set PVCs to reach Bound status")
         wait_for_pvcs_in_deviceset_to_reach_status(
             target_ds["name"],
             new_count,


### PR DESCRIPTION
Add a new test that verifies adding capacity to the second device class on a vSphere LSO ODF cluster with multiple StorageDeviceSets. The test adds one disk per OCS node, waits for new Available PVs to appear, increments the device set count, and verifies PVC binding, StorageCluster readiness, Ceph health, and basic cluster functionality.

Also adds `set_deviceset_count_by_index` to `storage_cluster.py` so any StorageDeviceSet can be patched by index rather than always targeting index 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to provision additional persistent volumes for a specific device set and target device-set index, with automated availability checks.
  * Support updating a specific device set's capacity (by index) rather than only the first set.

* **Tests**
  * New functional test validating capacity expansion via CLI on vSphere LSO with multiple device classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->