### PR TITLE
Fix downstream subctl image extract path and binary handling

### DIFF
--- a/conf/ocsci/submariner_downstream.yaml
+++ b/conf/ocsci/submariner_downstream.yaml
@@ -1,3 +1,3 @@
 ENV_DATA:
   submariner_source: "downstream"
-  subctl_version: "subctl-rhel9:v0.21"
+  subctl_version: "subctl-rhel9:v0.23"

--- a/conf/ocsci/submariner_downstream_unreleased.yaml
+++ b/conf/ocsci/submariner_downstream_unreleased.yaml
@@ -2,4 +2,4 @@ ENV_DATA:
   submariner_source: "downstream"
   submariner_release_type: "unreleased"
   submariner_channel: ""
-  subctl_version: "subctl-rhel9:v0.21"
+  subctl_version: "subctl-rhel9:v0.23"

--- a/ocs_ci/deployment/acm.py
+++ b/ocs_ci/deployment/acm.py
@@ -8,13 +8,9 @@ import logging
 import tempfile
 import shutil
 import requests
-import subprocess
-import time
-import glob
 
 import semantic_version
 import platform
-import tarfile
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -242,113 +238,52 @@ class Submariner(object):
                 os.path.join(config.RUN["bin_dir"], "subctl"),
             )
         elif self.source == "downstream":
-            try:
-                self.download_downstream_binary()
-            except IndexError:
-                self.download_downstream_binary(
-                    download_url=constants.SUBCTL_BREW_DOWNSTREAM_URL
-                )
-
-    @retry((tarfile.TarError, EOFError, FileNotFoundError), tries=8, delay=5)
-    def wait_for_tar_file(self, subctl_download_tar_file):
-        """
-        1. First check if file exists
-        2. Check if file is accessible
-        3. check if tarfile is intact
-        """
-        if not os.path.exists(subctl_download_tar_file):
-            raise FileNotFoundError(f"Tar file not found {subctl_download_tar_file}")
-        else:
-            logger.info(f"Found the tar file {subctl_download_tar_file}")
-
-        if os.path.isfile(f"{subctl_download_tar_file}") and os.access(
-            f"{subctl_download_tar_file}", os.R_OK
-        ):
-            logger.info(f"File {subctl_download_tar_file} successfully downloaded")
-            try:
-                # Check if tar is readable without any errors
-                with tarfile.open(subctl_download_tar_file) as tar:
-                    tar.getmembers()
-                logger.info("the tar.xz is intact and readable")
-            except (tarfile.TarError, EOFError) as tar_error:
-                logger.error(f"The tar.xz is corrupted or not readable {tar_error}")
-                raise
-        else:
-            logger.warning(
-                f"File {subctl_download_tar_file} is not accessible or corrupted,"
-                f"Retrying reading the tar file again"
-            )
-            raise tarfile.TarError()
+            self.download_downstream_binary()
 
     @retry((SubctlDownloadFailed, CommandFailed))
     def download_downstream_binary(self, download_url=constants.SUBCTL_DOWNSTREAM_URL):
         """
-        Download downstream subctl binary
+        Download downstream subctl binary from container image.
+        Extracts the binary directly from /usr/local/bin/subctl in the image.
 
         Raises:
             UnsupportedPlatformError : If current platform has no supported subctl binary
+            SubctlDownloadFailed : If the binary extraction fails
         """
 
         subctl_ver = config.ENV_DATA["subctl_version"]
-        version_str = subctl_ver.split(":")[1]
         pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-        processor = platform.processor()
         arch = platform.machine()
-        if arch == "x86_64" and processor == "x86_64":
+        if arch == "x86_64":
             binary_pltfrm = "amd64"
-        elif arch == "arm64" and processor == "arm":
+        elif arch == "arm64":
             binary_pltfrm = "arm64"
         else:
             raise UnsupportedPlatformError(
-                "Not a supported architecture for subctl binary"
+                f"Not a supported architecture for subctl binary: {arch}"
             )
+        target_dir = config.RUN["bin_dir"]
+        os.makedirs(target_dir, exist_ok=True)
         cmd = (
             f"oc image extract --filter-by-os linux/{binary_pltfrm} --registry-config "
             f"{pull_secret_path} {download_url}{subctl_ver} "
-            f'--path="/dist/subctl-{version_str}*-linux-{binary_pltfrm}.tar.xz":/tmp --confirm'
+            f"--path=/usr/local/bin/subctl:{target_dir} --confirm"
         )
-        run_cmd(cmd)
-        # After oc image extract wait for some time
-        # so that tar won't fail
-        time.sleep(10)
-        # Check if file exists before calling tar
-        subctl_download_tar_file = glob.glob(
-            f"/tmp/subctl-{version_str}*-linux-{binary_pltfrm}.tar.xz"
-        )[0]
         try:
-            self.wait_for_tar_file(subctl_download_tar_file)
-        except Exception as e:
-            logger.error(
-                f"Unexpected error during subctl tar file download/extract: {e}"
+            run_cmd(cmd)
+        except CommandFailed as e:
+            logger.error(f"Failed to extract subctl binary: {e}")
+            raise SubctlDownloadFailed(
+                f"Failed to extract subctl from {download_url}{subctl_ver}"
             )
-            raise SubctlDownloadFailed("Failed to download subctl tar file")
-
-        decompress = f"tar -C /tmp/ -xf {subctl_download_tar_file}"
-        p = subprocess.run(
-            decompress,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True,
-            text=True,
-        )
-        if p.returncode:
-            logger.error("Failed to untar subctl")
-            if p.stderr:
-                logger.error(f"{p.stderr}")
-            raise CommandFailed
-        else:
-            logger.info(f"Tar decompressed successfully {p.stdout}")
-        target_dir = config.RUN["bin_dir"]
-        install_cmd = (
-            f"install -m744 /tmp/subctl-{version_str}*/subctl-{version_str}*-linux-{binary_pltfrm} "
-            f"{target_dir} "
-        )
-        run_cmd(install_cmd, shell=True)
-        subctl_bin_file = glob.glob(
-            f"{target_dir}/subctl-{version_str}*-linux-{binary_pltfrm}"
-        )[0]
-        run_cmd(f"mv {subctl_bin_file} {target_dir}/subctl", shell=True)
-        os.environ["PATH"] = os.environ["PATH"] + ":" + os.path.abspath(f"{target_dir}")
+        subctl_path = os.path.join(target_dir, "subctl")
+        if not os.path.isfile(subctl_path):
+            raise SubctlDownloadFailed(
+                f"subctl binary not found at {subctl_path} after extraction"
+            )
+        os.chmod(subctl_path, 0o744)
+        os.environ["PATH"] = os.environ["PATH"] + ":" + os.path.abspath(target_dir)
+        logger.info(f"subctl binary downloaded to {subctl_path}")
 
     def submariner_configure_upstream(self):
         """

--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1380,33 +1380,42 @@ def _collect_ocs_logs(
             if not cluster_config.ENV_DATA.get(
                 "import_clusters_to_acm", False
             ) or cluster_config.ENV_DATA.get("submariner_source", ""):
+                subctl_available = True
                 with subctl_lock:
                     try:
                         run_cmd("subctl")
                     except (CommandFailed, FileNotFoundError):
-                        log.debug("subctl binary not found, downloading now...")
-                        # Importing here to avoid circular import error
-                        from ocs_ci.deployment.acm import Submariner
+                        if not cluster_config.ENV_DATA.get("subctl_version"):
+                            log.warning(
+                                "subctl binary not found and subctl_version not configured, "
+                                "skipping submariner log collection"
+                            )
+                            subctl_available = False
+                        else:
+                            log.debug("subctl binary not found, downloading now...")
+                            # Importing here to avoid circular import error
+                            from ocs_ci.deployment.acm import Submariner
 
-                        submariner = Submariner()
-                        submariner.download_binary()
+                            submariner = Submariner()
+                            submariner.download_binary()
 
-                submariner_log_path = os.path.join(
-                    log_dir_path,
-                    "submariner",
-                )
-                run_cmd(f"mkdir -p {submariner_log_path}")
-                cwd = os.getcwd()
-                run_cmd(f"chmod -R 777 {submariner_log_path}")
-                os.chdir(submariner_log_path)
-                submariner_log_collect = (
-                    f"subctl gather --kubeconfig {cluster_config.RUN['kubeconfig']}"
-                )
-                log.info("Collecting submariner logs")
-                out = run_cmd(submariner_log_collect, timeout=1200)
-                run_cmd(f"chmod -R 777 {submariner_log_path}")
-                os.chdir(cwd)
-                log.info(out)
+                if subctl_available:
+                    submariner_log_path = os.path.join(
+                        log_dir_path,
+                        "submariner",
+                    )
+                    run_cmd(f"mkdir -p {submariner_log_path}")
+                    cwd = os.getcwd()
+                    run_cmd(f"chmod -R 777 {submariner_log_path}")
+                    os.chdir(submariner_log_path)
+                    submariner_log_collect = (
+                        f"subctl gather --kubeconfig {cluster_config.RUN['kubeconfig']}"
+                    )
+                    log.info("Collecting submariner logs")
+                    out = run_cmd(submariner_log_collect, timeout=1200)
+                    run_cmd(f"chmod -R 777 {submariner_log_path}")
+                    os.chdir(cwd)
+                    log.info(out)
 
 
 def collect_ocs_logs(

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import pytest
 import time
 
@@ -31,10 +32,12 @@ def pytest_collection_modifyitems(items):
                 items.remove(item)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def check_subctl_cli():
-    # Check whether subctl cli is present
     if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
+        return
+    if platform.system() == "Darwin":
+        log.warning("subctl binary is not available for macOS, skipping download")
         return
     try:
         run_cmd("./bin/subctl")


### PR DESCRIPTION
## Summary
Downstream subctl is no longer shipped under /dist/ as a .tar.xz; current images expose a Linux binary at /usr/local/bin/subctl. This PR updates extraction to match, removes obsolete tar/brew handling, and updates related fixture and log-collection behavior.
Bumps subctl_version from v0.21 to v0.23 to match current submariner.