### PR TITLE
added test_blackbox_exporter_probe

### DIFF
--- a/ocs_ci/ocs/resources/probe.py
+++ b/ocs_ci/ocs/resources/probe.py
@@ -1,0 +1,91 @@
+"""
+Probe resource related functionalities
+"""
+
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.ocs import OCS
+
+logger = logging.getLogger(__name__)
+
+
+class Probe(OCS):
+    """
+    Handles Probe resource operations for monitoring
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize Probe object
+
+        Args:
+            **kwargs: Additional keyword arguments passed to parent OCS class
+        """
+        kwargs.setdefault("kind", "Probe")
+        super(Probe, self).__init__(**kwargs)
+
+    def get_probe_config(self, probe_name, namespace=None):
+        """
+        Get the probe configuration.
+
+        Args:
+            probe_name (str): Name of the probe resource
+            namespace (str, optional): Namespace of the probe.
+                Defaults to openshift-storage if not provided.
+        Returns:
+            dict: Probe configuration as a dictionary
+        """
+        if namespace is None:
+            namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+
+        logger.info(f"Fetching probe configuration for: {probe_name}")
+        probe_ocp = OCP(
+            kind="Probe",
+            namespace=namespace,
+            resource_name=probe_name,
+        )
+        probe_config = probe_ocp.get()
+        logger.info(f"Successfully retrieved probe config for {probe_name}")
+        logger.debug(f"Probe config: {probe_config}")
+        return probe_config
+
+    def get_static_targets(self, probe_config):
+        """
+        Extract static target IPs from the probe configuration.
+
+        Args:
+            probe_config (dict): Probe configuration dictionary
+        Returns:
+            list: List of IP addresses configured as static targets in the probe
+        Raises:
+            RuntimeError: If unable to extract IPs from probe configuration
+        """
+        logger.info("Extracting static target IPs from probe configuration")
+        probe_ips = []
+
+        try:
+            spec = probe_config.get("spec", {})
+            targets = spec.get("targets", {})
+            static_config = targets.get("staticConfig", {})
+            static_ips = static_config.get("static", [])
+
+            if static_ips:
+                probe_ips = static_ips
+                logger.info(f"Found {len(probe_ips)} IPs in probe static config")
+                for ip in probe_ips:
+                    logger.debug(f"Probe target IP: {ip}")
+            else:
+                logger.warning("No static IPs found in probe configuration")
+                logger.debug(f"Probe config structure: {probe_config}")
+
+        except Exception as e:
+            logger.info(f"Probe config structure: {probe_config}")
+            logger.error(f"Error extracting IPs from probe config: {e}")
+            raise RuntimeError(
+                f"Failed to extract IPs from probe configuration: {e}"
+            ) from e
+
+        logger.info(f"Extracted {len(probe_ips)} IPs from probe configuration")
+        return probe_ips

--- a/ocs_ci/ocs/resources/probe.py
+++ b/ocs_ci/ocs/resources/probe.py
@@ -34,6 +34,7 @@ class Probe(OCS):
             probe_name (str): Name of the probe resource
             namespace (str, optional): Namespace of the probe.
                 Defaults to openshift-storage if not provided.
+
         Returns:
             dict: Probe configuration as a dictionary
         """
@@ -59,8 +60,10 @@ class Probe(OCS):
 
         Args:
             probe_config (dict): Probe configuration dictionary
+
         Returns:
             list: List of IP addresses configured as static targets in the probe
+
         Raises:
             RuntimeError: If unable to extract IPs from probe configuration
         """

