### PR TITLE
Skip test_rgw_keda_ha in external mode

### DIFF
--- a/tests/functional/object/rgw/test_keda_ha.py
+++ b/tests/functional/object/rgw/test_keda_ha.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     rgw,
     skipif_disconnected_cluster,
+    skipif_external_mode,
     tier1,
 )
 from ocs_ci.ocs import constants
@@ -31,6 +32,7 @@ RGW_SCALE_TARGET_REF = {
 @rgw
 @red_squad
 @skipif_disconnected_cluster
+@skipif_external_mode  # Setting up KEDA on the external cluster is out of scope
 class TestKedaHA:
     """
     Test RGW's integration with the KEDA autoscaler


### PR DESCRIPTION
  ## Summary
  - The `enable_rgw_hpa` fixture annotates `ocs-storagecluster`, which does not exist in external mode (`ocs-external-storagecluster`)
  - Beyond the name mismatch, the test requires installing KEDA via Helm on the cluster where RGW runs. In external mode that cluster is not managed by OCS-CI, so
  setting up KEDA and its prerequisites there is out of scope
  - Added `@skipif_external_mode` to `TestKedaHA`, consistent with other RGW tests in the same directory
