### PR TITLE
Add NooBaa managed identity for Azure STS/WIF deployments

### DIFF
--- a/ocs_ci/deployment/azure.py
+++ b/ocs_ci/deployment/azure.py
@@ -141,6 +141,12 @@ class AZUREIPI(AZUREBase):
         """
         if config.DEPLOYMENT.get("sts_enabled"):
             self.azure_util.set_auth_env_vars()
+            self.azure_util.az_login()
+            self.azure_util.delete_noobaa_managed_identity(
+                cluster_name=self.cluster_name,
+                resource_group=self.cluster_name,
+                subscription_id=config.AUTH["azure_auth"]["subscription_id"],
+            )
             cco.delete_oidc_resource_group(
                 self.cluster_name,
                 config.ENV_DATA["region"],

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1350,12 +1350,11 @@ class Deployment(object):
             logger.test_step("Create Azure managed identity for NooBaa STS")
             azure_util = AzureUtil()
             azure_util.az_login()
-            mi_data = azure_util.create_noobaa_managed_identity(
+            self.azure_noobaa_mi_client_id = azure_util.create_noobaa_managed_identity(
                 cluster_name=config.ENV_DATA["cluster_name"],
                 resource_group=config.ENV_DATA["cluster_name"],
                 subscription_id=config.AUTH["azure_auth"]["subscription_id"],
             )
-            self.azure_noobaa_mi_client_id = mi_data["client_id"]
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -18,6 +18,7 @@ import yaml
 from botocore.exceptions import EndpointConnectionError, BotoCoreError
 
 from ocs_ci.deployment.helpers import storage_class
+from ocs_ci.utility.azure_utils import AZURE as AzureUtil
 from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
 from ocs_ci.deployment.helpers.external_cluster_helpers import (
@@ -215,6 +216,7 @@ class Deployment(object):
 
     def __init__(self):
         self.sts_role_arn = None
+        self.azure_noobaa_mi_client_id = None
         storage_class.set_custom_storage_class_path()
         logger.info(
             f"Deployment platform {self.platform} initiated with storage class: {self.storage_class}"
@@ -1228,15 +1230,19 @@ class Deployment(object):
             if "config" not in subscription_yaml_data["spec"]:
                 subscription_yaml_data["spec"]["config"] = {}
             azure_auth_data = config.AUTH["azure_auth"]
+            mi_client_id = (
+                self.azure_noobaa_mi_client_id or azure_auth_data["client_id"]
+            )
             azure_sub_data = [
-                {"name": "CLIENTID", "value": azure_auth_data["client_id"]},
+                {"name": "CLIENTID", "value": mi_client_id},
                 {"name": "TENANTID", "value": azure_auth_data["tenant_id"]},
                 {"name": "SUBSCRIPTIONID", "value": azure_auth_data["subscription_id"]},
+                {"name": "RESOURCEGROUP", "value": config.ENV_DATA["cluster_name"]},
             ]
             if "env" not in subscription_yaml_data["spec"]["config"]:
                 subscription_yaml_data["spec"]["config"]["env"] = azure_sub_data
             else:
-                subscription_yaml_data["spec"]["config"]["env"].append(azure_sub_data)
+                subscription_yaml_data["spec"]["config"]["env"].extend(azure_sub_data)
 
         subscription_yaml_data["metadata"]["namespace"] = self.namespace
         subscription_manifest = tempfile.NamedTemporaryFile(
@@ -1336,6 +1342,20 @@ class Deployment(object):
             log_step("Create STS role and attach AmazonS3FullAccess Policy")
             role_data = create_and_attach_sts_role()
             self.sts_role_arn = role_data["Role"]["Arn"]
+        azure_sts_deployment = (
+            config.DEPLOYMENT.get("sts_enabled")
+            and platform == constants.AZURE_PLATFORM
+        )
+        if azure_sts_deployment:
+            logger.test_step("Create Azure managed identity for NooBaa STS")
+            azure_util = AzureUtil()
+            azure_util.az_login()
+            mi_data = azure_util.create_noobaa_managed_identity(
+                cluster_name=config.ENV_DATA["cluster_name"],
+                resource_group=config.ENV_DATA["cluster_name"],
+                subscription_id=config.AUTH["azure_auth"]["subscription_id"],
+            )
+            self.azure_noobaa_mi_client_id = mi_data["client_id"]
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")
         upgrade = config.UPGRADE.get("upgrade", False)

--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -494,6 +494,145 @@ class AZURE:
         os.environ["AZURE_CLIENT_ID"] = self._client_id
         os.environ["AZURE_CLIENT_SECRET"] = self._client_secret
 
+    def create_noobaa_managed_identity(
+        self, cluster_name, resource_group, subscription_id
+    ):
+        """
+        Create an Azure user-assigned managed identity for NooBaa with
+        federated credentials for workload identity federation (STS).
+
+        Creates:
+
+        1. A user-assigned managed identity named '{cluster_name}-noobaa-mi'
+        2. Role assignments: 'Storage Account Contributor' and
+           'Storage Blob Data Contributor' scoped to the cluster resource group
+        3. Federated credentials for NooBaa service accounts (noobaa,
+           noobaa-core, noobaa-endpoint) linked to the cluster's OIDC issuer
+
+        Assumes the caller has already authenticated via az_login().
+
+        Args:
+            cluster_name (str): Name of the OCP cluster
+            resource_group (str): Azure resource group name
+            subscription_id (str): Azure subscription ID
+
+        Returns:
+            dict: {"client_id": str, "resource_group": str}
+
+        """
+        mi_name = f"{cluster_name}-noobaa-mi"
+        region = config.ENV_DATA["region"]
+
+        logger.info(
+            f"Creating managed identity {mi_name} in resource group {resource_group}"
+        )
+        result = exec_cmd(
+            f"az identity create --name {mi_name} --resource-group {resource_group} "
+            f"--location {region} --subscription {subscription_id} -o json"
+        )
+        mi_data = json.loads(result.stdout)
+        client_id = mi_data["clientId"]
+        principal_id = mi_data["principalId"]
+
+        scope = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+        roles = ["Storage Account Contributor", "Storage Blob Data Contributor"]
+        for role in roles:
+            logger.info(f"Assigning role '{role}' to managed identity {mi_name}")
+            exec_cmd(
+                f"az role assignment create --assignee-object-id {principal_id} "
+                f'--assignee-principal-type ServicePrincipal --role "{role}" '
+                f"--scope {scope} --subscription {subscription_id}"
+            )
+
+        logger.info("Retrieving OIDC issuer URL from the cluster")
+        auth_result = exec_cmd("oc get authentication cluster -ojson")
+        auth_data = json.loads(auth_result.stdout)
+        oidc_issuer = auth_data["spec"]["serviceAccountIssuer"]
+
+        namespace = config.ENV_DATA.get(
+            "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        service_accounts = ["noobaa", "noobaa-core", "noobaa-endpoint"]
+        for sa in service_accounts:
+            subject = f"system:serviceaccount:{namespace}:{sa}"
+            logger.info(
+                f"Creating federated credential for {subject} on managed identity {mi_name}"
+            )
+            exec_cmd(
+                f"az identity federated-credential create "
+                f"--name {mi_name}-{sa} "
+                f"--identity-name {mi_name} "
+                f"--resource-group {resource_group} "
+                f"--issuer {oidc_issuer} "
+                f'--subject "{subject}" '
+                f"--audiences openshift "
+                f"--subscription {subscription_id}"
+            )
+
+        logger.info(f"Managed identity {mi_name} created with client ID {client_id}")
+        return {"client_id": client_id, "resource_group": resource_group}
+
+    def delete_noobaa_managed_identity(
+        self, cluster_name, resource_group, subscription_id
+    ):
+        """
+        Delete the NooBaa Azure managed identity created for STS deployments.
+
+        Deleting the MI cascades to its federated credentials, but role
+        assignments are NOT auto-deleted — they become orphaned. This method
+        explicitly removes role assignments before deleting the identity.
+
+        Safe to call if the identity doesn't exist (e.g., partial teardown).
+        Assumes the caller has already authenticated via az_login().
+
+        Args:
+            cluster_name (str): Name of the OCP cluster
+            resource_group (str): Azure resource group name
+            subscription_id (str): Azure subscription ID
+
+        """
+        mi_name = f"{cluster_name}-noobaa-mi"
+        logger.info(
+            f"Deleting managed identity {mi_name} from resource group {resource_group}"
+        )
+
+        # Get the MI's principal ID for role assignment cleanup
+        show_result = exec_cmd(
+            f"az identity show --name {mi_name} --resource-group {resource_group} "
+            f"--subscription {subscription_id} -o json",
+            ignore_error=True,
+        )
+        if show_result.returncode:
+            logger.warning(
+                f"Managed identity {mi_name} not found (may already be deleted): {show_result.stderr}"
+            )
+            return
+
+        mi_data = json.loads(show_result.stdout)
+        principal_id = mi_data.get("principalId", "")
+
+        if principal_id:
+            scope = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}"
+            logger.info(
+                f"Removing role assignments for principal {principal_id} in scope {scope}"
+            )
+            exec_cmd(
+                f"az role assignment delete --assignee {principal_id} --scope {scope}",
+                ignore_error=True,
+            )
+
+        result = exec_cmd(
+            f"az identity delete --name {mi_name} --resource-group {resource_group} "
+            f"--subscription {subscription_id}",
+            ignore_error=True,
+        )
+        if result.returncode:
+            logger.warning(
+                f"Failed to delete managed identity {mi_name}: {result.stderr}"
+            )
+        else:
+            logger.info(f"Managed identity {mi_name} deleted successfully")
+
 
 class AzureAroUtil(AZURE):
     """

