### PR TITLE
Add Ceph health monitoring during RDR StorageCluster wait

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -128,6 +128,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
     get_osd_count,
     StorageCluster,
     validate_serviceexport,
+    wait_for_storagecluster_ready_with_health_check,
 )
 from ocs_ci.ocs.uninstall import uninstall_ocs
 from ocs_ci.ocs.utils import (
@@ -528,7 +529,15 @@ class Deployment(object):
                                 namespace=config.ENV_DATA["cluster_namespace"],
                             )
                             storage_cluster.reload_data()
-                            storage_cluster.wait_for_phase(phase="Ready", timeout=1000)
+                            # Use health-aware wait for RDR to handle known issues
+                            # like slow ops (DFBUGS-2456)
+                            wait_for_storagecluster_ready_with_health_check(
+                                storage_cluster,
+                                timeout=1000,
+                                sleep=30,
+                                fix_ceph_health=True,
+                                update_jira=True,
+                            )
                             if (
                                 get_provider_service_type() != "NodePort"
                                 and cluster.ENV_DATA.get("cluster_type", "").lower()

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -7,6 +7,7 @@ import ipaddress
 import logging
 import re
 import tempfile
+import time
 import json
 
 from jsonschema import validate
@@ -3615,6 +3616,25 @@ def get_deviceset_name_per_count():
     return {d.get("name"): d["count"] for d in device_sets}
 
 
+def get_storage_client():
+    """
+    Get the StorageClient OCP object for the configured storage client.
+
+    Returns:
+        ocs_ci.ocs.ocp.OCP: StorageClient OCP object with resource_name set
+            to the storage client name from config.
+    """
+    return ocp.OCP(
+        kind=constants.STORAGECLIENT,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=(
+            config.cluster_ctx.ENV_DATA.get("storage_client_name")
+            or config.ENV_DATA.get("storage_client_name")
+            or constants.STORAGE_CLIENT_NAME
+        ),
+    )
+
+
 def wait_for_storagecluster_ready_with_health_check(
     storage_cluster,
     timeout=1000,
@@ -3627,6 +3647,10 @@ def wait_for_storagecluster_ready_with_health_check(
     This function is particularly useful for RDR deployments where slow ops issues
     can prevent the cluster from reaching Ready state.
 
+    The health check uses per-issue recovery attempt tracking (max 2 attempts per issue).
+    Jira is updated only on first occurrence of each specific issue with occurrence count.
+    After max attempts, the same issue will fail immediately without additional recovery.
+
     Args:
         storage_cluster (StorageCluster): The StorageCluster object to monitor
         timeout (int): Total timeout in seconds to wait for Ready phase (default: 1000)
@@ -3636,7 +3660,8 @@ def wait_for_storagecluster_ready_with_health_check(
 
     Raises:
         ResourceWrongStatusException: If StorageCluster doesn't reach Ready within timeout
-        CephHealthException: If Ceph health issues cannot be recovered
+        CephHealthException: If Ceph health issues cannot be recovered or same issue
+            persists after max recovery attempts
 
     Returns:
         bool: True if StorageCluster reached Ready phase
@@ -3644,7 +3669,6 @@ def wait_for_storagecluster_ready_with_health_check(
     """
     from ocs_ci.utility.utils import ceph_health_check
     from ocs_ci.ocs.exceptions import CephHealthException, CephHealthRecoveredException
-    import time
 
     log.info(
         f"Waiting for StorageCluster {storage_cluster.resource_name} to reach Ready "

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -3615,20 +3615,99 @@ def get_deviceset_name_per_count():
     return {d.get("name"): d["count"] for d in device_sets}
 
 
-def get_storage_client():
+def wait_for_storagecluster_ready_with_health_check(
+    storage_cluster,
+    timeout=1000,
+    sleep=30,
+    fix_ceph_health=True,
+    update_jira=True,
+):
     """
-    Get the StorageClient OCP object for the configured storage client.
+    Wait for StorageCluster to reach Ready phase with periodic Ceph health checks.
+    This function is particularly useful for RDR deployments where slow ops issues
+    can prevent the cluster from reaching Ready state.
+
+    Args:
+        storage_cluster (StorageCluster): The StorageCluster object to monitor
+        timeout (int): Total timeout in seconds to wait for Ready phase (default: 1000)
+        sleep (int): Sleep interval between checks in seconds (default: 30)
+        fix_ceph_health (bool): If True, attempt to fix Ceph health issues like slow ops
+        update_jira (bool): If True, update Jira with details if known issue is hit
+
+    Raises:
+        ResourceWrongStatusException: If StorageCluster doesn't reach Ready within timeout
+        CephHealthException: If Ceph health issues cannot be recovered
 
     Returns:
-        ocs_ci.ocs.ocp.OCP: StorageClient OCP object with resource_name set
-            to the storage client name from config.
+        bool: True if StorageCluster reached Ready phase
+
     """
-    return ocp.OCP(
-        kind=constants.STORAGECLIENT,
-        namespace=config.ENV_DATA["cluster_namespace"],
-        resource_name=(
-            config.cluster_ctx.ENV_DATA.get("storage_client_name")
-            or config.ENV_DATA.get("storage_client_name")
-            or constants.STORAGE_CLIENT_NAME
-        ),
+    from ocs_ci.utility.utils import ceph_health_check
+    from ocs_ci.ocs.exceptions import CephHealthException, CephHealthRecoveredException
+    import time
+
+    log.info(
+        f"Waiting for StorageCluster {storage_cluster.resource_name} to reach Ready "
+        f"phase with Ceph health monitoring (timeout={timeout}s, interval={sleep}s)"
+    )
+
+    start_time = time.time()
+    health_check_interval = max(60, sleep * 2)  # Check health every 60s minimum
+    last_health_check = 0
+
+    while time.time() - start_time < timeout:
+        # Check if StorageCluster is Ready
+        storage_cluster.reload_data()
+        if storage_cluster.check_phase("Ready"):
+            log.info(
+                f"StorageCluster {storage_cluster.resource_name} successfully "
+                "reached Ready phase"
+            )
+            return True
+
+        # Periodic Ceph health check with auto-fix
+        current_time = time.time()
+        if current_time - last_health_check >= health_check_interval:
+            log.info("Performing periodic Ceph health check...")
+            try:
+                ceph_health_check(
+                    namespace=storage_cluster.namespace,
+                    tries=3,
+                    delay=30,
+                    fix_ceph_health=fix_ceph_health,
+                    update_jira=update_jira,
+                    no_exception_if_jira_issue_updated=True,
+                )
+                log.info("Ceph health check passed")
+            except CephHealthRecoveredException as ex:
+                log.warning(
+                    "Ceph health issue was recovered (e.g., slow ops fixed): "
+                    f"{ex}. Continuing to wait for StorageCluster Ready phase..."
+                )
+            except CephHealthException as ex:
+                log.warning(
+                    f"Ceph health check failed but continuing: {ex}. "
+                    "StorageCluster phase check will determine overall status."
+                )
+            last_health_check = current_time
+
+        # Get current phase for logging
+        try:
+            current_phase = storage_cluster.data.get("status", {}).get(
+                "phase", "Unknown"
+            )
+            log.info(
+                f"StorageCluster phase: {current_phase}, "
+                f"elapsed: {int(current_time - start_time)}s/{timeout}s"
+            )
+        except Exception as e:
+            log.debug(f"Could not get current phase: {e}")
+
+        time.sleep(sleep)
+
+    # Timeout reached
+    elapsed = int(time.time() - start_time)
+    raise ResourceWrongStatusException(
+        f"StorageCluster {storage_cluster.resource_name} did not reach Ready phase "
+        f"within {timeout}s (elapsed: {elapsed}s)"
     )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3130,9 +3130,13 @@ def wait_for_ceph_health_not_ok(timeout=300, sleep=10):
     sampler.wait_for_func_status(True)
 
 
-def ceph_health_resolve_crash():
+def ceph_health_resolve_crash(health_status):
     """
-    Fix ceph health issue with daemon crash
+    Fix ceph health issue with daemon crash.
+
+    Args:
+        health_status (str): Ceph health status output (not used by this function,
+            but required for consistency - all recovery functions must accept it)
     """
     log.warning("Trying to fix the issue with crash by archiving crashes")
     from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
@@ -3229,6 +3233,68 @@ def restart_mon_pods(mon_ids):
         )
 
 
+# Module-level Ceph health fix configurations with per-issue tracking
+# Runtime field recovery_attempts is initialized on-demand using .get() with default 0
+# max_recovery_attempts defaults to 2 if not specified
+# Jira is updated on each recovery attempt (up to max_recovery_attempts)
+#
+# IMPORTANT: All recovery functions (func) must accept health_status as first parameter.
+# This is a required convention for consistency, even if the function doesn't use it.
+ceph_health_fixes = [
+    {
+        "pattern": r"daemons have recently crashed",
+        "func": ceph_health_resolve_crash,
+        "func_kwargs": {},
+        "ceph_health_tries": 5,
+        "ceph_health_delay": 30,
+        "max_recovery_attempts": 2,  # Example: override default (2)
+    },
+    {
+        "pattern": r"modules have recently crashed",
+        "func": ceph_health_resolve_crash,
+        "func_kwargs": {},
+        "ceph_health_tries": 5,
+        "ceph_health_delay": 30,
+        # max_recovery_attempts not specified, will default to 2
+        "known_issues": [
+            {
+                "issue": "DFBUGS-2781",
+                "pattern": r"mgr module prometheus crashed in",
+                # Runtime fields initialized on-demand
+            },
+        ],
+    },
+    {
+        "pattern": r"slow ops, oldest one blocked for \d+ sec, .*(?:has|have) slow ops",
+        "func": ceph_health_resolve_mon_slow_ops,
+        "func_kwargs": {},
+        "ceph_health_tries": 6,
+        "ceph_health_delay": 30,
+        "known_issues": [
+            {
+                "issue": "DFBUGS-2456",
+                "func": lambda: config.MULTICLUSTER.get("multicluster_mode")
+                == "regional-dr",
+            },
+        ],
+    },
+    {
+        "pattern": r"HEALTH_WARN \d+ network partitions? detected",
+        "func": ceph_health_resolve_network_partition,
+        "func_kwargs": {},
+        "ceph_health_tries": 6,
+        "ceph_health_delay": 30,
+        "known_issues": [
+            {
+                "issue": "DFBUGS-4521",
+                "pattern": r"Netsplit detected between mon",
+            },
+        ],
+    },
+    # TODO: Add more patterns and fix functions
+]
+
+
 def ceph_health_recover(
     health_status,
     namespace=None,
@@ -3236,7 +3302,13 @@ def ceph_health_recover(
     no_exception_if_jira_issue_updated=False,
 ):
     """
-    Function which tries to recover ceph health to be HEALTH OK
+    Function which tries to recover ceph health to be HEALTH OK.
+
+    Uses module-level ceph_health_fixes configuration with per-issue tracking.
+    Each fix pattern can specify max_recovery_attempts (default: 2).
+    Tracks recovery attempts separately for specific Jira issues vs generic pattern matches.
+    Updates Jira on each recovery attempt (up to max_recovery_attempts).
+    Runtime field recovery_attempts is initialized on-demand.
 
     Args:
         health_status (str): Ceph health status
@@ -3246,64 +3318,12 @@ def ceph_health_recover(
             and ceph health is recovered
 
     Raises:
-        CephHealthNotRecoveredException: When Ceph health was not recovered
+        CephHealthNotRecoveredException: When Ceph health was not recovered or when
+            the same issue persists after max_recovery_attempts
         CephHealthRecoveredException: When Ceph health was recovered
 
     """
-    ceph_health_fixes = [
-        {
-            "pattern": r"daemons have recently crashed",
-            "func": ceph_health_resolve_crash,
-            "func_args": [],
-            "func_kwargs": {},
-            "ceph_health_tries": 5,
-            "ceph_health_delay": 30,
-        },
-        {
-            "pattern": r"modules have recently crashed",
-            "func": ceph_health_resolve_crash,
-            "func_args": [],
-            "func_kwargs": {},
-            "ceph_health_tries": 5,
-            "ceph_health_delay": 30,
-            "known_issues": [
-                {
-                    "issue": "DFBUGS-2781",
-                    "pattern": r"mgr module prometheus crashed in",
-                },
-            ],
-        },
-        {
-            "pattern": r"slow ops, oldest one blocked for \d+ sec, .*(?:has|have) slow ops",
-            "func": ceph_health_resolve_mon_slow_ops,
-            "func_args": [health_status],
-            "func_kwargs": {},
-            "ceph_health_tries": 6,
-            "ceph_health_delay": 30,
-            "known_issues": [
-                {
-                    "issue": "DFBUGS-2456",
-                    "func": lambda: config.MULTICLUSTER.get("multicluster_mode")
-                    == "regional-dr",
-                },
-            ],
-        },
-        {
-            "pattern": r"HEALTH_WARN \d+ network partitions? detected",
-            "func": ceph_health_resolve_network_partition,
-            "func_args": [health_status],
-            "func_kwargs": {},
-            "ceph_health_tries": 6,
-            "ceph_health_delay": 30,
-            "known_issues": [
-                {
-                    "issue": "DFBUGS-4521",
-                    "pattern": r"Netsplit detected between mon",
-                },
-            ],
-        },
-        # TODO: Add more patterns and fix functions
-    ]
+    global ceph_health_fixes
     for fix_dict in ceph_health_fixes:
         pattern = fix_dict["pattern"]
         jira_issues = fix_dict.get("known_issues", [])
@@ -3312,6 +3332,58 @@ def ceph_health_recover(
                 "Trying to fix Ceph Health because we found in Health status the matching pattern"
                 f": '{pattern}'!"
             )
+
+            # --- BEGIN TRACKING LOGIC ---
+            # Identify the specific Jira issue (if any) to use appropriate tracking
+            issue_confirmed = False
+            confirmed_known_issue = None
+            jira_issue_id = None
+            for jira_issue in jira_issues:
+                jira_issue_id = jira_issue["issue"]
+                jira_issue_pattern = jira_issue.get("pattern")
+                jira_issue_function = jira_issue.get("func")
+                if jira_issue_pattern:
+                    if re.search(jira_issue["pattern"], health_status):
+                        issue_confirmed = True
+                        confirmed_known_issue = jira_issue
+                if jira_issue_function:
+                    if jira_issue_function():
+                        issue_confirmed = True
+                        confirmed_known_issue = jira_issue
+                if issue_confirmed:
+                    break
+
+            # Determine which tracking to use: known_issue level or pattern level
+            if issue_confirmed and confirmed_known_issue:
+                # Use known_issue tracking
+                tracking_dict = confirmed_known_issue
+                issue_key = jira_issue_id
+            else:
+                # Use pattern-level tracking
+                tracking_dict = fix_dict
+                issue_key = pattern
+
+            # Get max attempts from fix_dict (default: 2)
+            fix_max_attempts = fix_dict.get("max_recovery_attempts", 2)
+
+            # Get and increment recovery attempt counter (initialize if doesn't exist)
+            current_attempt = tracking_dict.get("recovery_attempts", 0) + 1
+            tracking_dict["recovery_attempts"] = current_attempt
+
+            log.info(
+                f"Ceph health issue '{issue_key}' detected "
+                f"(attempt {current_attempt}/{fix_max_attempts})"
+            )
+
+            # If we've exceeded max attempts, fail immediately without MG collection
+            if current_attempt > fix_max_attempts:
+                raise CephHealthNotRecoveredException(
+                    f"Ceph health issue '{issue_key}' persisted after "
+                    f"{fix_max_attempts} recovery attempts. "
+                    f"Health status: {health_status}"
+                )
+            # --- END TRACKING LOGIC ---
+
             # Avoid circular dependencies, importing here
             from ocs_ci.ocs.utils import collect_ocs_logs
             from ocs_ci.framework.pytest_customization import ocscilib
@@ -3341,23 +3413,12 @@ def ceph_health_recover(
             except Exception:
                 odf_version = version_module.get_ocs_version_from_csv()
             ocp_version = version_module.get_semantic_ocp_running_version()
-            issue_confirmed = False
             issue_commented = False
-            jira_issue_id = None
-            for jira_issue in jira_issues:
-                jira_issue_id = jira_issue["issue"]
-                jira_issue_pattern = jira_issue.get("pattern")
-                jira_issue_function = jira_issue.get("func")
-                if jira_issue_pattern:
-                    if re.search(jira_issue["pattern"], health_status):
-                        issue_confirmed = True
-                if jira_issue_function:
-                    issue_confirmed = jira_issue_function()
-                if issue_confirmed:
-                    break
+            # Note: issue_confirmed and jira_issue_id already determined in tracking logic above
             if issue_confirmed and update_jira:
                 msg_lines = [
                     "*OCS-CI report*",
+                    f"Issue occurrence: {current_attempt} of {fix_max_attempts} max attempts",
                     f"ODF version: {odf_version}",
                     f"OCP version: {ocp_version}",
                 ]
@@ -3380,9 +3441,8 @@ def ceph_health_recover(
                 except Exception as ex:
                     log.error(f"Failed to connect or comment to Jira: {ex}")
 
-            fix_dict["func"](
-                *fix_dict.get("func_args", []), **fix_dict.get("func_kwargs", {})
-            )
+            # Call recovery function (all must accept health_status as first parameter)
+            fix_dict["func"](health_status, **fix_dict.get("func_kwargs", {}))
             try:
                 ceph_health_check(
                     namespace,
@@ -3447,7 +3507,10 @@ def ceph_health_check(
         delay=delay,
         backoff=1,
     )(ceph_health_check_base)(
-        namespace, fix_ceph_health, update_jira, no_exception_if_jira_issue_updated
+        namespace,
+        fix_ceph_health,
+        update_jira,
+        no_exception_if_jira_issue_updated,
     )
 
 


### PR DESCRIPTION
During RDR deployment with globalnet, StorageCluster can get stuck in "Progressing" state due to Ceph monitor slow ops issues, preventing the cluster from reaching "Ready" phase. This causes deployment to timeout after waiting for the Ready state.

This adds a new function wait_for_storagecluster_ready_with_health_check() that wraps the wait_for_phase() call with periodic Ceph health checks (every 60s). When slow ops are detected, it automatically:
- Collects MustGather logs
- Restarts the affected MON pods (fixes Paxos commit deadlock)
- Updates Jira [DFBUGS-2456](https://redhat.atlassian.net/browse/DFBUGS-2456) with deployment details
- Continues waiting for Ready phase after recovery

Applied specifically to regional-dr deployment flow where slow ops issues are known to occur during monitor topology changes.

Fixes: [DFBUGS-2456](https://redhat.atlassian.net/browse/DFBUGS-2456)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health-aware cluster readiness for multicluster/globalnet deployments: waits for Ready while performing periodic Ceph health checks, with optional automatic remediation, configurable timeouts/sleeps, and optional one-time ticket updates when an issue is first reported.

* **Refactor**
  * Centralized Ceph health-fix patterns with per-issue tracking and configurable max recovery attempts; recovery flows now enforce attempt limits and ensure each issue updates tickets at most once.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->