### PR TITLE
Add SVG parametrize and provider Prometheus checks to alert test

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -4669,7 +4669,7 @@ def get_cephfs_subvolumegroup():
             kind=constants.CONFIGMAP,
             namespace=config.ENV_DATA["cluster_namespace"],
         )
-        ceph_csi_configmap = configmap_obj.get(resource_name="ceph-csi-configs")
+        ceph_csi_configmap = configmap_obj.get(resource_name="ceph-csi-config")
         json_config = ceph_csi_configmap.get("data").get("config.json")
         json_config_list = json.loads(json_config)
         for dict_item in json_config_list:

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -91,24 +91,15 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
         ), f"Failed to create VolumeSnapshotClass {snapclass_name} on provider"
         log.info("Created VolumeSnapshotClass %s on provider", snapclass_name)
 
-        consumer_ns = config.ENV_DATA["cluster_namespace"]
-        consumer_ocp = ocp.OCP(kind=constants.STORAGECONSUMER, namespace=consumer_ns)
-        consumer_name = None
-        current_snapclasses = []
-        for name in get_consumer_names():
-            consumer_data = consumer_ocp.get(resource_name=name)
-            if (
-                consumer_data.get("status", {}).get("client", {}).get("name")
-                == storage_client_name
-            ):
-                consumer_name = name
-                current_snapclasses = consumer_data.get("spec", {}).get(
-                    "volumeSnapshotClasses", []
-                )
-                break
-        assert consumer_name, (
-            f"StorageConsumer for storage client '{storage_client_name}' "
-            "not found on provider"
+        consumer_name, consumer_data = _find_consumer_for_storage_client(
+            storage_client_name
+        )
+        consumer_ocp = ocp.OCP(
+            kind=constants.STORAGECONSUMER,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        current_snapclasses = consumer_data.get("spec", {}).get(
+            "volumeSnapshotClasses", []
         )
 
         updated_snapclasses = [*current_snapclasses, {"name": snapclass_name}]
@@ -156,6 +147,58 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
             log.info("Deleted VolumeSnapshotClass %s from provider", snapclass_name)
 
     return _teardown
+
+
+def _find_consumer_for_storage_client(storage_client_name):
+    """
+    Find the StorageConsumer CR on the provider that owns ``storage_client_name``.
+
+    Must be called within an active provider config context.
+
+    Args:
+        storage_client_name (str): StorageClient CR name on the client cluster.
+
+    Returns:
+        tuple[str, dict]: ``(consumer_name, consumer_data)`` for the matching
+            StorageConsumer.
+
+    Raises:
+        AssertionError: If no matching StorageConsumer is found.
+    """
+    consumer_ns = config.ENV_DATA["cluster_namespace"]
+    consumer_ocp = ocp.OCP(kind=constants.STORAGECONSUMER, namespace=consumer_ns)
+    for name in get_consumer_names():
+        consumer_data = consumer_ocp.get(resource_name=name)
+        if (
+            consumer_data.get("status", {}).get("client", {}).get("name")
+            == storage_client_name
+        ):
+            return name, consumer_data
+    raise AssertionError(
+        f"No StorageConsumer found for storage client '{storage_client_name}'"
+    )
+
+
+def get_consumer_svg_on_provider(storage_client_name):
+    """
+    Return the CephFS subvolume group name for a storage client on the
+    provider cluster.
+
+    The SVG name equals the StorageConsumer CR name on the provider.
+    Must be called within an active provider config context.
+
+    Args:
+        storage_client_name (str): StorageClient CR name on the client
+            cluster.
+
+    Returns:
+        str: Subvolume group name on the provider cluster.
+
+    Raises:
+        AssertionError: If no matching StorageConsumer is found.
+    """
+    consumer_name, _ = _find_consumer_for_storage_client(storage_client_name)
+    return consumer_name
 
 
 def get_cephfs_snap_entries(snap_runner):

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -5,8 +5,8 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import get_snapshot_content_obj
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.utility import templating
-from ocs_ci.ocs.managedservice import get_consumer_names
 from ocs_ci.ocs.resources import ocs
+from ocs_ci.ocs.resources.storageconsumer import find_consumer_for_storage_client
 from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
         ), f"Failed to create VolumeSnapshotClass {snapclass_name} on provider"
         log.info("Created VolumeSnapshotClass %s on provider", snapclass_name)
 
-        consumer_name, consumer_data = _find_consumer_for_storage_client(
+        consumer_name, consumer_data = find_consumer_for_storage_client(
             storage_client_name
         )
         consumer_ocp = ocp.OCP(
@@ -147,58 +147,6 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
             log.info("Deleted VolumeSnapshotClass %s from provider", snapclass_name)
 
     return _teardown
-
-
-def _find_consumer_for_storage_client(storage_client_name):
-    """
-    Find the StorageConsumer CR on the provider that owns ``storage_client_name``.
-
-    Must be called within an active provider config context.
-
-    Args:
-        storage_client_name (str): StorageClient CR name on the client cluster.
-
-    Returns:
-        tuple[str, dict]: ``(consumer_name, consumer_data)`` for the matching
-            StorageConsumer.
-
-    Raises:
-        AssertionError: If no matching StorageConsumer is found.
-    """
-    consumer_ns = config.ENV_DATA["cluster_namespace"]
-    consumer_ocp = ocp.OCP(kind=constants.STORAGECONSUMER, namespace=consumer_ns)
-    for name in get_consumer_names():
-        consumer_data = consumer_ocp.get(resource_name=name)
-        if (
-            consumer_data.get("status", {}).get("client", {}).get("name")
-            == storage_client_name
-        ):
-            return name, consumer_data
-    raise AssertionError(
-        f"No StorageConsumer found for storage client '{storage_client_name}'"
-    )
-
-
-def get_consumer_svg_on_provider(storage_client_name):
-    """
-    Return the CephFS subvolume group name for a storage client on the
-    provider cluster.
-
-    The SVG name equals the StorageConsumer CR name on the provider.
-    Must be called within an active provider config context.
-
-    Args:
-        storage_client_name (str): StorageClient CR name on the client
-            cluster.
-
-    Returns:
-        str: Subvolume group name on the provider cluster.
-
-    Raises:
-        AssertionError: If no matching StorageConsumer is found.
-    """
-    consumer_name, _ = _find_consumer_for_storage_client(storage_client_name)
-    return consumer_name
 
 
 def get_cephfs_snap_entries(snap_runner):

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -761,6 +761,8 @@ class OCP(object):
 
         """
         command = ["oc", "login", "-u", user, "-p", password]
+        if self.skip_tls_verify:
+            command.append("--insecure-skip-tls-verify")
         status = exec_cmd(
             command, secrets=[password], threading_lock=self.threading_lock
         )

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -974,6 +974,60 @@ def get_ready_consumers_names():
     return [consumer.name for consumer in ready_consumers]
 
 
+def find_consumer_for_storage_client(storage_client_name):
+    """
+    Find the StorageConsumer CR on the provider that owns ``storage_client_name``.
+
+    Must be called within an active provider config context.
+
+    Args:
+        storage_client_name (str): StorageClient CR name on the client cluster.
+
+    Returns:
+        tuple[str, dict]: ``(consumer_name, consumer_data)`` for the matching
+            StorageConsumer.
+
+    Raises:
+        AssertionError: If no matching StorageConsumer is found.
+    """
+    consumer_ns = config.ENV_DATA["cluster_namespace"]
+    consumer_ocp = ocp.OCP(kind=constants.STORAGECONSUMER, namespace=consumer_ns)
+    for name in get_consumer_names():
+        consumer_data = consumer_ocp.get(resource_name=name)
+        if (
+            consumer_data.get("status", {}).get("client", {}).get("name")
+            == storage_client_name
+        ):
+            return name, consumer_data
+    raise AssertionError(
+        f"No StorageConsumer found for storage client '{storage_client_name}'"
+    )
+
+
+def get_consumer_svg_on_provider(storage_client_name):
+    """
+    Return the CephFS subvolume group name for a storage client on the
+    provider cluster.
+
+    The SVG name equals the StorageConsumer CR name on the provider.
+    Must be called within an active provider config context.
+
+    Args:
+        storage_client_name (str): StorageClient CR name on the client
+            cluster.
+
+    Returns:
+        str: Subvolume group name on the provider cluster.
+
+    Raises:
+        AssertionError: If no matching StorageConsumer is found.
+    """
+    consumer_name, _ = find_consumer_for_storage_client(storage_client_name)
+    # The CephFS subvolume group name on the provider equals the
+    # StorageConsumer CR name (this mapping may change in future versions).
+    return consumer_name
+
+
 def check_consumer_rns(consumer_name, pool_list, rns_list):
     """
     Verify that the Rados namespaces on the consumer match the expected ones.

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -565,6 +565,7 @@ class PrometheusAPI(object):
                 namespace=defaults.OCS_MONITORING_NAMESPACE,
                 threading_lock=self._threading_lock,
                 cluster_kubeconfig=kubeconfig,
+                skip_tls_verify=config.ENV_DATA.get("skip_tls_verify", False),
             )
             kube_data = ""
             with open(kubeconfig, "r") as kube_file:

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -76,8 +76,11 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
             status=constants.STATUS_BOUND,
         )
 
+        storage_client = (
+            get_storage_client().resource_name if config.multicluster else None
+        )
         self._snap_runner = odf_cli_cephfs_snap_setup_helper(
-            storage_client=get_storage_client().resource_name
+            storage_client=storage_client
         )
 
         self.api = PrometheusAPI(

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -1,16 +1,24 @@
 import logging
+import random
+import time
 
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import green_squad
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.pytest_customization.marks import green_squad, polarion_id
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    hci_provider_and_client_required,
+    tier1,
+)
 from ocs_ci.helpers import helpers
+from ocs_ci.helpers.helpers import get_cephfs_subvolumegroup
 from ocs_ci.helpers.odf_cephfs_snap import (
     create_provider_retain_cephfs_snapclass,
     delete_volumesnaps_volumesnapcontents,
     get_cephfs_snap_by_name,
     get_cephfs_snap_entries,
+    get_consumer_svg_on_provider,
 )
 from ocs_ci.helpers.odf_cli import odf_cli_cephfs_snap_setup_helper
 from ocs_ci.ocs import constants
@@ -76,6 +84,13 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
             threading_lock=threading_lock,
             cluster_context=config.RunWithFirstConsumerConfigContextIfAvailable,
         )
