### PR TITLE
Fix get_used_percentage for non-LSO deployments in test_mon_data_avail_warn

### DIFF
--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -93,6 +93,7 @@ class TestMonDataAvailWarn(E2ETest):
             path = f"/var/lib/ceph/mon/ceph-{self.mon_suffix}"
             cmd = f"df -Th {path}"
             mount_details = self.mon_pod.exec_sh_cmd_on_pod(command=cmd, sh="sh")
+            mount_details = mount_details.strip().splitlines()[-1]
         used_percent = mount_details.split()[5].replace("%", "")
         return int(used_percent)
 


### PR DESCRIPTION


PR #14707 split get_used_percentage() into LSO/non-LSO branches and applied .strip().splitlines()[-1] to the LSO path to extract the data line from df -Th output. The non-LSO else branch was missing this step, causing mount_details.split()[5] to hit 'Use%' from the df header row instead of the actual percentage, raising ValueError: invalid literal for int() with base 10: 'Use'.

Apply the same .strip().splitlines()[-1] to the non-LSO branch.