### PR TITLE
Add dual-stack (IPv4+IPv6) OCP deployment support for vSphere UPI

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_dual_stack_ipv4_primary.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_dual_stack_ipv4_primary.yaml
@@ -1,0 +1,15 @@
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  dual_stack: true
+  primary_stack: "ipv4"
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_dual_stack_ipv6_primary.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_dual_stack_ipv6_primary.yaml
@@ -1,0 +1,15 @@
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  dual_stack: true
+  primary_stack: "ipv6"
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/conf/ocsci/vsphere_upi_enable_dual_stack_ipv4_primary.yaml
+++ b/conf/ocsci/vsphere_upi_enable_dual_stack_ipv4_primary.yaml
@@ -1,0 +1,3 @@
+DEPLOYMENT:
+  dual_stack: true
+  primary_stack: "ipv4"

--- a/conf/ocsci/vsphere_upi_enable_dual_stack_ipv6_primary.yaml
+++ b/conf/ocsci/vsphere_upi_enable_dual_stack_ipv6_primary.yaml
@@ -1,0 +1,3 @@
+DEPLOYMENT:
+  dual_stack: true
+  primary_stack: "ipv6"

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -119,14 +119,6 @@ logger = logging.getLogger(__name__)
 __all__ = ["VSPHEREUPI", "VSPHEREIPI", "VSPHEREAI", "VSPHEREAgentAI"]
 
 
-def is_dual_stack():
-    return config.DEPLOYMENT.get("dual_stack", False)
-
-
-def is_ipv4_primary():
-    return config.DEPLOYMENT.get("primary_stack", "ipv4") == "ipv4"
-
-
 class VSPHEREBASE(Deployment):
 
     def __init__(self):
@@ -532,7 +524,10 @@ class VSPHEREUPI(VSPHEREBASE):
         self.token = config.ENV_DATA.get("ipam_token")
         self.cidr = config.ENV_DATA.get("machine_cidr")
         self.vm_network = config.ENV_DATA.get("vm_network")
-        if is_dual_stack() and not is_ipv4_primary():
+        if (
+            config.DEPLOYMENT.get("dual_stack")
+            and config.DEPLOYMENT.get("primary_stack") == "ipv6"
+        ):
             self.cidr = config.ENV_DATA.get("machine_cidr_ipv6", self.cidr)
 
     class OCPDeployment(BaseOCPDeployment):
@@ -958,7 +953,7 @@ class VSPHEREUPI(VSPHEREBASE):
             # Inject dual-stack flag into ENV_DATA so Jinja2 template can use it
             config.ENV_DATA["dual_stack"] = config.DEPLOYMENT.get("dual_stack", False)
 
-            if is_dual_stack():
+            if config.DEPLOYMENT.get("dual_stack"):
                 if config.DEPLOYMENT.get("ipv6"):
                     raise UnexpectedDeploymentConfiguration(
                         "Cannot set both 'dual_stack' and 'ipv6'. "
@@ -985,7 +980,10 @@ class VSPHEREUPI(VSPHEREBASE):
                 ]
 
             # Reorder network lists for IPv6-primary dual-stack
-            if is_dual_stack() and not is_ipv4_primary():
+            if (
+                config.DEPLOYMENT.get("dual_stack")
+                and config.DEPLOYMENT.get("primary_stack") == "ipv6"
+            ):
                 networking = install_config_obj["networking"]
                 networking["clusterNetwork"].reverse()
                 networking["machineNetwork"].reverse()
@@ -1112,7 +1110,7 @@ class VSPHEREUPI(VSPHEREBASE):
                 )
                 # Because ignition file for bootstrap in ipv6/dual-stack is too big to be passed by terraform
                 # changing encoding to gzip+base64 instead of plain text.
-                if config.DEPLOYMENT.get("ipv6") or is_dual_stack():
+                if config.DEPLOYMENT.get("ipv6") or config.DEPLOYMENT.get("dual_stack"):
                     bootstrap_ignition_path = os.path.join(
                         config.ENV_DATA["cluster_path"], constants.BOOTSTRAP_IGN
                     )
