### PR TITLE
ec-day2-tests-adjustments-NON-ui

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2896,
+        "line_number": 2924,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2032,
+        "line_number": 2035,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2139,
+        "line_number": 2142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2140,
+        "line_number": 2143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2141,
+        "line_number": 2144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2145,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2147,
+        "line_number": 2157,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2162,
+        "line_number": 2172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2163,
+        "line_number": 2173,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2171,
+        "line_number": 2181,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2172,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2173,
+        "line_number": 2183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2174,
+        "line_number": 2184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
+        "line_number": 2185,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2771,
+        "line_number": 2778,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2936,
+        "line_number": 2935,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2937,
+        "line_number": 2936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3658,
+        "line_number": 3657,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3659,
+        "line_number": 3658,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -106,6 +106,7 @@ rdr = pytest.mark.rdr
 mdr = pytest.mark.mdr
 resiliency = pytest.mark.resiliency
 chaos = pytest.mark.chaos
+ec_allowed = pytest.mark.ec_allowed
 
 tier_marks = [
     tier1,

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -728,6 +728,9 @@ def create_ceph_block_pool(
     namespace=None,
     device_class=None,
     yaml_file=None,
+    erasure_coded=False,
+    data_chunks=None,
+    coding_chunks=None,
 ):
     """
     Create a Ceph block pool with optional parameters.
@@ -741,20 +744,34 @@ def create_ceph_block_pool(
         namespace (str): The pool namespace (optional).
         device_class (str): The device class name (optional).
         yaml_file (str): The name of the YAML file for the Ceph block pool (optional).
+        erasure_coded (bool): True to create an erasure coded pool instead of replicated.
+        data_chunks (int): Number of data chunks for the EC profile (optional).
+            When None and erasure_coded=True, resolved automatically via get_ec_profile().
+            Pass explicit int to override auto-selection.
+        coding_chunks (int): Number of coding chunks for the EC profile (optional).
+            When None and erasure_coded=True, resolved automatically via get_ec_profile().
 
     Returns:
         OCS: The OCS instance for the Ceph block pool.
 
     """
-    # Load the YAML template
     if yaml_file:
         cbp_data = templating.load_yaml(yaml_file)
+    elif erasure_coded:
+        from ocs_ci.ocs.cluster import get_ec_profile
+
+        resolved_data_chunks, resolved_coding_chunks = (
+            (data_chunks, coding_chunks)
+            if data_chunks is not None and coding_chunks is not None
+            else get_ec_profile()
+        )
+        cbp_data = templating.load_yaml(constants.CEPHBLOCKPOOL_EC_YAML)
+        cbp_data["spec"]["erasureCoded"]["dataChunks"] = resolved_data_chunks
+        cbp_data["spec"]["erasureCoded"]["codingChunks"] = resolved_coding_chunks
     elif device_class:
-        # Use the appropriate yaml for the device class CephBlockPool
         cbp_data = templating.load_yaml(constants.DEVICECLASS_CEPHBLOCKPOOL_YAML)
         cbp_data["spec"]["deviceClass"] = device_class
     else:
-        # Use the appropriate yaml for the CephBlockPool
         cbp_data = templating.load_yaml(constants.CEPHBLOCKPOOL_YAML)
 
     cbp_data["metadata"]["name"] = (
@@ -764,12 +781,18 @@ def create_ceph_block_pool(
         namespace or config.ENV_DATA["cluster_namespace"]
     )
 
-    cbp_data["spec"]["replicated"]["size"] = replica
-    cbp_data["spec"]["failureDomain"] = failure_domain or get_failure_domin()
+    if not erasure_coded:
+        cbp_data["spec"]["replicated"]["size"] = replica
+        cbp_data["spec"]["failureDomain"] = failure_domain or get_failure_domin()
 
     if compression:
         cbp_data["spec"]["compressionMode"] = compression
-        cbp_data["spec"]["parameters"]["compression_mode"] = compression
+        cbp_data["spec"].setdefault("parameters", {})["compression_mode"] = compression
+
+    if erasure_coded:
+        from ocs_ci.ocs.cluster import ensure_ec_metadata_pool_exists
+
+        ensure_ec_metadata_pool_exists()
 
     cbp_obj = create_resource(**cbp_data)
     cbp_obj.reload()
@@ -963,6 +986,7 @@ def create_storage_class(
     annotations=None,
     mapOptions=None,
     mounter=None,
+    data_pool_name=None,
 ):
     """
     Create a storage class
@@ -989,6 +1013,8 @@ def create_storage_class(
         annotations(dict): dict of annotations to be added to the storageclass.
         mapOptions (str): mapOtions match the configuration of ocs-storagecluster-ceph-rbd-virtualization storage class
         mounter (str): mounter to match the configuration of ocs-storagecluster-ceph-rbd-virtualization storage class
+        data_pool_name (str): EC data pool name; sets dataPool in StorageClass parameters (optional).
+            Required when creating an EC-backed StorageClass where interface_name is the metadata pool.
 
     Returns:
         OCS: An OCS instance for the storage class
@@ -1025,6 +1051,8 @@ def create_storage_class(
             provisioner if provisioner else defaults.CEPHFS_PROVISIONER
         )
     sc_data["parameters"]["pool"] = interface_name
+    if data_pool_name:
+        sc_data["parameters"]["dataPool"] = data_pool_name
 
     sc_data["metadata"]["name"] = (
         sc_name

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2391,6 +2391,140 @@ def is_lso_cluster():
     return config.DEPLOYMENT.get("local_storage", False)
 
 
+def is_ec_pool_supported():
+    """
+    Check if erasure coded RBD pools are supported on this cluster.
+
+    All conditions must be met:
+    - Platform is vSphere or baremetal
+    - Cluster uses local storage (LSO / no-provisioner / localblock)
+    - Failure domain is 'host'
+    - At least 3 OSDs are running
+
+    Returns:
+        bool: True if EC pools are supported, False otherwise
+    """
+    from ocs_ci.helpers.helpers import get_failure_domin
+    from ocs_ci.ocs.resources import pod
+
+    platform = config.ENV_DATA["platform"].lower()
+    if platform not in constants.ON_PREM_PLATFORMS:
+        return False
+    if not is_lso_cluster():
+        return False
+    if get_failure_domin() != "host":
+        return False
+    if len(pod.get_osd_pods()) < 3:
+        return False
+    return True
+
+
+def get_ec_metadata_pool_name():
+    """
+    Return the name of the replicated metadata pool for EC RBD StorageClasses
+    as configured in the StorageCluster spec.
+
+    Returns:
+        str: pool name, or empty string if not configured
+    """
+    sc_obj = storage_cluster.get_storage_cluster()
+    sc_data = sc_obj.get()["items"][0]
+    return (
+        sc_data.get("spec", {})
+        .get("managedResources", {})
+        .get("cephBlockPools", {})
+        .get("erasureCodedMetadataPool", "")
+    )
+
+
+def ensure_ec_metadata_pool_exists(
+    metadata_pool_name="replicated-metadata-pool", timeout=300
+):
+    """
+    Ensure the replicated metadata pool for EC RBD exists and is Ready.
+
+    If the StorageCluster does not yet have erasureCodedMetadataPool set,
+    patches it and waits for the pool to be created and reach Ready phase.
+
+    If the StorageCluster already has the field set but the pool does NOT exist
+    or is NOT Ready, this is a critical failure — raises an exception.
+
+    Args:
+        metadata_pool_name (str): Name of the metadata pool
+        timeout (int): Seconds to wait for pool to become Ready after patch
+
+    Raises:
+        AssertionError: If pool is expected to exist but is not Ready (critical failure path)
+        TimeoutExpiredError: If pool does not become Ready within timeout after patching
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    configured_name = get_ec_metadata_pool_name()
+    pool_ocp = OCP(
+        kind=constants.CEPHBLOCKPOOL,
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+
+    def pool_is_ready():
+        try:
+            pool = pool_ocp.get(resource_name=metadata_pool_name)
+            return pool.get("status", {}).get("phase") == "Ready"
+        except Exception:
+            return False
+
+    if configured_name:
+        assert pool_is_ready(), (
+            f"StorageCluster has erasureCodedMetadataPool='{configured_name}' "
+            f"but CephBlockPool '{metadata_pool_name}' is not Ready. "
+            "This is a critical failure — inspect the cluster."
+        )
+        return
+
+    logger.info(
+        f"Patching StorageCluster to add erasureCodedMetadataPool: {metadata_pool_name}"
+    )
+    sc_obj = storage_cluster.get_storage_cluster()
+    sc_data = sc_obj.get()["items"][0]
+    sc_name = sc_data["metadata"]["name"]
+    patch = {
+        "spec": {
+            "managedResources": {
+                "cephBlockPools": {"erasureCodedMetadataPool": metadata_pool_name}
+            }
+        }
+    }
+    sc_obj.patch(
+        resource_name=sc_name,
+        params=patch,
+        format_type="merge",
+    )
+
+    logger.info(f"Waiting up to {timeout}s for {metadata_pool_name} to become Ready")
+    for sample in TimeoutSampler(timeout=timeout, sleep=10, func=pool_is_ready):
+        if sample:
+            logger.info(f"Pool {metadata_pool_name} is Ready")
+            return
+
+
+def get_ec_profile():
+    """
+    Return the EC profile (data_chunks, coding_chunks) appropriate for this cluster.
+
+    Selection:
+    - 6+ storage nodes → k=2, m=2
+    - 3-5 storage nodes → k=2, m=1
+
+    Returns:
+        tuple[int, int]: (data_chunks, coding_chunks)
+    """
+    from ocs_ci.ocs.node import get_osd_running_nodes
+
+    osd_node_count = len(get_osd_running_nodes())
+    if osd_node_count >= 6:
+        return 2, 2
+    return 2, 1
+
+
 def is_flexible_scaling_enabled():
     """
     Check if flexible scaling is enabled

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -868,6 +868,7 @@ TOOL_POD_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "toolbox_pod.yaml")
 CEPHFILESYSTEM_YAML = os.path.join(TEMPLATE_CSI_FS_DIR, "CephFileSystem.yaml")
 
 CEPHBLOCKPOOL_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "cephblockpool.yaml")
+CEPHBLOCKPOOL_EC_YAML = os.path.join(TEMPLATE_DEPLOYMENT_DIR, "cephblockpool_ec.yaml")
 
 VSPHERE_THICK_STORAGECLASS_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR, "vsphere_storageclass_thick.yaml"

--- a/ocs_ci/templates/ocs-deployment/cephblockpool_ec.yaml
+++ b/ocs_ci/templates/ocs-deployment/cephblockpool_ec.yaml
@@ -1,0 +1,9 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: ec-pool
+  namespace: openshift-storage
+spec:
+  erasureCoded:
+    dataChunks: 2
+    codingChunks: 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -80,6 +80,7 @@ markers =
     ignore_leftover_label: marker for ignoring lefotover of resources having specific label
     ignore_resource_not_found_error_label: ignore resource_not_found error such as when deleting a resource that was already deleted
     stretchcluster_required: maker to select stretch ceph cluster related tests
+    ec_allowed: marker for tests that support erasure coded RBD pool variants
 # Clusterctx used without hyphen, to keep the original format if it's None
 log_format = %(asctime)s - %(threadName)s - %(name)s - %(levelname)s %(clusterctx)s - %(message)s
 # Don't set log_cli_level to DEBUG because we get memory issues on Jenkins

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1027,23 +1027,77 @@ def pagerduty_integration(request, pagerduty_service):
 
 
 @pytest.fixture(scope="class")
-def ceph_pool_factory_class(request, replica=3, compression=None):
-    return ceph_pool_factory_fixture(request, replica=replica, compression=compression)
-
-
-@pytest.fixture(scope="session")
-def ceph_pool_factory_session(request, replica=3, compression=None):
-    return ceph_pool_factory_fixture(request, replica=replica, compression=compression)
-
-
-@pytest.fixture(scope="function")
-def ceph_pool_factory(request, replica=3, compression=None, pool_name=None):
+def ceph_pool_factory_class(
+    request,
+    replica=3,
+    compression=None,
+    pool_name=None,
+    erasure_coded=False,
+    data_chunks=None,
+    coding_chunks=None,
+):
     return ceph_pool_factory_fixture(
-        request, replica=replica, compression=compression, pool_name=pool_name
+        request,
+        replica=replica,
+        compression=compression,
+        pool_name=pool_name,
+        erasure_coded=erasure_coded,
+        data_chunks=data_chunks,
+        coding_chunks=coding_chunks,
     )
 
 
-def ceph_pool_factory_fixture(request, replica=3, compression=None, pool_name=None):
+@pytest.fixture(scope="session")
+def ceph_pool_factory_session(
+    request,
+    replica=3,
+    compression=None,
+    pool_name=None,
+    erasure_coded=False,
+    data_chunks=None,
+    coding_chunks=None,
+):
+    return ceph_pool_factory_fixture(
+        request,
+        replica=replica,
+        compression=compression,
+        pool_name=pool_name,
+        erasure_coded=erasure_coded,
+        data_chunks=data_chunks,
+        coding_chunks=coding_chunks,
+    )
+
+
+@pytest.fixture(scope="function")
+def ceph_pool_factory(
+    request,
+    replica=3,
+    compression=None,
+    pool_name=None,
+    erasure_coded=False,
+    data_chunks=None,
+    coding_chunks=None,
+):
+    return ceph_pool_factory_fixture(
+        request,
+        replica=replica,
+        compression=compression,
+        pool_name=pool_name,
+        erasure_coded=erasure_coded,
+        data_chunks=data_chunks,
+        coding_chunks=coding_chunks,
+    )
+
+
+def ceph_pool_factory_fixture(
+    request,
+    replica=3,
+    compression=None,
+    pool_name=None,
+    erasure_coded=False,
+    data_chunks=None,
+    coding_chunks=None,
+):
     """
     Create a Ceph pool factory.
     Calling this fixture creates new Ceph pool instance.
@@ -1057,10 +1111,18 @@ def ceph_pool_factory_fixture(request, replica=3, compression=None, pool_name=No
         replica=replica,
         compression=compression,
         pool_name=pool_name,
+        erasure_coded=erasure_coded,
+        data_chunks=data_chunks,
+        coding_chunks=coding_chunks,
     ):
         if interface == constants.CEPHBLOCKPOOL:
             ceph_pool_obj = helpers.create_ceph_block_pool(
-                replica=replica, compression=compression, pool_name=pool_name
+                replica=replica,
+                compression=compression,
+                pool_name=pool_name,
+                erasure_coded=erasure_coded,
+                data_chunks=data_chunks,
+                coding_chunks=coding_chunks,
             )
         elif interface == constants.CEPHFILESYSTEM:
             cfs = ocp.OCP(
@@ -1211,6 +1273,8 @@ def storageclass_factory_fixture(
         annotations=None,
         mapOptions=None,
         mounter=None,
+        erasure_coded=False,
+        data_pool_name=None,
     ):
         """
         Args:
@@ -1239,6 +1303,11 @@ def storageclass_factory_fixture(
             annotations (dict): dict of annotation to be added to the storageclass.
             mapOptions (str): mapOtions match the configuration of ocs-storagecluster-ceph-rbd-virtualization SC
             mounter (str): mounter to match the configuration of ocs-storagecluster-ceph-rbd-virtualization SC
+            erasure_coded (bool): True to create an erasure coded RBD pool backed StorageClass.
+                Requires new_rbd_pool=True. The StorageClass will have pool set to the shared
+                metadata pool and dataPool set to the new EC data pool.
+            data_pool_name (str): Explicit EC data pool name to set as dataPool in the StorageClass.
+                Use when sharing an existing EC pool across multiple SCs without creating a new one.
 
         Returns:
             object: helpers.create_storage_class instance with links to
@@ -1248,6 +1317,7 @@ def storageclass_factory_fixture(
             sc_obj = helpers.create_resource(**custom_data)
         else:
             secret = secret or secret_factory(interface=interface)
+            ec_data_pool_name = None
             if interface == constants.CEPHBLOCKPOOL:
                 if ocsci_config.ENV_DATA.get("new_rbd_pool") or new_rbd_pool:
                     pool_obj = ceph_pool_factory(
@@ -1256,8 +1326,15 @@ def storageclass_factory_fixture(
                         compression=ocsci_config.ENV_DATA.get("compression")
                         or compression,
                         pool_name=pool_name,
+                        erasure_coded=erasure_coded,
                     )
-                    interface_name = pool_obj.name
+                    if erasure_coded:
+                        from ocs_ci.ocs.cluster import get_ec_metadata_pool_name
+
+                        interface_name = get_ec_metadata_pool_name()
+                        ec_data_pool_name = pool_obj.name
+                    else:
+                        interface_name = pool_obj.name
                 else:
                     if pool_name is None:
                         interface_name = helpers.default_ceph_block_pool()
@@ -1281,6 +1358,7 @@ def storageclass_factory_fixture(
                 annotations=annotations,
                 mapOptions=mapOptions,
                 mounter=mounter,
+                data_pool_name=data_pool_name or ec_data_pool_name,
             )
             assert sc_obj, f"Failed to create {interface} storage class"
             sc_obj.secret = secret

--- a/tests/cross_functional/performance/io_workload/test_fio_benchmark.py
+++ b/tests/cross_functional/performance/io_workload/test_fio_benchmark.py
@@ -497,7 +497,7 @@ class TestFIOBenchmark(PASTest):
                 *["random", "64KiB", 60, True],
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7964"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -508,7 +508,7 @@ class TestFIOBenchmark(PASTest):
                 *["sequential", "64KiB", 60, True],
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7965"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/cross_functional/performance/io_workload/test_fio_benchmark.py
+++ b/tests/cross_functional/performance/io_workload/test_fio_benchmark.py
@@ -13,12 +13,16 @@ from ocs_ci.framework import config
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import grey_squad
+from ocs_ci.framework.pytest_customization.marks import grey_squad, ec_allowed
 from ocs_ci.framework.testlib import performance, performance_c, skipif_ocs_version
 from ocs_ci.ocs.perfresult import PerfResult
 from ocs_ci.helpers.helpers import get_full_test_logs_path
 from ocs_ci.ocs.perftests import PASTest
-from ocs_ci.ocs.cluster import CephCluster, calculate_compression_ratio
+from ocs_ci.ocs.cluster import (
+    CephCluster,
+    calculate_compression_ratio,
+    is_ec_pool_supported,
+)
 from ocs_ci.helpers.performance_lib import run_command
 from ocs_ci.ocs.elasticsearch import ElasticSearch
 from ocs_ci.ocs import benchmark_operator
@@ -481,19 +485,41 @@ class TestFIOBenchmark(PASTest):
 
     @skipif_ocs_version("<4.6")
     @pytest.mark.parametrize(
-        argnames=["io_pattern", "bs", "cmp_ratio"],
+        argnames=["io_pattern", "bs", "cmp_ratio", "erasure_coded"],
         argvalues=[
-            pytest.param(*["random", "1024KiB", 60]),
-            pytest.param(*["random", "64KiB", 60]),
-            pytest.param(*["random", "16KiB", 60]),
-            pytest.param(*["sequential", "1024KiB", 60]),
-            pytest.param(*["sequential", "64KiB", 60]),
-            pytest.param(*["sequential", "16KiB", 60]),
+            pytest.param(*["random", "1024KiB", 60, False]),
+            pytest.param(*["random", "64KiB", 60, False]),
+            pytest.param(*["random", "16KiB", 60, False]),
+            pytest.param(*["sequential", "1024KiB", 60, False]),
+            pytest.param(*["sequential", "64KiB", 60, False]),
+            pytest.param(*["sequential", "16KiB", 60, False]),
+            pytest.param(
+                *["random", "64KiB", 60, True],
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *["sequential", "64KiB", 60, True],
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
         ],
     )
     @pytest.mark.polarion_id("OCS-2617")
     def test_fio_compressed_workload(
-        self, storageclass_factory, io_pattern, bs, cmp_ratio
+        self, storageclass_factory, io_pattern, bs, cmp_ratio, erasure_coded
     ):
         """
         This is a basic fio perf test which run on compression enabled volume
@@ -529,12 +555,13 @@ class TestFIOBenchmark(PASTest):
         # Saving the Original elastic-search IP and PORT - if defined in yaml
         self.es_info_backup(self.es)
 
-        log.info("Creating compressed pool & SC")
+        log.info("Creating pool & SC")
         sc_obj = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL,
             new_rbd_pool=True,
             replica=3,
-            compression="aggressive",
+            compression="none" if erasure_coded else "aggressive",
+            erasure_coded=erasure_coded,
         )
 
         sc = sc_obj.name

--- a/tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -1,14 +1,15 @@
 import logging
+import pytest
 
 from ocs_ci.helpers import helpers
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
 from ocs_ci.framework.testlib import (
-    polarion_id,
     skipif_ocs_version,
     tier2,
     skipif_external_mode,
     skipif_hci_provider_and_client,
 )
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 
 log = logging.getLogger(__name__)
 
@@ -16,10 +17,28 @@ log = logging.getLogger(__name__)
 @green_squad
 @tier2
 @skipif_ocs_version("<4.3")
-@polarion_id("OCS-2130")
 @skipif_external_mode
 @skipif_hci_provider_and_client
-def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(teardown_factory):
+@pytest.mark.parametrize(
+    "erasure_coded",
+    [
+        pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2130")]),
+        pytest.param(
+            True,
+            marks=[
+                ec_allowed,
+                pytest.mark.polarion_id("OCS-XXXX"),
+                pytest.mark.skipif(
+                    not is_ec_pool_supported(),
+                    reason="Erasure coded pools are not supported on this cluster",
+                ),
+            ],
+        ),
+    ],
+)
+def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(
+    erasure_coded, teardown_factory
+):
     """
     Test to verify new ceph block pool can be created without deleting
     ceph block pool having invalid parameters
@@ -40,7 +59,9 @@ def test_verify_new_cbp_creation_not_blocked_by_invalid_cbp(teardown_factory):
     )
 
     log.info("Create valid ceph block pool")
-    cbp_valid = helpers.create_ceph_block_pool(verify=False)
+    cbp_valid = helpers.create_ceph_block_pool(
+        erasure_coded=erasure_coded, verify=False
+    )
     teardown_factory(cbp_valid)
     assert helpers.verify_block_pool_exists(
         cbp_valid.name

--- a/tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
+++ b/tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
             True,
             marks=[
                 ec_allowed,
-                pytest.mark.polarion_id("OCS-XXXX"),
+                pytest.mark.polarion_id("OCS-7981"),
                 pytest.mark.skipif(
                     not is_ec_pool_supported(),
                     reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -61,7 +61,7 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7978"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py
@@ -2,7 +2,8 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -26,7 +27,6 @@ log = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @skipif_ocs_version("<4.6")
 @skipif_ocp_version("<4.6")
-@pytest.mark.polarion_id("OCS-2424")
 class TestRestoreSnapshotUsingDifferentSc(ManageTest):
     """
     Tests to verify snapshot restore using an SC different than that of parent
@@ -53,9 +53,27 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
             access_modes_cephfs=[constants.ACCESS_MODE_RWO],
         )
 
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2424")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     @tier2
     def test_snapshot_restore_using_different_sc(
         self,
+        erasure_coded,
         storageclass_factory,
         snapshot_factory,
         snapshot_restore_factory,
@@ -125,7 +143,9 @@ class TestRestoreSnapshotUsingDifferentSc(ManageTest):
         ):
             sc_objs[constants.CEPHBLOCKPOOL].append(
                 storageclass_factory(
-                    interface=constants.CEPHBLOCKPOOL, new_rbd_pool=True
+                    interface=constants.CEPHBLOCKPOOL,
+                    new_rbd_pool=True,
+                    erasure_coded=erasure_coded,
                 ).name
             )
 

--- a/tests/functional/pv/pvc_snapshot/test_verify_rbd_trash_purge.py
+++ b/tests/functional/pv/pvc_snapshot/test_verify_rbd_trash_purge.py
@@ -91,7 +91,7 @@ class TestVerifyRbdTrashPurge(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7977"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/pv/pvc_snapshot/test_verify_rbd_trash_purge.py
+++ b/tests/functional/pv/pvc_snapshot/test_verify_rbd_trash_purge.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -11,16 +11,22 @@ from ocs_ci.framework.testlib import (
     skipif_hci_provider_and_client,
     skipif_external_mode,
 )
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture
+def erasure_coded():
+    """Default pool type: replicated. Overridden per-test via parametrize."""
+    return False
+
+
 @green_squad
 @tier2
 @skipif_ocs_version("<4.8")
-@pytest.mark.polarion_id("OCS-2595")
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @skipif_external_mode
@@ -36,6 +42,7 @@ class TestVerifyRbdTrashPurge(ManageTest):
         storageclass_factory,
         multi_pvc_factory,
         snapshot_factory,
+        erasure_coded,
     ):
         """
         Create RBD pool, storage class, PVCs and snapshots
@@ -47,6 +54,7 @@ class TestVerifyRbdTrashPurge(ManageTest):
         self.sc_obj = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL,
             new_rbd_pool=True,
+            erasure_coded=erasure_coded,
         )
 
         # Create PVC
@@ -75,7 +83,24 @@ class TestVerifyRbdTrashPurge(ManageTest):
                 timeout=600,
             )
 
-    def test_verify_rbd_trash_purge_when_snapshots_present(self):
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2595")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_verify_rbd_trash_purge_when_snapshots_present(self, erasure_coded):
         """
         Verify RBD trash purge command when the RBD image in trash have snapshots. Verifies bug 1964373.
 

--- a/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -191,7 +191,7 @@ class TestRbdSpaceReclaim(ManageTest):
                 marks=[
                     ec_allowed,
                     tier2,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7962"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -13,7 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_external_mode,
     skipif_hci_provider_and_client,
 )
-from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.cluster import CephCluster, is_ec_pool_supported
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     TimeoutExpiredError,
@@ -152,7 +152,13 @@ class TestRbdSpaceReclaim(ManageTest):
     @skipif_hci_provider_and_client
     @skipif_external_mode
     @pytest.mark.parametrize(
-        argnames=["replica", "compression", "volume_binding_mode", "pvc_status"],
+        argnames=[
+            "replica",
+            "compression",
+            "volume_binding_mode",
+            "pvc_status",
+            "erasure_coded",
+        ],
         argvalues=[
             pytest.param(
                 *[
@@ -160,6 +166,7 @@ class TestRbdSpaceReclaim(ManageTest):
                     "aggressive",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=pytest.mark.polarion_id("OCS-4587"),
             ),
@@ -169,8 +176,27 @@ class TestRbdSpaceReclaim(ManageTest):
                     "none",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=pytest.mark.polarion_id("OCS-4587"),
+            ),
+            pytest.param(
+                *[
+                    3,
+                    "none",
+                    constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                    constants.STATUS_BOUND,
+                    True,
+                ],
+                marks=[
+                    ec_allowed,
+                    tier2,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
             ),
         ],
     )
@@ -180,6 +206,7 @@ class TestRbdSpaceReclaim(ManageTest):
         compression,
         volume_binding_mode,
         pvc_status,
+        erasure_coded,
         project_factory,
         storageclass_factory_class,
         pvc_factory,
@@ -217,6 +244,7 @@ class TestRbdSpaceReclaim(ManageTest):
             compression=compression,
             volume_binding_mode=volume_binding_mode,
             pool_name="test-pool-cronjob",
+            erasure_coded=erasure_coded,
         )
 
         pvc_obj = pvc_factory(

--- a/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
@@ -5,16 +5,16 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
     tier1,
     tier2,
-    polarion_id,
     skipif_managed_service,
     skipif_external_mode,
 )
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
     TimeoutExpiredError,
@@ -32,6 +32,12 @@ from ocs_ci.utility.utils import TimeoutSampler
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture
+def erasure_coded():
+    """Default pool type: replicated. Overridden per-test via parametrize."""
+    return False
+
+
 @green_squad
 @skipif_ocs_version("<4.10")
 class TestRbdSpaceReclaim(ManageTest):
@@ -41,7 +47,9 @@ class TestRbdSpaceReclaim(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory, storageclass_factory, create_pvcs_and_pods):
+    def setup(
+        self, project_factory, storageclass_factory, create_pvcs_and_pods, erasure_coded
+    ):
         """
         Create PVCs and pods
 
@@ -55,6 +63,7 @@ class TestRbdSpaceReclaim(ManageTest):
                 interface=constants.CEPHBLOCKPOOL,
                 replica=self.pool_replica,
                 new_rbd_pool=True,
+                erasure_coded=erasure_coded,
             )
         self.data_pool = helpers.get_data_pool_name(sc_obj=self.sc_obj)
         self.pool_size_factor = helpers.get_pool_size_factor(self.data_pool)
@@ -67,11 +76,27 @@ class TestRbdSpaceReclaim(ManageTest):
             sc_rbd=self.sc_obj,
         )
 
-    @polarion_id("OCS-2741")
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2741")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     @tier1
     @skipif_external_mode
     @skipif_managed_service
-    def test_rbd_space_reclaim(self):
+    def test_rbd_space_reclaim(self, erasure_coded):
         """
         Test to verify RBD space reclamation
 
@@ -150,11 +175,27 @@ class TestRbdSpaceReclaim(ManageTest):
         if check_file_existence(pod_obj=pod_obj, file_path=file_path):
             log.info(f"{fio_filename2} is intact")
 
-    @polarion_id("OCS-2774")
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2774")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     @tier2
     @skipif_managed_service
     @skipif_external_mode
-    def test_rbd_space_reclaim_no_space(self):
+    def test_rbd_space_reclaim_no_space(self, erasure_coded):
         """
         Test to verify RBD space reclamation
 
@@ -207,10 +248,26 @@ class TestRbdSpaceReclaim(ManageTest):
             f"Memory remains intact. Used size after io is {used_after_reclaiming_space}."
         )
 
-    @polarion_id("OCS-3733")
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-3733")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     @tier2
     @skipif_external_mode
-    def test_no_volume_mounted(self):
+    def test_no_volume_mounted(self, erasure_coded):
         """
         Test reclaimspace job with no volume mounted
 

--- a/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py
@@ -84,7 +84,7 @@ class TestRbdSpaceReclaim(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7974"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -183,7 +183,7 @@ class TestRbdSpaceReclaim(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7975"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -256,7 +256,7 @@ class TestRbdSpaceReclaim(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7976"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
+++ b/tests/functional/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
@@ -5,10 +5,13 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
     green_squad,
+    ec_allowed,
 )
 from ocs_ci.ocs.cluster import (
     validate_compression,
     validate_replica_data,
+    is_ec_pool_supported,
+    get_ec_metadata_pool_name,
 )
 from ocs_ci.ocs.constants import CEPHBLOCKPOOL
 from ocs_ci.ocs.exceptions import PoolNotReplicatedAsNeeded, PoolNotCompressedAsExpected
@@ -20,7 +23,6 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_external_mode
 @skipif_ocs_version("<4.6")
-@pytest.mark.polarion_id("OCS-2391")
 class TestMultipleScOnePoolRep2Comp(ManageTest):
     """
     Create new rbd pool with replica 2 and compression.
@@ -33,8 +35,26 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
 
     replica = 2
 
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-2391")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     def test_multiple_sc_one_pool_rep2_comp(
         self,
+        erasure_coded,
         ceph_pool_factory,
         storageclass_factory,
         pvc_factory,
@@ -46,30 +66,54 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
         *. Creates PVCs using new Storage Classes
         *. Mount PVC to an app pod
         *. Run IO on an app pod
-        *. Verify compression and replication
+        *. Verify compression and replication (skipped for EC pools)
 
         """
 
-        log.info("Creating new pool with replica2 and compression")
-        pool_obj = ceph_pool_factory(
-            interface=CEPHBLOCKPOOL,
-            replica=self.replica,
-            compression="aggressive",
-        )
+        if erasure_coded:
+            log.info("Creating new EC pool")
+            pool_obj = ceph_pool_factory(
+                interface=CEPHBLOCKPOOL,
+                erasure_coded=True,
+            )
+            metadata_pool_name = get_ec_metadata_pool_name()
 
-        log.info(f"Creating first storageclass with pool {pool_obj.name}")
-        sc_obj1 = storageclass_factory(
-            interface=CEPHBLOCKPOOL,
-            new_rbd_pool=False,
-            pool_name=pool_obj.name,
-        )
+            log.info(f"Creating first storageclass with EC pool {pool_obj.name}")
+            sc_obj1 = storageclass_factory(
+                interface=CEPHBLOCKPOOL,
+                new_rbd_pool=False,
+                pool_name=metadata_pool_name,
+                data_pool_name=pool_obj.name,
+            )
 
-        log.info(f"Creating second storageclass with pool {pool_obj.name}")
-        sc_obj2 = storageclass_factory(
-            interface=CEPHBLOCKPOOL,
-            new_rbd_pool=False,
-            pool_name=pool_obj.name,
-        )
+            log.info(f"Creating second storageclass with EC pool {pool_obj.name}")
+            sc_obj2 = storageclass_factory(
+                interface=CEPHBLOCKPOOL,
+                new_rbd_pool=False,
+                pool_name=metadata_pool_name,
+                data_pool_name=pool_obj.name,
+            )
+        else:
+            log.info("Creating new pool with replica2 and compression")
+            pool_obj = ceph_pool_factory(
+                interface=CEPHBLOCKPOOL,
+                replica=self.replica,
+                compression="aggressive",
+            )
+
+            log.info(f"Creating first storageclass with pool {pool_obj.name}")
+            sc_obj1 = storageclass_factory(
+                interface=CEPHBLOCKPOOL,
+                new_rbd_pool=False,
+                pool_name=pool_obj.name,
+            )
+
+            log.info(f"Creating second storageclass with pool {pool_obj.name}")
+            sc_obj2 = storageclass_factory(
+                interface=CEPHBLOCKPOOL,
+                new_rbd_pool=False,
+                pool_name=pool_obj.name,
+            )
 
         sc_obj_list = [sc_obj1, sc_obj2]
         pod_obj_list = []
@@ -93,14 +137,15 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
                 readwrite="readwrite",
             )
 
-        log.info(f"validating info on pool {pool_obj.name}")
-        validate_rep_result = validate_replica_data(pool_obj.name, self.replica)
-        if validate_rep_result is False:
-            raise PoolNotReplicatedAsNeeded(
-                f"pool {pool_obj.name} not replicated as expected"
-            )
-        validate_comp_result = validate_compression(pool_obj.name)
-        if validate_comp_result is False:
-            raise PoolNotCompressedAsExpected(
-                f"pool {pool_obj.name} not compressed as expected"
-            )
+        if not erasure_coded:
+            log.info(f"validating info on pool {pool_obj.name}")
+            validate_rep_result = validate_replica_data(pool_obj.name, self.replica)
+            if validate_rep_result is False:
+                raise PoolNotReplicatedAsNeeded(
+                    f"pool {pool_obj.name} not replicated as expected"
+                )
+            validate_comp_result = validate_compression(pool_obj.name)
+            if validate_comp_result is False:
+                raise PoolNotCompressedAsExpected(
+                    f"pool {pool_obj.name} not compressed as expected"
+                )

--- a/tests/functional/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
+++ b/tests/functional/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py
@@ -43,7 +43,7 @@ class TestMultipleScOnePoolRep2Comp(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7979"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
+++ b/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
@@ -42,7 +42,7 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
                 False,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7971"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -54,7 +54,7 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7972"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -66,7 +66,7 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7973"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
+++ b/tests/functional/storageclass/test_create_2sc_at_once_with_io.py
@@ -7,10 +7,12 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
     green_squad,
+    ec_allowed,
 )
 from ocs_ci.ocs.cluster import (
     validate_compression,
     validate_replica_data,
+    is_ec_pool_supported,
 )
 from ocs_ci.ocs.exceptions import (
     PoolNotCompressedAsExpected,
@@ -31,17 +33,63 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
     different replica and compression options
     """
 
+    @pytest.mark.parametrize(
+        argnames=["sc1_erasure_coded", "sc2_erasure_coded"],
+        argvalues=[
+            pytest.param(False, False),
+            pytest.param(
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                False,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                True,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
     def test_new_sc_rep2_rep3_at_once(
-        self, storageclass_factory, pvc_factory, pod_factory
+        self,
+        sc1_erasure_coded,
+        sc2_erasure_coded,
+        storageclass_factory,
+        pvc_factory,
+        pod_factory,
     ):
         """
-
         This test function does below,
         *. Creates 2 Storage Class with creating new rbd pool replica 2 and 3 with compression
         *. Creates PVCs using new Storage Classes
         *. Mount PVC to an app pod
         *. Run IO on an app pod
-        *. Validate compression and replication
+        *. Validate compression and replication (skipped for EC pools)
 
         """
 
@@ -51,19 +99,25 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
             interface=interface_type,
             new_rbd_pool=True,
             replica=2,
-            compression="aggressive",
+            compression="none" if sc1_erasure_coded else "aggressive",
+            erasure_coded=sc1_erasure_coded,
         )
 
         sc_obj2 = storageclass_factory(
             interface=interface_type,
             new_rbd_pool=True,
             replica=3,
-            compression="aggressive",
+            compression="none" if sc2_erasure_coded else "aggressive",
+            erasure_coded=sc2_erasure_coded,
         )
 
         replicas = dict()
         replicas[sc_obj1.name] = 2
         replicas[sc_obj2.name] = 3
+        ec_flags = {
+            sc_obj1.name: sc1_erasure_coded,
+            sc_obj2.name: sc2_erasure_coded,
+        }
         sc_obj_list = [sc_obj1, sc_obj2]
 
         log.info("Creating pvc and pods")
@@ -91,6 +145,8 @@ class TestCreate2ScAtOnceWithIo(ManageTest):
             )
 
         for sc_obj in sc_obj_list:
+            if ec_flags[sc_obj.name]:
+                continue
             cbp_name = sc_obj.get()["parameters"]["pool"]
             cbp_size = replicas[sc_obj.name]
             compression_result = validate_compression(cbp_name)

--- a/tests/functional/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/functional/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -37,7 +37,7 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7980"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_create_multiple_sc_with_different_pool_name.py
+++ b/tests/functional/storageclass/test_create_multiple_sc_with_different_pool_name.py
@@ -3,13 +3,14 @@ import logging
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_fio_rw_iops
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
     skipif_external_mode,
     skipif_hci_provider_and_client,
 )
+from ocs_ci.ocs.cluster import is_ec_pool_supported, get_ec_metadata_pool_name
 from tests.fixtures import create_rbd_secret, create_project
 
 log = logging.getLogger(__name__)
@@ -23,13 +24,31 @@ log = logging.getLogger(__name__)
     create_project.__name__,
     create_rbd_secret.__name__,
 )
-@pytest.mark.polarion_id("OCS-624")
 class TestCreateMultipleScWithDifferentPoolName(ManageTest):
     """
     Create Multiple Storage Class with different pool name
     """
 
-    def test_create_multiple_sc_with_different_pool_name(self, teardown_factory):
+    @pytest.mark.parametrize(
+        "erasure_coded",
+        [
+            pytest.param(False, marks=[pytest.mark.polarion_id("OCS-624")]),
+            pytest.param(
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_create_multiple_sc_with_different_pool_name(
+        self, erasure_coded, teardown_factory
+    ):
         """
         This test function does below,
         *. Creates multiple Storage Classes with different pool name
@@ -43,20 +62,34 @@ class TestCreateMultipleScWithDifferentPoolName(ManageTest):
         sc_list = []
         for i in range(2):
             log.info("Creating cephblockpool")
-            cbp_obj = helpers.create_ceph_block_pool()
+            cbp_obj = helpers.create_ceph_block_pool(erasure_coded=erasure_coded)
             log.info(f"{cbp_obj.name} created successfully")
-            log.info(f"Creating a RBD storage class using {cbp_obj.name}")
-            cbp_list.append(cbp_obj)
-            sc_obj = helpers.create_storage_class(
-                interface_type=constants.CEPHBLOCKPOOL,
-                interface_name=cbp_obj.name,
-                secret_name=self.rbd_secret_obj.name,
-            )
+
+            if erasure_coded:
+                metadata_pool_name = get_ec_metadata_pool_name()
+                log.info(
+                    f"Creating a RBD EC storage class using data pool {cbp_obj.name} "
+                    f"and metadata pool {metadata_pool_name}"
+                )
+                sc_obj = helpers.create_storage_class(
+                    interface_type=constants.CEPHBLOCKPOOL,
+                    interface_name=metadata_pool_name,
+                    secret_name=self.rbd_secret_obj.name,
+                    data_pool_name=cbp_obj.name,
+                )
+            else:
+                log.info(f"Creating a RBD storage class using {cbp_obj.name}")
+                sc_obj = helpers.create_storage_class(
+                    interface_type=constants.CEPHBLOCKPOOL,
+                    interface_name=cbp_obj.name,
+                    secret_name=self.rbd_secret_obj.name,
+                )
 
             log.info(
                 f"StorageClass: {sc_obj.name} "
                 f"created successfully using {cbp_obj.name}"
             )
+            cbp_list.append(cbp_obj)
             sc_list.append(sc_obj)
             teardown_factory(cbp_obj)
             teardown_factory(sc_obj)

--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -197,7 +197,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 False,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7966"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -213,7 +213,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 False,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7967"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -229,7 +229,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 False,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7968"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -246,7 +246,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7969"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -262,7 +262,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 True,
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7970"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -2,7 +2,8 @@ import pytest
 import logging
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -169,16 +170,105 @@ class TestCrossScCloneSnapRestore(ManageTest):
         restore_pvc_obj3.delete()
 
     @pytest.mark.parametrize(
-        argnames=["interface_type", "sc1_replica", "sc_replica2", "sc2_compression"],
+        argnames=[
+            "interface_type",
+            "sc1_replica",
+            "sc_replica2",
+            "sc2_compression",
+            "erasure_coded",
+            "sc1_erasure_coded",
+        ],
         argvalues=[
-            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", False),
-            pytest.param(*[constants.CEPHFILESYSTEM], "", "", False),
-            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", True),
-            pytest.param(*[constants.CEPHFILESYSTEM], "", "", True),
-            pytest.param(*[constants.CEPHBLOCKPOOL], 3, 2, False),
-            pytest.param(*[constants.CEPHFILESYSTEM], 3, 2, False),
-            pytest.param(*[constants.CEPHBLOCKPOOL], 2, 3, False),
-            pytest.param(*[constants.CEPHFILESYSTEM], 2, 3, False),
+            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", False, False, False),
+            pytest.param(*[constants.CEPHFILESYSTEM], "", "", False, False, False),
+            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", True, False, False),
+            pytest.param(*[constants.CEPHFILESYSTEM], "", "", True, False, False),
+            pytest.param(*[constants.CEPHBLOCKPOOL], 3, 2, False, False, False),
+            pytest.param(*[constants.CEPHFILESYSTEM], 3, 2, False, False, False),
+            pytest.param(*[constants.CEPHBLOCKPOOL], 2, 3, False, False, False),
+            pytest.param(*[constants.CEPHFILESYSTEM], 2, 3, False, False, False),
+            # SC1=replicated, SC2=EC
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                "",
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                3,
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                2,
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            # SC1=EC, SC2=replicated
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                "",
+                3,
+                False,
+                False,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                "",
+                2,
+                False,
+                False,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
         ],
     )
     @skipif_mcg_only
@@ -197,6 +287,8 @@ class TestCrossScCloneSnapRestore(ManageTest):
         sc1_replica,
         sc_replica2,
         sc2_compression,
+        erasure_coded,
+        sc1_erasure_coded,
         pvc_factory,
         pod_factory,
         pvc_clone_factory,
@@ -216,11 +308,17 @@ class TestCrossScCloneSnapRestore(ManageTest):
         Args:
             sc1_replica (str/int): Number of replica for the first sc object. If is empty string, use default
             sc2_replica (str/int): Number of replica for the second sc object. If is empty string, use default
-            sc2_compression (bool) If true, sc2 is created with compression = True, otherwise use default
+            sc2_compression (bool): If true, sc2 is created with compression = True, otherwise use default
+            erasure_coded (bool): If true, sc2 is created as an erasure coded pool
+            sc1_erasure_coded (bool): If true, sc1 is created as an erasure coded pool on a new pool
         """
 
-        # Create a Storage Class on default pool
-        if sc1_replica == "":
+        # Create a Storage Class on the first pool
+        if sc1_erasure_coded:
+            sc_obj1 = storageclass_factory(
+                interface=interface_type, new_rbd_pool=True, erasure_coded=True
+            )
+        elif sc1_replica == "":
             sc_obj1 = storageclass_factory(interface=interface_type)
         else:
             sc_obj1 = storageclass_factory(
@@ -243,14 +341,20 @@ class TestCrossScCloneSnapRestore(ManageTest):
                     interface=interface_type,
                     new_rbd_pool=True,
                     compression="aggressive",
+                    erasure_coded=erasure_coded,
                 )
             else:
                 sc_obj2 = storageclass_factory(
-                    interface=interface_type, new_rbd_pool=True
+                    interface=interface_type,
+                    new_rbd_pool=True,
+                    erasure_coded=erasure_coded,
                 )
         else:
             sc_obj2 = storageclass_factory(
-                interface=interface_type, replica=sc_replica2, new_rbd_pool=True
+                interface=interface_type,
+                replica=sc_replica2,
+                new_rbd_pool=True,
+                erasure_coded=erasure_coded,
             )
         pool_name2 = run_cmd(
             f"oc get sc {sc_obj2.name} -o jsonpath={{'.parameters.pool'}}"

--- a/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
+++ b/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
@@ -12,10 +12,15 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_ibm_cloud_managed,
     runs_on_provider,
+    ec_allowed,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.cluster import get_percent_used_capacity, CephCluster
+from ocs_ci.ocs.cluster import (
+    get_percent_used_capacity,
+    CephCluster,
+    is_ec_pool_supported,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 
@@ -30,6 +35,7 @@ def preconditions_rbd_pool_created_associated_to_sc(
     replica,
     storageclass_factory_class,
     volume_binding_mode,
+    erasure_coded=False,
 ):
     """
     Helper method to create storageclass with the pool and verify that in pool list
@@ -43,6 +49,7 @@ def preconditions_rbd_pool_created_associated_to_sc(
     :param replica: replica size
     :param storageclass_factory_class: storageclass factory fixture
     :param volume_binding_mode: volume binding mode
+    :param erasure_coded: True to create an erasure coded pool
     :return: ceph blockpool name
     """
     interface_type = constants.CEPHBLOCKPOOL
@@ -53,6 +60,7 @@ def preconditions_rbd_pool_created_associated_to_sc(
         compression=compression,
         volume_binding_mode=volume_binding_mode,
         pool_name="test-pool",
+        erasure_coded=erasure_coded,
     )
     logger.info(f"Creating a PVC using {sc_obj.name}")
     pvc_obj = pvc_factory(
@@ -93,7 +101,13 @@ def preconditions_rbd_pool_created_associated_to_sc(
 class TestDeleteRbdPool(ManageTest):
     @skipif_external_mode
     @pytest.mark.parametrize(
-        argnames=["replica", "compression", "volume_binding_mode", "pvc_status"],
+        argnames=[
+            "replica",
+            "compression",
+            "volume_binding_mode",
+            "pvc_status",
+            "erasure_coded",
+        ],
         argvalues=[
             pytest.param(
                 *[
@@ -101,6 +115,7 @@ class TestDeleteRbdPool(ManageTest):
                     "aggressive",
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
+                    False,
                 ],
                 marks=[tier3, pytest.mark.polarion_id("OCS-5134")],
             ),
@@ -110,6 +125,7 @@ class TestDeleteRbdPool(ManageTest):
                     "aggressive",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=[tier3, pytest.mark.polarion_id("OCS-5135")],
             ),
@@ -119,6 +135,7 @@ class TestDeleteRbdPool(ManageTest):
                     "none",
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
+                    False,
                 ],
                 marks=[tier3, pytest.mark.polarion_id("OCS-5136")],
             ),
@@ -128,8 +145,27 @@ class TestDeleteRbdPool(ManageTest):
                     "none",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=[tier3, pytest.mark.polarion_id("OCS-5137")],
+            ),
+            pytest.param(
+                *[
+                    3,
+                    "none",
+                    constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                    constants.STATUS_BOUND,
+                    True,
+                ],
+                marks=[
+                    ec_allowed,
+                    tier3,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
             ),
         ],
     )
@@ -139,6 +175,7 @@ class TestDeleteRbdPool(ManageTest):
         compression,
         volume_binding_mode,
         pvc_status,
+        erasure_coded,
         storageclass_factory_class,
         pvc_factory,
         pod_factory,
@@ -160,6 +197,7 @@ class TestDeleteRbdPool(ManageTest):
             replica,
             storageclass_factory_class,
             volume_binding_mode,
+            erasure_coded=erasure_coded,
         )
 
         distr_res = distribute_storage_classes_to_all_consumers_factory()

--- a/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
+++ b/tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py
@@ -160,7 +160,7 @@ class TestDeleteRbdPool(ManageTest):
                 marks=[
                     ec_allowed,
                     tier3,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7961"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
+++ b/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
@@ -88,7 +88,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                 marks=[
                     ec_allowed,
                     tier2,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7957"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -106,7 +106,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                 marks=[
                     ec_allowed,
                     tier2,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7958"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
+++ b/tests/functional/storageclass/test_new_sc_rbd_replica2_3.py
@@ -7,9 +7,11 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     skipif_ocs_version,
     green_squad,
+    ec_allowed,
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
+    is_ec_pool_supported,
     validate_compression,
     validate_replica_data,
 )
@@ -27,7 +29,13 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
     """
 
     @pytest.mark.parametrize(
-        argnames=["replica", "compression", "volume_binding_mode", "pvc_status"],
+        argnames=[
+            "replica",
+            "compression",
+            "volume_binding_mode",
+            "pvc_status",
+            "erasure_coded",
+        ],
         argvalues=[
             pytest.param(
                 *[
@@ -35,6 +43,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     "aggressive",
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
+                    False,
                 ],
                 marks=[tier1, pytest.mark.polarion_id("OCS-2400")],
             ),
@@ -44,6 +53,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     "aggressive",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=[tier2, pytest.mark.polarion_id("OCS-2397")],
             ),
@@ -53,6 +63,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     "none",
                     constants.WFFC_VOLUMEBINDINGMODE,
                     constants.STATUS_PENDING,
+                    False,
                 ],
                 marks=[tier2, pytest.mark.polarion_id("OCS-2401")],
             ),
@@ -62,8 +73,45 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
                     "none",
                     constants.IMMEDIATE_VOLUMEBINDINGMODE,
                     constants.STATUS_BOUND,
+                    False,
                 ],
                 marks=[tier2, pytest.mark.polarion_id("OCS-2406")],
+            ),
+            pytest.param(
+                *[
+                    2,
+                    "none",
+                    constants.WFFC_VOLUMEBINDINGMODE,
+                    constants.STATUS_PENDING,
+                    True,
+                ],
+                marks=[
+                    ec_allowed,
+                    tier2,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *[
+                    3,
+                    "none",
+                    constants.IMMEDIATE_VOLUMEBINDINGMODE,
+                    constants.STATUS_BOUND,
+                    True,
+                ],
+                marks=[
+                    ec_allowed,
+                    tier2,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
             ),
         ],
     )
@@ -73,6 +121,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
         compression,
         volume_binding_mode,
         pvc_status,
+        erasure_coded,
         storageclass_factory,
         pvc_factory,
         pod_factory,
@@ -91,6 +140,7 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
             replica=replica,
             compression=compression,
             volume_binding_mode=volume_binding_mode,
+            erasure_coded=erasure_coded,
         )
 
         log.info(f"Creating a PVC using {sc_obj.name}")
