### PR TITLE
`test_write_to_full_bucket`: Increase PV-pool backingstore memory limit to 800Mi

### DIFF
--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -77,9 +77,9 @@ class TestPvPool:
                         MIN_PV_BACKINGSTORE_SIZE_IN_GB,
                         "ocs-storagecluster-ceph-rbd",
                         "100m",
-                        "500Mi",
+                        "800Mi",
                         "100m",
-                        "500Mi",
+                        "800Mi",
                     )
                 ]
             },

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -133,7 +133,7 @@ class TestPvPool:
         ), f"BackingStore {bs_name} did not recover to healthy status after freeing objects"
 
         # 4. Confirm that uploading is possible again now that there is space
-        retry((CommandFailed,), tries=5, delay=20, backoff=1)(
+        retry((CommandFailed,), tries=5, delay=30, backoff=1)(
             awscli_pod_session.exec_s3_cmd_on_pod
         )(
             f"cp /tmp/testfile s3://{bucket.name}/{uploaded_objs[0]}",

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -114,13 +114,24 @@ class TestPvPool:
                 break
 
         # 3. Free up some space in the bucket
-        for obj in uploaded_objs[:3]:
+        for obj in uploaded_objs[:5]:
             awscli_pod_session.exec_s3_cmd_on_pod(
                 f"rm s3://{bucket.name}/{obj}", mcg_obj_session
             )
 
+        # Wait for the BackingStore to detect the freed space
+        bs_name = bucket.bucketclass.backingstores[0].name
+        sample = TimeoutSampler(
+            timeout=600,
+            sleep=30,
+            func=check_pv_backingstore_status,
+            backingstore_name=bs_name,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        sample.wait_for_func_status(result=True)
+
         # 4. Confirm that uploading is possible again now that there is space
-        retry((CommandFailed,), tries=10, delay=30, backoff=1)(
+        retry((CommandFailed,), tries=3, delay=10, backoff=1)(
             awscli_pod_session.exec_s3_cmd_on_pod
         )(
             f"cp /tmp/testfile s3://{bucket.name}/{uploaded_objs[0]}",

--- a/tests/functional/object/mcg/test_pv_pool.py
+++ b/tests/functional/object/mcg/test_pv_pool.py
@@ -128,10 +128,12 @@ class TestPvPool:
             backingstore_name=bs_name,
             namespace=config.ENV_DATA["cluster_namespace"],
         )
-        sample.wait_for_func_status(result=True)
+        assert sample.wait_for_func_status(
+            result=True
+        ), f"BackingStore {bs_name} did not recover to healthy status after freeing objects"
 
         # 4. Confirm that uploading is possible again now that there is space
-        retry((CommandFailed,), tries=3, delay=10, backoff=1)(
+        retry((CommandFailed,), tries=5, delay=20, backoff=1)(
             awscli_pod_session.exec_s3_cmd_on_pod
         )(
             f"cp /tmp/testfile s3://{bucket.name}/{uploaded_objs[0]}",


### PR DESCRIPTION
  ## Summary
  - Increase PV-pool backingstore pod memory (request + limit) from 500Mi to 800Mi in `test_write_to_full_bucket`
  - The NooBaa agent consistently OOMKills at 500Mi when handling 500MB file writes — RSS climbs to ~494–506 MB
  with concurrent inflight writes, exceeding the 500Mi cgroup limit (524 MB)
  - Confirmed via must-gather across 3 independent failed runs (PV-pool pod exits with code 137 / SIGKILL)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of PV-backed storage tests by increasing requested PV capacity to `800Mi`.
  * When capacity is reached, the test now frees 5 uploaded objects (instead of 3).
  * Added a health check polling step (up to 600s, polling every 30s) to confirm the backing store returns to a healthy state before retrying uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->