+
+        self.provider_api = None
+        if config.multicluster:
+            self.provider_api = PrometheusAPI(
+                threading_lock=threading_lock,
+                cluster_context=config.RunWithProviderConfigContextIfAvailable,
+            )
 
         self.snap_list_names = []
 
@@ -267,42 +282,137 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
             snap_list_names, constants.CEPHFS_SNAPSHOT_STATE_BOUND
         )
 
-    @tier1
-    def test_cephfs_orphaned_snapshot_alert(self):
+    def _wait_for_orphaned_alert_firing(self):
         """
+        Wait for the CephFSOrphanedSnapshot alert to fire.
+
+        In multicluster mode the alert fires on the provider Prometheus;
+        the consumer check is skipped due to DFBUGS-7011 (ocs_client_alert
+        federation not active).  In standalone mode the single cluster's
+        Prometheus is used.
+        """
+        api = self.provider_api or self.api
+        log.info(
+            "Waiting for CephFSOrphanedSnapshot alert to fire on %s",
+            "provider" if self.provider_api else "consumer",
+        )
+        wait_for_alert_firing(
+            api,
+            constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT,
+            expected_severity="warning",
+            expected_message_substr=constants.CEPHFS_SNAPSHOT_STATE_ORPHANED,
+        )
+        # Skip consumer alert check in multicluster mode — DFBUGS-7011
+        # (ocs_client_alert federation not active)
+
+    def _wait_for_orphaned_alert_cleared(self):
+        """
+        Wait for the CephFSOrphanedSnapshot alert to clear.
+
+        In multicluster mode the provider Prometheus is checked; the consumer
+        check is skipped due to DFBUGS-7011 (ocs_client_alert federation not
+        active).  In standalone mode the single cluster's Prometheus is used.
+        """
+        api = self.provider_api or self.api
+        log.info(
+            "Waiting for CephFSOrphanedSnapshot alerts to clear on %s",
+            "provider" if self.provider_api else "consumer",
+        )
+        wait_for_alert_cleared(api, constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT)
+        # Skip consumer alert check in multicluster mode — DFBUGS-7011
+        # (ocs_client_alert federation not active)
+
+    def _resolve_svg(self, svg_param):
+        """
+        Resolve ``svg_param`` to an actual subvolume group name and set it
+        on ``self._snap_runner``.
+
+        Args:
+            svg_param (str or None): ``"consumer_svg_on_provider"`` fetches
+                the consumer's SVG from the provider cluster.
+                ``"default_svg"`` uses the cluster's default subvolume group.
+                ``None`` leaves the snap runner without an explicit ``--svg``
+                flag (original behaviour).
+        """
+        if svg_param == "consumer_svg_on_provider":
+            storage_client_name = get_storage_client().resource_name
+            with config.RunWithProviderConfigContextIfAvailable():
+                svg = get_consumer_svg_on_provider(storage_client_name)
+            log.info("Using consumer SVG on provider: %s", svg)
+        elif svg_param == "default_svg":
+            svg = get_cephfs_subvolumegroup()
+            log.info("Using default CephFS subvolumegroup: %s", svg)
+        else:
+            svg = None
+            log.info("Using no explicit --svg (odf-cli default)")
+        self._snap_runner.svg = svg
+
+    @tier1
+    @pytest.mark.parametrize(
+        "svg_param",
+        [
+            pytest.param(None, marks=polarion_id("OCS-7944")),
+            pytest.param("default_svg", marks=polarion_id("OCS-7946")),
+            pytest.param(
+                "consumer_svg_on_provider",
+                marks=[hci_provider_and_client_required, polarion_id("OCS-7947")],
+            ),
+        ],
+        ids=["no_svg", "default_svg", "consumer_svg_on_provider"],
+    )
+    def test_cephfs_orphaned_snapshot_alert(self, svg_param):
+        """
+        Args:
+            svg_param (str or None): Controls the ``--svg`` flag passed to
+                odf-cli. ``"consumer_svg_on_provider"`` uses the consumer's
+                SVG on the provider (provider-client only).
+                ``"default_svg"`` uses the cluster's default subvolume group.
+                ``None`` omits ``--svg`` (original behaviour).
+
         Steps:
-        1. Verify no CephFS snapshots exist.
-        2. Create 7 VolumeSnapshots (3 to be orphaned, 4 to remain bound)
-           using the Retain snapclass and wait until each is ready.
-        3. List snapshots with odf cephfs-snap ls; verify each is present
+        1. Resolve the ``--svg`` value from ``svg_param`` and update the
+           snap runner.
+        2. Verify no CephFS snapshots exist.
+        3. Create N VolumeSnapshots (num_of_orphaned to be orphaned,
+           num_of_bound to remain bound) using the Retain snapclass and
+           wait until each is ready.
+        4. List snapshots with odf cephfs-snap ls; verify each is present
            and in a Bound state.
-        4. Verify both VolumeSnapshot and VolumeSnapshotContent exist in
+        5. Verify both VolumeSnapshot and VolumeSnapshotContent exist in
            Kubernetes for each snapshot.
-        5. Delete the VolumeSnapshots and VolumeSnapshotContents for the
-           first 3 snapshots only. Their Ceph-side snapshots are retained
-           due to the Retain policy, becoming orphaned.
-        6. Verify the 3 deleted snapshots are orphaned and the remaining
-           4 are still in Bound state.
-        7. Wait for the CephFSOrphanedSnapshot Prometheus alert to fire
+        6. Delete the VolumeSnapshots and VolumeSnapshotContents for the
+           first num_of_orphaned snapshots only. Their Ceph-side snapshots
+           are retained due to the Retain policy, becoming orphaned.
+        7. Verify the num_of_orphaned deleted snapshots are orphaned and
+           the remaining num_of_bound are still in Bound state.
+        8. Wait for the CephFSOrphanedSnapshot Prometheus alert to fire
            (one alert per storage client, regardless of orphan count)
            and validate it.
-        8. Delete the 3 orphaned snapshots via odf cephfs-snap delete.
-        9. Verify only the 4 bound snapshots remain.
-        10. Verify all alerts are cleared.
+        9. Delete the num_of_orphaned orphaned snapshots via odf cephfs-snap
+           delete.
+        10. Verify only the num_of_bound bound snapshots remain.
+        11. Verify all alerts are cleared.
         """
