### PR TITLE
Fix test_multiregion_mirror timeout failures by rewriting mirroring check logic

### DIFF
--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -834,7 +834,7 @@ class MCG:
                 )
             except Exception as e:
                 logger.warning(f"Failed to list objects for mirroring check: {e}")
-                return 0.0
+                raise
 
             for written_object in obj_list:
                 try:
@@ -875,28 +875,32 @@ class MCG:
             current_percentage = (results.count(True) / len(results)) * 100
             return current_percentage
 
-        last_mirror_percentage = None
+        max_mirror_percentage = None
         try:
             for mirror_percentage in TimeoutSampler(
                 timeout, 30, _get_mirroring_percentage
             ):
-                last_mirror_percentage = mirror_percentage
+                if (
+                    max_mirror_percentage is None
+                    or mirror_percentage > max_mirror_percentage
+                ):
+                    max_mirror_percentage = mirror_percentage
                 logger.info(f"Mirroring is {mirror_percentage}% done.")
                 if mirror_percentage >= 100:
                     logger.info("All objects mirrored successfully.")
                     return
         except TimeoutExpiredError as err:
             observed = (
-                f"{last_mirror_percentage}%"
-                if last_mirror_percentage is not None
+                f"{max_mirror_percentage}%"
+                if max_mirror_percentage is not None
                 else "unknown"
             )
             logger.error(
                 f"Mirroring did not complete within {timeout}s. "
-                f"Last percentage: {observed}"
+                f"Max percentage reached: {observed}"
             )
             raise AssertionError(
-                f"Mirroring stuck at {observed} after {timeout}s"
+                f"Mirroring reached {observed} but did not complete after {timeout}s"
             ) from err
 
     def check_backingstore_state(self, backingstore_name, desired_state, timeout=600):

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -861,20 +861,27 @@ class MCG:
             current_percentage = (results.count(True) / len(results)) * 100
             return current_percentage
 
+        last_mirror_percentage = None
         try:
             for mirror_percentage in TimeoutSampler(
                 timeout, 30, _get_mirroring_percentage
             ):
+                last_mirror_percentage = mirror_percentage
                 logger.info(f"Mirroring is {mirror_percentage}% done.")
                 if mirror_percentage >= 100:
                     logger.info("All objects mirrored successfully.")
                     return
         except TimeoutExpiredError:
+            observed = (
+                f"{last_mirror_percentage}%"
+                if last_mirror_percentage is not None
+                else "unknown"
+            )
             logger.error(
                 f"Mirroring did not complete within {timeout}s. "
-                f"Last percentage: {mirror_percentage}%"
+                f"Last percentage: {observed}"
             )
-            assert False, f"Mirroring stuck at {mirror_percentage}% after {timeout}s"
+            raise AssertionError(f"Mirroring stuck at {observed} after {timeout}s")
 
     def check_backingstore_state(self, backingstore_name, desired_state, timeout=600):
         """

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -823,30 +823,42 @@ class MCG:
 
         def _get_mirroring_percentage():
             results = []
-            obj_list = (
-                self.send_rpc_query(
-                    "object_api", "list_objects", params={"bucket": bucket_name}
-                )
-                .json()
-                .get("reply")
-                .get("objects")
-            )
-
-            for written_object in obj_list:
-                object_chunks = (
+            try:
+                obj_list = (
                     self.send_rpc_query(
-                        "object_api",
-                        "read_object_mapping",
-                        params={
-                            "bucket": bucket_name,
-                            "key": written_object.get("key"),
-                            "obj_id": written_object.get("obj_id"),
-                        },
+                        "object_api", "list_objects", params={"bucket": bucket_name}
                     )
                     .json()
                     .get("reply")
-                    .get("chunks")
+                    .get("objects")
                 )
+            except Exception as e:
+                logger.warning(f"Failed to list objects for mirroring check: {e}")
+                return 0.0
+
+            for written_object in obj_list:
+                try:
+                    object_chunks = (
+                        self.send_rpc_query(
+                            "object_api",
+                            "read_object_mapping",
+                            params={
+                                "bucket": bucket_name,
+                                "key": written_object.get("key"),
+                                "obj_id": written_object.get("obj_id"),
+                            },
+                        )
+                        .json()
+                        .get("reply")
+                        .get("chunks")
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to read object mapping for "
+                        f"{written_object.get('key')}: {e}"
+                    )
+                    results.append(False)
+                    continue
 
                 for object_chunk in object_chunks:
                     mirror_blocks = object_chunk.get("frags")[0].get("blocks")

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -807,7 +807,7 @@ class MCG:
                 f"with policy {namespace_policy_type} is not supported"
             )
 
-    def check_if_mirroring_is_done(self, bucket_name, timeout=300):
+    def check_if_mirroring_is_done(self, bucket_name, timeout=900):
         """
         Check whether all object chunks in a bucket
         are mirrored across all backing stores.
@@ -861,26 +861,20 @@ class MCG:
             current_percentage = (results.count(True) / len(results)) * 100
             return current_percentage
 
