### PR TITLE
Add RDR health check fixture and fix ceph_health_recover no-op when no pattern matches

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -384,6 +384,46 @@ def relocate(
     config.switch_ctx(restore_index)
 
 
+def check_rbd_mirror_running(namespace=None):
+    """
+    Check if the rbd-mirror daemon deployment is running with at least one ready replica.
+    Ceph HEALTH_OK does not reflect rbd-mirror daemon absence, so this explicit
+    check is needed to catch silent failures before tests run.
+
+    Args:
+        namespace (str): Namespace to check in.
+            Defaults to config.ENV_DATA['cluster_namespace'].
+
+    Returns:
+        bool: True if rbd-mirror deployment has ready replicas
+
+    Raises:
+        UnexpectedDeploymentConfiguration: If the rbd-mirror deployment is
+            not found or not running
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    dep_ocp = OCP(kind=constants.DEPLOYMENT, namespace=namespace)
+    try:
+        dep_data = dep_ocp.get(resource_name=constants.RBD_MIRROR_DAEMON_DEPLOYMENT)
+    except CommandFailed:
+        raise UnexpectedDeploymentConfiguration(
+            f"{constants.RBD_MIRROR_DAEMON_DEPLOYMENT} deployment not found in {namespace}"
+        )
+    spec_replicas = dep_data.get("spec", {}).get("replicas") or 0
+    ready_replicas = dep_data.get("status", {}).get("readyReplicas") or 0
+    if spec_replicas < 1 or ready_replicas < 1:
+        raise UnexpectedDeploymentConfiguration(
+            f"{constants.RBD_MIRROR_DAEMON_DEPLOYMENT} is not running: "
+            f"spec.replicas={spec_replicas}, status.readyReplicas={ready_replicas}"
+        )
+    logger.info(
+        f"{constants.RBD_MIRROR_DAEMON_DEPLOYMENT} is running: "
+        f"replicas={spec_replicas}, readyReplicas={ready_replicas}"
+    )
+    return True
+
+
 def check_mirroring_status_ok(
     replaying_images=None,
     replaying_groups=None,

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3466,6 +3466,9 @@ def ceph_health_recover(
                 " This might be because of product bug, so please do not ignore this error and"
                 " analyze why this has happened!"
             )
+    raise CephHealthNotRecoveredException(
+        f"No known fix pattern matched for health status: {health_status}"
+    )
 
 
 def ceph_health_check(

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -8,8 +8,18 @@ from ocs_ci.deployment import acm
 from ocs_ci.ocs.resources.storage_cluster import get_all_storageclass
 from ocs_ci.ocs.utils import get_non_acm_cluster_config
 from ocs_ci.utility.utils import run_cmd
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    CephHealthException,
+    CephHealthNotRecoveredException,
+    CephHealthRecoveredException,
+    UnexpectedDeploymentConfiguration,
+)
 from ocs_ci.helpers import helpers
+from ocs_ci.helpers.dr_helpers import (
+    check_rbd_mirror_running,
+    check_mirroring_status_ok,
+)
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +52,55 @@ def check_subctl_cli():
         log.debug("subctl binary not found, downloading now...")
         submariner = acm.Submariner()
         submariner.download_binary()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def rdr_health_check():
+    """
+    Verify cluster health on both managed clusters before each RDR test.
+    Checks Ceph health, rbd-mirror daemon status, and mirroring health.
+
+    """
+    if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
+        return
+
+    if config.RUN["cli_params"].get("dev_mode"):
+        log.info("Skipping RDR health checks for development mode")
+        return
+
+    restore_index = config.cur_index
+    try:
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            if not config.RUN.get("cephcluster"):
+                continue
+            cluster_name = config.ENV_DATA.get("cluster_name")
+            log.info(f"Running RDR health check on managed cluster: {cluster_name}")
+            try:
+                helpers.ceph_health_check_with_toolbox_recovery(
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    tries=5,
+                    delay=10,
+                )
+                log.info(f"Ceph health check passed on {cluster_name}")
+            except (CephHealthException, CephHealthNotRecoveredException) as e:
+                log.error(f"Ceph health check failed on {cluster_name}: {e}")
+                pytest.skip(f"Ceph health check failed on {cluster_name}")
+            except CephHealthRecoveredException:
+                log.warning(
+                    f"Ceph health was not OK but recovered on {cluster_name}. "
+                    "Proceeding with test execution."
+                )
+            try:
+                check_rbd_mirror_running()
+            except UnexpectedDeploymentConfiguration as e:
+                log.error(f"rbd-mirror daemon check failed on {cluster_name}: {e}")
+                pytest.skip(f"rbd-mirror daemon check failed on {cluster_name}")
+            if not check_mirroring_status_ok():
+                log.error(f"Mirroring health is not OK on {cluster_name}")
+                pytest.skip(f"Mirroring health is not OK on {cluster_name}")
+    finally:
+        config.switch_ctx(restore_index)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
  - Add `rdr_health_check` autouse fixture in regional-dr conftest that runs Ceph health, rbd-mirror daemon, and mirroring status checks on both managed clusters before each RDR test
  - Also adds check_rbd_mirror_running() helper in dr_helpers to detect missing rbd-mirror daemon
  - Fix `ceph_health_recover` silently returning when no known fix pattern matches, allowing tests to proceed on unhealthy clusters

  ## Problem
  The framework-level `health_checker` fixture doesn't cover RDR adequately:
  1. It early-returns when cluster context is the ACM hub, skipping health checks entirely for RDR tests (#14865)
  2. When it does run, it only checks the single active cluster context, not both managed clusters in the DR pair (#14866)
  3. It has no check for rbd-mirror daemon, which can be absent while Ceph reports HEALTH_OK (#14867)

  Additionally, `ceph_health_recover` has a bug where health warnings that don't match any known fix pattern could allow the health-check path to treat the cluster as healthy.

  ## Approach
  New RDR-specific fixture rather than modifying the framework `health_checker` to avoid side effects across other test suites.

Fixes #14865
Fixes #14866
Fixes #14867