### PR TITLE
[MCG 4.22] Add Azure STS backingstore and namespacestore tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,9 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7083,
         "line_number": 7091,
-        "line_number": 7140,
         "type": "Private Key",
         "verified_result": null
       }
@@ -579,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 374,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -600,7 +598,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2896,
-        "line_number": 2897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -648,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -656,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 846,
+        "line_number": 838,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -664,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2016,
+        "line_number": 2032,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -672,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2123,
+        "line_number": 2139,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -680,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2124,
+        "line_number": 2140,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -688,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2125,
+        "line_number": 2141,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -696,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2126,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -704,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2131,
+        "line_number": 2147,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -712,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2146,
+        "line_number": 2162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -720,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2147,
+        "line_number": 2163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -728,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2155,
+        "line_number": 2171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -736,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2156,
+        "line_number": 2172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -744,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2157,
+        "line_number": 2173,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -752,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2158,
+        "line_number": 2174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -760,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2159,
+        "line_number": 2175,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -768,8 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2767,
-        "line_number": 2752,
+        "line_number": 2771,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -777,8 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2924,
-        "line_number": 2909,
+        "line_number": 2936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -786,8 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2925,
-        "line_number": 2910,
+        "line_number": 2937,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -795,8 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3646,
-        "line_number": 3631,
+        "line_number": 3658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,8 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3647,
-        "line_number": 3632,
+        "line_number": 3659,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1023,7 +1015,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 653,
+        "line_number": 746,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -836,9 +836,6 @@ def oc_create_azure_sts_backingstore(cld_mgr, backingstore_name, uls_name, regio
         "azureBlob": {
             "targetBlobContainer": uls_name,
             "clientId": cld_mgr.azure_sts_client.client_id,
-            "tenantId": cld_mgr.azure_sts_client.tenant_id,
-            "subscriptionId": cld_mgr.azure_sts_client.subscription_id,
-            "resourcegroupId": cld_mgr.azure_sts_client.resource_group,
             "secret": {
                 "name": cld_mgr.azure_sts_client.secret.name,
                 "namespace": bs_data["metadata"]["namespace"],

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -793,6 +793,61 @@ def cli_create_aws_sts_backingstore(
     )
 
 
+def cli_create_azure_sts_backingstore(
+    mcg_obj, cld_mgr, backingstore_name, uls_name, region
+):
+    """
+    Create a new backingstore of type azure-sts-blob using managed identity credentials
+
+    Args:
+        mcg_obj (MCG): Used for execution for the NooBaa CLI command
+        cld_mgr (CloudManager): holds Azure STS credentials for backingstore creation
+        backingstore_name (str): backingstore name
+        uls_name (str): underlying storage name
+        region (str): which region to create backingstore (should be the same as uls)
+
+    """
+    mcg_obj.exec_mcg_cmd(
+        f"backingstore create azure-sts-blob {backingstore_name} "
+        f"--target-blob-container {uls_name} "
+        f"--tenant-id {cld_mgr.azure_sts_client.tenant_id} "
+        f"--client-id {cld_mgr.azure_sts_client.client_id} "
+        f"--account-name {cld_mgr.azure_sts_client.account_name}",
+        use_yes=True,
+    )
+
+
+def oc_create_azure_sts_backingstore(cld_mgr, backingstore_name, uls_name, region):
+    """
+    Create a new backingstore with Azure STS (managed identity) using oc create command
+
+    Args:
+        cld_mgr (CloudManager): holds Azure STS credentials for backingstore creation
+        backingstore_name (str): backingstore name
+        uls_name (str): underlying storage name
+        region (str): which region to create backingstore (should be the same as uls)
+
+    """
+    bs_data = templating.load_yaml(constants.MCG_BACKINGSTORE_YAML)
+    bs_data["metadata"]["name"] = backingstore_name
+    bs_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    bs_data["spec"] = {
+        "type": constants.BACKINGSTORE_TYPE_AZURE,
+        "azureBlob": {
+            "targetBlobContainer": uls_name,
+            "clientId": cld_mgr.azure_sts_client.client_id,
+            "tenantId": cld_mgr.azure_sts_client.tenant_id,
+            "subscriptionId": cld_mgr.azure_sts_client.subscription_id,
+            "resourcegroupId": cld_mgr.azure_sts_client.resource_group,
+            "secret": {
+                "name": cld_mgr.azure_sts_client.secret.name,
+                "namespace": bs_data["metadata"]["namespace"],
+            },
+        },
+    }
+    create_resource(**bs_data)
+
+
 def oc_create_google_backingstore(cld_mgr, backingstore_name, uls_name, region):
     """
     Create a new backingstore with GCP underlying storage using oc create command

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1794,6 +1794,7 @@ PSA_RESTRICTED = "restricted"
 AWS_PLATFORM = "aws"
 AZURE_PLATFORM = "azure"
 AZURE_WITH_LOGS_PLATFORM = "azure-with-logs"
+AZURE_STS_PLATFORM = "azure-sts"
 GCP_PLATFORM = "gcp"
 VSPHERE_PLATFORM = "vsphere"
 BAREMETAL_PLATFORM = "baremetal"
@@ -2921,7 +2922,15 @@ SQUAD_CHECK_IGNORED_MARKERS = ["ignore_owner", "libtest"]
 PRODUCTION_JOBS_PREFIX = ["jnk"]
 
 # Cloud Manager available platforms
-CLOUD_MNGR_PLATFORMS = ["AWS", "GCP", "AZURE", "AZURE_WITH_LOGS", "IBMCOS", "AWS_STS"]
+CLOUD_MNGR_PLATFORMS = [
+    "AWS",
+    "GCP",
+    "AZURE",
+    "AZURE_WITH_LOGS",
+    "IBMCOS",
+    "AWS_STS",
+    "AZURE_STS",
+]
 
 # Vault related configurations
 VAULT_VERSION_INFO_URL = "https://github.com/hashicorp/vault/releases/latest"

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -16,6 +16,8 @@ from ocs_ci.ocs.bucket_utils import (
     cli_create_aws_backingstore,
     cli_create_rgw_backingstore,
     cli_create_aws_sts_backingstore,
+    cli_create_azure_sts_backingstore,
+    oc_create_azure_sts_backingstore,
 )
 from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
@@ -285,6 +287,7 @@ def backingstore_factory(
                 "ibmcos": oc_create_ibmcos_backingstore,
                 "rgw": oc_create_rgw_backingstore,
                 "pv": oc_create_pv_backingstore,
+                "azure-sts": oc_create_azure_sts_backingstore,
             },
             "cli": {
                 "aws": cli_create_aws_backingstore,
@@ -294,6 +297,7 @@ def backingstore_factory(
                 "rgw": cli_create_rgw_backingstore,
                 "pv": cli_create_pv_backingstore,
                 "aws-sts": cli_create_aws_sts_backingstore,
+                "azure-sts": cli_create_azure_sts_backingstore,
             },
         }
 

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -31,6 +31,7 @@ from ocs_ci.utility.utils import (
     TimeoutSampler,
     load_auth_config,
     get_role_arn_from_sub,
+    get_azure_sts_creds_from_sub,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class CloudManager(ABC):
             "GCP": GoogleClient,
             "AZURE": AzureClient,
             "AZURE_WITH_LOGS": AzureWithLogsClient,
+            "AZURE_STS": AzureSTSClient,
             "IBMCOS": IbmCosClient,
             "RGW": RgwClient,
         }
@@ -118,6 +120,16 @@ class CloudManager(ABC):
             )
         except ClusterNotInSTSModeException:
             setattr(self, "aws_sts_client", None)
+
+        # set the client for Azure STS enabled cluster
+        try:
+            setattr(
+                self,
+                "azure_sts_client",
+                cloud_map["AZURE_STS"](full_auth_dict=cred_dict),
+            )
+        except ClusterNotInSTSModeException:
+            setattr(self, "azure_sts_client", None)
 
 
 class CloudClient(ABC):
@@ -756,3 +768,53 @@ class AwsSTSClient(S3Client):
             *args,
             **kwargs,
         )
+
+
+class AzureSTSClient(AzureClient):
+    """
+    Implementation of an Azure Client for STS (managed identity) clusters.
+
+    Reuses AzureClient's blob_service_client for ULS operations but creates
+    a different k8s secret with managed identity fields instead of AccountKey.
+
+    """
+
+    @config.run_with_provider_context_if_available
+    def __init__(self, full_auth_dict, *args, **kwargs):
+        sts_creds = get_azure_sts_creds_from_sub()
+        azure_auth_dict = full_auth_dict.get("AZURE")
+        if not azure_auth_dict:
+            logger.error("Cluster is in Azure STS mode, but no AZURE credentials found")
+            raise ClusterNotInSTSModeException
+
+        self.client_id = sts_creds["client_id"]
+        self.tenant_id = sts_creds["tenant_id"]
+        self.subscription_id = sts_creds["subscription_id"]
+        self.resource_group = sts_creds.get("resource_group", "")
+
+        super().__init__(auth_dict=azure_auth_dict, *args, **kwargs)
+
+    def create_azure_secret(self):
+        """
+        Create a Kubernetes secret for Azure STS backingstores/namespacestores.
+
+        Contains AccountName, azure_tenant_id, and azure_client_id
+        for managed identity authentication (no AccountKey).
+
+        """
+        bs_secret_data = templating.load_yaml(constants.MCG_BACKINGSTORE_SECRET_YAML)
+        bs_secret_data["metadata"]["name"] = create_unique_resource_name(
+            "cldmgr-azure-sts", "secret"
+        )
+        bs_secret_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+        bs_secret_data["data"]["AccountName"] = base64.urlsafe_b64encode(
+            self.account_name.encode("UTF-8")
+        ).decode("ascii")
+        bs_secret_data["data"]["azure_tenant_id"] = base64.urlsafe_b64encode(
+            self.tenant_id.encode("UTF-8")
+        ).decode("ascii")
+        bs_secret_data["data"]["azure_client_id"] = base64.urlsafe_b64encode(
+            self.client_id.encode("UTF-8")
+        ).decode("ascii")
+
+        return create_resource(**bs_secret_data)

--- a/ocs_ci/ocs/resources/cloud_uls.py
+++ b/ocs_ci/ocs/resources/cloud_uls.py
@@ -32,6 +32,7 @@ def cloud_uls_factory(
         "gcp": set(),
         "azure": set(),
         "azure-with-logs": set(),
+        "azure-sts": set(),
         "ibmcos": set(),
         "rgw": set(),
     }
@@ -42,6 +43,7 @@ def cloud_uls_factory(
             "gcp": cld_mgr.gcp_client,
             "azure": cld_mgr.azure_client,
             "azure-with-logs": cld_mgr.azure_with_logs_client,
+            "azure-sts": cld_mgr.azure_sts_client,
             "ibmcos": cld_mgr.ibmcos_client,
         }
     except AttributeError as e:
@@ -59,6 +61,11 @@ def cloud_uls_factory(
         ulsMap["aws-sts"] = cld_mgr.aws_sts_client
     except AttributeError:
         log.warning("Cluster is not deployed STS mode")
+
+    try:
+        ulsMap["azure-sts"] = cld_mgr.azure_sts_client
+    except AttributeError:
+        log.warning("Cluster is not deployed in Azure STS mode")
 
     def _create_uls(uls_dict):
         """
@@ -82,6 +89,7 @@ def cloud_uls_factory(
             "gcp": set(),
             "azure": set(),
             "azure-with-logs": set(),
+            "azure-sts": set(),
             "ibmcos": set(),
             "rgw": set(),
         }

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -265,6 +265,13 @@ def cli_create_namespacestore(
             f"--private-key-json-file {constants.GOOGLE_CREDS_JSON_PATH} "
             f"--target-bucket {uls_name}"
         ),
+        constants.AZURE_STS_PLATFORM: lambda: (
+            f"azure-sts-blob {nss_name} "
+            f"--target-blob-container {uls_name} "
+            f"--tenant-id {get_attr_chain(cld_mgr, 'azure_sts_client.tenant_id')} "
+            f"--client-id {get_attr_chain(cld_mgr, 'azure_sts_client.client_id')} "
+            f"--account-name {get_attr_chain(cld_mgr, 'azure_sts_client.account_name')}"
+        ),
         constants.NAMESPACE_FILESYSTEM: lambda: (
             f"nsfs {nss_name} "
             f"--pvc-name {uls_name} "
@@ -365,6 +372,24 @@ def oc_create_namespacestore(
                 "endpoint": get_attr_chain(cld_mgr, "ibmcos_client.endpoint"),
                 "secret": {
                     "name": get_attr_chain(cld_mgr, "ibmcos_client.secret.name"),
+                    "namespace": nss_data["metadata"]["namespace"],
+                },
+            },
+        },
+        constants.AZURE_STS_PLATFORM: lambda: {
+            "type": "azure-blob",
+            "azureBlob": {
+                "targetBlobContainer": uls_name,
+                "clientId": get_attr_chain(cld_mgr, "azure_sts_client.client_id"),
+                "tenantId": get_attr_chain(cld_mgr, "azure_sts_client.tenant_id"),
+                "subscriptionId": get_attr_chain(
+                    cld_mgr, "azure_sts_client.subscription_id"
+                ),
+                "resourcegroupId": get_attr_chain(
+                    cld_mgr, "azure_sts_client.resource_group"
+                ),
+                "secret": {
+                    "name": get_attr_chain(cld_mgr, "azure_sts_client.secret.name"),
                     "namespace": nss_data["metadata"]["namespace"],
                 },
             },

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -381,13 +381,6 @@ def oc_create_namespacestore(
             "azureBlob": {
                 "targetBlobContainer": uls_name,
                 "clientId": get_attr_chain(cld_mgr, "azure_sts_client.client_id"),
-                "tenantId": get_attr_chain(cld_mgr, "azure_sts_client.tenant_id"),
-                "subscriptionId": get_attr_chain(
-                    cld_mgr, "azure_sts_client.subscription_id"
-                ),
-                "resourcegroupId": get_attr_chain(
-                    cld_mgr, "azure_sts_client.resource_group"
-                ),
                 "secret": {
                     "name": get_attr_chain(cld_mgr, "azure_sts_client.secret.name"),
                     "namespace": nss_data["metadata"]["namespace"],

--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -552,30 +552,22 @@ class AZURE:
             logger.info(
                 f"Looking up resource ID for test storage account '{test_storage_account}'"
             )
-            try:
-                sa_result = exec_cmd(
-                    f"az storage account show --name {test_storage_account} "
-                    f"--subscription {subscription_id} --query id -o tsv"
-                )
-                sa_resource_id = sa_result.stdout.decode().strip()
-                if sa_resource_id:
-                    for role in roles:
-                        logger.info(
-                            f"Assigning role '{role}' on test storage account "
-                            f"'{test_storage_account}'"
-                        )
-                        exec_cmd(
-                            f"az role assignment create --assignee-object-id {principal_id} "
-                            f'--assignee-principal-type ServicePrincipal --role "{role}" '
-                            f"--scope {sa_resource_id} --subscription {subscription_id}"
-                        )
-            except Exception:
-                logger.warning(
-                    f"Could not assign roles on test storage account "
-                    f"'{test_storage_account}'. Azure STS backingstore/namespacestore "
-                    f"tests targeting this account may fail.",
-                    exc_info=True,
-                )
+            sa_result = exec_cmd(
+                f"az storage account show --name {test_storage_account} "
+                f"--subscription {subscription_id} --query id -o tsv"
+            )
+            sa_resource_id = sa_result.stdout.decode().strip()
+            if sa_resource_id:
+                for role in roles:
+                    logger.info(
+                        f"Assigning role '{role}' on test storage account "
+                        f"'{test_storage_account}'"
+                    )
+                    exec_cmd(
+                        f"az role assignment create --assignee-object-id {principal_id} "
+                        f'--assignee-principal-type ServicePrincipal --role "{role}" '
+                        f"--scope {sa_resource_id} --subscription {subscription_id}"
+                    )
 
         logger.info("Retrieving OIDC issuer URL from the cluster")
         auth_result = exec_cmd("oc get authentication cluster -ojson")

--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -557,7 +557,7 @@ class AZURE:
                     f"az storage account show --name {test_storage_account} "
                     f"--subscription {subscription_id} --query id -o tsv"
                 )
-                sa_resource_id = sa_result.stdout.strip()
+                sa_resource_id = sa_result.stdout.decode().strip()
                 if sa_resource_id:
                     for role in roles:
                         logger.info(

--- a/ocs_ci/utility/azure_utils.py
+++ b/ocs_ci/utility/azure_utils.py
@@ -506,6 +506,7 @@ class AZURE:
         1. A user-assigned managed identity named '{cluster_name}-noobaa-mi'
         2. Role assignments: 'Storage Account Contributor' and
            'Storage Blob Data Contributor' scoped to the cluster resource group
+           (and to the test storage account from AUTH config, if available)
         3. Federated credentials for NooBaa service accounts (noobaa,
            noobaa-core, noobaa-endpoint) linked to the cluster's OIDC issuer
 
@@ -543,6 +544,38 @@ class AZURE:
                 f'--assignee-principal-type ServicePrincipal --role "{role}" '
                 f"--scope {scope} --subscription {subscription_id}"
             )
+
+        test_storage_account = config.AUTH.get("AZURE", {}).get(
+            "STORAGE_ACCOUNT_NAME", ""
+        )
+        if test_storage_account:
+            logger.info(
+                f"Looking up resource ID for test storage account '{test_storage_account}'"
+            )
+            try:
+                sa_result = exec_cmd(
+                    f"az storage account show --name {test_storage_account} "
+                    f"--subscription {subscription_id} --query id -o tsv"
+                )
+                sa_resource_id = sa_result.stdout.strip()
+                if sa_resource_id:
+                    for role in roles:
+                        logger.info(
+                            f"Assigning role '{role}' on test storage account "
+                            f"'{test_storage_account}'"
+                        )
+                        exec_cmd(
+                            f"az role assignment create --assignee-object-id {principal_id} "
+                            f'--assignee-principal-type ServicePrincipal --role "{role}" '
+                            f"--scope {sa_resource_id} --subscription {subscription_id}"
+                        )
+            except Exception:
+                logger.warning(
+                    f"Could not assign roles on test storage account "
+                    f"'{test_storage_account}'. Azure STS backingstore/namespacestore "
+                    f"tests targeting this account may fail.",
+                    exc_info=True,
+                )
 
         logger.info("Retrieving OIDC issuer URL from the cluster")
         auth_result = exec_cmd("oc get authentication cluster -ojson")

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6268,6 +6268,41 @@ def get_role_arn_from_sub():
         raise ClusterNotInSTSModeException
 
 
+def get_azure_sts_creds_from_sub():
+    """
+    Get Azure STS credentials (managed identity) from the ODF Subscription.
+
+    Returns:
+        dict: Keys are ``client_id``, ``tenant_id``,
+            ``subscription_id``, and ``resource_group``.
+
+    Raises:
+        ClusterNotInSTSModeException: If cluster not in STS mode
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    if not config.DEPLOYMENT.get("sts_enabled"):
+        raise ClusterNotInSTSModeException
+
+    env_key_map = {
+        "CLIENTID": "client_id",
+        "TENANTID": "tenant_id",
+        "SUBSCRIPTIONID": "subscription_id",
+        "RESOURCEGROUP": "resource_group",
+    }
+    odf_sub = OCP(
+        kind=constants.SUBSCRIPTION,
+        resource_name=constants.ODF_SUBSCRIPTION,
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    creds = {}
+    for item in odf_sub.get()["spec"]["config"]["env"]:
+        if item["name"] in env_key_map:
+            creds[env_key_map[item["name"]]] = item["value"]
+    return creds
+
+
 def get_glibc_version():
     """
     Gets the GLIBC version.

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6297,9 +6297,15 @@ def get_azure_sts_creds_from_sub():
         namespace=config.ENV_DATA["cluster_namespace"],
     )
     creds = {}
-    for item in odf_sub.get()["spec"]["config"]["env"]:
+    env_items = odf_sub.get().get("spec", {}).get("config", {}).get("env", [])
+    for item in env_items:
         if item["name"] in env_key_map:
             creds[env_key_map[item["name"]]] = item["value"]
+
+    required = {"client_id", "tenant_id", "subscription_id"}
+    if not required.issubset(creds):
+        raise ClusterNotInSTSModeException
+
     return creds
 
 

--- a/tests/functional/object/mcg/test_bucket_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_deletion.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     mcg,
     sts_deployment_required,
+    aws_platform_required,
     skipif_fips_enabled,
 )
 from ocs_ci.framework.testlib import MCGTest
@@ -101,7 +102,7 @@ class TestBucketDeletion(MCGTest):
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier1, sts_deployment_required],
+                marks=[tier1, sts_deployment_required, aws_platform_required],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_bucket_replication.py
+++ b/tests/functional/object/mcg/test_bucket_replication.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     mcg,
     sts_deployment_required,
+    aws_platform_required,
     skipif_noobaa_external_pgsql,
     jira,
 )
@@ -70,6 +71,7 @@ class TestReplication(MCGTest):
                 marks=[
                     tier2,
                     sts_deployment_required,
+                    aws_platform_required,
                     pytest.mark.polarion_id("OCS-5494"),
                 ],
             ),
@@ -284,6 +286,7 @@ class TestReplication(MCGTest):
                 marks=[
                     tier2,
                     sts_deployment_required,
+                    aws_platform_required,
                     pytest.mark.polarion_id("OCS-5495"),
                 ],
             ),

