### PR TITLE
Fix PVC clone and expand submit UI locators

### DIFF
--- a/ocs_ci/ocs/ui/pvc_ui.py
+++ b/ocs_ci/ocs/ui/pvc_ui.py
@@ -3,7 +3,6 @@ import time
 
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.helpers_ui import format_locator
-from ocs_ci.ocs.ui.views import generic_locators
 from ocs_ci.utility.utils import get_running_ocp_version
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ui.helpers_ui import get_element_type
@@ -334,4 +333,4 @@ class PvcUI(PageNavigator):
             self.do_click(self.pvc_loc[cloned_pvc_access_mode])
 
         logger.info("Click on Clone button")
-        self.do_click(generic_locators["confirm_action"], enable_screenshot=True)
+        self.do_click(self.pvc_loc["clone-btn"], enable_screenshot=True)

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -675,11 +675,18 @@ pvc = {
     "search_pvc": ('input[data-test-id="item-filter"]', By.CSS_SELECTOR),
     "clone_pvc": ("button[data-test-action='Clone PVC']", By.CSS_SELECTOR),
     "clone_name_input": ("//input[@aria-label='Clone PVC']", By.XPATH),
+    "clone-btn": (
+        'button[form="clone-pvc-form"], button[data-test="confirm-action"], #confirm-action',
+        By.CSS_SELECTOR,
+    ),
     "search-project": ("input[placeholder='Select project...']", By.CSS_SELECTOR),
     "test-project-link": ("//a[normalize-space()='{}']", By.XPATH),
     "expand_pvc": ("button[data-test-action='Expand PVC']", By.CSS_SELECTOR),
     "resize-value": ("//input[@name='requestSizeValue']", By.XPATH),
-    "expand-btn": ("#confirm-action", By.CSS_SELECTOR),
+    "expand-btn": (
+        'button[form="expand-pvc-form"], button[data-test="confirm-action"], #confirm-action',
+        By.CSS_SELECTOR,
+    ),
     "pvc-status": (
         "dd[data-test-id='pvc-status'] span[data-test='status-text']",
         By.CSS_SELECTOR,


### PR DESCRIPTION
This PR fixes PVC UI failures in Clone and Expand flows after console button markup changes.
Also, update clone flow to use dedicated locator instead of generic locator.