### PR TITLE
Fix DR cluster operator upgrade test pod/CSV selection

### DIFF
--- a/ocs_ci/ocs/dr_upgrade.py
+++ b/ocs_ci/ocs/dr_upgrade.py
@@ -181,66 +181,216 @@ class DRUpgrade(OCSUpgrade):
         ), "CSV version not upgraded"
         check_all_csvs_are_succeeded(namespace=self.namespace)
 
+    def _get_current_operator_pod_and_csv(self):
+        """
+        Get the current running pod and succeeded CSV for the DR operator.
+
+        This method filters out old/terminated resources and selects the newest
+        running pod and succeeded CSV. It's designed to avoid selecting stale
+        resources from previous ReplicaSets during upgrades.
+
+        Returns:
+            tuple: (pod_name, pod_status, csv_name, csv_version) or (None, None, None, None)
+                   if no valid resources found
+        """
+        # Get all pods matching the pattern
+        all_pods = pod.get_all_pods(namespace=self.namespace)
+        matching_pods = [
+            p for p in all_pods if self.pod_name_pattern in p.get()["metadata"]["name"]
+        ]
+
+        if not matching_pods:
+            log.warning(f"No pods found matching pattern: {self.pod_name_pattern}")
+            return None, None, None, None
+
+        # Sort by creation timestamp (newest first) and filter by status
+        matching_pods.sort(
+            key=lambda x: x.get()["metadata"].get("creationTimestamp", ""),
+            reverse=True,
+        )
+
+        pod_name = None
+        pod_status = None
+
+        # Check pod statuses - prefer Running, but report error states immediately
+        for p in matching_pods:
+            p_name = p.get()["metadata"]["name"]
+            p_status = p.get()["status"]["phase"]
+
+            # Check for error states that indicate real problems
+            container_statuses = p.get()["status"].get("containerStatuses", [])
+            has_error = any(
+                cs.get("state", {}).get("waiting", {}).get("reason")
+                in ["CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull"]
+                for cs in container_statuses
+            )
+
+            if has_error:
+                log.error(
+                    f"Pod {p_name} has error state, container statuses: {container_statuses}"
+                )
+                # Continue checking other pods, newest might be healthy
+
+            if p_status == "Running":
+                pod_name = p_name
+                pod_status = p_status
+                log.info(f"Found running pod: {pod_name}")
+                break
+            elif p_status in ["Pending", "ContainerCreating"]:
+                log.info(
+                    f"Pod {p_name} is in transitional state: {p_status}, "
+                    "will retry if no Running pod found"
+                )
+                if not pod_name:
+                    pod_name = p_name
+                    pod_status = p_status
+            elif p_status in ["Terminating", "Terminated", "Failed"]:
+                log.debug(
+                    f"Skipping pod {p_name} in terminal/terminating state: {p_status}"
+                )
+
+        if not pod_name:
+            log.warning(
+                f"No suitable pod found for {self.pod_name_pattern}. "
+                f"Checked {len(matching_pods)} pods."
+            )
+            return None, None, None, None
+
+        # Get CSV data - filter for operator name and Succeeded phase
+        csv_objs = CSV(namespace=self.namespace)
+        csv_list = csv_objs.get()["items"]
+
+        matching_csvs = [
+            csv for csv in csv_list if self.operator_name in csv["metadata"]["name"]
+        ]
+
+        if not matching_csvs:
+            log.warning(f"No CSVs found for operator: {self.operator_name}")
+            return pod_name, pod_status, None, None
+
+        # Sort by creation timestamp (newest first)
+        matching_csvs.sort(
+            key=lambda x: x["metadata"].get("creationTimestamp", ""), reverse=True
+        )
+
+        csv_name = None
+        csv_version = None
+
+        # Prefer Succeeded CSVs, but report if all are in transitional/error states
+        for csv in matching_csvs:
+            c_name = csv["metadata"]["name"]
+            c_phase = csv.get("status", {}).get("phase", "Unknown")
+
+            if c_phase == "Succeeded":
+                csv_name = c_name
+                csv_obj = CSV(namespace=self.namespace, resource_name=csv_name)
+                csv_version = csv_obj.get_resource(
+                    resource_name=csv_name, column="VERSION"
+                )
+                log.info(f"Found Succeeded CSV: {csv_name}, version: {csv_version}")
+                break
+            elif c_phase in ["Installing", "Pending"]:
+                log.info(
+                    f"CSV {c_name} is in transitional phase: {c_phase}, will retry"
+                )
+                if not csv_name:
+                    csv_name = c_name
+                    csv_obj = CSV(namespace=self.namespace, resource_name=csv_name)
+                    csv_version = csv_obj.get_resource(
+                        resource_name=csv_name, column="VERSION"
+                    )
+            elif c_phase in ["Failed"]:
+                log.error(f"CSV {c_name} is in Failed phase")
+
+        return pod_name, pod_status, csv_name, csv_version
+
     def collect_data(self):
         """
-        Collect DR operator related pods and csv data
-        """
-        pod_data = pod.get_all_pods(namespace=self.namespace)
-        for p in pod_data:
-            if self.pod_name_pattern in p.get()["metadata"]["name"]:
-                pod_obj = OCP(
-                    namespace=self.namespace,
-                    resource_name=p.get()["metadata"]["name"],
-                    kind="Pod",
-                )
-                if self.upgrade_phase == "pre_upgrade":
-                    self.pre_upgrade_data["age"] = pod_obj.get_resource(
-                        resource_name=p.get()["metadata"]["name"], column="AGE"
-                    )
-                    self.pre_upgrade_data["pod_status"] = pod_obj.get_resource_status(
-                        resource_name=p.get()["metadata"]["name"]
-                    )
-                if self.upgrade_phase == "post_upgrade":
-                    self.post_upgrade_data["age"] = pod_obj.get_resource(
-                        resource_name=p.get()["metadata"]["name"], column="AGE"
-                    )
-                    self.post_upgrade_data["pod_status"] = pod_obj.get_resource_status(
-                        resource_name=p.get()["metadata"]["name"]
-                    )
+        Collect DR operator related pods and csv data with retry mechanism.
 
