### PR TITLE
Add endpoint network disruption test for DFBUGS-5838

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -59,6 +59,9 @@ TEMPLATE_COUCHBASE_SERVER_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "server")
 TEMPLATE_COUCHBASE_PILLOWFIGHT_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "pillowfight")
 TEMPLATE_CEPHFS_STRESS_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "cephfs_stress")
 TEMPLATE_MCG_DIR = os.path.join(TEMPLATE_DIR, "mcg")
+TEMPLATE_BLOCK_NB_EGRESS_NETWORK_POLICY = os.path.join(
+    TEMPLATE_MCG_DIR, "block_egress_network_policy.yaml"
+)
 TEMPLATE_RGW_DIR = os.path.join(TEMPLATE_DIR, "rgw")
 TEMPLATE_AMQ_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "amq")
 TEMPLATE_OPENSHIFT_INFRA_DIR = os.path.join(TEMPLATE_DIR, "openshift-infra/")

--- a/ocs_ci/templates/mcg/block_egress_network_policy.yaml
+++ b/ocs_ci/templates/mcg/block_egress_network_policy.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: block-cloud-egress
-  namespace: openshift-storage
 spec:
   # Only targets noobaa-endpoint pods, not other pods in the namespace
   podSelector:

--- a/ocs_ci/templates/mcg/block_egress_network_policy.yaml
+++ b/ocs_ci/templates/mcg/block_egress_network_policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: block-cloud-egress
+  namespace: openshift-storage
+spec:
+  # Only targets noobaa-endpoint pods, not other pods in the namespace
+  podSelector:
+    matchLabels:
+      noobaa-s3: noobaa
+  policyTypes:
+    - Egress
+  # Allow egress only to pods within the cluster (any namespace).
+  # All external traffic (cloud storage, internet) is blocked.
+  egress:
+    - to:
+        - namespaceSelector: {}

--- a/tests/functional/object/mcg/test_endpoint_network_disruption.py
+++ b/tests/functional/object/mcg/test_endpoint_network_disruption.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import tempfile
 import threading
