### PR TITLE
Fix must-gather image repo and tag for ODF 4.14-4.18

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -574,10 +574,34 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 334,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
         "line_number": 376,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 378,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -151,9 +151,9 @@ REPORTING:
   # but we still enable option to overwirte it if needed. Otherwise if
   # specified, the ARM architecture is not supported.
   ocp_must_gather_image: ""
-  default_ocs_must_gather_image: "quay.io/rhceph-dev/ocs-must-gather"
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"
   odf_live_must_gather_image: "registry.redhat.io/odf4/odf-must-gather-rhel9"
-  default_ocs_must_gather_latest_tag: "latest-4.22"
+  default_ocs_must_gather_latest_tag: "v4.22"
   gather_on_deploy_failure: true
   collect_logs_on_success_run: False
   rp_client_log_level: "ERROR"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.14.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.14.yaml
@@ -7,5 +7,5 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.14'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.14'
+  default_ocs_must_gather_latest_tag: 'v4.14'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.15.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.15.yaml
@@ -7,5 +7,5 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.15'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.15'
+  default_ocs_must_gather_latest_tag: 'v4.15'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.16.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.16.yaml
@@ -9,5 +9,5 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.16'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.16'
+  default_ocs_must_gather_latest_tag: 'v4.16'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.17.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.17.yaml
@@ -8,5 +8,5 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.17'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.17'
+  default_ocs_must_gather_latest_tag: 'v4.17'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.18.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.18.yaml
@@ -8,5 +8,5 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.18'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.18'
+  default_ocs_must_gather_latest_tag: 'v4.18'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/ocs_version/ocs-4.99.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.99.yaml
@@ -8,6 +8,6 @@ DEPLOYMENT:
 ENV_DATA:
   ocs_version: '4.99'
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.15'
-  default_ocs_must_gather_image: "quay.io/rhceph-dev/ocs-must-gather"
+  default_ocs_must_gather_latest_tag: 'v4.15'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"
   us_ds: 'US'

--- a/ocs_ci/ocs/must_gather/const_must_gather.py
+++ b/ocs_ci/ocs/must_gather/const_must_gather.py
@@ -885,6 +885,22 @@ GATHER_COMMANDS_OTHERS_EXCLUDE_4_11 = ["odf-csi-addons-operator.yaml"]
 
 GATHER_COMMANDS_OTHERS_EXCLUDE_4_13 = ["noobaa-db-pg-0-init.log"]
 
