### PR TITLE
Use ACM hub cluster if not disconnected else skip subctl download

### DIFF
--- a/ocs_ci/deployment/acm.py
+++ b/ocs_ci/deployment/acm.py
@@ -95,7 +95,15 @@ class Submariner(object):
 
     def deploy(self):
         # Download subctl binary in any case.
-        self.download_binary()
+        # If the current context cluster is in disconnected environment, try from ACM cluster context
+        if config.DEPLOYMENT.get("disconnected"):
+            with config.RunWithAcmConfigContext():
+                if config.DEPLOYMENT.get("disconnected"):
+                    logger.warning(
+                        "Skip subctl binary download because the cluster is in disconnected environment"
+                    )
+                else:
+                    self.download_binary()
         if self.source == "upstream":
             self.deploy_upstream()
         elif self.source == "downstream":

--- a/ocs_ci/deployment/acm.py
+++ b/ocs_ci/deployment/acm.py
@@ -104,6 +104,8 @@ class Submariner(object):
                     )
                 else:
                     self.download_binary()
+        else:
+            self.download_binary()
         if self.source == "upstream":
             self.deploy_upstream()
         elif self.source == "downstream":


### PR DESCRIPTION
If the current context cluster is in disconnected environment, try from ACM cluster context to download subctl binary. Skip subctl binary download if ACM cluster is also in disconnected environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined `Submariner` deployment handling for disconnected environments. Binary download behavior now intelligently adapts based on deployment configuration. When operating in disconnected mode, downloads execute within the proper system context. Standard deployments continue with normal procedures. Enhanced logging tracks download status across environment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->