### PR TITLE
destroy OIDC provider on ROSA HCP. Adjust the flow.

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -164,6 +164,20 @@ class ROSAOCP(BaseOCPDeployment):
                     return
                 raise
             subnet_ids = aws.get_cluster_subnet_ids(cluster_name=self.cluster_name)
+            oidc_endpoint_url = None
+            if rosa_hcp:
+                try:
+                    auth = ocp.OCP().exec_oc_cmd(
+                        "get authentication cluster "
+                        "-o jsonpath='{.spec.serviceAccountIssuer}'"
+                    )
+                    oidc_endpoint_url = str(auth).strip()
+                    logger.info(f"Pre-fetched OIDC endpoint URL: {oidc_endpoint_url}")
+                except Exception as e:
+                    logger.warning(
+                        f"Could not pre-fetch OIDC endpoint URL, will retry during "
+                        f"cleanup if cluster is still reachable: {e}"
+                    )
             log_step(f"Destroying ROSA cluster. Hosted CP: {rosa_hcp}")
             delete_status = rosa.destroy_appliance_mode_cluster(self.cluster_name)
             if not delete_status:
@@ -190,8 +204,11 @@ class ROSAOCP(BaseOCPDeployment):
                 if oidc_config_id:
                     rosa.delete_oidc_config(oidc_config_id)
                 # use sts IAM roles for ROSA HCP is mandatory
-                delete_sts_iam_roles()
-                delete_subnet_tags(f"kubernetes.io/cluster/{cluster_id}", subnet_ids)
+                delete_sts_iam_roles(oidc_endpoint_url=oidc_endpoint_url)
+                if subnet_ids:
+                    delete_subnet_tags(
+                        f"kubernetes.io/cluster/{cluster_id}", *subnet_ids
+                    )
             rosa.delete_oidc_provider(self.cluster_name)
             account_roles_prefix = (
                 f"{constants.ACCOUNT_ROLE_PREFIX_ROSA_HCP}-{self.cluster_name}"

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2240,7 +2240,13 @@ class AWS(object):
             )
             logger.info(f"Deleted OIDC provider: {oidc_provider_arn}")
         except Exception as e:
-            logger.error(f"Error deleting OIDC provider: {e}")
+            if "NoSuchEntity" in str(e):
+                logger.warning(
+                    f"OIDC provider {oidc_provider_arn} not found — "
+                    "likely already deleted by rosa delete oidc-config"
+                )
+            else:
+                logger.error(f"Error deleting OIDC provider: {e}")
 
     def cleanup_oidc_providers_by_prefix(self, url_prefix):
         """
@@ -2927,9 +2933,16 @@ def create_and_attach_sts_role():
     return role_data
 
 
-def delete_sts_iam_roles():
+def delete_sts_iam_roles(oidc_endpoint_url=None):
     """
     Delete IAM roles for the cluster.