-        num_of_orphaned = 3
-        num_of_bound = 4
+        seed = int(time.time())
+        random.seed(seed)
+        log.info("Random seed for this test run: %d", seed)
+        num_of_orphaned = random.randint(1, 4)
+        num_of_bound = random.randint(4, 7)
 
-        # Step 1: verify no snapshots exist
-        log.info("Step 1: Verifying no CephFS snapshots exist")
+        # Step 1: resolve --svg and update the snap runner
+        log.info("Step 1: Resolving odf-cli --svg from svg_param=%s", svg_param)
+        self._resolve_svg(svg_param)
+
+        # Step 2: verify no snapshots exist
+        log.info("Step 2: Verifying no CephFS snapshots exist")
         assert not get_cephfs_snap_entries(
             self._snap_runner
         ), "Expected no CephFS snapshots before the test"
 
-        # Steps 2-4: create all snapshots with Retain policy,
+        # Steps 3-5: create all snapshots with Retain policy,
         # verify Ceph state is Bound and k8s objects exist
         log.info(
-            "Steps 2-4: Creating %d CephFS VolumeSnapshots with Retain "
+            "Steps 3-5: Creating %d CephFS VolumeSnapshots with Retain "
             "policy and verifying Kubernetes objects",
             num_of_orphaned + num_of_bound,
         )
