### PR TITLE
Add support for multiple RHCOS templates in VMware deployments

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -258,8 +258,9 @@ higher priority).
 * `ocs_version` - Version of OCS that is being deployed
 * `acm_version` - Version of acm to be used for this run (applicable mostly to DR scenarios)
 * `vm_template` - VMWare template to use for RHCOS images (legacy single template, used as fallback)
+* `vm_template_overwrite` - VM template to overwirthe for early testing deployment e.g. rhcos-47.84.202103151537-0-vmware.x86_64
 * `vm_templates` - Dictionary of available RHCOS templates by major version for VMWare deployments (e.g., `{"9": "rhcos-9.6...", "10": "rhcos-10.2..."}`)
-* `rhcos_version` - Select which RHCOS major version to use from vm_templates dictionary (e.g., "9" or "10"). Defaults to "9" if not specified.
+* `rhcos_version` - Select which RHCOS major version to use from vm_templates dictionary (e.g., "9" or "10"). Defaults to "9" if not specified. When set to "10", automatically configures `featureSet: "TechPreviewNoUpgrade"` and `osImageStream: "rhel-10"` in install-config.yaml.
 * `fio_storageutilization_min_mbps` - Minimal write speed of FIO used in workload_fio_storageutilization
 * `TF_LOG_LEVEL` - Terraform log level
 * `TF_LOG_FILE` - Terraform log file
@@ -432,7 +433,6 @@ higher priority).
 * `early_testing` - set to True if it's early testing of RHCOS and provide  release_img
     e.g. registry.ci.openshift.org/rhcos-devel/rhel4784:4.7.2
 * `release_img` - release image for early testing of RHCOS or multi arch setup
-* `vm_template_overwrite` - VM template to overwirthe for early testing deployment e.g. rhcos-47.84.202103151537-0-vmware.x86_64
 * `multi_arch` - Set to True if it's multi arch setup/deployment - it will use
     proper OCP release image for OCP deployment or you can set custom via
     release_img e.g. quay.io/openshift-release-dev/ocp-release:4.21.0-rc.1-multi.

--- a/conf/README.md
+++ b/conf/README.md
@@ -257,7 +257,9 @@ higher priority).
 * `skip_ocs_deployment` - Skip the OCS deployment step or not (Default: false)
 * `ocs_version` - Version of OCS that is being deployed
 * `acm_version` - Version of acm to be used for this run (applicable mostly to DR scenarios)
-* `vm_template` - VMWare template to use for RHCOS images
+* `vm_template` - VMWare template to use for RHCOS images (legacy single template, used as fallback)
+* `vm_templates` - Dictionary of available RHCOS templates by major version for VMWare deployments (e.g., `{"9": "rhcos-9.6...", "10": "rhcos-10.2..."}`)
+* `rhcos_version` - Select which RHCOS major version to use from vm_templates dictionary (e.g., "9" or "10"). Defaults to "9" if not specified.
 * `fio_storageutilization_min_mbps` - Minimal write speed of FIO used in workload_fio_storageutilization
 * `TF_LOG_LEVEL` - Terraform log level
 * `TF_LOG_FILE` - Terraform log file

--- a/conf/ocsci/rhcos10_testing.yaml
+++ b/conf/ocsci/rhcos10_testing.yaml
@@ -2,5 +2,10 @@
 # Config for testing with RHCOS 10 template
 # Usage: Include this config file to use RHCOS 10 instead of RHCOS 9
 # Example: --ocsci-conf conf/ocsci/rhcos10_testing.yaml
+#
+# This automatically configures:
+# - VM template from vm_templates["10"] in OCP version config
+# - featureSet: "TechPreviewNoUpgrade" in install-config.yaml
+# - osImageStream: "rhel-10" in install-config.yaml
 ENV_DATA:
   rhcos_version: "10"

