### PR TITLE
MCG PriorityClassNames feature: Add PVPool backingstore tests (RHSTOR-7764)

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1129,6 +1129,26 @@ def get_noobaa_endpoint_pods():
     return noobaa_endpoint_pods
 
 
+def get_noobaa_pvpool_pods(backingstore_name, namespace=None):
+    """
+    Fetches the PVPool agent pods for a given NooBaa backingstore.
+
+    Args:
+        backingstore_name (str): Name of the PVPool backingstore
+        namespace (str): Namespace of the backingstore. Defaults to
+            the cluster namespace from ENV_DATA
+
+    Returns:
+        list: List of Pod objects for the given backingstore
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    pod_data_list = get_pods_having_label(
+        label=f"pool={backingstore_name}", namespace=namespace
+    )
+    return [Pod(**pod_data) for pod_data in pod_data_list]
+
+
 def get_odf_operator_controller_manager(
     ocs_label=constants.ODF_OPERATOR_CONTROL_MANAGER_LABEL, namespace=None
 ):

--- a/tests/functional/object/mcg/test_noobaa_priority_class.py
+++ b/tests/functional/object/mcg/test_noobaa_priority_class.py
@@ -226,11 +226,12 @@ class TestNoobaaPriorityClass(MCGTest):
             )
 
     def _wait_for_pvpool_pods_priority_class(
-        self, bs_name, expected_pc, namespace, timeout=360
+        self, bs_name, expected_pc, namespace, expected_count=None, timeout=360
     ):
         """
         Poll PVPool pods until all carry the expected priorityClassName and are Running.
