### PR TITLE
Add retry logic for getting router-default service in configure_ingress_load_balancer_security_group

### DIFF
--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -1399,7 +1399,21 @@ def configure_ingress_load_balancer_security_group():
             namespace="openshift-ingress",
             resource_name="router-default",
         )
-        service_data = ocp_obj.get()
+
+        # Retry getting service data as it may not be immediately available
+        logger.debug(
+            "Attempting to retrieve router-default service data with retry logic"
+        )
+        service_data = None
+        try:
+            for sample in TimeoutSampler(timeout=900, sleep=30, func=ocp_obj.get):
+                if sample:
+                    service_data = sample
+                    logger.debug("Successfully retrieved router-default service data")
+                    break
+        except Exception as e:
+            logger.warning(f"Failed to retrieve router-default service data: {e}")
+            return
 
         # Extract load balancer hostname
         lb_ingress = (


### PR DESCRIPTION
The router-default service may not be immediately available during cluster initialization. Add TimeoutSampler retry logic with a 900-second timeout and 30-second intervals to handle this scenario gracefully.

This prevents failures when the function is called before the ingress load balancer is fully provisioned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ingress load balancer configuration by implementing retry logic for service data retrieval, with enhanced error handling and logging to gracefully manage temporary unavailability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->