### PR TITLE
Assuming ceph version is >= 19 if not determined for ODF 4.18 and above

### DIFF
--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -1204,11 +1204,12 @@ def _external_ceph_semantic_version_or_none():
 
 def external_rgw_ca_should_use_cephadm_fetch():
     """
-    True when external Ceph reports version >= 19.0 (cephadm certmgr path).
+    True when external Ceph reports version >= 19.0 (cephadm certmgr path), or if
+    version is not determined (None) - assuming that from ODF 4.18 we are using Ceph >= 19.
     """
     v = _external_ceph_semantic_version_or_none()
     if v is None:
-        return False
+        return True
     return v >= version.get_semantic_version("19.0", only_major_minor=True)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of external Ceph cluster deployments when cluster version detection fails. The system now defaults to using the cephadm-based certificate retrieval method for unknown versions, ensuring proper compatibility with Ceph >= 19. This provides more reliable certificate fetching in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->