### PR TITLE
Update blackbox exporter version check to 4.21.7-1

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -430,7 +430,7 @@ def ocs_install_verification(
         odf_semantic_version = get_semantic_running_odf_version()
         blackbox_label = (
             constants.BLACKBOX_POD_LABEL_422_AND_ABOVE
-            if odf_semantic_version >= get_semantic_version("4.22.0-78")
+            if odf_semantic_version >= get_semantic_version("4.21.7-1")
             else constants.BLACKBOX_POD_LABEL
         )
         resources_dict.update(

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -636,7 +636,7 @@ class TestHealthOverview(ManageTest):
         odf_semantic_version = get_semantic_running_odf_version()
         blackbox_label = (
             constants.BLACKBOX_POD_LABEL_422_AND_ABOVE
-            if odf_semantic_version >= get_semantic_version("4.22.0-78")
+            if odf_semantic_version >= get_semantic_version("4.21.7-1")
             else constants.BLACKBOX_POD_LABEL
         )
         deployment_labels = [

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -388,7 +388,7 @@ class TestHealthOverview(ManageTest):
             odf_semantic_version = get_semantic_running_odf_version()
             blackbox_label = (
                 constants.BLACKBOX_POD_LABEL_422_AND_ABOVE
-                if odf_semantic_version >= get_semantic_version("4.22.0-78")
+                if odf_semantic_version >= get_semantic_version("4.21.7-1")
                 else constants.BLACKBOX_POD_LABEL
             )
             deployment_labels = [

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -185,7 +185,7 @@ def test_blackbox_pod_after_upgrade():
         pytest.skip("The test is not supported on odf version less than 4.21")
     else:
         odf_semantic_version = version.get_semantic_running_odf_version()
-        if odf_semantic_version >= version.get_semantic_version("4.22.0-78"):
+        if odf_semantic_version >= version.get_semantic_version("4.21.7-1"):
             blackbox_label = constants.BLACKBOX_POD_LABEL_422_AND_ABOVE
             expected_label_key = "app"
         else:


### PR DESCRIPTION
The blackbox-exporter label changed in 4.21.7-1 build, not 4.22.0-78. Update version checks across storage_cluster.py and test files to use the correct version threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted ODF version threshold for selecting the blackbox exporter pod label from 4.22.0-78 to 4.21.7-1, applied consistently across installation verification and upgrade-related checks and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/red-hat-storage/ocs-ci/pull/15246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->