### PR TITLE
Wait for ReclaimSpaceCronJob and fall back to <pvc>-reclaimspace when annotation is missing

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6599,48 +6599,70 @@ def remove_toleration():
     return success
 
 
-def get_reclaimspacecronjob_for_pvc(pvc_obj):
+def get_reclaimspacecronjob_for_pvc(pvc_obj, timeout=120):
     """
     Retrieve the ReclaimSpaceCronJob object associated with a given PVC.
 
+    Waits until the ReclaimSpaceCronJob CR exists. The controller may set the
+    ``reclaimspace.csiaddons.openshift.io/cronjob`` annotation on the PVC, or
+    create the CR as ``<pvc_name>-reclaimspace`` without the annotation first;
+    both patterns are handled (same as storageclass reclaim-space tests).
+
     Args:
         pvc_obj (object): PersistentVolumeClaim (PVC) object.
+        timeout (int): Seconds to wait for the ReclaimSpaceCronJob to appear.
 
     Returns:
         object: OCP object representing the ReclaimSpaceCronJob associated with the PVC.
 
     Raises:
-        ValueError: If the PVC does not have the required annotation for ReclaimSpaceCronJob.
+        ValueError: If no ReclaimSpaceCronJob is found within the timeout.
     """
-    # Reload PVC object if annotations are missing
-    if "annotations" not in pvc_obj.data["metadata"]:
-        pvc_obj.reload()
+    cronjob_annotation_key = "reclaimspace.csiaddons.openshift.io/cronjob"
+    default_name = f"{pvc_obj.name}-reclaimspace"
 
