### PR TITLE
Fix remaining invalid principal and policy version in bucket policy tests

### DIFF
--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 import boto3
@@ -193,7 +192,7 @@ def gen_bucket_policy(
     resources = list(
         map(lambda bucket_name: "arn:aws:s3:::%s" % bucket_name, resources_list)
     )
-    ver = datetime.date.today().strftime("%Y-%m-%d")
+    ver = "2012-10-17"
 
     principal = principal_property if principal_property else "Principal"
     effect = effect if effect else "Allow"

--- a/tests/functional/object/mcg/test_bucket_policy.py
+++ b/tests/functional/object/mcg/test_bucket_policy.py
@@ -927,14 +927,14 @@ class TestS3BucketPolicy(MCGTest):
             "statement_2": {
                 "Action": "s3:PutObject",
                 "Effect": "Allow",
-                "Principal": {"AWS": obc_obj.obc_account},
+                "Principal": {"AWS": obc_obj.id_for_policy_principal},
                 "Resource": [f'arn:aws:s3:::{obc_obj.bucket_name}/{"*"}'],
                 "Sid": "Statement-2",
             },
             "statement_3": {
                 "Action": "s3:DeleteObject",
                 "Effect": "Deny",
-                "Principal": {"AWS": [obc_obj.obc_account]},
+                "Principal": {"AWS": [obc_obj.id_for_policy_principal]},
                 "Resource": [f'arn:aws:s3:::{"*"}'],
                 "Sid": "Statement-3",
             },


### PR DESCRIPTION
This is a fix for https://github.com/red-hat-storage/ocs-ci/issues/14331 . 

 Problem: 

In ODF 4.21, NooBaa started requiring ARN-format principals in bucket policies instead of raw account names. A prior fix (PR #14364) addressed most occurrences, but
  test_bucket_policy_multi_statement was missed because it constructs policy dicts manually rather than through gen_bucket_policy(). Additionally, gen_bucket_policy() used datetime.date.today()
   for the policy Version field, producing invalid values like "2026-05-20" instead of the AWS standard "2012-10-17".

  Fix:
  - Replaced obc_obj.obc_account with obc_obj.id_for_policy_principal in the two manually-built policy statements in test_bucket_policy_multi_statement
  - Changed gen_bucket_policy() to use the standard AWS policy version "2012-10-17", aligning it with gen_bucket_policy_ui_compatible()
  - Removed the unused datetime import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bucket policy generation to use the standard AWS policy version format.

* **Tests**
  * Enhanced bucket policy tests to validate correct principal identifiers in multi-statement policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->