### PR TITLE
Add disconnected deployment support for external mode

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1894,10 +1894,13 @@ class Deployment(object):
             )
             raise
 
-    def deploy_with_external_mode(self):
+    def deploy_with_external_mode(self, image=None):
         """
         This function handles the deployment of OCS on
         external/indpendent RHCS cluster
+
+        Args:
+            image (str): Image of ocs registry.
 
         """
         if config.EXTERNAL_MODE.get("rgw_secure"):
@@ -1911,7 +1914,7 @@ class Deployment(object):
                 logger.info("Creating namespace and operator group.")
                 run_cmd(f"oc apply -f {constants.OLM_YAML}")
             if not live_deployment:
-                create_catalog_source()
+                create_catalog_source(image)
             self.subscribe_ocs()
             operator_selector = get_selector_for_ocs_operator()
             subscription_plan_approval = config.DEPLOYMENT.get(
@@ -2156,7 +2159,7 @@ class Deployment(object):
                 label_nodes(nodes=worker_node_objs, label=constants.OPERATOR_NODE_LABEL)
 
         if config.DEPLOYMENT["external_mode"]:
-            self.deploy_with_external_mode()
+            self.deploy_with_external_mode(image)
         else:
             self.deploy_ocs_via_operator(image)
             if config.ENV_DATA["mcg_only_deployment"]:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4956,6 +4956,10 @@ def mirror_image(image, cluster_config=None):
             mirror_base = f"{mirror_registry}/{mirror_registry_path}"
 
         mirrored_image = mirror_base + re.sub(r"^[^/]*", "", orig_image_full)
+        # remove the sha256 hash from the mirrored image (if present) and replace it by temporary custom tag:
+        if "@sha256" in mirrored_image:
+            mirrored_image = mirrored_image.split("@")[0]
+            mirrored_image += f":odf-qe-temp-tag-{get_random_str(10)}"
         # mirror the image
         log.info(
             f"Mirroring image '{image}' ('{orig_image_full}') to '{mirrored_image}'"


### PR DESCRIPTION
Propagate catalog source image to the deploy_with_external_mode to support disconnected deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * External-mode deployment now accepts an optional custom OCS image parameter, letting users specify which image is used when creating the catalog source.
* **Bug Fixes**
  * Image mirroring now strips digest suffixes and applies a temporary tag so mirror targets use tag/path references, improving compatibility of mirrored images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->