### PR TITLE
Fix intermittent test_pv_pool_with_nfs failures due to NFS mount timeout

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import os
 import pandas as pd
 import random
 import secrets
-import socket
 import string
 import time
 import tempfile
@@ -10771,12 +10770,28 @@ def setup_nfs(request, setup_rbac):
                 f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
             )
 
+        log.info(f"Checking DNS resolution of NFS server '{nfs_server}' from cluster")
         try:
-            socket.getaddrinfo(nfs_server, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        except socket.gaierror:
-            pytest.skip(
-                f"NFS server '{nfs_server}' is not DNS-resolvable from this cluster; "
-                f"skipping NFS test"
+            node_name = (
+                exec_cmd("oc get nodes -o jsonpath='{.items[0].metadata.name}'")
+                .stdout.decode()
+                .strip()
+                .strip("'")
+            )
+            result = exec_cmd(
+                f"oc debug node/{node_name} --to-namespace=default "
+                f"-- chroot /host getent hosts {nfs_server}",
+                ignore_error=True,
+            )
+            if not result.stdout or not result.stdout.decode().strip():
+                pytest.skip(
+                    f"NFS server '{nfs_server}' is not DNS-resolvable from "
+                    f"cluster node {node_name}; skipping NFS test"
+                )
+        except Exception:
+            log.warning(
+                f"Could not verify DNS resolution of '{nfs_server}' from cluster, "
+                f"proceeding with test"
             )
 
         log.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10763,6 +10763,13 @@ def setup_nfs(request, setup_rbac):
 
         # Update the deployment with ocs-ci noobaa nfs server
         # noobaa nfs mount path and create the deployment
+        nfs_server = config.ENV_DATA.get("nb_nfs_server")
+        nfs_mount = config.ENV_DATA.get("nb_nfs_mount")
+        if not nfs_server or not nfs_mount:
+            raise ValueError(
+                f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
+            )
+
         log.info(
             "Updating NFS client provisioner data with Noobaa NFS server and NFS mount path info"
         )
@@ -10771,25 +10778,49 @@ def setup_nfs(request, setup_rbac):
         )
         nfs_client_prov_dep_data["spec"]["template"]["spec"]["containers"][0]["env"][1][
             "value"
-        ] = config.ENV_DATA.get("nb_nfs_server")
+        ] = nfs_server
         nfs_client_prov_dep_data["spec"]["template"]["spec"]["containers"][0]["env"][2][
             "value"
-        ] = config.ENV_DATA.get("nb_nfs_mount")
+        ] = nfs_mount
         nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"][0]["nfs"][
             "server"
-        ] = config.ENV_DATA.get("nb_nfs_server")
+        ] = nfs_server
         nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"][0]["nfs"][
             "path"
-        ] = config.ENV_DATA.get("nb_nfs_mount")
+        ] = nfs_mount
         log.info("Creating NFS client provisioner deployment")
         create_resource(**nfs_client_prov_dep_data)
         nfs_client_dep_obj = OCS(**nfs_client_prov_dep_data)
 
         log.info("Waiting for NFS client provisioner pods to be running")
-        assert wait_for_pods_to_be_in_statuses(
+        pods_running = wait_for_pods_to_be_in_statuses(
             expected_statuses=constants.STATUS_RUNNING,
             namespace=constants.NFS_NAMESPACE_NAME,
-        ), "NFS provisioner pods didn't start up successfully"
+            timeout=600,
+        )
+        if not pods_running:
+            ocp_pod = OCP(kind=constants.POD, namespace=constants.NFS_NAMESPACE_NAME)
+            try:
+                pod_data = ocp_pod.get()
+                for pod in pod_data.get("items", []):
+                    pod_name = pod["metadata"]["name"]
+                    phase = pod.get("status", {}).get("phase")
+                    log.error(f"NFS provisioner pod {pod_name} phase: {phase}")
+                    for cond in pod.get("status", {}).get("conditions", []):
+                        log.error(
+                            f"  Condition {cond.get('type')}: "
+                            f"{cond.get('status')} - {cond.get('message', '')}"
+                        )
+            except Exception:
+                log.exception("Failed to get NFS pod details for diagnostics")
+            try:
+                ocp_event = OCP(kind="Event", namespace=constants.NFS_NAMESPACE_NAME)
+                event_data = ocp_event.get()
+                for event in event_data.get("items", []):
+                    log.error(f"  Event: {event.get('reason')}: {event.get('message')}")
+            except Exception:
+                log.exception("Failed to get NFS namespace events for diagnostics")
+        assert pods_running, "NFS provisioner pods didn't start up successfully"
 
     finally:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10780,14 +10780,28 @@ def setup_nfs(request, setup_rbac):
             0
         ]
         env_by_name = {e.get("name"): e for e in container.get("env", [])}
