### PR TITLE
[z-stream 4.16.16] Enable 31 tests for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -684,3 +684,5 @@ skipif_kms_deployment = pytest.mark.skipif(
     config.DEPLOYMENT.get("kms_deployment") is True,
     reason="This test is not supported for KMS deployment.",
 )
+# z-stream marker
+zstream_4_16_16 = pytest.mark.zstream_4_16_16

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_16_16: z-stream 4.16.16 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_app_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_app_failover_and_relocate.py
@@ -5,7 +5,7 @@ import pytest
 
 from ocs_ci.deployment.cnv import CNVInstaller
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import rdr, tier1, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, tier1, turquoise_squad, zstream_4_16_16
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.ocs import constants
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
+@zstream_4_16_16
 class TestCnvApplicationRDR:
     """
     Includes tests related to CNV workloads on RDR environment.

--- a/tests/functional/pod_and_daemons/test_mgr_pods.py
+++ b/tests/functional/pod_and_daemons/test_mgr_pods.py
@@ -11,7 +11,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import exceptions
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @post_upgrade
 @post_ocs_upgrade
+@zstream_4_16_16
 class TestMgrPods(BaseTest):
     """
     This test class contains tests that would check mgr pods from odf-version 4.15

--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -5,7 +5,7 @@ from ocs_ci.utility import metadata_utils
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -36,6 +36,7 @@ ERRMSG = "Error in command"
 @skipif_proxy_cluster
 @green_squad
 @ignore_leftovers
+@zstream_4_16_16
 class TestMetadataUnavailable(ManageTest):
     """
     Test metadata feature is unavailable for ODF < 4.12
@@ -143,6 +144,7 @@ class TestMetadataUnavailable(ManageTest):
 @skipif_proxy_cluster
 @green_squad
 @ignore_leftovers
+@zstream_4_16_16
 class TestDefaultMetadataDisabled(ManageTest):
     """
     Test metadata feature disabled by default for ODF 4.12
@@ -229,6 +231,7 @@ class TestDefaultMetadataDisabled(ManageTest):
 @skipif_proxy_cluster
 @green_squad
 @ignore_leftovers
+@zstream_4_16_16
 class TestMetadata(ManageTest):
     """
     This test class consists of tests to verify cephfs metadata for

--- a/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
+++ b/tests/functional/pv/pv_encryption/test_encrypted_pvc_no_expansion_option.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -56,6 +56,7 @@ else:
 @skipif_hci_provider_and_client
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
+@zstream_4_16_16
 class TestEncryptedPVCNOExpansionOption(ManageTest):
     """
     Test Encrypted Volume Expansion

--- a/tests/functional/pv/pv_services/test_ceph_daemon_kill_during_resource_creation.py
+++ b/tests/functional/pv/pv_services/test_ceph_daemon_kill_during_resource_creation.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, node
@@ -109,6 +109,7 @@ log = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_16_16
 class TestDaemonKillDuringResourceCreation(ManageTest):
     """
     Base class for ceph daemon kill related disruption tests

--- a/tests/functional/pv/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
+++ b/tests/functional/pv/pv_services/test_ceph_daemon_kill_during_resource_deletion.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -97,6 +97,7 @@ log = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_16_16
 class TestDaemonKillDuringPodPvcDeletion(ManageTest):
     """
     Delete ceph daemon while deletion of PVCs/pods is progressing

--- a/tests/functional/pv/pv_services/test_cephfs_with_mds_network_failure.py
+++ b/tests/functional/pv/pv_services/test_cephfs_with_mds_network_failure.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4b,
     skipif_external_mode,
     green_squad,
+    zstream_4_16_16,
 )
 from ocs_ci.ocs.resources.pod import search_pattern_in_pod_logs
 from ocs_ci.helpers.helpers import change_vm_network_state
@@ -22,6 +23,7 @@ log = logging.getLogger(__name__)
 @green_squad
 @skipif_external_mode
 @vsphere_platform_required
+@zstream_4_16_16
 class TestCephFSWithMDSNetworkFailure:
     def teardown(self):
         """

--- a/tests/functional/pv/pv_services/test_create_pvc_invalid_access_mode.py
+++ b/tests/functional/pv/pv_services/test_create_pvc_invalid_access_mode.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import ManageTest, tier3
 from ocs_ci.ocs.exceptions import CommandFailed
 
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_16_16
 class TestCreatePvcInvalidAccessMode(ManageTest):
     """
     This test class consists of tests to verify that PVC creation will not

