### PR TITLE
Wait for NooBaa DB readiness after endpoint max count change

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2417,7 +2417,8 @@ def wait_for_noobaa_db_ready(timeout=300, sleep=10, stability_count=3):
     Wait for all NooBaa DB pods to be container-ready (1/1) and stable.
 
     Operations like endpoint scaling can trigger CNPG to rolling-restart
-    DB pods. This function requires all DB pods to report ready for
+    DB pods. This function first waits for the restart to begin (at least
+    one pod goes not-ready), then requires all DB pods to report ready for
     multiple consecutive checks, ensuring the pods are genuinely stable
     and not mid-rolling-restart.
 
@@ -2453,8 +2454,28 @@ def wait_for_noobaa_db_ready(timeout=300, sleep=10, stability_count=3):
         for pod_info in pods:
             container_statuses = pod_info.get("status", {}).get("containerStatuses")
             if not container_statuses or not container_statuses[0].get("ready"):
+                pod_name = pod_info.get("metadata", {}).get("name", "unknown")
+                logger.info(f"Pod {pod_name} container not ready: {container_statuses}")
                 return False
         return True
+
+    # Wait for the rolling restart to begin before checking stability.
+    # Without this, the stability checks could pass before the CNPG
+    # operator even starts restarting pods.
+    restart_grace_timeout = 60
+    logger.info(f"Waiting up to {restart_grace_timeout}s for a DB pod restart to begin")
+    try:
+        for not_ready in TimeoutSampler(
+            restart_grace_timeout, sleep, _all_db_pods_ready
+        ):
+            if not not_ready:
+                logger.info("Detected DB pod restart, proceeding to stability checks")
+                break
+    except TimeoutExpiredError:
+        logger.info(
+            "No DB pod restart detected within the grace period, "
+            "proceeding to stability checks"
+        )
 
     try:
         for is_ready in TimeoutSampler(timeout, sleep, _all_db_pods_ready):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2465,10 +2465,10 @@ def wait_for_noobaa_db_ready(timeout=300, sleep=10, stability_count=3):
     restart_grace_timeout = 60
     logger.info(f"Waiting up to {restart_grace_timeout}s for a DB pod restart to begin")
     try:
