### PR TITLE
Fix race condition in test_block_external_access disableRoutes propagation

### DIFF
--- a/tests/functional/object/mcg/test_block_external_access.py
+++ b/tests/functional/object/mcg/test_block_external_access.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework import config
 from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -292,6 +293,24 @@ class TestBlockExternalAccess(MCGTest):
         assert (
             disable_routes == val
         ), f"Disable routes is expected to be {val}, is {disable_routes}"
+
+        # Wait for the disableRoutes value to propagate to noobaa CR if the change was made on storagecluster
+        if is_storage_cluster:
+            noobaa_obj = ocp.OCP(
+                resource_name=constants.NOOBAA_RESOURCE_NAME,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                kind=constants.NOOBAA_RESOURCE_NAME,
+            )
+            logger.info(f"Waiting for disableRoutes={val} to propagate to noobaa CR")
+            for noobaa_data in TimeoutSampler(
+                timeout=120, sleep=5, func=noobaa_obj.get
+            ):
+                noobaa_disable_routes = noobaa_data.get("spec", {}).get(
+                    "disableRoutes", False
+                )
+                if noobaa_disable_routes == val:
+                    logger.info("disableRoutes successfully propagated to noobaa CR")
+                    break
 
     def delete_multiCloudGateway_section_from_storagecluster(self):
         """


### PR DESCRIPTION
  ## Summary
  - `set_disable_routes_value` patches the storagecluster but doesn't wait for
    the OCS operator to propagate `disableRoutes` to the noobaa CR. The noobaa
    operator reads its own CR, so it can reconcile with the stale value and
    recreate routes before the test checks them.
  - Add a `TimeoutSampler` poll (120s, 5s interval) after patching the
    storagecluster to wait for the noobaa CR's `spec.disableRoutes` to match
    the expected value before proceeding.
