### PR TITLE
Reduce noobaa-core load in object expiration tests by tuning lifecycle intervals

### DIFF
--- a/tests/functional/object/mcg/test_lifecycle_configuration.py
+++ b/tests/functional/object/mcg/test_lifecycle_configuration.py
@@ -74,7 +74,7 @@ class TestLifecycleConfiguration(MCGTest):
             to the noobaa-core statefulset
 
         """
-        new_interval_in_miliseconds = 60 * 1000
+        new_interval_in_miliseconds = 2 * 60 * 1000
         add_env_vars_to_noobaa_core_class(
             [
                 (constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds),

--- a/tests/functional/object/mcg/test_object_expiration.py
+++ b/tests/functional/object/mcg/test_object_expiration.py
@@ -56,9 +56,12 @@ class TestObjectExpiration(MCGTest):
         Reduce the interval in which the lifecycle background worker is running
 
         """
-        new_interval_in_miliseconds = 60 * 1000
+        new_interval_in_miliseconds = 2 * 60 * 1000
         add_env_vars_to_noobaa_core_class(
-            [(constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds)]
+            [
+                (constants.LIFECYCLE_INTERVAL_PARAM, new_interval_in_miliseconds),
+                (constants.LIFECYCLE_SCHED_MINUTES, new_interval_in_miliseconds),
+            ]
         )
 
     @tier1


### PR DESCRIPTION
  ## Problem
Object expiration tests have been failing intermittently with 504 Gateway Timeout due to noobaa-endpoint losing connectivity to noobaa-mgmt after the noobaa-core pod restart triggered by the test fixture.

The fixture sets `LIFECYCLE_INTERVAL` to 60s (vs the 8h default) to avoid waiting hours for expiration, but leaves `LIFECYCLE_SCHEDULE_MIN` at its 5-minute default. This means the lifecycle bg worker fires every 60s but skips actual rule processing on most invocations (gated by the 5-min schedule minimum) — adding unnecessary `system_store.refresh()` and RPC overhead on a freshly-restarted noobaa-core while the effective processing rate is still only once per 5 minutes.

  ## Solution
Set both `LIFECYCLE_INTERVAL` and `LIFECYCLE_SCHEDULE_MIN` to 2 minutes. This cuts bg worker invocations in half while making lifecycle rules actually process every 2 minutes — faster than the previous effective 5-minute rate.