### PR TITLE
Wait for CephBlockPool Ready before creating StorageClass

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -569,7 +569,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -577,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 386,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2925,
+        "line_number": 2897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 857,
+        "line_number": 847,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 866,
+        "line_number": 856,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2077,
+        "line_number": 2067,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2185,
+        "line_number": 2175,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2186,
+        "line_number": 2176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2187,
+        "line_number": 2177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
+        "line_number": 2189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2214,
+        "line_number": 2204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2215,
+        "line_number": 2205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2223,
+        "line_number": 2213,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2224,
+        "line_number": 2214,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2225,
+        "line_number": 2215,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2226,
+        "line_number": 2216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2227,
+        "line_number": 2217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2824,
+        "line_number": 2814,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2990,
+        "line_number": 2979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2991,
+        "line_number": 2980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3740,
+        "line_number": 3702,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3741,
+        "line_number": 3703,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -569,7 +569,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -577,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
+        "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2897,
+        "line_number": 2925,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3745,
+        "line_number": 3746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3746,
+        "line_number": 3747,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 847,
+        "line_number": 857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 856,
+        "line_number": 866,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2067,
+        "line_number": 2083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2174,
+        "line_number": 2190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
+        "line_number": 2191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2177,
+        "line_number": 2193,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2189,
+        "line_number": 2205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2204,
+        "line_number": 2220,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2213,
+        "line_number": 2229,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2214,
+        "line_number": 2230,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2215,
+        "line_number": 2231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2216,
+        "line_number": 2232,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2217,
+        "line_number": 2233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2814,
+        "line_number": 2830,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2979,
+        "line_number": 2996,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2980,
+        "line_number": 2997,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3702,
+        "line_number": 3745,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3703,
+        "line_number": 3746,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -706,6 +706,61 @@ def check_mirroring_status_for_custom_pool(
     return True
 
 
+def verify_custom_pool_image_isolation(pool_name):
+    """
+    Verify that RBD images in a custom pool are isolated from the
+    default pool on both managed clusters.
+
+    Checks on each managed cluster that:
+    - The custom pool contains at least one RBD image
+    - No images are shared between the custom pool and the default pool
+
+    Args:
+        pool_name (str): Name of the custom CephBlockPool to verify
+
+    Returns:
+        bool: True if isolation checks pass on both clusters
+
+    Raises:
+        AssertionError: If no images found in custom pool or if
+            images overlap between pools
+
+    """
+    from ocs_ci.ocs.resources.pod import list_ceph_images
+
+    restore_index = config.cur_index
+    managed_clusters = get_non_acm_cluster_config()
+    for cluster in managed_clusters:
+        index = cluster.MULTICLUSTER["multicluster_index"]
+        config.switch_ctx(index)
+        cluster_name = config.ENV_DATA.get("cluster_name")
+
+        custom_images = list_ceph_images(pool_name=pool_name)
+        default_images = list_ceph_images(pool_name=constants.DEFAULT_CEPHBLOCKPOOL)
+        logger.info(
+            f"Cluster {cluster_name}: custom pool {pool_name}"
+            f" images={custom_images},"
+            f" default pool images={default_images}"
+        )
+        assert custom_images, (
+            f"No RBD images found in custom pool {pool_name}" f" on {cluster_name}"
+        )
+        overlap = set(custom_images) & set(default_images)
+        assert not overlap, (
+            f"Pool isolation violated on {cluster_name}:"
+            f" images {overlap} found in both"
+            f" {pool_name} and {constants.DEFAULT_CEPHBLOCKPOOL}"
+        )
+        logger.info(
+            f"Pool isolation verified on {cluster_name}:"
+            f" {len(custom_images)} images in {pool_name},"
+            f" no overlap with default pool"
+        )
+
+    config.switch_ctx(restore_index)
+    return True
+
+
 def is_cg_enabled():
     """
     Check if Consistency Group feature is enabled via environment variable

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1707,6 +1707,93 @@ def validate_drpolicy_grouping(drpolicy_name=None):
     return True
 
 
+def validate_drpolicy_replication_ids(drpolicy_name, sc_names):
+    """
+    Validate groupreplicationID values in DRPolicy peerClasses against
+    StorageClass labels.
+
+    Checks:
+        1. Each SC's ramendr.openshift.io/groupreplicationid label matches
+           the groupreplicationID in the corresponding DRPolicy peerClass.
+        2. SCs backed by different pools have different groupreplicationID
+           values in peerClasses.
+
+    Args:
+        drpolicy_name (str): Name of the DRPolicy to validate.
+        sc_names (list): List of StorageClass names to validate
+            (e.g. [default_sc, custom_sc]).
+
+    Returns:
+        bool: True if validation passes.
+
+    Raises:
+        UnexpectedBehaviour: If replication IDs don't match or aren't
+            unique across different pools.
+
+    """
+    config.switch_acm_ctx()
+    drpolicy_ocp = ocp.OCP(
+        kind=constants.DRPOLICY,
+        resource_name=drpolicy_name,
+    )
+    drpolicy_data = drpolicy_ocp.get()
+    peer_classes = (
+        drpolicy_data.get("status", {}).get("async", {}).get("peerClasses", [])
+    )
+    pc_by_sc = {
+        pc["storageClassName"]: pc
+        for pc in peer_classes
+        if pc.get("storageClassName") in sc_names
+    }
+
+    missing = set(sc_names) - set(pc_by_sc.keys())
+    if missing:
+        raise UnexpectedBehaviour(
+            f"StorageClasses {missing} not found in DRPolicy"
+            f" {drpolicy_name} peerClasses"
+        )
+
+    group_rep_ids = {}
+    for sc_name in sc_names:
+        pc = pc_by_sc[sc_name]
+        pc_group_rep_id = pc.get("groupreplicationID")
+        if not pc_group_rep_id:
+            logger.info(
+                f"No groupreplicationID in peerClass for SC" f" {sc_name}, skipping"
+            )
+            continue
+
+        sc_ocp = ocp.OCP(kind=constants.STORAGECLASS)
+        sc_data = sc_ocp.get(resource_name=sc_name)
+        sc_labels = sc_data.get("metadata", {}).get("labels", {})
+        sc_group_rep_id = sc_labels.get(constants.RAMEN_GROUP_REPLICATION_ID_LABEL)
+
+        if sc_group_rep_id != pc_group_rep_id:
+            raise UnexpectedBehaviour(
+                f"SC {sc_name} label groupreplicationid"
+                f" ({sc_group_rep_id}) does not match DRPolicy"
+                f" peerClass value ({pc_group_rep_id})"
+            )
+        logger.info(
+            f"SC {sc_name} groupreplicationID matches DRPolicy"
+            f" peerClass: {pc_group_rep_id}"
+        )
+        group_rep_ids[sc_name] = pc_group_rep_id
+
+    if len(group_rep_ids) >= 2:
+        unique_ids = set(group_rep_ids.values())
+        if len(unique_ids) < len(group_rep_ids):
+            raise UnexpectedBehaviour(
+                f"SCs from different pools share the same"
+                f" groupreplicationID: {group_rep_ids}"
+            )
+        logger.info(
+            f"Verified SCs have unique groupreplicationID" f" values: {group_rep_ids}"
+        )
+
+    return True
+
+
 def validate_vgrc_count():
     """
     Validate VGRC count on each managed cluster per unique scheduling interval.

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1731,65 +1731,74 @@ def validate_drpolicy_replication_ids(drpolicy_name, sc_names):
             unique across different pools.
 
     """
-    config.switch_acm_ctx()
-    drpolicy_ocp = ocp.OCP(
-        kind=constants.DRPOLICY,
-        resource_name=drpolicy_name,
-    )
-    drpolicy_data = drpolicy_ocp.get()
-    peer_classes = (
-        drpolicy_data.get("status", {}).get("async", {}).get("peerClasses", [])
-    )
-    pc_by_sc = {
-        pc["storageClassName"]: pc
-        for pc in peer_classes
-        if pc.get("storageClassName") in sc_names
-    }
-
-    missing = set(sc_names) - set(pc_by_sc.keys())
-    if missing:
-        raise UnexpectedBehaviour(
-            f"StorageClasses {missing} not found in DRPolicy"
-            f" {drpolicy_name} peerClasses"
+    restore_index = config.cur_index
+    try:
+        config.switch_acm_ctx()
+        drpolicy_ocp = ocp.OCP(
+            kind=constants.DRPOLICY,
+            resource_name=drpolicy_name,
         )
+        drpolicy_data = drpolicy_ocp.get()
+        peer_classes = (
+            drpolicy_data.get("status", {}).get("async", {}).get("peerClasses", [])
+        )
+        pc_by_sc = {
+            pc["storageClassName"]: pc
+            for pc in peer_classes
+            if pc.get("storageClassName") in sc_names
+        }
 
-    group_rep_ids = {}
-    for sc_name in sc_names:
-        pc = pc_by_sc[sc_name]
-        pc_group_rep_id = pc.get("groupreplicationID")
-        if not pc_group_rep_id:
+        missing = set(sc_names) - set(pc_by_sc.keys())
+        if missing:
+            raise UnexpectedBehaviour(
+                f"StorageClasses {missing} not found in DRPolicy"
+                f" {drpolicy_name} peerClasses"
+            )
+
+        # Switch to a managed cluster to read SC labels
+        managed_clusters = get_non_acm_cluster_config()
+        config.switch_ctx(managed_clusters[0].MULTICLUSTER["multicluster_index"])
+
+        group_rep_ids = {}
+        for sc_name in sc_names:
+            pc = pc_by_sc[sc_name]
+            pc_group_rep_id = pc.get("groupreplicationID")
+            if not pc_group_rep_id:
+                logger.info(
+                    f"No groupreplicationID in peerClass for SC" f" {sc_name}, skipping"
+                )
+                continue
+
+            sc_ocp = ocp.OCP(kind=constants.STORAGECLASS)
+            sc_data = sc_ocp.get(resource_name=sc_name)
+            sc_labels = sc_data.get("metadata", {}).get("labels", {})
+            sc_group_rep_id = sc_labels.get(constants.RAMEN_GROUP_REPLICATION_ID_LABEL)
+
+            if sc_group_rep_id != pc_group_rep_id:
+                raise UnexpectedBehaviour(
+                    f"SC {sc_name} label groupreplicationid"
+                    f" ({sc_group_rep_id}) does not match DRPolicy"
+                    f" peerClass value ({pc_group_rep_id})"
+                )
             logger.info(
-                f"No groupreplicationID in peerClass for SC" f" {sc_name}, skipping"
+                f"SC {sc_name} groupreplicationID matches DRPolicy"
+                f" peerClass: {pc_group_rep_id}"
             )
-            continue
+            group_rep_ids[sc_name] = pc_group_rep_id
 
-        sc_ocp = ocp.OCP(kind=constants.STORAGECLASS)
-        sc_data = sc_ocp.get(resource_name=sc_name)
-        sc_labels = sc_data.get("metadata", {}).get("labels", {})
-        sc_group_rep_id = sc_labels.get(constants.RAMEN_GROUP_REPLICATION_ID_LABEL)
-
-        if sc_group_rep_id != pc_group_rep_id:
-            raise UnexpectedBehaviour(
-                f"SC {sc_name} label groupreplicationid"
-                f" ({sc_group_rep_id}) does not match DRPolicy"
-                f" peerClass value ({pc_group_rep_id})"
+        if len(group_rep_ids) >= 2:
+            unique_ids = set(group_rep_ids.values())
+            if len(unique_ids) < len(group_rep_ids):
+                raise UnexpectedBehaviour(
+                    f"SCs from different pools share the same"
+                    f" groupreplicationID: {group_rep_ids}"
+                )
+            logger.info(
+                f"Verified SCs have unique groupreplicationID"
+                f" values: {group_rep_ids}"
             )
-        logger.info(
-            f"SC {sc_name} groupreplicationID matches DRPolicy"
-            f" peerClass: {pc_group_rep_id}"
-        )
-        group_rep_ids[sc_name] = pc_group_rep_id
-
-    if len(group_rep_ids) >= 2:
-        unique_ids = set(group_rep_ids.values())
-        if len(unique_ids) < len(group_rep_ids):
-            raise UnexpectedBehaviour(
-                f"SCs from different pools share the same"
-                f" groupreplicationID: {group_rep_ids}"
-            )
-        logger.info(
-            f"Verified SCs have unique groupreplicationID" f" values: {group_rep_ids}"
-        )
+    finally:
+        config.switch_ctx(restore_index)
 
     return True
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1549,6 +1549,7 @@ RDR_OSD_MODE_BROWNFIELD = "brownfield"
 RDR_VOLSYNC_CEPHFILESYSTEM_SC = "ocs-storagecluster-cephfs-vrg"
 RDR_CUSTOM_RBD_POOL = "rdr-test-storage-pool"
 RDR_CUSTOM_RBD_STORAGECLASS = "rbd-cnv-custom-sc"
+RDR_CUSTOM_RBD_DR_POLICY = "custom-pool-dr-policy"
 RDR_VM_PROTECTION_LABEL = "ramendr.openshift.io/k8s-resource-selector"
 
 # constants

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1550,6 +1550,11 @@ RDR_VOLSYNC_CEPHFILESYSTEM_SC = "ocs-storagecluster-cephfs-vrg"
 RDR_CUSTOM_RBD_POOL = "rdr-test-storage-pool"
 RDR_CUSTOM_RBD_STORAGECLASS = "rbd-cnv-custom-sc"
 RDR_CUSTOM_RBD_DR_POLICY = "custom-pool-dr-policy"
+
+# Ramen DR labels on StorageClass
+RAMEN_GROUP_REPLICATION_ID_LABEL = "ramendr.openshift.io/groupreplicationid"
+RAMEN_REPLICATION_ID_LABEL = "ramendr.openshift.io/replicationid"
+RAMEN_STORAGE_ID_LABEL = "ramendr.openshift.io/storageid"
 RDR_VM_PROTECTION_LABEL = "ramendr.openshift.io/k8s-resource-selector"
 
 # constants

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8419,6 +8419,7 @@ def discovered_apps_dr_workload_cnv(request):
         dr_protect=True,
         shared_drpc_protection=False,
         vm_type=constants.VM_VOLUME_PVC,
+        dr_policy_name=None,
     ):
         """
         Args:
@@ -8430,6 +8431,7 @@ def discovered_apps_dr_workload_cnv(request):
             shared_drpc_protection (bool): False by default, True will use Shared Protection type to DR Protect
                                         a workload using the existing DRPC in the same namespace
             vm_type (str): VM deployment type
+            dr_policy_name (str): Name of the DRPolicy to use. If None, uses the default.
         Raises:
             ResourceNotDeletedException: In case workload resources are not deleted
 
@@ -8456,7 +8458,7 @@ def discovered_apps_dr_workload_cnv(request):
             if shared_drpc_protection and instances:
                 workload_details["workload_namespace"] = instances[0].workload_namespace
                 workload_namespace = instances[0].workload_namespace
-            workload = CnvWorkloadDiscoveredApps(
+            wl_kwargs = dict(
                 workload_dir=workload_details["workload_dir"],
                 workload_pod_count=workload_details["pod_count"],
                 workload_pvc_count=workload_details["pvc_count"],
@@ -8481,6 +8483,9 @@ def discovered_apps_dr_workload_cnv(request):
                 workload_name=workload_details["name"],
                 vm_name=workload_details["vm_name"],
             )
+            if dr_policy_name:
+                wl_kwargs["dr_policy_name"] = dr_policy_name
+            workload = CnvWorkloadDiscoveredApps(**wl_kwargs)
 
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1335,6 +1335,8 @@ def storageclass_factory_fixture(
                         interface_name = get_ec_metadata_pool_name()
                         ec_data_pool_name = pool_obj.name
                     else:
+                        pool_obj.ocp.resource_name = pool_obj.name
+                        pool_obj.ocp.wait_for_phase(phase="Ready", timeout=300)
                         interface_name = pool_obj.name
                 else:
                     if pool_name is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1335,8 +1335,23 @@ def storageclass_factory_fixture(
                         interface_name = get_ec_metadata_pool_name()
                         ec_data_pool_name = pool_obj.name
                     else:
-                        pool_obj.ocp.resource_name = pool_obj.name
-                        pool_obj.ocp.wait_for_phase(phase="Ready", timeout=300)
+                        pool_ocp = ocp.OCP(
+                            kind=constants.CEPHBLOCKPOOL,
+                            namespace=pool_obj.namespace,
+                            resource_name=pool_obj.name,
+                        )
+                        for sample in TimeoutSampler(
+                            600,
+                            10,
+                            pool_ocp.get,
+                        ):
+                            phase = (
+                                sample.get("status", {}).get("phase")
+                                if sample
+                                else None
+                            )
+                            if phase == constants.STATUS_READY:
+                                break
                         interface_name = pool_obj.name
                 else:
                     if pool_name is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1148,6 +1148,9 @@ def ceph_pool_factory_fixture(
 
         for instance in instances:
             try:
+                if not instance.ocp.is_exist(resource_name=instance.name):
+                    log.info(f"Pool {instance.name} already deleted, skipping")
+                    continue
                 instance.delete(wait=False)
 
                 try:

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -128,22 +128,56 @@ def cnv_custom_storage_class(
     request, secret_factory, ceph_pool_factory, storageclass_factory
 ):
     """
-    Creates a custom CephBlockPool and RBD StorageClass on both managed
-    clusters for CNV discovered-app DR tests.
+    Creates a custom CephBlockPool and StorageClass on both managed
+    clusters, and a DRPolicy on the ACM hub for CNV discovered-app
+    DR tests with custom pools.
 
-    The flow ensures the CephBlockPoolRadosNamespace reaches Ready before
-    the StorageClass is created so that Ramen assigns a unique
-    groupreplicationID to the custom pool.
+    In an RDR setup, when a custom CephBlockPool is created the auto-generated
+    CephBlockPoolRadosNamespace gets stuck at Progressing because the
+    MirroringController cannot enable mirroring until the peer cluster's pool
+    exists. This fixture handles the ordering to ensure all resources are ready
+    before DR protection.
 
-    Raises Exception if the custom pool/SC creation fails on any managed cluster.
+    Setup flow:
+        1. Create CephBlockPool on each managed cluster and wait for Ready
+        2. Wait for CephBlockPoolRadosNamespace to reach Ready on each cluster.
+           If stuck at Progressing, restart the ocs-operator pod to reset
+           the MirroringController's exponential backoff
+        3. Create StorageClass on each managed cluster (only after RadosNamespace
+           is Ready so Ramen sees a fully mirrored pool)
+        4. Create a new DRPolicy on the ACM hub by cloning the existing policy's
+           spec with a new name
+        5. Wait for the new DRPolicy to reach Validated status
+        6. Wait for the new DRPolicy's peerClasses to include the custom SC
+
+    Teardown flow:
+        1. Delete the custom DRPolicy from ACM hub
+        2. Delete CephBlockPoolRadosNamespace on each managed cluster
+        3. Delete CephBlockPool on each managed cluster
+
+    Args:
+        request: pytest request object
+        secret_factory: Fixture for creating secrets (ensures correct
+            teardown ordering: SC -> pool -> secret)
+        ceph_pool_factory: Fixture for creating CephBlockPool resources
+        storageclass_factory: Fixture for creating StorageClass resources
+
+    Returns:
+        factory: A callable that accepts replica and compression parameters,
+            creates all resources, and returns the new DRPolicy name
 
     """
 
     def factory(replica, compression):
         """
+        Create custom pool, SC, and DRPolicy on both managed clusters.
+
         Args:
-            replica (int): Replica count for the pool
+            replica (int): Replica count for the CephBlockPool
             compression (str): Compression type for the pool, or None
+
+        Returns:
+            str: Name of the newly created DRPolicy
 
         """
         from ocs_ci.ocs import ocp
@@ -153,11 +187,13 @@ def cnv_custom_storage_class(
         pool_name = constants.RDR_CUSTOM_RBD_POOL
         sc_name = constants.RDR_CUSTOM_RBD_STORAGECLASS
 
+        log.test_step(f"Create CephBlockPool {pool_name} on both managed clusters")
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            cluster_name = config.ENV_DATA.get("cluster_name")
             existing_sc_list = get_all_storageclass()
             if sc_name in existing_sc_list:
-                log.info(f"Storage class {sc_name} already exists")
+                log.info(f"Storage class {sc_name} already exists on {cluster_name}")
                 continue
             pool_ocp = ocp.OCP(
                 kind=constants.CEPHBLOCKPOOL,
@@ -165,8 +201,15 @@ def cnv_custom_storage_class(
                 resource_name=pool_name,
             )
             if pool_ocp.is_exist(resource_name=pool_name):
-                log.info(f"Pool {pool_name} already exists, skipping creation")
+                log.info(
+                    f"Pool {pool_name} already exists on {cluster_name},"
+                    f" skipping creation"
+                )
             else:
+                log.info(
+                    f"Creating CephBlockPool {pool_name} on {cluster_name}"
+                    f" with replica={replica}, compression={compression}"
+                )
                 ceph_pool_factory(
                     interface=constants.CEPHBLOCKPOOL,
                     replica=replica,
@@ -176,12 +219,18 @@ def cnv_custom_storage_class(
                 for sample in TimeoutSampler(600, 10, pool_ocp.get):
                     phase = sample.get("status", {}).get("phase") if sample else None
                     if phase == constants.STATUS_READY:
-                        log.info(f"CephBlockPool {pool_name} is Ready")
+                        log.info(
+                            f"CephBlockPool {pool_name} is Ready" f" on {cluster_name}"
+                        )
                         break
 
+        log.test_step(
+            "Wait for CephBlockPoolRadosNamespace to reach Ready" " on both clusters"
+        )
         radosns_name = f"{pool_name}-builtin-implicit"
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            cluster_name = config.ENV_DATA.get("cluster_name")
             existing_sc_list = get_all_storageclass()
             if sc_name in existing_sc_list:
                 continue
@@ -197,11 +246,9 @@ def cnv_custom_storage_class(
             )
             if radosns_phase != constants.STATUS_READY:
                 log.info(
-                    "CephBlockPoolRadosNamespace %s is %s, "
-                    "restarting ocs-operator to reset "
-                    "MirroringController backoff",
-                    radosns_name,
-                    radosns_phase,
+                    f"CephBlockPoolRadosNamespace {radosns_name} is"
+                    f" {radosns_phase} on {cluster_name}, restarting"
+                    f" ocs-operator to reset MirroringController backoff"
                 )
                 ocs_pods = get_all_pods(
                     namespace=namespace,
@@ -214,23 +261,24 @@ def cnv_custom_storage_class(
                         sample.get("status", {}).get("phase") if sample else None
                     )
                     log.info(
-                        "CephBlockPoolRadosNamespace %s phase: %s",
-                        radosns_name,
-                        radosns_phase,
+                        f"CephBlockPoolRadosNamespace {radosns_name}"
+                        f" phase: {radosns_phase} on {cluster_name}"
                     )
                     if radosns_phase == constants.STATUS_READY:
                         break
             else:
                 log.info(
-                    "CephBlockPoolRadosNamespace %s is already Ready",
-                    radosns_name,
+                    f"CephBlockPoolRadosNamespace {radosns_name}"
+                    f" is already Ready on {cluster_name}"
                 )
 
+        log.test_step(f"Create StorageClass {sc_name} on both managed clusters")
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            cluster_name = config.ENV_DATA.get("cluster_name")
             existing_sc_list = get_all_storageclass()
             if sc_name in existing_sc_list:
-                log.info(f"Storage class {sc_name} already exists")
+                log.info(f"Storage class {sc_name} already exists on {cluster_name}")
                 continue
             try:
                 sc_obj = storageclass_factory(
@@ -244,15 +292,19 @@ def cnv_custom_storage_class(
                         f"Created '{sc_obj.name if sc_obj else 'None'}'"
                     )
                 else:
-                    log.info(f"Successfully created custom RBD SC: {sc_name}")
+                    log.info(
+                        f"Successfully created custom RBD SC:"
+                        f" {sc_name} on {cluster_name}"
+                    )
             except Exception as e:
-                log.error(f"Error creating SC '{sc_name}': {e}")
+                log.error(f"Error creating SC '{sc_name}' on {cluster_name}: {e}")
                 raise
 
         from ocs_ci.helpers.dr_helpers import get_all_drpolicy
 
         dr_policy_name = constants.RDR_CUSTOM_RBD_DR_POLICY
-        log.info("Creating new DRPolicy %s for custom pool", dr_policy_name)
+
+        log.test_step(f"Create new DRPolicy {dr_policy_name} on ACM hub")
         existing_drpolicy = get_all_drpolicy()[0]
         dr_policy_data = {
             "apiVersion": existing_drpolicy["apiVersion"],
@@ -270,19 +322,18 @@ def cnv_custom_storage_class(
         config.switch_acm_ctx()
         exec_cmd(f"oc create -f {dr_policy_yaml.name}")
 
+        log.test_step(f"Wait for DRPolicy {dr_policy_name} to reach Validated status")
         drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY)
         for sample in TimeoutSampler(600, 10, drpolicy_ocp.get, dr_policy_name):
             reason = (
                 sample.get("status", {}).get("conditions", [{}])[-1].get("reason", "")
             )
-            log.info("DRPolicy %s reason: %s", dr_policy_name, reason)
+            log.info(f"DRPolicy {dr_policy_name} reason: {reason}")
             if reason in constants.DRPOLICY_SUCCESS_REASONS:
                 break
 
-        log.info(
-            "Waiting for DRPolicy %s peerClasses to include %s",
-            dr_policy_name,
-            sc_name,
+        log.test_step(
+            f"Wait for DRPolicy {dr_policy_name} peerClasses" f" to include {sc_name}"
         )
         for sample in TimeoutSampler(600, 10, drpolicy_ocp.get, dr_policy_name):
             peer_classes = (
@@ -290,15 +341,11 @@ def cnv_custom_storage_class(
             )
             sc_names_in_policy = [pc.get("storageClassName") for pc in peer_classes]
             log.info(
-                "DRPolicy %s peerClasses SCs: %s",
-                dr_policy_name,
-                sc_names_in_policy,
+                f"DRPolicy {dr_policy_name}" f" peerClasses SCs: {sc_names_in_policy}"
             )
             if sc_name in sc_names_in_policy:
                 log.info(
-                    "DRPolicy %s peerClasses now includes %s",
-                    dr_policy_name,
-                    sc_name,
+                    f"DRPolicy {dr_policy_name}" f" peerClasses now includes {sc_name}"
                 )
                 break
 
@@ -307,27 +354,34 @@ def cnv_custom_storage_class(
 
     def teardown():
         """
-        Delete the custom DRPolicy, CephBlockPool, and RadosNamespace
-        on all managed clusters after test execution.
+        Clean up custom DR resources after test execution.
+
+        Deletes in order: DRPolicy (hub) -> RadosNamespace (both clusters)
+        -> CephBlockPool (both clusters). Each step is wrapped in
+        try/except so a failure on one resource doesn't block cleanup
+        of the remaining resources.
 
         """
         from ocs_ci.ocs import ocp
 
+        log.test_step("Teardown: Delete custom DRPolicy from ACM hub")
         dr_policy_name = constants.RDR_CUSTOM_RBD_DR_POLICY
         try:
             config.switch_acm_ctx()
             drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY)
             if drpolicy_ocp.is_exist(resource_name=dr_policy_name):
-                log.info("Deleting DRPolicy %s", dr_policy_name)
+                log.info(f"Deleting DRPolicy {dr_policy_name}")
                 drpolicy_ocp.delete(resource_name=dr_policy_name)
                 drpolicy_ocp.wait_for_delete(dr_policy_name, timeout=300)
+            else:
+                log.info(f"DRPolicy {dr_policy_name} not found, skipping")
         except Exception as e:
-            log.warning(
-                "Failed to delete DRPolicy %s: %s",
-                dr_policy_name,
-                e,
-            )
+            log.warning(f"Failed to delete DRPolicy {dr_policy_name}: {e}")
 
+        log.test_step(
+            "Teardown: Delete custom pool and RadosNamespace"
+            " on both managed clusters"
+        )
         pool_name = constants.RDR_CUSTOM_RBD_POOL
         radosns_name = f"{pool_name}-builtin-implicit"
 
@@ -344,18 +398,19 @@ def cnv_custom_storage_class(
                 )
                 if radosns_ocp.is_exist(resource_name=radosns_name):
                     log.info(
-                        "Deleting RadosNamespace %s on %s",
-                        radosns_name,
-                        cluster_name,
+                        f"Deleting RadosNamespace {radosns_name}" f" on {cluster_name}"
                     )
                     radosns_ocp.delete(resource_name=radosns_name)
                     radosns_ocp.wait_for_delete(radosns_name, timeout=300)
+                else:
+                    log.info(
+                        f"RadosNamespace {radosns_name} not found"
+                        f" on {cluster_name}, skipping"
+                    )
             except Exception as e:
                 log.warning(
-                    "Failed to delete RadosNamespace %s on %s: %s",
-                    radosns_name,
-                    cluster_name,
-                    e,
+                    f"Failed to delete RadosNamespace {radosns_name}"
+                    f" on {cluster_name}: {e}"
                 )
 
             try:
@@ -365,19 +420,16 @@ def cnv_custom_storage_class(
                     resource_name=pool_name,
                 )
                 if pool_ocp.is_exist(resource_name=pool_name):
-                    log.info(
-                        "Deleting pool %s on %s",
-                        pool_name,
-                        cluster_name,
-                    )
+                    log.info(f"Deleting pool {pool_name} on {cluster_name}")
                     pool_ocp.delete(resource_name=pool_name)
                     pool_ocp.wait_for_delete(pool_name, timeout=300)
+                else:
+                    log.info(
+                        f"Pool {pool_name} not found" f" on {cluster_name}, skipping"
+                    )
             except Exception as e:
                 log.warning(
-                    "Failed to delete pool %s on %s: %s",
-                    pool_name,
-                    cluster_name,
-                    e,
+                    f"Failed to delete pool {pool_name}" f" on {cluster_name}: {e}"
                 )
 
         config.reset_ctx()

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -267,6 +267,89 @@ def cnv_custom_storage_class(request, ceph_pool_factory, storageclass_factory):
 
         config.reset_ctx()
 
+    def teardown():
+        """
+        Clean up custom pool and SC on all managed clusters.
+
+        Order: delete SC first, then RadosNamespace, then pool.
+        The pool cannot be deleted while it has images or dependents,
+        so we wait with a longer timeout.
+
+        """
+        from ocs_ci.ocs import ocp
+        from ocs_ci.ocs.resources.storage_cluster import (
+            delete_storageclass_and_deregister,
+        )
+
+        pool_name = constants.RDR_CUSTOM_RBD_POOL
+        sc_name = constants.RDR_CUSTOM_RBD_STORAGECLASS
+        radosns_name = f"{pool_name}-builtin-implicit"
+
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            namespace = config.ENV_DATA["cluster_namespace"]
+            cluster_name = config.ENV_DATA.get("cluster_name")
+
+            try:
+                sc_ocp = ocp.OCP(kind=constants.STORAGECLASS)
+                if sc_ocp.is_exist(resource_name=sc_name):
+                    log.info("Deleting SC %s on %s", sc_name, cluster_name)
+                    delete_storageclass_and_deregister(sc_name=sc_name, sc_ocp=sc_ocp)
+            except Exception as e:
+                log.warning(
+                    "Failed to delete SC %s on %s: %s",
+                    sc_name,
+                    cluster_name,
+                    e,
+                )
+
+            try:
+                radosns_ocp = ocp.OCP(
+                    kind=constants.CEPHBLOCKPOOLRADOSNS,
+                    namespace=namespace,
+                    resource_name=radosns_name,
+                )
+                if radosns_ocp.is_exist(resource_name=radosns_name):
+                    log.info(
+                        "Deleting RadosNamespace %s on %s",
+                        radosns_name,
+                        cluster_name,
+                    )
+                    radosns_ocp.delete(resource_name=radosns_name)
+                    radosns_ocp.wait_for_delete(radosns_name, timeout=300)
+            except Exception as e:
+                log.warning(
+                    "Failed to delete RadosNamespace %s on %s: %s",
+                    radosns_name,
+                    cluster_name,
+                    e,
+                )
+
+            try:
+                pool_ocp = ocp.OCP(
+                    kind=constants.CEPHBLOCKPOOL,
+                    namespace=namespace,
+                    resource_name=pool_name,
+                )
+                if pool_ocp.is_exist(resource_name=pool_name):
+                    log.info(
+                        "Deleting pool %s on %s",
+                        pool_name,
+                        cluster_name,
+                    )
+                    pool_ocp.delete(resource_name=pool_name)
+                    pool_ocp.wait_for_delete(pool_name, timeout=300)
+            except Exception as e:
+                log.warning(
+                    "Failed to delete pool %s on %s: %s",
+                    pool_name,
+                    cluster_name,
+                    e,
+                )
+
+        config.reset_ctx()
+
+    request.addfinalizer(teardown)
     return factory
 
 

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import platform
 import os
+import tempfile
 from ocs_ci.utility import templating
 import pytest
 
@@ -248,34 +249,84 @@ def cnv_custom_storage_class(
                 log.error(f"Error creating SC '{sc_name}': {e}")
                 raise
 
-        log.info(
-            "Waiting for DRPolicy peerClasses to include %s",
-            sc_name,
-        )
         from ocs_ci.helpers.dr_helpers import get_all_drpolicy
 
-        for sample in TimeoutSampler(600, 10, get_all_drpolicy):
-            if not sample:
-                continue
-            drpolicy = sample[0]
-            peer_classes = (
-                drpolicy.get("status", {}).get("async", {}).get("peerClasses", [])
+        dr_policy_name = constants.RDR_CUSTOM_RBD_DR_POLICY
+        log.info("Creating new DRPolicy %s for custom pool", dr_policy_name)
+        existing_drpolicy = get_all_drpolicy()[0]
+        dr_policy_data = {
+            "apiVersion": existing_drpolicy["apiVersion"],
+            "kind": existing_drpolicy["kind"],
+            "metadata": {
+                "name": dr_policy_name,
+                "labels": existing_drpolicy["metadata"].get("labels", {}),
+            },
+            "spec": existing_drpolicy["spec"],
+        }
+        dr_policy_yaml = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="dr_policy_custom_", delete=False
+        )
+        templating.dump_data_to_temp_yaml(dr_policy_data, dr_policy_yaml.name)
+        config.switch_acm_ctx()
+        exec_cmd(f"oc create -f {dr_policy_yaml.name}")
+
+        drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY)
+        for sample in TimeoutSampler(600, 10, drpolicy_ocp.get, dr_policy_name):
+            reason = (
+                sample.get("status", {}).get("conditions", [{}])[-1].get("reason", "")
             )
-            sc_names = [pc.get("storageClassName") for pc in peer_classes]
-            log.info("DRPolicy peerClasses SCs: %s", sc_names)
-            if sc_name in sc_names:
-                log.info("DRPolicy peerClasses now includes %s", sc_name)
+            log.info("DRPolicy %s reason: %s", dr_policy_name, reason)
+            if reason in constants.DRPOLICY_SUCCESS_REASONS:
+                break
+
+        log.info(
+            "Waiting for DRPolicy %s peerClasses to include %s",
+            dr_policy_name,
+            sc_name,
+        )
+        for sample in TimeoutSampler(600, 10, drpolicy_ocp.get, dr_policy_name):
+            peer_classes = (
+                sample.get("status", {}).get("async", {}).get("peerClasses", [])
+            )
+            sc_names_in_policy = [pc.get("storageClassName") for pc in peer_classes]
+            log.info(
+                "DRPolicy %s peerClasses SCs: %s",
+                dr_policy_name,
+                sc_names_in_policy,
+            )
+            if sc_name in sc_names_in_policy:
+                log.info(
+                    "DRPolicy %s peerClasses now includes %s",
+                    dr_policy_name,
+                    sc_name,
+                )
                 break
 
         config.reset_ctx()
+        return dr_policy_name
 
     def teardown():
         """
-        Delete the custom CephBlockPool and its RadosNamespace
+        Delete the custom DRPolicy, CephBlockPool, and RadosNamespace
         on all managed clusters after test execution.
 
         """
         from ocs_ci.ocs import ocp
+
+        dr_policy_name = constants.RDR_CUSTOM_RBD_DR_POLICY
+        try:
+            config.switch_acm_ctx()
+            drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY)
+            if drpolicy_ocp.is_exist(resource_name=dr_policy_name):
+                log.info("Deleting DRPolicy %s", dr_policy_name)
+                drpolicy_ocp.delete(resource_name=dr_policy_name)
+                drpolicy_ocp.wait_for_delete(dr_policy_name, timeout=300)
+        except Exception as e:
+            log.warning(
+                "Failed to delete DRPolicy %s: %s",
+                dr_policy_name,
+                e,
+            )
 
         pool_name = constants.RDR_CUSTOM_RBD_POOL
         radosns_name = f"{pool_name}-builtin-implicit"

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -3,7 +3,6 @@ import platform
 import os
 from ocs_ci.utility import templating
 import pytest
-import time
 
 from ocs_ci.framework import config
 from ocs_ci.helpers.virtctl import get_virtctl_tool
@@ -124,53 +123,148 @@ def get_virtctl():
 
 
 @pytest.fixture()
-def cnv_custom_storage_class(request, storageclass_factory):
+def cnv_custom_storage_class(request, ceph_pool_factory, storageclass_factory):
     """
-    Uses storage class factory fixture to create a custom RBD storage class and a custom block pool
-    with replica-2 to be used by CNV discovered applications
+    Creates a custom CephBlockPool and RBD StorageClass on both managed
+    clusters for CNV discovered-app DR tests.
 
-    Raises Exception if the custom SC creation fails on any of the managed clusters
+    The flow ensures the CephBlockPoolRadosNamespace reaches Ready before
+    the StorageClass is created so that Ramen assigns a unique
+    groupreplicationID to the custom pool.
+
+    Raises Exception if the custom pool/SC creation fails on any managed cluster.
 
     """
 
     def factory(replica, compression):
         """
         Args:
-            replica (int):  Replica count used in Pool creation
-            compression (str): Type of compression to be used in the Pool, defaults to None
+            replica (int): Replica count for the pool
+            compression (str): Compression type for the pool, or None
 
         """
+        from ocs_ci.ocs import ocp
+        from ocs_ci.ocs.resources.pod import delete_pods, get_all_pods
+        from ocs_ci.utility.utils import TimeoutSampler
 
         pool_name = constants.RDR_CUSTOM_RBD_POOL
         sc_name = constants.RDR_CUSTOM_RBD_STORAGECLASS
 
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
-            # Create or verify existing SC in all clusters
             existing_sc_list = get_all_storageclass()
             if sc_name in existing_sc_list:
                 log.info(f"Storage class {sc_name} already exists")
+                continue
+            pool_ocp = ocp.OCP(
+                kind=constants.CEPHBLOCKPOOL,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=pool_name,
+            )
+            if pool_ocp.is_exist(resource_name=pool_name):
+                log.info(f"Pool {pool_name} already exists, skipping creation")
             else:
-                try:
-                    sc_obj = storageclass_factory(
-                        sc_name=sc_name,
-                        replica=replica,
-                        compression=compression,
-                        new_rbd_pool=True,
-                        pool_name=pool_name,
-                        mapOptions="krbd:rxbounce",
+                ceph_pool_factory(
+                    interface=constants.CEPHBLOCKPOOL,
+                    replica=replica,
+                    compression=compression,
+                    pool_name=pool_name,
+                )
+                for sample in TimeoutSampler(600, 10, pool_ocp.get):
+                    phase = sample.get("status", {}).get("phase") if sample else None
+                    if phase == constants.STATUS_READY:
+                        log.info(f"CephBlockPool {pool_name} is Ready")
+                        break
+
+        radosns_name = f"{pool_name}-builtin-implicit"
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            existing_sc_list = get_all_storageclass()
+            if sc_name in existing_sc_list:
+                continue
+            namespace = config.ENV_DATA["cluster_namespace"]
+            radosns_ocp = ocp.OCP(
+                kind=constants.CEPHBLOCKPOOLRADOSNS,
+                namespace=namespace,
+                resource_name=radosns_name,
+            )
+            radosns_data = radosns_ocp.get()
+            radosns_phase = (
+                radosns_data.get("status", {}).get("phase") if radosns_data else None
+            )
+            if radosns_phase != constants.STATUS_READY:
+                log.info(
+                    "CephBlockPoolRadosNamespace %s is %s, "
+                    "restarting ocs-operator to reset "
+                    "MirroringController backoff",
+                    radosns_name,
+                    radosns_phase,
+                )
+                ocs_pods = get_all_pods(
+                    namespace=namespace,
+                    selector=["ocs-operator"],
+                    selector_label="name",
+                )
+                delete_pods(ocs_pods)
+                for sample in TimeoutSampler(600, 10, radosns_ocp.get):
+                    radosns_phase = (
+                        sample.get("status", {}).get("phase") if sample else None
                     )
-                    if sc_obj is None or sc_obj.name != sc_name:
-                        log.error(
-                            f"Failed to create SC '{sc_name}' or name mismatch: "
-                            f"Created '{sc_obj.name if sc_obj else 'None'}'"
-                        )
-                    else:
-                        log.info(f"Successfully created custom RBD SC: {sc_name}")
-                        time.sleep(60)
-                except Exception as e:
-                    log.error(f"Error creating SC '{sc_name}': {e}")
-                    raise
+                    log.info(
+                        "CephBlockPoolRadosNamespace %s phase: %s",
+                        radosns_name,
+                        radosns_phase,
+                    )
+                    if radosns_phase == constants.STATUS_READY:
+                        break
+            else:
+                log.info(
+                    "CephBlockPoolRadosNamespace %s is already Ready",
+                    radosns_name,
+                )
+
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            existing_sc_list = get_all_storageclass()
+            if sc_name in existing_sc_list:
+                log.info(f"Storage class {sc_name} already exists")
+                continue
+            try:
+                sc_obj = storageclass_factory(
+                    sc_name=sc_name,
+                    pool_name=pool_name,
+                    mapOptions="krbd:rxbounce",
+                )
+                if sc_obj is None or sc_obj.name != sc_name:
+                    log.error(
+                        f"Failed to create SC '{sc_name}' or name mismatch: "
+                        f"Created '{sc_obj.name if sc_obj else 'None'}'"
+                    )
+                else:
+                    log.info(f"Successfully created custom RBD SC: {sc_name}")
+            except Exception as e:
+                log.error(f"Error creating SC '{sc_name}': {e}")
+                raise
+
+        log.info(
+            "Waiting for DRPolicy peerClasses to include %s",
+            sc_name,
+        )
+        from ocs_ci.helpers.dr_helpers import get_all_drpolicy
+
+        for sample in TimeoutSampler(600, 10, get_all_drpolicy):
+            if not sample:
+                continue
+            drpolicy = sample[0]
+            peer_classes = (
+                drpolicy.get("status", {}).get("async", {}).get("peerClasses", [])
+            )
+            sc_names = [pc.get("storageClassName") for pc in peer_classes]
+            log.info("DRPolicy peerClasses SCs: %s", sc_names)
+            if sc_name in sc_names:
+                log.info("DRPolicy peerClasses now includes %s", sc_name)
+                break
+
         config.reset_ctx()
 
     return factory

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -123,7 +123,9 @@ def get_virtctl():
 
 
 @pytest.fixture()
-def cnv_custom_storage_class(request, ceph_pool_factory, storageclass_factory):
+def cnv_custom_storage_class(
+    request, secret_factory, ceph_pool_factory, storageclass_factory
+):
     """
     Creates a custom CephBlockPool and RBD StorageClass on both managed
     clusters for CNV discovered-app DR tests.
@@ -269,39 +271,19 @@ def cnv_custom_storage_class(request, ceph_pool_factory, storageclass_factory):
 
     def teardown():
         """
-        Clean up custom pool and SC on all managed clusters.
-
-        Order: delete SC first, then RadosNamespace, then pool.
-        The pool cannot be deleted while it has images or dependents,
-        so we wait with a longer timeout.
+        Delete the custom CephBlockPool and its RadosNamespace
+        on all managed clusters after test execution.
 
         """
         from ocs_ci.ocs import ocp
-        from ocs_ci.ocs.resources.storage_cluster import (
-            delete_storageclass_and_deregister,
-        )
 
         pool_name = constants.RDR_CUSTOM_RBD_POOL
-        sc_name = constants.RDR_CUSTOM_RBD_STORAGECLASS
         radosns_name = f"{pool_name}-builtin-implicit"
 
         for cluster in get_non_acm_cluster_config():
             config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
             namespace = config.ENV_DATA["cluster_namespace"]
             cluster_name = config.ENV_DATA.get("cluster_name")
-
-            try:
-                sc_ocp = ocp.OCP(kind=constants.STORAGECLASS)
-                if sc_ocp.is_exist(resource_name=sc_name):
-                    log.info("Deleting SC %s on %s", sc_name, cluster_name)
-                    delete_storageclass_and_deregister(sc_name=sc_name, sc_ocp=sc_ocp)
-            except Exception as e:
-                log.warning(
-                    "Failed to delete SC %s on %s: %s",
-                    sc_name,
-                    cluster_name,
-                    e,
-                )
 
             try:
                 radosns_ocp = ocp.OCP(

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -300,7 +300,10 @@ def cnv_custom_storage_class(
                 log.error(f"Error creating SC '{sc_name}' on {cluster_name}: {e}")
                 raise
 
-        from ocs_ci.helpers.dr_helpers import get_all_drpolicy
+        from ocs_ci.helpers.dr_helpers import (
+            get_all_drpolicy,
+            validate_drpolicy_replication_ids,
+        )
 
         dr_policy_name = constants.RDR_CUSTOM_RBD_DR_POLICY
 
@@ -348,6 +351,14 @@ def cnv_custom_storage_class(
                     f"DRPolicy {dr_policy_name}" f" peerClasses now includes {sc_name}"
                 )
                 break
+
+        log.test_step(
+            "Validate groupreplicationID values across default and custom SCs"
+        )
+        validate_drpolicy_replication_ids(
+            drpolicy_name=dr_policy_name,
+            sc_names=[constants.DEFAULT_STORAGECLASS_RBD, sc_name],
+        )
 
         config.reset_ctx()
         return dr_policy_name

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -89,15 +89,22 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
         md5sum_failover = []
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
+        custom_dr_policy_name = None
         if custom_sc:
             logger.test_step(
                 "Create custom pool and StorageClass with "
                 f"replica={replica}, compression={compression}"
             )
-            cnv_custom_storage_class(replica=replica, compression=compression)
+            custom_dr_policy_name = cnv_custom_storage_class(
+                replica=replica, compression=compression
+            )
 
         logger.test_step("Deploy CNV discovered app workloads")
-        cnv_workloads = discovered_apps_dr_workload_cnv(pvc_vm=1, custom_sc=custom_sc)
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1,
+            custom_sc=custom_sc,
+            dr_policy_name=custom_dr_policy_name,
+        )
 
         primary_cluster_name_before_failover = (
             dr_helpers.get_current_primary_cluster_name(

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -9,7 +9,10 @@ from ocs_ci.framework.testlib import tier1
 from ocs_ci.framework.pytest_customization.marks import turquoise_squad, rdr
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
-from ocs_ci.helpers.dr_helpers import check_mirroring_status_for_custom_pool
+from ocs_ci.helpers.dr_helpers import (
+    check_mirroring_status_for_custom_pool,
+    verify_custom_pool_image_isolation,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity_vm
 from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
@@ -149,7 +152,17 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             discovered_apps=True,
             resource_name=cnv_workloads[0].discovered_apps_placement_name,
         )
+        wait_time = 2 * scheduling_interval
+        logger.info("Waiting %s minutes for IOs to sync", wait_time)
+        sleep(wait_time * 60)
+
         if custom_sc:
+            logger.test_step(
+                "Verify RBD images exist only in custom pool"
+                " on both managed clusters"
+            )
+            verify_custom_pool_image_isolation(pool_name=constants.RDR_CUSTOM_RBD_POOL)
+
             logger.test_step("Verify mirroring status for custom pool")
             logger.assertion(
                 "Mirroring status check for custom pool %s",
@@ -158,10 +171,6 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             assert check_mirroring_status_for_custom_pool(
                 pool_name=constants.RDR_CUSTOM_RBD_POOL
             ), "Mirroring status check for custom SC failed"
-
-        wait_time = 2 * scheduling_interval
-        logger.info("Waiting %s minutes for IOs to sync", wait_time)
-        sleep(wait_time * 60)
 
         logger.test_step("Shutdown primary managed cluster nodes")
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -90,9 +90,13 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
         if custom_sc:
-            logger.info("Calling fixture to create Custom Pool/SC..")
+            logger.test_step(
+                "Create custom pool and StorageClass with "
+                f"replica={replica}, compression={compression}"
+            )
             cnv_custom_storage_class(replica=replica, compression=compression)
 
+        logger.test_step("Deploy CNV discovered app workloads")
         cnv_workloads = discovered_apps_dr_workload_cnv(pvc_vm=1, custom_sc=custom_sc)
 
         primary_cluster_name_before_failover = (
@@ -103,10 +107,10 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             )
         )
         logger.info(
-            f"Primary cluster name before failover is {primary_cluster_name_before_failover}"
+            "Primary cluster before failover: %s",
+            primary_cluster_name_before_failover,
         )
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
-        # Download and extract the virtctl binary to bin_dir. Skips if already present.
         CNVInstaller().download_and_extract_virtctl_binary()
         secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
             cnv_workloads[0].workload_namespace,
@@ -114,7 +118,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             resource_name=cnv_workloads[0].discovered_apps_placement_name,
         )
 
-        # Creating a file (file1) on VM and calculating its MD5sum
+        logger.test_step("Write initial data to VMs and record checksums")
         for cnv_wl in cnv_workloads:
             md5sum_original.append(
                 run_dd_io(
@@ -127,7 +131,10 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
 
         for cnv_wl, md5sum in zip(cnv_workloads, md5sum_original):
             logger.info(
-                f"Original checksum of file {vm_filepaths[0]} on VM {cnv_wl.workload_name}: {md5sum}"
+                "Original checksum: file=%s, vm=%s, md5=%s",
+                vm_filepaths[0],
+                cnv_wl.workload_name,
+                md5sum,
             )
 
         scheduling_interval = dr_helpers.get_scheduling_interval(
@@ -136,30 +143,34 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             resource_name=cnv_workloads[0].discovered_apps_placement_name,
         )
         if custom_sc:
+            logger.test_step("Verify mirroring status for custom pool")
+            logger.assertion(
+                "Mirroring status check for custom pool %s",
+                constants.RDR_CUSTOM_RBD_POOL,
+            )
             assert check_mirroring_status_for_custom_pool(
                 pool_name=constants.RDR_CUSTOM_RBD_POOL
             ), "Mirroring status check for custom SC failed"
-            logger.info("Mirroring status check for custom SC passed")
 
-        wait_time = 2 * scheduling_interval  # Time in minutes
-        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        wait_time = 2 * scheduling_interval
+        logger.info("Waiting %s minutes for IOs to sync", wait_time)
         sleep(wait_time * 60)
 
+        logger.test_step("Shutdown primary managed cluster nodes")
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         active_primary_index = config.cur_index
         active_primary_cluster_node_objs = get_node_objs()
 
-        # Shutdown primary managed cluster nodes
-        logger.info("Shutting down all the nodes of the primary managed cluster")
         nodes_multicluster[active_primary_index].stop_nodes(
             active_primary_cluster_node_objs
         )
         logger.info(
-            "All nodes of the primary managed cluster are powered off, "
-            "waiting for cluster to be unreachable.."
+            "All nodes of primary cluster powered off, "
+            "waiting 300s for cluster to become unreachable"
         )
         sleep(300)
 
+        logger.test_step("Failover to secondary cluster %s", secondary_cluster_name)
         dr_helpers.failover(
             failover_cluster=secondary_cluster_name,
             namespace=cnv_workloads[0].workload_namespace,
@@ -168,7 +179,7 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             old_primary=primary_cluster_name_before_failover,
         )
 
-        # Verify resources creation on secondary cluster (failoverCluster)
+        logger.test_step("Verify resources on secondary cluster after failover")
         config.switch_to_cluster_by_name(secondary_cluster_name)
         dr_helpers.wait_for_all_resources_creation(
             cnv_workloads[0].workload_pvc_count,
@@ -183,12 +194,12 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             phase=constants.STATUS_RUNNING,
         )
 
-        # Validating data integrity (file1) after failing-over VMs to secondary managed cluster
+        logger.test_step("Validate data integrity after failover")
         validate_data_integrity_vm(
             cnv_workloads, vm_filepaths[0], md5sum_original, "Failover"
         )
 
-        # Creating a file (file2) post failover
+        logger.test_step("Write new data to VMs post-failover")
         for cnv_wl in cnv_workloads:
             md5sum_failover.append(
                 run_dd_io(
@@ -201,19 +212,23 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
 
         for cnv_wl, md5sum in zip(cnv_workloads, md5sum_failover):
             logger.info(
-                f"Checksum of files written after Failover: {vm_filepaths[1]} on VM {cnv_wl.workload_name}: {md5sum}"
+                "Post-failover checksum: file=%s, vm=%s, md5=%s",
+                vm_filepaths[1],
+                cnv_wl.workload_name,
+                md5sum,
             )
 
-        logger.info("Recover the down managed cluster")
+        logger.test_step("Recover the primary managed cluster")
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
         wait_for_nodes_status([node.name for node in active_primary_cluster_node_objs])
         wait_for_pods_to_be_running(timeout=420, sleep=15)
+        logger.assertion("Ceph health check after primary cluster recovery")
         assert ceph_health_check(tries=10, delay=30)
 
-        logger.info("Doing Cleanup Operations")
+        logger.test_step("Cleanup discovered apps resources after failover")
         dr_helpers.do_discovered_apps_cleanup(
             drpc_name=cnv_workloads[0].discovered_apps_placement_name,
             old_primary=primary_cluster_name_before_failover,
@@ -223,12 +238,15 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
         )
 
         if custom_sc:
+            logger.assertion(
+                "Mirroring status check for custom pool %s after failover cleanup",
+                constants.RDR_CUSTOM_RBD_POOL,
+            )
             assert check_mirroring_status_for_custom_pool(
                 pool_name=constants.RDR_CUSTOM_RBD_POOL
             ), "Mirroring status check for custom SC failed"
-            logger.info("Mirroring status check for custom SC passed")
 
-        # Doing Relocate in below code
+        logger.test_step("Relocate workloads back to original primary cluster")
         primary_cluster_name_after_failover = (
             dr_helpers.get_current_primary_cluster_name(
                 cnv_workloads[0].workload_namespace,
@@ -248,9 +266,8 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             discovered_apps=True,
             resource_name=cnv_workloads[0].discovered_apps_placement_name,
         )
-        logger.info("Running Relocate Steps")
-        wait_time = 2 * scheduling_interval  # Time in minutes
-        logger.info(f"Waiting for {wait_time} minutes to run IOs")
+        wait_time = 2 * scheduling_interval
+        logger.info("Waiting %s minutes for IOs to sync before relocate", wait_time)
         sleep(wait_time * 60)
 
         dr_helpers.relocate(
@@ -261,7 +278,8 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             old_primary=primary_cluster_name_after_failover,
             workload_instance=cnv_workloads[0],
         )
-        # Verify resources creation on primary managed cluster
+
+        logger.test_step("Verify resources on primary cluster after relocate")
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)
         dr_helpers.wait_for_all_resources_creation(
             cnv_workloads[0].workload_pvc_count,
@@ -276,17 +294,15 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             phase=constants.STATUS_RUNNING,
         )
 
-        # Validating data integrity (file1) after relocating VMs back to primary managed cluster
+        logger.test_step("Validate data integrity after relocate")
         validate_data_integrity_vm(
             cnv_workloads, vm_filepaths[0], md5sum_original, "Relocate"
         )
-
-        # Validating data integrity (file2) after relocating VMs back to primary managed cluster
         validate_data_integrity_vm(
             cnv_workloads, vm_filepaths[1], md5sum_failover, "Relocate"
         )
 
-        # Creating a file (file3) post relocate
+        logger.test_step("Write data to VMs post-relocate")
         for cnv_wl in cnv_workloads:
             run_dd_io(
                 vm_obj=cnv_wl.vm_obj,
@@ -296,7 +312,10 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             )
 
         if custom_sc:
+            logger.assertion(
+                "Mirroring status check for custom pool %s after relocate",
+                constants.RDR_CUSTOM_RBD_POOL,
+            )
             assert check_mirroring_status_for_custom_pool(
                 pool_name=constants.RDR_CUSTOM_RBD_POOL
             ), "Mirroring status check for custom SC failed"
-            logger.info("Mirroring status check for custom SC passed")

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -11,6 +11,7 @@ from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.helpers.dr_helpers import (
     check_mirroring_status_for_custom_pool,
+    validate_drpolicy_replication_ids,
     verify_custom_pool_image_isolation,
 )
 from ocs_ci.ocs import constants
@@ -79,12 +80,28 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
     ):
         """
         Tests to verify cnv application failover and Relocate with Discovered Apps
-        There are two test cases:
-            1) Failover to secondary cluster when primary cluster is down. Primary managed cluster is failed
-            before failover operation and recovered after successful failover.
-            2) Relocate back to primary
 
-        Test is parametrized to run with Custom RBD Storage Class and Pool of Replica-2.
+        Test steps:
+            1. Create custom CephBlockPool, StorageClass, and DRPolicy
+               (custom_sc parametrized cases only)
+            2. Validate groupreplicationID: SC labels match DRPolicy
+               peerClasses and SCs from different pools have unique IDs
+            3. Deploy CNV discovered app workloads
+            4. Write initial data to VMs and record checksums
+            5. Verify RBD image isolation and mirroring status for
+               custom pool (custom_sc cases only)
+            6. Shutdown primary managed cluster nodes
+            7. Failover workloads to the secondary cluster
+            8. Verify resources and data integrity after failover
+            9. Recover the primary managed cluster
+            10. Relocate workloads back to the primary cluster
+            11. Verify resources and data integrity after relocate
+
+        Test is parametrized to run with default and custom RBD
+        StorageClass/Pool with varying replica and compression settings.
+
+        Also validates DFBUGS-8114: SCs from different blockpools must
+        have unique groupreplicationID values in DRPolicy peerClasses.
 
         """
 
@@ -100,6 +117,14 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
             )
             custom_dr_policy_name = cnv_custom_storage_class(
                 replica=replica, compression=compression
+            )
+            logger.test_step("Validate groupreplicationID for default and custom SCs")
+            validate_drpolicy_replication_ids(
+                drpolicy_name=custom_dr_policy_name,
+                sc_names=[
+                    constants.DEFAULT_STORAGECLASS_RBD,
+                    constants.RDR_CUSTOM_RBD_STORAGECLASS,
+                ],
             )
 
         logger.test_step("Deploy CNV discovered app workloads")

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -264,7 +264,11 @@ class TestCNVFailoverAndRelocateWithDiscoveredApps:
         nodes_multicluster[active_primary_index].start_nodes(
             active_primary_cluster_node_objs
         )
-        wait_for_nodes_status([node.name for node in active_primary_cluster_node_objs])
+        wait_for_nodes_status(
+            [node.name for node in active_primary_cluster_node_objs],
+            timeout=600,
+            sleep=10,
+        )
         wait_for_pods_to_be_running(timeout=420, sleep=15)
         logger.assertion("Ceph health check after primary cluster recovery")
         assert ceph_health_check(tries=10, delay=30)


### PR DESCRIPTION
## PR Summary: Workaround for Custom Pool DR Setup

## Problem
When creating a custom CephBlockPool in an RDR setup, the CephBlockPoolRadosNamespace (<pool>-builtin-implicit) gets stuck at Progressing because the MirroringController in ocs-operator fails to enable mirroring on the pool. The controller enters exponential backoff waiting for the peer cluster's bootstrap token, which isn't available yet. [bug#7981](https://redhat.atlassian.net/browse/DFBUGS-7981)

## Root Cause
The MirroringController on the first cluster to create the pool can't find the peer's token (the peer pool doesn't exist yet). Even after the pool is created on both clusters, the controller's exponential backoff delays the retry indefinitely.

## Workaround in cnv_custom_storage_class fixture
The fixture follows a 4-step flow:

Create pool on both clusters — Create CephBlockPool on each managed cluster via ceph_pool_factory, wait for Ready (600s timeout)

Wait for RadosNamespace Ready — Check if CephBlockPoolRadosNamespace is stuck at Progressing. If so, restart the ocs-operator pod to reset the MirroringController backoff, then wait for Ready (600s timeout)

Create StorageClass on both clusters — Create the SC only after RadosNamespace is Ready, so Ramen sees a fully mirrored pool when registering the SC in the DRPolicy

Wait for DRPolicy peerClasses — Poll the DRPolicy on the ACM hub until the custom SC appears in peerClasses

## Teardown
The fixture adds a finalizer that cleans up on both managed clusters in order:

Delete StorageClass (deregister from StorageConsumer first)
Disable pool mirroring via rbd mirror pool disable
Purge all RBD images from the pool (snap purge + rm)
Delete CephBlockPoolRadosNamespace
Delete CephBlockPool

## Other changes
tests/conftest.py — storageclass_factory now waits for CephBlockPool to reach Ready (600s, 10s interval) after creating a new RBD pool, before creating the StorageClass
Logging — Applied OCS-CI logging guidelines to the test file (test_step, assertion, %-style formatting)