### PR TITLE
Add encrypted BlueStore dm-crypt OSD simulation on worker nodes

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_encrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_encrypted.yaml
@@ -1,0 +1,26 @@
+---
+# Deploys an LSO-backed ODF cluster via CLI on vSphere UPI (VMDK, 3m/3w).
+# After LSO installs and provisions PVs from clean disks, the LSO operator is
+# scaled down and LUKS headers are written to the backing disks
+# (simulate_bluestore_label_dmcrypt). LSO stays down while the StorageCluster
+# is deployed with wipeDevicesFromOtherClusters so Rook wipes the LUKS headers
+# and provisions new encrypted OSDs. LSO is restored once OSD pods are Running.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: false
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  simulate_bluestore_label_dmcrypt: true
+  wipe_devices_from_other_clusters: true
+  encryption_at_rest: true

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_encrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_encrypted.yaml
@@ -24,3 +24,6 @@ ENV_DATA:
   simulate_bluestore_label_dmcrypt: true
   wipe_devices_from_other_clusters: true
   encryption_at_rest: true
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8019'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_unencrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_unencrypted.yaml
@@ -1,0 +1,26 @@
+---
+# Deploys an LSO-backed ODF cluster via CLI on vSphere UPI (VMDK, 3m/3w).
+# After LSO installs and provisions PVs from clean disks, the LSO operator is
+# scaled down and LUKS headers are written to the backing disks
+# (simulate_bluestore_label_dmcrypt). LSO stays down while the StorageCluster
+# is deployed with wipeDevicesFromOtherClusters so Rook wipes the LUKS headers
+# and provisions new unencrypted OSDs. LSO is restored once OSD pods are Running.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: false
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  simulate_bluestore_label_dmcrypt: true
+  wipe_devices_from_other_clusters: true
+  encryption_at_rest: false

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_unencrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_unencrypted.yaml
@@ -24,3 +24,6 @@ ENV_DATA:
   simulate_bluestore_label_dmcrypt: true
   wipe_devices_from_other_clusters: true
   encryption_at_rest: false
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8020'

