### PR TITLE
Fix ACM hub namespace name and configure ACM to import MCE clusters after installing multiclusterhub

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2670,7 +2670,9 @@ class Deployment(object):
         Returns:
              bool: True if ACM HUB operator is installed, False otherwise
         """
-        ocp_obj = OCP(kind=constants.ROOK_OPERATOR, namespace=self.namespace)
+        ocp_obj = OCP(
+            kind=constants.ROOK_OPERATOR, namespace=constants.ACM_HUB_NAMESPACE
+        )
         return ocp_obj.check_resource_existence(
             timeout=6,
             should_exist=True,
@@ -2685,6 +2687,8 @@ class Deployment(object):
         if self.acm_operator_installed():
             logger.info("ACM Operator is already installed")
             self.deploy_multicluster_hub()
+            if config.ENV_DATA.get("configure_acm_to_import_mce"):
+                self.configure_acm_to_import_mce_clusters()
             return
 
         if config.ENV_DATA.get("acm_hub_unreleased"):


### PR DESCRIPTION
Use the correct namespace to check whether ACM operator is installed.
Configure ACM to import MCE clusters after installing multiclusterhub when ACM operator is already present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACM hub operator detection to use the dedicated ACM hub namespace for more reliable validation during deployment initialization.
  * Enhanced conditional configuration behavior: when ACM is already installed, the multi-cluster import configuration is now applied if enabled, before completing the deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->