### PR TITLE
Fix test_account_update_with_custom_creds_using_cli CLI path mismatch and shell quoting

### DIFF
--- a/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
+++ b/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
@@ -1,6 +1,8 @@
 import logging
+import shlex
 import string
 import random
+from pathlib import Path
 
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -13,48 +15,72 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import retrieve_cli_binary
 from ocs_ci.utility.utils import run_cmd, get_random_str
 from ocs_ci.helpers.helpers import get_s3_credentials_from_secret
-from pathlib import Path
 from ocs_ci.utility import version as version_module
-from ocs_ci.utility.utils import get_noobaa_cli_config
+from ocs_ci.ocs import constants
 
 
 logger = logging.getLogger(__name__)
-# Use version-appropriate CLI path and command prefix
-mcg_cli, mcg_command_prefix = get_noobaa_cli_config()
 
 
-def build_mcg_command(command_args):
+def ensure_mcg_cli():
+    """
+    Ensure the NooBaa CLI binary is downloaded and return
+    (cli_path, command_prefix).
+
+    For >= 4.20: uses ODFCLIRetriever → (bin_dir/odf, "noobaa")
+    For <  4.20: uses retrieve_cli_binary("mcg") → (DATA_DIR/mcg-cli, "")
+
+    Returns:
+        tuple: (cli_path, command_prefix)
+    """
+    ocs_version = version_module.get_semantic_ocs_version_from_config()
+
+    if ocs_version >= version_module.VERSION_4_20:
+        from ocs_ci.helpers.odf_cli import ODFCLIRetriever
+
+        retriever = ODFCLIRetriever()
+        if not retriever.check_odf_cli_binary():
+            retriever.retrieve_odf_cli_binary()
+        return retriever.local_cli_path, "noobaa"
+    else:
+        cli_path = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
+        if not Path(cli_path).exists():
+            retrieve_cli_binary(cli_type="mcg")
+        return cli_path, ""
+
+
+def build_mcg_command(cli_path, prefix, command_args):
     """
     Build NooBaa CLI command with appropriate prefix based on version.
 
     Args:
+        cli_path (str): Path to the CLI binary
+        prefix (str): Command prefix ("noobaa" for odf-cli, "" for mcg-cli)
         command_args (str): Command arguments to append after CLI and prefix
 
     Returns:
         str: Complete CLI command string
     """
-    if mcg_command_prefix:
-        # For odf-cli: odf-cli noobaa <command>
-        return f"{mcg_cli} {mcg_command_prefix} {command_args}"
+    if prefix:
+        return f"{cli_path} {prefix} {command_args}"
     else:
-        # For mcg-cli: mcg-cli <command>
-        return f"{mcg_cli} {command_args}"
+        return f"{cli_path} {command_args}"
 
 
 @red_squad
 @mcg
 class TestCustomCredsUsingMcgCli(MCGTest):
-    def update_nb_account(self, account_name, access_key, secret_key):
+    def update_nb_account(self, cli_path, prefix, account_name, access_key, secret_key):
         """
         Update noobaa account with custom credential values
         """
         namespace = config.ENV_DATA["cluster_namespace"]
-
-        # Build command based on CLI version
-        cmd = build_mcg_command(f"account credentials {account_name}")
-
-        cmd += f" --access-key={access_key} --secret-key={secret_key} -n {namespace}"
-
+        cmd = build_mcg_command(cli_path, prefix, f"account credentials {account_name}")
+        cmd += (
+            f" --access-key={shlex.quote(access_key)}"
+            f" --secret-key={shlex.quote(secret_key)}"
+            f" -n {namespace}"
+        )
         output = run_cmd(cmd=cmd, ignore_error=True)
         logger.info(output)
 
@@ -64,23 +90,16 @@ class TestCustomCredsUsingMcgCli(MCGTest):
         """
         1. Create a new account using MCG CLI
         2. Retrive creds of the account
-        3. Change creds of the with custom value suing CLI
+        3. Change creds of the with custom value using CLI
         4. Verify creds are updated using CLI
-        5. Validate custom credentials against against length and valid characters
+        5. Validate custom credentials against length and valid characters
         """
