### PR TITLE
[release-4.20] add workaround for issue 15085

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2866,6 +2866,14 @@ def create_catalog_source(image=None, ignore_upgrade=False):
             upgrade, latest_tag=config.DEPLOYMENT.get("default_latest_tag", "latest")
         )
     catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
+
+    # workaround for https://github.com/red-hat-storage/ocs-ci/issues/15085
+    # Remove extractContent for disconnected deployments to avoid init container issues
+    # in air-gapped environments while keeping memoryTarget to prevent OOM
+    if config.DEPLOYMENT.get("disconnected"):
+        if "grpcPodConfig" in catalog_source_data.get("spec", {}):
+            catalog_source_data["spec"]["grpcPodConfig"].pop("extractContent", None)
+
     managed_ibmcloud = (
         config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM
         and config.ENV_DATA["deployment_type"] == "managed"

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -460,6 +460,12 @@ def prepare_disconnected_ocs_deployment(upgrade=False):
         # create redhat-operators CatalogSource
         catalog_source_data = templating.load_yaml(constants.CATALOG_SOURCE_YAML)
 
+        # workaround for https://github.com/red-hat-storage/ocs-ci/issues/15085
+        # Remove extractContent for disconnected deployments to avoid init container issues
+        # in air-gapped environments while keeping memoryTarget to prevent OOM
+        if "grpcPodConfig" in catalog_source_data.get("spec", {}):
+            catalog_source_data["spec"]["grpcPodConfig"].pop("extractContent", None)
+
         catalog_source_manifest = tempfile.NamedTemporaryFile(
             mode="w+", prefix="catalog_source_manifest", delete=False
         )


### PR DESCRIPTION
Backport of https://github.com/red-hat-storage/ocs-ci/pull/15086

Remove extractContent section from catalogsource for disconnected deployments.

This is a workaround for: https://github.com/red-hat-storage/ocs-ci/issues/15085