--- a/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
+++ b/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_and_io.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from functools import partial
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import (
@@ -57,6 +57,7 @@ log = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_16_16
 class TestDaemonKillDuringCreationOperations(ManageTest):
     """
     This class consists of tests which verifies ceph daemon kill during

--- a/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
+++ b/tests/functional/pv/pv_services/test_daemon_kill_during_pvc_pod_creation_deletion_and_io.py
@@ -6,7 +6,7 @@ from time import sleep
 import pytest
 from functools import partial
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4,
@@ -47,6 +47,7 @@ log = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @skipif_external_mode
 @ignore_leftover_label(constants.ROOK_CEPH_DETECT_VERSION_LABEL)
+@zstream_4_16_16
 class TestDaemonKillDuringMultipleCreateDeleteOperations(ManageTest):
     """
     Kill ceph daemon while creation/deletion of PVCs, and pods are progressing

--- a/tests/functional/pv/pv_services/test_del_mon_service_and_create_pvc.py
+++ b/tests/functional/pv/pv_services/test_del_mon_service_and_create_pvc.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_external_mode,
@@ -37,6 +37,7 @@ POD_OBJ = OCP(kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
 @tier4c
 @ignore_leftovers
 @skipif_external_mode
+@zstream_4_16_16
 class TestPvcCreationAfterDelMonService(E2ETest):
     """
     Tests to verify PVC creation after deleting

--- a/tests/functional/pv/pv_services/test_pvc_assign_pod_node.py
+++ b/tests/functional/pv/pv_services/test_pvc_assign_pod_node.py
@@ -4,7 +4,7 @@ import random
 
 from ocs_ci.framework import config
 from concurrent.futures import ThreadPoolExecutor
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @green_squad
+@zstream_4_16_16
 class TestPvcAssignPodNode(ManageTest):
     """
     Automates the following test cases:

--- a/tests/functional/pv/pv_services/test_pvc_deletion_during_io.py
+++ b/tests/functional/pv/pv_services/test_pvc_deletion_during_io.py
@@ -3,7 +3,7 @@ import logging
 
 from ocs_ci.ocs import exceptions, constants
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_16_16
 class TestDeletePVCWhileRunningIO(ManageTest):
     """
     Delete PVC while IO is in progress

--- a/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
+++ b/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
     green_squad,
+    zstream_4_16_16,
 )
 from ocs_ci.ocs.cluster import (
     validate_compression,
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_ocs_version("<4.6")
 @pytest.mark.polarion_id("OCS-2394")
+@zstream_4_16_16
 class TestCreate2ScAtOnceWithIo(ManageTest):
     """
     Create a new 2 Storage Class on a new rbd pool with

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     black_squad,
     ibmcloud_platform_required,
+    zstream_4_16_16,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -71,6 +72,7 @@ logger = logging.getLogger(__name__)
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_16_16
 class TestResizeOSD(ManageTest):
     """
     Automates the resize OSD test procedure

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -27,7 +27,7 @@ from ocs_ci.ocs.node import (
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_16_16
 from ocs_ci.framework.testlib import (
     tier1,
     tier2,
@@ -89,6 +89,7 @@ def teardown(request):
 
 @brown_squad
 @ignore_leftovers
+@zstream_4_16_16
 class TestNodesMaintenance(ManageTest):
     """
     Test basic flows of maintenance (unschedule and drain) and

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     bugzilla,
     skipif_ocs_version,
     brown_squad,
+    zstream_4_16_16,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -36,6 +37,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")
 @bugzilla("1908414")
+@zstream_4_16_16
 class TestCephDefaultValuesCheck(ManageTest):
     def test_ceph_default_values_check(self):
         """


### PR DESCRIPTION
# Z-Stream Test Enablement for ODF 4.16.16

This PR enables automated test coverage for z-stream release **4.16.16**, validating critical bugfixes across multiple ODF components.

## Z-Stream Version

**4.16.16**

## Changes Under Validation

This release includes 6 bugfixes across core ODF components:

| Bug ID | Component | Type | Summary |
|--------|-----------|------|---------|
| [DFBUGS-1668](https://redhat.atlassian.net/browse/DFBUGS-1668) | ocs-operator | bugfix | New crush rules causing issues due to deviceClass conflict between ssd & hdd [ODF 4.16.z] |
| [DFBUGS-265](https://redhat.atlassian.net/browse/DFBUGS-265) | rook | bugfix | [2321878] [GSS] operator not reconciling sccs |
| [DFBUGS-2854](https://redhat.atlassian.net/browse/DFBUGS-2854) | ocs-operator | bugfix | [Backport to 4.16.z] [GSS]Rook-ceph-exporter pods keep spinning up |
| [DFBUGS-3795](https://redhat.atlassian.net/browse/DFBUGS-3795) | ocs-operator | bugfix | [Backport to 4.16.z][GSS]ocs-metrics-exporter does not inherit node selector in 4.18 via sub via https://access.redhat.com/solutions/6992305 |
| [DFBUGS-3723](https://redhat.atlassian.net/browse/DFBUGS-3723) | disaster-recovery | bugfix | [4.16 clone][RDR] Change severity of WorkloadUnprotected alert to critical |
| [DFBUGS-2870](https://redhat.atlassian.net/browse/DFBUGS-2870) | ceph-csi | bugfix | [release-4.16]VolumeID may not be set in PVC-PVC clone case if csi-rbdpluing-provisioner restarts |

## Test Coverage

### Summary
- **Total tests enabled**: 31
- **Component coverage**: rook, ocs-operator, ceph-csi, disaster-recovery

### Key Test Areas

The test suite provides comprehensive coverage across critical functional areas:

**High-Priority Tests (score ≥ 0.95)**
- **PVC lifecycle & I/O validation** (2 tests) - Validates PVC deletion during active I/O operations
- **OSD resize operations** (6 tests) - Covers resize scenarios including node restarts, resource deletion, near-full capacity, and large size differences
- **Node maintenance** (2 tests) - Tests maintenance mode and multi-node scenarios

**Core Functionality Tests (score ≥ 0.90)**
- **Metadata management** (2 tests) - Validates metadata feature availability and PVC naming behavior
- **Storage class operations** (1 test) - Tests concurrent replica-2 and replica-3 storage class creation with I/O
- **Ceph configuration validation** (4 tests) - Verifies default values, config overrides, MDS cache limits, and NooBaa postgres settings
- **MGR pod behavior** (3 tests) - Tests MGR pod count, daemon failover, and pod reboot scenarios

**Additional Coverage**
- Storage size UI reflection post-resize
- PVC-to-PVC cloning reliability (CSI)
- Alert severity configuration (disaster recovery)

### Top 10 Critical Tests

1. `test_pvc_deletion_during_io.py::TestDeletePVCWhileRunningIO` (score: 0.95) - Validates PVC deletion behavior under active I/O load
2. `test_resize_osd.py::TestResizeOSD::test_resize_osd` (score: 0.95) - Core OSD resize functionality
3. `test_resize_osd.py::TestResizeOSD::test_resize_osd_with_node_restart` (score: 0.95) - Resilience during node operations
4. `test_resize_osd.py::TestResizeOSD::test_resize_osd_with_resource_delete` (score: 0.95) - Recovery from resource deletion
5. `test_resize_osd.py::TestResizeOSD::test_resize_osd_when_capacity_near_full` (score: 0.95) - Behavior under capacity pressure
6. `test_resize_osd.py::TestResizeOSD::test_resize_osd_for_large_diff` (score: 0.95) - Large-scale resize operations
7. `test_resize_osd.py::TestResizeOSD::test_ui_storage_size_post_resize_osd` (score: 0.95) - UI consistency validation
8. `test_nodes_maintenance.py::TestNodesMaintenance::test_node_maintenance` (score: 0.95) - Node maintenance procedures
9. `test_nodes_maintenance.py::TestNodesMaintenance::test_2_nodes_different_types` (score: 0.95) - Multi-node maintenance scenarios
10. `test_create_2sc_at_once_with_io.py::TestCreate2ScAtOnceWithIo` (score: 0.93) - Concurrent storage class creation

---

**Testing Status**: Ready for CI validation  
**Automated AI Generated**