### PR TITLE
Fix nightly oc client download using pullSpec extraction

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1519,18 +1519,6 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
             download_client = False
 
     if download_client:
-        # Move existing client binaries to backup location
-        client_binary_backup = f"{client_binary_path}.bak"
-        kubectl_binary_backup = f"{kubectl_binary_path}.bak"
-
-        backup_created = False
-        try:
-            os.rename(client_binary_path, client_binary_backup)
-            os.rename(kubectl_binary_path, kubectl_binary_backup)
-            backup_created = True
-        except FileNotFoundError:
-            pass
-
         # Download the client
         log.info(f"Downloading openshift client ({version}).")
         # record current working directory and switch to BIN_DIR
@@ -1539,6 +1527,9 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
 
         tarball = "openshift-client.tar.gz"
         download_successful = False
+        backup_created = False
+        client_binary_backup = f"{client_binary_path}.bak"
+        kubectl_binary_backup = f"{kubectl_binary_path}.bak"
 
         # For nightly builds, try pullSpec extraction first (more reliable than downloadURL)
         if "nightly" in version and not custom_ocp_image:
@@ -1553,7 +1544,7 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
                 log.info(f"Using pullSpec: {pullspec}")
 
                 # Check if oc client exists to perform extraction
-                if not client_exist and not backup_created:
+                if not client_exist:
                     log.info(
                         "No existing oc client found. Downloading GA version as bootstrap "
                         "to enable extraction from pullSpec."
@@ -1567,18 +1558,11 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
                         )
 
                 # Now try to extract from pullSpec using the available oc (existing or bootstrap)
+                # Note: extract_ocp_binary_from_image() handles its own backup internally
                 if os.path.isfile(client_binary_path):
                     try:
                         log.info(f"Extracting oc client from pullSpec: {pullspec}")
                         extract_ocp_binary_from_image("oc", pullspec, bin_dir)
-                        # Also extract kubectl
-                        try:
-                            extract_ocp_binary_from_image("kubectl", pullspec, bin_dir)
-                        except Exception as kubectl_ex:
-                            log.warning(
-                                f"Failed to extract kubectl from pullSpec, "
-                                f"will create symlink later: {kubectl_ex}"
-                            )
                         download_successful = True
                         log.info(
                             "Successfully extracted oc client from pullSpec "
@@ -1596,7 +1580,17 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
                 )
 
         # If pullSpec extraction wasn't attempted or failed, try traditional downloadURL method
+        # Create backup before attempting methods that don't handle their own backup
         if not download_successful:
