### PR TITLE
adding skip and mandatory encryption parameter

### DIFF
--- a/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
+++ b/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     system_test,
     magenta_squad,
     ignore_leftovers,
+    encryption_at_rest_required,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.helpers.keyrotation_helper import (
@@ -23,6 +24,7 @@ log = logging.getLogger(__name__)
 @magenta_squad
 @system_test
 @ignore_leftovers
+@encryption_at_rest_required
 class TestKeyRotationWithClusterFull(E2ETest):
     @pytest.fixture(autouse=True)
     def init_sanity(self):

--- a/tests/cross_functional/system_test/test_graceful_nodes_shutdown.py
+++ b/tests/cross_functional/system_test/test_graceful_nodes_shutdown.py
@@ -30,6 +30,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_no_kms,
     skipif_ocs_version,
     magenta_squad,
+    jira,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.node import get_nodes, wait_for_nodes_status
@@ -38,6 +39,7 @@ from ocs_ci.ocs.resources.fips import check_fips_enabled
 logger = logging.getLogger(__name__)
 
 
+@jira("OCPBUGS-58027")
 class TestGracefulNodesShutdown(E2ETest):
     """
     Test uncorrupted data and operational cluster after graceful nodes shutdown


### PR DESCRIPTION
Adding skip for graceful node shutdown testcase due to active OCP bug and adding mandate param ENCRYPTON_AT_REST for cluster wide key rotation