### PR TITLE
Fix NFS mount failure on IBM Cloud by fixing retry logic and opening port 2049

### DIFF
--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -1502,20 +1502,16 @@ def _get_lb_security_groups(svc_name, namespace):
     lb_ingress = svc_data.get("status", {}).get("loadBalancer", {}).get("ingress", [])
     if not lb_ingress:
         logger.warning(
-            "No LB ingress on service %s, cannot configure " "security group",
-            svc_name,
+            f"No LB ingress on service {svc_name}, cannot configure " f"security group"
         )
         return []
 
     lb_hostname = lb_ingress[0].get("hostname") or lb_ingress[0].get("ip")
     if not lb_hostname:
-        logger.warning(
-            "No hostname/IP in LB ingress for service %s",
-            svc_name,
-        )
+        logger.warning(f"No hostname/IP in LB ingress for service {svc_name}")
         return []
 
-    logger.debug("LB endpoint for %s: %s", svc_name, lb_hostname)
+    logger.debug(f"LB endpoint for {svc_name}: {lb_hostname}")
 
     cmd = f"ibmcloud is lbs --resource-group-name {rg_name} " f"--output json"
     out = run_ibmcloud_cmd(cmd)
@@ -1528,18 +1524,12 @@ def _get_lb_security_groups(svc_name, namespace):
             break
 
     if not matching_lb:
-        logger.error(
-            "Could not find IBM Cloud VPC LB with hostname %s",
-            lb_hostname,
-        )
+        logger.error(f"Could not find IBM Cloud VPC LB with hostname {lb_hostname}")
         return []
 
     security_groups = matching_lb.get("security_groups", [])
     if not security_groups:
-        logger.warning(
-            "No security groups on LB %s",
-            matching_lb.get("name"),
-        )
+        logger.warning(f"No security groups on LB {matching_lb.get('name')}")
     return security_groups
 
 
@@ -1559,13 +1549,12 @@ def configure_nfs_lb_security_group():
     for sg in security_groups:
         sg_name = sg.get("name")
         try:
-            logger.info("Adding inbound TCP 2049 to %s", sg_name)
+            logger.info(f"Adding inbound TCP 2049 to {sg_name}")
             add_security_group_rule(sg_name, "inbound", "tcp", 2049, 2049)
         except Exception as e:
             logger.warning(
-                "Failed to add port 2049 rule to %s " "(may already exist): %s",
-                sg_name,
-                e,
+                f"Failed to add port 2049 rule to {sg_name} "
+                f"(may already exist): {e}"
             )
 
     logger.info("NFS LB security group configuration done")
@@ -1592,11 +1581,7 @@ def remove_nfs_lb_security_group_rules():
             out = run_ibmcloud_cmd(cmd)
             sg_detail = json.loads(out)
         except Exception as e:
-            logger.warning(
-                "Could not fetch rules for %s: %s",
-                sg_name,
-                e,
-            )
+            logger.warning(f"Could not fetch rules for {sg_name}: {e}")
             continue
 
         for rule in sg_detail.get("rules", []):
@@ -1607,22 +1592,14 @@ def remove_nfs_lb_security_group_rules():
                 and rule.get("port_max") == 2049
             ):
                 rule_id = rule.get("id")
-                logger.info(
-                    "Deleting rule %s from %s",
-                    rule_id,
-                    sg_name,
-                )
+                logger.info(f"Deleting rule {rule_id} from {sg_name}")
                 try:
                     run_ibmcloud_cmd(
                         f"ibmcloud is security-group-rule-delete "
                         f"{sg_id} {rule_id} --force"
                     )
                 except Exception as e:
-                    logger.warning(
-                        "Failed to delete rule %s: %s",
-                        rule_id,
-                        e,
-                    )
+                    logger.warning(f"Failed to delete rule {rule_id}: {e}")
 
     logger.info("NFS LB security group cleanup done")
 

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -36,7 +36,6 @@ from ocs_ci.utility import version as util_version
 from ocs_ci.utility.utils import get_infra_id, get_ocp_version, run_cmd, TimeoutSampler
 from ocs_ci.ocs.node import get_nodes
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -1475,6 +1474,157 @@ def configure_ingress_load_balancer_security_group():
     except Exception as e:
         logger.error(f"Failed to configure ingress load balancer security group: {e}")
         raise