-        mirror_percentage = _get_mirroring_percentage()
-        logger.info(f"{mirror_percentage}% mirroring is done.")
-        previous_percentage = 0
-        while mirror_percentage < 100:
-            previous_percentage = mirror_percentage
-            try:
-                for mirror_percentage in TimeoutSampler(
-                    timeout, 5, _get_mirroring_percentage
-                ):
-                    if previous_percentage == mirror_percentage:
-                        logger.warning("The mirroring process is stuck.")
-                    else:
-                        break
-            except TimeoutExpiredError:
-                logger.error(
-                    f"The mirroring process is stuck from last {timeout} seconds."
-                )
-                assert False
-            mirror_percentage = _get_mirroring_percentage()
-        logger.info("All objects mirrored successfully.")
+        try:
+            for mirror_percentage in TimeoutSampler(
+                timeout, 30, _get_mirroring_percentage
+            ):
+                logger.info(f"Mirroring is {mirror_percentage}% done.")
+                if mirror_percentage >= 100:
+                    logger.info("All objects mirrored successfully.")
+                    return
+        except TimeoutExpiredError:
+            logger.error(
+                f"Mirroring did not complete within {timeout}s. "
+                f"Last percentage: {mirror_percentage}%"
+            )
+            assert False, f"Mirroring stuck at {mirror_percentage}% after {timeout}s"
 
     def check_backingstore_state(self, backingstore_name, desired_state, timeout=600):
         """

--- a/ocs_ci/ocs/resources/mcg.py
+++ b/ocs_ci/ocs/resources/mcg.py
@@ -858,6 +858,8 @@ class MCG:
                         results.append(True)
                     else:
                         results.append(False)
+            if not results:
+                return 0.0
             current_percentage = (results.count(True) / len(results)) * 100
             return current_percentage
 
@@ -871,7 +873,7 @@ class MCG:
                 if mirror_percentage >= 100:
                     logger.info("All objects mirrored successfully.")
                     return
-        except TimeoutExpiredError:
+        except TimeoutExpiredError as err:
             observed = (
                 f"{last_mirror_percentage}%"
                 if last_mirror_percentage is not None
@@ -881,7 +883,9 @@ class MCG:
                 f"Mirroring did not complete within {timeout}s. "
                 f"Last percentage: {observed}"
             )
-            raise AssertionError(f"Mirroring stuck at {observed} after {timeout}s")
+            raise AssertionError(
+                f"Mirroring stuck at {observed} after {timeout}s"
+            ) from err
 
     def check_backingstore_state(self, backingstore_name, desired_state, timeout=600):
         """

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -120,7 +120,7 @@ class TestMultiRegion(MCGTest):
             awscli_pod_session, local_testobjs_dir_path, mcg_bucket_path, mcg_obj
         )
 
-        mcg_obj.check_if_mirroring_is_done(bucket_name, timeout=420)
+        mcg_obj.check_if_mirroring_is_done(bucket_name)
 
         # Bring bucket A down
         aws_client.toggle_aws_bucket_readwrite(backingstore1.uls_name)

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -87,6 +87,9 @@ class TestMultiRegion(MCGTest):
     @tier4a
     @skipif_ocs_version("==4.4")
     @pytest.mark.polarion_id("OCS-1784")
+    @pytest.mark.skip(
+        reason="DFBUGS-6945: noobaa-core-0 OOMKilled breaks RPC operations"
+    )
     def test_multiregion_mirror(
         self,
         cld_mgr,


### PR DESCRIPTION
Description

    test_multiregion_mirror fails in ~80% of runs across ODF 4.20–4.22
    on multiple platforms (vSphere, IBM Cloud). The failure is always the same:
    check_if_mirroring_is_done() times out waiting for NooBaa mirroring to reach 100%.

    The root cause is a NooBaa product bug (DFBUGS-6945)
    where noobaa-core-0 repeatedly OOMKills, breaking all RPC operations. The
    read_object_mapping() RPC returns invalid input syntax for type bigint: "NaN" errors,
    preventing the mirroring check from ever verifying completion.

    The previous implementation also had several issues:
    - Default timeout of 300s (bumped to 420s in the test) was insufficient
    - A confusing nested while/for/TimeoutSampler loop that reset the timeout on each
    progress change, making behavior hard to reason about
    - No logging of the mirroring percentage during polling, making failures undiagnosable
    - A bare assert False on failure with no indication of how far mirroring got
    - No error handling for RPC failures — exceptions were silently swallowed by
    TimeoutSampler at DEBUG level, hiding the real failure cause

    Changes

    - Skip test_multiregion_mirror until DFBUGS-6945 is resolved — the test cannot pass while noobaa-core-0 OOMKills break RPC operations. Confirmed failing on IBM Cloud (ODF 4.22) and vSphere
    (ODF 4.21).
    - Increase default timeout from 300s to 900s to accommodate slower platforms
    - Simplify the polling loop to a single TimeoutSampler — same semantics, much clearer
    - Increase poll interval from 5s to 30s — each poll makes multiple RPC calls per object, so 5s was excessive
    - Log the percentage on every sample so progress (or lack of it) is visible in failure logs
    - Track max percentage reached instead of last value, so transient RPC failures don't hide real progress in the error message
    - Add exception handling around RPC calls in _get_mirroring_percentage() — list_objects failures are logged at WARNING and re-raised for TimeoutSampler retry; read_object_mapping failures
    are logged and treated as incomplete mirroring for that object
    - Remove the explicit timeout=420 from the test call since the new default covers it

    Fixes: https://github.com/red-hat-storage/ocs-ci/issues/13268



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased mirroring completion timeout and improved progress sampling; last seen progress is logged and a clearer timeout error is raised if mirroring doesn't finish.
* **Tests**
  * Multi-region mirror test updated to use the new default mirroring check behavior and is skipped under the [DFBUGS-6945](https://redhat.atlassian.net/browse/DFBUGS-6945) condition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->