### PR TITLE
Add kubeadmin-password download support for HyperShift hosted clusters

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7091,
+        "line_number": 7135,
         "type": "Private Key",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7135,
+        "line_number": 7140,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1097,6 +1097,51 @@ class HyperShiftBase:
             return
         return kubeconfig_path
 
+    @staticmethod
+    def download_hosted_cluster_kubeadmin_password(name: str, cluster_path: str):
+        """
+        Download HyperShift hosted cluster kubeadmin password
+
+        Args:
+            name (str): name of the cluster
+            cluster_path (str): path to create auth directory and download
+                kubeadmin-password there
+
+        Returns:
+            str: path to the downloaded kubeadmin-password file, None if failed
+
+        """
+        path_abs = os.path.expanduser(cluster_path)
+        auth_path = os.path.join(path_abs, "auth")
+        os.makedirs(auth_path, exist_ok=True)
+        password_path = os.path.join(auth_path, "kubeadmin-password")
+
+        logger.info(
+            f"Downloading kubeadmin-password for HyperShift hosted cluster "
+            f"{name} to {password_path}"
+        )
+
+        try:
+            with config.RunWithProviderConfigContextIfAvailable():
+                OCP().exec_oc_cmd(
+                    f"extract secret/kubeadmin-password -n clusters-{name} "
+                    f"--to {auth_path} --confirm"
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to download kubeadmin-password for HyperShift "
+                f"hosted cluster {name}\n{e}"
+            )
+            return
+
+        if not os.path.isfile(password_path) or not os.stat(password_path).st_size > 0:
+            logger.error(
+                f"Failed to download kubeadmin-password for HyperShift "
+                f"hosted cluster {name}"
+            )
+            return
+        return password_path
+
     def get_hosted_cluster_progress(self, name: str):
         """
         Get HyperShift hosted cluster creation progress
@@ -1473,6 +1518,33 @@ def create_kubeconfig_file_hosted_cluster():
 
     config.RUN["kubeconfig"] = kubeconfig_path
     logger.info("Created kubeconfig file")
+
+
+@retry(CommandFailed, tries=3, delay=20, backoff=1)
+def create_kubeadmin_password_file_hosted_cluster():
+    """
+    Export kubeadmin-password to auth directory in cluster path.
+
+    This function is wrapped with retry decorator to handle CommandFailed
+    errors. It will retry up to 3 times with 20 sec delay between attempts.
+
+    Raises:
+        CommandFailed: if the kubeadmin-password file could not be downloaded
+
+    """
+    cluster_path = config.ENV_DATA["cluster_path"]
+    cluster_name = config.ENV_DATA["cluster_name"]
+
+    with config.RunWithProviderConfigContextIfAvailable():
+        password_path = HyperShiftBase.download_hosted_cluster_kubeadmin_password(
+            cluster_name, cluster_path=cluster_path
+        )
+    if not password_path:
+        raise CommandFailed(
+            f"Failed to create kubeadmin-password file for hosted cluster "
+            f"{cluster_name}"
+        )
+    logger.info("Created kubeadmin-password file")
 
 
 def wait_for_worker_nodes_ready(timeout=600, sleep=10, expected_nodes=None):

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1135,6 +1135,12 @@ class HyperShiftBase:
             )
             return None
 
+        # oc extract names the file after the secret key ("password"),
+        # rename it to the expected "kubeadmin-password" filename
+        extracted_path = os.path.join(auth_path, "password")
+        if os.path.isfile(extracted_path):
+            os.rename(extracted_path, password_path)
+
         if not os.path.isfile(password_path) or not os.stat(password_path).st_size > 0:
             logger.error(
                 "Failed to download kubeadmin-password for HyperShift "

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1127,19 +1127,21 @@ class HyperShiftBase:
                     f"extract secret/kubeadmin-password -n clusters-{name} "
                     f"--to {auth_path} --confirm"
                 )
-        except Exception as e:
-            logger.error(
-                f"Failed to download kubeadmin-password for HyperShift "
-                f"hosted cluster {name}\n{e}"
+        except CommandFailed:
+            logger.exception(
+                "Failed to download kubeadmin-password for HyperShift "
+                "hosted cluster %s",
+                name,
             )
-            return
+            return None
 
         if not os.path.isfile(password_path) or not os.stat(password_path).st_size > 0:
             logger.error(
-                f"Failed to download kubeadmin-password for HyperShift "
-                f"hosted cluster {name}"
+                "Failed to download kubeadmin-password for HyperShift "
+                "hosted cluster %s",
+                name,
             )
-            return
+            return None
         return password_path
 
     def get_hosted_cluster_progress(self, name: str):

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1537,10 +1537,9 @@ def create_kubeadmin_password_file_hosted_cluster():
     cluster_path = config.ENV_DATA["cluster_path"]
     cluster_name = config.ENV_DATA["cluster_name"]
 
-    with config.RunWithProviderConfigContextIfAvailable():
-        password_path = HyperShiftBase.download_hosted_cluster_kubeadmin_password(
-            cluster_name, cluster_path=cluster_path
-        )
+    password_path = HyperShiftBase.download_hosted_cluster_kubeadmin_password(
+        cluster_name, cluster_path=cluster_path
+    )
     if not password_path:
         raise CommandFailed(
             f"Failed to create kubeadmin-password file for hosted cluster "

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -1173,6 +1173,7 @@ class HostedClients(HyperShiftBase):
         # stage 2 download all available kubeconfig files
         log_step("Download kubeconfig for all clusters")
         kubeconfig_paths = self.download_hosted_clusters_kubeconfig_files()
+        self.download_hosted_clusters_kubeadmin_password_files()
 
         # stage 3 verify OCP clusters are ready
         log_step(
@@ -1508,6 +1509,49 @@ class HostedClients(HyperShiftBase):
             )
 
         return self.kubeconfig_paths
+
+    def download_hosted_clusters_kubeadmin_password_files(
+        self, cluster_names_paths_dict=None
+    ):
+        """
+        Download kubeadmin-password for multiple HyperShift hosted clusters.
+
+        Args:
+            cluster_names_paths_dict (dict): Optional mapping of cluster name
+                to cluster path. If omitted, uses clusters from config.
+
+        Returns:
+            list: paths to downloaded kubeadmin-password files
+
+        """
+        if cluster_names_paths_dict is None:
+            cluster_names_paths_dict = dict()
+
+        cluster_names = (
+            list(cluster_names_paths_dict.keys())
+            if cluster_names_paths_dict
+            else list(config.ENV_DATA.get("clusters", {}).keys())
+        )
+        cluster_names = [
+            name
+            for name in cluster_names
+            if (
+                config.ENV_DATA.get("clusters", {}).get(name, {}).get("cluster_type")
+                is None
+                or config.ENV_DATA.get("clusters", {}).get(name, {}).get("cluster_type")
+                == "hci_client"
+            )
+        ]
+
+        password_paths = []
+        for name in cluster_names:
+            path = cluster_names_paths_dict.get(name) or config.ENV_DATA.setdefault(
+                "clusters", {}
+            ).setdefault(name, {}).get("hosted_cluster_path")
+            password_paths.append(
+                self.download_hosted_cluster_kubeadmin_password(name, path)
+            )
+        return password_paths
 
     def get_kubeconfig_path(self, cluster_name):
         """