--- a/ocs_ci/ocs/resources/probe.py
+++ b/ocs_ci/ocs/resources/probe.py
@@ -38,8 +38,10 @@ class Probe(OCS):
             dict: Probe configuration as a dictionary
         """
         if namespace is None:
-            namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
-
+            namespace = (
+                getattr(self, "namespace", None)
+                or constants.OPENSHIFT_STORAGE_NAMESPACE
+            )
         logger.info(f"Fetching probe configuration for: {probe_name}")
         probe_ocp = OCP(
             kind="Probe",

--- a/ocs_ci/utility/networking.py
+++ b/ocs_ci/utility/networking.py
@@ -344,3 +344,51 @@ def create_drs_nad(cluster_name):
     with config.RunWithProviderConfigContextIfAvailable():
         nad_obj = OCS(**nad_yaml)
         nad_obj.apply(**nad_yaml)
+
+
+def get_pod_ips(pod_selector, namespace):
+    """
+    Get pod IPs for pods matching the selector in a given namespace.
+    Only returns IPs for pods that are in Running state and not terminating.
+
+    Args:
+        pod_selector (str): Label selector to filter pods (e.g., "app=rook-ceph-osd")
+        namespace (str): Namespace to search for pods
+    Returns:
+        dict: Dictionary mapping pod names to their IP addresses
+    """
+    from ocs_ci.ocs import constants
+
+    logger.info(
+        f"Getting pod IPs for selector: {pod_selector} in namespace: {namespace}"
+    )
+    pod_ocp = OCP(kind=constants.POD, namespace=namespace)
+    pods = pod_ocp.get(selector=pod_selector)
+
+    if not pods or "items" not in pods:
+        logger.warning(f"No pods found with selector: {pod_selector}")
+        return {}
+
+    pod_ips = {}
+    for pod in pods["items"]:
+        pod_name = pod["metadata"]["name"]
+
+        pod_phase = pod.get("status", {}).get("phase")
+        deletion_timestamp = pod.get("metadata", {}).get("deletionTimestamp")
+
+        if pod_phase != "Running" or deletion_timestamp:
+            logger.debug(
+                f"Skipping pod {pod_name} - phase: {pod_phase}, "
+                f"terminating: {bool(deletion_timestamp)}"
+            )
+            continue
+
+        pod_ip = pod.get("status", {}).get("podIP")
+        if pod_ip:
+            pod_ips[pod_name] = pod_ip
+            logger.info(f"Pod: {pod_name}, IP: {pod_ip}")
+        else:
+            logger.warning(f"No IP found for pod: {pod_name}")
+
+    logger.info(f"Found {len(pod_ips)} pod IPs for selector: {pod_selector}")
+    return pod_ips

--- a/ocs_ci/utility/networking.py
+++ b/ocs_ci/utility/networking.py
@@ -354,10 +354,10 @@ def get_pod_ips(pod_selector, namespace):
     Args:
         pod_selector (str): Label selector to filter pods (e.g., "app=rook-ceph-osd")
         namespace (str): Namespace to search for pods
+
     Returns:
         dict: Dictionary mapping pod names to their IP addresses
     """