--- a/conf/ocsci/simulate_bluestore_label_dmcrypt.yaml
+++ b/conf/ocsci/simulate_bluestore_label_dmcrypt.yaml
@@ -1,0 +1,6 @@
+# Enables simulation of encrypted Ceph OSD BlueStore metadata (dm-crypt/LUKS)
+# on OSD disks. Used to test whether Ceph correctly detects existing encrypted
+# BlueStore metadata when deploying a new cluster.
+# Intended for use only with LSO (Local Storage Operator) deployments.
+ENV_DATA:
+  simulate_bluestore_label_dmcrypt: true

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1561,68 +1561,45 @@ def clean_disk(
         logger.info(out)
 
 
-def detect_simulation_disk_on_node(wnode, namespace=None, timeout=300):
+def detect_simulation_disk_on_node(wnode, namespace=None):
     """
-    Detects the last available /dev/sd*, /dev/nvme*n0* disk on a given worker node.
+    Detects an available /dev/sd* or /dev/nvme* disk on a given worker node.
+
+    Uses ``disks_available_to_cleanup`` to identify non-OS disks regardless
+    of platform. This avoids the alphabetical-ordering pitfall where the extra
+    disk sorts before the OS disk (e.g. compute-0: sda=extra, sdb=OS would
+    cause a naive ``tail -1`` to pick the OS disk).
 
     Args:
         wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object.
         namespace (str): Namespace for the debug pod.
-        timeout (int): Timeout for the command execution.
 
     Returns:
-        str or None: The detected disk path (e.g., "/dev/sdb", "/dev/nvme*n0*") or None if not found.
+        str or None: The detected disk path (e.g., "/dev/sdb") or None if
+            not found.
 
     """
     namespace = namespace or constants.DEFAULT_NAMESPACE
 
     logger.info(
-        f"Attempting to auto-detect a suitable /dev/sd*, /dev/nvme*n0* "
+        f"Attempting to auto-detect a suitable /dev/sd*, /dev/nvme* "
         f"disk on worker node: {wnode.name}."
     )
-    # Determine disk naming pattern based on platform type
-    platform = config.ENV_DATA["platform"].lower()
-    if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
-        disk_names_available = disks_available_to_cleanup(wnode, namespace=namespace)
-        candidate_disks = [
-            disk_name
-            for disk_name in disk_names_available
-            if disk_name.startswith(("nvme", "sd"))
-        ]
-        if not candidate_disks:
-            raise ValueError(
-                f"Didn't find any sd*/nvme* disks available on node {wnode.name}"
-            )
-        disk_name_pattern = "|".join(
-            f"^{re.escape(disk_name)}$" for disk_name in candidate_disks
-        )
-    else:
-        # SATA/SCSI disks typically used in virtualized environments
-        disk_name_pattern = "^sd[a-z]$"
 
-    # Construct command to find the last matching disk device
-    cmd = [
-        f'lsblk -dn -o NAME | grep -E "{disk_name_pattern}" | sed "s#^#/dev/#" | tail -1'
+    disk_names_available = disks_available_to_cleanup(wnode, namespace=namespace)
+    candidate_disks = [
+        disk_name
+        for disk_name in disk_names_available
+        if disk_name.startswith(("nvme", "sd"))
     ]
-    ocp_obj = ocp.OCP()
 
-    out = ocp_obj.exec_oc_debug_cmd(
-        node=wnode.name,
-        cmd_list=cmd,
-        namespace=namespace,
-        use_root=True,
-        timeout=timeout,
-    )
-
-    logger.info(f"Disk detection command output: {out}")
-    disk_name = out.strip()
-
-    if not disk_name:
+    if not candidate_disks:
         logger.warning(
             f"No suitable disk found for BlueStore simulation on worker node: {wnode.name}."
         )
         return None
 
+    disk_name = f"/dev/{candidate_disks[-1]}"
     logger.info(f"Detected disk for simulation: {disk_name}")
     return disk_name
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2315,8 +2315,14 @@ class Deployment(object):
             from ocs_ci.deployment.helpers.ceph_cluster import (
                 post_deployment_verify_wipe_devices,
             )
+            from ocs_ci.ocs.resources.storage_cluster import (
+                osd_encryption_verification,
+            )
 
             post_deployment_verify_wipe_devices()
+            if config.ENV_DATA.get("encryption_at_rest"):
+                logger.info("Verify OSD encryption at rest")
+                osd_encryption_verification()
 
             if not config.COMPONENTS["disable_cephfs"]:
                 # Check for CephFilesystem creation in ocp

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2312,54 +2312,11 @@ class Deployment(object):
                 timeout=600,
             )
 
-            wipe_devices_from_other_clusters = config.ENV_DATA.get(
-                "wipe_devices_from_other_clusters", False
+            from ocs_ci.deployment.helpers.ceph_cluster import (
+                post_deployment_verify_wipe_devices,
             )
-            odf_forceful_deployment = config.DEPLOYMENT.get(
-                "odf_forceful_deployment", False
-            )
-            simulate_bluestore_label = config.ENV_DATA.get(
-                "simulate_bluestore_label", False
-            )
-            simulate_bluestore_label_dmcrypt = config.ENV_DATA.get(
-                "simulate_bluestore_label_dmcrypt", False
-            )
-            if wipe_devices_from_other_clusters or odf_forceful_deployment:
-                from ocs_ci.deployment.helpers.ceph_cluster import (
-                    verify_wipe_devices_from_other_clusters,
-                    verify_wipe_encrypted_devices_from_other_clusters,
-                )
 
-                if simulate_bluestore_label:
-                    logger.info(
-                        "Verify wipe devices from other clusters "
-                        "(StorageCluster CR flag and OSD prepare logs)"
-                    )
-                    verify_wipe_devices_from_other_clusters()
-                elif simulate_bluestore_label_dmcrypt:
-                    logger.info(
-                        "Verify wipe of encrypted (LUKS) devices from other "
-                        "clusters (StorageCluster CR flag and OSD prepare logs)"
-                    )
-                    verify_wipe_encrypted_devices_from_other_clusters()
-                else:
-                    logger.info(
-                        "Neither simulate_bluestore_label nor "
-                        "simulate_bluestore_label_dmcrypt is set. "
-                        "Skipping simulation-specific wipe verification."
-                    )
-            else:
-                from ocs_ci.deployment.helpers.ceph_cluster import (
-                    verify_no_wipe_devices_from_other_clusters,
-                )
-
-                logger.info(
-                    "Verify no wipe of foreign bluestore data occurred "
-                    "(StorageCluster CR flag and OSD prepare logs)"
-                )
-                assert (
-                    verify_no_wipe_devices_from_other_clusters()
-                ), "No-wipe verification failed"
+            post_deployment_verify_wipe_devices()
 
             if not config.COMPONENTS["disable_cephfs"]:
                 # Check for CephFilesystem creation in ocp

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -30,14 +30,18 @@ from ocs_ci.deployment.helpers.mcg_helpers import (
     mcg_only_post_deployment_checks,
 )
 from ocs_ci.ocs.managedservice import get_provider_service_type
-from ocs_ci.ocs.resources.storage_cluster import verify_storage_cluster_extended
+from ocs_ci.ocs.resources.storage_cluster import (
+    verify_storage_cluster_extended,
+)
 from ocs_ci.deployment.helpers.odf_deployment_helpers import (
     get_required_csvs,
     set_ceph_config,
     is_storage_system_needed,
 )
 from ocs_ci.deployment.acm import Submariner
-from ocs_ci.deployment.ingress_node_firewall import restrict_ssh_access_to_nodes
+from ocs_ci.deployment.ingress_node_firewall import (
+    restrict_ssh_access_to_nodes,
+)
 from ocs_ci.deployment.helpers.lso_helpers import (
     setup_local_storage,
     cleanup_nodes_for_lso_install,
@@ -163,7 +167,10 @@ from ocs_ci.utility import (
     pgsql,
     version,
 )
-from ocs_ci.utility.aws import update_config_from_s3, create_and_attach_sts_role
+from ocs_ci.utility.aws import (
+    update_config_from_s3,
+    create_and_attach_sts_role,
+)
 from ocs_ci.utility.multicluster import create_mce_catsrc
 from ocs_ci.utility.operators import NMStateOperator, OADPOperator
 from ocs_ci.utility.retry import retry
@@ -383,14 +390,16 @@ class Deployment(object):
                 mode="w+", prefix="gitops_subscription_manifest", delete=False
             )
             templating.dump_data_to_temp_yaml(
-                gitops_subscription_yaml_data, gitops_subscription_manifest.name
+                gitops_subscription_yaml_data,
+                gitops_subscription_manifest.name,
             )
             run_cmd(f"oc apply -f {gitops_subscription_manifest.name}")
         else:
             run_cmd(f"oc apply -f {constants.GITOPS_SUBSCRIPTION_YAML}")
 
         self.wait_for_subscription(
-            constants.GITOPS_OPERATOR_NAME, namespace=constants.GITOPS_NAMESPACE
+            constants.GITOPS_OPERATOR_NAME,
+            namespace=constants.GITOPS_NAMESPACE,
         )
         logger.info("Sleeping for 120 seconds after subscribing to GitOps Operator")
         time.sleep(120)
@@ -558,7 +567,8 @@ class Deployment(object):
                                 "ocs_registry_image", None
                             )
                             ocs_install_verification(
-                                timeout=2000, ocs_registry_image=ocs_registry_image
+                                timeout=2000,
+                                ocs_registry_image=ocs_registry_image,
                             )
                     config.reset_ctx()
                 if config.REPORTING["collect_logs_on_success_run"]:
@@ -701,10 +711,13 @@ class Deployment(object):
                                 "source"
                             ] = oadp_catsrc_name
                         oadp_subscription_manifest = tempfile.NamedTemporaryFile(
-                            mode="w+", prefix="oadp_subscription_manifest", delete=False
+                            mode="w+",
+                            prefix="oadp_subscription_manifest",
+                            delete=False,
                         )
                         templating.dump_data_to_temp_yaml(
-                            oadp_subscription_yaml_data, oadp_subscription_manifest.name
+                            oadp_subscription_yaml_data,
+                            oadp_subscription_manifest.name,
                         )
                         run_cmd(f"oc apply -f {oadp_subscription_manifest.name}")
                         self.wait_for_subscription(
@@ -955,7 +968,9 @@ class Deployment(object):
             setup_local_storage(storageclass=constants.DEFAULT_STORAGECLASS_LSO)
 
         if config.DEPLOYMENT.get("enable_nested_virtualization"):
-            from ocs_ci.deployment.hub_spoke import enable_nested_virtualization
+            from ocs_ci.deployment.hub_spoke import (
+                enable_nested_virtualization,
+            )
 
             enable_nested_virtualization()
         if (
@@ -1259,8 +1274,14 @@ class Deployment(object):
             azure_sub_data = [
                 {"name": "CLIENTID", "value": mi_client_id},
                 {"name": "TENANTID", "value": azure_auth_data["tenant_id"]},
-                {"name": "SUBSCRIPTIONID", "value": azure_auth_data["subscription_id"]},
-                {"name": "RESOURCEGROUP", "value": config.ENV_DATA["cluster_name"]},
+                {
+                    "name": "SUBSCRIPTIONID",
+                    "value": azure_auth_data["subscription_id"],
+                },
+                {
+                    "name": "RESOURCEGROUP",
+                    "value": config.ENV_DATA["cluster_name"],
+                },
             ]
             if "env" not in subscription_yaml_data["spec"]["config"]:
                 subscription_yaml_data["spec"]["config"]["env"] = azure_sub_data
@@ -1299,7 +1320,11 @@ class Deployment(object):
 
         ocp.OCP(kind=constants.SUBSCRIPTION_COREOS, namespace=namespace)
         for sample in TimeoutSampler(
-            300, 10, ocp.OCP, kind=constants.SUBSCRIPTION_COREOS, namespace=namespace
+            300,
+            10,
+            ocp.OCP,
+            kind=constants.SUBSCRIPTION_COREOS,
+            namespace=namespace,
         ):
             subscriptions = sample.get().get("items", [])
             for subscription in subscriptions:
@@ -1445,6 +1470,21 @@ class Deployment(object):
                     add_new_disks=add_new_disks_for_lso,
                 )
 
+        simulate_bluestore_label_dmcrypt = config.ENV_DATA.get(
+            "simulate_bluestore_label_dmcrypt", False
+        )
+        if local_storage and simulate_bluestore_label_dmcrypt:
+            from ocs_ci.deployment.helpers.ceph_cluster import (
+                simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes,
+            )
+
+            logger.test_step(
+                "Simulate encrypted Ceph BlueStore (dm-crypt) on worker nodes"
+            )
+            assert simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes(
+                add_disks=False, clear_signatures=False
+            ), ("Encrypted BlueStore (dm-crypt) simulation failed on " "worker nodes")
+
         log_step("Creating namespace and operator group")
         # patch OLM YAML with the namespace
         olm_ns_op_group_data = list(templating.load_yaml(constants.OLM_YAML, True))
@@ -1496,12 +1536,17 @@ class Deployment(object):
             worker_nodes = get_worker_nodes()
             node_obj = ocp.OCP(kind="node")
             platform = config.ENV_DATA.get("platform").lower()
-            if platform not in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
+            if platform not in [
+                constants.BAREMETAL_PLATFORM,
+                constants.HCI_BAREMETAL,
+            ]:
                 for node in worker_nodes:
                     for interface in interfaces:
                         ip_link_cmd = f"ip link set promisc on {interface}"
                         node_obj.exec_oc_debug_cmd(
-                            node=node, cmd_list=[ip_link_cmd], namespace="default"
+                            node=node,
+                            cmd_list=[ip_link_cmd],
+                            namespace="default",
                         )
 
             if create_public_net:
@@ -1905,7 +1950,9 @@ class Deployment(object):
 
         # Wait for noobaa-core StatefulSet to exist
         sts_obj = ocp.OCP(
-            kind="StatefulSet", namespace=self.namespace, resource_name="noobaa-core"
+            kind="StatefulSet",
+            namespace=self.namespace,
+            resource_name="noobaa-core",
         )
 
         # Wait for StatefulSet for noobaa-core exists before patching
@@ -2133,7 +2180,10 @@ class Deployment(object):
 
     @retry(exception_to_check=AssertionError, tries=12, delay=30, backoff=1)
     def objectstore_user_check(self):
-        if self.platform in [constants.BAREMETAL_PLATFORM, constants.VSPHERE_PLATFORM]:
+        if self.platform in [
+            constants.BAREMETAL_PLATFORM,
+            constants.VSPHERE_PLATFORM,
+        ]:
             logger.info("Checking cephobjectstore user exist for bug: DFBUGS-2929")
             cephobjectstoreuser = ocp.OCP(
                 kind="cephobjectstoreuser",
@@ -2247,7 +2297,9 @@ class Deployment(object):
             # check for odf-console
             if ocs_version >= version.VERSION_4_9:
                 assert pod.wait_for_resource(
-                    condition="Running", selector="app=odf-console", timeout=600
+                    condition="Running",
+                    selector="app=odf-console",
+                    timeout=600,
                 )
 
             # Creating toolbox pod
@@ -2266,18 +2318,36 @@ class Deployment(object):
             odf_forceful_deployment = config.DEPLOYMENT.get(
                 "odf_forceful_deployment", False
             )
+            simulate_bluestore_label = config.ENV_DATA.get(
+                "simulate_bluestore_label", False
+            )
+            simulate_bluestore_label_dmcrypt = config.ENV_DATA.get(
+                "simulate_bluestore_label_dmcrypt", False
+            )
             if wipe_devices_from_other_clusters or odf_forceful_deployment:
                 from ocs_ci.deployment.helpers.ceph_cluster import (
                     verify_wipe_devices_from_other_clusters,
+                    verify_wipe_encrypted_devices_from_other_clusters,
                 )
 
-                logger.info(
-                    "Verify wipe devices from other clusters "
-                    "(StorageCluster CR flag and OSD prepare logs)"
-                )
-                assert (
+                if simulate_bluestore_label:
+                    logger.info(
+                        "Verify wipe devices from other clusters "
+                        "(StorageCluster CR flag and OSD prepare logs)"
+                    )
                     verify_wipe_devices_from_other_clusters()
-                ), "Wipe devices from other clusters verification failed"
+                elif simulate_bluestore_label_dmcrypt:
+                    logger.info(
+                        "Verify wipe of encrypted (LUKS) devices from other "
+                        "clusters (StorageCluster CR flag and OSD prepare logs)"
+                    )
+                    verify_wipe_encrypted_devices_from_other_clusters()
+                else:
+                    logger.info(
+                        "Neither simulate_bluestore_label nor "
+                        "simulate_bluestore_label_dmcrypt is set. "
+                        "Skipping simulation-specific wipe verification."
+                    )
             else:
                 from ocs_ci.deployment.helpers.ceph_cluster import (
                     verify_no_wipe_devices_from_other_clusters,
@@ -2913,7 +2983,11 @@ class Deployment(object):
         )
         acm_hub_subscription_yaml_data["spec"]["channel"] = channel
         retry(
-            (ResourceNameNotSpecifiedException, ChannelNotFound, CommandFailed),
+            (
+                ResourceNameNotSpecifiedException,
+                ChannelNotFound,
+                CommandFailed,
+            ),
             tries=10,
             delay=2,
         )(package_manifest.get_current_csv)(channel, constants.ACM_HUB_OPERATOR_NAME)
@@ -2956,10 +3030,13 @@ class Deployment(object):
         ] = f"{constants.ACM_CATSRC_IMAGE}:{acm_image_tag}"
 
         acm_konflux_catsrc_yaml_data_manifest = tempfile.NamedTemporaryFile(
-            mode="w+", prefix="acm_konflux_catsrc_yaml_data_manifest", delete=False
+            mode="w+",
+            prefix="acm_konflux_catsrc_yaml_data_manifest",
+            delete=False,
         )
         templating.dump_data_to_temp_yaml(
-            acm_konflux_catsrc_yaml_data, acm_konflux_catsrc_yaml_data_manifest.name
+            acm_konflux_catsrc_yaml_data,
+            acm_konflux_catsrc_yaml_data_manifest.name,
         )
         run_cmd(f"oc create -f {acm_konflux_catsrc_yaml_data_manifest.name}")
 
@@ -2998,7 +3075,11 @@ class Deployment(object):
         )
         acm_hub_subscription_yaml_data["spec"]["channel"] = channel
         retry(
-            (ResourceNameNotSpecifiedException, ChannelNotFound, CommandFailed),
+            (
+                ResourceNameNotSpecifiedException,
+                ChannelNotFound,
+                CommandFailed,
+            ),
             tries=10,
             delay=2,
         )(package_manifest.get_current_csv)(channel, constants.ACM_HUB_OPERATOR_NAME)
