### PR TITLE
Adds config files for fdf gaed version

### DIFF
--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18-ga.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18-ga.yaml
@@ -1,0 +1,5 @@
+# Installs the FDF GA version matching the OCP version
+---
+DEPLOYMENT:
+  fdf_pre_release: false
+  fdf_image_tag: v4.19

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.19-ga.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.19-ga.yaml
@@ -1,0 +1,7 @@
+# Installs the FDF GA version matching the OCP version
+---
+DEPLOYMENT:
+  fdf_pre_release: false
+  fdf_image_tag: v4.19
+
+# Made with Bob

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.20-ga.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.20-ga.yaml
@@ -1,0 +1,7 @@
+# Installs the FDF GA version matching the OCP version
+---
+DEPLOYMENT:
+  fdf_pre_release: false
+  fdf_image_tag: v4.20
+
+# Made with Bob

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.21-ga.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.21-ga.yaml
@@ -1,0 +1,5 @@
+# Installs the FDF GA version matching the OCP version
+---
+DEPLOYMENT:
+  fdf_pre_release: false
+  fdf_image_tag: v4.21


### PR DESCRIPTION
Whats currently happening if someone is selecting fdf 4.20 then its not selecting the image from the gaed repo but its getting it from the pre released repo 