### PR TITLE
[release-4.21] change default openshift_install_timeout to 2 hours

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -231,7 +231,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -241,7 +241,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 27,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -251,7 +251,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -261,7 +261,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -271,7 +271,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 27,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -281,7 +281,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -291,7 +291,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 29,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -301,7 +301,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -311,7 +311,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w_encryption_azure_kv.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w_encryption_azure_kv.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
   kms_deployment: true
 ENV_DATA:
@@ -22,4 +21,3 @@ ENV_DATA:
 REPORTING:
   polarion:
     deployment_id: 'OCS-5798'
-

--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w_perfplus.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w_perfplus.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_1az_rhcos_3m_3w_perfplus_standard_ssd.yaml
+++ b/conf/deployment/azure/ipi_1az_rhcos_3m_3w_perfplus_standard_ssd.yaml
@@ -2,7 +2,6 @@
 # Azure Performance Plus with Standard SSD (StandardSSD_LRS)
 # For disks 513 GiB or larger. Use when Standard SSD + Performance Plus is required.
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_3az_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_3az_rhcos_3m_3w_perfplus.yaml
+++ b/conf/deployment/azure/ipi_3az_rhcos_3m_3w_perfplus.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_3az_rhcos_3m_3w_perfplus_standard_ssd.yaml
+++ b/conf/deployment/azure/ipi_3az_rhcos_3m_3w_perfplus_standard_ssd.yaml
@@ -2,7 +2,6 @@
 # Azure Performance Plus with Standard SSD (StandardSSD_LRS)
 # For disks 513 GiB or larger. Use when Standard SSD + Performance Plus is required.
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'azure'

--- a/conf/deployment/azure/ipi_3az_rhcos_sts_3m_3w.yaml
+++ b/conf/deployment/azure/ipi_3az_rhcos_sts_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
   sts_enabled: true
   subscription_plan_approval: "Manual"

--- a/conf/deployment/azure/managed_aro_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/managed_aro_3az_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
   use_custom_ingress_ssl_cert: true
   use_custom_api_ssl_cert: true

--- a/conf/deployment/azure/managed_aro_germanywestcentral_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/azure/managed_aro_germanywestcentral_3az_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
   use_custom_ingress_ssl_cert: true
   use_custom_api_ssl_cert: true

--- a/conf/deployment/ibmcloud/ipi_1az_rhcos_sno_1m_0w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_rhcos_sno_1m_0w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml
@@ -2,7 +2,6 @@
 # This conifg is for IBM Cloud IPI deployment with custom VPC where we create
 # VPC and network stuff on by own in ocs-ci in us-east (Washington DC).
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml
@@ -2,7 +2,6 @@
 # This conifg is for IBM Cloud IPI deployment with custom VPC where we create
 # VPC and network stuff on by own in ocs-ci in us-south (Dalas).
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_1az_us_south2_rhcos_odf_qe_vpc_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_1az_us_south2_rhcos_odf_qe_vpc_3m_3w.yaml
@@ -2,7 +2,6 @@
 # This conifg is for IBM Cloud IPI deployment with custom VPC where we create
 # VPC and network stuff on by own in ocs-ci in us-south (Dallas).
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
   ocs_operator_nodes_to_label: 6
 ENV_DATA:

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml
+++ b/conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml
@@ -1,6 +1,5 @@
 ---
 DEPLOYMENT:
-  openshift_install_timeout: 4800
   allow_lower_instance_requirements: false
 ENV_DATA:
   platform: 'ibm_cloud'

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -90,7 +90,7 @@ DEPLOYMENT:
   # Following options are defaults for deployment with infra worker nodes
   infra_nodes: False
   # How long should ocs-ci wait for `openshift-install create cluster` run?
-  openshift_install_timeout: 3600
+  openshift_install_timeout: 7200
   # redhat-operators CatalogSource image (used for disconnected installation)
   cs_redhat_operators_image: "registry.redhat.io/redhat/redhat-operator-index"
   # Deployment with KMS (vault etc)


### PR DESCRIPTION
* change default openshift_install_timeout to 2 hours
* rely on default value of openshift_install_timeout parameter

Backport of https://github.com/red-hat-storage/ocs-ci/pull/14910