### PR TITLE
skip blackbox check after upgrade

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -268,11 +268,13 @@ def ocs_install_verification(
 
     # From 4.21, new resource blackbox-exporter added as part of feature odf
     # health overview
+    # Skip blackbox check after upgrade due to DFBUGS-7007
     odf_running_version = get_ocs_version_from_csv(only_major_minor=True)
     if (
         not external
         and not config.DEPLOYMENT.get("mcg_only_deployment", False)
         and (odf_running_version >= version.VERSION_4_21)
+        and not post_upgrade_verification
     ):
         odf_semantic_version = get_semantic_running_odf_version()
         blackbox_label = (

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -172,6 +172,7 @@ def deprecated_test_noobaa_service_mon_after_ocs_upgrade():
 @skipif_hci_client
 @skipif_mcg_only
 @jira("DFBUGS-5211")
+@jira("DFBUGS-7007")
 @pytest.mark.polarion_id("OCS-7419")
 @purple_squad
 def test_blackbox_pod_after_upgrade():


### PR DESCRIPTION
bug: https://redhat.atlassian.net/browse/DFBUGS-7007

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted blackbox-exporter endpoint verification for ODF versions 4.21 and later to correctly skip validation checks during post-upgrade verification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->