### PR TITLE
deploy nightly builds on ROSA HCP with w/a (backport #14980 to release-4.20)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1974,
+        "line_number": 1976,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2081,
+        "line_number": 2083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2082,
+        "line_number": 2084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2083,
+        "line_number": 2085,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2084,
+        "line_number": 2086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2089,
+        "line_number": 2091,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2105,
+        "line_number": 2107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2113,
+        "line_number": 2115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2114,
+        "line_number": 2116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2115,
+        "line_number": 2117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2116,
+        "line_number": 2118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2117,
+        "line_number": 2119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2825,
+        "line_number": 2827,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2826,
+        "line_number": 2828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3525,
+        "line_number": 3527,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3526,
+        "line_number": 3528,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -389,7 +389,7 @@
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 250,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -472,6 +472,16 @@
         "verified_result": null
       }
     ],
+    "docs/logging_guide.md": [
+      {
+        "hashed_secret": "605cf0632d1f0b7aebb3c0cd5c51a92145bb28a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1421,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/supported_platforms.md": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
@@ -533,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2207,
+        "line_number": 6947,
         "type": "Private Key",
         "verified_result": null
       }
@@ -559,7 +569,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 327,
+        "line_number": 331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -567,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 377,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -587,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2810,
+        "line_number": 2831,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -598,6 +608,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
+      {
+        "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -641,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1957,
+        "line_number": 1974,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -649,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2064,
+        "line_number": 2081,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -657,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2065,
+        "line_number": 2082,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -665,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2066,
+        "line_number": 2083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -673,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2067,
+        "line_number": 2084,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -681,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2072,
+        "line_number": 2089,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -689,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2087,
+        "line_number": 2104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -697,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2088,
+        "line_number": 2105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -705,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2096,
+        "line_number": 2113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -713,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2097,
+        "line_number": 2114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -721,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2098,
+        "line_number": 2115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -729,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2099,
+        "line_number": 2116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2100,
+        "line_number": 2117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -745,7 +765,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2808,
+        "line_number": 2825,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -753,7 +773,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2809,
+        "line_number": 2826,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -761,7 +781,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3508,
+        "line_number": 3525,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -769,7 +789,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3509,
+        "line_number": 3526,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -833,7 +853,7 @@
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1262,
+        "line_number": 1269,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -977,7 +997,7 @@
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 686,
+        "line_number": 687,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -987,7 +1007,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 746,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -1017,7 +1037,7 @@
         "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1025,7 +1045,7 @@
         "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1033,7 +1053,7 @@
         "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1041,7 +1061,7 @@
         "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1049,7 +1069,7 @@
         "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1057,7 +1077,7 @@
         "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1065,7 +1085,7 @@
         "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1073,7 +1093,7 @@
         "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 33,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1081,7 +1101,7 @@
         "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 34,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1089,7 +1109,7 @@
         "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 35,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1097,7 +1117,7 @@
         "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 36,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1105,7 +1125,7 @@
         "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 37,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1113,7 +1133,7 @@
         "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 38,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1121,7 +1141,7 @@
         "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 39,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1129,7 +1149,7 @@
         "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1137,7 +1157,7 @@
         "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1145,7 +1165,7 @@
         "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 42,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1153,7 +1173,7 @@
         "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 43,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1161,7 +1181,7 @@
         "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 44,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1169,7 +1189,7 @@
         "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 44,
+        "line_number": 45,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1177,7 +1197,7 @@
         "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 46,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1185,7 +1205,7 @@
         "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 47,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1193,7 +1213,7 @@
         "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 48,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1201,7 +1221,7 @@
         "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 49,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1209,7 +1229,7 @@
         "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 49,
+        "line_number": 50,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1217,7 +1237,7 @@
         "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 51,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1225,7 +1245,7 @@
         "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 51,
+        "line_number": 52,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1233,7 +1253,7 @@
         "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 53,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1241,7 +1261,7 @@
         "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 54,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1249,7 +1269,7 @@
         "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 55,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1257,7 +1277,7 @@
         "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 56,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1265,7 +1285,7 @@
         "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 57,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1273,7 +1293,7 @@
         "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 58,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1281,12 +1301,20 @@
         "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 59,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
       {
-        "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "hashed_secret": "a9c2f9fb9293eac7f7055dc5ad8510ed89446890",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6828bcb400541dcb69f04098c046c36947a664be",
         "is_secret": false,
         "is_verified": false,
         "line_number": 61,
@@ -1294,10 +1322,50 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "hashed_secret": "a7f8c0d263a1263d2f858d388e0f6ed799c3ed85",
         "is_secret": false,
         "is_verified": false,
         "line_number": 62,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e7aac35a54098dff672130afc60ba0395f339089",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "642e4f0372448c534f32262a96e7d9f2b27b47d2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 64,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3bdd128c4f1e6c4d3ade5eb86dcfecc387e13a38",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 65,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 69,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1084,10 +1084,17 @@ class Deployment(object):
             subscription_yaml_data["spec"]["channel"] = default_channel
         if config.DEPLOYMENT.get("stage"):
             subscription_yaml_data["spec"]["source"] = constants.OPERATOR_SOURCE_NAME
-        if config.DEPLOYMENT.get("live_deployment"):
+        rosa_hcp_non_ga = platform == constants.ROSA_HCP_PLATFORM and bool(
+            config.DEPLOYMENT.get("ocs_registry_image")
+        )
+        if config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
             subscription_yaml_data["spec"]["source"] = config.DEPLOYMENT.get(
                 "live_content_source", defaults.LIVE_CONTENT_SOURCE
             )
+        elif platform == constants.ROSA_HCP_PLATFORM and (
+            not live_deployment or rosa_hcp_non_ga
+        ):
+            subscription_yaml_data["spec"]["source"] = constants.OCS_CATALOG_SOURCE_NAME
         if aws_sts_deployment:
             if "config" not in subscription_yaml_data["spec"]:
                 subscription_yaml_data["spec"]["config"] = {}
@@ -1246,7 +1253,8 @@ class Deployment(object):
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
         rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
-        if not live_deployment and not (
+        rosa_hcp_non_ga = rosa_hcp and bool(config.DEPLOYMENT.get("ocs_registry_image"))
+        if (not live_deployment or rosa_hcp_non_ga) and not (
             stage_testing and konflux_build and not rosa_hcp
         ):
             log_step("Create catalog source and wait it to be READY")
@@ -2843,10 +2851,12 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         ignore_upgrade (bool): Ignore upgrade parameter.
 
     """
-    # Because custom catalog source will be called: redhat-operators, we need to disable
-    # default sources. This should not be an issue as OCS internal registry images
-    # are now based on OCP registry image
-    disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
+    rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+    if not rosa_hcp:
+        # Because custom catalog source will be called: redhat-operators, we need to disable
+        # default sources. This should not be an issue as OCS internal registry images
+        # are now based on OCP registry image
+        disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
     logger.info("Adding CatalogSource")
     if not image:
         image = config.DEPLOYMENT.get("ocs_registry_image", "")
@@ -2857,7 +2867,7 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+        if not rosa_hcp:
             run_cmd(
                 "oc patch image.config.openshift.io/cluster --type merge -p '"
                 '{"spec": {"registrySources": {"insecureRegistries": '
@@ -2877,7 +2887,14 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         image_tag = get_latest_ds_olm_tag(
             upgrade, latest_tag=config.DEPLOYMENT.get("default_latest_tag", "latest")
         )
-    catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+    if rosa_hcp:
+        catalog_source_data = templating.load_yaml(
+            constants.PROVIDER_MODE_CATALOGSOURCE
+        )
+        cs_name = constants.OCS_CATALOG_SOURCE_NAME
+    else:
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+        cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     managed_ibmcloud = (
         config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
         and config.ENV_DATA["deployment_type"] == "managed"
@@ -2885,7 +2902,6 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     if managed_ibmcloud:
         create_ocs_secret(constants.MARKETPLACE_NAMESPACE)
         catalog_source_data["spec"]["secrets"] = [constants.OCS_SECRET]
-    cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     change_cs_condition = (
         (image or image_tag)
         and catalog_source_data["kind"] == "CatalogSource"
@@ -2908,7 +2924,7 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     templating.dump_data_to_temp_yaml(catalog_source_data, catalog_source_manifest.name)
     run_cmd(f"oc apply -f {catalog_source_manifest.name}", timeout=2400)
     catalog_source = CatalogSource(
-        resource_name=constants.OPERATOR_CATALOG_SOURCE_NAME,
+        resource_name=cs_name,
         namespace=constants.MARKETPLACE_NAMESPACE,
     )
     # Wait for catalog source is ready

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1245,25 +1245,36 @@ class Deployment(object):
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
-        if not live_deployment and not (stage_testing and konflux_build):
+        rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+        if not live_deployment and not (
+            stage_testing and konflux_build and not rosa_hcp
+        ):
             log_step("Create catalog source and wait it to be READY")
             create_catalog_source(image)
         if konflux_build and stage_testing:
-            log_step("Creating stage ImageDigestMirrorSet")
-            exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-            if not upgrade:
-                log_step("Creating stage TagMirrorSet")
-                exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
-                log_step("Sleeping 60 seconds after applying tag mirror set.")
-            time.sleep(60)
-            log_step("Waiting max 30 mins for master MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/master", timeout=2100
-            )
-            log_step("Waiting max 30 mins for worker MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/worker", timeout=2100
-            )
+            if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+                log_step(
+                    "ROSA HCP: mirrors applied via worker filesystem "
+                    "inside get_and_apply_idms_from_catalog — skipping IDMS apply and MCP wait"
+                )
+            else:
+                log_step("Creating stage ImageDigestMirrorSet")
+                exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+                if not upgrade:
+                    log_step("Creating stage TagMirrorSet")
+                    exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
+                    log_step("Sleeping 60 seconds after applying tag mirror set.")
+                time.sleep(60)
+                log_step("Waiting max 30 mins for master MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/master",
+                    timeout=2100,
+                )
+                log_step("Waiting max 30 mins for worker MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/worker",
+                    timeout=2100,
+                )
 
         # with Hub/Spoke deployments LSO on IBM BareMetal is a mandatory requirement, it is installed on Dependency
         # stage when config["DEPLOYMENT"]["lso_standalone_deployment"] is set to True
@@ -2846,14 +2857,15 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        run_cmd(
-            "oc patch image.config.openshift.io/cluster --type merge -p '"
-            '{"spec": {"registrySources": {"insecureRegistries": '
-            '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
-            "}}}'"
-        )
-        run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-        wait_for_machineconfigpool_status("all", timeout=1800)
+        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+            run_cmd(
+                "oc patch image.config.openshift.io/cluster --type merge -p '"
+                '{"spec": {"registrySources": {"insecureRegistries": '
+                '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
+                "}}}'"
+            )
+            run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+            wait_for_machineconfigpool_status("all", timeout=1800)
     if not ignore_upgrade:
         upgrade = config.UPGRADE.get("upgrade", False)
     else:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1138,10 +1138,17 @@ class Deployment(object):
             subscription_yaml_data["spec"]["channel"] = default_channel
         if config.DEPLOYMENT.get("stage"):
             subscription_yaml_data["spec"]["source"] = constants.OPERATOR_SOURCE_NAME
-        if config.DEPLOYMENT.get("live_deployment"):
+        rosa_hcp_non_ga = platform == constants.ROSA_HCP_PLATFORM and bool(
+            config.DEPLOYMENT.get("ocs_registry_image")
+        )
+        if config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
             subscription_yaml_data["spec"]["source"] = config.DEPLOYMENT.get(
                 "live_content_source", defaults.LIVE_CONTENT_SOURCE
             )
+        elif platform == constants.ROSA_HCP_PLATFORM and (
+            not live_deployment or rosa_hcp_non_ga
+        ):
+            subscription_yaml_data["spec"]["source"] = constants.OCS_CATALOG_SOURCE_NAME
         if aws_sts_deployment:
             if "config" not in subscription_yaml_data["spec"]:
                 subscription_yaml_data["spec"]["config"] = {}
@@ -1266,7 +1273,8 @@ class Deployment(object):
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
         rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
-        if not live_deployment and not (
+        rosa_hcp_non_ga = rosa_hcp and bool(config.DEPLOYMENT.get("ocs_registry_image"))
+        if (not live_deployment or rosa_hcp_non_ga) and not (
             stage_testing and konflux_build and not rosa_hcp
         ):
             log_step("Create catalog source and wait it to be READY")
@@ -2863,10 +2871,12 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         ignore_upgrade (bool): Ignore upgrade parameter.
 
     """
-    # Because custom catalog source will be called: redhat-operators, we need to disable
-    # default sources. This should not be an issue as OCS internal registry images
-    # are now based on OCP registry image
-    disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
+    rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+    if not rosa_hcp:
+        # Because custom catalog source will be called: redhat-operators, we need to disable
+        # default sources. This should not be an issue as OCS internal registry images
+        # are now based on OCP registry image
+        disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
     logger.info("Adding CatalogSource")
     if not image:
         image = config.DEPLOYMENT.get("ocs_registry_image", "")
@@ -2877,7 +2887,7 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+        if not rosa_hcp:
             run_cmd(
                 "oc patch image.config.openshift.io/cluster --type merge -p '"
                 '{"spec": {"registrySources": {"insecureRegistries": '
@@ -2906,6 +2916,14 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         if "grpcPodConfig" in catalog_source_data.get("spec", {}):
             catalog_source_data["spec"]["grpcPodConfig"].pop("extractContent", None)
 
+    if rosa_hcp:
+        catalog_source_data = templating.load_yaml(
+            constants.PROVIDER_MODE_CATALOGSOURCE
+        )
+        cs_name = constants.OCS_CATALOG_SOURCE_NAME
+    else:
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+        cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     managed_ibmcloud = (
         config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
         and config.ENV_DATA["deployment_type"] == "managed"
@@ -2913,7 +2931,6 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     if managed_ibmcloud:
         create_ocs_secret(constants.MARKETPLACE_NAMESPACE)
         catalog_source_data["spec"]["secrets"] = [constants.OCS_SECRET]
-    cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     change_cs_condition = (
         (image or image_tag)
         and catalog_source_data["kind"] == "CatalogSource"

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1265,25 +1265,36 @@ class Deployment(object):
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
-        if not live_deployment and not (stage_testing and konflux_build):
+        rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+        if not live_deployment and not (
+            stage_testing and konflux_build and not rosa_hcp
+        ):
             log_step("Create catalog source and wait it to be READY")
             create_catalog_source(image)
         if konflux_build and stage_testing:
-            log_step("Creating stage ImageDigestMirrorSet")
-            exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-            if not upgrade:
-                log_step("Creating stage TagMirrorSet")
-                exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
-                log_step("Sleeping 60 seconds after applying tag mirror set.")
-            time.sleep(60)
-            log_step("Waiting max 30 mins for master MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/master", timeout=2100
-            )
-            log_step("Waiting max 30 mins for worker MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/worker", timeout=2100
-            )
+            if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+                log_step(
+                    "ROSA HCP: mirrors applied via worker filesystem "
+                    "inside get_and_apply_idms_from_catalog — skipping IDMS apply and MCP wait"
+                )
+            else:
+                log_step("Creating stage ImageDigestMirrorSet")
+                exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+                if not upgrade:
+                    log_step("Creating stage TagMirrorSet")
+                    exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
+                    log_step("Sleeping 60 seconds after applying tag mirror set.")
+                time.sleep(60)
+                log_step("Waiting max 30 mins for master MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/master",
+                    timeout=2100,
+                )
+                log_step("Waiting max 30 mins for worker MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/worker",
+                    timeout=2100,
+                )
 
         # with Hub/Spoke deployments LSO on IBM BareMetal is a mandatory requirement, it is installed on Dependency
         # stage when config["DEPLOYMENT"]["lso_standalone_deployment"] is set to True
@@ -2866,14 +2877,15 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        run_cmd(
-            "oc patch image.config.openshift.io/cluster --type merge -p '"
-            '{"spec": {"registrySources": {"insecureRegistries": '
-            '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
-            "}}}'"
-        )
-        run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-        wait_for_machineconfigpool_status("all", timeout=1800)
+        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+            run_cmd(
+                "oc patch image.config.openshift.io/cluster --type merge -p '"
+                '{"spec": {"registrySources": {"insecureRegistries": '
+                '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
+                "}}}'"
+            )
+            run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+            wait_for_machineconfigpool_status("all", timeout=1800)
     if not ignore_upgrade:
         upgrade = config.UPGRADE.get("upgrade", False)
     else:

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -21,7 +21,10 @@ from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.ocs.resources.pod import get_operator_pods
 from ocs_ci.utility import openshift_dedicated as ocm, rosa
 from ocs_ci.utility.aws import AWS as AWSUtil, delete_sts_iam_roles, delete_subnet_tags
-from ocs_ci.utility.deployment import create_openshift_install_log_file
+from ocs_ci.utility.deployment import (
+    create_openshift_install_log_file,
+    deploy_roks_icsp_daemonset,
+)
 from ocs_ci.utility.rosa import (
     get_associated_oidc_config_id,
     delete_account_roles,
@@ -308,6 +311,12 @@ class ROSA(CloudDeploymentBase):
 
         # rosa hcp is self-managed and doesn't support ODF addon
         if rosa_hcp:
+            if config.DEPLOYMENT.get("konflux_build"):
+                log_step(
+                    "ROSA HCP + Konflux: deploying roks-icsp DaemonSet "
+                    "for worker filesystem-based mirror configuration"
+                )
+                deploy_roks_icsp_daemonset()
             super(ROSA, self).deploy_ocs()
         else:
             rosa.install_odf_addon(self.cluster_name)

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -323,22 +323,28 @@ class ROSA(CloudDeploymentBase):
 
         pod = ocp.OCP(kind=constants.POD, namespace=self.namespace)
 
+        # ROSA HCP ODF deployment is slower due to worker filesystem mirror
+        # configuration and image pull via registries.conf.d mirrors — double timeouts
+        timeout_multiplier = 2 if rosa_hcp else 1
+
         if config.ENV_DATA.get("cluster_type") != "consumer":
             # Check for Ceph pods
             assert pod.wait_for_resource(
                 condition="Running",
                 selector=constants.MON_APP_LABEL,
                 resource_count=3,
-                timeout=600,
+                timeout=600 * timeout_multiplier,
             )
             assert pod.wait_for_resource(
-                condition="Running", selector=constants.MGR_APP_LABEL, timeout=600
+                condition="Running",
+                selector=constants.MGR_APP_LABEL,
+                timeout=600 * timeout_multiplier,
             )
             assert pod.wait_for_resource(
                 condition="Running",
                 selector=constants.OSD_APP_LABEL,
                 resource_count=3,
-                timeout=600,
+                timeout=600 * timeout_multiplier,
             )
 
         if config.DEPLOYMENT.get("pullsecret_workaround") or config.DEPLOYMENT.get(
@@ -353,7 +359,9 @@ class ROSA(CloudDeploymentBase):
             )()
 
         # Verify health of ceph cluster
-        ceph_health_check(namespace=self.namespace, tries=60, delay=10)
+        ceph_health_check(
+            namespace=self.namespace, tries=60 * timeout_multiplier, delay=10
+        )
 
         # Workaround for the bug 2166900
         if config.ENV_DATA.get("cluster_type") == "consumer":

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1742,6 +1742,23 @@ ROSA_PLATFORM = "rosa"
 FUSIONAAS_PLATFORM = "fusion_aas"
 ROSA_HCP_PLATFORM = "rosa_hcp"
 ROSA_PLATFORMS = [ROSA_PLATFORM, ROSA_HCP_PLATFORM]
+ROSA_HCP_DS_NAMESPACE = "kube-system"
+ROSA_HCP_DS_LABEL = "app=roks-icsp"
+ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
+ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
+ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"
+)
+ROSA_HCP_ROKS_ICSP_DS_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-daemonset.yaml"
+)
+ROSA_HCP_ROKS_ICSP_SVC_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-service.yaml"
+)
+ROSA_HCP_ROKS_ICSP_MC_CRD_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-machineconfig-crd.yaml"
+)
 HCI_BAREMETAL = "hci_baremetal"
 HCI_VSPHERE = "hci_vsphere"
 ACM_OCP_DEPLOYMENT = "acm_ocp_deployment"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1746,6 +1746,8 @@ ROSA_HCP_DS_NAMESPACE = "kube-system"
 ROSA_HCP_DS_LABEL = "app=roks-icsp"
 ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
 ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_HOST_KUBELET_CONFIG = "/host/var/lib/kubelet/config.json"
+ROSA_HCP_CRIO_CONF_DROP_IN = "/host/etc/crio/crio.conf.d/00-default"
 ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
 ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1743,6 +1743,23 @@ ROSA_PLATFORM = "rosa"
 FUSIONAAS_PLATFORM = "fusion_aas"
 ROSA_HCP_PLATFORM = "rosa_hcp"
 ROSA_PLATFORMS = [ROSA_PLATFORM, ROSA_HCP_PLATFORM]
+ROSA_HCP_DS_NAMESPACE = "kube-system"
+ROSA_HCP_DS_LABEL = "app=roks-icsp"
+ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
+ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
+ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"
+)
+ROSA_HCP_ROKS_ICSP_DS_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-daemonset.yaml"
+)
+ROSA_HCP_ROKS_ICSP_SVC_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-service.yaml"
+)
+ROSA_HCP_ROKS_ICSP_MC_CRD_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-machineconfig-crd.yaml"
+)
 HCI_BAREMETAL = "hci_baremetal"
 HCI_VSPHERE = "hci_vsphere"
 ACM_OCP_DEPLOYMENT = "acm_ocp_deployment"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1747,6 +1747,8 @@ ROSA_HCP_DS_NAMESPACE = "kube-system"
 ROSA_HCP_DS_LABEL = "app=roks-icsp"
 ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
 ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_HOST_KUBELET_CONFIG = "/host/var/lib/kubelet/config.json"
