### PR TITLE
Add fixture to download virtctl before RDR tests

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -110,7 +110,8 @@ def rdr_health_check():
 
 @pytest.fixture(scope="session", autouse=True)
 def get_virtctl():
-    get_virtctl_tool()
+    with config.RunWithProviderConfigContextIfAvailable():
+        get_virtctl_tool()
 
 
 @pytest.fixture()

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import time
 
 from ocs_ci.framework import config
+from ocs_ci.helpers.virtctl import get_virtctl_tool
 from ocs_ci.ocs import constants
 from ocs_ci.deployment import acm
 from ocs_ci.ocs.resources.storage_cluster import get_all_storageclass
@@ -57,6 +58,7 @@ def check_subctl_cli():
         submariner.download_binary()
 
 
+<<<<<<< HEAD
 @pytest.fixture(autouse=True, scope="function")
 def rdr_health_check():
     """
@@ -104,6 +106,11 @@ def rdr_health_check():
                 pytest.skip(f"Mirroring health is not OK on {cluster_name}")
     finally:
         config.switch_ctx(restore_index)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def get_virtctl():
+    get_virtctl_tool()
 
 
 @pytest.fixture()

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -58,7 +58,6 @@ def check_subctl_cli():
         submariner.download_binary()
 
 
-<<<<<<< HEAD
 @pytest.fixture(autouse=True, scope="function")
 def rdr_health_check():
     """


### PR DESCRIPTION
Fixes #15143 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved regional disaster-recovery functional test infrastructure by adding an automatic, session-scoped setup that ensures the required command-line tool is prepared before tests run. This reduces manual test setup, lowers flaky failures, and makes test runs more reliable and repeatable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->