### PR TITLE
[release-4.19] update get_all_path to collect paths from tar.gz file

### DIFF
--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -252,15 +252,54 @@ class MustGather(object):
                 logger.error("noobaa_diagnostics.tar.gz does not exist")
                 self.files_not_exist.append("noobaa_diagnostics.tar.gz")
 
-    def get_all_paths(self):
+    def _get_paths_from_tarball(self, tarball_path):
         """
-        Get all paths in must gather dir
+        Collect all member paths from a must-gather tar.gz archive.
+
+        Args:
+            tarball_path (str): path to the .tar.gz file
+
+        Returns:
+            list: paths of all members (files and dirs) in the archive
 
         """
-        for root, dirs, files in os.walk(self.root):
+        paths = []
+        try:
+            with tarfile.open(tarball_path, "r:*") as tar:
+                for member in tar.getmembers():
+                    # Add the member path (files and dirs)
+                    paths.append(member.name)
+                    # Ensure parent directory paths are included for substring
+                    # matching in verify_paths_in_dir / verify_paths_not_in_dir
+                    parts = member.name.replace("\\", "/").split("/")
+                    for i in range(1, len(parts)):
+                        parent = "/".join(parts[:i])
+                        if parent and parent not in paths:
+                            paths.append(parent)
+        except (tarfile.TarError, OSError) as e:
+            logger.warning(f"Could not read tarball {tarball_path}: {e}")
+        return paths
+
+    def get_all_paths(self):
+        """
+        Get all paths in must gather dir (directory and/or tar.gz archives).
+
+        When REPORTING["tarball_mg_logs"] is used, must-gather may be packed
+        into a .tar.gz; this method collects paths from both directory trees
+        and from inside such tarballs.
+
+        """
+        self.full_paths = []
+
+        for root_dir, dirs, files in os.walk(self.root):
             for name in files + dirs:
-                full_path = os.path.join(root, name)
+                full_path = os.path.join(root_dir, name)
                 self.full_paths.append(full_path)
+            # Collect paths from must-gather tarballs found under root
+            for name in files:
+                if name.endswith(".tar.gz"):
+                    tarball_path = os.path.join(root_dir, name)
+                    self.full_paths.extend(self._get_paths_from_tarball(tarball_path))
 
     def verify_paths_in_dir(self, paths):
         """


### PR DESCRIPTION
Cherry-pick of #14281 to release-4.19.

- Backports `_get_paths_from_tarball()` to `get_all_paths()` so must-gather path verification works when `tarball_mg_logs=true` and `delete_packed_mg_logs=true` (both defaults)
- Without this fix, `test_must_gather_minimal_crd_modular` has 0% pass rate on release-4.19 because the expanded directory is deleted after tarballing and the old `get_all_paths()` cannot read paths from inside the tarball
- Replaces #15075 (robot PR had DCO sign-off mismatch)