### PR TITLE
add test for GKLM kms over kmip

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5938,6 +5938,86 @@ def pv_encryption_kmip_setup_factory(request):
     return factory
 
 
+@pytest.fixture(scope="function")
+def pv_encryption_kmip_no_crypto_rpc_setup_factory(request):
+    """
+    Create KMIP resources and setup csi-kms-connection-details configMap
+    with USE_CRYPTO_RPC set to false
+
+    """
+    kmip = KMS.KMIP()
+
+    def factory():
+        """
+        Returns:
+            object: KMIP (KMS) object
+        """
+        kmip.update_kmip_env_vars()
+        get_ksctl_cli()
+        kmip.kmsid = create_unique_resource_name("test", "kmip")
+        kmip.kmip_secret_name = kmip.create_kmip_secret(type="csi")
+
+        conn_data = {
+            "KMS_PROVIDER": "kmip",
+            "KMS_SERVICE_NAME": kmip.kmsid,
+            "KMIP_ENDPOINT": f"{kmip.kmip_endpoint}:{kmip.kmip_port}",
+            "KMIP_SECRET_NAME": kmip.kmip_secret_name,
+            "TLS_SERVER_NAME": kmip.kmip_tls_server_name,
+            "USE_CRYPTO_RPC": "false",
+            "UNIQUE_IDENTIFIER": kmip.kmip_key_identifier,
+        }
+
+        ocp_obj = OCP(
+            kind="configmap", namespace=ocsci_config.ENV_DATA["cluster_namespace"]
+        )
+
+        try:
+            ocp_obj.get_resource(
+                resource_name="csi-kms-connection-details", column="NAME"
+            )
+            vdict = {kmip.kmsid: conn_data}
+            KMS.update_csi_kms_vault_connection_details(vdict)
+
+        except CommandFailed as cfe:
+            if "not found" not in str(cfe):
+                raise
+            else:
+                kmip.kmsid = "1-kmip"
+                conn_data["KMS_SERVICE_NAME"] = kmip.kmsid
+                csi_kms_conn_details = {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "csi-kms-connection-details",
+                        "namespace": ocsci_config.ENV_DATA["cluster_namespace"],
+                    },
+                    "data": {
+                        kmip.kmsid: json.dumps(conn_data),
+                    },
+                }
+                kmip.create_resource(csi_kms_conn_details, prefix="csikmsconn")
+
+        return kmip
+
+    def finalizer():
+        """
+        Remove the kmip config from csi-kms-connection-details configMap
+
+        """
+        if len(KMS.get_encryption_kmsid()) > 1:
+            KMS.remove_kmsid(kmip.kmsid)
+        if kmip.kmip_secret_name:
+            run_cmd(
+                f"oc delete secret {kmip.kmip_secret_name} -n"
+                f" {ocsci_config.ENV_DATA['cluster_namespace']}"
+            )
+        if kmip.kmip_key_identifier:
+            kmip.delete_ciphertrust_key(key_id=kmip.kmip_key_identifier)
+
+    request.addfinalizer(finalizer)
+    return factory
+
+
 def pv_encryption_hpcs_setup_factory(request):
     """
     Create hpcs resources and setup csi-kms-connection-details configMap

--- a/tests/functional/pv/pv_encryption/test_kmip_rbd_pv_encryption.py
+++ b/tests/functional/pv/pv_encryption/test_kmip_rbd_pv_encryption.py
@@ -123,3 +123,105 @@ class TestKmipRbdPvEncryptionKMIP(ManageTest):
         for pod_obj in pod_objs:
             pod_obj.get_fio_results()
         log.info("IO completed on all pods")
+
+
+@green_squad
+@aws_platform_required
+@skipif_ocs_version("<4.12")
+@kms_config_required
+@skipif_managed_service
+@skipif_hci_provider_and_client
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
+@polarion_id("OCS-XXXX")
+class TestKmipRbdPvEncryptionNoCryptoRPC(ManageTest):
+    """
+    Test to verify RBD PV encryption using KMIP with USE_CRYPTO_RPC disabled
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        pv_encryption_kmip_no_crypto_rpc_setup_factory,
+    ):
+        """
+        Setup csi-kms-connection-details configmap with USE_CRYPTO_RPC=false
+
+        """
+        log.info("Setting up csi-kms-connection-details configmap (no crypto RPC)")
+        self.kms = pv_encryption_kmip_no_crypto_rpc_setup_factory()
+        log.info("csi-kms-connection-details setup successful")
+
+    @tier1
+    def test_rbd_pv_encryption_kmip_no_crypto_rpc(
+        self,
+        project_factory,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Test to verify creation and deletion of encrypted RBD PVC
+        with USE_CRYPTO_RPC set to false
+
+        """
+        # Create a project
+        proj_obj = project_factory()
+
+        # Create an encryption enabled storageclass for RBD
+        sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            encrypted=True,
+            encryption_kms_id=self.kms.kmsid,
+        )
+
+        # Create RBD PVCs with volume mode Block
+        pvc_size = 5
+        pvc_objs = multi_pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            project=proj_obj,
+            storageclass=sc_obj,
+            size=pvc_size,
+            access_modes=[
+                f"{constants.ACCESS_MODE_RWX}-Block",
+                f"{constants.ACCESS_MODE_RWO}-Block",
+            ],
+            status=constants.STATUS_BOUND,
+            num_of_pvc=3,
+            wait_each=False,
+        )
+
+        # Create pods
+        pod_objs = create_pods(
+            pvc_objs,
+            pod_factory,
+            constants.CEPHBLOCKPOOL,
+            pods_for_rwx=1,
+            status=constants.STATUS_RUNNING,
+        )
+
+        vol_handles = []
+        for pvc_obj in pvc_objs:
+            pv_obj = pvc_obj.backed_pv_obj
+            vol_handles.append(pv_obj.get().get("spec").get("csi").get("volumeHandle"))
+
+        # Verify whether encrypted device is present inside the pod and run IO
+        for vol_handle, pod_obj in zip(vol_handles, pod_objs):
+            node = pod_obj.get_node()
+            assert verify_crypt_device_present_onnode(
+                node, vol_handle
+            ), f"Crypt devicve {vol_handle} not found on node:{node}"
+
+            pod_obj.run_io(
+                storage_type="block",
+                size=f"{pvc_size - 1}G",
+                io_direction="write",
+                runtime=60,
+            )
+        log.info("IO started on all pods")
+
+        # Wait for IO completion
+        for pod_obj in pod_objs:
+            pod_obj.get_fio_results()
+        log.info("IO completed on all pods")


### PR DESCRIPTION
This patch adds a new test case for KMIP with `USE_CRYPTO_RPC` set to false in kms configmap.

Setting `USE_CRYPTO_RPC` uses local crypto instead of remote (which is not supported by GKLM) and can be tested with any KMIP compatible KMS(ciphertrust in this case).