### PR TITLE
Fix environment_check and storageclass_factory teardown (StorageClient, non-ODF PV/PVC)

### DIFF
--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -136,6 +136,14 @@ def assign_get_values(
             if name.startswith(defaults.SRE_BUILD_TEST_NAMESPACE):
                 log.debug(f"ignoring item: {constants.NAMESPACE} with name {name}")
                 continue
+        if item.get("kind") == constants.STORAGECLASS:
+            owner_refs = item.get("metadata", {}).get("ownerReferences", [])
+            if any(ref.get("kind") == "StorageClient" for ref in owner_refs):
+                name = item.get("metadata", {}).get("name", "")
+                log.debug(
+                    f"ignoring controller-owned StorageClass: {name}"
+                )
+                continue
         items_filtered.append(item)
 
     ignored = len(items) - len(items_filtered)

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -16,12 +16,9 @@ log = logging.getLogger(__name__)
 def _pv_or_pvc_storage_provisioner(item):
     kind = item.get("kind")
     if kind == constants.PV:
-        return (
-            item.get("spec", {}).get("csi", {}).get("driver")
-            or item.get("metadata", {})
-            .get("annotations", {})
-            .get("pv.kubernetes.io/provisioned-by")
-        )
+        return item.get("spec", {}).get("csi", {}).get("driver") or item.get(
+            "metadata", {}
+        ).get("annotations", {}).get("pv.kubernetes.io/provisioned-by")
     if kind == constants.PVC:
         annotations = item.get("metadata", {}).get("annotations", {})
         return annotations.get(

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -13,6 +13,24 @@ from ocs_ci.ocs import ocp, defaults, constants, exceptions
 log = logging.getLogger(__name__)
 
 
+def _pv_or_pvc_storage_provisioner(item):
+    kind = item.get("kind")
+    if kind == constants.PV:
+        return (
+            item.get("spec", {}).get("csi", {}).get("driver")
+            or item.get("metadata", {})
+            .get("annotations", {})
+            .get("pv.kubernetes.io/provisioned-by")
+        )
+    if kind == constants.PVC:
+        return (
+            item.get("metadata", {})
+            .get("annotations", {})
+            .get("volume.kubernetes.io/storage-provisioner")
+        )
+    return None
+
+
 def compare_dicts(before, after):
     """
     Comparing 2 dicts and providing diff list of [added items, removed items]
@@ -100,6 +118,16 @@ def assign_get_values(
         ):
             log.debug("ignoring item in %s namespace: %s", ns, item)
             continue
+        if item.get("kind") in (constants.PV, constants.PVC):
+            provisioner = _pv_or_pvc_storage_provisioner(item)
+            if provisioner and provisioner not in constants.OCS_PROVISIONERS:
+                log.debug(
+                    "ignoring non-ODF %s with provisioner %s: %s",
+                    item.get("kind"),
+                    provisioner,
+                    item.get("metadata", {}).get("name"),
+                )
+                continue
         if item.get("kind") == constants.POD:
             name = item.get("metadata", {}).get("name", "")
             if name.endswith("-debug") or "-debug-" in name:
@@ -140,9 +168,7 @@ def assign_get_values(
             owner_refs = item.get("metadata", {}).get("ownerReferences", [])
             if any(ref.get("kind") == "StorageClient" for ref in owner_refs):
                 name = item.get("metadata", {}).get("name", "")
-                log.debug(
-                    f"ignoring controller-owned StorageClass: {name}"
-                )
+                log.debug("ignoring controller-owned StorageClass: %s", name)
                 continue
         items_filtered.append(item)
 

--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -23,11 +23,10 @@ def _pv_or_pvc_storage_provisioner(item):
             .get("pv.kubernetes.io/provisioned-by")
         )
     if kind == constants.PVC:
-        return (
-            item.get("metadata", {})
-            .get("annotations", {})
-            .get("volume.kubernetes.io/storage-provisioner")
-        )
+        annotations = item.get("metadata", {}).get("annotations", {})
+        return annotations.get(
+            "volume.kubernetes.io/storage-provisioner"
+        ) or annotations.get("volume.beta.kubernetes.io/storage-provisioner")
     return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1283,10 +1283,17 @@ def storageclass_factory_fixture(
         return sc_obj
 
     def finalizer():
+        """Run teardown for every factory-created StorageClass instance."""
         for instance in instances:
             _delete_storageclass_with_retry(instance)
 
     def _delete_storageclass_with_retry(instance, max_attempts=3, wait_timeout=20):
+        """
+        Delete a StorageClass while tolerating controller-driven recreation.
+
+        Clears StorageClient ownerReferences when present, deletes the object,
+        and retries when a controller recreates it before the delete completes.
+        """
         for attempt in range(max_attempts):
             try:
                 sc_data = instance.ocp.get(resource_name=instance.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1302,7 +1302,14 @@ def storageclass_factory_fixture(
                     return
                 raise
 
-            owner_refs = sc_data.get("metadata", {}).get("ownerReferences", [])
+            owner_refs = sc_data.get("metadata", {}).get("ownerReferences") or []
+            if not isinstance(owner_refs, list):
+                log.warning(
+                    "Unexpected ownerReferences type for StorageClass %s: %s",
+                    instance.name,
+                    type(owner_refs).__name__,
+                )
+                owner_refs = []
             filtered = [r for r in owner_refs if r.get("kind") != "StorageClient"]
             if len(filtered) < len(owner_refs):
                 patch_value = "null" if not filtered else json.dumps(filtered)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1302,17 +1302,20 @@ def storageclass_factory_fixture(
                     return
                 raise
 
-            if sc_data.get("metadata", {}).get("ownerReferences"):
+            owner_refs = sc_data.get("metadata", {}).get("ownerReferences", [])
+            filtered = [r for r in owner_refs if r.get("kind") != "StorageClient"]
+            if len(filtered) < len(owner_refs):
+                patch_value = "null" if not filtered else json.dumps(filtered)
                 try:
                     instance.ocp.patch(
                         resource_name=instance.name,
-                        params='{"metadata": {"ownerReferences": null}}',
+                        params=f'{{"metadata": {{"ownerReferences": {patch_value}}}}}',
                         format_type="merge",
                     )
                 except CommandFailed:
                     log.warning(
-                        f"Failed to clear ownerReferences from "
-                        f"StorageClass {instance.name}"
+                        f"Failed to clear StorageClient ownerReferences "
+                        f"from StorageClass {instance.name}"
                     )
 
             instance.ocp.delete(resource_name=instance.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1320,9 +1320,7 @@ def storageclass_factory_fixture(
 
             instance.ocp.delete(resource_name=instance.name)
             try:
-                instance.ocp.wait_for_delete(
-                    instance.name, timeout=wait_timeout
-                )
+                instance.ocp.wait_for_delete(instance.name, timeout=wait_timeout)
                 return
             except TimeoutError:
                 if attempt < max_attempts - 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1283,12 +1283,49 @@ def storageclass_factory_fixture(
         return sc_obj
 
     def finalizer():
-        """
-        Delete the storageclass
-        """
         for instance in instances:
-            instance.delete()
-            instance.ocp.wait_for_delete(instance.name, timeout=120)
+            _delete_storageclass_with_retry(instance)
+
+    def _delete_storageclass_with_retry(instance, max_attempts=3, wait_timeout=20):
+        for attempt in range(max_attempts):
+            try:
+                sc_data = instance.ocp.get(resource_name=instance.name)
+            except CommandFailed as ex:
+                if "NotFound" in str(ex):
+                    return
+                raise
+
+            if sc_data.get("metadata", {}).get("ownerReferences"):
+                try:
+                    instance.ocp.patch(
+                        resource_name=instance.name,
+                        params='{"metadata": {"ownerReferences": null}}',
+                        format_type="merge",
+                    )
+                except CommandFailed:
+                    log.warning(
+                        f"Failed to clear ownerReferences from "
+                        f"StorageClass {instance.name}"
+                    )
+
+            instance.ocp.delete(resource_name=instance.name)
+            try:
+                instance.ocp.wait_for_delete(
+                    instance.name, timeout=wait_timeout
+                )
+                return
+            except TimeoutError:
+                if attempt < max_attempts - 1:
+                    log.warning(
+                        f"StorageClass {instance.name} was recreated by "
+                        f"a controller after deletion "
+                        f"(attempt {attempt + 1}/{max_attempts}), retrying"
+                    )
+
+        log.warning(
+            f"StorageClass {instance.name} could not be permanently "
+            f"deleted after {max_attempts} attempts"
+        )
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
Supersedes [#15156](https://github.com/red-hat-storage/ocs-ci/pull/15156) and [#14561](https://github.com/red-hat-storage/ocs-ci/pull/14561) (branch renamed).

## Summary

**[OCSQE-4285](https://redhat.atlassian.net/browse/OCSQE-4285):** The StorageClient controller in OCS 4.20+ adopts test-created StorageClasses via `ownerReferences` and can recreate them immediately after deletion, causing `TimeoutError` in `storageclass_factory` and `ResourceLeftoversException` when recreated SCs appear in the environment diff.

**[OCSQE-4715](https://redhat.atlassian.net/browse/OCSQE-4715):** On OPP / vSphere interop, teardown can fail when the environment checker treats platform CSI PVs/PVCs (for example Quay in `local-quay` using `csi.vsphere.vmware.com`) as test leftovers. Tests pass; `ResourceLeftoversException` still fires.

## Changes

| File | Change |
|------|--------|
| `tests/conftest.py` | `storageclass_factory` finalizer: clear `ownerReferences`, retry delete; docstrings on helpers |
| `ocs_ci/utility/environment_check.py` | Skip StorageClasses owned by `StorageClient` |
| `ocs_ci/utility/environment_check.py` | Skip PV/PVC when provisioner is not in `constants.OCS_PROVISIONERS` |

## Validation

The OPP vSphere periodic job (`periodic-ci-stolostron-policy-collection-main-ocp4.22-interop-opp-vsphere`) passed with this fix applied. Both the non-ODF PV/PVC filtering and the StorageClient ownerReference handling worked as expected; no false `ResourceLeftoversException` failures in teardown.

## Refs

- [OCSQE-4285](https://issues.redhat.com/browse/OCSQE-4285)
- [OCSQE-4715](https://issues.redhat.com/browse/OCSQE-4715)

Rehearsal context for the StorageClient path: [openshift/release#75559](https://github.com/openshift/release/pull/75559), [openshift/release#75602](https://github.com/openshift/release/pull/75602) (see superseded PR descriptions).