### PR TITLE
Fix PermanentRedirect error in test_mcg_namespace_object_versions_crd

### DIFF
--- a/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
@@ -467,7 +467,7 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         )[0]
         ns_bucket = ns_buc.name
         namespace_res = ns_buc.bucketclass.namespacestores[0].uls_name
-        aws_s3_client = cld_mgr.aws_client.s3_client
+        aws_s3_client = cld_mgr.aws_client.client.meta.client
 
         # Put, Get bucket versioning and verify
         logger.info(f"Enabling bucket versioning on resource bucket: {namespace_res}")

--- a/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
+++ b/tests/functional/object/mcg/lifecycle/test_mcg_namespace_s3_ops_crd.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 
-import boto3
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
@@ -461,17 +460,6 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         obj_versions = []
         version_key = "ObjKey-" + str(uuid.uuid4().hex)
         total_versions = 10
-        aws_s3_resource = boto3.resource(
-            "s3",
-            endpoint_url=constants.MCG_NS_AWS_ENDPOINT.format(
-                bucketclass_dict["namespace_policy_dict"]["namespacestore_dict"]["aws"][
-                    0
-                ][1]
-            ),
-            aws_access_key_id=cld_mgr.aws_client.access_key,
-            aws_secret_access_key=cld_mgr.aws_client.secret_key,
-        )
-
         ns_buc = bucket_factory(
             amount=1,
             interface=bucketclass_dict["interface"],
@@ -479,7 +467,7 @@ class TestMcgNamespaceS3OperationsCrd(E2ETest):
         )[0]
         ns_bucket = ns_buc.name
         namespace_res = ns_buc.bucketclass.namespacestores[0].uls_name
-        aws_s3_client = aws_s3_resource.meta.client
+        aws_s3_client = cld_mgr.aws_client.s3_client
 
         # Put, Get bucket versioning and verify
         logger.info(f"Enabling bucket versioning on resource bucket: {namespace_res}")


### PR DESCRIPTION
Problem:

  test_mcg_namespace_object_versions_crd[bucketclass_dict0] is constantly failing on 4.18 with a PermanentRedirect error when calling PutBucketVersioning.

  The test manually constructs a boto3 S3 client hardcoded to the eu-central-1 endpoint, but the underlying ULS bucket is created in a different region (based on the cloud manager's AWS
  credentials). This region mismatch causes AWS to reject the request.

  Fix:

  Replaced the manually constructed boto3.resource client with cld_mgr.aws_client.s3_client, which is already configured with the correct region where ULS buckets are provisioned. Removed the
  now-unused boto3 import.

  Fixes: https://github.com/red-hat-storage/ocs-ci/issues/14303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed direct per-test S3 client creation and switched tests to use the centralized AWS S3 client from test infrastructure for object/version operations.
  * Improves test reliability, maintainability, and consistency across S3-related functional tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->