### PR TITLE
EC day1 tuning operational tests tier1 - pool agnostic

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2796,
+        "line_number": 2931,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -619,6 +619,106 @@ def default_ceph_block_pool():
     return cbp_name if cbp_name else constants.DEFAULT_BLOCKPOOL
 
 
+def get_data_pool_name(interface_type=constants.CEPHBLOCKPOOL, sc_obj=None):
+    """
+    Return the name of the pool where actual block data is written.
+
+    On standard (replicated) deployments the StorageClass has a single
+    ``pool`` parameter that serves both as the RBD metadata pool and the
+    data pool, so this function returns the same value as
+    ``default_ceph_block_pool()``.
+
+    On Erasure-Coded deployments the StorageClass exposes two parameters:
+      * ``pool``     – the replicated metadata pool (stores RBD image headers)
+      * ``dataPool`` – the EC pool where all actual object data is written
+
+    For size-tracking purposes (``fetch_used_size``) we must monitor
+    ``dataPool`` on EC clusters; monitoring the metadata pool would always
+    show negligible growth regardless of how much data is written.
+
+    Args:
+        interface_type (str): Interface type constant (default CEPHBLOCKPOOL).
+        sc_obj: Optional StorageClass OCP object. When provided, it is used
+            directly instead of resolving the default StorageClass for
+            ``interface_type``. Useful for callers that already have a
+            specific SC object (e.g. a custom pool created by a test).
+
+    Returns:
+        str: Name of the pool that receives the actual written data.
+    """
+    if sc_obj is None:
+        sc_obj = default_storage_class(interface_type)
+    params = sc_obj.get().get("parameters", {})
+    data_pool = params.get("dataPool")
+    if data_pool:
+        logger.info(
+            f"EC deployment detected: using dataPool '{data_pool}' for data size tracking"
+        )
+        return data_pool
+    pool = params.get("pool") or constants.DEFAULT_BLOCKPOOL
+    logger.info(f"Replicated deployment: using pool '{pool}' for data size tracking")
+    return pool
+
+
+def get_pool_size_factor(pool_name):
+    """
+    Return the raw-storage multiplier for a given Ceph pool.
+
+    When data is written to a pool, the pool's raw ``size_bytes`` (as
+    reported by ``rados df``) grows by ``logical_bytes * factor``.
+
+    * **Replicated pool** – factor equals the replica count (``size``).
+      E.g. size=3 → factor=3.
+
+    * **Erasure-Coded pool** – factor equals ``(k + m) / k`` where *k* is
+      ``spec.erasureCoded.dataChunks`` and *m* is
+      ``spec.erasureCoded.codingChunks`` from the ``CephBlockPool`` CR.
+      E.g. k=2, m=1 → factor=1.5.
+
+    The factor is derived from the ``CephBlockPool`` CR without running any
+    Ceph commands, so no toolbox pod is required.
+
+    Args:
+        pool_name (str): Name of the CephBlockPool resource.
+
+    Returns:
+        float: Raw-storage multiplier for expected-size calculations.
+    """
+    pool_ocp = ocp.OCP(
+        kind=constants.CEPHBLOCKPOOL,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=pool_name,
+    )
+    pool_cr = pool_ocp.get()
+    ec_spec = pool_cr.get("spec", {}).get("erasureCoded", {})
+    k = ec_spec.get("dataChunks", 0)
+    m = ec_spec.get("codingChunks", 0)
+
+    if k > 0:
+        factor = (k + m) / k
+        logger.info(
+            f"Pool '{pool_name}' is EC (k={k}, m={m}): "
+            f"raw-storage factor = (k+m)/k = {factor}"
+        )
+        return factor
+
+    # Replicated pool – read size from CR spec first, fall back to ceph cmd
+    rep_size = pool_cr.get("spec", {}).get("replicated", {}).get("size", 0)
+    if rep_size:
+        logger.info(
+            f"Pool '{pool_name}' is replicated (size={rep_size}): "
+            f"raw-storage factor = {rep_size}"
+        )
+        return float(rep_size)
+
+    # Last resort: query via toolbox
+    ct_pod = pod.get_ceph_tools_pod()
+    size_info = ct_pod.exec_ceph_cmd(ceph_cmd=f"ceph osd pool get {pool_name} size")
+    factor = float(size_info["size"])
+    logger.info(f"Pool '{pool_name}' replicated size from ceph = {factor}")
+    return factor
+
+
 def create_ceph_block_pool(
     pool_name=None,
     replica=3,
@@ -3774,7 +3874,7 @@ def run_cmd_verify_cli_output(
 
 
 def check_rbd_image_used_size(
-    pvc_objs, usage_to_compare, rbd_pool=constants.DEFAULT_BLOCKPOOL, expect_match=True
+    pvc_objs, usage_to_compare, rbd_pool=None, expect_match=True
 ):
     """
     Check if RBD image used size of the PVCs are matching with the given value
@@ -3782,7 +3882,11 @@ def check_rbd_image_used_size(
     Args:
         pvc_objs (list): List of PVC objects
         usage_to_compare (str): Value of image used size to be compared with actual value. eg: "5GiB"
-        rbd_pool (str): Name of the pool
+        rbd_pool (str): Name of the RBD metadata pool (``parameters.pool`` from the
+            StorageClass). On EC clusters this is the replicated metadata pool
+            (e.g. ``replicated-metadata-pool``), **not** the EC data pool.
+            When ``None`` the value is resolved automatically from the default
+            RBD StorageClass via ``default_ceph_block_pool()``.
         expect_match (bool): True to verify the used size is equal to 'usage_to_compare' value.
             False to verify the used size is not equal to 'usage_to_compare' value.
 
@@ -3790,6 +3894,8 @@ def check_rbd_image_used_size(
         bool: True if the verification is success for all the PVCs, False otherwise
 
     """
+    if rbd_pool is None:
+        rbd_pool = default_ceph_block_pool()
     ct_pod = pod.get_ceph_tools_pod()
     no_match_list = []
     for pvc_obj in pvc_objs:
@@ -6000,7 +6106,10 @@ def get_rbd_image_info(rbd_pool, rbd_image_name):
     Get RBD image information. (e.g provisioned size, used size, image ,   )
 
     Args:
-        rbd_pool(str) : pool name
+        rbd_pool(str) : RBD **metadata** pool name (i.e. ``parameters.pool``
+            from the StorageClass, **not** ``parameters.dataPool``). On EC
+            clusters this is the replicated metadata pool
+            (e.g. ``replicated-metadata-pool``).
         rbd_image_name(str) : name of rbd image
 
     Returns:

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -3,6 +3,7 @@ import logging
 import threading
 import pytest
 from ocs_ci.framework.pytest_customization.marks import blue_squad, tier1, polarion_id
+from ocs_ci.helpers.helpers import default_ceph_block_pool
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.utility.prometheus import PrometheusAPI
@@ -180,7 +181,7 @@ def get_ceph_rbd_metrics(pvc_obj):
     """
     ceph_toolbox = pod_helpers.get_ceph_tools_pod()
     pv_data = pvc_obj.backed_pv_obj.get()
-    rbd_pool = constants.DEFAULT_BLOCKPOOL
+    rbd_pool = default_ceph_block_pool()
     rbd_image = (
         pv_data.get("spec", {})
         .get("csi", {})

--- a/tests/functional/pv/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
+++ b/tests/functional/pv/pv_services/test_pvc_delete_verify_size_is_returned_to_backendpool.py
@@ -6,8 +6,7 @@ size is returned to backend pool
 import logging
 import pytest
 
-from ocs_ci.framework import config
-from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
 from ocs_ci.helpers import helpers
 from ocs_ci.framework.pytest_customization.marks import green_squad, provider_mode
@@ -65,34 +64,37 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         self, pause_and_resume_cluster_load, pvc_factory, pod_factory
     ):
         """
-        Test case to verify after delete pvc size returned to backend pools
-        """
+        Test case to verify after delete pvc size returned to backend pools.
 
+        Works on both replicated and Erasure-Coded deployments:
+
+        * ``cbp_name``  – pool that holds the RBD image header/metadata.
+          Used by ``verify_pv_not_exists`` (``rbd info -p <pool>``).
+          On replicated clusters this is also the data pool.
+          On EC clusters this is the lightweight metadata pool.
+
+        * ``data_pool`` – pool where actual block data is written.
+          On replicated clusters this is the same as ``cbp_name``.
+          On EC clusters this is the ``dataPool`` parameter of the
+          StorageClass (erasure-coded pool).
+
+        * ``size_factor`` – raw-storage multiplier used to compute the
+          expected pool-size growth after writing data:
+          - Replicated: ``replica_count``  (e.g. 3)
+          - EC:         ``(k + m) / k``   (e.g. 1.5 for k=2, m=1)
+        """
+        # Pool used for RBD image existence checks (always the metadata pool)
         cbp_name = helpers.default_ceph_block_pool()
 
-        sc_obj = helpers.default_storage_class(constants.CEPHBLOCKPOOL)
-        data_pool_name = sc_obj.get().get("parameters", {}).get("dataPool")
+        # Pool where actual data lands; identical to cbp_name on replicated clusters
+        data_pool = helpers.get_data_pool_name()
 
-        pool_for_size = cbp_name
-        size_factor = None
-
-        if data_pool_name:
-            pool_cr = ocp.OCP(
-                kind=constants.CEPHBLOCKPOOL,
-                namespace=config.ENV_DATA["cluster_namespace"],
-            ).get(resource_name=data_pool_name)
-            ec_spec = pool_cr.get("spec", {}).get("erasureCoded", {})
-            k = ec_spec.get("dataChunks", 0)
-            m = ec_spec.get("codingChunks", 0)
-            if k > 0:
-                pool_for_size = data_pool_name
-                size_factor = (k + m) / k
-
-        if size_factor is None:
-            tools_pod = pod.get_ceph_tools_pod()
-            cmd = f"ceph osd pool get {cbp_name} size"
-            size_info = tools_pod.exec_ceph_cmd(ceph_cmd=cmd)
-            size_factor = int(size_info["size"])
+        # Raw-storage multiplier for the expected-size calculation
+        size_factor = helpers.get_pool_size_factor(data_pool)
+        logger.info(
+            f"cbp_name (metadata/rbd pool): {cbp_name} | "
+            f"data_pool: {data_pool} | size_factor: {size_factor}"
+        )
 
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL, size=10, status=constants.STATUS_BOUND
@@ -104,13 +106,13 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         )
         pvc_obj.reload()
 
-        used_before_io = helpers.fetch_used_size(pool_for_size)
+        used_before_io = helpers.fetch_used_size(data_pool)
         logger.info(f"Used before IO {used_before_io}")
 
-        # Write 6Gb
+        # Write 6 GB; expected physical growth = 6 GB × size_factor
         pod.run_io_and_verify_mount_point(pod_obj, bs="10M", count="600")
         exp_size = used_before_io + (6 * size_factor)
-        used_after_io = helpers.fetch_used_size(pool_for_size, exp_size)
+        used_after_io = helpers.fetch_used_size(data_pool, exp_size)
         logger.info(f"Used space after IO {used_after_io}")
 
         rbd_image_id = pvc_obj.image_uuid
@@ -119,6 +121,8 @@ class TestPVCDeleteAndVerifySizeIsReturnedToBackendPool(ManageTest):
         pvc_obj.delete()
         pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
 
+        # Verify RBD image is gone from the metadata pool
         verify_pv_not_exists(pvc_obj, cbp_name, rbd_image_id)
-        used_after_deleting_pvc = helpers.fetch_used_size(pool_for_size, used_before_io)
+        # Verify data pool usage returned to pre-IO baseline
+        used_after_deleting_pvc = helpers.fetch_used_size(data_pool, used_before_io)
         logger.info(f"Used after deleting PVC {used_after_deleting_pvc}")

--- a/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
@@ -25,6 +25,7 @@ from ocs_ci.ocs.resources.pod import (
     check_file_existence,
     delete_pods,
 )
+from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import fetch_used_size, default_storage_class
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -55,6 +56,8 @@ class TestRbdSpaceReclaim(ManageTest):
                 replica=self.pool_replica,
                 new_rbd_pool=True,
             )
