### PR TITLE
Increase timeout for cosbench workload

### DIFF
--- a/tests/functional/workloads/app/cosbench/test_cosbench.py
+++ b/tests/functional/workloads/app/cosbench/test_cosbench.py
@@ -104,6 +104,7 @@ class TestCosbenchWorkload(E2ETest):
             containers=buckets,
             objects=objects,
             validate=True,
+            timeout=1200,
         )
 
         # Dispose containers and objects


### PR DESCRIPTION
Fixes #15201 

 Root Cause: Insufficient timeout (300s default) for mixed read/write workload complexity

Why 1200 seconds?
  - Init workload (create-only, 500 objects) took ~5 minutes
  - Main workload does reads AND writes on same 500 objects = 2x complexity
  - 1200s = 4x default timeout, provides safety margin



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workload operation test parameters to improve test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->