### PR TITLE
[4.18] Fix NFS CSI pod leftover false positives in `TestBucketCreationAndDeletion`

### DIFF
--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     red_squad,
     mcg,
+    ignore_leftover_label,
 )
 from ocs_ci.ocs.bucket_utils import sync_object_directory
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD, AWSCLI_TEST_OBJ_DIR
@@ -26,6 +27,8 @@ from ocs_ci.framework.pytest_customization.marks import skipif_managed_service
 logger = logging.getLogger(__name__)
 
 
+# Ignore NFS plugin leftovers from a previous test
+@ignore_leftover_label("app=csi-nfsplugin", "app=csi-nfsplugin-provisioner")
 @mcg
 @red_squad
 @runs_on_provider


### PR DESCRIPTION
  ## Summary
  - `test_bucket_creation_deletion[1-OC-PVPOOL]` consistently fails with
    `ResourceLeftoversException` due to `csi-nfsplugin` and
    `csi-nfsplugin-provisioner` pods still terminating from the preceding
    NFS test class
  - This has only been observed in 4.17 and 4.18 — no NFS CSI pod
    leftover failures were found in 4.19 or above launches despite the 
    same test execution order
  - The `environment_checker` fixture is class-scoped, so its finalizer
    runs after the last test in the class — `1-OC-PVPOOL` is always that
    last tier1 parametrization, making it the consistent victim
  - Added `@ignore_leftover_label` with both NFS CSI pod labels to
    `TestBucketCreationAndDeletion` so these transient pods are excluded
    from the PRE/POST environment diff