-        # get csv data
-        csv_objs = CSV(namespace=self.namespace)
-        for csv in csv_objs.get()["items"]:
-            if self.operator_name in csv["metadata"]["name"]:
-                csv_obj = CSV(
-                    namespace=self.namespace, resource_name=csv["metadata"]["name"]
+        This method waits for the operator pod to be Running and CSV to be Succeeded,
+        retrying if resources are in transitional states (Pending, Installing, etc.).
+        """
+        timeout = 300  # 5 minutes timeout for operator to stabilize
+        sleep = 10
+
+        log.info(
+            f"Collecting {self.upgrade_phase} data for {self.operator_name} "
+            f"(timeout: {timeout}s)"
+        )
+
+        pod_name = None
+        pod_status = None
+        csv_name = None
+        csv_version = None
+
+        for sample in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=self._get_current_operator_pod_and_csv,
+        ):
+            pod_name, pod_status, csv_name, csv_version = sample
+
+            # Check if we have stable resources
+            if pod_status == "Running" and csv_version and csv_name:
+                # Verify CSV is in Succeeded state by checking again
+                csv_obj = CSV(namespace=self.namespace, resource_name=csv_name)
+                csv_phase = csv_obj.get()["status"]["phase"]
+                if csv_phase == "Succeeded":
+                    log.info(
+                        f"Operator resources stable: pod={pod_name} ({pod_status}), "
+                        f"csv={csv_name} ({csv_phase}, v{csv_version})"
+                    )
+                    break
+                else:
+                    log.info(
+                        f"CSV {csv_name} phase is {csv_phase}, waiting for Succeeded"
+                    )
+            else:
+                log.info(
+                    f"Waiting for operator to stabilize: "
+                    f"pod={pod_name} ({pod_status}), csv={csv_name} (v{csv_version})"
                 )
-                if self.upgrade_phase == "pre_upgrade":
-                    version = csv_obj.get_resource(
-                        resource_name=csv_obj.resource_name, column="VERSION"
-                    )
-                    if version:
-                        self.pre_upgrade_data["version"] = version
-                        log.info(
-                            f"Pre-upgrade CSV version for {self.operator_name}: {version}"
-                        )
-                    else:
-                        log.error(
-                            f"Couldn't capture Pre-upgrade CSV version for {self.operator_name}"
-                        )
-                if self.upgrade_phase == "post_upgrade":
-                    version = csv_obj.get_resource(
-                        resource_name=csv_obj.resource_name, column="VERSION"
-                    )
-                    if version:
-                        self.post_upgrade_data["version"] = version
-                        log.info(
-                            f"Post-upgrade CSV version for {self.operator_name}: {version}"
-                        )
-                    else:
-                        log.error(
-                            f"Couldn't capture Post upgrade CSV version for {self.operator_name}"
-                        )
+
+        # Store collected data based on phase
+        if self.upgrade_phase == "pre_upgrade":
+            if pod_name:
+                pod_obj = OCP(
+                    namespace=self.namespace, resource_name=pod_name, kind="Pod"
+                )
+                self.pre_upgrade_data["age"] = pod_obj.get_resource(
+                    resource_name=pod_name, column="AGE"
+                )
+                self.pre_upgrade_data["pod_status"] = pod_status
+            if csv_version:
+                self.pre_upgrade_data["version"] = csv_version
+                log.info(
+                    f"Pre-upgrade CSV version for {self.operator_name}: {csv_version}"
+                )
+            else:
+                log.error(
+                    f"Couldn't capture Pre-upgrade CSV version for {self.operator_name}"
+                )
+
+        if self.upgrade_phase == "post_upgrade":
+            if pod_name:
+                pod_obj = OCP(
+                    namespace=self.namespace, resource_name=pod_name, kind="Pod"
+                )
+                self.post_upgrade_data["age"] = pod_obj.get_resource(
+                    resource_name=pod_name, column="AGE"
+                )
+                self.post_upgrade_data["pod_status"] = pod_status
+            if csv_version:
+                self.post_upgrade_data["version"] = csv_version
+                log.info(
+                    f"Post-upgrade CSV version for {self.operator_name}: {csv_version}"
+                )
+            else:
+                log.error(
+                    f"Couldn't capture Post upgrade CSV version for {self.operator_name}"
+                )
+
         # Make sure all csvs are in succeeded state
         check_all_csvs_are_succeeded(namespace=self.namespace)
 


### PR DESCRIPTION
The DR cluster operator upgrade test was failing because collect_data() was selecting old terminated pods and CSVs instead of current ones.

Root cause:
- Pod selection iterated all pods without filtering by status, could select terminated pods from old ReplicaSets
- CSV selection iterated all CSVs without filtering by phase, could select old CSVs in "Installing" phase during cleanup
- No retry mechanism for transitional states during operator rollout
- No break after finding resources, overwrote data on each iteration

The test failed 1h43m after the upgrade completed because it queried:
- Old terminated pod (ramen-dr-cluster-operator-67994d48d6-4rfwl)
- Old CSV in Installing phase (odr-cluster-operator.v4.21.5-rhodf)

While the actual running resources were:
- New pod (ramen-dr-cluster-operator-bf7c79f7c-qx8dj) in Running state
- New CSV (odr-cluster-operator.v4.22.0-82.stable) in Succeeded phase

Fix:
- Add _get_current_operator_pod_and_csv() helper that sorts resources by creation timestamp (newest first)
- Filter pods by status (prefer Running, skip Terminated/Terminating)
- Filter CSVs by phase (prefer Succeeded, skip failed/old ones)
- Add TimeoutSampler retry mechanism with 5-minute timeout
- Re-fetch resources every 10 seconds until both pod=Running and CSV=Succeeded
- Handle transitional states (Pending, Installing) with retry
- Log error states (CrashLoopBackOff) but continue checking other pods

This ensures the test selects current resources and handles the operator rollout window properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disaster recovery upgrade stability with enhanced operator state verification and retry mechanisms.
  * Better error tracking and logging for operator version capture during upgrade operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->