+        self.data_pool = helpers.get_data_pool_name(sc_obj=self.sc_obj)
+        self.pool_size_factor = helpers.get_pool_size_factor(self.data_pool)
 
         self.pvc, self.pod = create_pvcs_and_pods(
             pvc_size=pvc_size_gi,
@@ -90,8 +93,7 @@ class TestRbdSpaceReclaim(ManageTest):
         fio_filename2 = "fio_file2"
 
         # Fetch the used size of pool
-        cbp_name = self.sc_obj.get().get("parameters").get("pool")
-        used_size_before_io = fetch_used_size(cbp_name)
+        used_size_before_io = fetch_used_size(self.data_pool)
         log.info(f"Used size before IO is {used_size_before_io}")
 
         # Create two 10 GB file
@@ -106,8 +108,8 @@ class TestRbdSpaceReclaim(ManageTest):
             pod_obj.get_fio_results()
 
         # Verify used size after IO
-        exp_used_size_after_io = used_size_before_io + (20 * self.pool_replica)
-        used_size_after_io = fetch_used_size(cbp_name, exp_used_size_after_io)
+        exp_used_size_after_io = used_size_before_io + (20 * self.pool_size_factor)
+        used_size_after_io = fetch_used_size(self.data_pool, exp_used_size_after_io)
         log.info(f"Used size after IO is {used_size_after_io}")
 
         # Delete one file
@@ -135,7 +137,7 @@ class TestRbdSpaceReclaim(ManageTest):
 
         # Verify space is reclaimed by checking the used size of the RBD pool
         used_after_reclaiming_space = fetch_used_size(
-            cbp_name, used_size_after_io - (10 * self.pool_replica)
+            self.data_pool, used_size_after_io - (10 * self.pool_size_factor)
         )
         log.info(
             f"Space has been reclaimed. Used size after io is {used_after_reclaiming_space}."
@@ -172,8 +174,7 @@ class TestRbdSpaceReclaim(ManageTest):
         fio_filename2 = "fio_file2"
 
         # Fetch the used size of pool
-        cbp_name = self.sc_obj.get().get("parameters").get("pool")
-        used_size_before_io = fetch_used_size(cbp_name)
+        used_size_before_io = fetch_used_size(self.data_pool)
         log.info(f"Used size before IO is {used_size_before_io}")
 
         # Create a 10 GB file
@@ -188,8 +189,8 @@ class TestRbdSpaceReclaim(ManageTest):
             pod_obj.get_fio_results()
 
         # Verify used size after IO
-        exp_used_size_after_io = used_size_before_io + (20 * self.pool_replica)
-        used_size_after_io = fetch_used_size(cbp_name, exp_used_size_after_io)
+        exp_used_size_after_io = used_size_before_io + (20 * self.pool_size_factor)
+        used_size_after_io = fetch_used_size(self.data_pool, exp_used_size_after_io)
         log.info(f"Used size after IO is {used_size_after_io}")
 
         # Create ReclaimSpaceJob
@@ -199,7 +200,9 @@ class TestRbdSpaceReclaim(ManageTest):
         self.reclaim_space_job(reclaim_space_job)
 
         # Verify space is reclaimed by checking the used size of the RBD pool
-        used_after_reclaiming_space = fetch_used_size(cbp_name, used_size_after_io)
+        used_after_reclaiming_space = fetch_used_size(
+            self.data_pool, used_size_after_io
+        )
         log.info(
             f"Memory remains intact. Used size after io is {used_after_reclaiming_space}."
         )
@@ -227,8 +230,7 @@ class TestRbdSpaceReclaim(ManageTest):
         fio_filename1 = "fio_file1"
 
         # Fetch the used size of pool
-        cbp_name = self.sc_obj.get().get("parameters").get("pool")
-        used_size_before_io = fetch_used_size(cbp_name)
+        used_size_before_io = fetch_used_size(self.data_pool)
         log.info(f"Used size before IO is {used_size_before_io}")
 
         # Create a 10 GB file
@@ -242,8 +244,8 @@ class TestRbdSpaceReclaim(ManageTest):
         pod_obj.get_fio_results()
 
         # Verify used size after IO
-        exp_used_size_after_io = used_size_before_io + (10 * self.pool_replica)
-        used_size_after_io = fetch_used_size(cbp_name, exp_used_size_after_io)
+        exp_used_size_after_io = used_size_before_io + (10 * self.pool_size_factor)
+        used_size_after_io = fetch_used_size(self.data_pool, exp_used_size_after_io)
         log.info(f"Used size after IO is {used_size_after_io}")
 
         # Delete the file


### PR DESCRIPTION
Fix EC pool compatibility for RBD pool-size tests   - Pool AGNOSTIC approach !!!                                                                                                                                

On Erasure-Coded deployments the RBD StorageClass exposes two pools — pool (replicated metadata) and dataPool (EC data). Tests were monitoring and querying the wrong pool, causing incorrect size tracking and rbd du failures.

Changes:                                                                                                                                                                           
  - helpers.py: get_data_pool_name() accepts optional sc_obj; check_rbd_image_used_size() resolves pool lazily via default_ceph_block_pool() instead of hardcoded constant
  - test_block_pvc_kubelet_rbd_usage.py: use default_ceph_block_pool() for rbd du pool
  - test_pvc_delete_verify_size_is_returned_to_backendpool.py: use get_data_pool_name() + get_pool_size_factor() for correct EC size accounting
  - test_rbd_space_reclaim.py: replace hardcoded pool_replica=3 with dynamic data_pool + pool_size_factor

----------

Tested cases on EC day-1 cluster

- test_rbd_metrics_validation_multi_scenario[1-256-Block] ✅
- test_rbd_metrics_validation_multi_scenario[1-256-Filesystem] ✅
- test_pvc_delete_and_verify_size_is_returned_to_backend_pool ✅
- test_rbd_space_reclaim ✅
- test_rbd_space_reclaim_no_space ✅
- test_no_volume_mounted ✅

Execution logs: 
https://url.corp.redhat.com/898cfee

- [x] test on replica cluster 