-        for not_ready in TimeoutSampler(
+        for pods_ready in TimeoutSampler(
             restart_grace_timeout, sleep, _all_db_pods_ready
         ):
-            if not not_ready:
+            if not pods_ready:
                 logger.info("Detected DB pod restart, proceeding to stability checks")
                 break
     except TimeoutExpiredError:

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2411,6 +2411,72 @@ def wait_for_noobaa_pods_running(timeout=300, sleep=10):
     sampler.wait_for_func_status(True)
 
 
+@config.run_with_provider_context_if_available
+def wait_for_noobaa_db_ready(timeout=300, sleep=10, stability_count=3):
+    """
+    Wait for all NooBaa DB pods to be container-ready (1/1) and stable.
+
+    Operations like endpoint scaling can trigger CNPG to rolling-restart
+    DB pods. This function requires all DB pods to report ready for
+    multiple consecutive checks, ensuring the pods are genuinely stable
+    and not mid-rolling-restart.
+
+    The expected pod count is derived from the CNPG Cluster CR's
+    spec.instances field.
+
+    Args:
+        timeout (int): Overall timeout in seconds
+        sleep (int): Seconds between checks
+        stability_count (int): Number of consecutive ready checks required
+
+    """
+    namespace = config.ENV_DATA["cluster_namespace"]
+    stable_checks = 0
+
+    cnpg_cluster = OCP(
+        kind=constants.CNPG_CLUSTER_KIND,
+        resource_name=constants.NB_DB_CNPG_CLUSTER_NAME,
+        namespace=namespace,
+    )
+    expected_instances = cnpg_cluster.get()["spec"]["instances"]
+    logger.info(f"Expecting {expected_instances} NooBaa DB pod(s) from CNPG Cluster CR")
+
+    def _all_db_pods_ready():
+        pods = get_pods_having_label(
+            constants.NOOBAA_DB_LABEL_419_AND_ABOVE, namespace=namespace
+        )
+        if len(pods) < expected_instances:
+            logger.info(
+                f"Found {len(pods)} NooBaa DB pods, waiting for {expected_instances}"
+            )
+            return False
+        for pod_info in pods:
+            container_statuses = pod_info.get("status", {}).get("containerStatuses")
+            if not container_statuses or not container_statuses[0].get("ready"):
+                return False
+        return True
+
+    try:
+        for is_ready in TimeoutSampler(timeout, sleep, _all_db_pods_ready):
+            if is_ready:
+                stable_checks += 1
+                logger.info(f"NooBaa DB pods ready ({stable_checks}/{stability_count})")
+                if stable_checks >= stability_count:
+                    logger.info("NooBaa DB pods are stable and ready")
+                    return
+            else:
+                if stable_checks > 0:
+                    logger.warning(
+                        "NooBaa DB readiness check failed, resetting counter"
+                    )
+                stable_checks = 0
+    except TimeoutExpiredError:
+        raise TimeoutExpiredError(
+            f"NooBaa DB pods did not stabilize within {timeout}s. "
+            f"Achieved {stable_checks}/{stability_count} consecutive ready checks."
+        )
+
+
 def verify_pods_upgraded(
     old_images, selector, count=1, timeout=720, ignore_psql_12_verification=False
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ from ocs_ci.ocs.resources.pod import (
     delete_deployment_pods,
     cal_md5sum,
     wait_for_pods_to_be_in_statuses,
+    wait_for_noobaa_db_ready,
 )
 from ocs_ci.ocs.resources.pvc import (
     PVC,
@@ -5271,6 +5272,8 @@ def nb_ensure_endpoint_count(request):
                 f" {min_ep_count}, max count: {max_ep_count}, ready count:"
                 f" {ready_nb_ep_count}"
             )
+        log.info("Waiting for NooBaa DB pods to stabilize after endpoint scaling")
+        wait_for_noobaa_db_ready()
 
 
 @pytest.fixture(scope="class")

--- a/tests/cross_functional/kcs/test_disable_mcg_external_service.py
+++ b/tests/cross_functional/kcs/test_disable_mcg_external_service.py
@@ -4,6 +4,7 @@ import logging
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import wait_for_noobaa_db_ready
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     tier2,
@@ -47,6 +48,7 @@ class TestDisableMCGExternalService:
             params='{"spec": {"multiCloudGateway": {"endpoints": {"minCount": 2,"maxCount": 4}}}}',
             format_type="merge",
         )
+        wait_for_noobaa_db_ready()
 
         def finalizer():
 
@@ -61,6 +63,7 @@ class TestDisableMCGExternalService:
                 params='{"spec": {"multiCloudGateway": {"endpoints": {"minCount": 1,"maxCount": 2}}}}',
                 format_type="merge",
             )
+            wait_for_noobaa_db_ready()
 
         request.addfinalizer(finalizer)
         return noobaa_ocp_obj


### PR DESCRIPTION
## Motivation
Endpoint scaling (maxCount change) triggers CNPG to restart PostgreSQL
pods sequentially ([DFBUGS-6888](https://redhat.atlassian.net/browse/DFBUGS-6888)). The `nb_ensure_endpoint_count` fixture
sets maxCount from 1→2 on the first MCG test in a session, causing a DB
restart that often fails the next test — frequently seen as the first MCG
failure in acceptance launches.

## Changes
- Add `wait_for_noobaa_db_ready()` in `ocs_ci/ocs/resources/pod.py` that
  checks all DB pods are container-ready (1/1) for multiple consecutive
  checks, handling both the propagation delay and sequential pod restarts.
  Expected pod count is derived from the CNPG Cluster CR's `spec.instances`.
- Call it after endpoint scaling in `nb_ensure_endpoint_count` and in
  `test_disable_mcg_external_service`'s fixture and finalizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to wait for NooBaa database pods to be ready and remain stable, with configurable timeout, polling interval, and required consecutive ready checks (includes an initial restart-grace phase).
* **Tests**
  * Updated test setup/fixtures to synchronize with NooBaa database pod readiness: now waits before/after endpoint scaling and during related patching/cleanup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->