### PR TITLE
Update odf-cli path

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -106,7 +106,7 @@ class ODFCLIRetriever:
         """Get architecture-specific path for ODF CLI binary in the container image."""
         system = platform.system()
         machine = platform.machine()
-        path = "/usr/share/odf/"
+        path = "/releases/"
 
         if system == "Linux":
             path = os.path.join(path, "linux")


### PR DESCRIPTION
Fix for 
`FileNotFoundError: ODF CLI binary not found at /home/jenkins-build/workspace/ocs-ci/ocs-ci.git/bin/odf`
odf cli now has an updated path under `/releases'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the base path used to locate architecture-specific ODF CLI binaries inside container images, improving binary extraction and correct handling/renaming for macOS binaries during deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->