### PR TITLE
delete storage policies as post destroy checks

### DIFF
--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -161,6 +161,7 @@ class VSPHEREBASE(Deployment):
         config.ENV_DATA["version_4_9_object"] = version.VERSION_4_9
 
         self.wait_time = 90
+        self.infra_id = None
 
     def attach_disk(self, size=100, disk_type=constants.VM_DISK_TYPE, ssd=False):
         """
@@ -479,6 +480,30 @@ class VSPHEREBASE(Deployment):
         # destroy the folder in templates
         template_folder = get_infra_id(self.cluster_path)
         self.vsphere.destroy_folder(template_folder, self.cluster, self.datacenter)
+        # Use infra_id captured before destroy operation
+        if self.infra_id:
+            template_folder = self.infra_id
+            self.vsphere.destroy_folder(template_folder, self.cluster, self.datacenter)
+
+            # delete storage policy created by OCP installer
+            # Storage policy name format: openshift-storage-policy-<infraID>
+            storage_policy_name = f"openshift-storage-policy-{self.infra_id}"
+            logger.info(f"Deleting storage policy: {storage_policy_name}")
+            deleted = self.vsphere.delete_storage_policy_by_exact_name(
+                storage_policy_name
+            )
+            if deleted:
+                logger.info(
+                    f"Successfully deleted storage policy: {storage_policy_name}"
+                )
+            else:
+                logger.info(
+                    f"Storage policy not found or failed to delete: {storage_policy_name}"
+                )
+        else:
+            logger.warning(
+                "infra_id not available, skipping folder and storage policy deletion"
+            )
 
         # remove .terraform directory ( this is only to reclaim space )
         terraform_plugins_dir = os.path.join(
@@ -1363,6 +1388,17 @@ class VSPHEREUPI(VSPHEREBASE):
 
         """
         previous_dir = os.getcwd()
+
+        # Get infra_id before destroy operations (metadata.json will be deleted)
+        try:
+            self.infra_id = get_infra_id(self.cluster_path)
+            logger.info(f"Captured infra_id for cleanup: {self.infra_id}")
+        except (FileNotFoundError, KeyError) as err:
+            logger.warning(
+                f"Failed to get infra_id from metadata.json: {err}. "
+                f"Storage policy cleanup may not work."
+            )
+            self.infra_id = None
 
         # Download terraform binary based on terraform version
         # in terraform.log

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -6,6 +6,7 @@ import logging
 import os
 import ssl
 import time
+import shutil
 
 import atexit
 
@@ -34,7 +35,7 @@ from ocs_ci.ocs.constants import (
     NODE_READY,
 )
 from ocs_ci.framework import config
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -1972,3 +1973,66 @@ class VSPHERE(object):
             f"VM {vm.name} did not reach the desired status {desired_status} within the timeout period."
         )
         return False
+
+    def delete_storage_policy_by_exact_name(self, policy_name):
+        """
+        Delete a storage policy by its exact name using govc.
+
+        Args:
+            policy_name (str): Exact name of the storage policy to delete
+
+        Returns:
+            bool: True if policy was deleted, False otherwise
+
+        """
+        # Check if govc is available using shutil.which
+        govc_path = shutil.which("govc")
+        if not govc_path:
+            logger.warning(
+                f"govc command not found. Storage policy '{policy_name}' leftovers cannot be checked automatically. "
+                f"Please install govc (https://github.com/vmware/govmomi/releases) "
+            )
+            return False
+
+        # Set up govc environment variables
+        # Merge with existing environment to preserve PATH
+        govc_env = os.environ.copy()
+        govc_env.update(
+            {
+                "GOVC_URL": self._host,
+                "GOVC_USERNAME": self._user,
+                "GOVC_PASSWORD": self._password,
+                "GOVC_INSECURE": "true",
+            }
+        )
+
+        try:
+            # List all storage policies to verify the policy exists
+            logger.info(f"Checking if storage policy exists: {policy_name}")
+            list_cmd = "govc storage.policy.ls"
+            result = exec_cmd(list_cmd, env=govc_env, timeout=60)
+            policies_output = result.stdout.decode("utf-8").strip().split("\n")
+
+            # govc output format: "UUID  policy-name"
+            # Check if the policy name exists in any line
+            policy_found = False
+            for policy_line in policies_output:
+                if policy_name in policy_line:
+                    policy_found = True
+                    logger.info(f"Found storage policy in line: {policy_line}")
+                    break
+
+            if not policy_found:
+                logger.info(f"Storage policy not found: {policy_name}")
+                return False
+
+            # Delete the storage policy
+            logger.info(f"Deleting storage policy: {policy_name}")
+            delete_cmd = f"govc storage.policy.rm '{policy_name}'"
+            exec_cmd(delete_cmd, env=govc_env)
+            logger.info(f"Successfully deleted storage policy: {policy_name}")
+            return True
+
+        except Exception as err:
+            logger.warning(f"Failed to delete storage policy {policy_name}: {err}")
+            return False


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VMware cluster cleanup reliability by capturing and retaining the infrastructure ID before destroy operations so post-destroy cleanup can proceed even if metadata is missing.

* **New Features**
  * Added automatic removal of vSphere storage policies and installer/template folders created during deployment, with safe handling and logging when cleanup tools or identifiers are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->