@@ -3033,7 +3114,8 @@ class Deployment(object):
 
         # check if MCH is already installed
         if OCP(
-            kind=constants.ACM_MULTICLUSTER_HUB, namespace=constants.ACM_HUB_NAMESPACE
+            kind=constants.ACM_MULTICLUSTER_HUB,
+            namespace=constants.ACM_HUB_NAMESPACE,
         ).check_resource_existence(
             should_exist=True,
             resource_name=constants.ACM_MULTICLUSTER_RESOURCE,
@@ -3059,7 +3141,8 @@ class Deployment(object):
             bool: True if MultiCluster Hub is running, False otherwise
         """
         ocp_obj = OCP(
-            kind=constants.ACM_MULTICLUSTER_HUB, namespace=constants.ACM_HUB_NAMESPACE
+            kind=constants.ACM_MULTICLUSTER_HUB,
+            namespace=constants.ACM_HUB_NAMESPACE,
         )
         try:
             mch_running = ocp_obj.wait_for_resource(
@@ -3155,7 +3238,8 @@ def create_catalog_source(image=None, ignore_upgrade=False):
     image_tag = image_and_tag[1] if len(image_and_tag) == 2 else None
     if not image_tag and config.REPORTING.get("us_ds") == "DS":
         image_tag = get_latest_ds_olm_tag(
-            upgrade, latest_tag=config.DEPLOYMENT.get("default_latest_tag", "latest")
+            upgrade,
+            latest_tag=config.DEPLOYMENT.get("default_latest_tag", "latest"),
         )
     if rosa_hcp:
         catalog_source_data = templating.load_yaml(
@@ -3525,7 +3609,11 @@ class MultiClusterDROperatorsDeploy(object):
             )
 
         retry(
-            (ResourceNameNotSpecifiedException, ChannelNotFound, CommandFailed),
+            (
+                ResourceNameNotSpecifiedException,
+                ChannelNotFound,
+                CommandFailed,
+            ),
             tries=27,
             delay=20,
         )(package_manifest.get_current_csv)(
@@ -3548,7 +3636,8 @@ class MultiClusterDROperatorsDeploy(object):
             mode="w+", prefix="odf_multicluster_orchestrator", delete=False
         )
         templating.dump_data_to_temp_yaml(
-            odf_multicluster_orchestrator_data, odf_multicluster_orchestrator.name
+            odf_multicluster_orchestrator_data,
+            odf_multicluster_orchestrator.name,
         )
         run_cmd(f"oc create -f {odf_multicluster_orchestrator.name}")
         orchestrator_controller = ocp.OCP(
@@ -3705,7 +3794,12 @@ class MultiClusterDROperatorsDeploy(object):
         }
         logger.debug("Merge back the ramen_section with config_map_data")
         config_map_data["data"].update(ramen_section)
-        for key in ["annotations", "creationTimestamp", "resourceVersion", "uid"]:
+        for key in [
+            "annotations",
+            "creationTimestamp",
+            "resourceVersion",
+            "uid",
+        ]:
             if config_map_data["metadata"].get(key):
                 config_map_data["metadata"].pop(key)
 
@@ -3732,7 +3826,8 @@ class MultiClusterDROperatorsDeploy(object):
             resource_name=constants.ACM_ODR_HUB_OPERATOR_RESOURCE
         )
         current_csv = package_manifest.get_current_csv(
-            channel=self.channel, csv_pattern=constants.ACM_ODR_HUB_OPERATOR_RESOURCE
+            channel=self.channel,
+            csv_pattern=constants.ACM_ODR_HUB_OPERATOR_RESOURCE,
         )
         logger.info("Sleeping for 90 seconds after subscribing ")
         time.sleep(90)
@@ -3780,7 +3875,8 @@ class MultiClusterDROperatorsDeploy(object):
         managed_clusters = get_non_acm_cluster_config()
         for cluster in managed_clusters:
             cluster_name = cluster.ENV_DATA.get(
-                "cluster_name", f"index-{cluster.MULTICLUSTER['multicluster_index']}"
+                "cluster_name",
+                f"index-{cluster.MULTICLUSTER['multicluster_index']}",
             )
             logger.info(
                 f"[custom_ramen_image] Patching CSV on "
@@ -3984,7 +4080,11 @@ class MultiClusterDROperatorsDeploy(object):
         return bucket_name
 
     @retry(
-        (TimeoutExpiredError, ACMClusterConfigurationException, WrongVersionExpression),
+        (
+            TimeoutExpiredError,
+            ACMClusterConfigurationException,
+            WrongVersionExpression,
+        ),
         tries=20,
         delay=10,
     )
@@ -4403,7 +4503,10 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
                     f"already exists"
                 )
                 orchestrator_controller.wait_for_resource(
-                    condition="1", column="AVAILABLE", resource_count=1, timeout=300
+                    condition="1",
+                    column="AVAILABLE",
+                    resource_count=1,
+                    timeout=300,
                 )
                 continue
             if config.ENV_DATA.get("setup_fdf_catsrc_for_hub"):

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -569,7 +569,7 @@ def verify_no_wipe_devices_from_other_clusters():
     return True
 
 
-def verify_wipe_devices_from_other_clusters():
+def verify_wipe_unencrypted_devices_from_other_clusters():
     """
     Verify that the cluster correctly wiped pre-existing bluestore OSDs from
     another cluster before provisioning new OSDs.
@@ -713,6 +713,64 @@ def verify_wipe_encrypted_devices_from_other_clusters():
                 return False
 
     return True
+
+
+def post_deployment_verify_wipe_devices():
+    """
+    Post-deployment wipe verification dispatcher.
+
+    Reads ``wipe_devices_from_other_clusters`` and
+    ``odf_forceful_deployment`` from config to decide which verification
+    path to take:
+
+    * If either flag is set, verifies the correct wipe scenario occurred
+      (unencrypted or dm-crypt, depending on ``simulate_bluestore_label``
+      / ``simulate_bluestore_label_dmcrypt``).
+    * Otherwise, asserts that no wipe of foreign bluestore data took place.
+
+    Raises:
+        AssertionError: When the no-wipe check fails.
+
+    """
+    wipe_devices_from_other_clusters = config.ENV_DATA.get(
+        "wipe_devices_from_other_clusters", False
+    )
+    odf_forceful_deployment = config.DEPLOYMENT.get("odf_forceful_deployment", False)
+    simulate_bluestore_label = config.ENV_DATA.get("simulate_bluestore_label", False)
+    simulate_bluestore_label_dmcrypt = config.ENV_DATA.get(
+        "simulate_bluestore_label_dmcrypt", False
+    )
+    if wipe_devices_from_other_clusters or odf_forceful_deployment:
+        if simulate_bluestore_label:
+            logger.info(
+                "Verify wipe devices from other clusters "
+                "(StorageCluster CR flag and OSD prepare logs)"
+            )
+            assert (
+                verify_wipe_unencrypted_devices_from_other_clusters()
+            ), "Unencrypted wipe verification failed"
+        elif simulate_bluestore_label_dmcrypt:
+            logger.info(
+                "Verify wipe of encrypted (LUKS) devices from other "
+                "clusters (StorageCluster CR flag and OSD prepare logs)"
+            )
+            assert (
+                verify_wipe_encrypted_devices_from_other_clusters()
+            ), "Encrypted wipe verification failed"
+        else:
+            logger.info(
+                "Neither simulate_bluestore_label nor "
+                "simulate_bluestore_label_dmcrypt is set. "
+                "Skipping simulation-specific wipe verification."
+            )
+    else:
+        logger.info(
+            "Verify no wipe of foreign bluestore data occurred "
+            "(StorageCluster CR flag and OSD prepare logs)"
+        )
+        assert (
+            verify_no_wipe_devices_from_other_clusters()
+        ), "No-wipe verification failed"
 
 
 def _detect_ceph_image_tag(node_obj):

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -1,6 +1,6 @@
 import os
-import logging
 import re
+import logging
 from pathlib import Path
 
 from ocs_ci.deployment.baremetal import (
@@ -635,4 +635,324 @@ def verify_wipe_devices_from_other_clusters():
                 )
                 return False
 
+    return True
+
+
+def verify_wipe_encrypted_devices_from_other_clusters():
+    """
+    Verify that the cluster correctly wiped pre-existing encrypted (LUKS)
+    OSDs from another cluster before provisioning new encrypted OSDs.
+
+    Used when ``simulate_bluestore_label_dmcrypt`` is set — the simulation
+    stamps LUKS headers on each disk, and this function confirms Rook
+    detected and wiped them before creating fresh encrypted OSDs.
+
+    Performs two checks:
+
+    1. **StorageCluster CR** — asserts that
+       ``spec.managedResources.cephCluster.cleanupPolicy.wipeDevicesFromOtherClusters``
+       is exactly ``true``.
+
+    2. **OSD prepare logs** — checks each ``rook-ceph-osd-prepare`` pod for
+       the following regex patterns:
+
+       - ``cleaning encrypted disk ".+" that is part of a different ceph
+         cluster`` — LUKS header detected as belonging to a foreign cluster
+       - ``successfully zapped device ".+"`` — low-level wipe succeeded
+       - ``completed wiping device ".+" belonging to a different ceph
+         cluster`` — wipe fully complete
+       - ``ceph-volume raw prepare .+ --dmcrypt`` — new encrypted OSD
+         prepared after the wipe
+
+    Returns:
+        bool: True if both checks pass, False otherwise.
+
+    """
+    from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
+
+    # Check 1: StorageCluster CR flag
+    flag = get_wipe_devices_from_other_clusters_flag()
+    if flag is True:
+        logger.info("StorageCluster has wipeDevicesFromOtherClusters set to true")
+    else:
+        logger.error(
+            "StorageCluster wipeDevicesFromOtherClusters is %r, expected true",
+            flag,
+        )
+        return False
+
+    # Check 2: OSD prepare pod logs
+    expected_patterns = [
+        re.compile(
+            r'cleaning encrypted disk ".+" that is part of a different ceph cluster'
+        ),
+        re.compile(r'successfully zapped device ".+"'),
+        re.compile(
+            r'completed wiping device ".+" belonging to a different ceph cluster'
+        ),
+        re.compile(r"ceph-volume raw prepare .+ --dmcrypt"),
+    ]
+
+    osd_prepare_pods = get_osd_prepare_pods()
+    if not osd_prepare_pods:
+        logger.error("No rook-ceph-osd-prepare pods found")
+        return False
+
+    for pod in osd_prepare_pods:
+        logs = get_pod_logs(pod.name)
+        logger.info(
+            "Verifying encrypted bluestore wipe log entries in pod %s", pod.name
+        )
+        for pattern in expected_patterns:
+            if not pattern.search(logs):
+                logger.error(
+                    "Expected log pattern not found in pod %r: %r",
+                    pod.name,
+                    pattern.pattern,
+                )
+                return False
+
+    return True
+
+
+def _detect_ceph_image_tag(node_obj):
+    """
+    Detect the Ceph container image tag from a node using cephadm.
+
+    Args:
+        node_obj (Node): Node object to run the command on.
+
+    Returns:
+        str: Ceph image tag (e.g. "v18.2.0"), or empty string if undetectable.
+
+    """
+    try:
+        tag_out = node_obj.run_cmd("cephadm version", timeout=60)
+        m = re.search(r"cephadm version\s+(\S+)", tag_out or "")
+        if m:
+            ceph_tag = f"v{m.group(1)}"
+            logger.info("Detected Ceph image tag: %s", ceph_tag)
+            return ceph_tag
+    except Exception:
+        logger.warning("Could not detect Ceph version; script will auto-detect the tag")
+    return ""
+
+
+def simulate_ceph_bluestore_dmcrypt_on_node_disk(wnode, disk_name=None, namespace=None):
+    """
+    Simulates an encrypted Ceph BlueStore OSD (dm-crypt/LUKS) on a disk of a
+    given worker node.
+
+    Uploads the simulate_bluestore_label_dmcrypt.sh script to the node and
+    executes it, creating a LUKS container with BlueStore metadata inside and
+    LUKS header metadata matching a real Rook encrypted OSD layout.
+
+    Args:
+        wnode (ocs_ci.ocs.resources.ocs.OCS): The worker node object where the
+            simulation should be performed.
+        disk_name (str, optional): The disk device name to simulate on.
+            If not provided, auto-detects the last /dev/sd* or nvme disk.
+        namespace (str): Namespace for the debug pod.
+
+    Returns:
+        bool: True if the simulation succeeded, False otherwise.
+
+    """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+
+    if not disk_name:
+        disk_name = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+
+    if not disk_name:
+        logger.error("Disk detection failed. Aborting encrypted BlueStore simulation.")
+        return False
+
+    node_obj = Node(wnode.name, namespace, use_root=True)
+
+    script_name = "simulate_bluestore_label_dmcrypt.sh"
+    top_dir = Path(constants.TOP_DIR)
+    script_src_path = os.path.join(top_dir, "scripts", "bash", script_name)
+    script_dest_path = f"/tmp/{script_name}"
+
+    logger.info(
+        f"Uploading encrypted BlueStore simulation script to "
+        f"worker node {wnode.name}"
+    )
+    node_obj.upload_script(
+        script_src_path=script_src_path,
+        script_dest_path=script_dest_path,
+        timeout=300,
+    )
+
+    ceph_tag = _detect_ceph_image_tag(node_obj)
+
+    # Pass VERIFY_DISK_EMPTY=false: Stage 3 wipes the disk anyway, and a
+    # prior failed attempt may have left partial LUKS data at LBA0.
+    logger.info(
+        f"Running encrypted BlueStore simulation script on {wnode.name}. "
+        f"ceph-volume prepare can take 5-10 min..."
+    )
+    out = ""
+    try:
+        out = node_obj.run_script(
+            script_dest_path,
+            args=[disk_name, ceph_tag, "false"],
+            timeout=660,
+        )
+    except Exception as e:
+        logger.warning("Simulation script failed on %s: %s", wnode.name, e)
+
+    logger.info("Script output:\n" + out)
+    result = "Encrypted BlueStore simulation complete" in out
+    if result:
+        logger.info(
+            f"Encrypted BlueStore simulation succeeded on worker node {wnode.name}"
+        )
+    else:
+        logger.warning(
+            f"Encrypted BlueStore simulation failed on worker node {wnode.name}"
+        )
+    return result
+
+
+def simulate_ceph_bluestore_dmcrypt_on_wnodes(wnodes, namespace=None, disk_map=None):
+    """
+    Simulates encrypted Ceph BlueStore OSDs (dm-crypt/LUKS) on worker nodes.
+
+    Args:
+        wnodes (list): List of worker node objects where the simulation
+            should be performed.
+        namespace (str): Namespace for the debug pod.
+        disk_map (dict): Map of node name to pre-detected disk name. When
+            provided, skips per-node disk detection.
+
+    Returns:
+        bool: True if the simulation succeeded on all nodes, False otherwise.
+
+    """
+    for wnode in wnodes:
+        logger.info(f"Simulating encrypted Ceph BlueStore on worker node: {wnode.name}")
+        disk_name = (disk_map or {}).get(wnode.name)
+        result = simulate_ceph_bluestore_dmcrypt_on_node_disk(
+            wnode, disk_name=disk_name, namespace=namespace
+        )
+        if not result:
+            logger.warning(
+                f"Failed to simulate encrypted Ceph BlueStore on "
+                f"worker node: {wnode.name}"
+            )
+            return False
+
+    logger.info("Encrypted Ceph BlueStore simulation succeeded on all worker nodes.")
+    return True
+
+
+def simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes(
+    wnodes=None,
+    namespace=None,
+    add_disks=True,
+    remove_ceph_cluster=True,
+    clear_signatures=True,
+):
+    """
+    Simulates the full encrypted Ceph BlueStore (dm-crypt/LUKS) process on
+    the specified worker nodes.
+
+    Steps performed on each worker node:
+    1. Adds disks to the nodes if specified.
+    2. Installs a minimal Ceph cluster and configuration.
+    3. Simulates an encrypted BlueStore OSD on the node's disk.
+    4. Removes the minimal Ceph cluster if specified.
+    5. Clears BlueStore signatures from disks if specified.
+
+    Args:
+        wnodes (list): List of worker node objects. Defaults to all worker nodes.
+        namespace (str): Namespace for the debug pod.
+        add_disks (bool): Whether to add disks to the nodes before simulation.
+        remove_ceph_cluster (bool): Whether to remove the minimal Ceph cluster
+            after simulation.
+        clear_signatures (bool): Whether to clear BlueStore signatures from
+            disks after simulation.
+
+    Returns:
+        bool: True if all steps succeeded on all nodes, False otherwise.
+
+    """
+    namespace = namespace or constants.DEFAULT_NAMESPACE
+    wnodes = wnodes or get_nodes()
+    wnode_names = [wnode.name for wnode in wnodes]
+    logger.info(
+        "Starting full encrypted Ceph BlueStore simulation process on "
+        f"worker nodes: {wnode_names}"
+    )
+
+    # Step 1: Optionally add disks to worker nodes
+    platform = config.ENV_DATA["platform"].lower()
+    if add_disks and platform == constants.VSPHERE_PLATFORM:
+        logger.info("Adding disks to worker nodes before simulation.")
+        disks_already_added = all(
+            disks_available_to_cleanup(wnode, namespace) for wnode in wnodes
+        )
+        if disks_already_added:
+            logger.info(
+                "Disks are already added to all worker nodes. Skipping addition."
+            )
+        else:
+            add_disk_for_vsphere_platform()
+
+    # Step 2: Detect disks once so the same device is used for simulation and cleanup
+    disk_map = {}
+    for wnode in wnodes:
+        disk = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        if not disk:
+            logger.error(f"Disk detection failed on node {wnode.name}. Aborting.")
+            return False
+        disk_map[wnode.name] = disk
+
+    # Step 3: Install minimal Ceph cluster and configuration
+    host_node = wnodes[0]
+    result = install_minimal_ceph_cluster_and_conf_on_wnodes(
+        wnodes, host_node, namespace
+    )
+    if not result:
+        logger.warning("Failed to install minimal Ceph cluster and configuration.")
+        return False
+
+    # Steps 4-6: simulation + cleanup (cleanup always runs when flags are set)
+    simulation_result = False
+    cleanup_ok = True
+    try:
+        # Step 4: Simulate encrypted BlueStore OSDs on all worker nodes
+        simulation_result = simulate_ceph_bluestore_dmcrypt_on_wnodes(
+            wnodes, namespace, disk_map
+        )
+        if not simulation_result:
+            logger.warning(
+                "Failed to simulate encrypted Ceph BlueStore on worker nodes."
+            )
+    finally:
+        # Step 5: Optionally remove the minimal Ceph cluster
+        if remove_ceph_cluster:
+            logger.info("Removing minimal Ceph cluster from host node.")
+            if not remove_minimal_ceph_cluster(host_node, namespace):
+                logger.warning("Failed to remove minimal Ceph cluster from host node.")
+                cleanup_ok = False
+
+        # Step 6: Optionally clear BlueStore signatures from disks
+        if clear_signatures:
+            logger.info("Clearing Ceph BlueStore signatures from worker node disks.")
+            if not clear_ceph_bluestore_signature_on_wnodes(
+                wnodes, disk_names=disk_map, namespace=namespace
+            ):
+                logger.warning(
+                    "Failed to clear Ceph BlueStore signatures from worker nodes."
+                )
+                cleanup_ok = False
+
+    if not simulation_result or not cleanup_ok:
+        return False
+
+    logger.info(
+        "Full encrypted Ceph BlueStore simulation process completed successfully."
+    )
     return True

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -569,35 +569,15 @@ def verify_no_wipe_devices_from_other_clusters():
     return True
 
 
-def verify_wipe_unencrypted_devices_from_other_clusters():
+def verify_wipe_devices_from_other_clusters_flag():
     """
-    Verify that the cluster correctly wiped pre-existing bluestore OSDs from
-    another cluster before provisioning new OSDs.
-
-    Performs two checks:
-
-    1. **StorageCluster CR** — asserts that
-       ``spec.managedResources.cephCluster.cleanupPolicy.wipeDevicesFromOtherClusters``
-       is exactly ``true``.
-
-    2. **OSD prepare logs** — checks each ``rook-ceph-osd-prepare`` pod for
-       the following regex patterns, which confirm that foreign bluestore data
-       was detected and zapped:
-
-       - ``completed wiping OSD <id> device "<dev>" belonging to a different
-         ceph cluster`` — foreign bluestore data detected and zapped
-       - ``successfully zapped osd.<id> path "<dev>"`` — low-level wipe
-         succeeded
-       - ``ceph-volume raw dmcrypt prepare successful`` — new OSD prepared
-         (emitted for both encrypted and unencrypted OSDs)
+    Verify that the StorageCluster CR has wipeDevicesFromOtherClusters set
+    to true.
 
     Returns:
-        bool: True if both checks pass, False otherwise.
+        bool: True if the flag is set to true, False otherwise.
 
     """
-    from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
-
-    # Check 1: StorageCluster CR flag
     flag = get_wipe_devices_from_other_clusters_flag()
     if flag is True:
         logger.info("StorageCluster has wipeDevicesFromOtherClusters set to true")
@@ -607,8 +587,32 @@ def verify_wipe_unencrypted_devices_from_other_clusters():
             flag,
         )
         return False