+ROSA_HCP_CRIO_CONF_DROP_IN = "/host/etc/crio/crio.conf.d/00-default"
 ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
 ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-daemonset.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-daemonset.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: roks-icsp-ds
+  namespace: kube-system
+  labels:
+    app: roks-icsp
+spec:
+  selector:
+    matchLabels:
+      app: roks-icsp
+  template:
+    metadata:
+      labels:
+        app: roks-icsp
+    spec:
+      serviceAccountName: sa-roks-sync
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: roks-icsp
+          image: quay.io/cicdtest/roks-enabler:rosa
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: host
+              mountPath: /host
+          resources: {}
+      volumes:
+        - name: host
+          hostPath:
+            path: /

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-machineconfig-crd.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-machineconfig-crd.yaml
@@ -1,0 +1,28 @@
+---
+# Minimal stub CRD for machineconfigs.machineconfiguration.openshift.io
+# Required on ROSA HCP where the MachineConfig controller is absent.
+# The roks-icsp DaemonSet (quay.io/cicdtest/roks-enabler:rosa) checks for
+# this CRD to determine whether ICSP syncing to worker nodes is available.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machineconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfig
+    listKind: MachineConfigList
+    plural: machineconfigs
+    shortNames:
+      - mc
+    singular: machineconfig
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: MachineConfig defines the configuration for a machine
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-service.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-roks-icsp
+  namespace: kube-system
+  labels:
+    app: roks-icsp
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: roks-icsp
+  type: ClusterIP

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-serviceaccount.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-roks-sync
+  namespace: kube-system

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2240,6 +2240,59 @@ class AWS(object):
             else:
                 logger.error(f"Error deleting OIDC provider: {e}")
 