@@ -2693,16 +2691,14 @@ def clone_openshift_installer():
                     branch="release-4.12",
                 )
             else:
-                if config.DEPLOYMENT.get("dual_stack"):
+                if config.DEPLOYMENT.get("dual_stack") or config.DEPLOYMENT.get("ipv6"):
                     constants.VSPHERE_INSTALLER_REPO = (
                         "https://gitlab.cee.redhat.com/srozen/installer_ipv6.git"
                     )
-                    branch = "dual-stack"
-                elif config.DEPLOYMENT.get("ipv6"):
-                    constants.VSPHERE_INSTALLER_REPO = (
-                        "https://gitlab.cee.redhat.com/srozen/installer_ipv6.git"
-                    )
-                    branch = "master"
+                    if config.DEPLOYMENT.get("dual_stack"):
+                        branch = "dual-stack"
+                    else:
+                        branch = "master"
                 else:
                     branch = f"release-{ocp_version}"
                 clone_repo(
@@ -2846,7 +2842,10 @@ def update_machine_conf(folder_structure=True):
 
     """
     cidr_var = "var.machine_cidr"
-    if is_dual_stack() and not is_ipv4_primary():
+    if (
+        config.DEPLOYMENT.get("dual_stack")
+        and config.DEPLOYMENT.get("primary_stack") == "ipv6"
+    ):
         cidr_var = "var.machine_cidr_ipv6"
 
     if not folder_structure:
@@ -2994,12 +2993,7 @@ def generate_terraform_vars_with_folder():
         config.ENV_DATA["compute_ignition_path"] = compute_ignition_path
 
     # Copy DNS address to vm_dns_addresses
-    if is_dual_stack() and not is_ipv4_primary():
-        config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA.get(
-            "dns_ipv6", config.ENV_DATA["dns"]
-        )
-    else:
-        config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA["dns"]
+    config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA["dns"]
 
     # Get the infra ID from metadata.json and update in ENV_DATA
     metadata_path = os.path.join(config.ENV_DATA["cluster_path"], "metadata.json")

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -119,6 +119,14 @@ logger = logging.getLogger(__name__)
 __all__ = ["VSPHEREUPI", "VSPHEREIPI", "VSPHEREAI", "VSPHEREAgentAI"]
 
 
+def is_dual_stack():
+    return config.DEPLOYMENT.get("dual_stack", False)
+
+
+def is_ipv4_primary():
+    return config.DEPLOYMENT.get("primary_stack", "ipv4") == "ipv4"
+
+
 class VSPHEREBASE(Deployment):
 
     def __init__(self):
@@ -944,6 +952,23 @@ class VSPHEREUPI(VSPHEREBASE):
             ocp_install_template_path = os.path.join(
                 "ocp-deployment", ocp_install_template
             )
+
+            # Inject dual-stack flag into ENV_DATA so Jinja2 template can use it
+            config.ENV_DATA["dual_stack"] = config.DEPLOYMENT.get("dual_stack", False)
+
+            if is_dual_stack():
+                if config.DEPLOYMENT.get("ipv6"):
+                    raise UnexpectedDeploymentConfiguration(
+                        "Cannot set both 'dual_stack' and 'ipv6'. "
+                        "Use 'dual_stack: true' with 'primary_stack: ipv6' "
+                        "for IPv6-primary dual-stack."
+                    )
+                for var in ("machine_cidr_ipv6", "ipam_ipv6", "ipam_token_ipv6"):
+                    if not config.ENV_DATA.get(var):
+                        raise UnexpectedDeploymentConfiguration(
+                            f"Dual-stack deployment requires ENV_DATA.{var}"
+                        )
+
             install_config_str = _templating.render_template(
                 ocp_install_template_path, config.ENV_DATA
             )
@@ -957,6 +982,14 @@ class VSPHEREUPI(VSPHEREBASE):
                 install_config_obj["platform"]["vsphere"]["network"] = config.ENV_DATA[
                     "vm_network"
                 ]
+
+            # Reorder network lists for IPv6-primary dual-stack
+            if is_dual_stack() and not is_ipv4_primary():
+                networking = install_config_obj["networking"]
+                networking["clusterNetwork"].reverse()
+                networking["machineNetwork"].reverse()
+                networking["serviceNetwork"].reverse()
+
             install_config_obj["pullSecret"] = self.get_pull_secret()
             install_config_obj["sshKey"] = self.get_ssh_key()
 
@@ -1076,9 +1109,9 @@ class VSPHEREUPI(VSPHEREBASE):
                     f"{self.installer} create ignition-configs "
                     f"--dir {self.cluster_path} "
                 )
-                # Because ignition file for bootstrap in ipv6 is too big to be passed by terraform changing
-                # encoding to gzip+base64 instead of pain text.
-                if config.DEPLOYMENT.get("ipv6"):
+                # Because ignition file for bootstrap in ipv6/dual-stack is too big to be passed by terraform
+                # changing encoding to gzip+base64 instead of plain text.
+                if config.DEPLOYMENT.get("ipv6") or is_dual_stack():
                     bootstrap_ignition_path = os.path.join(
                         config.ENV_DATA["cluster_path"], constants.BOOTSTRAP_IGN
                     )
@@ -2659,7 +2692,12 @@ def clone_openshift_installer():
                     branch="release-4.12",
                 )
             else:
-                if config.DEPLOYMENT.get("ipv6"):
+                if config.DEPLOYMENT.get("dual_stack"):
+                    constants.VSPHERE_INSTALLER_REPO = (
+                        "https://gitlab.cee.redhat.com/srozen/installer_ipv6.git"
+                    )
+                    branch = "dual-stack"
+                elif config.DEPLOYMENT.get("ipv6"):
                     constants.VSPHERE_INSTALLER_REPO = (
                         "https://gitlab.cee.redhat.com/srozen/installer_ipv6.git"
                     )
@@ -3159,6 +3197,57 @@ def release_ips(hosts):
         return
     ipam = IPAM(appiapp="address")
     ipam.release_ips(hosts)
+
+
+def assign_ipv6_ips(num_of_vips=None, hosts=None):
+    """
+    Assign IPv6 IPs from the IPv6 IPAM server for dual-stack deployments.
+
+    Args:
+        num_of_vips (int): Number of IPs to assign
+        hosts (list): List of hosts to assign IPs
+
+    Returns:
+        list: List of assigned IPv6 IPs
+    """
+    ipam_ipv6 = IPAM(
+        appiapp="address",
+        ipam=config.ENV_DATA["ipam_ipv6"],
+        token=config.ENV_DATA["ipam_token_ipv6"],
+    )
+    subnet_ipv6 = config.ENV_DATA["machine_cidr_ipv6"].split("/")[0]
+
+    if num_of_vips:
+        hosts = [
+            f"{config.ENV_DATA.get('cluster_name')}-{i}" for i in range(num_of_vips)
+        ]
+        ipv6_ips = ipam_ipv6.assign_ips(hosts, subnet_ipv6)
+    elif hosts:
+        hosts = [f"{host}" for host in hosts]
+        ipv6_ips = ipam_ipv6.assign_ips(hosts, subnet_ipv6)
+    else:
+        raise ValueError("Either hosts or num_of_vips should be passed")
+
+    logger.debug(f"IPv6 IPs reserved for hosts {hosts} are {ipv6_ips}")
+    return ipv6_ips
+
+
+def release_ipv6_ips(hosts):
+    """
+    Release IPv6 IPs from the IPv6 IPAM server.
+
+    Args:
+        hosts (list): List of hosts to release IPs
+    """
+    if not hosts:
+        logger.info("No hosts to release IPv6 IPs")
+        return
+    ipam_ipv6 = IPAM(
+        appiapp="address",
+        ipam=config.ENV_DATA["ipam_ipv6"],
+        token=config.ENV_DATA["ipam_token_ipv6"],
+    )
+    ipam_ipv6.release_ips(hosts)
 
 
 def create_dns_records(ips):

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -2859,11 +2859,6 @@ def update_machine_conf(folder_structure=True):
 
     """
     cidr_var = "var.machine_cidr"
-    if (
-        config.DEPLOYMENT.get("dual_stack")
-        and config.DEPLOYMENT.get("primary_stack") == "ipv6"
-    ):
-        cidr_var = "var.machine_cidr_ipv6"
 
     if not folder_structure:
         gw_string = "${cidrhost(%s,1)}" % cidr_var

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -532,6 +532,8 @@ class VSPHEREUPI(VSPHEREBASE):
         self.token = config.ENV_DATA.get("ipam_token")
         self.cidr = config.ENV_DATA.get("machine_cidr")
         self.vm_network = config.ENV_DATA.get("vm_network")
+        if is_dual_stack() and not is_ipv4_primary():
+            self.cidr = config.ENV_DATA.get("machine_cidr_ipv6", self.cidr)
 
     class OCPDeployment(BaseOCPDeployment):
         def __init__(self):
@@ -2844,8 +2846,12 @@ def update_machine_conf(folder_structure=True):
             Currently True for OCP release greater than 4.4 versions
 
     """
+    cidr_var = "var.machine_cidr"
+    if is_dual_stack() and not is_ipv4_primary():
+        cidr_var = "var.machine_cidr_ipv6"
+
     if not folder_structure:
-        gw_string = "${cidrhost(var.machine_cidr,1)}"
+        gw_string = "${cidrhost(%s,1)}" % cidr_var
         gw_conf_file = constants.INSTALLER_IGNITION
         disk_size_conf_file = constants.INSTALLER_MACHINE_CONF
         # update dns
@@ -2859,10 +2865,11 @@ def update_machine_conf(folder_structure=True):
 
     else:
         if Version.coerce(get_ocp_version()) >= Version.coerce("4.6"):
-            gw_string = "${cidrhost(var.machine_cidr, 1)}"
+            gw_string = "${cidrhost(%s, 1)}" % cidr_var
             gw_conf_file = constants.VM_MAIN
         else:
-            gw_string = "${cidrhost(machine_cidr, 1)}"
+            cidr_ref = cidr_var.replace("var.", "")
+            gw_string = "${cidrhost(%s, 1)}" % cidr_ref
             gw_conf_file = constants.VM_IFCFG
 
         disk_size_conf_file = constants.VM_MAIN
@@ -2988,7 +2995,12 @@ def generate_terraform_vars_with_folder():
         config.ENV_DATA["compute_ignition_path"] = compute_ignition_path
 
     # Copy DNS address to vm_dns_addresses
-    config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA["dns"]
+    if is_dual_stack() and not is_ipv4_primary():
+        config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA.get(
+            "dns_ipv6", config.ENV_DATA["dns"]
+        )
+    else:
+        config.ENV_DATA["vm_dns_addresses"] = config.ENV_DATA["dns"]
 
     # Get the infra ID from metadata.json and update in ENV_DATA
     metadata_path = os.path.join(config.ENV_DATA["cluster_path"], "metadata.json")

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1125,6 +1125,7 @@ class VSPHEREUPI(VSPHEREBASE):
                         control_plane_ignition_path,
                         compute_ignition_path,
                     ]
+
                     for ignition_path in ignition_paths:
                         # Read the file and compress it + base64
                         with open(ignition_path, "rb") as f_in:
@@ -1223,11 +1224,14 @@ class VSPHEREUPI(VSPHEREBASE):
                 time.sleep(600)
                 logger.info("waiting for bootstrap to complete")
                 try:
+                    bootstrap_timeout = (
+                        7200 if config.DEPLOYMENT.get("dual_stack") else 3600
+                    )
                     run_cmd(
                         f"{self.installer} wait-for bootstrap-complete "
                         f"--dir {self.cluster_path} "
                         f"--log-level {log_cli_level}",
-                        timeout=3600,
+                        timeout=bootstrap_timeout,
                     )
                 except (CommandFailed, TimeoutExpired) as e:
                     err = str(e)
@@ -1301,11 +1305,12 @@ class VSPHEREUPI(VSPHEREBASE):
 
                 # wait for install to complete
                 logger.info("waiting for install to complete")
+                install_timeout = 7200 if config.DEPLOYMENT.get("dual_stack") else 3600
                 run_cmd(
                     f"{self.installer} wait-for install-complete "
                     f"--dir {self.cluster_path} "
                     f"--log-level {log_cli_level}",
-                    timeout=3600,
+                    timeout=install_timeout,
                 )
 
                 # Approving CSRs here in-case if any exists
@@ -2756,9 +2761,11 @@ def update_gw(str_to_replace, config_file):
     """
     # update gateway
     if config.ENV_DATA.get("gateway"):
-        replace_content_in_file(
-            config_file, str_to_replace, f"{config.ENV_DATA.get('gateway')}"
-        )
+        if config.DEPLOYMENT.get("dual_stack"):
+            gw = config.ENV_DATA.get("gateway_ipv6", config.ENV_DATA.get("gateway"))
+        else:
+            gw = config.ENV_DATA.get("gateway")
+        replace_content_in_file(config_file, str_to_replace, f"{gw}")
 
 
 def add_shutdown_wait_timeout():
@@ -2770,13 +2777,23 @@ def add_shutdown_wait_timeout():
     force powered-off after this timeout, otherwise an error is returned. Default: 3 minutes.
 
     """
-    with open(constants.VM_MAIN, "r") as fd:
-        obj = hcl2.load(fd)
-        obj["resource"][0]["vsphere_virtual_machine"]["vm"][
-            "shutdown_wait_timeout"
-        ] = 10
-    dump_data_to_json(obj, f"{constants.VM_MAIN}.json")
-    os.rename(constants.VM_MAIN, f"{constants.VM_MAIN}.backup")
+    if config.DEPLOYMENT.get("dual_stack"):
+        with open(constants.VM_MAIN, "r") as fd:
+            content = fd.read()
+        content = content.replace(
+            '"stealclock.enable"',
+            '"shutdown_wait_timeout" = 10\n' '    "stealclock.enable"',
+        )
+        with open(constants.VM_MAIN, "w") as fd:
+            fd.write(content)
+    else:
+        with open(constants.VM_MAIN, "r") as fd:
+            obj = hcl2.load(fd)
+            obj["resource"][0]["vsphere_virtual_machine"]["vm"][
+                "shutdown_wait_timeout"
+            ] = 10
+        dump_data_to_json(obj, f"{constants.VM_MAIN}.json")
+        os.rename(constants.VM_MAIN, f"{constants.VM_MAIN}.backup")
 
 
 def update_dns():

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -965,11 +965,10 @@ class VSPHEREUPI(VSPHEREBASE):
                         "Use 'dual_stack: true' with 'primary_stack: ipv6' "
                         "for IPv6-primary dual-stack."
                     )
-                for var in ("machine_cidr_ipv6", "ipam_ipv6", "ipam_token_ipv6"):
-                    if not config.ENV_DATA.get(var):
-                        raise UnexpectedDeploymentConfiguration(
-                            f"Dual-stack deployment requires ENV_DATA.{var}"
-                        )
+                if not config.ENV_DATA.get("machine_cidr_ipv6"):
+                    raise UnexpectedDeploymentConfiguration(
+                        "Dual-stack deployment requires ENV_DATA.machine_cidr_ipv6"
+                    )
 
             install_config_str = _templating.render_template(
                 ocp_install_template_path, config.ENV_DATA
@@ -3209,57 +3208,6 @@ def release_ips(hosts):
         return
     ipam = IPAM(appiapp="address")
     ipam.release_ips(hosts)
-
-
-def assign_ipv6_ips(num_of_vips=None, hosts=None):
-    """
-    Assign IPv6 IPs from the IPv6 IPAM server for dual-stack deployments.
-
-    Args:
-        num_of_vips (int): Number of IPs to assign
-        hosts (list): List of hosts to assign IPs
-
-    Returns:
-        list: List of assigned IPv6 IPs
-    """
-    ipam_ipv6 = IPAM(
-        appiapp="address",
-        ipam=config.ENV_DATA["ipam_ipv6"],
-        token=config.ENV_DATA["ipam_token_ipv6"],
-    )
-    subnet_ipv6 = config.ENV_DATA["machine_cidr_ipv6"].split("/")[0]
-
-    if num_of_vips:
-        hosts = [
-            f"{config.ENV_DATA.get('cluster_name')}-{i}" for i in range(num_of_vips)
-        ]
-        ipv6_ips = ipam_ipv6.assign_ips(hosts, subnet_ipv6)
-    elif hosts:
-        hosts = [f"{host}" for host in hosts]
-        ipv6_ips = ipam_ipv6.assign_ips(hosts, subnet_ipv6)
-    else:
-        raise ValueError("Either hosts or num_of_vips should be passed")
-
-    logger.debug(f"IPv6 IPs reserved for hosts {hosts} are {ipv6_ips}")
-    return ipv6_ips
-
-
-def release_ipv6_ips(hosts):
-    """
-    Release IPv6 IPs from the IPv6 IPAM server.
-
-    Args:
-        hosts (list): List of hosts to release IPs
-    """
-    if not hosts:
-        logger.info("No hosts to release IPv6 IPs")
-        return
-    ipam_ipv6 = IPAM(
-        appiapp="address",
-        ipam=config.ENV_DATA["ipam_ipv6"],
-        token=config.ENV_DATA["ipam_token_ipv6"],
-    )
-    ipam_ipv6.release_ips(hosts)
 
 
 def create_dns_records(ips):

--- a/ocs_ci/templates/ocp-deployment/install-config-vsphere-upi.yaml.j2
+++ b/ocs_ci/templates/ocp-deployment/install-config-vsphere-upi.yaml.j2
@@ -6,10 +6,23 @@ networking:
   clusterNetwork:
     - cidr: {{ cluster_network_cidr | default('10.128.0.0/14') }}
       hostPrefix: {{ cluster_host_prefix | default(23) }}
+{% if dual_stack %}
+    - cidr: {{ cluster_network_cidr_ipv6 | default('fd01::/48') }}
+      hostPrefix: {{ cluster_host_prefix_ipv6 | default(64) }}
+{% endif %}
+{% if dual_stack %}
+  machineNetwork:
+    - cidr: '{{ machine_cidr }}'
+    - cidr: '{{ machine_cidr_ipv6 }}'
+{% else %}
   machineCIDR: '{{ machine_cidr }}'
+{% endif %}
   networkType: {{ network_type | default('OVNKubernetes') }}
   serviceNetwork:
     - {{ service_network_cidr | default('172.30.0.0/16') }}
+{% if dual_stack %}
+    - {{ service_network_cidr_ipv6 | default('fd02::/112') }}
+{% endif %}
 {% if fips %}
 fips: {{ fips }}
 {% endif %}

--- a/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
+++ b/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
@@ -26,6 +26,7 @@ ssh_public_key_path: {{ ssh_public_key_path | default('~/.ssh/openshift-dev.pub'
 folder: {{ folder }}
 {% if dual_stack %}
 machine_cidr_ipv6: {{ machine_cidr_ipv6 }}
+gateway_v4: {{ gateway }}
 gateway_ipv6: {{ gateway_ipv6 }}
 vm_dns_ipv6_addresses: {{ dns_ipv6 }}
 ipam_ipv6: {{ ipam_ipv6 }}

--- a/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
+++ b/ocs_ci/templates/ocp-deployment/terraform_4_5.tfvars.j2
@@ -24,3 +24,10 @@ compute_num_cpus: {{ worker_num_cpus | default('12') }}
 vm_dns_addresses: {{ vm_dns_addresses }}
 ssh_public_key_path: {{ ssh_public_key_path | default('~/.ssh/openshift-dev.pub')}}
 folder: {{ folder }}
+{% if dual_stack %}
+machine_cidr_ipv6: {{ machine_cidr_ipv6 }}
+gateway_ipv6: {{ gateway_ipv6 }}
+vm_dns_ipv6_addresses: {{ dns_ipv6 }}
+ipam_ipv6: {{ ipam_ipv6 }}
+ipam_token_ipv6: {{ ipam_token_ipv6 }}
+{% endif %}

--- a/ocs_ci/utility/load_balancer.py
+++ b/ocs_ci/utility/load_balancer.py
@@ -41,6 +41,7 @@ class LoadBalancer(object):
                 config.DEPLOYMENT.get("disconnected")
                 or config.DEPLOYMENT.get("proxy")
                 or config.DEPLOYMENT.get("ipv6")
+                or config.DEPLOYMENT.get("dual_stack")
             )
             else None
         )
@@ -64,9 +65,12 @@ class LoadBalancer(object):
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), self.terraform_state_file
             )
-        ip_address = get_module_ip(
-            self.terraform_state_file, constants.LOAD_BALANCER_MODULE
-        )
+        if config.DEPLOYMENT.get("dual_stack"):
+            ip_address = get_module_ip(self.terraform_state_file, "module.ipam_lb_v4")
+        else:
+            ip_address = get_module_ip(
+                self.terraform_state_file, constants.LOAD_BALANCER_MODULE
+            )
         return ip_address[0]
 
     def restart_service(self, service_name):

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4293,6 +4293,10 @@ def convert_yaml2tfvars(yaml):
                 fd.write(f'vm_dns_addresses = ["{val}"]\n')
                 continue
 
+            if key == "vm_dns_ipv6_addresses":
+                fd.write(f'vm_dns_ipv6_addresses = ["{val}"]\n')
+                continue
+
             fd.write(key)
             fd.write(" = ")
             fd.write('"')


### PR DESCRIPTION
Add configurable dual-stack networking for vSphere UPI deployments. Users can choose IPv4-primary or IPv6-primary via DEPLOYMENT.primary_stack.

## Changes
- Add is_dual_stack()/is_ipv4_primary() helpers and config validation
- Update install-config template with conditional machineNetwork and secondary clusterNetwork/serviceNetwork entries
- Update terraform tfvars template to pass IPv6 network variables
- Add ignition compression for dual-stack (same as IPv6 single-stack)
- Add dual-stack branch selection for installer repo
- Add assign_ipv6_ips()/release_ipv6_ips() for dual IPAM support
- Add deployment and overlay configs for both primary stack options

## Related PRs/MRs
- **Installer repo (Terraform):** https://gitlab.cee.redhat.com/srozen/installer_ipv6/-/tree/dual-stack — dual-stack VM networking, dual IPAM, HAProxy dual-bind, merge_ignition.sh for .nmconnection injection
- **ocs4-jenkins:** https://gitlab.cee.redhat.com/ocs/ocs4-jenkins/-/merge_requests/2555 — adds vSphere8-DC-CP-DUAL-STACK-VC1 credential for Jenkins CI dual-stack deployments

## Validation
- IPv6-primary: https://jenkins-csb-odf-qe-stage.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/1511/
- IPv4-primary: https://jenkins-csb-odf-qe-stage.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/1515/