+
+
+def _get_lb_security_groups(svc_name, namespace):
+    """
+    Look up the IBM Cloud VPC load balancer backing a Kubernetes
+    LoadBalancer Service and return its security groups.
+
+    Args:
+        svc_name (str): Kubernetes Service name
+        namespace (str): Kubernetes namespace
+
+    Returns:
+        list: security group dicts from the VPC LB, empty list on
+            failure
+
+    """
+    rg_name = get_resource_group_name(config.ENV_DATA["cluster_path"])
+
+    svc_ocp = OCP(
+        kind="Service",
+        namespace=namespace,
+        resource_name=svc_name,
+    )
+    svc_data = svc_ocp.get()
+
+    lb_ingress = svc_data.get("status", {}).get("loadBalancer", {}).get("ingress", [])
+    if not lb_ingress:
+        logger.warning(
+            "No LB ingress on service %s, cannot configure " "security group",
+            svc_name,
+        )
+        return []
+
+    lb_hostname = lb_ingress[0].get("hostname") or lb_ingress[0].get("ip")
+    if not lb_hostname:
+        logger.warning(
+            "No hostname/IP in LB ingress for service %s",
+            svc_name,
+        )
+        return []
+
+    logger.debug("LB endpoint for %s: %s", svc_name, lb_hostname)
+
+    cmd = f"ibmcloud is lbs --resource-group-name {rg_name} " f"--output json"
+    out = run_ibmcloud_cmd(cmd)
+    load_balancers = json.loads(out)
+
+    matching_lb = None
+    for lb in load_balancers:
+        if lb.get("hostname") == lb_hostname:
+            matching_lb = lb
+            break
+
+    if not matching_lb:
+        logger.error(
+            "Could not find IBM Cloud VPC LB with hostname %s",
+            lb_hostname,
+        )
+        return []
+
+    security_groups = matching_lb.get("security_groups", [])
+    if not security_groups:
+        logger.warning(
+            "No security groups on LB %s",
+            matching_lb.get("name"),
+        )
+    return security_groups
+
+
+def configure_nfs_lb_security_group():
+    """
+    Add an inbound TCP rule for port 2049 (NFS) to the security
+    groups attached to the NFS LoadBalancer on IBM Cloud VPC.
+
+    Must be called after the ``rook-ceph-nfs-my-nfs-load-balancer``
+    Service has an ingress address assigned.
+    """
+    svc_name = "rook-ceph-nfs-my-nfs-load-balancer"
+    namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+    logger.info("Configuring NFS LB security group for port 2049")
+
+    security_groups = _get_lb_security_groups(svc_name, namespace)
+    for sg in security_groups:
+        sg_name = sg.get("name")
+        try:
+            logger.info("Adding inbound TCP 2049 to %s", sg_name)
+            add_security_group_rule(sg_name, "inbound", "tcp", 2049, 2049)
+        except Exception as e:
+            logger.warning(
+                "Failed to add port 2049 rule to %s " "(may already exist): %s",
+                sg_name,
+                e,
+            )
+
+    logger.info("NFS LB security group configuration done")
+
+
+def remove_nfs_lb_security_group_rules():
+    """
+    Remove inbound TCP 2049 rules from the security groups attached
+    to the NFS LoadBalancer on IBM Cloud VPC.
+
+    Should be called before deleting the NFS LoadBalancer Service so
+    the VPC LB is still present for look-up.
+    """
+    svc_name = "rook-ceph-nfs-my-nfs-load-balancer"
+    namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+    logger.info("Removing NFS LB security group rules for port 2049")
+
+    security_groups = _get_lb_security_groups(svc_name, namespace)
+    for sg in security_groups:
+        sg_id = sg.get("id")
+        sg_name = sg.get("name")
+        try:
+            cmd = f"ibmcloud is security-group {sg_id} " f"--output json"
+            out = run_ibmcloud_cmd(cmd)
+            sg_detail = json.loads(out)
+        except Exception as e:
+            logger.warning(
+                "Could not fetch rules for %s: %s",
+                sg_name,
+                e,
+            )
+            continue
+
+        for rule in sg_detail.get("rules", []):
+            if (
+                rule.get("direction") == "inbound"
+                and rule.get("protocol") == "tcp"
+                and rule.get("port_min") == 2049
+                and rule.get("port_max") == 2049
+            ):
+                rule_id = rule.get("id")
+                logger.info(
+                    "Deleting rule %s from %s",
+                    rule_id,
+                    sg_name,
+                )
+                try:
+                    run_ibmcloud_cmd(
+                        f"ibmcloud is security-group-rule-delete "
+                        f"{sg_id} {rule_id} --force"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to delete rule %s: %s",
+                        rule_id,
+                        e,
+                    )
+
+    logger.info("NFS LB security group cleanup done")
 
 
 def create_address_prefix(prefix_name, vpc, zone, cidr):