@@ -310,18 +420,18 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         orphaned_snaps = self.snap_list_names[:num_of_orphaned]
         bound_snaps = self.snap_list_names[num_of_orphaned:]
 
-        # Step 5: delete k8s objects for the orphaned group only;
+        # Step 6: delete k8s objects for the orphaned group only;
         # Ceph-side snapshots are retained, becoming orphaned
         log.info(
-            "Step 5: Deleting VolumeSnapshots and VolumeSnapshotContents "
+            "Step 6: Deleting VolumeSnapshots and VolumeSnapshotContents "
             "for %d snapshot(s)",
             num_of_orphaned,
         )
         delete_volumesnaps_volumesnapcontents(orphaned_snaps)
 
-        # Step 6: verify the two groups are in the expected states
+        # Step 7: verify the two groups are in the expected states
         log.info(
-            "Step 6: Verifying %d snapshot(s) are orphaned and "
+            "Step 7: Verifying %d snapshot(s) are orphaned and "
             "%d snapshot(s) remain bound",
             num_of_orphaned,
             num_of_bound,
@@ -329,25 +439,20 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         self.verify_cephfs_snapshots_orphaned(orphaned_snaps)
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
-        # Step 7: wait for the alert to fire and validate
-        log.info("Step 7: Waiting for CephFSOrphanedSnapshot alert to fire")
-        wait_for_alert_firing(
-            self.api,
-            constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT,
-            expected_severity="warning",
-            expected_message_substr=constants.CEPHFS_SNAPSHOT_STATE_ORPHANED,
-        )
+        # Step 8: wait for the alert to fire and validate
+        log.info("Step 8: Waiting for CephFSOrphanedSnapshot alert to fire")
+        self._wait_for_orphaned_alert_firing()
 
-        # Step 8: delete the orphaned snapshots via odf CLI
+        # Step 9: delete the orphaned snapshots via odf CLI
         log.info(
-            "Step 8: Deleting %d orphaned snapshot(s) via odf CLI",
+            "Step 9: Deleting %d orphaned snapshot(s) via odf CLI",
             num_of_orphaned,
         )
         self.delete_orphaned_cephfs_snapshots(orphaned_snaps)
 
-        # Step 9: verify only the bound group remains
+        # Step 10: verify only the bound group remains
         log.info(
-            "Step 9: Verifying %d bound snapshot(s) remain",
+            "Step 10: Verifying %d bound snapshot(s) remain",
             num_of_bound,
         )
         snap_entries = get_cephfs_snap_entries(self._snap_runner)
@@ -357,6 +462,6 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         )
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
-        # Step 10: verify all alerts are cleared
-        log.info("Step 10: Waiting for CephFSOrphanedSnapshot alerts to clear")
-        wait_for_alert_cleared(self.api, constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT)
+        # Step 11: verify all alerts are cleared
+        log.info("Step 11: Waiting for CephFSOrphanedSnapshot alerts to clear")
+        self._wait_for_orphaned_alert_cleared()

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -18,8 +18,8 @@ from ocs_ci.helpers.odf_cephfs_snap import (
     delete_volumesnaps_volumesnapcontents,
     get_cephfs_snap_by_name,
     get_cephfs_snap_entries,
-    get_consumer_svg_on_provider,
 )