@@ -99,12 +149,10 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
         )
         log.info(f"PVC: {pvc_obj.name} created successfully using " f"{sc_obj.name}")
 
-        # Create app pod and mount each PVC
         log.info(f"Creating an app pod and mount {pvc_obj.name}")
         pod_obj = pod_factory(interface=interface_type, pvc=pvc_obj)
         log.info(f"{pod_obj.name} created successfully and mounted {pvc_obj.name}")
 
-        # Run IO on each app pod for sometime
         log.info(f"Running FIO on {pod_obj.name}")
         pod_obj.run_io(
             "fs",
@@ -122,7 +170,8 @@ class TestCreateNewScWithNeWRbDPool(ManageTest):
             f"Cluster used space with replica size {replica}, "
             f"compression mode {compression}={cluster_used_space}"
         )
-        cbp_name = sc_obj.get().get("parameters").get("pool")
-        if compression != "none":
-            validate_compression(cbp_name)
-        validate_replica_data(cbp_name, replica)
+        if not erasure_coded:
+            cbp_name = sc_obj.get().get("parameters").get("pool")
+            if compression != "none":
+                validate_compression(cbp_name)
+            validate_replica_data(cbp_name, replica)

--- a/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -126,7 +126,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
                 marks=[
                     ec_allowed,
                     tier2,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7963"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",

--- a/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -1,7 +1,8 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, ec_allowed
+from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -112,10 +113,26 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
     @skipif_ocs_version("<4.6")
     @skipif_ocp_version("<4.6")
     @pytest.mark.parametrize(
-        argnames=["replica", "compression"],
+        argnames=["replica", "compression", "erasure_coded"],
         argvalues=[
-            pytest.param(*[3, "aggressive"], marks=pytest.mark.polarion_id("OCS-2536")),
-            pytest.param(*[2, "aggressive"], marks=pytest.mark.polarion_id("OCS-2305")),
+            pytest.param(
+                *[3, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2536")
+            ),
+            pytest.param(
+                *[2, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2305")
+            ),
+            pytest.param(
+                *[3, "none", True],
+                marks=[
+                    ec_allowed,
+                    tier2,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
         ],
     )
     def test_compressed_sc_and_support_snap_clone(
@@ -128,6 +145,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
         pgsql_teardown,
         replica,
         compression,
+        erasure_coded,
     ):
         """
         1. Create new sc with compression
@@ -148,6 +166,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
             new_rbd_pool=True,
             replica=replica,
             compression=compression,
+            erasure_coded=erasure_coded,
         )
 
         # Deploy PGSQL workload

--- a/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -3,7 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, ec_allowed
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -15,6 +15,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs.cluster import (
     get_percent_used_capacity,
+    is_ec_pool_supported,
 )
 from ocs_ci.ocs import flowtest
 
@@ -31,12 +32,46 @@ log = logging.getLogger(__name__)
 @skipif_proxy_cluster
 class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
     @pytest.mark.parametrize(
-        argnames=["replica", "compression"],
+        argnames=["replica", "compression", "erasure_coded"],
         argvalues=[
-            pytest.param(*[3, "aggressive"], marks=pytest.mark.polarion_id("OCS-2347")),
-            pytest.param(*[2, "aggressive"], marks=pytest.mark.polarion_id("OCS-2345")),
-            pytest.param(*[3, "none"], marks=pytest.mark.polarion_id("OCS-2346")),
-            pytest.param(*[2, "none"], marks=pytest.mark.polarion_id("OCS-2344")),
+            pytest.param(
+                *[3, "aggressive", False],
+                marks=pytest.mark.polarion_id("OCS-2347"),
+            ),
+            pytest.param(
+                *[2, "aggressive", False],
+                marks=pytest.mark.polarion_id("OCS-2345"),
+            ),
+            pytest.param(
+                *[3, "none", False],
+                marks=pytest.mark.polarion_id("OCS-2346"),
+            ),
+            pytest.param(
+                *[2, "none", False],
+                marks=pytest.mark.polarion_id("OCS-2344"),
+            ),
+            pytest.param(
+                *[3, "none", True],
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            pytest.param(
+                *[2, "none", True],
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
         ],
     )
     def test_new_sc_new_rbd_pool_e2e_wl(
@@ -46,6 +81,7 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
         pgsql_factory_fixture,
         replica,
         compression,
+        erasure_coded,
     ):
         """
         Testing workloads on new storage class with new cephblockpool
@@ -56,6 +92,7 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
             new_rbd_pool=True,
             replica=replica,
             compression=compression,
+            erasure_coded=erasure_coded,
         )
         bg_handler = flowtest.BackgroundOps()
         executor_run_bg_ios_ops = ThreadPoolExecutor(max_workers=5)

--- a/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -54,7 +54,7 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
                 *[3, "none", True],
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7959"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",
@@ -65,7 +65,7 @@ class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
                 *[2, "none", True],
                 marks=[
                     ec_allowed,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-7960"),
                     pytest.mark.skipif(
                         not is_ec_pool_supported(),
                         reason="Erasure coded pools are not supported on this cluster",


### PR DESCRIPTION
 Add day-2 EC RBD pool support: helpers, fixtures, and 27 new test permutations. Not including ui tests
                                                                                                                                                                                                                                                                                 
  Adjusted fixtures:                                              
  - ceph_pool_factory / ceph_pool_factory_class / ceph_pool_factory_session — erasure_coded, data_chunks, coding_chunks                                                                                                                                                          
  - storageclass_factory / storageclass_factory_class / storageclass_factory_session — erasure_coded, data_pool_name                                                                                                                                                             

  Adjusted helper functions:
  - create_ceph_block_pool — erasure_coded, data_chunks, coding_chunks
  - create_storage_class — data_pool_name (sets dataPool CSI parameter)
  - get_data_pool_name — already handles EC via dataPool SC parameter
  - get_pool_size_factor — already handles EC pools (reads CephBlockPool CR)

  New helpers in cluster.py:
  - is_ec_pool_supported
  - get_ec_metadata_pool_name
  - ensure_ec_metadata_pool_exists
  - get_ec_profile

------
tests modified with additional parametrization:

```
1. tests/functional/storageclass/test_new_sc_rbd_replica2_3.py::TestCreateNewScWithNeWRbDPool::test_new_sc_new_rbd_pool
  2. tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py::TestCreateNewScWithNeWRbDPoolE2EWorkloads::test_new_sc_new_rbd_pool_e2e_wl
  3. tests/functional/storageclass/test_delete_rbd_pool_attached_to_sc.py::TestDeleteRbdPool::test_delete_rbd_pool_associated_with_sc
  4. tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py::TestRbdSpaceReclaim::test_reclaim_space_cronjob_with_annotation
  5. tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py::TestCompressedSCAndSupportSnapClone::test_compressed_sc_and_support_snap_clone
  6. tests/cross_functional/performance/io_workload/test_fio_benchmark.py::TestFIOBenchmark::test_fio_compressed_workload
  7. tests/functional/storageclass/test_cross_sc_clone_snap_restore.py::TestCrossScCloneSnapRestore::test_cross_class_different_pool_clone_snap_restore
  8. tests/functional/storageclass/test_create_2sc_at_once_with_io.py::TestCreate2ScAtOnceWithIo::test_new_sc_rep2_rep3_at_once
  9. tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py::TestRbdSpaceReclaim::test_rbd_space_reclaim
  10. tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py::TestRbdSpaceReclaim::test_rbd_space_reclaim_no_space
  11. tests/functional/pv/space_reclaim/test_rbd_space_reclaim.py::TestRbdSpaceReclaim::test_no_volume_mounted
  12. tests/functional/pv/pvc_snapshot/test_verify_rbd_trash_purge.py::TestVerifyRbdTrashPurge::test_verify_rbd_trash_purge_when_snapshots_present
  13. tests/functional/pv/pvc_snapshot/test_restore_snapshot_using_different_sc.py::TestRestoreSnapshotUsingDifferentSc::test_snapshot_restore_using_different_sc
  14. tests/functional/storageclass/test_create_2_sc_with_1_pool_comp_rep2.py::TestMultipleScOnePoolRep2Comp::test_multiple_sc_one_pool_rep2_comp
  15. tests/functional/storageclass/test_create_multiple_sc_with_different_pool_name.py::TestCreateMultipleScWithDifferentPoolName::test_create_multiple_sc_with_different_pool_name
  16. tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py::test_verify_new_cbp_creation_not_blocked_by_invalid_cbp
```

TODO:

- [x] run tests with all parameters
- [x] add polarion id's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end support for erasure-coded (EC) RBD pools: EC metadata-pool handling, EC-aware StorageClass data-pool selection, and automatic EC profile selection. Added EC CephBlockPool manifest template.

* **Tests**
  * Many functional and performance suites now run both replicated and EC scenarios (EC cases skipped when unsupported). Test factories/fixtures updated to create and reference EC pools.

* **Chores**
  * Added a pytest marker alias for EC test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->