+
+    Args:
+        oidc_endpoint_url (str): Optional OIDC endpoint URL (serviceAccountIssuer)
+            pre-fetched while the cluster API was still reachable. When provided,
+            the cluster API is not contacted. When None, the function attempts to
+            retrieve the URL from the live cluster; if the cluster is already
+            unreachable the OIDC provider deletion is skipped with a warning.
     """
     logger.info("Deleting STS IAM Roles")
     cluster_path = config.ENV_DATA["cluster_path"]
@@ -2955,11 +2968,22 @@ def delete_sts_iam_roles():
                 role_name, instance_profile["InstanceProfileName"]
             )
         aws.delete_iam_role(role_name)
-    auth_cluster = exec_cmd("oc get authentication cluster -o json")
-    auth_cluster_dict = json.loads(auth_cluster.stdout)
-    oidc_provider_name = auth_cluster_dict["spec"]["serviceAccountIssuer"].replace(
-        "https://", ""
-    )
+
+    if oidc_endpoint_url is None:
+        auth_cluster = exec_cmd(
+            "oc get authentication cluster -o json", ignore_error=True
+        )
+        if auth_cluster.returncode != 0:
+            logger.warning(
+                "Could not retrieve authentication cluster info — cluster API is "
+                "unreachable and no oidc_endpoint_url was pre-fetched. "
+                "Skipping OIDC provider deletion."
+            )
+            return
+        auth_cluster_dict = json.loads(auth_cluster.stdout)
+        oidc_endpoint_url = auth_cluster_dict["spec"]["serviceAccountIssuer"]
+
+    oidc_provider_name = oidc_endpoint_url.replace("https://", "")
     aws.delete_oidc_provider(provider_name=oidc_provider_name)
 
 


### PR DESCRIPTION
  rosa.py:destroy() — before issuing the cluster delete command, while the cluster API is still guaranteed reachable, fetches the OIDC endpoint URL via oc get authentication        
  cluster. Stored in oidc_endpoint_url (or None if the fetch fails for any reason). Passed to delete_sts_iam_roles().                                                                
                                                                                                                                                                                     
  aws.py:delete_sts_iam_roles(oidc_endpoint_url=None) — now accepts the pre-fetched URL:
  - If oidc_endpoint_url is provided → skips the oc call entirely, uses the pre-fetched value, OIDC provider is always deleted
  - If oidc_endpoint_url is None (not pre-fetched, or called from non-ROSA paths) → falls back to the live oc get authentication cluster call with ignore_error=True, warns and skips
   only if truly unreachable
   
   Bypass the problem with **leftovers**: 
   
   ```
   INFO  - Deleting IAM role: dosypenk-264r
2026-04-26 16:15:42  09:15:42 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get authentication cluster -o json
2026-04-26 16:15:42  09:15:42 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Unable to connect to the server: dial tcp: lookup api.dosypenk-264r.w53c.s3.devshift.org on 10.11.5.160:53: no such host
2026-04-26 16:15:42  
2026-04-26 16:15:43  
2026-04-26 16:15:43  _ 1 of 1 completed, 1 Pass, 0 Fail, 0 Skip, 0 XPass, 0 XFail, 0 Error, 0 ReRun _
2026-04-26 16:15:43  09:15:42 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/functional/deployment/test_deployment.py::test_deployment immediately after test execution: 1514.66
2026-04-26 16:15:43  
2026-04-26 16:15:43  tests/functional/deployment/test_deployment.py::test_deployment ERROR
2026-04-26 16:15:43  _____________________ ERROR at teardown of test_deployment _____________________
2026-04-26 16:15:43  
2026-04-26 16:15:43      def cluster_teardown_finalizer():
2026-04-26 16:15:43          # If KMS is configured, clean up the backend resources
2026-04-26 16:15:43          # we are doing it before OCP cleanup
2026-04-26 16:15:43          if ocsci_config.DEPLOYMENT.get("kms_deployment"):
2026-04-26 16:15:43              try:
2026-04-26 16:15:43                  kms = KMS.get_kms_deployment()
2026-04-26 16:15:43                  kms.cleanup()
2026-04-26 16:15:43              except Exception as ex:
2026-04-26 16:15:43                  log.error(f"Failed to cleanup KMS. Exception is: {ex}")
2026-04-26 16:15:43          if ocsci_config.MULTICLUSTER.get("acm_cluster"):
2026-04-26 16:15:43              try:
2026-04-26 16:15:43                  from ocs_ci.utility.aws import AWS
2026-04-26 16:15:43      
2026-04-26 16:15:43                  thanos_bucket_name = (
2026-04-26 16:15:43                      f"dr-thanos-bucket-{config.ENV_DATA['cluster_name']}"
2026-04-26 16:15:43                  )
2026-04-26 16:15:43                  AWS().delete_bucket(thanos_bucket_name)
2026-04-26 16:15:43              except Exception as ex:
2026-04-26 16:15:43                  log.error(
2026-04-26 16:15:43                      f"Either failed to delete bucket or bucket doesn't exist {ex}"
2026-04-26 16:15:43                  )
2026-04-26 16:15:43  >       deployer.destroy_cluster(log_cli_level)
2026-04-26 16:15:43  
2026-04-26 16:15:43  tests/conftest.py:2120: 
2026-04-26 16:15:43  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-04-26 16:15:43  ocs_ci/deployment/deployment.py:2223: in destroy_cluster
2026-04-26 16:15:43      self.ocp_deployment.destroy(log_level)
2026-04-26 16:15:43  ocs_ci/deployment/rosa.py:193: in destroy
2026-04-26 16:15:43      delete_sts_iam_roles()
2026-04-26 16:15:43  ocs_ci/utility/aws.py:2786: in delete_sts_iam_roles
2026-04-26 16:15:43      auth_cluster = exec_cmd("oc get authentication cluster -o json")
2026-04-26 16:15:43  ocs_ci/utility/retry.py:79: in f_retry
2026-04-26 16:15:43      return f(*args, **kwargs)
2026-04-26 16:15:43  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-04-26 16:15:43  
2026-04-26 16:15:43  cmd = ['oc', '--kubeconfig', '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig', 'get', 'authentication', 'cluster', ...]
2026-04-26 16:15:43  secrets = None, timeout = 600, ignore_error = False, threading_lock = None
2026-04-26 16:15:43  silent = False, use_shell = False, cluster_config = None, lock_timeout = 7200
2026-04-26 16:15:43  output_file = None, kwargs = {}
2026-04-26 16:15:43  _env = {'ANTHROPIC_VERTEX_PROJECT_ID': 'itpc-gcp-core-pe-eng-claude', 'BASH_FUNC_which%%': '() {  ( alias;\n eval ${which_dec...ead-functions --show-tilde --show-dot $@\n}', 'BUILD_DISPLAY_NAME': '#76400 - dosypenk-264r', 'BUILD_ID': '76400', ...}
2026-04-26 16:15:43  kubeconfig_path = '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig'
2026-04-26 16:15:43  kube_index = 1, plugin_list = 'oc plugin list'
2026-04-26 16:15:43  cp = CompletedProcess(args=['oc', 'plugin', 'list'], returncode=1, stdout=b'', stderr=b'error: unable to find any kubectl plugins in your PATH\n')
2026-04-26 16:15:43  subcmd = 'get'
2026-04-26 16:15:43  
2026-04-26 16:15:43      @retry(
2026-04-26 16:15:43          CommandFailed,
2026-04-26 16:15:43          tries=6,
2026-04-26 16:15:43          delay=10,
2026-04-26 16:15:43          backoff=1,
2026-04-26 16:15:43          text_in_exception="client connection lost",
2026-04-26 16:15:43      )
2026-04-26 16:15:43      def exec_cmd(
2026-04-26 16:15:43          cmd,
2026-04-26 16:15:43          secrets=None,
2026-04-26 16:15:43          timeout=600,
2026-04-26 16:15:43          ignore_error=False,
2026-04-26 16:15:43          threading_lock=None,
2026-04-26 16:15:43          silent=False,
2026-04-26 16:15:43          use_shell=False,
2026-04-26 16:15:43          cluster_config=None,
2026-04-26 16:15:43          lock_timeout=7200,
2026-04-26 16:15:43          output_file=None,
2026-04-26 16:15:43          **kwargs,
2026-04-26 16:15:43      ):
2026-04-26 16:15:43          """
2026-04-26 16:15:43          Run an arbitrary command locally
2026-04-26 16:15:43      
2026-04-26 16:15:43          If the command is grep and matching pattern is not found, then this function
2026-04-26 16:15:43          returns "command terminated with exit code 1" in stderr.
2026-04-26 16:15:43      
2026-04-26 16:15:43          Args:
2026-04-26 16:15:43              cmd (str): command to run
2026-04-26 16:15:43              secrets (list): A list of secrets to be masked with asterisks
2026-04-26 16:15:43                  This kwarg is popped in order to not interfere with
2026-04-26 16:15:43                  subprocess.run(``**kwargs``)
2026-04-26 16:15:43              timeout (int): Timeout for the command, defaults to 600 seconds.
2026-04-26 16:15:43              ignore_error (bool): True if ignore non zero return code and do not
2026-04-26 16:15:43                  raise the exception.
2026-04-26 16:15:43              threading_lock (threading.RLock): threading.RLock object that is used
2026-04-26 16:15:43                  for handling concurrent oc commands
2026-04-26 16:15:43              silent (bool): If True will silent errors from the server, default false
2026-04-26 16:15:43              use_shell (bool): If True will pass the cmd without splitting
2026-04-26 16:15:43              cluster_config (MultiClusterConfig): In case of multicluster environment this object
2026-04-26 16:15:43                      will be non-null
2026-04-26 16:15:43              lock_timeout (int): maximum timeout to wait for lock to prevent deadlocks (default 2 hours)
2026-04-26 16:15:43              output_file (str): path where to write output of stderr from command - apply only when silent mode is True
2026-04-26 16:15:43      
2026-04-26 16:15:43          Raises:
2026-04-26 16:15:43              CommandFailed: In case the command execution fails
2026-04-26 16:15:43      
2026-04-26 16:15:43          Returns:
2026-04-26 16:15:43              (CompletedProcess) A CompletedProcess object of the command that was executed
2026-04-26 16:15:43              CompletedProcess attributes:
2026-04-26 16:15:43              args: The list or str args passed to run().
2026-04-26 16:15:43              returncode (str): The exit code of the process, negative for signals.
2026-04-26 16:15:43              stdout     (str): The standard output (None if not captured).
2026-04-26 16:15:43              stderr     (str): The standard error (None if not captured).
2026-04-26 16:15:43      
2026-04-26 16:15:43          """
2026-04-26 16:15:43          _env = kwargs.pop("env", os.environ.copy())
2026-04-26 16:15:43          kubeconfig_path = config.RUN.get("kubeconfig")
2026-04-26 16:15:43          if kubeconfig_path:
2026-04-26 16:15:43              _env["KUBECONFIG"] = kubeconfig_path
2026-04-26 16:15:43          if cluster_config:
2026-04-26 16:15:43              kubeconfig_path = cluster_config.RUN.get("kubeconfig")
2026-04-26 16:15:43              if kubeconfig_path:
2026-04-26 16:15:43                  _env["KUBECONFIG"] = cluster_config.RUN.get("kubeconfig")
2026-04-26 16:15:43          if isinstance(cmd, str) and not kwargs.get("shell"):
2026-04-26 16:15:43              cmd = shlex.split(cmd)
2026-04-26 16:15:43          if (
2026-04-26 16:15:43              kubeconfig_path
2026-04-26 16:15:43              and cmd[0] == "oc"
2026-04-26 16:15:43              and "--kubeconfig" not in cmd
2026-04-26 16:15:43              and "mirror" not in cmd
2026-04-26 16:15:43          ):
2026-04-26 16:15:43              kube_index = 1
2026-04-26 16:15:43              # check if we have an oc plugin in the command
2026-04-26 16:15:43              plugin_list = "oc plugin list"
2026-04-26 16:15:43              cp = subprocess.run(
2026-04-26 16:15:43                  shlex.split(plugin_list),
2026-04-26 16:15:43                  stdout=subprocess.PIPE,
2026-04-26 16:15:43                  stderr=subprocess.PIPE,
2026-04-26 16:15:43              )
2026-04-26 16:15:43              subcmd = cmd[1].split("-")
2026-04-26 16:15:43              if len(subcmd) > 1:
2026-04-26 16:15:43                  subcmd = "_".join(subcmd)
2026-04-26 16:15:43              if not isinstance(subcmd, str) and isinstance(subcmd, list):
2026-04-26 16:15:43                  subcmd = str(subcmd[0])
2026-04-26 16:15:43      
2026-04-26 16:15:43              for l in cp.stdout.decode().splitlines():
2026-04-26 16:15:43                  if subcmd in l:
2026-04-26 16:15:43                      # If oc cmdline has plugin name then we need to push the
2026-04-26 16:15:43                      # --kubeconfig to next index
2026-04-26 16:15:43                      kube_index = 2
2026-04-26 16:15:43                      log.info(f"Found oc plugin {subcmd}")
2026-04-26 16:15:43              cmd = list_insert_at_position(cmd, kube_index, ["--kubeconfig"])
2026-04-26 16:15:43              cmd = list_insert_at_position(cmd, kube_index + 1, [kubeconfig_path])
2026-04-26 16:15:43          try:
2026-04-26 16:15:43              if kwargs.get("shell"):
2026-04-26 16:15:43                  masked_cmd = mask_secrets(cmd, secrets)
2026-04-26 16:15:43              else:
2026-04-26 16:15:43                  masked_cmd = shlex.join(mask_secrets(cmd, secrets))
2026-04-26 16:15:43              log.info(f"Executing command: {masked_cmd}")
2026-04-26 16:15:43              if threading_lock and cmd[0] == "oc":
2026-04-26 16:15:43                  threading_lock.acquire(timeout=lock_timeout)
2026-04-26 16:15:43              completed_process = subprocess.run(
2026-04-26 16:15:43                  cmd,
2026-04-26 16:15:43                  stdout=subprocess.PIPE,
2026-04-26 16:15:43                  stderr=subprocess.PIPE,
2026-04-26 16:15:43                  stdin=subprocess.PIPE,
2026-04-26 16:15:43                  timeout=timeout,
2026-04-26 16:15:43                  env=_env,
2026-04-26 16:15:43                  **kwargs,
2026-04-26 16:15:43              )
2026-04-26 16:15:43          finally:
2026-04-26 16:15:43              if threading_lock and cmd[0] == "oc":
2026-04-26 16:15:43                  threading_lock.release()
2026-04-26 16:15:43          masked_stdout = mask_secrets(completed_process.stdout.decode(), secrets)
2026-04-26 16:15:43          if len(completed_process.stdout) > 0:
2026-04-26 16:15:43              log.debug(f"Command stdout: {masked_stdout}")
2026-04-26 16:15:43          else:
2026-04-26 16:15:43              log.debug("Command stdout is empty")
2026-04-26 16:15:43      
2026-04-26 16:15:43          masked_stderr = mask_secrets(completed_process.stderr.decode(), secrets)
2026-04-26 16:15:43          if len(completed_process.stderr) > 0:
2026-04-26 16:15:43              if not silent:
2026-04-26 16:15:43                  log.warning(f"Command stderr: {masked_stderr}")
2026-04-26 16:15:43              else:
2026-04-26 16:15:43                  if output_file:
2026-04-26 16:15:43                      with open(output_file, "a") as out_fd:
2026-04-26 16:15:43                          out_fd.write(masked_stderr)
2026-04-26 16:15:43          else:
2026-04-26 16:15:43              if not silent:
2026-04-26 16:15:43                  log.debug("Command stderr is empty")
2026-04-26 16:15:43          log.debug(f"Command return code: {completed_process.returncode}")
2026-04-26 16:15:43          if completed_process.returncode and not ignore_error:
2026-04-26 16:15:43              masked_stderr = bin_xml_escape(filter_out_emojis(masked_stderr))
2026-04-26 16:15:43              if (
2026-04-26 16:15:43                  "grep" in masked_cmd
2026-04-26 16:15:43                  and b"command terminated with exit code 1" in completed_process.stderr
2026-04-26 16:15:43              ):
2026-04-26 16:15:43                  log.info(f"No results found for grep command: {masked_cmd}")
2026-04-26 16:15:43              else:
2026-04-26 16:15:43  >               raise CommandFailed(
2026-04-26 16:15:43                      f"Error during execution of command: {masked_cmd}."
2026-04-26 16:15:43                      f"\nError is {masked_stderr}"
2026-04-26 16:15:43                  )
2026-04-26 16:15:43  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get authentication cluster -o json.
2026-04-26 16:15:43  E               Error is Unable to connect to the server: dial tcp: lookup api.dosypenk-264r.w53c.s3.devshift.org on 10.11.5.160:53: no such host
2026-04-26 16:15:43  
2026-04-26 16:15:43  ocs_ci/utility/utils.py:738: CommandFailed
```