--- a/conf/ocsci/rhcos10_testing.yaml
+++ b/conf/ocsci/rhcos10_testing.yaml
@@ -1,0 +1,6 @@
+---
+# Config for testing with RHCOS 10 template
+# Usage: Include this config file to use RHCOS 10 instead of RHCOS 9
+# Example: --ocsci-conf conf/ocsci/rhcos10_testing.yaml
+ENV_DATA:
+  rhcos_version: "10"

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -714,6 +714,17 @@ class BAREMETALUPI(BAREMETALBASE):
             install_config_obj["pullSecret"] = self.get_pull_secret()
             install_config_obj["sshKey"] = self.get_ssh_key()
             install_config_obj["metadata"]["name"] = config.ENV_DATA.get("cluster_name")
+
+            # Configure RHCOS 10 specific settings
+            rhcos_version = config.ENV_DATA.get("rhcos_version")
+            if rhcos_version and str(rhcos_version) == "10":
+                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                install_config_obj["osImageStream"] = "rhel-10"
+                logger.info(
+                    "Configured install-config for RHEL 10 deployment with "
+                    "TechPreviewNoUpgrade feature set"
+                )
+
             install_config_str = yaml.safe_dump(install_config_obj)
             install_config = os.path.join(self.cluster_path, "install-config.yaml")
             install_config_backup = os.path.join(

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -201,6 +201,17 @@ class OCPDeployment:
         ssh_key = self.get_ssh_key()
         if ssh_key:
             install_config_obj["sshKey"] = ssh_key
+
+        # Configure RHCOS 10 specific settings
+        rhcos_version = config.ENV_DATA.get("rhcos_version")
+        if rhcos_version and str(rhcos_version) == "10":
+            install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+            install_config_obj["osImageStream"] = "rhel-10"
+            logger.info(
+                "Configured install-config for RHEL 10 deployment with "
+                "TechPreviewNoUpgrade feature set"
+            )
+
         install_config_str = yaml.safe_dump(install_config_obj)
         install_config = os.path.join(self.cluster_path, "install-config.yaml")
         with open(install_config, "w") as f:

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -2788,6 +2788,53 @@ def generate_terraform_vars_and_update_machine_conf():
         update_machine_conf(folder_structure)
 
 
+def resolve_vm_template():
+    """
+    Resolve the VM template to use based on configuration.
+
+    Priority:
+    1. vm_template_overwrite (for early testing)
+    2. vm_templates[rhcos_version] (new multi-version support)
+    3. vm_template (legacy fallback)
+
+    Returns:
+        str: The VM template name to use
+    """
+    # Check for override first (early testing)
+    if config.ENV_DATA.get("vm_template_overwrite"):
+        template = config.ENV_DATA["vm_template_overwrite"]
+        logger.info(f"Using overridden VM template: {template}")
+        return template
+
+    # Check for multi-version templates
+    vm_templates = config.ENV_DATA.get("vm_templates")
+    rhcos_version = config.ENV_DATA.get("rhcos_version")
+
+    if vm_templates:
+        # Default to RHCOS 9 if no version specified
+        if not rhcos_version:
+            rhcos_version = "9"
+            logger.info("No rhcos_version specified, defaulting to RHCOS 9")
+
+        # Ensure rhcos_version is a string for dictionary lookup
+        rhcos_version = str(rhcos_version)
+
+        template = vm_templates.get(rhcos_version)
+        if template:
+            logger.info(f"Using RHCOS {rhcos_version} template: {template}")
+            return template
+        else:
+            logger.warning(
+                f"RHCOS version {rhcos_version} not found in vm_templates, "
+                "falling back to vm_template"
+            )
+
+    # Fallback to legacy single template
+    template = config.ENV_DATA.get("vm_template")
+    logger.info(f"Using legacy vm_template: {template}")
+    return template
+
+
 def generate_terraform_vars_with_folder():
     """
     Generates the terraform.tfvars file which includes folder structure
@@ -2830,16 +2877,14 @@ def generate_terraform_vars_with_folder():
     ssh_public_key_path = os.path.expanduser(config.DEPLOYMENT["ssh_key"])
     config.ENV_DATA["ssh_public_key_path"] = ssh_public_key_path
 
-    # overwrite RHCOS template
-    # This use-case is mainly used for early RHCOS testing
-    if config.ENV_DATA.get("vm_template_overwrite"):
-        config.ENV_DATA["vm_template"] = config.ENV_DATA["vm_template_overwrite"]
+    # Resolve RHCOS template to use
+    # Supports: vm_template_overwrite (early testing), vm_templates (multi-version), vm_template (legacy)
     if config.ENV_DATA["sno"]:
         config.ENV_DATA["iso_file"] = f"ISO/{config.ENV_DATA['cluster_name']}.iso"
         config.ENV_DATA["vm_template"] = "sno_template1"
-
         create_terraform_var_file("terraform_4_5_sno.tfvars.j2")
     else:
+        config.ENV_DATA["vm_template"] = resolve_vm_template()
         create_terraform_var_file("terraform_4_5.tfvars.j2")
 
 

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -896,6 +896,17 @@ class VSPHEREUPI(VSPHEREBASE):
                 ]
             install_config_obj["pullSecret"] = self.get_pull_secret()
             install_config_obj["sshKey"] = self.get_ssh_key()
+
+            # Configure RHCOS 10 specific settings
+            rhcos_version = config.ENV_DATA.get("rhcos_version")
+            if rhcos_version and str(rhcos_version) == "10":
+                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                install_config_obj["osImageStream"] = "rhel-10"
+                logger.info(
+                    "Configured install-config for RHEL 10 deployment with "
+                    "TechPreviewNoUpgrade feature set"
+                )
+
             # prepare configuration for disconnected deployment (including deployment behind proxy)
             if config.DEPLOYMENT.get("disconnected") or config.DEPLOYMENT.get("proxy"):
                 # set non-existing gateway, to make the cluster disconnected
@@ -1585,6 +1596,17 @@ class VSPHEREIPI(VSPHEREBASE):
             install_config_obj = yaml.safe_load(install_config_str)
             install_config_obj["pullSecret"] = self.get_pull_secret()
             install_config_obj["sshKey"] = self.get_ssh_key()
+
+            # Configure RHCOS 10 specific settings
+            rhcos_version = config.ENV_DATA.get("rhcos_version")
+            if rhcos_version and str(rhcos_version) == "10":
+                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                install_config_obj["osImageStream"] = "rhel-10"
+                logger.info(
+                    "Configured install-config for RHEL 10 deployment with "
+                    "TechPreviewNoUpgrade feature set"
+                )
+
             install_config_obj["platform"]["vsphere"]["apiVIP"] = config.ENV_DATA[
                 "vips"
             ][0]

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
@@ -9,6 +9,12 @@ DEPLOYMENT:
   # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
 ENV_DATA:
+  # Dictionary of available RHCOS templates by major version
+  # To use RHCOS 10, set rhcos_version: "10" in your custom config
+  vm_templates:
+    "9": "rhcos-9.6.20251023-0-vmware.x86_64"
+    "10": "rhcos-10.2.20260405-0-vmware.x86_64"
+  # Legacy single template (fallback if vm_templates not defined)
   vm_template: "rhcos-9.6.20251023-0-vmware.x86_64"
   acm_hub_channel: "release-2.16"
   acm_version: "2.16"


### PR DESCRIPTION
Related to:
https://redhat.atlassian.net/browse/OCSQE-4387

Introduces configurable RHCOS template selection to support both RHCOS 9 and RHCOS 10 for VMware deployments. Users can now easily switch between different RHCOS versions via configuration.

Changes:
- Add resolve_vm_template() function with priority-based resolution:
  1. vm_template_overwrite (early testing)
  2. vm_templates[rhcos_version] (multi-version support)
  3. vm_template (legacy fallback)
- Update OCP 4.22 config with vm_templates dictionary containing both RHCOS 9 and RHCOS 10 templates
- Add rhcos10_testing.yaml config for easy RHCOS 10 testing
- Maintain backward compatibility with existing configs

Usage:
  # Use RHCOS 10 by adding to config: ENV_DATA: rhcos_version: 10