@@ -45,11 +46,10 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
 
     @tier4c
     @pytest.mark.parametrize(
-        argnames=["disruption_during", "platform", "bucketclass_dict"],
+        argnames=["disruption_during", "bucketclass_dict"],
         argvalues=[
             pytest.param(
                 "download",
-                constants.AWS_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -62,7 +62,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.AZURE_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -75,7 +74,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.IBM_COS_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -88,7 +86,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.AWS_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"aws": [(1, None)]},
@@ -98,7 +95,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.AZURE_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"azure": [(1, None)]},
@@ -108,7 +104,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.GCP_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"gcp": [(1, None)]},
@@ -118,7 +113,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "download",
-                constants.IBM_COS_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"ibmcos": [(1, None)]},
@@ -128,7 +122,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.AWS_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -141,7 +134,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.AZURE_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -154,7 +146,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.IBM_COS_PLATFORM,
                 {
                     "interface": "OC",
                     "namespace_policy_dict": {
@@ -167,7 +158,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.AWS_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"aws": [(1, None)]},
@@ -177,7 +167,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.AZURE_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"azure": [(1, None)]},
@@ -187,7 +176,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.GCP_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"gcp": [(1, None)]},
@@ -197,7 +185,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
             ),
             pytest.param(
                 "upload",
-                constants.IBM_COS_PLATFORM,
                 {
                     "interface": "OC",
                     "backingstore_dict": {"ibmcos": [(1, None)]},
@@ -211,7 +198,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
         self,
         request,
         disruption_during,
-        platform,
         bucketclass_dict,
         mcg_obj,
         awscli_pod_session,
@@ -235,6 +221,14 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
         """
         namespace = config.ENV_DATA["cluster_namespace"]
         awscli_pod = awscli_pod_session
+
+        store_dict = bucketclass_dict.get(
+            "backingstore_dict",
+            bucketclass_dict.get("namespace_policy_dict", {}).get(
+                "namespacestore_dict", {}
+            ),
+        )
+        platform = next(iter(store_dict))
 
         # Step 1: Create bucket with parametrized bucketclass
         logger.info(f"Creating bucket backed by {platform} cloud storage")
@@ -340,6 +334,7 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
         templating.dump_data_to_temp_yaml(network_policy_data, temp_yaml.name)
         ocp_obj = ocp.OCP(kind=constants.NETWORK_POLICY, namespace=namespace)
         ocp_obj.exec_oc_cmd(f"apply -f {temp_yaml.name}")
+        os.unlink(temp_yaml.name)
         logger.info(
             "NetworkPolicy applied - external egress blocked "
             "for noobaa-endpoint pods"
@@ -365,7 +360,6 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
                 f"instead of Running"
             )
 
-        for ep in endpoint_pods_after:
             if ep.name in restart_counts_before:
                 current_restarts = ep.restart_count
                 assert current_restarts == restart_counts_before[ep.name], (
@@ -374,16 +368,15 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
                     f"after={current_restarts}"
                 )
 
-        for ep in endpoint_pods_after:
             panics = pod.search_pattern_in_pod_logs(
                 pod_name=ep.name,
                 pattern="PANIC.*uncaughtException",
                 container="endpoint",
                 since="5m",
             )
-            assert not panics, (
-                f"Found PANIC/uncaughtException in endpoint pod " f"{ep.name}: {panics}"
-            )
+            assert (
+                not panics
+            ), f"Found PANIC/uncaughtException in endpoint pod {ep.name}: {panics}"
 
         logger.info(
             f"All endpoint pods survived the cloud connection "

--- a/tests/functional/object/mcg/test_endpoint_network_disruption.py
+++ b/tests/functional/object/mcg/test_endpoint_network_disruption.py
@@ -335,6 +335,14 @@ class TestEndpointCloudNetworkDisruption(MCGTest):
         ocp_obj = ocp.OCP(kind=constants.NETWORK_POLICY, namespace=namespace)
         ocp_obj.exec_oc_cmd(f"apply -f {temp_yaml.name}")
         os.unlink(temp_yaml.name)
+
+        # NetworkPolicy has no STATUS; wait on NAME to confirm creation
+        ocp_obj.wait_for_resource(
+            condition=self.NETWORK_POLICY_NAME,
+            column="NAME",
+            resource_name=self.NETWORK_POLICY_NAME,
+            timeout=30,
+        )
         logger.info(
             "NetworkPolicy applied - external egress blocked "
             "for noobaa-endpoint pods"

--- a/tests/functional/object/mcg/test_endpoint_network_disruption.py
+++ b/tests/functional/object/mcg/test_endpoint_network_disruption.py
@@ -1,0 +1,391 @@
+import logging
+import subprocess
+import tempfile
+import threading
+import time
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    runs_on_provider,
+    skipif_managed_service,
+    skipif_proxy_cluster,
+)
+from ocs_ci.framework.testlib import (
+    MCGTest,
+    skipif_disconnected_cluster,
+    tier4c,
+)
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.bucket_utils import craft_s3_command
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility import templating
+
+logger = logging.getLogger(__name__)
+
+
+@mcg
+@red_squad
+@runs_on_provider
+@skipif_managed_service
+@skipif_disconnected_cluster
+@skipif_proxy_cluster
+class TestEndpointCloudNetworkDisruption(MCGTest):
+    """
+    Test class for verifying noobaa-endpoint pod resilience when
+    cloud storage connections are severed mid-stream.
+    """
+
+    LARGE_FILE_SIZE_MB = 2048
+    NETWORK_POLICY_NAME = "block-cloud-egress"
+
+    @tier4c
+    @pytest.mark.parametrize(
+        argnames=["disruption_during", "platform", "bucketclass_dict"],
+        argvalues=[
+            pytest.param(
+                "download",
+                constants.AWS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"aws": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7901"),
+                id="download-namespacestore-aws",
+            ),
+            pytest.param(
+                "download",
+                constants.AZURE_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"azure": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7902"),
+                id="download-namespacestore-azure",
+            ),
+            pytest.param(
+                "download",
+                constants.IBM_COS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"ibmcos": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7903"),
+                id="download-namespacestore-ibmcos",
+            ),
+            pytest.param(
+                "download",
+                constants.AWS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"aws": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7904"),
+                id="download-backingstore-aws",
+            ),
+            pytest.param(
+                "download",
+                constants.AZURE_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"azure": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7905"),
+                id="download-backingstore-azure",
+            ),
+            pytest.param(
+                "download",
+                constants.GCP_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"gcp": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7906"),
+                id="download-backingstore-gcp",
+            ),
+            pytest.param(
+                "download",
+                constants.IBM_COS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"ibmcos": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7907"),
+                id="download-backingstore-ibmcos",
+            ),
+            pytest.param(
+                "upload",
+                constants.AWS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"aws": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7908"),
+                id="upload-namespacestore-aws",
+            ),
+            pytest.param(
+                "upload",
+                constants.AZURE_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"azure": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7909"),
+                id="upload-namespacestore-azure",
+            ),
+            pytest.param(
+                "upload",
+                constants.IBM_COS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"ibmcos": [(1, None)]},
+                    },
+                },
+                marks=pytest.mark.polarion_id("OCS-7910"),
+                id="upload-namespacestore-ibmcos",
+            ),
+            pytest.param(
+                "upload",
+                constants.AWS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"aws": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7911"),
+                id="upload-backingstore-aws",
+            ),
+            pytest.param(
+                "upload",
+                constants.AZURE_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"azure": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7912"),
+                id="upload-backingstore-azure",
+            ),
+            pytest.param(
+                "upload",
+                constants.GCP_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"gcp": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7913"),
+                id="upload-backingstore-gcp",
+            ),
+            pytest.param(
+                "upload",
+                constants.IBM_COS_PLATFORM,
+                {
+                    "interface": "OC",
+                    "backingstore_dict": {"ibmcos": [(1, None)]},
+                },
+                marks=pytest.mark.polarion_id("OCS-7914"),
+                id="upload-backingstore-ibmcos",
+            ),
+        ],
+    )
+    def test_endpoint_survives_cloud_connection_severed(
+        self,
+        request,
+        disruption_during,
+        platform,
+        bucketclass_dict,
+        mcg_obj,
+        awscli_pod_session,
+        bucket_factory,
+    ):
+        """
+        Verify that noobaa-endpoint pods survive when TCP connections
+        to cloud storage are severed mid-stream, rather than crashing
+        with an unhandled exception.
+
+        Test steps:
+            1. Create a bucket backed by cloud storage (namespacestore
+               or backingstore depending on parametrization)
+            2. Generate a large file on the awscli pod
+            3. For download disruption: upload the file first
+            4. Record endpoint pod restart counts
+            5. Start a large upload or download in a background thread
+            6. Apply a NetworkPolicy to block all external egress
+               from noobaa-endpoint pods only
+            7. Verify endpoint pods did not crash or restart
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        awscli_pod = awscli_pod_session
+
+        # Step 1: Create bucket with parametrized bucketclass
+        logger.info(f"Creating bucket backed by {platform} cloud storage")
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        logger.info(f"Created bucket: {bucket.name}")
+
+        # Step 2: Generate a large file
+        logger.info(f"Generating {self.LARGE_FILE_SIZE_MB} MB file")
+        awscli_pod.exec_sh_cmd_on_pod(
+            f"dd if=/dev/urandom of=/tmp/bigfile "
+            f"bs=1M count={self.LARGE_FILE_SIZE_MB} status=none",
+            timeout=300,
+        )
+        request.addfinalizer(
+            lambda: awscli_pod.exec_sh_cmd_on_pod(
+                "rm -f /tmp/bigfile /tmp/bigfile_download"
+            )
+        )
+
+        # Step 3: For download disruption, upload the file first
+        if disruption_during == "download":
+            logger.info("Uploading file before download disruption test")
+            upload_cmd = craft_s3_command(
+                f"cp /tmp/bigfile s3://{bucket.name}/bigfile",
+                mcg_obj=mcg_obj,
+            )
+            awscli_pod.exec_cmd_on_pod(upload_cmd, out_yaml_format=False, timeout=600)
+            logger.info("Upload complete")
+
+        # Step 4: Record endpoint pod state before disruption
+        endpoint_pods = pod.get_noobaa_endpoint_pods()
+        assert endpoint_pods, "No noobaa-endpoint pods found"
+        restart_counts_before = {p.name: p.restart_count for p in endpoint_pods}
+        logger.info(f"Endpoint pod restart counts before: {restart_counts_before}")
+
+        # Step 5: Register NetworkPolicy cleanup finalizer
+        def _cleanup_network_policy():
+            try:
+                ocp.OCP(kind=constants.NETWORK_POLICY, namespace=namespace).delete(
+                    resource_name=self.NETWORK_POLICY_NAME
+                )
+                logger.info(f"Deleted NetworkPolicy {self.NETWORK_POLICY_NAME}")
+            except CommandFailed:
+                logger.warning(
+                    f"NetworkPolicy {self.NETWORK_POLICY_NAME} already deleted"
+                )
+
+        request.addfinalizer(_cleanup_network_policy)
+
+        # Step 6: Start operation in background, then apply NetworkPolicy
+        logger.info(f"Starting large {disruption_during} in background thread")
+        operation_disrupted = threading.Event()
+
+        if disruption_during == "download":
+            s3_cmd = craft_s3_command(
+                f"cp s3://{bucket.name}/bigfile /tmp/bigfile_download",
+                mcg_obj=mcg_obj,
+                max_attempts=2,
+            )
+        else:
+            s3_cmd = craft_s3_command(
+                f"cp /tmp/bigfile s3://{bucket.name}/bigfile",
+                mcg_obj=mcg_obj,
+                max_attempts=2,
+            )
+
+        def _s3_operation():
+            try:
+                awscli_pod.exec_cmd_on_pod(s3_cmd, out_yaml_format=False, timeout=120)
+                logger.info(
+                    f"{disruption_during.capitalize()} completed before "
+                    f"network disruption took effect"
+                )
+            except (CommandFailed, TimeoutError, subprocess.TimeoutExpired):
+                operation_disrupted.set()
+                logger.info(
+                    f"{disruption_during.capitalize()} failed as expected "
+                    f"due to network disruption"
+                )
+
+        operation_thread = threading.Thread(target=_s3_operation, daemon=True)
+        operation_thread.start()
+        time.sleep(2)
+
+        logger.info(
+            "Applying NetworkPolicy to block external egress "
+            "from noobaa-endpoint pods only"
+        )
+        network_policy_data = templating.load_yaml(
+            constants.TEMPLATE_BLOCK_NB_EGRESS_NETWORK_POLICY
+        )
+        network_policy_data["metadata"]["namespace"] = namespace
+        temp_yaml = tempfile.NamedTemporaryFile(
+            mode="w+",
+            prefix="network_policy_",
+            suffix=".yaml",
+            delete=False,
+        )
+        templating.dump_data_to_temp_yaml(network_policy_data, temp_yaml.name)
+        ocp_obj = ocp.OCP(kind=constants.NETWORK_POLICY, namespace=namespace)
+        ocp_obj.exec_oc_cmd(f"apply -f {temp_yaml.name}")
+        logger.info(
+            "NetworkPolicy applied - external egress blocked "
+            "for noobaa-endpoint pods"
+        )
+
+        operation_thread.join(timeout=120)
+        assert operation_disrupted.is_set(), (
+            f"{disruption_during.capitalize()} completed before the "
+            f"NetworkPolicy disrupted it. Increase LARGE_FILE_SIZE_MB "
+            f"to ensure the {disruption_during} is still in progress "
+            f"when the network is severed."
+        )
+
+        # Step 7: Verify endpoint pods survived
+        logger.info("Waiting 30 seconds for any crash to manifest, then verifying")
+        time.sleep(30)
+
+        endpoint_pods_after = pod.get_noobaa_endpoint_pods()
+        for ep in endpoint_pods_after:
+            pod_status = ep.get()["status"]["phase"]
+            assert pod_status == constants.STATUS_RUNNING, (
+                f"Endpoint pod {ep.name} is in {pod_status} state "
+                f"instead of Running"
+            )
+
+        for ep in endpoint_pods_after:
+            if ep.name in restart_counts_before:
+                current_restarts = ep.restart_count
+                assert current_restarts == restart_counts_before[ep.name], (
+                    f"Endpoint pod {ep.name} restarted: "
+                    f"before={restart_counts_before[ep.name]}, "
+                    f"after={current_restarts}"
+                )
+
+        for ep in endpoint_pods_after:
+            panics = pod.search_pattern_in_pod_logs(
+                pod_name=ep.name,
+                pattern="PANIC.*uncaughtException",
+                container="endpoint",
+                since="5m",
+            )
+            assert not panics, (
+                f"Found PANIC/uncaughtException in endpoint pod " f"{ep.name}: {panics}"
+            )
+
+        logger.info(
+            f"All endpoint pods survived the cloud connection "
+            f"disruption during {disruption_during}"
+        )


### PR DESCRIPTION
  ## Summary
  - Add test verifying noobaa-endpoint pods survive when cloud storage connections are severed mid-stream during upload and download
  - Uses a NetworkPolicy to block all external egress from endpoint pods while preserving internal cluster traffic
  - Covers AWS, Azure, GCP, and IBM COS across namespacestore and backingstore configurations (14 parametrized variants)

  ## Details
Automates verification of [DFBUGS-5838](https://issues.redhat.com/browse/DFBUGS-5838): noobaa-endpoint pods were crashing with Exit Code 1 due to an unhandled `AbortError` when TCP connections to cloud storage were severed.

  The test:
  1. Creates a bucket backed by cloud storage
  2. Starts a large (2 GB) upload or download in a background thread
  3. Applies a NetworkPolicy that blocks external egress from noobaa-endpoint pods only (internal cluster traffic is preserved via `namespaceSelector: {}`)
  4. Verifies the endpoint pods remain Running, have not restarted, and have no PANIC/uncaughtException in logs

  ### New files
  - `tests/functional/object/mcg/test_endpoint_network_disruption.py`
  - `ocs_ci/templates/mcg/block_egress_network_policy.yaml`

  ### Modified files
  - `ocs_ci/ocs/constants.py` — added `TEMPLATE_BLOCK_NB_EGRESS_NETWORK_POLICY`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional tests validating endpoint resilience when cloud connectivity is severed during uploads and downloads. Tests ensure transfers are disrupted as expected while endpoint pods remain running, without unexpected crashes, across multiple backend configurations and large-file scenarios.

* **Chores**
  * Added a network-policy template and supporting configuration to enable controlled egress-blocking test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->