--- a/tests/functional/object/mcg/test_multicloud.py
+++ b/tests/functional/object/mcg/test_multicloud.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     skipif_fips_enabled,
     sts_deployment_required,
+    azure_platform_required,
 )
 
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ class TestMultiCloud(MCGTest):
             ),
             pytest.param(
                 ("oc", {"azure-sts": [(1, None)]}),
-                marks=[sts_deployment_required],
+                marks=[sts_deployment_required, azure_platform_required],
             ),
         ],
         # A test ID list for describing the parametrized tests
@@ -89,7 +90,7 @@ class TestMultiCloud(MCGTest):
             pytest.param(("oc", {"ibmcos": [(1, None)]})),
             pytest.param(
                 ("oc", {"azure-sts": [(1, None)]}),
-                marks=[sts_deployment_required],
+                marks=[sts_deployment_required, azure_platform_required],
             ),
         ],
         # A test ID list for describing the parametrized tests

--- a/tests/functional/object/mcg/test_multicloud.py
+++ b/tests/functional/object/mcg/test_multicloud.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     skipif_fips_enabled,
+    sts_deployment_required,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,10 @@ class TestMultiCloud(MCGTest):
                 ("oc", {"ibmcos": [(1, None)]}),
                 marks=[skipif_fips_enabled],
             ),