--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -206,7 +206,7 @@ def create_nfs_load_balancer_service(
         log.info("ingress hostname, %s", hostname_add)
     elif "ip" in host_details:
         hostname_add = host_details["ip"]
-        log.info("ingress host ip, %s", hostname_add)
+        log.info(f"ingress host ip, {hostname_add}")
     else:
         log.error("host details unavailable")
         return None

--- a/ocs_ci/utility/nfs_utils.py
+++ b/ocs_ci/utility/nfs_utils.py
@@ -204,13 +204,22 @@ def create_nfs_load_balancer_service(
     if "hostname" in host_details:
         hostname_add = host_details["hostname"]
         log.info("ingress hostname, %s", hostname_add)
-        return hostname_add
     elif "ip" in host_details:
-        host_ip = host_details["ip"]
-        log.info("ingress host ip, %s", host_ip)
-        return host_ip
+        hostname_add = host_details["ip"]
+        log.info("ingress host ip, %s", hostname_add)
     else:
         log.error("host details unavailable")
+        return None
+
+    platform = config.ENV_DATA.get("platform", "").lower()
+    if platform == constants.IBMCLOUD_PLATFORM:
+        from ocs_ci.utility.ibmcloud import (
+            configure_nfs_lb_security_group,
+        )
+
+        configure_nfs_lb_security_group()
+
+    return hostname_add
 
 
 def update_etc_hosts_on_nfs_client(con, hostname):
@@ -304,6 +313,14 @@ def delete_nfs_load_balancer_service(
             "NFS LoadBalancer service %s does not exist, skipping delete", svc_name
         )
         return
+
+    platform = config.ENV_DATA.get("platform", "").lower()
+    if platform == constants.IBMCLOUD_PLATFORM:
+        from ocs_ci.utility.ibmcloud import (
+            remove_nfs_lb_security_group_rules,
+        )
+
+        remove_nfs_lb_security_group_rules()
 
     log.info("Deleting NFS LoadBalancer service %s", svc_name)
     storage_cluster_obj.exec_oc_cmd(f"delete service {svc_name}")

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -363,6 +363,28 @@ class TestNfsEnable(ManageTest):
                 nfs_utils.update_etc_hosts_on_nfs_client(con, hostname_add)
         return con
 
+    def _mount_nfs_with_retry(self, cmd, tries=28, delay=10):
+        """
+        Execute an NFS mount command on the client VM with retry.
+
+        Args:
+            cmd (str): Mount command to execute on the NFS client VM
+            tries (int): Number of retry attempts (default: 28)
+            delay (int): Delay in seconds between retries (default: 10)
+
+        Raises:
+            CommandFailed: If mount does not succeed within the retry limit
+        """
+
+        def _do_mount():
+            retcode, _, stderr = self.con.exec_cmd(cmd)
+            if retcode != 0:
+                raise CommandFailed(
+                    f"NFS mount command failed with retcode " f"{retcode}: {stderr}"
+                )
+
+        retry((CommandFailed), tries=tries, delay=delay)(_do_mount)()
+
     @tier1
     @polarion_id("OCS-4269")
     @skipif_hci_client
@@ -573,11 +595,7 @@ class TestNfsEnable(ManageTest):
             + self.test_folder
         )
 
-        retry(
-            (CommandFailed),
-            tries=28,
-            delay=10,
-        )(self.con.exec_cmd(export_nfs_external_cmd))
+        self._mount_nfs_with_retry(export_nfs_external_cmd)
 
         # Verify able to read exported volume
         command = f"cat {self.test_folder}/index.html"
@@ -745,11 +763,7 @@ class TestNfsEnable(ManageTest):
                 + " "
                 + self.test_folder
             )
-            retry(
-                (CommandFailed),
-                tries=28,
-                delay=10,
-            )(self.con.exec_cmd(export_nfs_external_cmd))
+            self._mount_nfs_with_retry(export_nfs_external_cmd)
 
             # Verify able to access exported volume
             command = f"cat {self.test_folder}/index.html"
@@ -878,11 +892,7 @@ class TestNfsEnable(ManageTest):
             + " "
             + self.test_folder
         )
-        retry(
-            (CommandFailed),
-            tries=28,
-            delay=10,
-        )(self.con.exec_cmd(export_nfs_external_cmd))
+        self._mount_nfs_with_retry(export_nfs_external_cmd)
 
         # Verify able to access exported volume
         command = f"cat {self.test_folder}/shared_file.html"
