### PR TITLE
Revert "Update odf-cli path"

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -106,7 +106,7 @@ class ODFCLIRetriever:
         """Get architecture-specific path for ODF CLI binary in the container image."""
         system = platform.system()
         machine = platform.machine()
-        path = "/releases/"
+        path = "/usr/share/odf/"
 
         if system == "Linux":
             path = os.path.join(path, "linux")


### PR DESCRIPTION
Reverts red-hat-storage/ocs-ci#15240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the container image path location used for ODF CLI binary retrieval to ensure proper extraction of the command-line tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->