+            pytest.param(
+                ("oc", {"azure-sts": [(1, None)]}),
+                marks=[sts_deployment_required],
+            ),
         ],
         # A test ID list for describing the parametrized tests
         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>
@@ -55,6 +60,7 @@ class TestMultiCloud(MCGTest):
             "GCP-OC-1",
             "IBMCOS-CLI-1",
             "IBMCOS-OC-1",
+            "AZURE-STS-OC-1",
         ],
     )
     def test_multicloud_backingstore_creation(
@@ -81,6 +87,10 @@ class TestMultiCloud(MCGTest):
             pytest.param(("oc", {"gcp": [(1, None)]})),
             pytest.param(("cli", {"ibmcos": [(1, None)]})),
             pytest.param(("oc", {"ibmcos": [(1, None)]})),
+            pytest.param(
+                ("oc", {"azure-sts": [(1, None)]}),
+                marks=[sts_deployment_required],
+            ),
         ],
         # A test ID list for describing the parametrized tests
         # <CLOUD_PROVIDER>-<METHOD>-<AMOUNT-OF-BACKINGSTORES>
@@ -93,6 +103,7 @@ class TestMultiCloud(MCGTest):
             "GCP-OC-1",
             "IBMCOS-CLI-1",
             "IBMCOS-OC-1",
