### PR TITLE
setup storage driven by config; for UI wizard manual tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -577,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 377,
+        "line_number": 379,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/README.md
+++ b/conf/README.md
@@ -255,6 +255,7 @@ higher priority).
 * `worker_availability_zones` - List of availability zones to create worker nodes in
 * `skip_ocp_deployment` - Skip the OCP deployment step or not (Default: false)
 * `skip_ocs_deployment` - Skip the OCS deployment step or not (Default: false)
+* `setup_storage` - Deploy ODF operator and create StorageCluster. When set to false, only the ODF operator is deployed and no StorageCluster is created (Default: true)
 * `ocs_version` - Version of OCS that is being deployed
 * `acm_version` - Version of acm to be used for this run (applicable mostly to DR scenarios)
 * `vm_template` - VMWare template to use for RHCOS images (legacy single template, used as fallback)

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -492,7 +492,7 @@ class Deployment(object):
                 config.reset_ctx()
                 # Run ocs_install_verification here only in case of multicluster.
                 # For single cluster, test_deployment will take care.
-                if config.multicluster:
+                if config.multicluster and config.ENV_DATA.get("setup_storage", True):
                     for i in range(config.nclusters):
                         if i in get_all_acm_indexes():
                             continue
@@ -1741,8 +1741,14 @@ class Deployment(object):
                 f"{constants.ROOK_OPERATOR_CONFIGMAP} -p {config_map_patch}"
             )
 
-        storage_cluster_setup = StorageClusterSetup()
-        storage_cluster_setup.setup_storage_cluster()
+        if config.ENV_DATA.get("setup_storage", True):
+            storage_cluster_setup = StorageClusterSetup()
+            storage_cluster_setup.setup_storage_cluster()
+        else:
+            logger.info(
+                "setup_storage is False — skipping StorageCluster creation. "
+                "ODF operator is deployed but no StorageCluster will be created."
+            )
 
         if config.DEPLOYMENT["infra_nodes"]:
             log_step("Labeling infra nodes")

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -182,6 +182,7 @@ ENV_DATA:
   worker_replicas: 3
   skip_ocp_deployment: false
   skip_ocs_deployment: false
+  setup_storage: true
   ocs_version: "4.22"
   prometheus_version: "4.10.0"
   # uncomment to use custom directory for storing measurement data related to

--- a/tests/functional/deployment/test_deployment.py
+++ b/tests/functional/deployment/test_deployment.py
@@ -32,7 +32,9 @@ def test_deployment(pvc_factory, pod_factory):
     if not teardown or deploy:
         log.info("Verifying OCP cluster is running")
         assert is_cluster_running(config.ENV_DATA["cluster_path"])
-        if not config.ENV_DATA["skip_ocs_deployment"]:
+        if not config.ENV_DATA["skip_ocs_deployment"] and config.ENV_DATA.get(
+            "setup_storage", True
+        ):
             if config.multicluster:
                 restore_ctx_index = config.cur_index
                 for cluster in get_non_acm_cluster_config():


### PR DESCRIPTION
This PR going to help test UI Storage system installation wizard manually. 
Operator will be installed and arnRole will be created as configured for any platform - automatically. 
This is especially valuable for unreleased versions and w/a pull-secret automation + IDMS application steps, to not perform them manually for the ROSA HCP clusters or other platforms. 

!!! With `setup_storage == False` we should not proceed to running the regression.