### PR TITLE
adding a fixtest_noobaa_sts_host_node_failure: Fix NooBaa DB pod label mismatch for CNPG-based deployments (ODF 4.19+)

### DIFF
--- a/tests/functional/object/mcg/test_host_node_failure.py
+++ b/tests/functional/object/mcg/test_host_node_failure.py
@@ -48,7 +48,10 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
     def labels_map(self):
         ocs_version = version.get_semantic_ocs_version_from_config()
         if ocs_version >= version.VERSION_4_19:
-            noobaa_db_label = constants.NOOBAA_DB_LABEL_419_AND_ABOVE
+            noobaa_db_label = (
+                f"{constants.NOOBAA_DB_LABEL_419_AND_ABOVE},"
+                f"{constants.NB_DB_PRIMARY_POD_LABEL}"
+            )
         else:
             noobaa_db_label = constants.NOOBAA_DB_LABEL_47_AND_ABOVE
         return {

--- a/tests/functional/object/mcg/test_host_node_failure.py
+++ b/tests/functional/object/mcg/test_host_node_failure.py
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.9")
 class TestNoobaaSTSHostNodeFailure(ManageTest):
     """
-    Test to verify NooBaa Statefulset pods recovers in case of a node failure
+    Test to verify NooBaa Statefulset pods recover in case of a node failure
 
     """
 

--- a/tests/functional/object/mcg/test_host_node_failure.py
+++ b/tests/functional/object/mcg/test_host_node_failure.py
@@ -19,6 +19,7 @@ from ocs_ci.helpers.helpers import (
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.exceptions import TimeoutExpiredError, CommandFailed
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.utility import version
 from ocs_ci.ocs.resources.pod import (
     get_pod_node,
     get_noobaa_pods,
@@ -43,11 +44,18 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
 
     """
 
-    labels_map = {
-        constants.NOOBAA_CORE_STATEFULSET: constants.NOOBAA_CORE_POD_LABEL,
-        constants.NOOBAA_DB_STATEFULSET: constants.NOOBAA_DB_LABEL_47_AND_ABOVE,
-        constants.NOOBAA_OPERATOR_DEPLOYMENT: constants.NOOBAA_OPERATOR_POD_LABEL,
-    }
+    @property
+    def labels_map(self):
+        ocs_version = version.get_semantic_ocs_version_from_config()
+        if ocs_version >= version.VERSION_4_19:
+            noobaa_db_label = constants.NOOBAA_DB_LABEL_419_AND_ABOVE
+        else:
+            noobaa_db_label = constants.NOOBAA_DB_LABEL_47_AND_ABOVE
+        return {
+            constants.NOOBAA_CORE_STATEFULSET: constants.NOOBAA_CORE_POD_LABEL,
+            constants.NOOBAA_DB_STATEFULSET: noobaa_db_label,
+            constants.NOOBAA_OPERATOR_DEPLOYMENT: constants.NOOBAA_OPERATOR_POD_LABEL,
+        }
 
     @pytest.fixture(autouse=True)
     def init_sanity(self):
@@ -101,15 +109,24 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
         )
 
         # Get noobaa statefulset pod and node where it is hosted
-        noobaa_sts_pod = get_noobaa_pods(noobaa_label=self.labels_map[noobaa_sts])[0]
+        noobaa_sts_pods = get_noobaa_pods(noobaa_label=self.labels_map[noobaa_sts])
+        assert (
+            noobaa_sts_pods
+        ), f"No pods found with label {self.labels_map[noobaa_sts]}"
+        noobaa_sts_pod = noobaa_sts_pods[0]
         noobaa_sts_pod_node = get_pod_node(noobaa_sts_pod)
         log.info(f"{noobaa_sts_pod.name} is running on {noobaa_sts_pod_node.name}")
 
         # Get the NooBaa operator pod and node where it is hosted
         # Check if NooBaa operator and statefulset pod are hosted on same node
-        noobaa_operator_pod = get_noobaa_pods(
+        noobaa_operator_pods = get_noobaa_pods(
             noobaa_label=self.labels_map[constants.NOOBAA_OPERATOR_DEPLOYMENT]
-        )[0]
+        )
+        assert noobaa_operator_pods, (
+            f"No pods found with label "
+            f"{self.labels_map[constants.NOOBAA_OPERATOR_DEPLOYMENT]}"
+        )
+        noobaa_operator_pod = noobaa_operator_pods[0]
         noobaa_operator_pod_node = get_pod_node(noobaa_operator_pod)
         log.info(
             f"{noobaa_operator_pod.name} is running on {noobaa_operator_pod_node.name}"

--- a/tests/functional/object/mcg/test_host_node_failure.py
+++ b/tests/functional/object/mcg/test_host_node_failure.py
@@ -102,8 +102,8 @@ class TestNoobaaSTSHostNodeFailure(ManageTest):
         node_restart_teardown,
     ):
         """
-        Test case to fail node where NooBaa Statefulset pod (noobaa-core, noobaa-db)
-        is hosted and verify the pod is rescheduled on a healthy node
+        Test case to fail the node where a NooBaa Statefulset pod (noobaa-core, noobaa-db)
+        is hosted and verify that the pod is rescheduled on a healthy node
 
         """
         executor = ThreadPoolExecutor(max_workers=1)


### PR DESCRIPTION
  Summary: 

  The test_noobaa_sts_host_node_failure test fails with IndexError: list index out of range for both noobaa-db-pg parametrizations on ODF 4.19+. The test uses a hardcoded label
  noobaa-db=postgres to find the NooBaa DB pod, but starting in ODF 4.19 the NooBaa DB migrated to CloudNativePG and the pods now use the label cnpg.io/cluster=noobaa-db-pg-cluster. Since no
  pods match the old label, get_noobaa_pods() returns an empty list and [0] crashes.

  The fix replaces the static labels_map with a @property that checks the ODF version at runtime and selects the correct label — NOOBAA_DB_LABEL_419_AND_ABOVE on ODF >= 4.19,
  NOOBAA_DB_LABEL_47_AND_ABOVE otherwise. This follows the same version-gating pattern already used elsewhere in the codebase (e.g. storage_cluster.py, helpers.py). Additionally, bare [0]
  accesses on pod lists are replaced with assertions that produce a clear error message if no pods are found.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/14330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved NooBaa test robustness: pod selection now adapts to product version and explicitly verifies matching pods exist before proceeding, reducing flaky failures during pod discovery.
* **Refactor**
  * Updated label-handling to be determined at runtime per test instance, simplifying pod lookup logic and making tests more resilient across versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->