+            # Move existing client binaries to backup location before trying other download methods
+            try:
+                os.rename(client_binary_path, client_binary_backup)
+                os.rename(kubectl_binary_path, kubectl_binary_backup)
+                backup_created = True
+                log.debug("Created backup of existing client binaries.")
+            except FileNotFoundError:
+                pass
+
             try:
                 url = get_openshift_mirror_url("openshift-client", version)
                 download_file(url, tarball)

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1063,13 +1063,13 @@ def expose_ocp_version(version):
 
     """
     if version.endswith(".nightly"):
-        latest_nightly_url = (
-            f"https://amd64.ocp.releases.ci.openshift.org/api/v1/"
-            f"releasestream/{version}/latest"
-        )
-        version_url_content = get_url_content(latest_nightly_url)
-        version_json = json.loads(version_url_content)
-        return version_json["name"]
+        release_info = get_nightly_release_info(version)
+        if release_info and release_info.get("name"):
+            return release_info["name"]
+        else:
+            raise ValueError(
+                f"Unable to get nightly release info for version {version}"
+            )
     if version.endswith("-ga"):
         channel = config.DEPLOYMENT.get("ocp_channel", "stable")
         ocp_version = version.rstrip("-ga")
@@ -1077,6 +1077,128 @@ def expose_ocp_version(version):
         return get_latest_ocp_version(f"{channel}-{ocp_version}", index)
     else:
         return version
+
+
+def get_nightly_release_info(version):
+    """
+    Get full release information for a nightly build including pullSpec.
+
+    Args:
+        version (str): Nightly version string (e.g., 4.22.0-0.nightly or
+                      4.22.0-0.nightly-2026-04-18-162844)
+
+    Returns:
+        dict: Release information including 'name', 'pullSpec', 'downloadURL', etc.
+              Returns None if unable to fetch the information.
+
+    """
+    if "nightly" not in version:
+        return None
+
+    # Extract the stream name (e.g., "4.22.0-0.nightly") from full version
+    # The API expects just the stream name, not the full timestamp version
+    if ".nightly" in version:
+        stream_name = version.split(".nightly")[0] + ".nightly"
+    else:
+        # Shouldn't happen, but handle it gracefully
+        stream_name = version
+
+    try:
+        latest_nightly_url = (
+            f"https://amd64.ocp.releases.ci.openshift.org/api/v1/"
+            f"releasestream/{stream_name}/latest"
+        )
+        log.debug(f"Fetching nightly release info from: {latest_nightly_url}")
+        version_url_content = get_url_content(latest_nightly_url)
+        release_info = json.loads(version_url_content)
+        log.debug(
+            f"Retrieved release info: name={release_info.get('name')}, "
+            f"pullSpec={release_info.get('pullSpec')}"
+        )
+        return release_info
+    except Exception as e:
+        log.warning(f"Failed to get nightly release info for {version}: {e}")
+        return None
+
+
+def download_ga_oc_client_as_bootstrap(bin_dir, target_version):
+    """
+    Download a GA oc client as bootstrap to enable extraction from pullSpec.
+
+    This function downloads a GA version of the oc client (potentially N-1 or N-2)
+    to use as a bootstrap client for extracting the correct nightly version from
+    the release image pullSpec.
+
+    Args:
+        bin_dir (str): Directory to download the client to
+        target_version (str): Target version to determine which GA version to use
+
+    Returns:
+        bool: True if successfully downloaded a bootstrap client, False otherwise
+
+    """
+    log.info(
+        "Attempting to download a GA oc client as bootstrap for nightly extraction"
+    )
+
+    version_major_minor = str(
+        version_module.get_semantic_version(target_version, only_major_minor=True)
+    )
+
+    previous_dir = os.getcwd()
+    os.chdir(bin_dir)
+    tarball = "openshift-client-bootstrap.tar.gz"
+
+    try:
+        # Try to download N, N-1, or N-2 GA version
+        for current_version_count in range(3):
+            previous_version = version_module.get_previous_version(
+                version_major_minor, current_version_count
+            )
+            log.debug(
+                f"Checking if version {previous_version} (offset {current_version_count}) is GA'ed"
+            )
+
+            if is_ocp_version_gaed(previous_version):
+                log.info(
+                    f"Version {previous_version} is GA'ed, downloading as bootstrap client"
+                )
+                # Temporarily set URL template for GA version
+                original_template = config.DEPLOYMENT.get("ocp_url_template")
+                config.DEPLOYMENT["ocp_url_template"] = (
+                    "https://mirror.openshift.com/pub/openshift-v4/clients/"
+                    "ocp/{version}/{file_name}-{os_type}-{version}.tar.gz"
+                )
+
+                try:
+                    ga_version = expose_ocp_version(f"{previous_version}-ga")
+                    url = get_openshift_mirror_url("openshift-client", ga_version)
+                    download_file(url, tarball)
+                    run_cmd(f"tar xzvf {tarball} oc kubectl")
+                    delete_file(tarball)
+                    log.info(
+                        f"Successfully downloaded GA oc client {ga_version} as bootstrap"
+                    )
+                    return True
+                except Exception as e:
+                    log.warning(
+                        f"Failed to download GA version {ga_version} as bootstrap: {e}"
+                    )
+                finally:
+                    # Restore original template
+                    if original_template:
+                        config.DEPLOYMENT["ocp_url_template"] = original_template
+                    else:
+                        config.DEPLOYMENT.pop("ocp_url_template", None)
+
+        log.warning("Could not find any GA'ed version to use as bootstrap")
+        return False
+
+    except Exception as e:
+        log.error(f"Failed to download bootstrap GA oc client: {e}")
+        return False
+    finally:
+        os.chdir(previous_dir)
 
 
 @retry(CommandFailed, tries=2, delay=5, backoff=2)
@@ -1416,24 +1538,92 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
         os.chdir(bin_dir)
 
         tarball = "openshift-client.tar.gz"
-        try:
-            url = get_openshift_mirror_url("openshift-client", version)
-            download_file(url, tarball)
-            run_cmd(f"tar xzvf {tarball} oc kubectl")
-            delete_file(tarball)
-        except Exception as e:
-            log.error(f"Failed to download the openshift client. Exception '{e}'")
-            # check given version is GA'ed or not
-            if "nightly" in version:
-                get_nightly_oc_via_ga(version, tarball)
+        download_successful = False
+
+        # For nightly builds, try pullSpec extraction first (more reliable than downloadURL)
+        if "nightly" in version and not custom_ocp_image:
+            log.info(
+                "Nightly build detected. Attempting to download via pullSpec "
+                "(more reliable than downloadURL extraction)."
+            )
+            release_info = get_nightly_release_info(version)
+
+            if release_info and release_info.get("pullSpec"):
+                pullspec = release_info["pullSpec"]
+                log.info(f"Using pullSpec: {pullspec}")
+
+                # Check if oc client exists to perform extraction
+                if not client_exist and not backup_created:
+                    log.info(
+                        "No existing oc client found. Downloading GA version as bootstrap "
+                        "to enable extraction from pullSpec."
+                    )
+                    if download_ga_oc_client_as_bootstrap(bin_dir, version):
+                        log.info("Bootstrap GA oc client downloaded successfully.")
+                    else:
+                        log.warning(
+                            "Failed to download bootstrap GA client. "
+                            "Will try downloadURL method as fallback."
+                        )
+
+                # Now try to extract from pullSpec using the available oc (existing or bootstrap)
+                if os.path.isfile(client_binary_path):
+                    try:
+                        log.info(f"Extracting oc client from pullSpec: {pullspec}")
+                        extract_ocp_binary_from_image("oc", pullspec, bin_dir)
+                        # Also extract kubectl
+                        try:
+                            extract_ocp_binary_from_image("kubectl", pullspec, bin_dir)
+                        except Exception as kubectl_ex:
+                            log.warning(
+                                f"Failed to extract kubectl from pullSpec, "
+                                f"will create symlink later: {kubectl_ex}"
+                            )
+                        download_successful = True
+                        log.info(
+                            "Successfully extracted oc client from pullSpec "
+                            "(avoids downloadURL timeout issues)."
+                        )
+                    except Exception as e:
+                        log.warning(
+                            f"Failed to extract oc client from pullSpec: {e}. "
+                            "Falling back to downloadURL method."
+                        )
+            else:
+                log.warning(
+                    "Could not retrieve pullSpec from release stream. "
+                    "Falling back to downloadURL method."
+                )
+
+        # If pullSpec extraction wasn't attempted or failed, try traditional downloadURL method
+        if not download_successful:
+            try:
+                url = get_openshift_mirror_url("openshift-client", version)
+                download_file(url, tarball)
+                run_cmd(f"tar xzvf {tarball} oc kubectl")
+                delete_file(tarball)
+                download_successful = True
+            except Exception as e:
+                log.error(f"Failed to download the openshift client. Exception '{e}'")
+                # check given version is GA'ed or not
+                if "nightly" in version:
+                    get_nightly_oc_via_ga(version, tarball)
+                    # Check if get_nightly_oc_via_ga succeeded
+                    if os.path.isfile(client_binary_path):
+                        download_successful = True
 
         if custom_ocp_image and not skip_if_client_downloaded_from_installer:
             extract_ocp_binary_from_image("oc", custom_ocp_image, bin_dir)
+        # Verify the downloaded/extracted client works
+        client_version_valid = False
         try:
             client_version = run_cmd(f"{client_binary_path} version --client")
+            client_version_valid = True
         except CommandFailed:
             log.error("Unable to get version from downloaded client.")
-        if client_version:
+
+        if client_version_valid:
+            # Download/extraction successful - clean up backups
             try:
                 delete_file(client_binary_backup)
                 delete_file(kubectl_binary_backup)
@@ -1441,15 +1631,57 @@ def get_openshift_client(version=None, bin_dir=None, force_download=False):
             except FileNotFoundError:
                 pass
         else:
+            # Download/extraction failed - handle fallback
+            log.warning(
+                "Failed to download/extract the correct oc client version. "
+                "Attempting fallback strategies."
+            )
+
             if backup_created:
+                # Restore the backup (previous version)
                 os.rename(client_binary_backup, client_binary_path)
                 os.rename(kubectl_binary_backup, kubectl_binary_path)
-                log.info("Restored backup binaries to their original location.")
+                log.warning(
+                    "Restored previous oc client version. Continuing with existing client "
+                    "to avoid deployment failure. NOTE: Version mismatch may cause issues."
+                )
+                try:
+                    client_version = run_cmd(f"{client_binary_path} version --client")
+                except CommandFailed:
+                    client_version = "unknown (restored from backup)"
+            elif os.path.isfile(client_binary_path):
+                # We have a bootstrap client from download_ga_oc_client_as_bootstrap
+                log.warning(
+                    "Using bootstrap GA oc client. Continuing with bootstrap client "
+                    "to avoid deployment failure. NOTE: Version mismatch may cause issues."
+                )
+                try:
+                    client_version = run_cmd(f"{client_binary_path} version --client")
+                except CommandFailed:
+                    client_version = "unknown (bootstrap)"
             else:
-                if not use_system_available_client_and_kubectl(
+                # Try to use system available client as last resort
+                if use_system_available_client_and_kubectl(
                     client_binary_path, kubectl_binary_path
                 ):
-                    raise FileNotFoundError("No system oc client exist to copy from!")
+                    log.warning(
+                        "Using system-available oc client as last resort. "
+                        "NOTE: Version mismatch may cause issues."
+                    )
+                    try:
+                        client_version = run_cmd(
+                            f"{client_binary_path} version --client"
+                        )
+                    except CommandFailed:
+                        client_version = "unknown (system)"
+                else:
+                    log.error(
+                        "All oc client download methods failed and no fallback available."
+                    )
+                    raise FileNotFoundError(
+                        "Failed to download oc client and no fallback available!"
+                    )
+
         if not os.path.exists("kubectl"):
             log.info("Creating kubectl link to oc binary.")
             os.link("oc", "kubectl")


### PR DESCRIPTION
When deploying with nightly OCP builds, get_openshift_client() was failing to download the matching nightly oc client due to downloadURL timeouts ("Extracting tools..." hangs), silently falling back to the latest GA version. This version mismatch caused cluster deployments to fail, particularly for STS/Manual CCO mode on AWS and Azure where critical fixes in the nightly oc were needed.

This commit implements a more reliable download strategy:

1. For nightly builds, use pullSpec extraction via 'oc adm release extract --command=oc' instead of relying on the downloadURL which frequently times out

2. Solve the chicken-and-egg problem (need oc to extract oc) by:
   - Using existing oc client if available, or
   - Downloading a GA version (N, N-1, or N-2) as bootstrap

3. Add multiple fallback layers:
   - pullSpec extraction (new, most reliable)
   - downloadURL extraction (existing method)
   - get_nightly_oc_via_ga (existing fallback)
   - Keep bootstrap/backup client if all downloads fail

4. Refactor expose_ocp_version() to use new get_nightly_release_info() helper to avoid code duplication

Changes:
- Add get_nightly_release_info() to fetch release stream API data
- Add download_ga_oc_client_as_bootstrap() for bootstrap client
- Modify get_openshift_client() to try pullSpec extraction first
- Improve error handling and logging for download failures

Benefits:
- More reliable: pullSpec extraction avoids downloadURL timeouts
- Better error handling: multiple fallback strategies
- Correct version: ensures nightly oc matches nightly OCP build
- No total failure: gracefully degrades rather than failing deployment

Fixes: #14941