+        missing_env = [k for k in ("NFS_SERVER", "NFS_PATH") if k not in env_by_name]
+        if missing_env:
+            raise ValueError(
+                f"NFS deployment template missing env vars: {', '.join(missing_env)}"
+            )
         env_by_name["NFS_SERVER"]["value"] = nfs_server
         env_by_name["NFS_PATH"]["value"] = nfs_mount
 
         nfs_volume = next(
-            v
-            for v in nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"]
-            if v.get("name") == "nfs-client-root"
+            (
+                v
+                for v in nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"]
+                if v.get("name") == "nfs-client-root"
+            ),
+            None,
         )
+        if nfs_volume is None:
+            raise ValueError("NFS deployment template missing volume 'nfs-client-root'")
+        if "nfs" not in nfs_volume:
+            raise ValueError(
+                "NFS deployment template volume 'nfs-client-root' is missing 'nfs' section"
+            )
         nfs_volume["nfs"]["server"] = nfs_server
         nfs_volume["nfs"]["path"] = nfs_mount
         log.info("Creating NFS client provisioner deployment")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10776,18 +10776,20 @@ def setup_nfs(request, setup_rbac):
         nfs_client_prov_dep_data = templating.load_yaml(
             constants.NFS_DEPLOYMENT_YAML_DIR
         )
-        nfs_client_prov_dep_data["spec"]["template"]["spec"]["containers"][0]["env"][1][
-            "value"
-        ] = nfs_server
-        nfs_client_prov_dep_data["spec"]["template"]["spec"]["containers"][0]["env"][2][
-            "value"
-        ] = nfs_mount
-        nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"][0]["nfs"][
-            "server"
-        ] = nfs_server
-        nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"][0]["nfs"][
-            "path"
-        ] = nfs_mount
+        container = nfs_client_prov_dep_data["spec"]["template"]["spec"]["containers"][
+            0
+        ]
+        env_by_name = {e.get("name"): e for e in container.get("env", [])}
+        env_by_name["NFS_SERVER"]["value"] = nfs_server
+        env_by_name["NFS_PATH"]["value"] = nfs_mount
+
+        nfs_volume = next(
+            v
+            for v in nfs_client_prov_dep_data["spec"]["template"]["spec"]["volumes"]
+            if v.get("name") == "nfs-client-root"
+        )
+        nfs_volume["nfs"]["server"] = nfs_server
+        nfs_volume["nfs"]["path"] = nfs_mount
         log.info("Creating NFS client provisioner deployment")
         create_resource(**nfs_client_prov_dep_data)
         nfs_client_dep_obj = OCS(**nfs_client_prov_dep_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 import random
 import secrets
+import socket
 import string
 import time
 import tempfile
@@ -10768,6 +10769,14 @@ def setup_nfs(request, setup_rbac):
         if not nfs_server or not nfs_mount:
             raise ValueError(
                 f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
+            )
+
+        try:
+            socket.getaddrinfo(nfs_server, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        except socket.gaierror:
+            pytest.skip(
+                f"NFS server '{nfs_server}' is not DNS-resolvable from this cluster; "
+                f"skipping NFS test"
             )
 
         log.info(


### PR DESCRIPTION
  Summary:

  The setup_nfs fixture frequently failed because the NFS client provisioner pod timed out during startup. The root causes were:

  - The default 180s timeout was too short for NFS volume mounts via the in-tree kubernetes.io/nfs plugin
  - On clusters without network access to the NFS server (e.g., IBM Cloud), the pod would hang until timeout with no useful diagnostics
  - Template manipulation used brittle positional indexing that could silently apply config to the wrong fields

  Changes:

  - Skip test on unreachable NFS servers — added an in-cluster DNS resolution check using oc debug node + getent hosts before proceeding with setup. If the NFS server is not resolvable from the
   cluster, the test is skipped with a clear message instead of failing after a long timeout.
  - Config validation — fail fast with a clear error if nb_nfs_server or nb_nfs_mount are missing from ENV_DATA
  - Name-based template lookups — replaced positional index access with lookups by env var name (NFS_SERVER, NFS_PATH) and volume name (nfs-client-root), with validation guards for missing
  fields
  - Increased timeout — 180s → 600s for wait_for_pods_to_be_in_statuses
  - Diagnostic logging on failure — logs pod phase, conditions, and namespace events before asserting

  Fixes https://github.com/red-hat-storage/ocs-ci/issues/14692




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Stronger NFS test setup: now requires NFS server and mount config, validates provisioning configuration (NFS server/path and volume presence), and skips tests when the NFS server is unreachable or not DNS-resolvable from the cluster.
  * Improved provisioning reliability: waits up to 10 minutes for provisioner pods to reach running state and, on timeout, gathers detailed diagnostics (per-pod phases/conditions and namespace event messages) to aid troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->