@@ -7900,6 +7944,9 @@ def hypershift_cluster_factory(
                     hosted_clients_obj.download_hosted_clusters_kubeconfig_files(
                         {cluster_name: cluster_path}, from_hcp=False
                     )
+                )
+                hosted_clients_obj.download_hosted_clusters_kubeadmin_password_files(
+                    {cluster_name: cluster_path}
                 )
                 if not kubeconf_paths:
                     logger.warning(

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -1173,7 +1173,12 @@ class HostedClients(HyperShiftBase):
         # stage 2 download all available kubeconfig files
         log_step("Download kubeconfig for all clusters")
         kubeconfig_paths = self.download_hosted_clusters_kubeconfig_files()
-        self.download_hosted_clusters_kubeadmin_password_files()
+        password_paths = self.download_hosted_clusters_kubeadmin_password_files()
+        if not password_paths or not all(password_paths):
+            logger.warning(
+                "kubeadmin-password could not be downloaded for one or more "
+                "hosted clusters"
+            )
 
         # stage 3 verify OCP clusters are ready
         log_step(
@@ -7945,9 +7950,15 @@ def hypershift_cluster_factory(
                         {cluster_name: cluster_path}, from_hcp=False
                     )
                 )
-                hosted_clients_obj.download_hosted_clusters_kubeadmin_password_files(
+                pw_paths = hosted_clients_obj.download_hosted_clusters_kubeadmin_password_files(
                     {cluster_name: cluster_path}
                 )
+                if not pw_paths or not all(pw_paths):
+                    logger.warning(
+                        "kubeadmin-password could not be downloaded for "
+                        "hosted cluster %s",
+                        cluster_name,
+                    )
                 if not kubeconf_paths:
                     logger.warning(
                         "kubeconfig was not found after download attempt; "

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -104,6 +104,7 @@ from ocs_ci.deployment import assisted_installer
 from ocs_ci.framework.logger_helper import log_step
 from .helpers.hypershift_base import (
     HyperShiftBase,
+    create_kubeadmin_password_file_hosted_cluster,
     create_kubeconfig_file_hosted_cluster,
     prepare_vsphere_agent_host_cluster_config,
     wait_for_hosted_cluster_available,
@@ -2350,6 +2351,7 @@ class VSPHEREAgentAI(VSPHEREBASE):
             wait_for_hosted_cluster_available(self.cluster_name, timeout=1200, sleep=30)
 
             create_kubeconfig_file_hosted_cluster()
+            create_kubeadmin_password_file_hosted_cluster()
 
             log_step(
                 "Waiting for worker nodes to appear and become ready in inventory of the Agent cluster"


### PR DESCRIPTION
- Add `download_hosted_cluster_kubeadmin_password` static method to HyperShiftBase, extracting the kubeadmin-password secret from the clusters-<name> namespace on the provider.
- Add `create_kubeadmin_password_file_hosted_cluster` standalone function with `@retry(CommandFailed, tries=3, delay=20)` decorator, parallel to the existing create_kubeconfig_file_hosted_cluster.
- Add `download_hosted_clusters_kubeadmin_password_files` batch method to HostedClients and call it alongside the kubeconfig download in both the main deployment flow and the per-cluster config block. Wire up the standalone function in vmware.py after `create_kubeconfig_file_hosted_cluster`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubeadmin password files for hosted clusters are now automatically downloaded and saved into each cluster’s directory as part of deployment flows (staged, push‑config and post‑availability).

* **Bug Fixes / Reliability**
  * Downloads are retried on transient failures, log warnings when extraction fails or yields empty files, and skip/report failed downloads without blocking deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->