+# NooBaa files not produced by the odf4-odf-must-gather-rhel9 image (used from 4.14+).
+# The new image collects NooBaa data via oc adm inspect (API-group subdirs)
+# and oc logs, producing different file names than the old ocs-must-gather image.
+GATHER_COMMANDS_OTHERS_EXCLUDE_4_14 = [
+    "BackingStoreList_crs.yaml",
+    "BucketClassList_crs.yaml",
+    "db-noobaa-db-pg-0-pvc-describe.txt",
+    "NamespaceStoreList_crs.yaml",
+    "noobaa-core-0-core.log",
+    "noobaa-core-0-pod-describe.txt",
+    "noobaa-db-pg-0-db.log",
+    "noobaa-db-pg-0-pod-describe.txt",
+    "noobaa-endpoint-scc-describe.txt",
+    "NooBaaList_crs.yaml",
+]
+
 if config.ENV_DATA["platform"].lower() in constants.MANAGED_SERVICE_PLATFORMS:
     GATHER_COMMANDS_OTHERS = list(
         set(GATHER_COMMANDS_OTHERS) - set(GATHER_COMMANDS_OPENSHIFT_DEDICATED_EXCLUDE)
@@ -1050,6 +1066,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1081,6 +1098,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1114,6 +1132,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1147,6 +1166,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1180,6 +1200,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1213,6 +1234,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
             )
         ),
         "OTHERS_MANAGED_SERVICES": list(
@@ -1253,6 +1275,7 @@ GATHER_COMMANDS_VERSION = {
             - set(
                 GATHER_COMMANDS_OTHERS_EXCLUDE_4_11
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_13
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_14
                 + GATHER_COMMANDS_OTHERS_EXCLUDE_4_20
             )
         ),

--- a/ocs_ci/ocs/must_gather/const_must_gather.py
+++ b/ocs_ci/ocs/must_gather/const_must_gather.py
@@ -11,13 +11,21 @@ https://github.com/openshift/ocs-operator/blob/fefc8a0e04e314801809df2e5292a20fa
 OCS4.5 Link:
 https://github.com/openshift/ocs-operator/blob/de48c9c00f8964f0f8813d7b3ddd25f7bc318449/must-gather/collection-scripts/
 
+OCS 4.14-4.16 Notes (backported commands):
+
+- Commands backported to release-4.14+: debug logs, progress, rbd task list
+  (see GATHER_COMMANDS_CEPH_4_14, GATHER_COMMANDS_JSON_4_14)
+- Commands backported to release-4.16+: healthcheck history, MDS tell commands
+  (see GATHER_COMMANDS_CEPH_4_16, GATHER_COMMANDS_JSON_4_16)
+- These were previously only tracked in CEPH/JSON_4_20 but exist in earlier
+  release branches per https://github.com/red-hat-storage/odf-must-gather
+
 OCS 4.20 Notes:
 
 - Significant structural changes: files now organized by API group in subdirectories
   (e.g., apps/, core/, noobaa/, ceph/)
 - The existing os.walk() validation logic handles the new structure automatically
-- Added 33 new CEPH commands (see GATHER_COMMANDS_CEPH_4_20)
-- Added 12 new JSON commands (see GATHER_COMMANDS_JSON_4_20)
+- Added rados/rbd collection commands (see GATHER_COMMANDS_CEPH_4_20)
 - Deprecated commands removed via GATHER_COMMANDS_JSON_4_20_EXCLUDE:
   * ceph_osd_blacklist_ls replaced by ceph_osd_blocklist_ls (terminology change)
   * ceph_balancer_pool_ls no longer collected
@@ -736,22 +744,46 @@ GATHER_COMMANDS_OTHERS_4_10 = [
     "odf-operator.yaml",
 ]
 
-# New commands added in 4.20
-GATHER_COMMANDS_CEPH_4_20 = [
-    "ceph-volume_raw_list",
-    "ceph_fs_subvolume_ls_ocs-storagecluster-cephfilesystem_csi",
-    "ceph_healthcheck_history_ls",
+# Commands backported to release-4.14+ (present in v4.14 images onward)
+GATHER_COMMANDS_CEPH_4_14 = [
     "ceph_log_last_10000_debug_audit",
     "ceph_log_last_10000_debug_cluster",
     "ceph_progress",
     "ceph_progress_json",
     "ceph_rbd_task_list",
+]
+
+GATHER_COMMANDS_JSON_4_14 = [
+    "ceph_log_last_10000_debug_audit_--format_json-pretty",
+    "ceph_log_last_10000_debug_cluster_--format_json-pretty",
+    "ceph_rbd_task_list_--format_json-pretty",
+]
+
+# Commands backported to release-4.16+ (healthcheck + MDS tell commands)
+GATHER_COMMANDS_CEPH_4_16 = [
+    "ceph_healthcheck_history_ls",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_client_ls",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_damage_ls",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_blocked_ops",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_historic_ops",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_ops_in_flight",
     "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_session_ls",
+]
+
+GATHER_COMMANDS_JSON_4_16 = [
+    "ceph_healthcheck_history_ls_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_client_ls_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_damage_ls_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_blocked_ops_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_historic_ops_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_ops_in_flight_--format_json-pretty",
+    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_session_ls_--format_json-pretty",
+]
+
+# Commands truly new in 4.20 (rados/rbd collection, ceph-volume, blocklist rename)
+GATHER_COMMANDS_CEPH_4_20 = [
+    "ceph-volume_raw_list",
+    "ceph_fs_subvolume_ls_ocs-storagecluster-cephfilesystem_csi",
     "cephfs_subvol_and_snap_info",
     "rados_cephfs_objects",
     "rados_ls_--pool=ocs-storagecluster-cephblockpool",
@@ -773,21 +805,11 @@ GATHER_COMMANDS_CEPH_4_20 = [
     "rbd_vol_and_snap_info_ocs-storagecluster-cephblockpool",
 ]
 
-# New JSON commands added in 4.20
+# JSON commands truly new in 4.20
 # Note: blacklist→blocklist terminology change in ceph_osd commands
 GATHER_COMMANDS_JSON_4_20 = [
     "ceph_fs_subvolume_ls_ocs-storagecluster-cephfilesystem_csi_--format_json-pretty",
-    "ceph_healthcheck_history_ls_--format_json-pretty",
-    "ceph_log_last_10000_debug_audit_--format_json-pretty",
-    "ceph_log_last_10000_debug_cluster_--format_json-pretty",
     "ceph_osd_blocklist_ls_--format_json-pretty",
-    "ceph_rbd_task_list_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_client_ls_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_damage_ls_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_blocked_ops_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_historic_ops_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_dump_ops_in_flight_--format_json-pretty",
-    "ceph_tell_mds.ocs-storagecluster-cephfilesystem:0_session_ls_--format_json-pretty",
 ]
 
 # Commands removed/deprecated in 4.20
@@ -1013,8 +1035,12 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.14: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1040,8 +1066,12 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.15: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1067,8 +1097,14 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.16: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14
+        + GATHER_COMMANDS_CEPH_4_16,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14
+        + GATHER_COMMANDS_JSON_4_16,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1094,8 +1130,14 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.17: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14
+        + GATHER_COMMANDS_CEPH_4_16,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14
+        + GATHER_COMMANDS_JSON_4_16,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1121,8 +1163,14 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.18: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14
+        + GATHER_COMMANDS_CEPH_4_16,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14
+        + GATHER_COMMANDS_JSON_4_16,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1148,8 +1196,14 @@ GATHER_COMMANDS_VERSION = {
         ),
     },
     4.19: {
-        "CEPH": GATHER_COMMANDS_CEPH + GATHER_COMMANDS_CEPH_4_7,
-        "JSON": GATHER_COMMANDS_JSON + GATHER_COMMANDS_JSON_4_7,
+        "CEPH": GATHER_COMMANDS_CEPH
+        + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14
+        + GATHER_COMMANDS_CEPH_4_16,
+        "JSON": GATHER_COMMANDS_JSON
+        + GATHER_COMMANDS_JSON_4_7
+        + GATHER_COMMANDS_JSON_4_14
+        + GATHER_COMMANDS_JSON_4_16,
         "OTHERS": list(
             set(
                 GATHER_COMMANDS_OTHERS
@@ -1177,11 +1231,15 @@ GATHER_COMMANDS_VERSION = {
     4.20: {
         "CEPH": GATHER_COMMANDS_CEPH
         + GATHER_COMMANDS_CEPH_4_7
+        + GATHER_COMMANDS_CEPH_4_14
+        + GATHER_COMMANDS_CEPH_4_16
         + GATHER_COMMANDS_CEPH_4_20,
         "JSON": list(
             set(
                 GATHER_COMMANDS_JSON
                 + GATHER_COMMANDS_JSON_4_7
+                + GATHER_COMMANDS_JSON_4_14
+                + GATHER_COMMANDS_JSON_4_16
                 + GATHER_COMMANDS_JSON_4_20
             )
             - set(GATHER_COMMANDS_JSON_4_20_EXCLUDE)

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -89,11 +89,12 @@ class MustGather(object):
             files = GATHER_COMMANDS_VERSION[ocs_version]["OTHERS_EXTERNAL"]
         else:
             files = GATHER_COMMANDS_VERSION[ocs_version][self.type_log]
+        self.get_all_paths()
         for file in files:
             self.files_not_exist.append(file)
-            for dir_name, subdir_list, files_list in os.walk(self.root):
-                if file in files_list:
-                    self.files_path[file] = os.path.join(dir_name, file)
+            for full_path in self.full_paths:
+                if os.path.basename(full_path) == file:
+                    self.files_path[file] = full_path
                     self.files_not_exist.remove(file)
                     break
 
@@ -124,6 +125,8 @@ class MustGather(object):
         # https://bugzilla.redhat.com/show_bug.cgi?id=2049204
         # self.verify_ceph_file_content()
         for file, file_path in self.files_path.items():
+            if not os.path.isabs(file_path):
+                continue
             if not Path(file_path).is_file():
                 self.files_not_exist.append(file)
             elif re.search(r"\.yaml$", file):

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -254,15 +254,19 @@ class MustGather(object):
         if self.type_log == "OTHERS" and ocs_version >= version.VERSION_4_6:
             flag = False
             logger.info("Verify noobaa_diagnostics folder exist")
-            for path, subdirs, files in os.walk(self.root):
-                for file in files:
-                    if re.search(r"noobaa_diagnostics_.*.tar.gz", file):
-                        flag = True
-                        logger.info(f"Extract noobaa_diagnostics dir {file}")
-                        path_noobaa_diag = os.path.join(path, file)
-                        files_noobaa_diag = tarfile.open(path_noobaa_diag)
-                        files_noobaa_diag.extractall(path)
-                        break
+            self.get_all_paths()
+            for full_path in self.full_paths:
+                if re.search(
+                    r"noobaa_diagnostics_.*.tar.gz", os.path.basename(full_path)
+                ):
+                    flag = True
+                    if os.path.isabs(full_path):
+                        logger.info(f"Extract noobaa_diagnostics: {full_path}")
+                        with tarfile.open(full_path) as f:
+                            f.extractall(os.path.dirname(full_path))
+                    else:
+                        logger.info(f"Found noobaa_diagnostics in tarball: {full_path}")
+                    break
             if not flag:
                 logger.error("noobaa_diagnostics.tar.gz does not exist")
                 self.files_not_exist.append("noobaa_diagnostics.tar.gz")

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -178,6 +178,7 @@ class MustGather(object):
             if pattern is False:
                 pod_names.append(pod.name)
 
+        pod_path = None
         for dir_name, subdir_list, files_list in os.walk(self.root):
             if re.search("openshift-storage/pods$", dir_name):
                 pod_path = dir_name
@@ -185,10 +186,21 @@ class MustGather(object):
 
         pod_files = []
         logger.info("Get pod names on openshift-storage/pods directory")
-        for pod_file in os.listdir(pod_path):
-            pattern = self.check_pod_name_pattern(pod_file)
-            if pattern is False:
-                pod_files.append(pod_file)
+        if pod_path:
+            for pod_file in os.listdir(pod_path):
+                pattern = self.check_pod_name_pattern(pod_file)
+                if pattern is False:
+                    pod_files.append(pod_file)
+        else:
+            pods_pattern = re.compile(r"openshift-storage/pods/([^/]+)")
+            seen = set()
+            for full_path in self.full_paths:
+                match = pods_pattern.search(full_path)
+                if match and match.group(1) not in seen:
+                    seen.add(match.group(1))
+                    pattern = self.check_pod_name_pattern(match.group(1))
+                    if pattern is False:
+                        pod_files.append(match.group(1))
 
         diff = list(set(pod_files) - set(pod_names)) + list(
             set(pod_names) - set(pod_files)

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1023,10 +1023,13 @@ def run_must_gather(
 
     if config.REPORTING.get("tarball_mg_logs"):
         tarball_path = f"{log_dir_path}.tar.gz"
+        log.info(f"Packing must-gather logs to {tarball_path}")
         try:
             with tarfile.open(tarball_path, "w:gz") as tar:
                 tar.add(log_dir_path, arcname=os.path.basename(log_dir_path))
+            log.info(f"Must-gather tarball created: {tarball_path}")
             if config.REPORTING.get("delete_packed_mg_logs"):
+                log.info(f"Deleting packed must-gather directory: {log_dir_path}")
                 shutil.rmtree(log_dir_path)
         except Exception as err:
             log.error(f"Failed during packing files! Error: {err}")


### PR DESCRIPTION
- Update must-gather tag format from `latest-4.X` to `v4.X` for ODF 4.14-4.18 version configs — `latest-4.X` tags don't exist on quay.io, causing silent ImagePullBackOff with fallback to generic OCP data
- Update default_config.yaml fallback from deprecated `ocs-must-gather` repo to `odf4-odf-must-gather-rhel9`
- Update ocs-4.99.yaml (upstream dev config) to use correct repo and tag format

**Impact**: Without this fix, all must-gather collections on ODF 4.14-4.18 silently fail — the tarball is created but contains only generic OCP inspect data with no OCS-specific diagnostics (no ceph status, no noobaa logs, no storagecluster info). The `test_must_gather` test catches this, but post-failure must-gather for other tests silently loses OCS diagnostic data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated must-gather default image and “latest” tag formats across OCS/ODF versions to align with RHEL9-based artifacts.
  * Expanded and reorganized must-gather diagnostic command sets for OCS 4.14+ and 4.16+ backports, refining OCS 4.20 coverage to remove command overlap.
  * Added extra progress logging when packaging must-gather logs into a tarball.

* **Bug Fixes**
  * Improved expected-file discovery within packed archives and skipped validation for relative paths.
  * Enhanced NooBaa diagnostics detection to properly extract matching diagnostics tarballs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->