+            "AZURE-STS-OC-1",
         ],
     )
     def deprecated_test_multicloud_backingstore_deletion(

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -36,6 +36,7 @@ from ocs_ci.ocs.bucket_utils import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
     sts_deployment_required,
+    azure_platform_required,
     red_squad,
     runs_on_provider,
     mcg,
@@ -130,6 +131,7 @@ class TestNamespace(MCGTest):
                 marks=[
                     tier1,
                     sts_deployment_required,
+                    azure_platform_required,
                     pytest.mark.polarion_id("OCS-XXXX"),
                 ],
             ),

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -35,6 +35,7 @@ from ocs_ci.ocs.bucket_utils import (
 )
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_aws_creds_are_missing,
+    sts_deployment_required,
     red_squad,
     runs_on_provider,
     mcg,
@@ -116,6 +117,21 @@ class TestNamespace(MCGTest):
                     },
                 },
                 marks=[tier1, pytest.mark.polarion_id("OCS-2409")],
+            ),
+            pytest.param(
+                {
+                    "interface": "OC",
+                    "namespace_policy_dict": {
+                        "type": "Single",
+                        "namespacestore_dict": {"azure-sts": [(1, None)]},
+                    },
+                },
+                # TODO: assign polarion ID
+                marks=[
+                    tier1,
+                    sts_deployment_required,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                ],
             ),
             pytest.param(
                 {
@@ -302,6 +318,7 @@ class TestNamespace(MCGTest):
         ids=[
             "AWS-OC-Single",
             "Azure-OC-Single",
+            "AZURE-STS-OC-Single",
             "RGW-OC-Single",
             "RGW-CLI-Single",
             "AWS-CLI-Single",

--- a/tests/functional/object/mcg/test_namespace_crd.py
+++ b/tests/functional/object/mcg/test_namespace_crd.py
@@ -127,12 +127,11 @@ class TestNamespace(MCGTest):
                         "namespacestore_dict": {"azure-sts": [(1, None)]},
                     },
                 },
-                # TODO: assign polarion ID
                 marks=[
                     tier1,
                     sts_deployment_required,
                     azure_platform_required,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7948"),
                 ],
             ),
             pytest.param(

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     tier2,
     sts_deployment_required,
+    aws_platform_required,
+    azure_platform_required,
     red_squad,
     mcg,
     polarion_id,
@@ -36,7 +38,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier2],
+                marks=[tier2, aws_platform_required],
             ),
             pytest.param(
                 *[
@@ -46,7 +48,7 @@ class TestSTSBucket:
                     },
                 ],
                 # TODO: assign polarion ID
