### PR TITLE
topology tests - fix TypeError (1 liner)

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/odf_topology_tab.py
@@ -10,7 +10,6 @@ from selenium.common.exceptions import (
     TimeoutException,
 )
 from selenium.webdriver.common.by import By
-from selenium.webdriver.remote.errorhandler import ErrorHandler
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -1273,7 +1272,7 @@ class OdfTopologyDeploymentsView(TopologyTab):
         )
         return details_dict
 
-    @retry(ErrorHandler)
+    @retry(TimeoutException)
     def filter_node_by_toggle_from_deployments_level(self, node_name):
         """
         Filters the node by toggle from the deployments level in the topology view.


### PR DESCRIPTION
Fix old code with emerged error:
```
args = (OdfTopologyDeploymentsView Web Page, 'control-plane-0'), kwargs = {}
mtries = 4, mdelay = 3, attempts = 1, exception_summary = set()


@wraps(f)
def f_retry(*args, **kwargs):
    mtries, mdelay = tries, delay
    attempts = 0
    exception_summary = set()
    while mtries > 1:
        attempts += 1
        if attempts == 2:
            # Show log only for second attempt
            logger.debug(
                f"Executing {f.__name__}. Tries: {mtries}. Delay: {mdelay}. Backoff: {backoff}"
            )
        try:
            if func is not None:
                func()
            return f(*args, **kwargs)

      except exception_to_check as e:
E           TypeError: catching classes that do not inherit from BaseException is not allowed
``` 

Verified: https://privatebin.corp.redhat.com/?e5c3aa96c291474e#CRm2uCchmaayKYZeoWaF92mgpaPQGtheTFjy8za7RBWv 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced topology operations to more robustly handle transient failures by improving retry logic to specifically catch and recover from timeout conditions, improving stability during UI interactions.

* **Chores**
  * Removed unused imports from the topology module to reduce code complexity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->