-    from ocs_ci.ocs import constants
 
     logger.info(
         f"Getting pod IPs for selector: {pod_selector} in namespace: {namespace}"

--- a/tests/functional/monitoring/test_blackbox_exporter_probe.py
+++ b/tests/functional/monitoring/test_blackbox_exporter_probe.py
@@ -10,7 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework.testlib import ManageTest, skipif_mcg_only
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.probe import Probe
+from ocs_ci.utility.networking import get_pod_ips
 
 logger = logging.getLogger(__name__)
 
@@ -22,95 +23,6 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_ocs_version("<4.22")
 class TestBlackboxExporterProbe(ManageTest):
-
-    def get_probe_config(self, probe_name="odf-blackbox-exporter"):
-        """
-        Get the probe configuration for odf-blackbox-exporter.
-        Args:
-            probe_name (str): Name of the probe resource. Default is "odf-blackbox-exporter"
-        Returns:
-            dict: Probe configuration as a dictionary
-        """
-        logger.info(f"Fetching probe configuration for: {probe_name}")
-        probe_ocp = OCP(
-            kind="Probe",
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
-            resource_name=probe_name,
-        )
-        probe_config = probe_ocp.get()
-        logger.info(f"Successfully retrieved probe config for {probe_name}")
-        logger.debug(f"Probe config: {probe_config}")
-        return probe_config
-
-    def get_pod_ips(self, pod_selector):
-        """
-        Get pod IPs for pods matching the selector.
-        Args:
-            pod_selector (str): Label selector to filter pods (e.g., "app=rook-ceph-osd")
-        Returns:
-            dict: Dictionary mapping pod names to their IP addresses
-        Example:
-            {'rook-ceph-osd-0-xxx': '10.0.0.1', 'rook-ceph-osd-1-xxx': '10.0.0.2'}
-        """
-        logger.info(f"Getting pod IPs for selector: {pod_selector}")
-        pod_ocp = OCP(
-            kind=constants.POD,
-            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
-        )
-        pods = pod_ocp.get(selector=pod_selector)
-        if not pods or "items" not in pods:
-            logger.warning(f"No pods found with selector: {pod_selector}")
-            return {}
-        pod_ips = {}
-        for pod in pods["items"]:
-            pod_name = pod["metadata"]["name"]
-            pod_phase = pod.get("status", {}).get("phase")
-            deletion_timestamp = pod.get("metadata", {}).get("deletionTimestamp")
-            if pod_phase != "Running" or deletion_timestamp:
-                logger.debug(f"Skipping pod {pod_name}")
-                continue
-            pod_ip = pod.get("status", {}).get("podIP")
-            if pod_ip:
-                pod_ips[pod_name] = pod_ip
-                logger.info(f"Pod: {pod_name}, IP: {pod_ip}")
-            else:
-                logger.warning(f"No IP found for pod: {pod_name}")
-        logger.info(f"Found {len(pod_ips)} pod IPs for selector: {pod_selector}")
-        return pod_ips
-
-    def get_ips_from_blackbox_probe(self, probe_config):
-        """
-        Extract target IPs from the blackbox exporter probe configuration.
-        Args:
-            probe_config (dict): Probe configuration dictionary
-        Returns:
-            list: List of IP addresses configured in the probe
-        """
-        logger.info("Extracting IPs from blackbox probe configuration")
-        probe_ips = []
-        try:
-            spec = probe_config.get("spec", {})
-            targets = spec.get("targets", {})
-            static_config = targets.get("staticConfig", {})
-            static_ips = static_config.get("static", [])
-
-            if static_ips:
-                probe_ips = static_ips
-                logger.info(f"Found {len(probe_ips)} IPs in probe static config")
-                for ip in probe_ips:
-                    logger.debug(f"Probe target IP: {ip}")
-            else:
-                logger.warning("No static IPs found in probe configuration")
-                logger.debug(f"Probe config structure: {probe_config}")
-
-        except Exception as e:
-            logger.info(f"Probe config structure: {probe_config}")
-            logger.error(f"Error extracting IPs from probe config: {e}")
-            raise RuntimeError(
-                f"Failed to extract IPs from probe configuration: {e}"
-            ) from e
-        logger.info(f"Extracted {len(probe_ips)} IPs from probe configuration")
-        return probe_ips
 
     @tier2
     @polarion_id("OCS-7941")
@@ -127,21 +39,26 @@ class TestBlackboxExporterProbe(ManageTest):
         """
         logger.info("Starting test: Verify blackbox probe contains OSD and MON IPs")
 
-        probe_config = self.get_probe_config("odf-blackbox-exporter")
+        probe = Probe()
+        probe_config = probe.get_probe_config("odf-blackbox-exporter")
         assert probe_config, "Failed to get probe configuration"
 
         logger.info("Getting OSD pod IPs...")
-        osd_ips = self.get_pod_ips(constants.OSD_APP_LABEL)
+        osd_ips = get_pod_ips(
+            constants.OSD_APP_LABEL, constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
         assert osd_ips, "No OSD pods found or no IPs available"
         logger.info(f"Found {len(osd_ips)} OSD pods with IPs")
 
         logger.info("Getting MON pod IPs...")
-        mon_ips = self.get_pod_ips(constants.MON_APP_LABEL)
+        mon_ips = get_pod_ips(
+            constants.MON_APP_LABEL, constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
         assert mon_ips, "No MON pods found or no IPs available"
         logger.info(f"Found {len(mon_ips)} MON pods with IPs")
 
         logger.info("Extracting IPs from probe configuration...")
-        probe_ips = self.get_ips_from_blackbox_probe(probe_config)
+        probe_ips = probe.get_static_targets(probe_config)
         assert probe_ips, "No IPs found in probe configuration"
         logger.info(f"Found {len(probe_ips)} IPs in probe configuration")
 

--- a/tests/functional/monitoring/test_blackbox_exporter_probe.py
+++ b/tests/functional/monitoring/test_blackbox_exporter_probe.py
@@ -64,6 +64,11 @@ class TestBlackboxExporterProbe(ManageTest):
         pod_ips = {}
         for pod in pods["items"]:
             pod_name = pod["metadata"]["name"]
+            pod_phase = pod.get("status", {}).get("phase")
+            deletion_timestamp = pod.get("metadata", {}).get("deletionTimestamp")
+            if pod_phase != "Running" or deletion_timestamp:
+                logger.debug(f"Skipping pod {pod_name}")
+                continue
             pod_ip = pod.get("status", {}).get("podIP")
             if pod_ip:
                 pod_ips[pod_name] = pod_ip

--- a/tests/functional/monitoring/test_blackbox_exporter_probe.py
+++ b/tests/functional/monitoring/test_blackbox_exporter_probe.py
@@ -42,9 +42,9 @@ class TestBlackboxExporterProbe(ManageTest):
         logger.debug(f"Probe config: {probe_config}")
         return probe_config
 
-    def get_pod_ips_from_network_annotations(self, pod_selector):
+    def get_pod_ips(self, pod_selector):
         """
-        Get pod IPs from network annotations for pods matching the selector.
+        Get pod IPs for pods matching the selector.
         Args:
             pod_selector (str): Label selector to filter pods (e.g., "app=rook-ceph-osd")
         Returns:
@@ -99,9 +99,11 @@ class TestBlackboxExporterProbe(ManageTest):
                 logger.debug(f"Probe config structure: {probe_config}")
 
         except Exception as e:
-            logger.error(f"Error extracting IPs from probe config: {e}")
             logger.info(f"Probe config structure: {probe_config}")
-
+            logger.error(f"Error extracting IPs from probe config: {e}")
+            raise RuntimeError(
+                f"Failed to extract IPs from probe configuration: {e}"
+            ) from e
         logger.info(f"Extracted {len(probe_ips)} IPs from probe configuration")
         return probe_ips
 
@@ -113,8 +115,8 @@ class TestBlackboxExporterProbe(ManageTest):
 
         Test Steps:
         1. Get the odf-blackbox-exporter probe configuration
-        2. Get IPs from network annotations for OSD pods
-        3. Get IPs from network annotations for MON pods
+        2. Get IPs for OSD pods
+        3. Get IPs for MON pods
         4. Extract IPs from the blackbox probe configuration
         5. Verify that all OSD and MON pod IPs are present in the probe configuration
         """
@@ -124,12 +126,12 @@ class TestBlackboxExporterProbe(ManageTest):
         assert probe_config, "Failed to get probe configuration"
 
         logger.info("Getting OSD pod IPs...")
-        osd_ips = self.get_pod_ips_from_network_annotations(constants.OSD_APP_LABEL)
+        osd_ips = self.get_pod_ips(constants.OSD_APP_LABEL)
         assert osd_ips, "No OSD pods found or no IPs available"
         logger.info(f"Found {len(osd_ips)} OSD pods with IPs")
 
         logger.info("Getting MON pod IPs...")
-        mon_ips = self.get_pod_ips_from_network_annotations(constants.MON_APP_LABEL)
+        mon_ips = self.get_pod_ips(constants.MON_APP_LABEL)
         assert mon_ips, "No MON pods found or no IPs available"
         logger.info(f"Found {len(mon_ips)} MON pods with IPs")
 

--- a/tests/functional/monitoring/test_blackbox_exporter_probe.py
+++ b/tests/functional/monitoring/test_blackbox_exporter_probe.py
@@ -1,0 +1,166 @@
+import logging
+from ocs_ci.framework.pytest_customization.marks import (
+    tier2,
+    blue_squad,
+    polarion_id,
+    skipif_external_mode,
+    skipif_managed_service,
+    skipif_ibm_cloud_managed,
+    skipif_ocs_version,
+)
+from ocs_ci.framework.testlib import ManageTest, skipif_mcg_only
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+
+logger = logging.getLogger(__name__)
+
+
+@blue_squad
+@skipif_mcg_only
+@skipif_external_mode
+@skipif_ibm_cloud_managed
+@skipif_managed_service
+@skipif_ocs_version("<4.22")
+class TestBlackboxExporterProbe(ManageTest):
+
+    def get_probe_config(self, probe_name="odf-blackbox-exporter"):
+        """
+        Get the probe configuration for odf-blackbox-exporter.
+        Args:
+            probe_name (str): Name of the probe resource. Default is "odf-blackbox-exporter"
+        Returns:
+            dict: Probe configuration as a dictionary
+        """
+        logger.info(f"Fetching probe configuration for: {probe_name}")
+        probe_ocp = OCP(
+            kind="Probe",
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+            resource_name=probe_name,
+        )
+        probe_config = probe_ocp.get()
+        logger.info(f"Successfully retrieved probe config for {probe_name}")
+        logger.debug(f"Probe config: {probe_config}")
+        return probe_config
+
+    def get_pod_ips_from_network_annotations(self, pod_selector):
+        """
+        Get pod IPs from network annotations for pods matching the selector.
+        Args:
+            pod_selector (str): Label selector to filter pods (e.g., "app=rook-ceph-osd")
+        Returns:
+            dict: Dictionary mapping pod names to their IP addresses
+        Example:
+            {'rook-ceph-osd-0-xxx': '10.0.0.1', 'rook-ceph-osd-1-xxx': '10.0.0.2'}
+        """
+        logger.info(f"Getting pod IPs for selector: {pod_selector}")
+        pod_ocp = OCP(
+            kind=constants.POD,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+        pods = pod_ocp.get(selector=pod_selector)
+        if not pods or "items" not in pods:
+            logger.warning(f"No pods found with selector: {pod_selector}")
+            return {}
+        pod_ips = {}
+        for pod in pods["items"]:
+            pod_name = pod["metadata"]["name"]
+            pod_ip = pod.get("status", {}).get("podIP")
+            if pod_ip:
+                pod_ips[pod_name] = pod_ip
+                logger.info(f"Pod: {pod_name}, IP: {pod_ip}")
+            else:
+                logger.warning(f"No IP found for pod: {pod_name}")
+        logger.info(f"Found {len(pod_ips)} pod IPs for selector: {pod_selector}")
+        return pod_ips
+
+    def get_ips_from_blackbox_probe(self, probe_config):
+        """
+        Extract target IPs from the blackbox exporter probe configuration.
+        Args:
+            probe_config (dict): Probe configuration dictionary
+        Returns:
+            list: List of IP addresses configured in the probe
+        """
+        logger.info("Extracting IPs from blackbox probe configuration")
+        probe_ips = []
+        try:
+            spec = probe_config.get("spec", {})
+            targets = spec.get("targets", {})
+            static_config = targets.get("staticConfig", {})
+            static_ips = static_config.get("static", [])
+
+            if static_ips:
+                probe_ips = static_ips
+                logger.info(f"Found {len(probe_ips)} IPs in probe static config")
+                for ip in probe_ips:
+                    logger.debug(f"Probe target IP: {ip}")
+            else:
+                logger.warning("No static IPs found in probe configuration")
+                logger.debug(f"Probe config structure: {probe_config}")
+
+        except Exception as e:
+            logger.error(f"Error extracting IPs from probe config: {e}")
+            logger.info(f"Probe config structure: {probe_config}")
+
+        logger.info(f"Extracted {len(probe_ips)} IPs from probe configuration")
+        return probe_ips
+
+    @tier2
+    @polarion_id("OCS-7941")
+    def test_blackbox_probe_osd_mon_ips(self):
+        """
+        Test to verify odf-blackbox-exporter probe contains correct OSD and MON pod IPs.
+
+        Test Steps:
+        1. Get the odf-blackbox-exporter probe configuration
+        2. Get IPs from network annotations for OSD pods
+        3. Get IPs from network annotations for MON pods
+        4. Extract IPs from the blackbox probe configuration
+        5. Verify that all OSD and MON pod IPs are present in the probe configuration
+        """
+        logger.info("Starting test: Verify blackbox probe contains OSD and MON IPs")
+
+        probe_config = self.get_probe_config("odf-blackbox-exporter")
+        assert probe_config, "Failed to get probe configuration"
+
+        logger.info("Getting OSD pod IPs...")
+        osd_ips = self.get_pod_ips_from_network_annotations(constants.OSD_APP_LABEL)
+        assert osd_ips, "No OSD pods found or no IPs available"
+        logger.info(f"Found {len(osd_ips)} OSD pods with IPs")
+
+        logger.info("Getting MON pod IPs...")
+        mon_ips = self.get_pod_ips_from_network_annotations(constants.MON_APP_LABEL)
+        assert mon_ips, "No MON pods found or no IPs available"
+        logger.info(f"Found {len(mon_ips)} MON pods with IPs")
+
+        logger.info("Extracting IPs from probe configuration...")
+        probe_ips = self.get_ips_from_blackbox_probe(probe_config)
+        assert probe_ips, "No IPs found in probe configuration"
+        logger.info(f"Found {len(probe_ips)} IPs in probe configuration")
+
+        logger.info("Verifying OSD IPs are present in probe configuration...")
+        missing_osd_ips = []
+        for pod_name, pod_ip in osd_ips.items():
+            if pod_ip not in probe_ips:
+                missing_osd_ips.append(f"{pod_name}: {pod_ip}")
+                logger.error(f"OSD pod IP not found in probe: {pod_name} ({pod_ip})")
+
+        logger.info("Verifying MON IPs are present in probe configuration...")
+        missing_mon_ips = []
+        for pod_name, pod_ip in mon_ips.items():
+            if pod_ip not in probe_ips:
+                missing_mon_ips.append(f"{pod_name}: {pod_ip}")
+                logger.error(f"MON pod IP not found in probe: {pod_name} ({pod_ip})")
+
+        assert not missing_osd_ips, (
+            f"The following OSD pod IPs are missing from probe configuration: "
+            f"{missing_osd_ips}"
+        )
+        assert not missing_mon_ips, (
+            f"The following MON pod IPs are missing from probe configuration: "
+            f"{missing_mon_ips}"
+        )
+        logger.info(
+            "Test passed: All OSD and MON pod IPs are present in "
+            "odf-blackbox-exporter probe configuration"
+        )


### PR DESCRIPTION
As part of ODF HealthOverview UI part II [RHSTOR-8145](https://redhat.atlassian.net/browse/RHSTOR-8145) ,
added a new test case test_blackbox_exporter_probe that will verify that odf-blackbox-exporter probe contains correct OSD and MON pod IPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a functional test that verifies the blackbox exporter probe’s target list includes all OSD and MON pod IPs; test auto-skips in unsupported or managed environments.
* **New Features**
  * Added a probe resource helper to fetch probe configurations and extract static target IPs.
* **Utilities**
  * Added a networking helper that discovers running pod names and their IPs in a namespace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->