-                marks=[tier1, polarion_id("OCS-XXXX")],
+                marks=[tier1, azure_platform_required, polarion_id("OCS-XXXX")],
             ),
             pytest.param(
                 *[
@@ -59,7 +61,7 @@ class TestSTSBucket:
                     },
                 ],
                 # TODO: assign polarion ID
-                marks=[tier1, polarion_id("OCS-XXXX")],
+                marks=[tier1, azure_platform_required, polarion_id("OCS-XXXX")],
             ),
             pytest.param(
                 *[None],

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -39,13 +39,41 @@ class TestSTSBucket:
                 marks=[tier2],
             ),
             pytest.param(
+                *[
+                    {
+                        "interface": "CLI",
+                        "backingstore_dict": {"azure-sts": [(1, None)]},
+                    },
+                ],
+                # TODO: assign polarion ID
+                marks=[tier1, polarion_id("OCS-XXXX")],
+            ),
+            pytest.param(
+                *[
+                    {
+                        "interface": "CLI",
+                        "namespace_policy_dict": {
+                            "type": "Single",
+                            "namespacestore_dict": {"azure-sts": [(1, None)]},
+                        },
+                    },
+                ],
+                # TODO: assign polarion ID
+                marks=[tier1, polarion_id("OCS-XXXX")],
+            ),
+            pytest.param(
                 *[None],
                 marks=[
                     tier1,
                 ],
             ),
         ],
