### PR TITLE
Add Ceph health monitoring during RDR StorageCluster wait

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -126,6 +126,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
     get_osd_count,
     StorageCluster,
     validate_serviceexport,
+    wait_for_storagecluster_ready_with_health_check,
 )
 from ocs_ci.ocs.uninstall import uninstall_ocs
 from ocs_ci.ocs.utils import (
@@ -518,7 +519,15 @@ class Deployment(object):
                                 namespace=config.ENV_DATA["cluster_namespace"],
                             )
                             storage_cluster.reload_data()
-                            storage_cluster.wait_for_phase(phase="Ready", timeout=1000)
+                            # Use health-aware wait for RDR to handle known issues
+                            # like slow ops (DFBUGS-2456)
+                            wait_for_storagecluster_ready_with_health_check(
+                                storage_cluster,
+                                timeout=1000,
+                                sleep=30,
+                                fix_ceph_health=True,
+                                update_jira=True,
+                            )
                             if (
                                 get_provider_service_type() != "NodePort"
                                 and cluster.ENV_DATA.get("cluster_type", "").lower()

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -3586,3 +3586,101 @@ def get_deviceset_name_per_count():
     """
     device_sets = get_all_device_sets()
     return {d.get("name"): d["count"] for d in device_sets}
+
+
+def wait_for_storagecluster_ready_with_health_check(
+    storage_cluster,
+    timeout=1000,
+    sleep=30,
+    fix_ceph_health=True,
+    update_jira=True,
+):
+    """
+    Wait for StorageCluster to reach Ready phase with periodic Ceph health checks.
+    This function is particularly useful for RDR deployments where slow ops issues
+    can prevent the cluster from reaching Ready state.
+
+    Args:
+        storage_cluster (StorageCluster): The StorageCluster object to monitor
+        timeout (int): Total timeout in seconds to wait for Ready phase (default: 1000)
+        sleep (int): Sleep interval between checks in seconds (default: 30)
+        fix_ceph_health (bool): If True, attempt to fix Ceph health issues like slow ops
+        update_jira (bool): If True, update Jira with details if known issue is hit
+
+    Raises:
+        ResourceWrongStatusException: If StorageCluster doesn't reach Ready within timeout
+        CephHealthException: If Ceph health issues cannot be recovered
+
+    Returns:
+        bool: True if StorageCluster reached Ready phase
+
+    """
+    from ocs_ci.utility.utils import ceph_health_check
+    from ocs_ci.ocs.exceptions import CephHealthException, CephHealthRecoveredException
+    import time
+
+    log.info(
+        f"Waiting for StorageCluster {storage_cluster.resource_name} to reach Ready "
+        f"phase with Ceph health monitoring (timeout={timeout}s, interval={sleep}s)"
+    )
+
+    start_time = time.time()
+    health_check_interval = max(60, sleep * 2)  # Check health every 60s minimum
+    last_health_check = 0
+
+    while time.time() - start_time < timeout:
+        # Check if StorageCluster is Ready
+        storage_cluster.reload_data()
+        if storage_cluster.check_phase("Ready"):
+            log.info(
+                f"StorageCluster {storage_cluster.resource_name} successfully "
+                "reached Ready phase"
+            )
+            return True
+
+        # Periodic Ceph health check with auto-fix
+        current_time = time.time()
+        if current_time - last_health_check >= health_check_interval:
+            log.info("Performing periodic Ceph health check...")
+            try:
+                ceph_health_check(
+                    namespace=storage_cluster.namespace,
+                    tries=3,
+                    delay=30,
+                    fix_ceph_health=fix_ceph_health,
+                    update_jira=update_jira,
+                    no_exception_if_jira_issue_updated=True,
+                )
+                log.info("Ceph health check passed")
+            except CephHealthRecoveredException as ex:
+                log.warning(
+                    "Ceph health issue was recovered (e.g., slow ops fixed): "
+                    f"{ex}. Continuing to wait for StorageCluster Ready phase..."
+                )
+            except CephHealthException as ex:
+                log.warning(
+                    f"Ceph health check failed but continuing: {ex}. "
+                    "StorageCluster phase check will determine overall status."
+                )
+            last_health_check = current_time
+
+        # Get current phase for logging
+        try:
+            current_phase = storage_cluster.data.get("status", {}).get(
+                "phase", "Unknown"
+            )
+            log.info(
+                f"StorageCluster phase: {current_phase}, "
+                f"elapsed: {int(current_time - start_time)}s/{timeout}s"
+            )
+        except Exception as e:
+            log.debug(f"Could not get current phase: {e}")
+
+        time.sleep(sleep)
+
+    # Timeout reached
+    elapsed = int(time.time() - start_time)
+    raise ResourceWrongStatusException(
+        f"StorageCluster {storage_cluster.resource_name} did not reach Ready phase "
+        f"within {timeout}s (elapsed: {elapsed}s)"
+    )


### PR DESCRIPTION
During RDR deployment with globalnet, StorageCluster can get stuck in "Progressing" state due to Ceph monitor slow ops issues, preventing the cluster from reaching "Ready" phase. This causes deployment to timeout after waiting for the Ready state.

This adds a new function wait_for_storagecluster_ready_with_health_check() that wraps the wait_for_phase() call with periodic Ceph health checks (every 60s). When slow ops are detected, it automatically:
- Collects MustGather logs
- Restarts the affected MON pods (fixes Paxos commit deadlock)
- Updates Jira [DFBUGS-2456](https://redhat.atlassian.net/browse/DFBUGS-2456) with deployment details
- Continues waiting for Ready phase after recovery

Applied specifically to regional-dr deployment flow where slow ops issues are known to occur during monitor topology changes.

Fixes: [DFBUGS-2456](https://redhat.atlassian.net/browse/DFBUGS-2456)