+    def cleanup_oidc_providers_by_prefix(self, url_prefix):
+        """
+        Delete all OIDC providers whose URL starts with the given prefix.
+
+        AWS has a hard limit of 100 OpenID Connect providers per account.
+        When HCP cluster deployments fail or are aborted without proper
+        cleanup, their OIDC providers remain and accumulate until the limit
+        is hit, blocking all new deployments.
+
+        This method lists all OIDC providers in the account and deletes
+        those whose issuer URL starts with the given prefix (typically
+        the cluster's OIDC bucket name). This safely scopes the cleanup
+        to a single cluster's providers without affecting other clusters.
+
+        Args:
+            url_prefix (str): URL prefix to match, e.g.
+                ``"mycluster-oidc-bucket.s3.us-west-2.amazonaws.com"``
+
+        Returns:
+            int: Number of OIDC providers deleted.
+        """
+        try:
+            response = self.iam_client.list_open_id_connect_providers()
+        except Exception as e:
+            logger.error(f"Failed to list OIDC providers: {e}")
+            return 0
+
+        providers = response.get("OpenIDConnectProviderList", [])
+        deleted_count = 0
+        for provider in providers:
+            arn = provider["Arn"]
+            url = (
+                arn.split(":oidc-provider/", 1)[-1] if ":oidc-provider/" in arn else ""
+            )
+            if not url.startswith(url_prefix):
+                continue
+
+            logger.info(f"Deleting OIDC provider matching prefix '{url_prefix}': {arn}")
+            try:
+                self.iam_client.delete_open_id_connect_provider(
+                    OpenIDConnectProviderArn=arn
+                )
+                deleted_count += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete OIDC provider {arn}: {e}")
+
+        if deleted_count:
+            logger.info(
+                f"Deleted {deleted_count} OIDC provider(s) "
+                f"matching prefix '{url_prefix}'"
+            )
+        return deleted_count
+
     def get_caller_identity(self):
         """
         Get STS Caller Identity Account ID

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -425,7 +425,8 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         pod_name = pod["metadata"]["name"]
         exec_cmd(
             f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\""
+            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\"",
+            silent=True,
         )
     logger.info(
         f"Written mirror config ({len(image_digest_mirrors)} entries) "
@@ -453,13 +454,15 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
                 f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
                 f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
                 ignore_error=True,
+                silent=True,
             )
             existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
             existing.setdefault("auths", {}).update(extra_auths)
             merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
             exec_cmd(
                 f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\""
+                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\"",
+                silent=True,
             )
         logger.info(
             f"Merged credentials for {list(extra_auths.keys())} into "
@@ -467,7 +470,9 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         )
 
     # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
-    worker_nodes = ocp_module.get_node_objs(node_type="worker")
+    from ocs_ci.ocs.node import get_nodes
+
+    worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
     for node in worker_nodes:
         ocp_module.OCP().exec_oc_debug_cmd(
             node=node.name,

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -2,6 +2,8 @@
 Utility functions that are used as a part of OCP or OCS deployments
 """
 