-        ids=["AWS-STS-NEW", "AWS-STS-DEFAULT"],
+        ids=[
+            "AWS-STS-BS-CLI",
+            "AZURE-STS-BS-CLI",
+            "AZURE-STS-NSS-CLI",
+            "STS-DEFAULT",
+        ],
     )
     def test_sts_bucket_ops(
         self,
@@ -57,7 +85,7 @@ class TestSTSBucket:
     ):
         """
         Test full object round trip verification
-        on  AWS STS bucket
+        on an STS-backed bucket (AWS STS or Azure STS)
 
         """
 

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -47,8 +47,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"azure-sts": [(1, None)]},
                     },
                 ],
-                # TODO: assign polarion ID
-                marks=[tier1, azure_platform_required, polarion_id("OCS-XXXX")],
+                marks=[tier1, azure_platform_required, polarion_id("OCS-7949")],
             ),
             pytest.param(
                 *[
@@ -60,8 +59,7 @@ class TestSTSBucket:
                         },
                     },
                 ],
-                # TODO: assign polarion ID
-                marks=[tier1, azure_platform_required, polarion_id("OCS-XXXX")],
+                marks=[tier1, azure_platform_required, polarion_id("OCS-7950")],
             ),
             pytest.param(
                 *[None],


### PR DESCRIPTION
Add Azure STS backingstore and namespacestore tests

## Summary
- Add support for creating Azure STS (managed identity / WIF) backingstores and namespacestores via `odf noobaa` CLI and OC CRDs
- Extract Azure STS credentials from the ODF Subscription for use in test cloud managers
- Grant MI role assignments on the test storage account during cluster setup so Azure STS resources can access it
- Add platform markers (`aws_platform_required` / `azure_platform_required`) to STS test params to prevent cross-platform runs

## Changes
- `ocs_ci/utility/utils.py` — Add `get_azure_sts_creds_from_sub()` to extract MI credentials from the ODF Subscription
- `ocs_ci/ocs/resources/cloud_manager.py` — Add `AzureSTSClient` cloud manager for Azure STS backingstores and namespacestores
- `ocs_ci/ocs/resources/cloud_uls.py`, `backingstore.py`, `namespacestore.py` — Wire up Azure STS resource creation via `odf noobaa` CLI
- `ocs_ci/ocs/bucket_utils.py`, `constants.py` — Add Azure STS constants and bucket utility support
- `ocs_ci/utility/azure_utils.py` — Grant MI role assignments on the test storage account during cluster setup
- `tests/functional/object/mcg/test_sts_bucket.py` — Add Azure STS backingstore and namespacestore IO test params
- `tests/functional/object/mcg/test_multicloud.py`, `test_namespace_crd.py` — Add Azure STS test params
- `tests/functional/object/mcg/test_bucket_deletion.py`, `test_bucket_replication.py` — Add `aws_platform_required` markers to existing AWS STS params
- All STS test params now carry `aws_platform_required` or `azure_platform_required` to prevent cross-platform runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Azure STS support: create/manage Azure STS backingstores, namespacestores, and underlying storage entries via both CLI and OC flows; cloud manager now recognizes Azure STS and tracks related ULS.

* **Tests**
  * Expanded test coverage for Azure STS scenarios; added platform-specific markers and new parametrized cases.

* **Chores**
  * Managed-identity setup can target a configured test storage account; added a utility to retrieve Azure STS credentials from the cluster subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->