-        Pass None to wait for the field to be absent.
+        Pass None for expected_pc to wait for the field to be absent.
+        If expected_count is set, also wait until exactly that many pods exist.
         """
         for pods in TimeoutSampler(
             timeout=timeout,
@@ -240,6 +241,8 @@ class TestNoobaaPriorityClass(MCGTest):
             namespace=namespace,
         ):
             if not pods:
+                continue
+            if expected_count is not None and len(pods) != expected_count:
                 continue
             all_match = True
             for pod in pods:
@@ -295,7 +298,9 @@ class TestNoobaaPriorityClass(MCGTest):
             assert (
                 "priorityClassName" not in bs_cr["spec"]["pvPool"]
             ), f"Backingstore {name} already has priorityClassName set"
-            for pod in get_noobaa_pvpool_pods(name, namespace):
+            pods = get_noobaa_pvpool_pods(name, namespace)
+            assert pods, f"No PVPool pods found for backingstore {name}"
+            for pod in pods:
                 assert (
                     "priorityClassName" not in pod.get()["spec"]
                 ), f"PVPool pod {pod.name} already has priorityClassName set"
@@ -304,7 +309,7 @@ class TestNoobaaPriorityClass(MCGTest):
         logger.test_step("Step 3: Creating 3 custom PriorityClasses")
         pc_map = {}
         for i, name in enumerate(bs_names, start=1):
-            pc_obj = helpers.create_priority_class(f"pvpool-{i}", 500000 + i)
+            pc_obj = helpers.create_priority_class(name, 500000 + i)
             teardown_factory(pc_obj)
             pc_map[name] = pc_obj.name
 
@@ -415,6 +420,7 @@ class TestNoobaaPriorityClass(MCGTest):
             bs_name=bs_name,
             expected_pc=OPENSHIFT_USER_CRITICAL,
             namespace=namespace,
+            expected_count=num_volumes,
         )
 
         # 4. Verify all PVPool pods have the expected priorityClassName
@@ -423,9 +429,9 @@ class TestNoobaaPriorityClass(MCGTest):
             f"priorityClassName={OPENSHIFT_USER_CRITICAL}"
         )
         pods = get_noobaa_pvpool_pods(bs_name, namespace)
-        assert len(pods) == num_volumes, (
-            f"Expected {num_volumes} PVPool pods for {bs_name}, " f"got {len(pods)}"
-        )
+        assert (
+            len(pods) == num_volumes
+        ), f"Expected {num_volumes} PVPool pods for {bs_name}, got {len(pods)}"
         for pod in pods:
             actual = pod.get()["spec"].get("priorityClassName")
             assert actual == OPENSHIFT_USER_CRITICAL, (
@@ -448,6 +454,7 @@ class TestNoobaaPriorityClass(MCGTest):
             bs_name=bs_name,
             expected_pc=None,
             namespace=namespace,
+            expected_count=num_volumes,
         )
 
         # 7. Verify all PVPool pods are Running without any priorityClassName
@@ -455,9 +462,9 @@ class TestNoobaaPriorityClass(MCGTest):
             "Step 7: Verifying all PVPool pods run without priorityClassName"
         )
         pods = get_noobaa_pvpool_pods(bs_name, namespace)
-        assert len(pods) == num_volumes, (
-            f"Expected {num_volumes} PVPool pods for {bs_name}, " f"got {len(pods)}"
-        )
+        assert (
+            len(pods) == num_volumes
+        ), f"Expected {num_volumes} PVPool pods for {bs_name}, got {len(pods)}"
         for pod in pods:
             actual = pod.get()["spec"].get("priorityClassName")
             assert actual is None, (

--- a/tests/functional/object/mcg/test_noobaa_priority_class.py
+++ b/tests/functional/object/mcg/test_noobaa_priority_class.py
@@ -263,9 +263,9 @@ class TestNoobaaPriorityClass(MCGTest):
         Test that priorityClassName configured on a PVPool backingstore CR
         propagates to its corresponding pod after operator reconciliation.
 
-        1. Create 3 PVPool backingstores via bucket_factory (1 volume each)
+        1. Create 2 PVPool backingstores via bucket_factory (1 volume each)
         2. Verify backingstore CRs and pods have no priorityClassName
-        3. Create 3 custom PriorityClasses (one per backingstore)
+        3. Create 2 custom PriorityClasses (one per backingstore)
         4. Patch each backingstore CR with its corresponding PriorityClass
         5. Wait for the operator to reconcile and pods to restart
         6. Verify each PvPool pod has the expected priorityClassName
@@ -276,8 +276,8 @@ class TestNoobaaPriorityClass(MCGTest):
         namespace = config.ENV_DATA["cluster_namespace"]
         bs_ocp = OCP(kind="backingstore", namespace=namespace)
 
-        # 1. Create 3 PVPool backingstores via bucket_factory
-        logger.test_step("Step 1: Creating 3 PVPool backingstores")
+        # 1. Create 2 PVPool backingstores via bucket_factory
+        logger.test_step("Step 1: Creating 2 PVPool backingstores")
         bucketclass_dict = {
             "interface": "OC",
             "backingstore_dict": {
@@ -285,7 +285,7 @@ class TestNoobaaPriorityClass(MCGTest):
             },
         }
         bs_names = []
-        for _ in range(3):
+        for _ in range(2):
             bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
             bs_names.append(bucket.bucketclass.backingstores[0].name)
 
@@ -305,8 +305,8 @@ class TestNoobaaPriorityClass(MCGTest):
                     "priorityClassName" not in pod.get()["spec"]
                 ), f"PVPool pod {pod.name} already has priorityClassName set"
 
-        # 3. Create 3 custom PriorityClasses
-        logger.test_step("Step 3: Creating 3 custom PriorityClasses")
+        # 3. Create 2 custom PriorityClasses
+        logger.test_step("Step 3: Creating 2 custom PriorityClasses")
         pc_map = {}
         for i, name in enumerate(bs_names, start=1):
             pc_obj = helpers.create_priority_class(name, 500000 + i)

--- a/tests/functional/object/mcg/test_noobaa_priority_class.py
+++ b/tests/functional/object/mcg/test_noobaa_priority_class.py
@@ -11,14 +11,17 @@ from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.constants import MIN_PV_BACKINGSTORE_SIZE_IN_GB, CEPHBLOCKPOOL_SC
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.mcg import MCG
 from ocs_ci.ocs.resources.pod import (
     get_noobaa_core_pod,
     get_noobaa_endpoint_pods,
+    get_noobaa_pvpool_pods,
     get_pods_having_label,
     Pod,
 )
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -221,3 +224,142 @@ class TestNoobaaPriorityClass(MCGTest):
                 f"noobaa-db pod {db_pod.name} priorityClassName mismatch: "
                 f"expected={db_pc!r}, actual={actual!r}"
             )
+
+    def _wait_for_pvpool_pods_priority_class(
+        self, bs_name, expected_pc, namespace, timeout=360
+    ):
+        """
+        Poll PVPool pods until all carry the expected priorityClassName and are Running.
+        Pass None to wait for the field to be absent.
+        """
+        for pods in TimeoutSampler(
+            timeout=timeout,
+            sleep=15,
+            func=get_noobaa_pvpool_pods,
+            backingstore_name=bs_name,
+            namespace=namespace,
+        ):
+            if not pods:
+                continue
+            all_match = True
+            for pod in pods:
+                pod_dict = pod.get()
+                actual_pc = pod_dict["spec"].get("priorityClassName")
+                phase = pod_dict.get("status", {}).get("phase")
+                if actual_pc != expected_pc or phase != "Running":
+                    all_match = False
+                    break
+            if all_match:
+                return
+
+    @tier2
+    @polarion_id("OCS-7954")
+    @config.run_with_provider_context_if_available
+    def test_pvpool_backingstore_priority_class(self, bucket_factory, teardown_factory):
+        """
+        Test that priorityClassName configured on a PVPool backingstore CR
+        propagates to its corresponding pod after operator reconciliation.
+
+        1. Create 3 PVPool backingstores via bucket_factory (1 volume each)
+        2. Verify backingstore CRs and pods have no priorityClassName
+        3. Create 3 custom PriorityClasses (one per backingstore)
+        4. Patch each backingstore CR with its corresponding PriorityClass
+        5. Wait for the operator to reconcile and pods to restart
+        6. Verify each PvPool pod has the expected priorityClassName
+        7. Patch each backingstore CR to remove the priorityClassName
+        8. Wait for the operator to reconcile and pods to restart
+        9. Verify all PvPool pods run without any priorityClassName
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        bs_ocp = OCP(kind="backingstore", namespace=namespace)
+
+        # 1. Create 3 PVPool backingstores via bucket_factory
+        logger.test_step("Step 1: Creating 3 PVPool backingstores")
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {
+                "pv": [(1, MIN_PV_BACKINGSTORE_SIZE_IN_GB, CEPHBLOCKPOOL_SC)]
+            },
+        }
+        bs_names = []
+        for _ in range(3):
+            bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
+            bs_names.append(bucket.bucketclass.backingstores[0].name)
+
+        # 2. Verify backingstore CRs and pods have no priorityClassName
+        logger.test_step(
+            "Step 2: Verifying backingstore CRs and pods have no priorityClassName"
+        )
+        for name in bs_names:
+            bs_cr = bs_ocp.get(resource_name=name)
+            assert (
+                "priorityClassName" not in bs_cr["spec"]["pvPool"]
+            ), f"Backingstore {name} already has priorityClassName set"
+            for pod in get_noobaa_pvpool_pods(name, namespace):
+                assert (
+                    "priorityClassName" not in pod.get()["spec"]
+                ), f"PVPool pod {pod.name} already has priorityClassName set"
+
+        # 3. Create 3 custom PriorityClasses
+        logger.test_step("Step 3: Creating 3 custom PriorityClasses")
+        pc_map = {}
+        for i, name in enumerate(bs_names, start=1):
+            pc_obj = helpers.create_priority_class(f"pvpool-{i}", 500000 + i)
+            teardown_factory(pc_obj)
+            pc_map[name] = pc_obj.name
+
+        # 4. Patch each backingstore CR with its corresponding PriorityClass
+        logger.test_step("Step 4: Patching each backingstore CR with its PriorityClass")
+        for name in bs_names:
+            patch = {"spec": {"pvPool": {"priorityClassName": pc_map[name]}}}
+            bs_ocp.patch(
+                resource_name=name,
+                params=json.dumps(patch),
+                format_type="merge",
+            )
+
+        # 5. Wait for the operator to reconcile and pods to restart
+        logger.test_step("Step 5: Waiting for operator reconciliation")
+        for name in bs_names:
+            self._wait_for_pvpool_pods_priority_class(
+                bs_name=name, expected_pc=pc_map[name], namespace=namespace
+            )
+
+        # 6. Verify each PvPool pod has the expected priorityClassName
+        logger.test_step("Step 6: Verifying pod priorityClassNames after patching")
+        for name in bs_names:
+            for pod in get_noobaa_pvpool_pods(name, namespace):
+                actual = pod.get()["spec"].get("priorityClassName")
+                assert actual == pc_map[name], (
+                    f"PVPool pod {pod.name} priorityClassName mismatch: "
+                    f"expected={pc_map[name]}, actual={actual}"
+                )
+
+        # 7. Remove priorityClassName from all backingstore CRs
+        logger.test_step("Step 7: Removing priorityClassName from all backingstore CRs")
+        for name in bs_names:
+            remove_patch = [{"op": "remove", "path": "/spec/pvPool/priorityClassName"}]
+            bs_ocp.patch(
+                resource_name=name,
+                params=json.dumps(remove_patch),
+                format_type="json",
+            )
+
+        # 8. Wait for the operator to reconcile and pods to restart
+        logger.test_step("Step 8: Waiting for operator reconciliation")
+        for name in bs_names:
+            self._wait_for_pvpool_pods_priority_class(
+                bs_name=name, expected_pc=None, namespace=namespace
+            )
+
+        # 9. Verify all PvPool pods run without any priorityClassName
+        logger.test_step(
+            "Step 9: Verifying all PvPool pods run without priorityClassName"
+        )
+        for name in bs_names:
+            for pod in get_noobaa_pvpool_pods(name, namespace):
+                actual = pod.get()["spec"].get("priorityClassName")
+                assert actual is None, (
+                    f"PVPool pod {pod.name} still has priorityClassName={actual} "
+                    f"after removal from backingstore CR"
+                )