@@ -1011,11 +1021,7 @@ class TestNfsEnable(ManageTest):
             + " "
             + self.test_folder
         )
-        retry(
-            (CommandFailed),
-            tries=28,
-            delay=10,
-        )(self.con.exec_cmd(export_nfs_external_cmd))
+        self._mount_nfs_with_retry(export_nfs_external_cmd)
 
         # Verify able to write new file in exported volume by external client
         command = (
@@ -1779,11 +1785,7 @@ class TestNfsEnable(ManageTest):
             + self.test_folder
         )
 
-        retry(
-            (CommandFailed),
-            tries=28,
-            delay=10,
-        )(self.con.exec_cmd(export_nfs_external_cmd))
+        self._mount_nfs_with_retry(export_nfs_external_cmd)
 
         # Verify able to read exported volume
         command = f"cat {self.test_folder}/index.html"

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1623,19 +1623,19 @@ class TestNfsEnable(ManageTest):
         # Checking for stale volumes
         output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
         stale_before = self.parse_subvolume_ls_output(output)
-        log.info("Stale subvolumes before delete: %s", stale_before)
+        log.info(f"Stale subvolumes before delete: {stale_before}")
 
         # Deleting stale subvolume
         delete_output = exec_cmd(
             cmd=f"{odf_cli_path} subvolume delete"
             f" {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}"
         )
-        log.info("Subvolume delete output: %s", delete_output.stdout)
+        log.info(f"Subvolume delete output: {delete_output.stdout}")
 
         # Verify the specific subvolume was deleted
         output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
         stale_after = self.parse_subvolume_ls_output(output)
-        log.info("Stale subvolumes after delete: %s", stale_after)
+        log.info(f"Stale subvolumes after delete: {stale_after}")
         stale_svs = {sv[1] for sv in stale_after}
         assert (
             new_pvc[1] not in stale_svs

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -1622,16 +1622,24 @@ class TestNfsEnable(ManageTest):
 
         # Checking for stale volumes
         output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
+        stale_before = self.parse_subvolume_ls_output(output)
+        log.info("Stale subvolumes before delete: %s", stale_before)
 
-        # Deleteing stale subvolume
-        exec_cmd(
-            cmd=f"{odf_cli_path} subvolume delete {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}"
+        # Deleting stale subvolume
+        delete_output = exec_cmd(
+            cmd=f"{odf_cli_path} subvolume delete"
+            f" {new_pvc[0]} {new_pvc[1]} {new_pvc[2]}"
         )
+        log.info("Subvolume delete output: %s", delete_output.stdout)
 
-        # Checking for stale volumes
+        # Verify the specific subvolume was deleted
         output = exec_cmd(cmd=f"{odf_cli_path} subvolume ls --stale")
-        stale_volumes = self.parse_subvolume_ls_output(output)
-        assert len(stale_volumes) == 0  # No stale volumes available
+        stale_after = self.parse_subvolume_ls_output(output)
+        log.info("Stale subvolumes after delete: %s", stale_after)
+        stale_svs = {sv[1] for sv in stale_after}
+        assert (
+            new_pvc[1] not in stale_svs
+        ), f"Subvolume {new_pvc[1]} still stale after delete"
 
         # Delete ocs-storagecluster-ceph-nfs-retain storageclass
         self.sc_obj.delete(resource_name=self.retain_nfs_sc_name)


### PR DESCRIPTION
# Summary

**Root cause of IBM Cloud failure:** 

`IBM Cloud VPC LoadBalancer security groups block inbound traffic by default. When the NFS LB service (rook-ceph-nfs-my-nfs-load-balancer) is created, port 2049 is not allowed through the security group, so mount requests from the external NFS client VM never reach the NFS server.`

**Fix:**

 Open inbound TCP port 2049 on IBM Cloud VPC LoadBalancer security group for the NFS LB service. IBM Cloud VPC LB security groups block inbound traffic by default — same issue that required configure_ingress_load_balancer_security_group() for ports 80/443 in #[15012(https://github.com/red-hat-storage/ocs-ci/pull/15012)]. The rule is added automatically in create_nfs_load_balancer_service() and cleaned up in delete_nfs_load_balancer_service().

Have updated, Stale subvolume assertion logic — the old assertion assert len(stale_volumes) == 0 fails if there are pre-existing stale subvolumes from other tests or previous runs. The test should only verify that its own subvolume (new_pvc[1]) was successfully deleted, not that the entire cluster has zero stale subvolumes. 

Changed to:
Log stale volumes before and after delete for debugging
Log the delete command output so failures are visible
Assert that the specific subvolume created by this test is no longer in the stale list