### PR TITLE
Fix unreliable pull-model ApplicationSet health check in RDR workloads

### DIFF
--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -913,7 +913,7 @@ class BusyBox_AppSet(DRWorkload):
             if _app_set["kind"] == constants.APPLICATION_SET:
                 return _app_set["spec"]["template"]["spec"]["destination"]["namespace"]
 
-    def _get_applicaionset_name(self):
+    def _get_applicationset_name(self):
         """
         Get ApplicationSet name
 
@@ -933,12 +933,12 @@ class BusyBox_AppSet(DRWorkload):
         """
 
         self.check_pod_pvc_status(skip_replication_resources=False)
-        config.switch_acm_ctx()
-        appset_resource_name = (
-            self._get_applicaionset_name() + "-" + self.preferred_primary_cluster
-        )
 
         if self.appset_model == "pull":
+            config.switch_to_cluster_by_name(self.preferred_primary_cluster)
+            appset_resource_name = (
+                self._get_applicationset_name() + "-" + self.preferred_primary_cluster
+            )
             sampler = TimeoutSampler(
                 120, sleep=5, func=self.check_workload_health_status
             )
@@ -949,14 +949,14 @@ class BusyBox_AppSet(DRWorkload):
 
     def check_workload_health_status(self):
         """
-        Checks the health status of the workload and returns whether it is healthy.
+        Checks workload health on the primary managed cluster.
 
         Returns:
             bool: True if the health status is "Healthy", False otherwise
 
         """
         appset_resource_name = (
-            self._get_applicaionset_name() + "-" + self.preferred_primary_cluster
+            self._get_applicationset_name() + "-" + self.preferred_primary_cluster
         )
         appset_obj = ocp.OCP(
             kind=constants.APPLICATION_ARGOCD,
@@ -964,7 +964,10 @@ class BusyBox_AppSet(DRWorkload):
             namespace=constants.GITOPS_CLUSTER_NAMESPACE,
         )
         health_status = appset_obj.get().get("status").get("health").get("status")
-        log.info(f"{appset_resource_name} health status: {health_status}")
+        log.info(
+            f"{appset_resource_name} health status on cluster "
+            f"{self.preferred_primary_cluster}: {health_status}"
+        )
         return health_status == "Healthy"
 
     def check_pod_pvc_status(self, skip_replication_resources=False):


### PR DESCRIPTION
## Summary

- Fix unreliable health check for pull-model ApplicationSet workloads when the hub application status stays `Progressing` but the app on managed cluster is `Healthy`. Check health on the primary managed cluster instead of the ACM hub.
- Limit context switching to pull-model deployments only, push-model verification no longer switches to the hub unnecessarily.
- Also fix _get_applicationset_name typo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved workload deployment verification to correctly manage primary cluster context switching.
  * Enhanced health status monitoring with improved diagnostic logging that includes cluster context information.

* **Refactor**
  * Updated naming convention for internal consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->