-        if not Path(mcg_cli).exists():
-            # Download appropriate CLI binary based on version
-            ocs_version = version_module.get_semantic_ocs_version_from_config()
-            if ocs_version >= version_module.VERSION_4_20:
-                retrieve_cli_binary(cli_type="odf")
-            else:
-                retrieve_cli_binary(cli_type="mcg")
+        cli_path, prefix = ensure_mcg_cli()
 
-        # Build version command based on CLI version
-        version_cmd = build_mcg_command("version")
-
+        version_cmd = build_mcg_command(cli_path, prefix, "version")
         output = run_cmd(cmd=version_cmd)
         logger.info(output)
+
         account_name = get_random_str(5)
         original_acc_credentials = mcg_account_factory(name=account_name)
         original_secret_key = original_acc_credentials["access_key"]
@@ -91,7 +110,9 @@ class TestCustomCredsUsingMcgCli(MCGTest):
         logger.info("Updating noobaa account credentials with custom values")
         new_access_key = get_random_str(20)
         new_secret_key = get_random_str(40)
-        self.update_nb_account(account_name, new_access_key, new_secret_key)
+        self.update_nb_account(
+            cli_path, prefix, account_name, new_access_key, new_secret_key
+        )
         retrived_access_key, retrived_secret_key = get_s3_credentials_from_secret(
             f"noobaa-account-{account_name}"
         )
@@ -104,11 +125,12 @@ class TestCustomCredsUsingMcgCli(MCGTest):
             retrived_secret_key == new_secret_key
         ), "Mismatch in updated and new secret key"
         logger.info("Custom credentials updated successfully")
+
         logger.info("Updating credentials with incorrect length")
         bad_length_access_key = get_random_str(19)
         bad_length_secret_key = get_random_str(39)
         self.update_nb_account(
-            account_name, bad_length_access_key, bad_length_secret_key
+            cli_path, prefix, account_name, bad_length_access_key, bad_length_secret_key
         )
         retrived_access_key, retrived_secret_key = get_s3_credentials_from_secret(
             f"noobaa-account-{account_name}"
@@ -122,6 +144,7 @@ class TestCustomCredsUsingMcgCli(MCGTest):
             retrived_secret_key != bad_length_secret_key
         ), "CLI is accepting secret key with invalid lenght"
         logger.info("Credentials with incorrect length didnt updated as expected")
+
         logger.info("Updating credentials with invalid characters")
         bad_access_key = bad_length_access_key + "".join(
             random.choices(
@@ -133,7 +156,9 @@ class TestCustomCredsUsingMcgCli(MCGTest):
                 [ch for ch in string.punctuation if ch not in ['"', "'", "+", "/"]], k=1
             )
         )
-        self.update_nb_account(account_name, bad_access_key, bad_secret_key)
+        self.update_nb_account(
+            cli_path, prefix, account_name, bad_access_key, bad_secret_key
+        )
         retrived_access_key, retrived_secret_key = get_s3_credentials_from_secret(
             f"noobaa-account-{account_name}"
         )

--- a/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
+++ b/tests/functional/object/mcg/test_custom_credentials_using_mcg_cli.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shlex
 import string
 import random
@@ -44,7 +45,7 @@ def ensure_mcg_cli():
         return retriever.local_cli_path, "noobaa"
     else:
         cli_path = constants.NOOBAA_OPERATOR_LOCAL_CLI_PATH
-        if not Path(cli_path).exists():
+        if not (Path(cli_path).is_file() and os.access(cli_path, os.X_OK)):
             retrieve_cli_binary(cli_type="mcg")
         return cli_path, ""
 


### PR DESCRIPTION
 PR Description:

  - Fix CLI binary path mismatch causing FileNotFoundError on ODF >= 4.20
  - Fix shell quoting of credentials causing ValueError on special characters
  - Replace module-level CLI path resolution with dynamic `ensure_mcg_cli()` that works across all OCS versions (4.17–4.21+)

Fixes https://github.com/red-hat-storage/ocs-ci/issues/13457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now automatically locate and use the appropriate NooBaa/MCG CLI binary for the current environment, improving reliability across OCS/ODF versions.
  * CLI path and prefix are explicitly passed through test steps and used for a CLI version check before credential tests.
  * Setup was simplified by removing prior module-level initialization and tightening credential update scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->