### PR TITLE
Deprecate test_db_scc — NooBaa DB no longer uses custom SCC

### DIFF
--- a/tests/functional/object/mcg/test_mcg_resources_disruptions.py
+++ b/tests/functional/object/mcg/test_mcg_resources_disruptions.py
@@ -226,7 +226,7 @@ class TestMCGResourcesDisruptions(MCGTest):
     @pytest.mark.polarion_id("OCS-2513")
     @skipif_managed_service
     @skipif_ocs_version("<4.7")
-    def test_db_scc(self, teardown):
+    def deprecated_test_db_scc(self, teardown):
         """
         Test noobaa db is assigned with scc(anyuid) after changing the default noobaa SCC
 


### PR DESCRIPTION
In ODF 4.19, NooBaa migrated its database to CNPG, which removed the noobaa-db SCC entirely — the DB pods now run under restricted-v2 with no elevated privileges needed. This test validated SCC priority behavior for the old custom SCC, so its entire premise no longer applies.
