### PR TITLE
Revert create_nfs_sc to create_nfs_sc_retain in test_nfs_pvc_subvolume_deletion

### DIFF
--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1552,6 +1552,12 @@ class TestNfsEnable(ManageTest):
 
     def parse_subvolume_ls_output(self, output):
         subvolumes = []
+        if hasattr(output, "stdout"):
+            output = (
+                output.stdout.decode()
+                if isinstance(output.stdout, bytes)
+                else output.stdout
+            )
         subvolumes_list = output.strip().split("\n")[1:]
         for item in subvolumes_list:
             fs, sv, svg, status = item.split(" ")

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1455,12 +1455,10 @@ class TestNfsEnable(ManageTest):
 
         """
         # checking subvolume before retain nfs pvc creation
-        from pathlib import Path
-
         self.retain_nfs_sc = nfs_utils.create_nfs_sc_retain(self.retain_nfs_sc_name)
-        if not (Path(config.RUN["bin_dir"]) / "odf").exists():
+        odf_cli_path = constants.ODF_CLI_LOCAL_PATH
+        if not os.path.exists(odf_cli_path):
             helpers.retrieve_cli_binary(cli_type="odf")
-        odf_cli_path = os.path.join(config.RUN["bin_dir"], "odf")
         output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls")
         inital_subvolume_list = self.parse_subvolume_ls_output(output)
         log.info(f"{inital_subvolume_list=}")

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1457,9 +1457,7 @@ class TestNfsEnable(ManageTest):
         # checking subvolume before retain nfs pvc creation
         from pathlib import Path
 
-        self.retain_nfs_sc = nfs_utils.create_nfs_sc(
-            sc_name_to_create=self.retain_nfs_sc_name, retain_reclaim_policy=True
-        )
+        self.retain_nfs_sc = nfs_utils.create_nfs_sc_retain(self.retain_nfs_sc_name)
         if not (Path(config.RUN["bin_dir"]) / "odf").exists():
             helpers.retrieve_cli_binary(cli_type="odf")
         odf_cli_path = os.path.join(config.RUN["bin_dir"], "odf")


### PR DESCRIPTION
# Problem
Commit a701355a ("Fixed odf-cli path issue #14080") was cherry-picked into release-4.19. As part of that cherry-pick, the call to nfs_utils.create_nfs_sc_retain() in test_nfs_pvc_subvolume_deletion was replaced with nfs_utils.create_nfs_sc(sc_name_to_create=..., retain_reclaim_policy=True).

However, create_nfs_sc() does not exist in ocs_ci/utility/nfs_utils.py on release-4.19 — it was only introduced in release-4.20. As a result, test_nfs_pvc_subvolume_deletion fails immediately on release-4.19 with an AttributeError.

> E       AttributeError: module 'ocs_ci.utility.nfs_utils' has no attribute 'create_nfs_sc'

run: https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/48542/2150249/2150305/log?logParams=history%3D2150305%26page.page%3D1


# Fix
Revert the call back to the function that exists on this branch:


# Before (broken on release-4.19)
self.retain_nfs_sc = nfs_utils.create_nfs_sc(
    sc_name_to_create=self.retain_nfs_sc_name, retain_reclaim_policy=True
)

# After (correct for release-4.19)
self.retain_nfs_sc = nfs_utils.create_nfs_sc_retain(self.retain_nfs_sc_name)