+import base64
+import json
 import logging
 import os
 import re
@@ -219,8 +221,17 @@ def get_and_apply_idms_from_catalog(image, apply=True, insecure=False):
     stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
     konflux_build = config.DEPLOYMENT.get("konflux_build")
     if stage_testing and konflux_build:
-        logger.info("Skipping applying IDMS rules from image for konflux stage testing")
-        return ""
+        if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+            logger.info(
+                "ROSA HCP + Konflux: extracting IDMS from catalog image for "
+                "filesystem-based mirror configuration on worker nodes"
+            )
+            apply = False
+        else:
+            logger.info(
+                "Skipping applying IDMS rules from image for konflux stage testing"
+            )
+            return ""
     idms_file_location = "/idms.yaml"
     idms_file_dest_dir = os.path.join(
         config.ENV_DATA["cluster_path"], f"idms-{config.RUN['run_id']}"
@@ -247,21 +258,222 @@ def get_and_apply_idms_from_catalog(image, apply=True, insecure=False):
         yaml.dump(idms_content, f)
 
     if apply and not config.DEPLOYMENT.get("disconnected"):
-        exec_cmd(f"oc apply -f {idms_file_dest_location}")
-        managed_ibmcloud = (
-            config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
-            and config.ENV_DATA["deployment_type"] == "managed"
-        )
-        if not managed_ibmcloud:
-            num_nodes = (
-                config.ENV_DATA["worker_replicas"]
-                + config.ENV_DATA["master_replicas"]
-                + config.ENV_DATA.get("infra_replicas", 0)
+        if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+            with open(idms_file_dest_location) as f:
+                _idms = yaml.safe_load(f)
+            apply_idms_via_worker_filesystem(
+                _idms.get("spec", {}).get("imageDigestMirrors", [])
             )
-            timeout = 2800 if num_nodes > 6 else 1900
-            wait_for_machineconfigpool_status(node_type="all", timeout=timeout)
+        else:
+            exec_cmd(f"oc apply -f {idms_file_dest_location}")
+            managed_ibmcloud = (
+                config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
+                and config.ENV_DATA["deployment_type"] == "managed"
+            )
+            if not managed_ibmcloud:
+                num_nodes = (
+                    config.ENV_DATA["worker_replicas"]
+                    + config.ENV_DATA["master_replicas"]
+                    + config.ENV_DATA.get("infra_replicas", 0)
+                )
+                timeout = 2800 if num_nodes > 6 else 1900
+                wait_for_machineconfigpool_status(node_type="all", timeout=timeout)
+
+    if (
+        stage_testing
+        and konflux_build
+        and config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+        and os.path.exists(idms_file_dest_location)
+    ):
+        with open(idms_file_dest_location) as f:
+            idms_content = yaml.safe_load(f)
+        image_digest_mirrors = idms_content.get("spec", {}).get(
+            "imageDigestMirrors", []
+        )
+        apply_idms_via_worker_filesystem(image_digest_mirrors)
 
     return idms_file_dest_location
+
+
+def deploy_roks_icsp_daemonset():
+    """
+    Deploy the roks-icsp privileged DaemonSet on ROSA HCP worker nodes.
+
+    The DaemonSet (quay.io/cicdtest/roks-enabler:rosa) mounts the host
+    filesystem at /host and is used to write CRI-O mirror configuration
+    directly to /host/etc/containers/registries.conf.d/ on each worker,
+    bypassing the ImageDigestMirrorSet API which is blocked on ROSA HCP
+    by ValidatingAdmissionPolicy.
+
+    Also creates a fake machineconfigs.machineconfiguration.openshift.io CRD
+    which is absent on ROSA HCP hosted clusters.
+
+    Source: https://github.com/xcliu-ca/rosa-icsp-gps/blob/main/enabler.sh
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    # Idempotent: skip if DaemonSet pods are already running
+    existing = get_pods_having_label(
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    )
+    if existing:
+        logger.info(
+            f"roks-icsp DaemonSet already running "
+            f"({len(existing)} pod(s)) — skipping deployment"
+        )
+        return
+
+    logger.info("Deploying roks-icsp DaemonSet on ROSA HCP worker nodes")
+
+    sa_manifest = templating.load_yaml(constants.ROSA_HCP_ROKS_ICSP_SA_YAML)
+
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_SA_YAML}")
+    exec_cmd(
+        f"oc adm policy add-cluster-role-to-user cluster-admin "
+        f"system:serviceaccount:{constants.ROSA_HCP_DS_NAMESPACE}:"
+        f"{sa_manifest['metadata']['name']}"
+    )
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_DS_YAML}")
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_SVC_YAML}")
+
+    # Create fake MachineConfig CRD if absent (not present on ROSA HCP)
+    existing_crd = exec_cmd(
+        "oc get crd machineconfigs.machineconfiguration.openshift.io "
+        "--ignore-not-found -o name",
+        ignore_error=True,
+    )
+    if not existing_crd.stdout.strip():
+        logger.info("Creating fake MachineConfig CRD for ROSA HCP compatibility")
+        exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_MC_CRD_YAML}")
+
+    # Wait for DaemonSet to roll out on all worker nodes
+    num_workers = config.ENV_DATA["worker_replicas"]
+    from ocs_ci.utility.utils import TimeoutSampler
+
+    for sample in TimeoutSampler(
+        timeout=180,
+        sleep=10,
+        func=get_pods_having_label,
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    ):
+        running = [p for p in sample if p.get("status", {}).get("phase") == "Running"]
+        if len(running) >= num_workers:
+            logger.info(
+                f"roks-icsp DaemonSet ready: {len(running)}/{num_workers} pods running"
+            )
+            return
+
+
+def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
+    """
+    Write CRI-O registry mirror configuration to worker nodes via a privileged
+    DaemonSet that mounts the host filesystem at /host.
+
+    Used on ROSA HCP where ImageDigestMirrorSet cannot be applied via oc apply
+    (blocked by ValidatingAdmissionPolicy).
+
+    Args:
+        image_digest_mirrors (list): list of dicts with 'source' and 'mirrors' keys,
+            matching the imageDigestMirrors schema from an ImageDigestMirrorSet.
+        conf_filename (str): filename to write inside registries.conf.d.
+            Defaults to ROSA_HCP_KONFLUX_MIRROR_CONF constant.
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+    from ocs_ci.ocs import ocp as ocp_module
+
+    if conf_filename is None:
+        conf_filename = constants.ROSA_HCP_KONFLUX_MIRROR_CONF
+
+    ds_pods = get_pods_having_label(
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    )
+    if not ds_pods:
+        logger.warning(
+            f"No DaemonSet pods found with label '{constants.ROSA_HCP_DS_LABEL}' "
+            f"in namespace '{constants.ROSA_HCP_DS_NAMESPACE}'. "
+            "Cannot apply IDMS via worker filesystem."
+        )
+        return
+
+    # Build CRI-O TOML content from IDMS entries
+    toml_lines = []
+    for entry in image_digest_mirrors:
+        source = entry["source"]
+        mirrors = entry.get("mirrors", [])
+        toml_lines += [
+            "[[registry]]",
+            f'prefix = "{source}"',
+            f'location = "{source}"',
+            "blocked = false",
+            "",
+        ]
+        for mirror in mirrors:
+            toml_lines += [
+                "[[registry.mirror]]",
+                f'location = "{mirror}"',
+                "insecure = false",
+                "",
+            ]
+    toml_content = "\n".join(toml_lines)
+    encoded = base64.b64encode(toml_content.encode()).decode()
+    dest_path = f"{constants.ROSA_HCP_HOST_REGISTRIES_CONF_D}/{conf_filename}"
+
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+        exec_cmd(
+            f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\""
+        )
+    logger.info(
+        f"Written mirror config ({len(image_digest_mirrors)} entries) "
+        f"to {dest_path} on {len(ds_pods)} worker node(s)"
+    )
+
+    # Merge mirror registry credentials into /host/etc/containers/auth.json
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+    with open(pull_secret_path) as f:
+        pull_secret = json.load(f)
+    mirror_registries = {
+        mirror.split("/")[0]
+        for entry in image_digest_mirrors
+        for mirror in entry.get("mirrors", [])
+    }
+    extra_auths = {
+        reg: creds
+        for reg, creds in pull_secret["auths"].items()
+        if reg in mirror_registries
+    }
+    if extra_auths:
+        for pod in ds_pods:
+            pod_name = pod["metadata"]["name"]
+            existing_raw = exec_cmd(
+                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
+                ignore_error=True,
+            )
+            existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
+            existing.setdefault("auths", {}).update(extra_auths)
+            merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
+            exec_cmd(
+                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\""
+            )
+        logger.info(
+            f"Merged credentials for {list(extra_auths.keys())} into "
+            f"{constants.ROSA_HCP_HOST_AUTH_JSON} on worker nodes"
+        )
+
+    # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
+    worker_nodes = ocp_module.get_node_objs(node_type="worker")
+    for node in worker_nodes:
+        ocp_module.OCP().exec_oc_debug_cmd(
+            node=node.name,
+            cmd_list=["systemctl reload crio"],
+        )
+    logger.info("CRI-O reloaded on all worker nodes")
 
 
 def add_mc_partitioned_disk_on_workers_to_ocp_deployment(disk):

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -426,59 +426,199 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         exec_cmd(
             f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
             f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\"",
-            silent=True,
+            secrets=[encoded],
         )
     logger.info(
         f"Written mirror config ({len(image_digest_mirrors)} entries) "
         f"to {dest_path} on {len(ds_pods)} worker node(s)"
     )
 
-    # Merge mirror registry credentials into /host/etc/containers/auth.json
+    # Build merged auth.json on OCS-CI side (DaemonSet container has no python3).
+    # CRI-O on ROSA HCP workers uses global_auth_file = kubelet/config.json
+    # (set in /etc/crio/crio.conf.d/00-default), NOT /etc/containers/auth.json.
+    # kubelet/config.json contains the OCM cluster pull-secret which lacks access
+    # to quay.io/rhceph-dev nightly images. We redirect CRI-O to use auth.json
+    # (which we control) by merging kubelet creds + mirror creds + a path-specific
+    # quay.io/rhceph-dev entry so it beats the generic quay.io:OCM from kubelet.
     pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
     with open(pull_secret_path) as f:
         pull_secret = json.load(f)
+    # Use .get() defensively in case pull-secret is missing the "auths" key
+    ps_auths = pull_secret.get("auths", {})
     mirror_registries = {
         mirror.split("/")[0]
         for entry in image_digest_mirrors
         for mirror in entry.get("mirrors", [])
     }
     extra_auths = {
-        reg: creds
-        for reg, creds in pull_secret["auths"].items()
-        if reg in mirror_registries
+        reg: creds for reg, creds in ps_auths.items() if reg in mirror_registries
     }
-    if extra_auths:
-        for pod in ds_pods:
-            pod_name = pod["metadata"]["name"]
-            existing_raw = exec_cmd(
-                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
-                ignore_error=True,
-                silent=True,
-            )
-            existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
-            existing.setdefault("auths", {}).update(extra_auths)
-            merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
-            exec_cmd(
-                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\"",
-                silent=True,
-            )
-        logger.info(
-            f"Merged credentials for {list(extra_auths.keys())} into "
-            f"{constants.ROSA_HCP_HOST_AUTH_JSON} on worker nodes"
-        )
+    # Path-specific entry: containers/image picks the most specific registry path
+    # match, so quay.io/rhceph-dev:ocsqe beats the generic quay.io:OCM token
+    # that kubelet provides when CRI-O pulls quay.io/rhceph-dev/* images.
+    quay_auth = ps_auths.get("quay.io")
+    if quay_auth:
+        extra_auths["quay.io/rhceph-dev"] = quay_auth
 
-    # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
+    # Always write auth.json — even if extra_auths is empty, auth.json must
+    # contain at least the kubelet cluster credentials so that CRI-O (which we
+    # will redirect to this file) can still pull all other cluster images.
+    # Writing unconditionally also avoids the race where the redirect proceeds
+    # but auth.json is stale/empty from a previous failed run.
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+
+        # Read kubelet/config.json (what CRI-O currently uses as global_auth_file)
+        # so we preserve all cluster-level credentials in our merged auth.json.
+        # The stdout is pull-secret JSON; exec_cmd logs it at DEBUG only and
+        # truncate_large_base64() shortens the actual token values automatically.
+        kubelet_auths = {}
+        for attempt in range(1, 4):
+            try:
+                kubelet_raw = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "cat {constants.ROSA_HCP_HOST_KUBELET_CONFIG}'
+                    f" 2>/dev/null || echo '{{}}'\"",
+                    ignore_error=True,
+                    silent=True,
+                )
+                kubelet_auths = json.loads(
+                    kubelet_raw.stdout.decode().strip() or "{}"
+                ).get("auths", {})
+                break
+            except ValueError as e:
+                # Malformed JSON from kubelet config — proceed with empty base
+                logger.warning(
+                    f"Could not parse kubelet config on {pod_name} (attempt {attempt}/3): {e}"
+                )
+                if attempt == 3:
+                    logger.warning(
+                        "Proceeding without cluster creds base for this worker"
+                    )
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 reading kubelet config on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    logger.warning(
+                        "Could not read kubelet config; proceeding without cluster creds base"
+                    )
+
+        # Merge: kubelet auths as base, overridden by mirror pull-secret creds.
+        # This preserves OCP infra image pull access while adding rhceph-dev.
+        merged = {"auths": {**kubelet_auths, **extra_auths}}
+        merged_b64 = base64.b64encode(json.dumps(merged).encode()).decode()
+
+        # Write via temp file + cp to avoid truncated-write if connection drops.
+        # merged_b64 is passed as a secret so it is masked in all log output.
+        for attempt in range(1, 4):
+            try:
+                exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"echo '{merged_b64}' | base64 -d"
+                    f" > /tmp/auth-merged.json"
+                    f' && cp /tmp/auth-merged.json {constants.ROSA_HCP_HOST_AUTH_JSON}"',
+                    secrets=[merged_b64],
+                )
+                # Verify file is non-empty (byte count only — no credentials logged)
+                verify = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "wc -c < {constants.ROSA_HCP_HOST_AUTH_JSON}"',
+                    ignore_error=True,
+                )
+                written = int(verify.stdout.decode().strip() or "0")
+                if written > 0:
+                    break
+                logger.warning(
+                    f"Attempt {attempt}/3: auth.json appears empty on {pod_name}, retrying"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 writing auth.json on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    raise
+
+    logger.info(
+        f"Written merged auth.json (registries: {list(extra_auths.keys())}) "
+        f"to {constants.ROSA_HCP_HOST_AUTH_JSON} on {len(ds_pods)} worker node(s)"
+    )
+
+    # Redirect CRI-O global_auth_file from kubelet/config.json to auth.json.
+    # Check first (idempotent), apply sed, then verify. Retry on exec failure.
+    crio_old = "/var/lib/kubelet/config.json"
+    crio_new = "/etc/containers/auth.json"
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+        for attempt in range(1, 4):
+            try:
+                check = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"grep -q 'global_auth_file.*kubelet'"
+                    f" {constants.ROSA_HCP_CRIO_CONF_DROP_IN} 2>/dev/null"
+                    f' && echo yes || echo no"',
+                    ignore_error=True,
+                )
+                if check.stdout.decode().strip() != "yes":
+                    logger.info(
+                        f"CRI-O drop-in on {pod_name} already redirected or not found — skipping"
+                    )
+                    break
+                exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "sed -i'
+                    f' \'s|global_auth_file = \\"{crio_old}\\"'
+                    f'|global_auth_file = \\"{crio_new}\\"|g\''
+                    f' {constants.ROSA_HCP_CRIO_CONF_DROP_IN}"',
+                )
+                verify = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"grep 'global_auth_file'"
+                    f' {constants.ROSA_HCP_CRIO_CONF_DROP_IN} 2>/dev/null"',
+                    ignore_error=True,
+                )
+                result = verify.stdout.decode().strip()
+                if crio_new not in result:
+                    raise Exception(
+                        f"CRI-O drop-in still shows old path after sed: {result}"
+                    )
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 redirecting CRI-O drop-in on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    raise
+    logger.info(
+        f"Redirected CRI-O global_auth_file to {constants.ROSA_HCP_HOST_AUTH_JSON} "
+        f"on all worker nodes"
+    )
+
+    # Restart CRI-O on each worker (full restart required — reload does not
+    # re-read crio.conf.d drop-in files containing global_auth_file).
     from ocs_ci.ocs.node import get_nodes
 
     worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
     for node in worker_nodes:
-        ocp_module.OCP().exec_oc_debug_cmd(
-            node=node.name,
-            cmd_list=["systemctl reload crio"],
-        )
-    logger.info("CRI-O reloaded on all worker nodes")
+        for attempt in range(1, 4):
+            try:
+                ocp_module.OCP().exec_oc_debug_cmd(
+                    node=node.name,
+                    cmd_list=["systemctl restart crio"],
+                )
+                logger.info(f"CRI-O restarted on {node.name}")
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 restarting CRI-O on {node.name}: {e}"
+                )
+                if attempt == 3:
+                    logger.error(
+                        f"Failed to restart CRI-O on {node.name} after 3 attempts. "
+                        "Image pulls from mirror registries may fail."
+                    )
+    logger.info("CRI-O restart complete on all worker nodes")
 
 
 def add_mc_partitioned_disk_on_workers_to_ocp_deployment(disk):


### PR DESCRIPTION
Backport of #14980 to release-4.20.

## Summary
- Deploy nightly builds on ROSA HCP with worker filesystem-based mirror configuration (roks-icsp DaemonSet)
- Destroy OIDC provider on ROSA HCP with pre-fetched endpoint URL and conditional subnet tag cleanup
- Create ODF via ocs-catalogsource on ROSA HCP for non-GA versions

## Conflict resolutions
- `.secrets.baseline`: took incoming version (detect-secrets rescanned)
- `ocs_ci/utility/aws.py`: preserved existing `NoSuchEntity` handling in `delete_oidc_provider`, added `cleanup_oidc_providers_by_prefix` method
- `ocs_ci/deployment/deployment.py`: kept `stage` source block from release-4.20 alongside new `rosa_hcp_non_ga` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)