-    # Retrieve the CronJob name from annotations
-    cron_job_name = pvc_obj.data["metadata"]["annotations"].get(
-        "reclaimspace.csiaddons.openshift.io/cronjob"
+    try:
+        for _ in TimeoutSampler(timeout=timeout, sleep=5, func=lambda: None):
+            pvc_obj.reload()
+            annotations = pvc_obj.data.get("metadata", {}).get("annotations") or {}
+            cron_job_name = annotations.get(cronjob_annotation_key) or default_name
+            try:
+                cron_obj = OCP(
+                    kind=constants.RECLAIMSPACECRONJOB,
+                    namespace=pvc_obj.namespace,
+                    resource_name=cron_job_name,
+                )
+                cron_obj.get()
+                logger.info(
+                    f"Found ReclaimSpaceCronJob '{cron_job_name}' for PVC '{pvc_obj.name}'"
+                )
+                return cron_obj
+            except Exception as ex:
+                logger.debug(
+                    f"ReclaimSpaceCronJob '{cron_job_name}' not yet available for PVC "
+                    f"'{pvc_obj.name}': {ex}"
+                )
+    except TimeoutExpiredError:
+        pass
+
+    logger.error(
+        f"ReclaimSpaceCronJob not found for PVC '{pvc_obj.name}' within {timeout}s "
+        f"(tried annotation '{cronjob_annotation_key}' and default name '{default_name}')."
     )
-    if not cron_job_name:
-        logger.error(f"PVC '{pvc_obj.name}' lacks annotation for reclaimspace cronjob.")
-        raise ValueError("PVC has no annotation for reclaimspace cronjob")
-
-    logger.info(f"Found ReclaimSpaceCronJob '{cron_job_name}' for PVC '{pvc_obj.name}'")
-
-    # Create and return the CronJob object
-    return OCP(
-        kind=constants.RECLAIMSPACECRONJOB,
-        namespace=pvc_obj.namespace,
-        resource_name=cron_job_name,
+    raise ValueError(
+        f"ReclaimSpaceCronJob not found for PVC '{pvc_obj.name}' within {timeout} seconds"
     )
 
 
-def change_reclaimspacecronjob_state_for_pvc(pvc_objs, suspend=True):
+def change_reclaimspacecronjob_state_for_pvc(pvc_objs, suspend=True, timeout=120):
     """
     Enable or disable the ReclaimSpace operation for the PVC's ReclaimSpaceCronJob.
 
     Args:
         pvc_objs (list): List of PersistentVolumeClaim (PVC) objects.
         suspend (bool): If True, disables ReclaimSpace; if False, enables ReclaimSpace.
+        timeout (int): Seconds to wait for the ReclaimSpaceCronJob CR to exist
+            (see ``get_reclaimspacecronjob_for_pvc``).
 
     Returns:
         bool: True if the operation was successfully applied to all PVCs.
@@ -6651,7 +6673,7 @@ def change_reclaimspacecronjob_state_for_pvc(pvc_objs, suspend=True):
         logger.info(f"{action} ReclaimSpace operation for PVC '{pvc_obj.name}'")
 
         # Retrieve the associated CronJob object
-        cron_obj = get_reclaimspacecronjob_for_pvc(pvc_obj)
+        cron_obj = get_reclaimspacecronjob_for_pvc(pvc_obj, timeout=timeout)
 
         # Update the annotation state
         state_value = "unmanaged" if suspend else "managed"
@@ -6754,18 +6776,20 @@ def set_schedule_precedence(precedence):
     logger.info("CSI Addons controller manager pods restarted.")
 
 
-def verify_reclaimspacecronjob_suspend_state_for_pvc(pvc_obj):
+def verify_reclaimspacecronjob_suspend_state_for_pvc(pvc_obj, timeout=120):
     """
     Verify the suspend state of the ReclaimSpaceCronJob associated with the given PVC.
 
     Args:
         pvc_obj (object): PersistentVolumeClaim (PVC) object.
+        timeout (int): Seconds to wait for the ReclaimSpaceCronJob CR to exist
+            (see ``get_reclaimspacecronjob_for_pvc``).
 
     Returns:
         bool: True if the suspend state is True and the state annotation is 'unmanaged', False otherwise.
     """
     # Retrieve the ReclaimSpaceCronJob object for the PVC
-    reclaimspace_cronjob = get_reclaimspacecronjob_for_pvc(pvc_obj)
+    reclaimspace_cronjob = get_reclaimspacecronjob_for_pvc(pvc_obj, timeout=timeout)
 
     # Extract and log the suspend state
     suspend_state = reclaimspace_cronjob.data["spec"].get("suspend", False)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6620,9 +6620,10 @@ def get_reclaimspacecronjob_for_pvc(pvc_obj, timeout=120):
     """
     cronjob_annotation_key = "reclaimspace.csiaddons.openshift.io/cronjob"
     default_name = f"{pvc_obj.name}-reclaimspace"
+    sleep = min(5, timeout)
 
     try:
-        for _ in TimeoutSampler(timeout=timeout, sleep=5, func=lambda: None):
+        for _ in TimeoutSampler(timeout=timeout, sleep=sleep, func=lambda: None):
             pvc_obj.reload()
             annotations = pvc_obj.data.get("metadata", {}).get("annotations") or {}
             cron_job_name = annotations.get(cronjob_annotation_key) or default_name
@@ -6637,7 +6638,9 @@ def get_reclaimspacecronjob_for_pvc(pvc_obj, timeout=120):
                     f"Found ReclaimSpaceCronJob '{cron_job_name}' for PVC '{pvc_obj.name}'"
                 )
                 return cron_obj
-            except Exception as ex:
+            except CommandFailed as ex:
+                if "Not Found" not in str(ex) and "NotFound" not in str(ex):
+                    raise
                 logger.debug(
                     f"ReclaimSpaceCronJob '{cron_job_name}' not yet available for PVC "
                     f"'{pvc_obj.name}': {ex}"

--- a/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
+++ b/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import math
+
+import pytest
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import tier2
@@ -11,8 +12,8 @@ from ocs_ci.helpers.helpers import (
     verify_reclaimspacecronjob_suspend_state_for_pvc,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
-from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources.pod import delete_pods
+from ocs_ci.utility.retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -49,21 +50,42 @@ class TestDisableReclaimSpaceOperation:
             annotations=reset_reclaimspace_annotations,
         )
 
-    @retry(UnexpectedBehaviour, tries=3, delay=10)
-    def wait_till_expected_image_size(self, pvc_obj, expected_size, tolerance=0.3):
-        """Wait until the RBD image size matches the expected size."""
+    def _check_rbd_used_size_once(self, pvc_obj, expected_size, tolerance=0.3):
+        """Single sample of RBD used size; raises UnexpectedBehaviour if not a match."""
         rbd_image_name = pvc_obj.get_rbd_image_name
         image_info = get_rbd_image_info(constants.DEFAULT_CEPHBLOCKPOOL, rbd_image_name)
         image_size = image_info.get("used_size_gib")
-        if not math.isclose(image_size, expected_size, abs_tol=tolerance):
-            raise UnexpectedBehaviour(
-                f"RBD image {rbd_image_name} size mismatch: {image_size}GiB, "
-                f"expected {expected_size}GiB (tolerance: ±{tolerance}GiB)"
+        if math.isclose(image_size, expected_size, abs_tol=tolerance):
+            log.info(
+                f"RBD Image {rbd_image_name} is size of {image_size}GiB "
+                f"(within tolerance ±{tolerance}GiB)"
             )
-        log.info(
-            f"RBD Image {rbd_image_name} is size of {image_size}GiB (within tolerance ±{tolerance}GiB)"
+            return True
+        raise UnexpectedBehaviour(
+            f"RBD image {rbd_image_name} size mismatch: {image_size}GiB, "
+            f"expected {expected_size}GiB (tolerance: ±{tolerance}GiB)"
         )
-        return True
+
+    @retry(UnexpectedBehaviour, tries=8, delay=10, backoff=1)
+    def wait_till_expected_image_size_after_write(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """After async ``dd`` to block PVC; brief poll until used size shows ~ written GiB."""
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
+
+    @retry(UnexpectedBehaviour, tries=3, delay=10, backoff=1)
+    def wait_till_expected_image_size_post_delete_reclaim_disabled(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """Reclaim suspended: used size should stay ~1 GiB; fail fast (short retry)."""
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
+
+    @retry(UnexpectedBehaviour, tries=18, delay=15, backoff=1)
+    def wait_till_expected_image_size_post_delete_reclaim_enabled(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """Reclaim enabled: expect trim toward ~0 GiB; long retry for async reclaim."""
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
 
     def execute_reclaimspace_test(self, pod_factory, suspend_state):
         """Test reclaim space operation for PVCs with pods."""
@@ -86,17 +108,23 @@ class TestDisableReclaimSpaceOperation:
                 shell=True,
             )
 
-        # Validate RBD image sizes after data writes
+        # Validate RBD image sizes after data writes (dd runs in background)
         for pvc_obj in self.pvc_objs:
-            self.wait_till_expected_image_size(pvc_obj, actual_data_written)
+            self.wait_till_expected_image_size_after_write(pvc_obj, actual_data_written)
 
         # Delete pods
         delete_pods(pod_objs, wait=True)
 
-        # Verify RBD image sizes after pods are deleted
         expected_volume_size = actual_data_written if suspend_state else 0.0
         for pvc_obj in self.pvc_objs:
-            self.wait_till_expected_image_size(pvc_obj, expected_volume_size)
+            if suspend_state:
+                self.wait_till_expected_image_size_post_delete_reclaim_disabled(
+                    pvc_obj, expected_volume_size
+                )
+            else:
+                self.wait_till_expected_image_size_post_delete_reclaim_enabled(
+                    pvc_obj, expected_volume_size
+                )
 
     @pytest.mark.polarion_id("OCS-6279")
     @tier2

--- a/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
+++ b/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import math
+
+import pytest
 from ocs_ci.framework.pytest_customization.marks import green_squad
 from ocs_ci.ocs import constants
 from ocs_ci.framework.testlib import tier2
@@ -11,8 +12,8 @@ from ocs_ci.helpers.helpers import (
     verify_reclaimspacecronjob_suspend_state_for_pvc,
 )
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
-from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources.pod import delete_pods
+from ocs_ci.utility.retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -49,21 +50,71 @@ class TestDisableReclaimSpaceOperation:
             annotations=reset_reclaimspace_annotations,
         )
 
-    @retry(UnexpectedBehaviour, tries=3, delay=10)
-    def wait_till_expected_image_size(self, pvc_obj, expected_size, tolerance=0.3):
-        """Wait until the RBD image size matches the expected size."""
+    def _check_rbd_used_size_once(self, pvc_obj, expected_size, tolerance=0.3):
+        """
+        Single sample of RBD used size; raises UnexpectedBehaviour if not a match.
+
+        Args:
+            pvc_obj (ocs_ci.ocs.resources.pvc.PVC): PVC object bound to the RBD image
+            expected_size (float): Expected used size of the RBD image in GiB
+            tolerance (float): Absolute tolerance in GiB for size comparison
+
+        Returns:
+            bool: True when the used size is within tolerance of expected_size
+
+        Raises:
+            UnexpectedBehaviour: If the RBD image used size does not match expected_size
+
+        """
         rbd_image_name = pvc_obj.get_rbd_image_name
         image_info = get_rbd_image_info(constants.DEFAULT_CEPHBLOCKPOOL, rbd_image_name)
         image_size = image_info.get("used_size_gib")
-        if not math.isclose(image_size, expected_size, abs_tol=tolerance):
-            raise UnexpectedBehaviour(
-                f"RBD image {rbd_image_name} size mismatch: {image_size}GiB, "
-                f"expected {expected_size}GiB (tolerance: ±{tolerance}GiB)"
+        if math.isclose(image_size, expected_size, abs_tol=tolerance):
+            log.info(
+                f"RBD Image {rbd_image_name} is size of {image_size}GiB "
+                f"(within tolerance ±{tolerance}GiB)"
             )
-        log.info(
-            f"RBD Image {rbd_image_name} is size of {image_size}GiB (within tolerance ±{tolerance}GiB)"
+            return True
+        raise UnexpectedBehaviour(
+            f"RBD image {rbd_image_name} size mismatch: {image_size}GiB, "
+            f"expected {expected_size}GiB (tolerance: ±{tolerance}GiB)"
         )
-        return True
+
+    @retry(UnexpectedBehaviour, tries=8, delay=10, backoff=1)
+    def wait_till_expected_image_size_after_write(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """
+        After async ``dd`` to block PVC; brief poll until used size shows ~ written GiB.
+
+        Args:
+            pvc_obj (ocs_ci.ocs.resources.pvc.PVC): PVC object bound to the RBD image
+            expected_size (float): Expected used size of the RBD image in GiB after write
+            tolerance (float): Absolute tolerance in GiB for size comparison
+
+        Returns:
+            bool: True when the used size is within tolerance of expected_size
+
+        Raises:
+            UnexpectedBehaviour: If the RBD image used size does not match expected_size
+                within the retry window
+
+        """
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
+
+    @retry(UnexpectedBehaviour, tries=3, delay=10, backoff=1)
+    def wait_till_expected_image_size_post_delete_reclaim_disabled(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """Reclaim suspended: used size should stay ~1 GiB; fail fast (short retry)."""
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
+
+    @retry(UnexpectedBehaviour, tries=18, delay=15, backoff=1)
+    def wait_till_expected_image_size_post_delete_reclaim_enabled(
+        self, pvc_obj, expected_size, tolerance=0.3
+    ):
+        """Reclaim enabled: expect trim toward ~0 GiB; long retry for async reclaim."""
+        return self._check_rbd_used_size_once(pvc_obj, expected_size, tolerance)
 
     def execute_reclaimspace_test(self, pod_factory, suspend_state):
         """Test reclaim space operation for PVCs with pods."""
@@ -86,17 +137,23 @@ class TestDisableReclaimSpaceOperation:
                 shell=True,
             )
 
-        # Validate RBD image sizes after data writes
+        # Validate RBD image sizes after data writes (dd runs in background)
         for pvc_obj in self.pvc_objs:
-            self.wait_till_expected_image_size(pvc_obj, actual_data_written)
+            self.wait_till_expected_image_size_after_write(pvc_obj, actual_data_written)
 
         # Delete pods
         delete_pods(pod_objs, wait=True)
 
-        # Verify RBD image sizes after pods are deleted
         expected_volume_size = actual_data_written if suspend_state else 0.0
         for pvc_obj in self.pvc_objs:
-            self.wait_till_expected_image_size(pvc_obj, expected_volume_size)
+            if suspend_state:
+                self.wait_till_expected_image_size_post_delete_reclaim_disabled(
+                    pvc_obj, expected_volume_size
+                )
+            else:
+                self.wait_till_expected_image_size_post_delete_reclaim_enabled(
+                    pvc_obj, expected_volume_size
+                )
 
     @pytest.mark.polarion_id("OCS-6279")
     @tier2

--- a/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
+++ b/tests/functional/pv/space_reclaim/test_disable_reclaimspace_operation.py
@@ -68,7 +68,11 @@ class TestDisableReclaimSpaceOperation:
         """
         rbd_image_name = pvc_obj.get_rbd_image_name
         image_info = get_rbd_image_info(constants.DEFAULT_CEPHBLOCKPOOL, rbd_image_name)
-        image_size = image_info.get("used_size_gib")
+        image_size = image_info.get("used_size_gib") if image_info else None
+        if image_size is None:
+            raise UnexpectedBehaviour(
+                f"RBD image info not yet available for {rbd_image_name}"
+            )
         if math.isclose(image_size, expected_size, abs_tol=tolerance):
             log.info(
                 f"RBD Image {rbd_image_name} is size of {image_size}GiB "


### PR DESCRIPTION

Fix flaky failures in test_disable_reclaimspace_operation when the CSI
Addons controller had not yet set reclaimspace.csiaddons.openshift.io/cronjob
on the PVC (or omitted it in favor of the conventional CR name).
- Poll get_reclaimspacecronjob_for_pvc until the reclaimspacecronjob exists,
  using the PVC annotation when present and otherwise <pvc_name>-reclaimspace,
  aligned with conftest _wait_for_cronjob_creation behavior.
- Add optional timeout (default 120s) and forward it from
  change_reclaimspacecronjob_state_for_pvc and
  verify_reclaimspacecronjob_suspend_state_for_pvc.
Only tests that call these helpers are affected; other reclaimspace tests
use different code paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reclaim space operations now wait (up to a configurable timeout) for the related CronJob to become available before proceeding, supporting both annotation-based and default PVC-derived naming.

* **Bug Fixes**
  * Verification and suspend-state updates are now timeout-aware, reducing failures when the CronJob resource is temporarily missing.

* **Tests**
  * Space-reclaim tests now validate RBD `used_size_gib` using phase-specific retry polling with tighter tolerance checks after writes and after pod deletion (reclaim enabled/disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->