### PR TITLE
deploy nightly builds on ROSA HCP with w/a (backport #14980 to release-4.19)

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1019,10 +1019,17 @@ class Deployment(object):
             subscription_yaml_data["spec"]["channel"] = default_channel
         if config.DEPLOYMENT.get("stage"):
             subscription_yaml_data["spec"]["source"] = constants.OPERATOR_SOURCE_NAME
-        if config.DEPLOYMENT.get("live_deployment"):
+        rosa_hcp_non_ga = platform == constants.ROSA_HCP_PLATFORM and bool(
+            config.DEPLOYMENT.get("ocs_registry_image")
+        )
+        if config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
             subscription_yaml_data["spec"]["source"] = config.DEPLOYMENT.get(
                 "live_content_source", defaults.LIVE_CONTENT_SOURCE
             )
+        elif platform == constants.ROSA_HCP_PLATFORM and (
+            not live_deployment or rosa_hcp_non_ga
+        ):
+            subscription_yaml_data["spec"]["source"] = constants.OCS_CATALOG_SOURCE_NAME
         if aws_sts_deployment:
             if "config" not in subscription_yaml_data["spec"]:
                 subscription_yaml_data["spec"]["config"] = {}
@@ -1177,7 +1184,8 @@ class Deployment(object):
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
         rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
-        if not live_deployment and not (
+        rosa_hcp_non_ga = rosa_hcp and bool(config.DEPLOYMENT.get("ocs_registry_image"))
+        if (not live_deployment or rosa_hcp_non_ga) and not (
             stage_testing and konflux_build and not rosa_hcp
         ):
             log_step("Create catalog source and wait it to be READY")
@@ -2746,10 +2754,12 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         ignore_upgrade (bool): Ignore upgrade parameter.
 
     """
-    # Because custom catalog source will be called: redhat-operators, we need to disable
-    # default sources. This should not be an issue as OCS internal registry images
-    # are now based on OCP registry image
-    disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
+    rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+    if not rosa_hcp:
+        # Because custom catalog source will be called: redhat-operators, we need to disable
+        # default sources. This should not be an issue as OCS internal registry images
+        # are now based on OCP registry image
+        disable_specific_source(constants.OPERATOR_CATALOG_SOURCE_NAME)
     logger.info("Adding CatalogSource")
     if not image:
         image = config.DEPLOYMENT.get("ocs_registry_image", "")
@@ -2760,7 +2770,7 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+        if not rosa_hcp:
             run_cmd(
                 "oc patch image.config.openshift.io/cluster --type merge -p '"
                 '{"spec": {"registrySources": {"insecureRegistries": '
@@ -2780,7 +2790,14 @@ def create_catalog_source(image=None, ignore_upgrade=False):
         image_tag = get_latest_ds_olm_tag(
             upgrade, latest_tag=config.DEPLOYMENT.get("default_latest_tag", "latest")
         )
-    catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+    if rosa_hcp:
+        catalog_source_data = templating.load_yaml(
+            constants.PROVIDER_MODE_CATALOGSOURCE
+        )
+        cs_name = constants.OCS_CATALOG_SOURCE_NAME
+    else:
+        catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+        cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     managed_ibmcloud = (
         config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
         and config.ENV_DATA["deployment_type"] == "managed"
@@ -2788,7 +2805,6 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     if managed_ibmcloud:
         create_ocs_secret(constants.MARKETPLACE_NAMESPACE)
         catalog_source_data["spec"]["secrets"] = [constants.OCS_SECRET]
-    cs_name = constants.OPERATOR_CATALOG_SOURCE_NAME
     change_cs_condition = (
         (image or image_tag)
         and catalog_source_data["kind"] == "CatalogSource"
@@ -2811,7 +2827,7 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     templating.dump_data_to_temp_yaml(catalog_source_data, catalog_source_manifest.name)
     run_cmd(f"oc apply -f {catalog_source_manifest.name}", timeout=2400)
     catalog_source = CatalogSource(
-        resource_name=constants.OPERATOR_CATALOG_SOURCE_NAME,
+        resource_name=cs_name,
         namespace=constants.MARKETPLACE_NAMESPACE,
     )
     # Wait for catalog source is ready

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1176,25 +1176,36 @@ class Deployment(object):
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)
-        if not live_deployment and not (stage_testing and konflux_build):
+        rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+        if not live_deployment and not (
+            stage_testing and konflux_build and not rosa_hcp
+        ):
             log_step("Create catalog source and wait it to be READY")
             create_catalog_source(image)
         if konflux_build and stage_testing:
-            log_step("Creating stage ImageDigestMirrorSet")
-            exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-            if not upgrade:
-                log_step("Creating stage TagMirrorSet")
-                exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
-                log_step("Sleeping 60 seconds after applying tag mirror set.")
-            time.sleep(60)
-            log_step("Waiting max 30 mins for master MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/master", timeout=2100
-            )
-            log_step("Waiting max 30 mins for worker MCP to get updated")
-            exec_cmd(
-                "oc wait --for=condition=Updated --timeout=30m mcp/worker", timeout=2100
-            )
+            if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+                log_step(
+                    "ROSA HCP: mirrors applied via worker filesystem "
+                    "inside get_and_apply_idms_from_catalog — skipping IDMS apply and MCP wait"
+                )
+            else:
+                log_step("Creating stage ImageDigestMirrorSet")
+                exec_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+                if not upgrade:
+                    log_step("Creating stage TagMirrorSet")
+                    exec_cmd(f"oc apply -f {constants.STAGE_TAG_MIRROR_SET_YAML}")
+                    log_step("Sleeping 60 seconds after applying tag mirror set.")
+                time.sleep(60)
+                log_step("Waiting max 30 mins for master MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/master",
+                    timeout=2100,
+                )
+                log_step("Waiting max 30 mins for worker MCP to get updated")
+                exec_cmd(
+                    "oc wait --for=condition=Updated --timeout=30m mcp/worker",
+                    timeout=2100,
+                )
 
         if local_storage:
             log_step("Deploy and setup Local Storage Operator")
@@ -2749,14 +2760,15 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             "stage_index_image_tag", f"v{ocp_version}"
         )
         image += f":{osbs_image_tag}"
-        run_cmd(
-            "oc patch image.config.openshift.io/cluster --type merge -p '"
-            '{"spec": {"registrySources": {"insecureRegistries": '
-            '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
-            "}}}'"
-        )
-        run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
-        wait_for_machineconfigpool_status("all", timeout=1800)
+        if config.ENV_DATA.get("platform") != constants.ROSA_HCP_PLATFORM:
+            run_cmd(
+                "oc patch image.config.openshift.io/cluster --type merge -p '"
+                '{"spec": {"registrySources": {"insecureRegistries": '
+                '["registry-proxy.engineering.redhat.com", "registry.stage.redhat.io"]'
+                "}}}'"
+            )
+            run_cmd(f"oc apply -f {constants.STAGE_IMAGE_DIGEST_MIRROR_SET_YAML}")
+            wait_for_machineconfigpool_status("all", timeout=1800)
     if not ignore_upgrade:
         upgrade = config.UPGRADE.get("upgrade", False)
     else:

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -21,7 +21,10 @@ from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.ocs.resources.pod import get_operator_pods
 from ocs_ci.utility import openshift_dedicated as ocm, rosa
 from ocs_ci.utility.aws import AWS as AWSUtil, delete_sts_iam_roles, delete_subnet_tags
-from ocs_ci.utility.deployment import create_openshift_install_log_file
+from ocs_ci.utility.deployment import (
+    create_openshift_install_log_file,
+    deploy_roks_icsp_daemonset,
+)
 from ocs_ci.utility.rosa import (
     get_associated_oidc_config_id,
     delete_account_roles,
@@ -308,6 +311,12 @@ class ROSA(CloudDeploymentBase):
 
         # rosa hcp is self-managed and doesn't support ODF addon
         if rosa_hcp:
+            if config.DEPLOYMENT.get("konflux_build"):
+                log_step(
+                    "ROSA HCP + Konflux: deploying roks-icsp DaemonSet "
+                    "for worker filesystem-based mirror configuration"
+                )
+                deploy_roks_icsp_daemonset()
             super(ROSA, self).deploy_ocs()
         else:
             rosa.install_odf_addon(self.cluster_name)

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -323,22 +323,28 @@ class ROSA(CloudDeploymentBase):
 
         pod = ocp.OCP(kind=constants.POD, namespace=self.namespace)
 
+        # ROSA HCP ODF deployment is slower due to worker filesystem mirror
+        # configuration and image pull via registries.conf.d mirrors — double timeouts
+        timeout_multiplier = 2 if rosa_hcp else 1
+
         if config.ENV_DATA.get("cluster_type") != "consumer":
             # Check for Ceph pods
             assert pod.wait_for_resource(
                 condition="Running",
                 selector=constants.MON_APP_LABEL,
                 resource_count=3,
-                timeout=600,
+                timeout=600 * timeout_multiplier,
             )
             assert pod.wait_for_resource(
-                condition="Running", selector=constants.MGR_APP_LABEL, timeout=600
+                condition="Running",
+                selector=constants.MGR_APP_LABEL,
+                timeout=600 * timeout_multiplier,
             )
             assert pod.wait_for_resource(
                 condition="Running",
                 selector=constants.OSD_APP_LABEL,
                 resource_count=3,
-                timeout=600,
+                timeout=600 * timeout_multiplier,
             )
 
         if config.DEPLOYMENT.get("pullsecret_workaround") or config.DEPLOYMENT.get(
@@ -353,7 +359,9 @@ class ROSA(CloudDeploymentBase):
             )()
 
         # Verify health of ceph cluster
-        ceph_health_check(namespace=self.namespace, tries=60, delay=10)
+        ceph_health_check(
+            namespace=self.namespace, tries=60 * timeout_multiplier, delay=10
+        )
 
         # Workaround for the bug 2166900
         if config.ENV_DATA.get("cluster_type") == "consumer":

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1698,6 +1698,23 @@ ROSA_PLATFORM = "rosa"
 FUSIONAAS_PLATFORM = "fusion_aas"
 ROSA_HCP_PLATFORM = "rosa_hcp"
 ROSA_PLATFORMS = [ROSA_PLATFORM, ROSA_HCP_PLATFORM]
+ROSA_HCP_DS_NAMESPACE = "kube-system"
+ROSA_HCP_DS_LABEL = "app=roks-icsp"
+ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
+ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
+ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"
+)
+ROSA_HCP_ROKS_ICSP_DS_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-daemonset.yaml"
+)
+ROSA_HCP_ROKS_ICSP_SVC_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-service.yaml"
+)
+ROSA_HCP_ROKS_ICSP_MC_CRD_YAML = os.path.join(
+    TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-machineconfig-crd.yaml"
+)
 HCI_BAREMETAL = "hci_baremetal"
 HCI_VSPHERE = "hci_vsphere"
 ACM_OCP_DEPLOYMENT = "acm_ocp_deployment"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1702,6 +1702,8 @@ ROSA_HCP_DS_NAMESPACE = "kube-system"
 ROSA_HCP_DS_LABEL = "app=roks-icsp"
 ROSA_HCP_HOST_REGISTRIES_CONF_D = "/host/etc/containers/registries.conf.d"
 ROSA_HCP_HOST_AUTH_JSON = "/host/etc/containers/auth.json"
+ROSA_HCP_HOST_KUBELET_CONFIG = "/host/var/lib/kubelet/config.json"
+ROSA_HCP_CRIO_CONF_DROP_IN = "/host/etc/crio/crio.conf.d/00-default"
 ROSA_HCP_KONFLUX_MIRROR_CONF = "020-konflux-mirror.conf"
 ROSA_HCP_ROKS_ICSP_SA_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "rosa-hcp-roks-icsp-serviceaccount.yaml"

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-daemonset.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-daemonset.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: roks-icsp-ds
+  namespace: kube-system
+  labels:
+    app: roks-icsp
+spec:
+  selector:
+    matchLabels:
+      app: roks-icsp
+  template:
+    metadata:
+      labels:
+        app: roks-icsp
+    spec:
+      serviceAccountName: sa-roks-sync
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: roks-icsp
+          image: quay.io/cicdtest/roks-enabler:rosa
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: host
+              mountPath: /host
+          resources: {}
+      volumes:
+        - name: host
+          hostPath:
+            path: /

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-machineconfig-crd.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-machineconfig-crd.yaml
@@ -1,0 +1,28 @@
+---
+# Minimal stub CRD for machineconfigs.machineconfiguration.openshift.io
+# Required on ROSA HCP where the MachineConfig controller is absent.
+# The roks-icsp DaemonSet (quay.io/cicdtest/roks-enabler:rosa) checks for
+# this CRD to determine whether ICSP syncing to worker nodes is available.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machineconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfig
+    listKind: MachineConfigList
+    plural: machineconfigs
+    shortNames:
+      - mc
+    singular: machineconfig
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: MachineConfig defines the configuration for a machine
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-service.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-roks-icsp
+  namespace: kube-system
+  labels:
+    app: roks-icsp
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: roks-icsp
+  type: ClusterIP

--- a/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-serviceaccount.yaml
+++ b/ocs_ci/templates/ocs-deployment/rosa-hcp-roks-icsp-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-roks-sync
+  namespace: kube-system

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2235,6 +2235,59 @@ class AWS(object):
             else:
                 logger.error(f"Error deleting OIDC provider: {e}")
 
+    def cleanup_oidc_providers_by_prefix(self, url_prefix):
+        """
+        Delete all OIDC providers whose URL starts with the given prefix.
+
+        AWS has a hard limit of 100 OpenID Connect providers per account.
+        When HCP cluster deployments fail or are aborted without proper
+        cleanup, their OIDC providers remain and accumulate until the limit
+        is hit, blocking all new deployments.
+
+        This method lists all OIDC providers in the account and deletes
+        those whose issuer URL starts with the given prefix (typically
+        the cluster's OIDC bucket name). This safely scopes the cleanup
+        to a single cluster's providers without affecting other clusters.
+
+        Args:
+            url_prefix (str): URL prefix to match, e.g.
+                ``"mycluster-oidc-bucket.s3.us-west-2.amazonaws.com"``
+
+        Returns:
+            int: Number of OIDC providers deleted.
+        """
+        try:
+            response = self.iam_client.list_open_id_connect_providers()
+        except Exception as e:
+            logger.error(f"Failed to list OIDC providers: {e}")
+            return 0
+
+        providers = response.get("OpenIDConnectProviderList", [])
+        deleted_count = 0
+        for provider in providers:
+            arn = provider["Arn"]
+            url = (
+                arn.split(":oidc-provider/", 1)[-1] if ":oidc-provider/" in arn else ""
+            )
+            if not url.startswith(url_prefix):
+                continue
+
+            logger.info(f"Deleting OIDC provider matching prefix '{url_prefix}': {arn}")
+            try:
+                self.iam_client.delete_open_id_connect_provider(
+                    OpenIDConnectProviderArn=arn
+                )
+                deleted_count += 1
+            except Exception as e:
+                logger.warning(f"Failed to delete OIDC provider {arn}: {e}")
+
+        if deleted_count:
+            logger.info(
+                f"Deleted {deleted_count} OIDC provider(s) "
+                f"matching prefix '{url_prefix}'"
+            )
+        return deleted_count
+
     def get_caller_identity(self):
         """
         Get STS Caller Identity Account ID

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -424,7 +424,8 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         pod_name = pod["metadata"]["name"]
         exec_cmd(
             f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\""
+            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\"",
+            silent=True,
         )
     logger.info(
         f"Written mirror config ({len(image_digest_mirrors)} entries) "
@@ -452,13 +453,15 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
                 f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
                 f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
                 ignore_error=True,
+                silent=True,
             )
             existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
             existing.setdefault("auths", {}).update(extra_auths)
             merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
             exec_cmd(
                 f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\""
+                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\"",
+                silent=True,
             )
         logger.info(
             f"Merged credentials for {list(extra_auths.keys())} into "
@@ -466,7 +469,9 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         )
 
     # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
-    worker_nodes = ocp_module.get_node_objs(node_type="worker")
+    from ocs_ci.ocs.node import get_nodes
+
+    worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
     for node in worker_nodes:
         ocp_module.OCP().exec_oc_debug_cmd(
             node=node.name,

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -2,6 +2,8 @@
 Utility functions that are used as a part of OCP or OCS deployments
 """
 
+import base64
+import json
 import logging
 import os
 import re
@@ -218,8 +220,17 @@ def get_and_apply_idms_from_catalog(image, apply=True, insecure=False):
     stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
     konflux_build = config.DEPLOYMENT.get("konflux_build")
     if stage_testing and konflux_build:
-        logger.info("Skipping applying IDMS rules from image for konflux stage testing")
-        return ""
+        if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+            logger.info(
+                "ROSA HCP + Konflux: extracting IDMS from catalog image for "
+                "filesystem-based mirror configuration on worker nodes"
+            )
+            apply = False
+        else:
+            logger.info(
+                "Skipping applying IDMS rules from image for konflux stage testing"
+            )
+            return ""
     idms_file_location = "/idms.yaml"
     idms_file_dest_dir = os.path.join(
         config.ENV_DATA["cluster_path"], f"idms-{config.RUN['run_id']}"
@@ -246,18 +257,244 @@ def get_and_apply_idms_from_catalog(image, apply=True, insecure=False):
         yaml.dump(idms_content, f)
 
     if apply and not config.DEPLOYMENT.get("disconnected"):
-        exec_cmd(f"oc apply -f {idms_file_dest_location}")
-        managed_ibmcloud = (
-            config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
-            and config.ENV_DATA["deployment_type"] == "managed"
-        )
-        if not managed_ibmcloud:
-            num_nodes = (
-                config.ENV_DATA["worker_replicas"]
-                + config.ENV_DATA["master_replicas"]
-                + config.ENV_DATA.get("infra_replicas", 0)
+        if config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM:
+            with open(idms_file_dest_location) as f:
+                _idms = yaml.safe_load(f)
+            apply_idms_via_worker_filesystem(
+                _idms.get("spec", {}).get("imageDigestMirrors", [])
             )
-            timeout = 2800 if num_nodes > 6 else 1900
-            wait_for_machineconfigpool_status(node_type="all", timeout=timeout)
+        else:
+            exec_cmd(f"oc apply -f {idms_file_dest_location}")
+            managed_ibmcloud = (
+                config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
+                and config.ENV_DATA["deployment_type"] == "managed"
+            )
+            if not managed_ibmcloud:
+                num_nodes = (
+                    config.ENV_DATA["worker_replicas"]
+                    + config.ENV_DATA["master_replicas"]
+                    + config.ENV_DATA.get("infra_replicas", 0)
+                )
+                timeout = 2800 if num_nodes > 6 else 1900
+                wait_for_machineconfigpool_status(node_type="all", timeout=timeout)
+
+    if (
+        stage_testing
+        and konflux_build
+        and config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
+        and os.path.exists(idms_file_dest_location)
+    ):
+        with open(idms_file_dest_location) as f:
+            idms_content = yaml.safe_load(f)
+        image_digest_mirrors = idms_content.get("spec", {}).get(
+            "imageDigestMirrors", []
+        )
+        apply_idms_via_worker_filesystem(image_digest_mirrors)
 
     return idms_file_dest_location
+
+
+def deploy_roks_icsp_daemonset():
+    """
+    Deploy the roks-icsp privileged DaemonSet on ROSA HCP worker nodes.
+
+    The DaemonSet (quay.io/cicdtest/roks-enabler:rosa) mounts the host
+    filesystem at /host and is used to write CRI-O mirror configuration
+    directly to /host/etc/containers/registries.conf.d/ on each worker,
+    bypassing the ImageDigestMirrorSet API which is blocked on ROSA HCP
+    by ValidatingAdmissionPolicy.
+
+    Also creates a fake machineconfigs.machineconfiguration.openshift.io CRD
+    which is absent on ROSA HCP hosted clusters.
+
+    Source: https://github.com/xcliu-ca/rosa-icsp-gps/blob/main/enabler.sh
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    # Idempotent: skip if DaemonSet pods are already running
+    existing = get_pods_having_label(
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    )
+    if existing:
+        logger.info(
+            f"roks-icsp DaemonSet already running "
+            f"({len(existing)} pod(s)) — skipping deployment"
+        )
+        return
+
+    logger.info("Deploying roks-icsp DaemonSet on ROSA HCP worker nodes")
+
+    sa_manifest = templating.load_yaml(constants.ROSA_HCP_ROKS_ICSP_SA_YAML)
+
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_SA_YAML}")
+    exec_cmd(
+        f"oc adm policy add-cluster-role-to-user cluster-admin "
+        f"system:serviceaccount:{constants.ROSA_HCP_DS_NAMESPACE}:"
+        f"{sa_manifest['metadata']['name']}"
+    )
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_DS_YAML}")
+    exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_SVC_YAML}")
+
+    # Create fake MachineConfig CRD if absent (not present on ROSA HCP)
+    existing_crd = exec_cmd(
+        "oc get crd machineconfigs.machineconfiguration.openshift.io "
+        "--ignore-not-found -o name",
+        ignore_error=True,
+    )
+    if not existing_crd.stdout.strip():
+        logger.info("Creating fake MachineConfig CRD for ROSA HCP compatibility")
+        exec_cmd(f"oc apply -f {constants.ROSA_HCP_ROKS_ICSP_MC_CRD_YAML}")
+
+    # Wait for DaemonSet to roll out on all worker nodes
+    num_workers = config.ENV_DATA["worker_replicas"]
+    from ocs_ci.utility.utils import TimeoutSampler
+
+    for sample in TimeoutSampler(
+        timeout=180,
+        sleep=10,
+        func=get_pods_having_label,
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    ):
+        running = [p for p in sample if p.get("status", {}).get("phase") == "Running"]
+        if len(running) >= num_workers:
+            logger.info(
+                f"roks-icsp DaemonSet ready: {len(running)}/{num_workers} pods running"
+            )
+            return
+
+
+def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
+    """
+    Write CRI-O registry mirror configuration to worker nodes via a privileged
+    DaemonSet that mounts the host filesystem at /host.
+
+    Used on ROSA HCP where ImageDigestMirrorSet cannot be applied via oc apply
+    (blocked by ValidatingAdmissionPolicy).
+
+    Args:
+        image_digest_mirrors (list): list of dicts with 'source' and 'mirrors' keys,
+            matching the imageDigestMirrors schema from an ImageDigestMirrorSet.
+        conf_filename (str): filename to write inside registries.conf.d.
+            Defaults to ROSA_HCP_KONFLUX_MIRROR_CONF constant.
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+    from ocs_ci.ocs import ocp as ocp_module
+
+    if conf_filename is None:
+        conf_filename = constants.ROSA_HCP_KONFLUX_MIRROR_CONF
+
+    ds_pods = get_pods_having_label(
+        label=constants.ROSA_HCP_DS_LABEL,
+        namespace=constants.ROSA_HCP_DS_NAMESPACE,
+    )
+    if not ds_pods:
+        logger.warning(
+            f"No DaemonSet pods found with label '{constants.ROSA_HCP_DS_LABEL}' "
+            f"in namespace '{constants.ROSA_HCP_DS_NAMESPACE}'. "
+            "Cannot apply IDMS via worker filesystem."
+        )
+        return
+
+    # Build CRI-O TOML content from IDMS entries
+    toml_lines = []
+    for entry in image_digest_mirrors:
+        source = entry["source"]
+        mirrors = entry.get("mirrors", [])
+        toml_lines += [
+            "[[registry]]",
+            f'prefix = "{source}"',
+            f'location = "{source}"',
+            "blocked = false",
+            "",
+        ]
+        for mirror in mirrors:
+            toml_lines += [
+                "[[registry.mirror]]",
+                f'location = "{mirror}"',
+                "insecure = false",
+                "",
+            ]
+    toml_content = "\n".join(toml_lines)
+    encoded = base64.b64encode(toml_content.encode()).decode()
+    dest_path = f"{constants.ROSA_HCP_HOST_REGISTRIES_CONF_D}/{conf_filename}"
+
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+        exec_cmd(
+            f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+            f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\""
+        )
+    logger.info(
+        f"Written mirror config ({len(image_digest_mirrors)} entries) "
+        f"to {dest_path} on {len(ds_pods)} worker node(s)"
+    )
+
+    # Merge mirror registry credentials into /host/etc/containers/auth.json
+    pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+    with open(pull_secret_path) as f:
+        pull_secret = json.load(f)
+    mirror_registries = {
+        mirror.split("/")[0]
+        for entry in image_digest_mirrors
+        for mirror in entry.get("mirrors", [])
+    }
+    extra_auths = {
+        reg: creds
+        for reg, creds in pull_secret["auths"].items()
+        if reg in mirror_registries
+    }
+    if extra_auths:
+        for pod in ds_pods:
+            pod_name = pod["metadata"]["name"]
+            existing_raw = exec_cmd(
+                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
+                ignore_error=True,
+            )
+            existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
+            existing.setdefault("auths", {}).update(extra_auths)
+            merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
+            exec_cmd(
+                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\""
+            )
+        logger.info(
+            f"Merged credentials for {list(extra_auths.keys())} into "
+            f"{constants.ROSA_HCP_HOST_AUTH_JSON} on worker nodes"
+        )
+
+    # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
+    worker_nodes = ocp_module.get_node_objs(node_type="worker")
+    for node in worker_nodes:
+        ocp_module.OCP().exec_oc_debug_cmd(
+            node=node.name,
+            cmd_list=["systemctl reload crio"],
+        )
+    logger.info("CRI-O reloaded on all worker nodes")
+
+
+def add_mc_partitioned_disk_on_workers_to_ocp_deployment(disk):
+    """
+    Add Machine Config for partitioned disk on worker nodes to OCP deployment
+
+    Args:
+        disk (str): path to root disk where the additional partition should be created common for all worker nodes
+
+    """
+    role = "worker"
+    logger.info(f"Creating and Adding Partitioned disk MC file for {role}")
+    with open(constants.PARTITIONED_DISK_MC) as file_stream:
+        part_disk_template_obj = yaml.safe_load(file_stream)
+
+    part_disk_template_obj["spec"]["config"]["storage"]["disks"][0]["device"] = disk
+
+    part_disk_template_str = yaml.safe_dump(part_disk_template_obj)
+    part_disk_file = os.path.join(
+        config.ENV_DATA["cluster_path"],
+        "openshift",
+        "98-osd-partition-worker.yaml",
+    )
+    with open(part_disk_file, "w") as f:
+        f.write(part_disk_template_str)

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -425,59 +425,199 @@ def apply_idms_via_worker_filesystem(image_digest_mirrors, conf_filename=None):
         exec_cmd(
             f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
             f"-- bash -c \"echo '{encoded}' | base64 -d > {dest_path}\"",
-            silent=True,
+            secrets=[encoded],
         )
     logger.info(
         f"Written mirror config ({len(image_digest_mirrors)} entries) "
         f"to {dest_path} on {len(ds_pods)} worker node(s)"
     )
 
-    # Merge mirror registry credentials into /host/etc/containers/auth.json
+    # Build merged auth.json on OCS-CI side (DaemonSet container has no python3).
+    # CRI-O on ROSA HCP workers uses global_auth_file = kubelet/config.json
+    # (set in /etc/crio/crio.conf.d/00-default), NOT /etc/containers/auth.json.
+    # kubelet/config.json contains the OCM cluster pull-secret which lacks access
+    # to quay.io/rhceph-dev nightly images. We redirect CRI-O to use auth.json
+    # (which we control) by merging kubelet creds + mirror creds + a path-specific
+    # quay.io/rhceph-dev entry so it beats the generic quay.io:OCM from kubelet.
     pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
     with open(pull_secret_path) as f:
         pull_secret = json.load(f)
+    # Use .get() defensively in case pull-secret is missing the "auths" key
+    ps_auths = pull_secret.get("auths", {})
     mirror_registries = {
         mirror.split("/")[0]
         for entry in image_digest_mirrors
         for mirror in entry.get("mirrors", [])
     }
     extra_auths = {
-        reg: creds
-        for reg, creds in pull_secret["auths"].items()
-        if reg in mirror_registries
+        reg: creds for reg, creds in ps_auths.items() if reg in mirror_registries
     }
-    if extra_auths:
-        for pod in ds_pods:
-            pod_name = pod["metadata"]["name"]
-            existing_raw = exec_cmd(
-                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"cat {constants.ROSA_HCP_HOST_AUTH_JSON} 2>/dev/null || echo '{{}}'\"",
-                ignore_error=True,
-                silent=True,
-            )
-            existing = json.loads(existing_raw.stdout.decode().strip() or "{}")
-            existing.setdefault("auths", {}).update(extra_auths)
-            merged_b64 = base64.b64encode(json.dumps(existing).encode()).decode()
-            exec_cmd(
-                f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
-                f"-- bash -c \"echo '{merged_b64}' | base64 -d > {constants.ROSA_HCP_HOST_AUTH_JSON}\"",
-                silent=True,
-            )
-        logger.info(
-            f"Merged credentials for {list(extra_auths.keys())} into "
-            f"{constants.ROSA_HCP_HOST_AUTH_JSON} on worker nodes"
-        )
+    # Path-specific entry: containers/image picks the most specific registry path
+    # match, so quay.io/rhceph-dev:ocsqe beats the generic quay.io:OCM token
+    # that kubelet provides when CRI-O pulls quay.io/rhceph-dev/* images.
+    quay_auth = ps_auths.get("quay.io")
+    if quay_auth:
+        extra_auths["quay.io/rhceph-dev"] = quay_auth
 
-    # Reload CRI-O on each worker so it picks up the new registries.conf.d entry
+    # Always write auth.json — even if extra_auths is empty, auth.json must
+    # contain at least the kubelet cluster credentials so that CRI-O (which we
+    # will redirect to this file) can still pull all other cluster images.
+    # Writing unconditionally also avoids the race where the redirect proceeds
+    # but auth.json is stale/empty from a previous failed run.
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+
+        # Read kubelet/config.json (what CRI-O currently uses as global_auth_file)
+        # so we preserve all cluster-level credentials in our merged auth.json.
+        # The stdout is pull-secret JSON; exec_cmd logs it at DEBUG only and
+        # truncate_large_base64() shortens the actual token values automatically.
+        kubelet_auths = {}
+        for attempt in range(1, 4):
+            try:
+                kubelet_raw = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "cat {constants.ROSA_HCP_HOST_KUBELET_CONFIG}'
+                    f" 2>/dev/null || echo '{{}}'\"",
+                    ignore_error=True,
+                    silent=True,
+                )
+                kubelet_auths = json.loads(
+                    kubelet_raw.stdout.decode().strip() or "{}"
+                ).get("auths", {})
+                break
+            except ValueError as e:
+                # Malformed JSON from kubelet config — proceed with empty base
+                logger.warning(
+                    f"Could not parse kubelet config on {pod_name} (attempt {attempt}/3): {e}"
+                )
+                if attempt == 3:
+                    logger.warning(
+                        "Proceeding without cluster creds base for this worker"
+                    )
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 reading kubelet config on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    logger.warning(
+                        "Could not read kubelet config; proceeding without cluster creds base"
+                    )
+
+        # Merge: kubelet auths as base, overridden by mirror pull-secret creds.
+        # This preserves OCP infra image pull access while adding rhceph-dev.
+        merged = {"auths": {**kubelet_auths, **extra_auths}}
+        merged_b64 = base64.b64encode(json.dumps(merged).encode()).decode()
+
+        # Write via temp file + cp to avoid truncated-write if connection drops.
+        # merged_b64 is passed as a secret so it is masked in all log output.
+        for attempt in range(1, 4):
+            try:
+                exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"echo '{merged_b64}' | base64 -d"
+                    f" > /tmp/auth-merged.json"
+                    f' && cp /tmp/auth-merged.json {constants.ROSA_HCP_HOST_AUTH_JSON}"',
+                    secrets=[merged_b64],
+                )
+                # Verify file is non-empty (byte count only — no credentials logged)
+                verify = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "wc -c < {constants.ROSA_HCP_HOST_AUTH_JSON}"',
+                    ignore_error=True,
+                )
+                written = int(verify.stdout.decode().strip() or "0")
+                if written > 0:
+                    break
+                logger.warning(
+                    f"Attempt {attempt}/3: auth.json appears empty on {pod_name}, retrying"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 writing auth.json on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    raise
+
+    logger.info(
+        f"Written merged auth.json (registries: {list(extra_auths.keys())}) "
+        f"to {constants.ROSA_HCP_HOST_AUTH_JSON} on {len(ds_pods)} worker node(s)"
+    )
+
+    # Redirect CRI-O global_auth_file from kubelet/config.json to auth.json.
+    # Check first (idempotent), apply sed, then verify. Retry on exec failure.
+    crio_old = "/var/lib/kubelet/config.json"
+    crio_new = "/etc/containers/auth.json"
+    for pod in ds_pods:
+        pod_name = pod["metadata"]["name"]
+        for attempt in range(1, 4):
+            try:
+                check = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"grep -q 'global_auth_file.*kubelet'"
+                    f" {constants.ROSA_HCP_CRIO_CONF_DROP_IN} 2>/dev/null"
+                    f' && echo yes || echo no"',
+                    ignore_error=True,
+                )
+                if check.stdout.decode().strip() != "yes":
+                    logger.info(
+                        f"CRI-O drop-in on {pod_name} already redirected or not found — skipping"
+                    )
+                    break
+                exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f'-- bash -c "sed -i'
+                    f' \'s|global_auth_file = \\"{crio_old}\\"'
+                    f'|global_auth_file = \\"{crio_new}\\"|g\''
+                    f' {constants.ROSA_HCP_CRIO_CONF_DROP_IN}"',
+                )
+                verify = exec_cmd(
+                    f"oc exec -n {constants.ROSA_HCP_DS_NAMESPACE} {pod_name} "
+                    f"-- bash -c \"grep 'global_auth_file'"
+                    f' {constants.ROSA_HCP_CRIO_CONF_DROP_IN} 2>/dev/null"',
+                    ignore_error=True,
+                )
+                result = verify.stdout.decode().strip()
+                if crio_new not in result:
+                    raise Exception(
+                        f"CRI-O drop-in still shows old path after sed: {result}"
+                    )
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 redirecting CRI-O drop-in on {pod_name}: {e}"
+                )
+                if attempt == 3:
+                    raise
+    logger.info(
+        f"Redirected CRI-O global_auth_file to {constants.ROSA_HCP_HOST_AUTH_JSON} "
+        f"on all worker nodes"
+    )
+
+    # Restart CRI-O on each worker (full restart required — reload does not
+    # re-read crio.conf.d drop-in files containing global_auth_file).
     from ocs_ci.ocs.node import get_nodes
 
     worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
     for node in worker_nodes:
-        ocp_module.OCP().exec_oc_debug_cmd(
-            node=node.name,
-            cmd_list=["systemctl reload crio"],
-        )
-    logger.info("CRI-O reloaded on all worker nodes")
+        for attempt in range(1, 4):
+            try:
+                ocp_module.OCP().exec_oc_debug_cmd(
+                    node=node.name,
+                    cmd_list=["systemctl restart crio"],
+                )
+                logger.info(f"CRI-O restarted on {node.name}")
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Attempt {attempt}/3 restarting CRI-O on {node.name}: {e}"
+                )
+                if attempt == 3:
+                    logger.error(
+                        f"Failed to restart CRI-O on {node.name} after 3 attempts. "
+                        "Image pulls from mirror registries may fail."
+                    )
+    logger.info("CRI-O restart complete on all worker nodes")
 
 
 def add_mc_partitioned_disk_on_workers_to_ocp_deployment(disk):


### PR DESCRIPTION
Backport of #14980 to release-4.19.

## Summary
- Deploy nightly builds on ROSA HCP with worker filesystem-based mirror configuration (roks-icsp DaemonSet)
- Destroy OIDC provider on ROSA HCP with pre-fetched endpoint URL and conditional subnet tag cleanup
- Create ODF via ocs-catalogsource on ROSA HCP for non-GA versions

## Conflict resolutions
- `.secrets.baseline`: deleted (not tracked in this branch)
- `ocs_ci/utility/aws.py`: preserved existing `NoSuchEntity` handling, added `cleanup_oidc_providers_by_prefix` method
- `ocs_ci/utility/deployment.py`: accepted new functions (`deploy_roks_icsp_daemonset`, `apply_idms_via_worker_filesystem`)
- `ocs_ci/deployment/deployment.py`: kept `stage` source block alongside new `rosa_hcp_non_ga` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)