### PR TITLE
ui/lso: fix vSphere LSO ODF deployment via UI on OCP 4.21

### DIFF
--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -457,22 +457,54 @@ def add_disk_for_vsphere_platform():
             provision_type = config.DEPLOYMENT.get(
                 "provision_type", constants.VM_DISK_TYPE
             )
-
-            vsphere_base.attach_disk(
-                device_size,
-                provision_type,
-                ssd=ssd_disk,
+            multiple_device_classes = config.DEPLOYMENT.get(
+                "deploy_multiple_device_classes"
             )
-            if config.DEPLOYMENT.get("deploy_multiple_device_classes"):
-                logger.info("Attaching additional disks for the second device class")
-                second_device_size = config.ENV_DATA.get(
-                    "second_device_size", device_size
-                )
+
+            # Importing here to avoid circular dependency (baremetal imports lso_helpers)
+            from ocs_ci.deployment.baremetal import disks_available_to_cleanup
+
+            workers = get_nodes(node_type="worker")
+            total_available_disks = sum(
+                len(disks_available_to_cleanup(w)) for w in workers
+            )
+            logger.info(
+                "Total available (non-boot) disks across worker nodes: " "%s",
+                total_available_disks,
+            )
+
+            if total_available_disks < 3:
                 vsphere_base.attach_disk(
-                    second_device_size,
+                    device_size,
                     provision_type,
                     ssd=ssd_disk,
                 )
+            else:
+                logger.info(
+                    "Workers already have %s available disks, skipping first "
+                    "disk attachment",
+                    total_available_disks,
+                )
+
+            if multiple_device_classes:
+                if total_available_disks < 6:
+                    logger.info(
+                        "Attaching additional disks for the second device class"
+                    )
+                    second_device_size = config.ENV_DATA.get(
+                        "second_device_size", device_size
+                    )
+                    vsphere_base.attach_disk(
+                        second_device_size,
+                        provision_type,
+                        ssd=ssd_disk,
+                    )
+                else:
+                    logger.info(
+                        "Workers already have %s available disks, skipping "
+                        "second device class disk attachment",
+                        total_available_disks,
+                    )
 
         if lso_type == constants.DIRECTPATH:
             logger.info(f"LSO Deployment type: {constants.DIRECTPATH}")

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -314,6 +314,8 @@ class DeploymentUI(PageNavigator):
                 "Next button on LSO is not clickable after 700 seconds"
             )
 
+        self.configure_in_transit_encryption()
+
         self.configure_encryption()
 
         self.configure_data_protection()

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -341,6 +341,24 @@ deployment_4_19 = {
     "0.5 TiB": ('button[data-test-dropdown-menu="0.5 TiB"]', By.CSS_SELECTOR),
 }
 deployment_4_21 = {
+    # In OCP 4.21 the OperatorHub tile changed from <a data-test="pkg-catalog-ns">
+    # to <div data-test="operator-{displayName}"> containing a button.
+    "choose_local_storage_version": (
+        "//div[@data-test='operator-Local Storage']//button | "
+        "//a[@data-test='local-storage-operator-redhat-operators-openshift-marketplace']",
+        By.XPATH,
+    ),
+    "choose_local_storage_version_non_ga": (
+        "//div[@data-test='operator-Local Storage']//button | "
+        "//a[@data-test='local-storage-operator-optional-operators-openshift-marketplace']",
+        By.XPATH,
+    ),
+    # In ODF 4.21 (PF5/PF6), the radio input is not element_to_be_clickable; target
+    # the visible label instead so the LLM fallback is never triggered.
+    "choose_lso_deployment": (
+        "//label[@for='bs-local-devices'] | //input[@id='bs-local-devices']",
+        By.XPATH,
+    ),
     "osd_size_dropdown": (
         "//button[contains(@aria-label, 'select') and contains(@class, 'dropdown--full-width')]",
         By.XPATH,


### PR DESCRIPTION
Three fixes for the UI-based ODF deployment flow on vSphere LSO:

1. views.py: add choose_lso_deployment override in deployment_4_21 to target the visible PF5 label instead of the hidden radio input, which was causing element_to_be_clickable to time out and the LLM fallback to click the wrong element.

2. deployment_ui.py: call configure_in_transit_encryption() in install_lso_cluster() before configure_encryption(), matching the install_internal_cluster() flow.

3. lso_helpers.py: skip VMDK disk attachment in add_disk_for_vsphere_platform() when worker nodes already have enough disks, using disks_available_to_cleanup() to count non-boot disks across all workers (>=3 skips first attach,
   >=6 skips second attach for multiple device classes).