### PR TITLE
Fix/sc deletion deregister storageconsumer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2896,
+        "line_number": 2897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 832,
+        "line_number": 833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 841,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2034,
+        "line_number": 2035,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2141,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2143,
+        "line_number": 2144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2144,
+        "line_number": 2145,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2149,
+        "line_number": 2150,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2164,
+        "line_number": 2165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2165,
+        "line_number": 2166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2173,
+        "line_number": 2174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2174,
+        "line_number": 2175,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
+        "line_number": 2176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2177,
+        "line_number": 2178,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2773,
+        "line_number": 2774,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2930,
+        "line_number": 2931,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2931,
+        "line_number": 2932,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3652,
+        "line_number": 3653,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3653,
+        "line_number": 3654,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -1393,7 +1393,7 @@ def get_all_storageclass_names():
 
 
 def delete_storageclasses(sc_objs):
-    """ "
+    """
     Function for Deleting storageclasses
 
     Args:
@@ -1402,10 +1402,11 @@ def delete_storageclasses(sc_objs):
     Returns:
         bool: True if deletion is successful
     """
+    from ocs_ci.ocs.resources.storage_cluster import delete_storageclass_and_deregister
 
     for sc in sc_objs:
         logger.info("Deleting StorageClass with name %s", sc.name)
-        sc.delete()
+        delete_storageclass_and_deregister(sc_name=sc.name, sc_ocp=sc.ocp)
     return True
 
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -609,6 +609,10 @@ DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD_NAMESPACE_PREFIX = (
     f"{DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD}-rados-namespace"
 )
 
+# Label on RBD/CephFS StorageClasses (all deployment types; provider/consumer model).
+OCS_EXTERNAL_STORAGECLASS_LABEL = "storageclass.ocs.openshift.io/is-external"
+OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE = "true"
+
 # Default StorageClass for Provider-mode
 DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{STORAGE_CLIENT_NAME}-cephfs"
 DEFAULT_STORAGECLASS_CLIENT_RBD = f"{STORAGE_CLIENT_NAME}-ceph-rbd"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -155,6 +155,157 @@ def verify_osd_tree_schema(ct_pod, deviceset_pvcs):
     )
 
 
+def remove_storageclass_from_storageconsumer(
+    sc_name, consumer_name=constants.INTERNAL_STORAGE_CONSUMER_NAME
+):
+    """
+    Remove a StorageClass entry from StorageConsumer.spec.storageClasses[].
+
+    This prevents the ocs-client-operator from recreating the SC on its
+    next reconcile cycle via the gRPC GetDesiredClientState() call.
+    Must be called BEFORE deleting the StorageClass.
+
+    Args:
+        sc_name (str): Name of the StorageClass to deregister.
+        consumer_name (str): Name of the StorageConsumer CR; default
+            ``ocs_ci.ocs.constants.INTERNAL_STORAGE_CONSUMER_NAME`` (``"internal"``).
+    """
+    consumer_ocp = OCP(
+        kind="StorageConsumer",
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    if not consumer_ocp.is_exist(resource_name=consumer_name):
+        log.debug(
+            f"StorageConsumer {consumer_name} not found; "
+            f"skipping deregistration of {sc_name}"
+        )
+        return
+
+    consumer = consumer_ocp.get(resource_name=consumer_name)
+    current_classes = consumer.get("spec", {}).get("storageClasses", [])
+    updated_classes = [sc for sc in current_classes if sc.get("name") != sc_name]
+
+    if len(updated_classes) == len(current_classes):
+        log.debug(
+            f"StorageClass {sc_name} not found in "
+            f"StorageConsumer {consumer_name}.spec.storageClasses; nothing to remove"
+        )
+        return
+
+    patch_body = json.dumps({"spec": {"storageClasses": updated_classes}})
+    consumer_ocp.patch(
+        resource_name=consumer_name,
+        params=patch_body,
+        format_type="merge",
+    )
+    log.info(
+        f"Removed {sc_name} from StorageConsumer "
+        f"{consumer_name}.spec.storageClasses"
+    )
+
+
+def _storageclass_ocs_external_label_patch():
+    """Merge-patch body for ``storageclass.ocs.openshift.io/is-external``."""
+    return {
+        "metadata": {
+            "labels": {
+                constants.OCS_EXTERNAL_STORAGECLASS_LABEL: (
+                    constants.OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE
+                ),
+            }
+        }
+    }
+
+
+def patch_storageclass_ocs_external_label(resource_name):
+    """
+    Merge-patch ``storageclass.ocs.openshift.io/is-external: "true"`` on a
+    StorageClass if it exists.
+
+    Used before deleting StorageClasses so the provider-side gRPC server
+    excludes the SC from the GetDesiredClientState() response. Applies to
+    all deployment types since ODF 4.22 uses the provider/consumer model
+    even for internal deployments.
+    """
+    sc_ocp = OCP(kind=constants.STORAGECLASS)
+    if not sc_ocp.is_exist(resource_name=resource_name):
+        log.warning(
+            f"StorageClass {resource_name} not found; skipping pre-delete external OCS label patch"
+        )
+        return
+    log.info(
+        f"Patching StorageClass {resource_name} before delete: "
+        f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL}="
+        f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE}"
+    )
+    sc_ocp.patch(
+        resource_name=resource_name,
+        params=json.dumps(_storageclass_ocs_external_label_patch()),
+        format_type="merge",
+    )
+
+
+def _delete_storageclass_ignore_not_found(sc_ocp, sc_name):
+    """
+    Cluster-scoped delete; succeeds if the StorageClass is already gone (TOCTOU-safe).
+    """
+    sc_ocp.exec_oc_cmd(
+        f"delete {constants.STORAGECLASS} {sc_name} --ignore-not-found",
+        timeout=600,
+    )
+
+
+def delete_storageclass_and_deregister(sc_name, sc_ocp=None, timeout=180):
+    """
+    Fully clean up a test-created StorageClass:
+        1. Deregister from StorageConsumer (prevents reconciler recreation)
+        2. Label with is-external (prevents gRPC serving)
+        3. Delete the SC
+        4. Verify it stays deleted (not recreated by operator)
+
+    Args:
+        sc_name (str): Name of the StorageClass.
+        sc_ocp (:obj:`~ocs_ci.ocs.ocp.OCP`, optional): OCP instance for StorageClass. Created if None.
+        timeout (int): Seconds to wait for deletion confirmation.
+
+    Raises:
+        TimeoutExpiredError: If the SC keeps getting recreated.
+    """
+    if sc_ocp is None:
+        sc_ocp = OCP(kind=constants.STORAGECLASS)
+
+    remove_storageclass_from_storageconsumer(sc_name)
+    patch_storageclass_ocs_external_label(sc_name)
+
+    if sc_ocp.is_exist(resource_name=sc_name):
+        log.info(f"Deleting StorageClass {sc_name}")
+        _delete_storageclass_ignore_not_found(sc_ocp, sc_name)
+
+    def _wait_storageclass_stays_deleted():
+        if not sc_ocp.is_exist(resource_name=sc_name):
+            return True
+        log.warning(
+            f"StorageClass {sc_name} was recreated; re-deregistering and deleting"
+        )
+        remove_storageclass_from_storageconsumer(sc_name)
+        patch_storageclass_ocs_external_label(sc_name)
+        log.info(f"Deleting StorageClass {sc_name}")
+        _delete_storageclass_ignore_not_found(sc_ocp, sc_name)
+        return False
+
+    sampler = TimeoutSampler(
+        timeout=timeout,
+        sleep=15,
+        func=_wait_storageclass_stays_deleted,
+    )
+    sampler.timeout_exc_args = [
+        timeout,
+        f"StorageClass {sc_name} keeps getting recreated after {timeout}s",
+    ]
+    sampler.wait_for_func_value(True)
+    log.info(f"StorageClass {sc_name} confirmed deleted")
+
+
 def ocs_install_verification(
     timeout=600,
     skip_osd_distribution_check=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1284,11 +1284,28 @@ def storageclass_factory_fixture(
 
     def finalizer():
         """
