### PR TITLE
add cert issue w/a to aws HCP clusters 4.22

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6947,
+        "line_number": 6966,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -25,6 +25,7 @@ from ocs_ci.deployment.helpers.hypershift_base import (
     get_current_nodepool_size,
     get_available_hosted_clusters_to_ocp_ver_dict,
     create_cluster_dir,
+    fix_hypershift_webhook_ca_bundle,
 )
 from ocs_ci.deployment.metallb import MetalLBInstaller
 from ocs_ci.framework.logger_helper import log_step, reset_current_module_log_steps
@@ -3732,9 +3733,18 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
             return ""
 
         except CommandFailed as e:
-            logger.error(f"Failed to create AWS HCP cluster '{self.name}'")
-            self._log_cmd_output(e)
-            raise
+            if "x509: certificate signed by unknown authority" in str(
+                e
+            ) and "hostedclusters.hypershift.openshift.io" in str(e):
+                logger.warning(
+                    "HyperShift webhook TLS error detected — applying CA bundle fix and retrying"
+                )
+                fix_hypershift_webhook_ca_bundle()
+                exec_cmd(cmd, timeout=2700)
+            else:
+                logger.error(f"Failed to create AWS HCP cluster '{self.name}'")
+                self._log_cmd_output(e)
+                raise
         except subprocess.TimeoutExpired as e:
             logger.error(
                 f"hypershift create cluster aws timed out after 2700s "


### PR DESCRIPTION
fix for the problem:

```
failed on setup with "ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: /home/jenkins/bin/hypershift create cluster aws --region us-east-2 --infra-id fbalak-ag1-infra --name fbalak-ag1 --sts-creds /tmp/sts-creds-fbalak-ag1-68qebfqc.json --role-arn arn:aws:iam::861790564636:role/aws-agent-deployer-role --infra-json /home/jenkins/clusters/fbalak-ag1/openshift-cluster-dir/aws_hcp_files/fbalak-ag1-infra-output.json --iam-json /home/jenkins/clusters/fbalak-ag1/openshift-cluster-dir/aws_hcp_files/fbalak-ag1-iam-output.json --instance-type m5.xlarge --node-pool-replicas 3 --vpc-cidr 10.1.0.0/16 --release-image registry.ci.openshift.org/ocp/release:4.22.0-0.nightly-2026-04-18-162844 --pull-secret /home/jenkins/workspace/qe-deploy-ocs-cluster-multi/ocs-ci/data/pull-secret --control-plane-availability-policy SingleReplica --infra-availability-policy SingleReplica --olm-disable-default-sources --generate-ssh --image-content-sources /tmp/idms_mirrors-koe3f7gg --wait --timeout 44m.
Error is {"level":"info","ts":"2026-04-20T05:41:21-04:00","msg":"Applied Kube resource","kind":"Namespace","namespace":"","name":"clusters"}
{"level":"info","ts":"2026-04-20T05:41:21-04:00","msg":"Applied Kube resource","kind":"Secret","namespace":"clusters","name":"fbalak-ag1-pull-secret"}
{"level":"info","ts":"2026-04-20T05:41:21-04:00","msg":"Applied Kube resource","kind":"Secret","namespace":"clusters","name":"fbalak-ag1-ssh-key"}
{"level":"info","ts":"2026-04-20T05:41:21-04:00","msg":"Applied Kube resource","kind":"Secret","namespace":"clusters","name":"fbalak-ag1-etcd-encryption-key"}
{"level":"error","ts":"2026-04-20T05:41:21-04:00","msg":"Failed to create cluster","error":"failed to apply object \"clusters/fbalak-ag1\": Internal error occurred: failed calling webhook \"hostedclusters.hypershift.openshift.io\": failed to call webhook: Post \"[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)\": tls: failed to verify certificate: x509: certificate signed by unknown authority","stacktrace":"github.com/openshift/hypershift/cmd/cluster/aws.NewCreateCommand.func1\n\t/tmp/tmp8y9_3_xo/cmd/cluster/aws/create.go:540\ngithub.com/spf13/cobra.(*Command).execute\n\t/tmp/tmp8y9_3_xo/vendor/github.com/spf13/cobra/command.go:1015\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/tmp/tmp8y9_3_xo/vendor/github.com/spf13/cobra/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/tmp/tmp8y9_3_xo/vendor/github.com/spf13/cobra/command.go:1071\ngithub.com/spf13/cobra.(*Command).ExecuteContext\n\t/tmp/tmp8y9_3_xo/vendor/github.com/spf13/cobra/command.go:1064\nmain.main\n\t/tmp/tmp8y9_3_xo/main.go:80\nruntime.main\n\t/home/jenkins/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.linux-amd64/src/runtime/proc.go:285"}
Error: failed to apply object "clusters/fbalak-ag1": Internal error occurred: failed calling webhook "hostedclusters.hypershift.openshift.io": failed to call webhook: Post "[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)": tls: failed to verify certificate: x509: certificate signed by unknown authority
failed to apply object "clusters/fbalak-ag1": Internal error occurred: failed calling webhook "hostedclusters.hypershift.openshift.io": failed to call webhook: Post "[https://operator.hypershift.svc:443/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s](https://operator.hypershift.svc/mutate-hypershift-openshift-io-v1beta1-hostedcluster?timeout=15s)": tls: failed to verify certificate: x509: certificate signed by unknown authority"
```