### PR TITLE
Fix parse_subvolume_ls_output to handle column-padded odf-cli output

### DIFF
--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1634,7 +1634,9 @@ class TestNfsEnable(ManageTest):
         subvolumes = []
         subvolumes_list = output.strip().split("\n")[1:]
         for item in subvolumes_list:
-            fs, sv, svg, status = item.split(" ")
+            if not item.strip():
+                continue
+            fs, sv, svg, status = item.split()
             subvolumes.append((fs, sv, svg, status))
         return subvolumes
 


### PR DESCRIPTION
Fix parse_subvolume_ls_output to handle column-padded odf-cli output

Description:

Problem
test_nfs_pvc_subvolume_deletion started failing on ODF 4.22.0-60 and later builds with:
`ValueError: too many values to unpack (expected 4)`
This is raised in parse_subvolume_ls_output at:

```
fs, sv, svg, status = item.split(" ")
Root cause: The odf-cli tool changed its subvolume ls output format starting around ODF 4.22.0-60, switching from single-space-delimited to column-aligned (padded) rows:
```

# Old format (<=4.22.0-42) — worked fine:
Filesystem  Subvolume  SubvolumeGroup  State
`ocs-storagecluster-cephfilesystem csi-vol-xxx csi in-use`

# New format (>=4.22.0-60) — breaks split(" "):
```
Filesystem                         Subvolume                                     SubvolumeGroup  State
ocs-storagecluster-cephfilesystem  csi-vol-xxx                                   csi             in-use
```
item.split(" ") splits on a single space, so multiple consecutive spaces produce empty strings, resulting in more than 4 values when unpacking into (fs, sv, svg, status).

Failures confirmed on:
> 
> Azure IPI, ODF 4.22.0-60, OCP 4.22 nightly
> vSphere UPI FIPS, ODF 4.22.0-62, OCP 4.22 nightly
> Earlier builds (e.g. ODF 4.22.0-42, vSphere UPI FIPS) passed fine with the old format.

Failed builds: 

> https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/48334/2141462/2141526/log
> https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/47899/2128964/2129028/log

worked fine:
https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/47231/2108447/2108510/log

Fix

> Replace item.split(" ") with item.split() (no argument), which splits on any whitespace and collapses consecutive spaces — handling both single-space and column-padded output formats. Also skip empty lines that may appear after stripping.