+from ocs_ci.ocs.resources.storageconsumer import get_consumer_svg_on_provider
 from ocs_ci.helpers.odf_cli import odf_cli_cephfs_snap_setup_helper
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources import pvc as pvc_resource
@@ -400,62 +400,47 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         num_of_orphaned = random.randint(1, 4)
         num_of_bound = random.randint(4, 7)
 
-        # Step 1: resolve --svg and update the snap runner
-        log.info("Step 1: Resolving odf-cli --svg from svg_param=%s", svg_param)
+        log.test_step("Resolve odf-cli --svg from svg_param=%s", svg_param)
         self._resolve_svg(svg_param)
 
-        # Step 2: verify no snapshots exist
-        log.info("Step 2: Verifying no CephFS snapshots exist")
+        log.test_step("Verify no CephFS snapshots exist")
         assert not get_cephfs_snap_entries(
             self._snap_runner
         ), "Expected no CephFS snapshots before the test"
 
-        # Steps 3-5: create all snapshots with Retain policy,
-        # verify Ceph state is Bound and k8s objects exist
-        log.info(
-            "Steps 3-5: Creating %d CephFS VolumeSnapshots with Retain "
-            "policy and verifying Kubernetes objects",
+        log.test_step(
+            "Create %d CephFS VolumeSnapshots with Retain "
+            "policy and verify Kubernetes objects",
             num_of_orphaned + num_of_bound,
         )
         self.create_retain_cephfs_snapshots(num_of_orphaned + num_of_bound)
         orphaned_snaps = self.snap_list_names[:num_of_orphaned]
         bound_snaps = self.snap_list_names[num_of_orphaned:]
 
-        # Step 6: delete k8s objects for the orphaned group only;
-        # Ceph-side snapshots are retained, becoming orphaned
-        log.info(
-            "Step 6: Deleting VolumeSnapshots and VolumeSnapshotContents "
-            "for %d snapshot(s)",
+        log.test_step(
+            "Delete VolumeSnapshots and VolumeSnapshotContents " "for %d snapshot(s)",
             num_of_orphaned,
         )
         delete_volumesnaps_volumesnapcontents(orphaned_snaps)
 
-        # Step 7: verify the two groups are in the expected states
-        log.info(
-            "Step 7: Verifying %d snapshot(s) are orphaned and "
-            "%d snapshot(s) remain bound",
+        log.test_step(
+            "Verify %d snapshot(s) are orphaned and %d snapshot(s) remain bound",
             num_of_orphaned,
             num_of_bound,
         )
         self.verify_cephfs_snapshots_orphaned(orphaned_snaps)
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
-        # Step 8: wait for the alert to fire and validate
-        log.info("Step 8: Waiting for CephFSOrphanedSnapshot alert to fire")
+        log.test_step("Wait for CephFSOrphanedSnapshot alert to fire")
         self._wait_for_orphaned_alert_firing()
 
-        # Step 9: delete the orphaned snapshots via odf CLI
-        log.info(
-            "Step 9: Deleting %d orphaned snapshot(s) via odf CLI",
+        log.test_step(
+            "Delete %d orphaned snapshot(s) via odf CLI",
             num_of_orphaned,
         )
         self.delete_orphaned_cephfs_snapshots(orphaned_snaps)
 
-        # Step 10: verify only the bound group remains
-        log.info(
-            "Step 10: Verifying %d bound snapshot(s) remain",
-            num_of_bound,
-        )
+        log.test_step("Verify %d bound snapshot(s) remain", num_of_bound)
         snap_entries = get_cephfs_snap_entries(self._snap_runner)
         assert len(snap_entries) == num_of_bound, (
             f"Expected {num_of_bound} snapshot(s) after cleanup, "
@@ -463,6 +448,5 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         )
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
-        # Step 11: verify all alerts are cleared
-        log.info("Step 11: Waiting for CephFSOrphanedSnapshot alerts to clear")
+        log.test_step("Wait for CephFSOrphanedSnapshot alerts to clear")
         self._wait_for_orphaned_alert_cleared()

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -289,41 +289,39 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         """
         Wait for the CephFSOrphanedSnapshot alert to fire.
 
-        In multicluster mode the alert fires on the provider Prometheus;
-        the consumer check is skipped due to DFBUGS-7011 (ocs_client_alert
-        federation not active).  In standalone mode the single cluster's
-        Prometheus is used.
+        In multicluster mode both the provider and consumer Prometheus are
+        checked.  In standalone mode the single cluster's Prometheus is used.
         """
-        api = self.provider_api or self.api
-        log.info(
-            "Waiting for CephFSOrphanedSnapshot alert to fire on %s",
-            "provider" if self.provider_api else "consumer",
-        )
+        if self.provider_api:
+            log.info("Waiting for CephFSOrphanedSnapshot alert to fire on provider")
+            wait_for_alert_firing(
+                self.provider_api,
+                constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT,
+                expected_severity="warning",
+                expected_message_substr=constants.CEPHFS_SNAPSHOT_STATE_ORPHANED,
+            )
+        log.info("Waiting for CephFSOrphanedSnapshot alert to fire on consumer")
         wait_for_alert_firing(
-            api,
+            self.api,
             constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT,
             expected_severity="warning",
             expected_message_substr=constants.CEPHFS_SNAPSHOT_STATE_ORPHANED,
         )
-        # Skip consumer alert check in multicluster mode — DFBUGS-7011
-        # (ocs_client_alert federation not active)
 
     def _wait_for_orphaned_alert_cleared(self):
         """
         Wait for the CephFSOrphanedSnapshot alert to clear.
 
-        In multicluster mode the provider Prometheus is checked; the consumer
-        check is skipped due to DFBUGS-7011 (ocs_client_alert federation not
-        active).  In standalone mode the single cluster's Prometheus is used.
+        In multicluster mode both the provider and consumer Prometheus are
+        checked.  In standalone mode the single cluster's Prometheus is used.
         """
-        api = self.provider_api or self.api
-        log.info(
-            "Waiting for CephFSOrphanedSnapshot alerts to clear on %s",
-            "provider" if self.provider_api else "consumer",
-        )
-        wait_for_alert_cleared(api, constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT)
-        # Skip consumer alert check in multicluster mode — DFBUGS-7011
-        # (ocs_client_alert federation not active)
+        if self.provider_api:
+            log.info("Waiting for CephFSOrphanedSnapshot alerts to clear on provider")
+            wait_for_alert_cleared(
+                self.provider_api, constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT
+            )
+        log.info("Waiting for CephFSOrphanedSnapshot alerts to clear on consumer")
+        wait_for_alert_cleared(self.api, constants.ALERT_CEPHFS_ORPHANED_SNAPSHOT)
 
     def _resolve_svg(self, svg_param):
         """


### PR DESCRIPTION
 - Parametrizes test_cephfs_orphaned_snapshot_alert with three --svg variants: no_svg (OCS-7944), default_svg
  (OCS-7946), and consumer_svg_on_provider (OCS-7947, provider-client only).
  - In multicluster (HCI provider-client) mode, checks the CephFSOrphanedSnapshot alert on the provider Prometheus,
  where the alert actually fires. The consumer check is skipped due to [DFBUGS-7011](https://redhat.atlassian.net/browse/DFBUGS-7011) (ocs_client_alert federation not
  active in ODF 4.22).
  - Adds get_consumer_svg_on_provider() helper that resolves the CephFS subvolume group name for a given storage client
   by matching the StorageConsumer CR on the provider.
  - Extends OCP.login() to pass --insecure-skip-tls-verify when skip_tls_verify=True, and wires
  PrometheusAPI.refresh_connection() to read ENV_DATA.skip_tls_verify from config (defaults to False, so no behaviour
  change for existing runs).

  Test plan

  - [ ] test_cephfs_orphaned_snapshot_alert[no_svg] — verified PASS on ikave-bm3 (provider) + c2-422-1 (client), ODF
  4.22
  - [ ] test_cephfs_orphaned_snapshot_alert[default_svg] — run on same cluster pair
  - [ ] test_cephfs_orphaned_snapshot_alert[consumer_svg_on_provider] — run on same cluster pair


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS verification toggle now applied to login and Prometheus connections.
  * Improved provider-side consumer discovery for multicluster CephFS snapshot handling.

* **Tests**
  * CephFS orphaned-snapshot alert test expanded: parameterized SVG modes, randomized snapshot counts, and provider-side/multicluster alert validation with clearer wait/clear steps.

* **Bug Fixes**
  * Fixed CephFS subvolume-group retrieval to read the correct Ceph-CSI config key.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->