+    return True
 
-    # Check 2: OSD prepare pod logs
+
+def verify_wipe_unencrypted_devices_from_other_clusters():
+    """
+    Verify that the cluster correctly wiped pre-existing bluestore OSDs from
+    another cluster before provisioning new OSDs.
+
+    Checks each ``rook-ceph-osd-prepare`` pod for the following regex
+    patterns, which confirm that foreign bluestore data was detected and
+    zapped:
+
+    - ``completed wiping OSD <id> device "<dev>" belonging to a different
+      ceph cluster`` — foreign bluestore data detected and zapped
+    - ``successfully zapped osd.<id> path "<dev>"`` — low-level wipe
+      succeeded
+    - ``ceph-volume raw dmcrypt prepare successful`` — new OSD prepared
+      (emitted for both encrypted and unencrypted OSDs)
+    - ``ceph-volume raw prepare .+`` — new OSD creation command
+
+    Returns:
+        bool: True if all checks pass, False otherwise.
+
+    """
+    from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
+
     expected_patterns = [
         re.compile(
             r'completed wiping OSD \d+ device ".+" belonging to a different'
@@ -616,6 +620,7 @@ def verify_wipe_unencrypted_devices_from_other_clusters():
         ),
         re.compile(r'successfully zapped osd\.\d+ path ".+"'),
         re.compile(r"ceph-volume raw dmcrypt prepare successful"),
+        re.compile(r"ceph-volume raw prepare .+"),
     ]
 
     osd_prepare_pods = get_osd_prepare_pods()