-        Delete the storageclass
+        Delete the storageclass by deregistering from StorageConsumer first
         """
+        from ocs_ci.ocs.resources.storage_cluster import (
+            delete_storageclass_and_deregister,
+        )
+
+        teardown_errors = []
         for instance in instances:
-            instance.delete()
-            instance.ocp.wait_for_delete(instance.name, timeout=120)
+            try:
+                delete_storageclass_and_deregister(
+                    sc_name=instance.name,
+                    sc_ocp=instance.ocp,
+                )
+            except Exception as e:
+                log.error(f"Failed to delete storageclass {instance.name}: {e}")
+                teardown_errors.append((instance.name, e))
+        if teardown_errors:
+            parts = [f"{name}: {exc}" for name, exc in teardown_errors]
+            raise RuntimeError(
+                "StorageClass teardown failed for "
+                f"{len(teardown_errors)} instance(s): " + "; ".join(parts)
+            ) from teardown_errors[-1][1]
 
     request.addfinalizer(finalizer)
     return factory


### PR DESCRIPTION
Storageclass Deletetion issue fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a label to mark StorageClasses as external so they are excluded from provider responses during cleanup.

* **Bug Fixes**
  * Improved StorageClass cleanup to prevent operator-driven recreation during teardown and avoid endless retries.

* **Chores**
  * Enhanced deletion/deregistration utilities with polling/retry for reliable removal.
  * Updated test fixture teardown to aggregate and report per-instance failures.
  * Updated secrets baseline line positions for previously detected hashed secrets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->