--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -517,7 +517,7 @@ class AZURE:
             subscription_id (str): Azure subscription ID
 
         Returns:
-            dict: {"client_id": str, "resource_group": str}
+            str: The client ID of the created managed identity
 
         """
         mi_name = f"{cluster_name}-noobaa-mi"
@@ -570,7 +570,7 @@ class AZURE:
             )
 
         logger.info(f"Managed identity {mi_name} created with client ID {client_id}")
-        return {"client_id": client_id, "resource_group": resource_group}
+        return client_id
 
     def delete_noobaa_managed_identity(
         self, cluster_name, resource_group, subscription_id

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6263,6 +6263,41 @@ def get_role_arn_from_sub():
         raise ClusterNotInSTSModeException
 
 
+def get_azure_sts_creds_from_sub():
+    """
+    Get Azure STS credentials (managed identity) from the ODF Subscription.
+
+    Returns:
+        dict: Keys are ``client_id``, ``tenant_id``,
+            ``subscription_id``, and ``resource_group``.
+
+    Raises:
+        ClusterNotInSTSModeException: If cluster not in STS mode
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    if not config.DEPLOYMENT.get("sts_enabled"):
+        raise ClusterNotInSTSModeException
+
+    env_key_map = {
+        "CLIENTID": "client_id",
+        "TENANTID": "tenant_id",
+        "SUBSCRIPTIONID": "subscription_id",
+        "RESOURCEGROUP": "resource_group",
+    }
+    odf_sub = OCP(
+        kind=constants.SUBSCRIPTION,
+        resource_name=constants.ODF_SUBSCRIPTION,
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    creds = {}
+    for item in odf_sub.get()["spec"]["config"]["env"]:
+        if item["name"] in env_key_map:
+            creds[env_key_map[item["name"]]] = item["value"]
+    return creds
+
+
 def get_glibc_version():
     """
     Gets the GLIBC version.

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6263,41 +6263,6 @@ def get_role_arn_from_sub():
         raise ClusterNotInSTSModeException
 
 
-def get_azure_sts_creds_from_sub():
-    """
-    Get Azure STS credentials (managed identity) from the ODF Subscription.
-
-    Returns:
-        dict: Keys are ``client_id``, ``tenant_id``,
-            ``subscription_id``, and ``resource_group``.
-
-    Raises:
-        ClusterNotInSTSModeException: If cluster not in STS mode
-
-    """
-    from ocs_ci.ocs.ocp import OCP
-
-    if not config.DEPLOYMENT.get("sts_enabled"):
-        raise ClusterNotInSTSModeException
-
-    env_key_map = {
-        "CLIENTID": "client_id",
-        "TENANTID": "tenant_id",
-        "SUBSCRIPTIONID": "subscription_id",
-        "RESOURCEGROUP": "resource_group",
-    }
-    odf_sub = OCP(
-        kind=constants.SUBSCRIPTION,
-        resource_name=constants.ODF_SUBSCRIPTION,
-        namespace=config.ENV_DATA["cluster_namespace"],
-    )
-    creds = {}
-    for item in odf_sub.get()["spec"]["config"]["env"]:
-        if item["name"] in env_key_map:
-            creds[env_key_map[item["name"]]] = item["value"]
-    return creds
-
-
 def get_glibc_version():
     """
     Gets the GLIBC version.


### PR DESCRIPTION
## Summary
- Create an Azure user-assigned managed identity with federated credentials for NooBaa service accounts (`noobaa`, `noobaa-core`, `noobaa-endpoint`) during ODF deployment on Azure STS clusters
- Pass the managed identity's client ID (instead of the service principal's) and resource group to the ODF Subscription env vars (`CLIENTID`, `RESOURCEGROUP`)
- Clean up the managed identity and its role assignments during cluster teardown
- Add `get_azure_sts_creds_from_sub()` utility for retrieving Azure STS credentials from the Subscription (for follow-up BackingStore/NamespaceStore work)

## Details
When deploying ODF on Azure with STS/WIF (`sts_enabled: true`), NooBaa needs a managed identity with federated credentials to authenticate to Azure Blob Storage via workload identity. Without this, NooBaa falls back to a PV-pool backing store.

This mirrors the existing AWS STS pattern (`create_and_attach_sts_role` / `get_role_arn_from_sub`).

**Changes:**
- `azure_utils.py`: `create_noobaa_managed_identity()` and `delete_noobaa_managed_identity()` on the `AZURE` class
- `deployment.py`: Wire MI creation into `deploy_ocs_via_operator()`, fix `subscribe_ocs()` to use MI client ID + add `RESOURCEGROUP` env var + fix `.append()` → `.extend()` bug
- `azure.py`: Wire MI deletion + role assignment cleanup into `AZUREIPI.destroy_cluster()`
- `utils.py`: Add `get_azure_sts_creds_from_sub()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure STS deployments now create a NooBaa user-assigned managed identity and configure workload identity federation for NooBaa service accounts.
* **Bug Fixes**
  * Cluster destruction for Azure STS now performs managed-identity cleanup to remove NooBaa-related identities and role assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->