### PR TITLE
Adding a fix to test_default_backingstore_override_post_upgrade

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9421,6 +9421,17 @@ def override_default_backingstore_session(
     )
 
 
+@pytest.fixture(scope="session")
+def override_default_backingstore_session_no_teardown(
+    mcg_obj_session,
+    backingstore_factory_session,
+    allow_default_backingstore_override,
+):
+    return override_default_backingstore_fixture(
+        None, mcg_obj_session, backingstore_factory_session
+    )
+
+
 @pytest.fixture(scope="function")
 def override_default_backingstore(
     request, mcg_obj_session, backingstore_factory, allow_default_backingstore_override
@@ -9500,7 +9511,8 @@ def override_default_backingstore_fixture(
             constants.DEFAULT_NOOBAA_BACKINGSTORE
         )
 
-    request.addfinalizer(finalizer)
+    if request is not None:
+        request.addfinalizer(finalizer)
     return _override_nb_default_backingstore_implementation
 
 

--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -83,7 +83,7 @@ class TestDefaultBackingstoreOverride(MCGTest):
         self,
         request,
         mcg_obj_session,
-        override_default_backingstore_session,
+        override_default_backingstore_session_no_teardown,
     ):
         """
         1. Override the current default using the new backingstore of the same type
@@ -91,7 +91,7 @@ class TestDefaultBackingstoreOverride(MCGTest):
 
         """
         # 1. Override the current default using the new backingstore of the same type
-        alt_default_bs_name = override_default_backingstore_session()
+        alt_default_bs_name = override_default_backingstore_session_no_teardown()
         # Cache the new default backingstore name to pass to the post-upgrade test
         request.config.cache.set("pre_upgrade_alt_bs_name", alt_default_bs_name)
 


### PR DESCRIPTION
This is a fix to https://github.com/red-hat-storage/ocs-ci/issues/14694. 

  Problem

  The test_default_backingstore_override_post_upgrade test was failing with ~18% pass rate. The post-upgrade test asserts that the overridden default backingstore is preserved after an upgrade,
   but it consistently found the original default instead.

  Root cause: The pre-upgrade test used the override_default_backingstore_session fixture, whose finalizer reverts the default backingstore at the end of the pre-upgrade pytest session — before
   the upgrade even runs. By the time the post-upgrade test executes in a new session, the override has already been undone.

  Fix

  - Created a new fixture override_default_backingstore_session_no_teardown that does not register a finalizer, allowing the override to persist across sessions through the upgrade.
  - Made the finalizer registration in override_default_backingstore_fixture conditional — it only registers when a request object is provided (i.e., when teardown is desired).
  - Updated the pre-upgrade test to use the new no-teardown fixture.

  Files changed

  - tests/conftest.py — added override_default_backingstore_session_no_teardown fixture; made finalizer conditional on request is not None
  - tests/functional/object/mcg/test_default_backingstore_override.py — switched pre-upgrade test to use override_default_backingstore_session_no_teardown

  Testing

Ran the full test file locally against an IBM Cloud cluster. Both upgrade-related tests (pre_upgrade and post_upgrade) passed.

==================================================================================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture configuration for backingstore override scenarios to better support testing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->