@@ -641,47 +646,28 @@ def verify_wipe_unencrypted_devices_from_other_clusters():
 def verify_wipe_encrypted_devices_from_other_clusters():
     """
     Verify that the cluster correctly wiped pre-existing encrypted (LUKS)
-    OSDs from another cluster before provisioning new encrypted OSDs.
+    OSDs from another cluster before provisioning new OSDs.
 
     Used when ``simulate_bluestore_label_dmcrypt`` is set — the simulation
     stamps LUKS headers on each disk, and this function confirms Rook
-    detected and wiped them before creating fresh encrypted OSDs.
+    detected and wiped them before creating fresh OSDs.
 
-    Performs two checks:
+    Checks each ``rook-ceph-osd-prepare`` pod for the following regex
+    patterns:
 
-    1. **StorageCluster CR** — asserts that
-       ``spec.managedResources.cephCluster.cleanupPolicy.wipeDevicesFromOtherClusters``
-       is exactly ``true``.
-
-    2. **OSD prepare logs** — checks each ``rook-ceph-osd-prepare`` pod for
-       the following regex patterns:
-
-       - ``cleaning encrypted disk ".+" that is part of a different ceph
-         cluster`` — LUKS header detected as belonging to a foreign cluster
-       - ``successfully zapped device ".+"`` — low-level wipe succeeded
-       - ``completed wiping device ".+" belonging to a different ceph
-         cluster`` — wipe fully complete
-       - ``ceph-volume raw prepare .+ --dmcrypt`` — new encrypted OSD
-         prepared after the wipe
+    - ``cleaning encrypted disk ".+" that is part of a different ceph
+      cluster`` — LUKS header detected as belonging to a foreign cluster
+    - ``successfully zapped device ".+"`` — low-level wipe succeeded
+    - ``completed wiping device ".+" belonging to a different ceph
+      cluster`` — wipe fully complete
+    - ``ceph-volume raw prepare .+`` — new OSD creation command
 
     Returns:
-        bool: True if both checks pass, False otherwise.
+        bool: True if all checks pass, False otherwise.
 
     """
     from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
 
