### PR TITLE
Update finding radosnamespace and cephblockpoolradosnamespace

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2931,
+        "line_number": 2896,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -65,6 +65,7 @@ from ocs_ci.helpers.helpers import (
     find_cephblockpoolradosnamespace,
     find_cephfilesystemsubvolumegroup,
     create_unique_resource_name,
+    find_radosnamespace,
 )
 from ocs_ci.helpers import helpers
 
@@ -420,8 +421,20 @@ def check_mirroring_status_ok(
         if not cephbpradosns:
             raise NotFoundError("Couldn't identify the cephblockpoolradosnamespace")
 
-        if "ocs-storagecluster-cephblockpool" not in cephbpradosns:
-            cephbpradosns = "ocs-storagecluster-cephblockpool-" + cephbpradosns
+        if (
+            "ocs-storagecluster-cephblockpool" not in cephbpradosns
+            or "replicated-metadata-pool" not in cephbpradosns
+        ):
+            cephblockpool_rns_names = [
+                cephbprns_data["metadata"]["name"]
+                for cephbprns_data in ocp.OCP(
+                    kind=constants.CEPHBLOCKPOOLRADOSNS,
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                ).get()["items"]
+            ]
+            cephbpradosns = list(
+                filter(lambda x: f"-{cephbpradosns}" in x, cephblockpool_rns_names)
+            )[0]
 
         logger.info(f"Got cephblockpoolradosnamespace {cephbpradosns}")
 
@@ -434,7 +447,17 @@ def check_mirroring_status_ok(
         )
     else:
         if ocs_version >= version.VERSION_4_19:
-            cephbpradosns = "ocs-storagecluster-cephblockpool-builtin-implicit"
+            # The name of builtin-implicit cephblockpoolradosnamespace is different in EC cluster and non EC cluster
+            cephblockpool_rns_names = [
+                cephbprns_data["metadata"]["name"]
+                for cephbprns_data in ocp.OCP(
+                    kind=constants.CEPHBLOCKPOOLRADOSNS,
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                ).get()["items"]
+            ]
+            cephbpradosns = list(
+                filter(lambda x: "-builtin-implicit" in x, cephblockpool_rns_names)
+            )[0]
             cbp_obj = ocp.OCP(
                 kind=constants.CEPHBLOCKPOOLRADOSNS,
                 namespace=config.ENV_DATA["cluster_namespace"],
@@ -1378,7 +1401,7 @@ def verify_backend_volume_deletion(
         cephbpradosns = (
             cephblockpoolradosns
             or config.ENV_DATA.get("radosnamespace_name", None)
-            or find_cephblockpoolradosnamespace(storageclient_uid=storageclient_uid)
+            or find_radosnamespace(storageclient_uid=storageclient_uid)
         )
 
         if not cephbpradosns:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -423,7 +423,7 @@ def check_mirroring_status_ok(
 
         if (
             "ocs-storagecluster-cephblockpool" not in cephbpradosns
-            or "replicated-metadata-pool" not in cephbpradosns
+            and "replicated-metadata-pool" not in cephbpradosns
         ):
             cephblockpool_rns_names = [
                 cephbprns_data["metadata"]["name"]

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6968,12 +6968,14 @@ def find_cephblockpoolradosnamespace(storageclient_uid=None):
             #  radosnamespace
             break
 
-    cephblockpool_rns_names = [
-        cephbprns_data["metadata"]["name"]
-        for cephbprns_data in ocp.OCP(kind=constants.CEPHBLOCKPOOLRADOSNS).get()[
-            "items"
+    with config.RunWithProviderConfigContextIfAvailable:
+        cephblockpool_rns_names = [
+            cephbprns_data["metadata"]["name"]
+            for cephbprns_data in ocp.OCP(
+                kind=constants.CEPHBLOCKPOOLRADOSNS,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            ).get()["items"]
         ]
-    ]
     if storageconsumer == constants.INTERNAL_STORAGE_CONSUMER_NAME:
         cephbpradosns = list(
             filter(lambda x: "-builtin-implicit" in x, cephblockpool_rns_names)

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6962,12 +6962,29 @@ def find_cephblockpoolradosnamespace(storageclient_uid=None):
     for storageconsumer_dict in storageconsumer_obj.get()["items"]:
         if storageconsumer_dict["status"]["client"]["clientId"] == storageclient_uid:
             storageconsumer = storageconsumer_dict["metadata"]["name"]
+            # TODO: Use configmap with name storageconsumer_dict["status"]["resourceNameMappingConfigMap"]["name"] to
+            #  identify the radosnamespace and then use it to find the cephblockpoolradosnamespace CR. This is not
+            #  applicable for internal storageconsumer because the configmap will not have the exact name of
+            #  radosnamespace
             break
+
+    cephblockpool_rns_names = [
+        cephbprns_data["metadata"]["name"]
+        for cephbprns_data in ocp.OCP(kind=constants.CEPHBLOCKPOOLRADOSNS).get()[
+            "items"
+        ]
+    ]
+    if storageconsumer == constants.INTERNAL_STORAGE_CONSUMER_NAME:
+        cephbpradosns = list(
+            filter(lambda x: "-builtin-implicit" in x, cephblockpool_rns_names)
+        )[0]
+    else:
+        cephbpradosns = list(
+            filter(lambda x: f"-{storageconsumer}" in x, cephblockpool_rns_names)
+        )[0]
     logger.info(
         f"StorageClient is {storageclient_name} with uid {storageclient_uid}. StorageConsumer is {storageconsumer}"
     )
-
-    cephbpradosns = storageconsumer
 
     # from ODF 4.19 and onwards, StorageRequest does not exist on new clusters, upgraded clusters have it,
     # but StorageRequest is not reconciled. StorageConsumer exists in storage hub cluster and in consumer clusters
@@ -7054,6 +7071,31 @@ def find_cephfilesystemsubvolumegroup(storageclient_uid=None):
             "cephfs-subvolumegroup"
         )
     return cephbfssubvolumegroup
+
+
+def find_radosnamespace(storageclient_uid=None):
+    """
+    Find the radosnamespace related to a storageclient if present
+
+    Args:
+        storageclient_id(string): The uid of the storageclient for which the lradosnamespace has to be identified
+
+    Returns:
+        str: The name of the radosnamespace, if present
+
+    """
+    cephblockpoolradosnamespace = find_cephblockpoolradosnamespace(
+        storageclient_uid=storageclient_uid
+    )
+    if "-builtin-implicit" not in cephblockpoolradosnamespace:
+        with config.RunWithProviderConfigContextIfAvailable():
+            cbp_rns = ocp.OCP(
+                kind=constants.CEPHBLOCKPOOLRADOSNS,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=cephblockpoolradosnamespace,
+            )
+            radosnamespace = cbp_rns.get()["spec"]["name"]
+        return radosnamespace
 
 
 def remove_port_from_url(url):

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6968,7 +6968,7 @@ def find_cephblockpoolradosnamespace(storageclient_uid=None):
             #  radosnamespace
             break
 
-    with config.RunWithProviderConfigContextIfAvailable:
+    with config.RunWithProviderConfigContextIfAvailable():
         cephblockpool_rns_names = [
             cephbprns_data["metadata"]["name"]
             for cephbprns_data in ocp.OCP(


### PR DESCRIPTION
Update the functions that find cephblockpoolradosnamespace CR and radosnamespace based on the new naming format in erasure coded cluster.
This change fixes #15126 as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage namespace resolution in distributed storage setups
  * Enhanced disaster recovery verification for mirroring status checks
  * Strengthened storage consumer configuration handling in provider/consumer scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->