--- a/tests/functional/object/mcg/test_noobaa_priority_class.py
+++ b/tests/functional/object/mcg/test_noobaa_priority_class.py
@@ -363,3 +363,104 @@ class TestNoobaaPriorityClass(MCGTest):
                     f"PVPool pod {pod.name} still has priorityClassName={actual} "
                     f"after removal from backingstore CR"
                 )
+
+    @tier2
+    @polarion_id("OCS-7955")
+    @config.run_with_provider_context_if_available
+    def test_pvpool_multi_volume_priority_class(self, bucket_factory):
+        """
+        Test that priorityClassName set on a multi-volume PVPool backingstore CR
+        propagates to all of its corresponding pods after operator reconciliation.
+
+        1. Create a PVPool backingstore with 3 volumes
+        2. Patch the backingstore CR with priorityClassName=openshift-user-critical
+        3. Wait for the NooBaa operator to reconcile and for the pods to restart
+        4. Verify that all 3 PVPool pods have priorityClassName=openshift-user-critical
+        5. Patch the backingstore CR to remove the priorityClassName field
+        6. Wait for the NooBaa operator to reconcile and for the pods to restart
+        7. Verify that all 3 PVPool pods are Running without any priorityClassName
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        bs_ocp = OCP(kind="backingstore", namespace=namespace)
+        num_volumes = 3
+
+        # 1. Create a PVPool backingstore with 3 volumes
+        logger.test_step(
+            f"Step 1: Creating a PVPool backingstore with {num_volumes} volumes"
+        )
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {
+                "pv": [(num_volumes, MIN_PV_BACKINGSTORE_SIZE_IN_GB, CEPHBLOCKPOOL_SC)]
+            },
+        }
+        bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
+        bs_name = bucket.bucketclass.backingstores[0].name
+
+        # 2. Patch the backingstore CR with priorityClassName
+        logger.test_step(
+            f"Step 2: Patching backingstore {bs_name} with "
+            f"priorityClassName={OPENSHIFT_USER_CRITICAL}"
+        )
+        patch = {"spec": {"pvPool": {"priorityClassName": OPENSHIFT_USER_CRITICAL}}}
+        bs_ocp.patch(
+            resource_name=bs_name,
+            params=json.dumps(patch),
+            format_type="merge",
+        )
+
+        # 3. Wait for the operator to reconcile and pods to restart
+        logger.test_step("Step 3: Waiting for operator reconciliation")
+        self._wait_for_pvpool_pods_priority_class(
+            bs_name=bs_name,
+            expected_pc=OPENSHIFT_USER_CRITICAL,
+            namespace=namespace,
+        )
+
+        # 4. Verify all PVPool pods have the expected priorityClassName
+        logger.test_step(
+            "Step 4: Verifying all PVPool pods have "
+            f"priorityClassName={OPENSHIFT_USER_CRITICAL}"
+        )
+        pods = get_noobaa_pvpool_pods(bs_name, namespace)
+        assert len(pods) == num_volumes, (
+            f"Expected {num_volumes} PVPool pods for {bs_name}, " f"got {len(pods)}"
+        )
+        for pod in pods:
+            actual = pod.get()["spec"].get("priorityClassName")
+            assert actual == OPENSHIFT_USER_CRITICAL, (
+                f"PVPool pod {pod.name} priorityClassName mismatch: "
+                f"expected={OPENSHIFT_USER_CRITICAL}, actual={actual}"
+            )
+
+        # 5. Remove priorityClassName from the backingstore CR
+        logger.test_step("Step 5: Removing priorityClassName from backingstore CR")
+        remove_patch = [{"op": "remove", "path": "/spec/pvPool/priorityClassName"}]
+        bs_ocp.patch(
+            resource_name=bs_name,
+            params=json.dumps(remove_patch),
+            format_type="json",
+        )
+
+        # 6. Wait for the operator to reconcile and pods to restart
+        logger.test_step("Step 6: Waiting for operator reconciliation")
+        self._wait_for_pvpool_pods_priority_class(
+            bs_name=bs_name,
+            expected_pc=None,
+            namespace=namespace,
+        )
+
+        # 7. Verify all PVPool pods are Running without any priorityClassName
+        logger.test_step(
+            "Step 7: Verifying all PVPool pods run without priorityClassName"
+        )
+        pods = get_noobaa_pvpool_pods(bs_name, namespace)
+        assert len(pods) == num_volumes, (
+            f"Expected {num_volumes} PVPool pods for {bs_name}, " f"got {len(pods)}"
+        )
+        for pod in pods:
+            actual = pod.get()["spec"].get("priorityClassName")
+            assert actual is None, (
+                f"PVPool pod {pod.name} still has priorityClassName={actual} "
+                f"after removal from backingstore CR"
+            )


### PR DESCRIPTION
## Summary
Add two tests for the NooBaa PriorityClassNames feature on PVPool backingstore CRDs,

## Changes
- Add `get_noobaa_pvpool_pods()` utility to `pod.py` for fetching PVPool agent pods
  by backingstore name
- Add `test_pvpool_backingstore_priority_class` — verifies PriorityClass propagation
  across 3 separate single-volume PVPool backingstores, each with a distinct custom
  PriorityClass
- Add `test_pvpool_multi_volume_priority_class` — verifies PriorityClass propagation
  to all pods of a single 3-volume PVPool backingstore using the built-in
  `openshift-user-critical` PriorityClass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added functional tests for NooBaa priority class configuration on single-volume and multi-volume PVPool backingstores
  - Tests verify priority class assignment, updates, and removal behavior on backingstore pods

* **Chores**
  - Added helper utility for retrieving NooBaa PVPool pod information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->