-    # Check 1: StorageCluster CR flag
-    flag = get_wipe_devices_from_other_clusters_flag()
-    if flag is True:
-        logger.info("StorageCluster has wipeDevicesFromOtherClusters set to true")
-    else:
-        logger.error(
-            "StorageCluster wipeDevicesFromOtherClusters is %r, expected true",
-            flag,
-        )
-        return False
-
-    # Check 2: OSD prepare pod logs
     expected_patterns = [
         re.compile(
             r'cleaning encrypted disk ".+" that is part of a different ceph cluster'
@@ -690,7 +676,7 @@ def verify_wipe_encrypted_devices_from_other_clusters():
         re.compile(
             r'completed wiping device ".+" belonging to a different ceph cluster'
         ),
-        re.compile(r"ceph-volume raw prepare .+ --dmcrypt"),
+        re.compile(r"ceph-volume raw prepare .+"),
     ]
 
     osd_prepare_pods = get_osd_prepare_pods()
@@ -741,6 +727,10 @@ def post_deployment_verify_wipe_devices():
         "simulate_bluestore_label_dmcrypt", False
     )
     if wipe_devices_from_other_clusters or odf_forceful_deployment:
+        logger.info("Verify StorageCluster wipeDevicesFromOtherClusters CR flag")
+        assert (
+            verify_wipe_devices_from_other_clusters_flag()
+        ), "StorageCluster wipeDevicesFromOtherClusters flag check failed"
         if simulate_bluestore_label:
             logger.info(
                 "Verify wipe devices from other clusters "
@@ -757,12 +747,6 @@ def post_deployment_verify_wipe_devices():
             assert (
                 verify_wipe_encrypted_devices_from_other_clusters()
             ), "Encrypted wipe verification failed"
-        else:
-            logger.info(
-                "Neither simulate_bluestore_label nor "
-                "simulate_bluestore_label_dmcrypt is set. "
-                "Skipping simulation-specific wipe verification."
-            )
     else:
         logger.info(
             "Verify no wipe of foreign bluestore data occurred "

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -301,7 +301,7 @@ def simulate_ceph_bluestore_on_node_disk(wnode, disk_name=None, namespace=None):
     namespace = namespace or constants.DEFAULT_NAMESPACE
 
     if not disk_name:
-        disk_name = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        disk_name = detect_simulation_disk_on_node(wnode, namespace)
 
     if not disk_name:
         logger.error("Disk detection failed. Aborting BlueStore simulation.")
@@ -435,7 +435,7 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
     # Step 2: Detect disks once so the same device is used for simulation and cleanup
     disk_map = {}
     for wnode in wnodes:
-        disk = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        disk = detect_simulation_disk_on_node(wnode, namespace)
         if not disk:
             logger.error(f"Disk detection failed on node {wnode.name}. Aborting.")
             return False
@@ -804,7 +804,7 @@ def simulate_ceph_bluestore_dmcrypt_on_node_disk(wnode, disk_name=None, namespac
     namespace = namespace or constants.DEFAULT_NAMESPACE
 
     if not disk_name:
-        disk_name = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        disk_name = detect_simulation_disk_on_node(wnode, namespace)
 
     if not disk_name:
         logger.error("Disk detection failed. Aborting encrypted BlueStore simulation.")
@@ -946,7 +946,7 @@ def simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes(
     # Step 2: Detect disks once so the same device is used for simulation and cleanup
     disk_map = {}
     for wnode in wnodes:
-        disk = detect_simulation_disk_on_node(wnode, namespace, timeout=300)
+        disk = detect_simulation_disk_on_node(wnode, namespace)
         if not disk:
             logger.error(f"Disk detection failed on node {wnode.name}. Aborting.")
             return False

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -656,7 +656,7 @@ def verify_wipe_encrypted_devices_from_other_clusters():
     Checks each ``rook-ceph-osd-prepare`` pod for the following regex
     patterns:
 
-    - ``cleaning encrypted disk ".+" that is part of a different ceph
+    - ``cleaning encrypted disk .+ that is part of a different ceph
       cluster`` — LUKS header detected as belonging to a foreign cluster
     - ``successfully zapped device ".+"`` — low-level wipe succeeded
     - ``completed wiping device ".+" belonging to a different ceph
@@ -671,7 +671,7 @@ def verify_wipe_encrypted_devices_from_other_clusters():
 
     expected_patterns = [
         re.compile(
-            r'cleaning encrypted disk ".+" that is part of a different ceph cluster'
+            r"cleaning encrypted disk .+ that is part of a different ceph cluster"
         ),
         re.compile(r'successfully zapped device ".+"'),
         re.compile(

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -8,6 +8,7 @@ from ocs_ci.deployment.baremetal import (
     disks_available_to_cleanup,
 )
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.node import get_nodes, get_node_internal_ip, Node
 from ocs_ci.framework import config
 from ocs_ci.deployment.helpers.lso_helpers import add_disk_for_vsphere_platform
@@ -775,7 +776,7 @@ def _detect_ceph_image_tag(node_obj):
             ceph_tag = f"v{m.group(1)}"
             logger.info("Detected Ceph image tag: %s", ceph_tag)
             return ceph_tag
-    except Exception:
+    except CommandFailed:
         logger.warning("Could not detect Ceph version; script will auto-detect the tag")
     return ""
 
@@ -841,7 +842,7 @@ def simulate_ceph_bluestore_dmcrypt_on_node_disk(wnode, disk_name=None, namespac
             args=[disk_name, ceph_tag, "false"],
             timeout=660,
         )
-    except Exception as e:
+    except CommandFailed as e:
         logger.warning("Simulation script failed on %s: %s", wnode.name, e)
 
     logger.info("Script output:\n" + out)

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -605,7 +605,7 @@ def verify_wipe_unencrypted_devices_from_other_clusters():
       succeeded
     - ``ceph-volume raw dmcrypt prepare successful`` — new OSD prepared
       (emitted for both encrypted and unencrypted OSDs)
-    - ``ceph-volume raw prepare .+`` — new OSD creation command
+    - ``ceph-volume .+ raw prepare`` — new OSD creation command
 
     Returns:
         bool: True if all checks pass, False otherwise.
@@ -620,7 +620,7 @@ def verify_wipe_unencrypted_devices_from_other_clusters():
         ),
         re.compile(r'successfully zapped osd\.\d+ path ".+"'),
         re.compile(r"ceph-volume raw dmcrypt prepare successful"),
-        re.compile(r"ceph-volume raw prepare .+"),
+        re.compile(r"ceph-volume .+ raw prepare"),
     ]
 
     osd_prepare_pods = get_osd_prepare_pods()
@@ -660,7 +660,7 @@ def verify_wipe_encrypted_devices_from_other_clusters():
     - ``successfully zapped device ".+"`` — low-level wipe succeeded
     - ``completed wiping device ".+" belonging to a different ceph
       cluster`` — wipe fully complete
-    - ``ceph-volume raw prepare .+`` — new OSD creation command
+    - ``ceph-volume .+ raw prepare`` — new OSD creation command
 
     Returns:
         bool: True if all checks pass, False otherwise.
@@ -676,7 +676,7 @@ def verify_wipe_encrypted_devices_from_other_clusters():
         re.compile(
             r'completed wiping device ".+" belonging to a different ceph cluster'
         ),
-        re.compile(r"ceph-volume raw prepare .+"),
+        re.compile(r"ceph-volume .+ raw prepare"),
     ]
 
     osd_prepare_pods = get_osd_prepare_pods()

--- a/scripts/bash/install_minimal_ceph_cluster.sh
+++ b/scripts/bash/install_minimal_ceph_cluster.sh
@@ -27,8 +27,11 @@ if cephadm shell -- ceph health &> /dev/null; then
     echo "Ceph cluster is already bootstrapped."
 else
     echo "Ceph cluster is not bootstrapped yet. Proceeding with bootstrap."
-    # Bootstrap the Ceph cluster (skip monitoring stack)
-    cephadm bootstrap --mon-ip ${NODE_IP} --skip-monitoring-stack
+    # --no-cleanup-on-failure: ceph orch host add fails on some nodes due to
+    # an internal auth error that is non-fatal — the MON and bootstrap-osd
+    # key are fully operational despite it.
+    cephadm bootstrap --mon-ip ${NODE_IP} --skip-monitoring-stack \
+        --no-cleanup-on-failure || true
 fi
 
 if cephadm shell -- ceph health | grep -qE 'HEALTH_OK|HEALTH_WARN'; then

--- a/scripts/bash/install_minimal_ceph_cluster_dmcrypt.sh
+++ b/scripts/bash/install_minimal_ceph_cluster_dmcrypt.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+CEPHADM_URL="https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm"
+CEPHADM_VERSION_MAJOR="20"
+
+# Download cephadm
+curl -fsSL "$CEPHADM_URL" -o /tmp/cephadm
+# Make it executable and move to PATH
+chmod +x /tmp/cephadm
+mv /tmp/cephadm /usr/local/bin/
+
+# Verify cephadm version
+cephadm version
+# Check that cephadm version starts with the expected major version
+if ! cephadm version | grep -q "^cephadm version ${CEPHADM_VERSION_MAJOR}\."; then
+  echo "Error: cephadm version is not ${CEPHADM_VERSION_MAJOR}.x"
+  exit 1
+fi
+
+# Get the node IP address
+NODE_IP=$(ip route get 1.1.1.1 | awk '{print $7}')
+echo "Node IP address: ${NODE_IP}"
+
+# Check if Bootstrap is already done
+if cephadm shell -- ceph health &> /dev/null; then
+    echo "Ceph cluster is already bootstrapped."
+else
+    echo "Ceph cluster is not bootstrapped yet. Proceeding with bootstrap."
+    # --no-cleanup-on-failure: ceph orch host add fails on some nodes due to
+    # an internal auth error that is non-fatal — the MON and bootstrap-osd
+    # key are fully operational despite it.
+    cephadm bootstrap --mon-ip ${NODE_IP} --skip-monitoring-stack \
+        --no-cleanup-on-failure || true
+fi
+
+if cephadm shell -- ceph health | grep -qE 'HEALTH_OK|HEALTH_WARN'; then
+    echo "Cluster is operational (OK or WARN)."
+else
+    echo "Cluster is in a critical state (HEALTH_ERR)."
+    exit 1
+fi
+
+# Get the ceph keyring
+KEY=$(cephadm shell -- ceph auth get-key client.bootstrap-osd)
+
+# Create bootstrap keyring
+mkdir -p /var/lib/ceph/bootstrap-osd
+cat <<EOF > /var/lib/ceph/bootstrap-osd/ceph.keyring
+[client.bootstrap-osd]
+    key = $KEY
+    caps mon = "allow profile bootstrap-osd"
+EOF
+
+# Set permissions
+chown root:root /var/lib/ceph/bootstrap-osd/ceph.keyring
+chmod 644 /var/lib/ceph/bootstrap-osd/ceph.keyring
+
+echo "Bootstrap the Ceph cluster (skip monitoring stack) completed successfully."

--- a/scripts/bash/install_minimal_ceph_conf_dmcrypt.sh
+++ b/scripts/bash/install_minimal_ceph_conf_dmcrypt.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+CEPHADM_URL="https://download.ceph.com/rpm-tentacle/el9/noarch/cephadm"
+CEPHADM_VERSION_MAJOR="20"
+
+ if [ "$#" -ne 3 ]; then
+   echo "Usage: $0 <fsid> <bootstrap-osd-key> <mon_host>"
+   exit 1
+ fi
+
+ fsid="$1"
+ key="$2"
+ host_node_ip="$3"
+
+ if [ -z "$fsid" ] || [ -z "$key" ] || [ -z "$host_node_ip" ]; then
+   echo "None of the arguments can be empty."
+   exit 1
+ fi
+
+# Download cephadm
+curl -fsSL "$CEPHADM_URL" -o /tmp/cephadm
+# Make it executable and move to PATH
+chmod +x /tmp/cephadm
+mv /tmp/cephadm /usr/local/bin/
+
+# Verify cephadm version
+cephadm version
+# Check that cephadm version starts with the expected major version
+if ! cephadm version | grep -q "^cephadm version ${CEPHADM_VERSION_MAJOR}\."; then
+  echo "Error: cephadm version is not ${CEPHADM_VERSION_MAJOR}.x"
+  exit 1
+fi
+
+# Create ceph.conf
+mkdir -p /etc/ceph
+cat <<EOF > /etc/ceph/ceph.conf
+[global]
+fsid = $fsid
+mon_host = $host_node_ip
+EOF
+
+# Create bootstrap keyring
+mkdir -p /var/lib/ceph/bootstrap-osd
+cat <<EOF > /var/lib/ceph/bootstrap-osd/ceph.keyring
+[client.bootstrap-osd]
+    key = $key
+    caps mon = "allow profile bootstrap-osd"
+EOF
+
+# Set permissions
+chown root:root /var/lib/ceph/bootstrap-osd/ceph.keyring
+chmod 644 /var/lib/ceph/bootstrap-osd/ceph.keyring
+
+echo "Minimal Ceph configuration and bootstrap keyring created successfully."

--- a/scripts/bash/simulate_bluestore_label_dmcrypt.sh
+++ b/scripts/bash/simulate_bluestore_label_dmcrypt.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+DEVICE="${1:-}"
+TAG="${2:-}"                     # Optional: Ceph container tag
+VERIFY_DISK_EMPTY="${3:-true}"   # Optional: verify disk is empty
+
+# Stage 0 — Argument validation
+if [[ -z "$DEVICE" ]]; then
+    echo "Usage: $0 /dev/sdX <ceph_tag> [verify_disk_empty:true|false]"
+    exit 1
+fi
+
+# If TAG not provided, auto-detect from cephadm
+if [[ -z "$TAG" ]]; then
+    detected_tag="v$(cephadm version | awk '/cephadm version/ {print $3}')"
+    echo ">>> No TAG specified, using detected version: $detected_tag"
+    TAG="$detected_tag"
+fi
+
+DEVICE_BASENAME=$(basename "$DEVICE")
+MAPPER_NAME="ceph-sim-${DEVICE_BASENAME}"
+KEY_FILE=$(mktemp /tmp/ceph-sim-key.XXXXXX)
+# Ensure the key file and open mapper are always cleaned up on exit
+trap 'rm -f "$KEY_FILE"; cryptsetup luksClose "$MAPPER_NAME" 2>/dev/null || true' EXIT
+
+echo ">>> Simulating encrypted BlueStore OSD on $DEVICE"
+echo ">>> Ceph image tag: $TAG"
+echo ">>> LUKS mapper name: /dev/mapper/$MAPPER_NAME"
+echo ">>> Verify disk empty: $VERIFY_DISK_EMPTY"
+
+# Stage 1 — Optional disk emptiness check
+if [[ "$VERIFY_DISK_EMPTY" == "true" ]]; then
+    echo ">>> Precheck: Verifying device is empty (first 22 bytes)..."
+    if dd if="$DEVICE" bs=1 count=22 status=none | tr -d '\000' | grep -q .; then
+        echo "ERROR: $DEVICE contains non-zero data at LBA0 — refusing to overwrite."
+        echo ">>> Please wipe or use a clean test disk."
+        exit 1
+    fi
+fi
+
+# Stage 2 — Device validation
+[ -b "$DEVICE" ] || { echo "ERROR: $DEVICE is not a block device"; exit 1; }
+[ "$(lsblk -no TYPE "$DEVICE")" = "disk" ] || { echo "ERROR: $DEVICE is not a whole disk"; exit 1; }
+[ "$(blockdev --getro "$DEVICE")" -eq 0 ] || { echo "ERROR: $DEVICE is read-only"; exit 1; }
+
+# Stage 3 — Disk cleanup
+echo ">>> Cleaning disk signatures and partition table..."
+sgdisk -Z "$DEVICE" || true
+wipefs -a "$DEVICE" || true
+blockdev --rereadpt "$DEVICE" || true
+udevadm settle || true
+
+# Stage 4 — Get Ceph FSID (from ceph.conf if present, else from cephadm shell)
+echo ">>> Getting Ceph FSID..."
+CEPH_FSID=""
+if [[ -f /etc/ceph/ceph.conf ]]; then
+    CEPH_FSID=$(awk '/^fsid[[:space:]]*=/{print $3}' /etc/ceph/ceph.conf | tr -d '[:space:]')
+    [[ -n "$CEPH_FSID" ]] && echo ">>> Read FSID from /etc/ceph/ceph.conf"
+fi
+if [[ -z "$CEPH_FSID" ]]; then
+    CEPH_FSID=$(cephadm shell -- ceph fsid 2>/dev/null | tr -d '[:space:]')
+    [[ -n "$CEPH_FSID" ]] && echo ">>> Got FSID via cephadm shell"
+fi
+if [[ -z "$CEPH_FSID" ]]; then
+    echo "ERROR: Failed to get Ceph FSID"
+    exit 1
+fi
+echo ">>> Ceph FSID: $CEPH_FSID"
+
+# Stage 5 — Generate random LUKS key and create LUKS container
+echo ">>> Generating random LUKS encryption key..."
+dd if=/dev/urandom bs=64 count=1 status=none > "$KEY_FILE"
+
+echo ">>> Creating LUKS container on $DEVICE..."
+cryptsetup --batch-mode --key-size 512 --key-file "$KEY_FILE" luksFormat "$DEVICE"
+
+# Stage 6 — Open the LUKS container
+echo ">>> Opening LUKS container as /dev/mapper/$MAPPER_NAME..."
+cryptsetup --key-file "$KEY_FILE" luksOpen "$DEVICE" "$MAPPER_NAME"
+
+# Stage 7 — Write BlueStore metadata inside the LUKS container
+echo ">>> Writing BlueStore metadata inside LUKS container via ceph-volume..."
+podman run --rm --privileged --net=host \
+  -v /dev:/dev \
+  -v /sys:/sys \
+  -v /run/udev:/run/udev:ro \
+  -v /etc/ceph:/etc/ceph:ro \
+  -v /var/lib/ceph/bootstrap-osd:/var/lib/ceph/bootstrap-osd:ro \
+  quay.io/ceph/ceph:"$TAG" \
+  ceph-volume --log-path /tmp/ceph-log \
+    raw prepare --bluestore --data "/dev/mapper/$MAPPER_NAME" --crush-device-class ssd
+
+# Stage 8 — Verify BlueStore metadata inside the container
+echo ">>> Verifying BlueStore metadata inside LUKS container..."
+podman run --rm --privileged --net=host \
+  -v /dev:/dev \
+  -v /sys:/sys \
+  -v /run/udev:/run/udev:ro \
+  -v /etc/ceph:/etc/ceph:ro \
+  -v /var/lib/ceph:/var/lib/ceph:ro \
+  quay.io/ceph/ceph:"$TAG" \
+  ceph-volume raw list "/dev/mapper/$MAPPER_NAME" --format json
+
+# Stage 9 — Set LUKS header metadata to match a real Rook encrypted OSD
+# (subsystem carries ceph_fsid; label carries pvc_name — both readable without key)
+echo ">>> Setting LUKS header metadata to simulate Rook encrypted OSD..."
+PVC_LABEL="pvc_name=sim-ocs-deviceset-localblock-0-data-${DEVICE_BASENAME}"
+cryptsetup config \
+  --subsystem "ceph_fsid=${CEPH_FSID}" \
+  --label "$PVC_LABEL" \
+  "$DEVICE"
+echo ">>> LUKS subsystem set to: ceph_fsid=${CEPH_FSID}"
+echo ">>> LUKS label set to: ${PVC_LABEL}"
+
+# Stage 10 — Close the LUKS container (key is discarded by the EXIT trap)
+echo ">>> Closing LUKS container..."
+cryptsetup luksClose "$MAPPER_NAME"
+# Remove the mapper from the trap now that it's already closed
+trap 'rm -f "$KEY_FILE"' EXIT
+
+# Stage 11 — Verify LUKS header metadata is intact (readable without key)
+echo ">>> Verifying LUKS header metadata..."
+cryptsetup luksDump "$DEVICE" | grep -E "Label|Subsystem|UUID"
+
+echo ">>> Encrypted BlueStore simulation complete."

--- a/tests/libtest/test_simulate_ceph_bluestore_label.py
+++ b/tests/libtest/test_simulate_ceph_bluestore_label.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.framework import config
 from ocs_ci.deployment.helpers.ceph_cluster import (
     simulate_full_ceph_bluestore_process_on_wnodes,
+    simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes,
 )
 
 log = logging.getLogger(__name__)
@@ -37,3 +38,24 @@ class TestSimulateCephBlueStoreLabel(ManageTest):
         result = simulate_full_ceph_bluestore_process_on_wnodes()
         assert result, "BlueStore label simulation failed on worker nodes"
         log.info("BlueStore label simulation succeeded on all worker nodes disks")
+
+    def test_simulate_bluestore_label_dmcrypt_on_worker_nodes(self):
+        """
+        Test simulates encrypted Ceph OSD dm-crypt data on the worker node disks.
+
+        Creates a LUKS container on each node's disk, writes BlueStore metadata
+        inside the encrypted container via ceph-volume, and stamps the LUKS
+        header with Rook-compatible metadata (ceph_fsid subsystem, pvc_name label).
+
+        """
+        if not config.ENV_DATA.get("simulate_bluestore_label_dmcrypt", False):
+            pytest.skip("simulate_bluestore_label_dmcrypt not set in config")
+        # clear_signatures=False: the LUKS header must remain on disk so
+        # that Rook can detect the encrypted OSD layout during ODF install.
+        result = simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes(
+            clear_signatures=False
+        )
+        assert (
+            result
+        ), "Encrypted BlueStore (dm-crypt) simulation failed on worker nodes"
+        log.info("Encrypted BlueStore simulation succeeded on all worker nodes disks")


### PR DESCRIPTION
See more details in the epic: https://redhat.atlassian.net/browse/RHSTOR-8102.

Added support for simulating an encrypted Ceph cluster (dm-crypt/LUKS) on worker node disks prior to deploying ODF. This allows testing Rook's `wipeDevicesFromOtherClusters` path on a new cluster. When `simulate_bluestore_label_dmcrypt` is enabled in `ENV_DATA`, `deploy_ocs_via_operator` executes `simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes` after the provisioning of PVs by LSO. The StorageCluster is then deployed with `wipe_devices_from_other_clusters: true`, prompting Rook to recognize LUKS headers as belonging to a different cluster, wipe them, and set up new OSDs.

  Changes:
  - Adds `simulate_full_ceph_bluestore_dmcrypt_process_on_wnodes` and supporting functions to `ceph_cluster.py`
  - Adds three bash scripts for the simulation (`simulate_bluestore_label_dmcrypt.sh`,
  `install_minimal_ceph_cluster_dmcrypt.sh`, `install_minimal_ceph_conf_dmcrypt.sh`)
  - Adds verify_wipe_encrypted_devices_from_other_clusters with log patterns from a real deployment run
  - Adds vSphere UPI LSO conf files for encrypted-to-encrypted and encrypted-to-unencrypted scenarios
  - Adds libtest `test_simulate_bluestore_label_dmcrypt_on_worker_nodes` to exercise the simulation in isolation

  Test plan

  - [ ] Run a full LSO CLI deployment on vSphere with `--ocsci-conf
  conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_encrypted_to_encrypted.yaml` and verify the simulation step appears in the deployment logs
  - [ ] Verify all OSD pods reach `Running` with `encryption_at_rest: true` (encrypted-to-encrypted scenario)
  - [ ] Verify all OSD pods reach `Running` with `encryption_at_rest: false` (encrypted-to-unencrypted scenario)
  - [ ] Verify `verify_wipe_encrypted_devices_from_other_clusters` passes in the deployment log
  - [ ] Run `test_simulate_bluestore_label_dmcrypt_on_worker_nodes` standalone with `--ocsci-conf
  conf/ocsci/simulate_bluestore_label_dmcrypt.yaml`

