### PR TITLE
Fix intermittent test failures caused by bucket deletion timeout in teardown - test _bucket_list_command

### DIFF
--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -273,7 +273,7 @@ class ObjectBucket(ABC):
         logger.info(f"{self.name} status is {status_var}")
         return status_var
 
-    def verify_deletion(self, timeout=60, interval=5):
+    def verify_deletion(self, timeout=180, interval=5):
         """
         Super method used for logging the deletion verification
         process and then calls the appropriate implementatation
@@ -292,7 +292,9 @@ class ObjectBucket(ABC):
                     logger.info(f"{self.name} still exists. Retrying...")
         except TimeoutExpiredError:
             logger.error(f"{self.name} was not deleted within {timeout} seconds.")
-            assert False, f"{self.name} was not deleted within {timeout} seconds."
+            raise TimeoutExpiredError(
+                f"{self.name} was not deleted within {timeout} seconds."
+            )
 
     def verify_health(self, timeout=800, interval=5, **kwargs):
         """

--- a/ocs_ci/ocs/resources/objectbucket.py
+++ b/ocs_ci/ocs/resources/objectbucket.py
@@ -291,10 +291,9 @@ class ObjectBucket(ABC):
                 else:
                     logger.info(f"{self.name} still exists. Retrying...")
         except TimeoutExpiredError:
-            logger.error(f"{self.name} was not deleted within {timeout} seconds.")
-            raise TimeoutExpiredError(
-                f"{self.name} was not deleted within {timeout} seconds."
-            )
+            msg = f"{self.name} was not deleted within {timeout} seconds."
+            logger.error(msg)
+            raise TimeoutExpiredError(msg) from None
 
     def verify_health(self, timeout=800, interval=5, **kwargs):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3619,6 +3619,8 @@ def bucket_factory_fixture(
                         log.warning(f"{bucket.name} could not be found in cleanup")
                     else:
                         raise
+                except Exception as e:
+                    log.warning(f"Failed to delete {bucket.name} during cleanup: {e}")
 
     request.addfinalizer(bucket_cleanup)
 


### PR DESCRIPTION
This is a fix to https://github.com/red-hat-storage/ocs-ci/issues/14301

test_bucket_list_command occasionally fails not because of a test logic issue, but because bucket cleanup during teardown times out verifying deletion. Two problems compound:

  1. verify_deletion uses assert False on timeout, which raises an AssertionError that bucket_cleanup doesn't catch — aborting cleanup of remaining buckets and failing the test.
  2. The default verification timeout of 60s is too short for slow or loaded clusters.

  Fixes:

  - objectbucket.py: Changed verify_deletion to raise TimeoutExpiredError instead of assert False, making the failure catchable by callers. Increased the default timeout from 60s to 180s.
  - conftest.py: Added a broad except Exception handler in bucket_cleanup so that a failed deletion of one bucket doesn't prevent cleanup of the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased object bucket deletion verification timeout from 60s to 180s to improve reliability for larger deletions.
  * Clearer error message when deletion verification times out, replacing ambiguous failures with explicit timeout notifications.
  * Bucket cleanup now logs a warning on deletion failure and continues, preventing teardown from being halted by unexpected errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->