### PR TITLE
Harden bucket logging tests against race condition and PVC leftovers

### DIFF
--- a/ocs_ci/ocs/resources/bucket_logging_manager.py
+++ b/ocs_ci/ocs/resources/bucket_logging_manager.py
@@ -430,6 +430,68 @@ class BucketLoggingManager:
                 )
             raise
 
+    def await_and_verify_bucket_logs(
+        self,
+        logs_bucket,
+        source_bucket,
+        expected_ops,
+        check_intent=False,
+        timeout=600,
+        sleep=10,
+    ):
+        """
+        Poll the target logs bucket until all expected operations
+        are found in the logs.
+
+        Unlike await_interm_logs_transfer, this method checks the final
+        destination directly, avoiding a race where intermediate logs
+        are transferred before the first poll.
+
+        Args:
+            logs_bucket(str): Name of the logs bucket
+            source_bucket(str): Name of the source bucket to filter by
+            expected_ops(list): A list of tuples representing operations.
+                                I.E [('PUT', 'object1'), ('GET', 'object2')]
+            check_intent(bool): Whether to also verify intent logs
+            timeout(int): The maximum time to wait for the logs
+            sleep(int): Time to sleep between each check
+
+        Returns:
+            list: The verified list of log dicts from the logs bucket
+
+        Raises:
+            TimeoutError: If the expected logs were not found in time
+        """
+        logger.info(
+            f"Waiting for all expected operations to appear in logs bucket {logs_bucket}"
+        )
+        last_logs = []
+        try:
+            for bucket_logs in TimeoutSampler(
+                timeout=timeout,
+                sleep=sleep,
+                func=self.get_bucket_logs,
+                logs_bucket=logs_bucket,
+                source_bucket=source_bucket,
+            ):
+                last_logs = bucket_logs
+                if bucket_logs and self.verify_logs_integrity(
+                    bucket_logs, expected_ops, check_intent
+                ):
+                    logger.info("All expected operations were found in the logs bucket")
+                    return bucket_logs
+                logger.info(
+                    f"Found {len(bucket_logs)} log entries so far, "
+                    "waiting for all expected operations"
+                )
+        except TimeoutError:
+            logger.error(
+                f"Expected operations were not found in the logs bucket "
+                f"{logs_bucket} within {timeout}s. "
+                f"Last poll returned {len(last_logs)} log entries."
+            )
+            raise
+
     def get_bucket_logs(self, logs_bucket, source_bucket=None):
         """
         Get the logs from a logs bucket

--- a/tests/functional/object/mcg/test_bucket_logs.py
+++ b/tests/functional/object/mcg/test_bucket_logs.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import pytest
@@ -106,6 +105,17 @@ class TestBucketLogs(MCGTest):
                 access_mode=constants.ACCESS_MODE_RWX,
             )
 
+            # Label the PVC and the PV to avoid false leftover errors
+            provided_logs_pvc.add_label(constants.CUSTOM_MCG_LABEL)
+            pv_ocp_obj = OCP(
+                namespace=config.ENV_DATA["cluster_namespace"],
+                kind=constants.PV,
+            )
+            pv_ocp_obj.add_label(
+                resource_name=provided_logs_pvc.backed_pv,
+                label=constants.CUSTOM_MCG_LABEL,
+            )
+
         # 1. Enable guaranteed bucket logs on top of the noobaa CR
         logs_pvc_name = provided_logs_pvc.name if use_provided_logs_pvc else None
         logs_manager.enable_bucket_logging_on_cr(logs_pvc=logs_pvc_name)
@@ -199,8 +209,7 @@ class TestBucketLogs(MCGTest):
         4. Get each object
         5. Head each object
         6. Delete the objects
-        7. Wait for the intermediate logs to be moved to the logs bucket
-        8. Validate that each operation and its intent are in the final logs
+        7. Wait for all expected operations to appear in the logs bucket
 
         Note that every operation should be logged twice with different op codes:
         The first should be the attempt of the operation with the 102 code,
@@ -239,23 +248,13 @@ class TestBucketLogs(MCGTest):
         # 6. Delete the objects
         rm_object_recursive(awscli_pod_session, source_bucket, mcg_obj_session)
 
-        # 7. Wait for the intermediate logs to be moved to the logs bucket
-        blm.await_interm_logs_transfer(logs_bucket)
-
-        # 8. Validate that each operation and its intent are in the final logs
-        bucket_logs = blm.get_bucket_logs(logs_bucket)
-
+        # 7. Wait for all expected operations to appear in the logs bucket
         expected_ops = []
         for obj_key in obj_keys:
             for op in ["PUT", "DELETE", "GET", "HEAD"]:
                 expected_ops.append((op, f"/{source_bucket}/{obj_key}"))
 
-        assert blm.verify_logs_integrity(
-            bucket_logs, expected_ops, check_intent=True
-        ), (
-            "Some of the expected logs were not found in the final logs"
-            f"Recieved: {json.dumps(bucket_logs, indent=4)}"
-            f"Expectation: {json.dumps(expected_ops, indent=4)}"
+        blm.await_and_verify_bucket_logs(
+            logs_bucket, source_bucket, expected_ops, check_intent=True
         )
-
         logger.info("All the expected logs were found")


### PR DESCRIPTION
  ## Summary
  - Fix race condition in `test_bucket_logs_integrity` where `await_interm_logs_transfer`
    times out if the NooBaa background worker transfers intermediate logs before the first
    poll. Replace with `await_and_verify_bucket_logs` which polls the target S3 logs bucket
    directly until all expected operations are confirmed.
  - Label the PVC and PV created in `test_guaranteed_bucket_logs_management` with
    `CUSTOM_MCG_LABEL` to prevent false `ResourceLeftoversException` errors when the PVC
    is slow to terminate.

Fixes #14515
