### PR TITLE
Fix namespacestore health check crash in test_obj_owner_in_obc_buckets and add diagnostic logging on timeout

### DIFF
--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -147,12 +147,16 @@ class NamespaceStore:
             bool: Based on whether the namespace store is healthy or not
 
         """
-        nss_data = OCP(
-            kind="namespacestore",
-            namespace=config.ENV_DATA["cluster_namespace"],
-            resource_name=self.name,
-        ).get()
-        return nss_data.get("status", {}).get("phase") == constants.STATUS_READY
+        try:
+            nss_data = OCP(
+                kind="namespacestore",
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=self.name,
+            ).get()
+            return nss_data.get("status", {}).get("phase") == constants.STATUS_READY
+        except CommandFailed:
+            log.info(f"Namespacestore {self.name} not found or not accessible yet")
+            return False
 
     def verify_health(self, timeout=360, interval=5):
         """
@@ -190,7 +194,7 @@ class NamespaceStore:
                     f"{self.name} stuck in phase '{phase}', conditions: {conditions}"
                 )
             except Exception:
-                log.error(f"Failed to retrieve status for {self.name}")
+                log.exception(f"Failed to retrieve status for {self.name}")
             log.error(
                 f"{self.name} did not reach a healthy state within {timeout} seconds."
             )

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -147,14 +147,12 @@ class NamespaceStore:
             bool: Based on whether the namespace store is healthy or not
 
         """
-        return (
-            OCP(
-                kind="namespacestore",
-                namespace=config.ENV_DATA["cluster_namespace"],
-                resource_name=self.name,
-            ).get()["status"]["phase"]
-            == constants.STATUS_READY
-        )
+        nss_data = OCP(
+            kind="namespacestore",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=self.name,
+        ).get()
+        return nss_data.get("status", {}).get("phase") == constants.STATUS_READY
 
     def verify_health(self, timeout=360, interval=5):
         """
@@ -180,6 +178,19 @@ class NamespaceStore:
                 else:
                     log.info(f"{self.name} is unhealthy. Rechecking.")
         except TimeoutExpiredError:
+            try:
+                nss_data = OCP(
+                    kind="namespacestore",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                    resource_name=self.name,
+                ).get()
+                phase = nss_data.get("status", {}).get("phase", "N/A")
+                conditions = nss_data.get("status", {}).get("conditions", [])
+                log.error(
+                    f"{self.name} stuck in phase '{phase}', conditions: {conditions}"
+                )
+            except Exception:
+                log.error(f"Failed to retrieve status for {self.name}")
             log.error(
                 f"{self.name} did not reach a healthy state within {timeout} seconds."
             )


### PR DESCRIPTION
## Problem

  `test_obj_owner_in_obc_buckets[ibmcos-nss]` consistently fails during setup
  when creating an IBM COS namespacestore. Two issues were identified:

  1. `oc_verify_health()` crashes with `KeyError: 'status'` when called on a
     freshly created namespacestore CR that hasn't been reconciled yet. The
     TimeoutSampler catches the exception and retries, but the method should
     return `False` gracefully instead of raising.

  2. When the namespacestore never reaches a Ready state and the health check
     times out, there is no diagnostic information logged about *why* it failed
     — only that it timed out. This makes root-cause analysis difficult.

  ## Fixes

  - **`oc_verify_health`**: Replaced `get()["status"]["phase"]` with safe
    attribute access via `.get("status", {}).get("phase")`, which returns
    `False` instead of raising `KeyError` on CRs without a status field.

  - **`verify_health`**: Added a diagnostic block in the `TimeoutExpiredError`
    handler that fetches the namespacestore CR and logs the actual phase and
    conditions before asserting, so future failures will show exactly what
    state the namespacestore is stuck in.

  ## Issue

  Fixes https://github.com/red-hat-storage/ocs-ci/issues/14302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust namespace store health checks that safely handle missing or unexpected status data, reducing false failures.
  * Improved timeout handling with additional diagnostic retrieval and logging of current status and conditions to aid troubleshooting without causing extra failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->