### PR TITLE
Added new test case to validate test run and clean for odf dr cli

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4,6 +4,7 @@ Helper functions specific for DR
 
 import json
 import logging
+import os
 import tempfile
 import time
 from datetime import datetime
@@ -58,8 +59,10 @@ from ocs_ci.utility.utils import (
     CommandFailed,
     run_cmd,
     exec_cmd,
+    create_directory_path,
     is_cluster_y_version_upgraded,
 )
+from ocs_ci.helpers.odf_cli import odf_cli_setup_helper
 from ocs_ci.helpers.helpers import (
     run_cmd_verify_cli_output,
     find_cephblockpoolradosnamespace,
@@ -3061,4 +3064,51 @@ def validate_protection_label(kind, namespace, protection_name=None):
 
     logger.info(
         f"Label is added to all {len(resource_items)} {kind} under {namespace} successfully"
+    )
+
+
+def run_odf_dr_test(action="run"):
+    """
+    Run ``odf dr test <action>`` and store the output in the log directory
+    following the must-gather path convention.
+
+    The output is stored at:
+        ``<log_dir>/dr_test_<action>_<run_id>/<cluster_name>/out/test-subscr/``
+
+    Args:
+        action (str): The dr test subcommand to execute. Either "run" or "clean".
+
+    Raises:
+        RuntimeError: If the ODF CLI binary cannot be initialized.
+        CommandFailed: If the ``odf dr test`` command fails.
+        AssertionError: If action is "run" and the output directory is empty.
+
+    """
+    odf_cli_runner = odf_cli_setup_helper()
+
+    output_dir = os.path.join(
+        os.path.expanduser(config.RUN["log_dir"]),
+        f"dr_test_{action}_{config.RUN['run_id']}",
+        config.ENV_DATA["cluster_name"],
+        "out",
+        "test-subscr",
+    )
+    create_directory_path(output_dir)
+
+    logger.info(f"Running ODF DR test {action}, output will be stored at: {output_dir}")
+    result = odf_cli_runner.run_command(f" dr test {action} -o {output_dir}")
+
+    cmd_output = result.stdout.decode()
+    assert "Validation Successful" in cmd_output, (
+        f"ODF DR test {action} did not report 'Validation Successful'. "
+        f"Output: {cmd_output}"
+    )
+
+    output_contents = os.listdir(output_dir)
+    assert (
+        len(output_contents) > 0
+    ), f"DR test {action} output directory is empty: {output_dir}"
+    logger.info(
+        f"ODF DR test {action} completed successfully. "
+        f"Output files: {output_contents}"
     )

--- a/tests/functional/disaster-recovery/regional-dr/test_dr_test_run.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_dr_test_run.py
@@ -1,0 +1,28 @@
+import logging
+
+from ocs_ci.framework.testlib import (
+    rdr,
+    tier1,
+    turquoise_squad,
+)
+from ocs_ci.helpers import dr_helpers
+
+logger = logging.getLogger(__name__)
+
+
+@rdr
+@tier1
+@turquoise_squad
+class TestDRTestRun:
+    """
+    Test ODF DR test run command
+
+    """
+
+    def test_dr_test_run(self):
+        """
+        Run ``odf dr test run`` and store the output in the log directory
+        following the must-gather path convention.
+
+        """
+        dr_helpers.run_odf_dr_test()


### PR DESCRIPTION
This covers critical test cases of [RHSTOR-7680](https://redhat.atlassian.net/browse/RHSTOR-7680)

This involves
1. Installing odf-cli 
2. Run commands like "odf dr test run -o out/test-subscr", "odf dr test clean -o out/test-subscr"
3. Validate output to successful validation, asserts otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper function to execute ODF disaster recovery test workflows with configurable actions and automated output validation.

* **Tests**
  * Added functional test case for disaster recovery test run validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->