### PR TITLE
Fix positional arg bug passing wait as topic_name in bucket notif test

### DIFF
--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -360,7 +360,9 @@ class TestBucketNotifications(MCGTest):
             should_wait = True if i == SETUP_NUM - 1 else False
 
             topic, conn_config_path = (
-                notif_manager.create_and_register_kafka_topic_with_noobaa(should_wait)
+                notif_manager.create_and_register_kafka_topic_with_noobaa(
+                    wait=should_wait
+                )
             )
             kafka_conn_resources.append((topic, conn_config_path))
 


### PR DESCRIPTION
## Summary
- `should_wait` was passed as the first positional arg to `create_and_register_kafka_topic_with_noobaa`, mapping to `topic_name` instead of `wait`
- When `True`, it passes through the `topic_name or generate_name()` guard and ends up as a boolean `metadata.name` in the KafkaTopic YAML, failing `oc create`