### PR TITLE
mirror ceph-volsync-plugin-operator for disconnected 4.22 deployment

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2583,9 +2583,7 @@ DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.21"] = (
 DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION[
     "4.22"
 ] = DISCON_CL_REQUIRED_PACKAGES_PER_ODF_VERSION["4.20"] + [
-    # disabling mirroring of ceph-volsync-plugin-operator because of
-    # https://redhat.atlassian.net/browse/DFBUGS-6114
-    # "ceph-volsync-plugin-operator",
+    "ceph-volsync-plugin-operator",
 ]
 
 # PSI-openstack constants


### PR DESCRIPTION
Related to fixed [DFBUGS-6114](https://url.corp.redhat.com/ef9e1d6).