### PR TITLE
Add IAM key revocation test for NooBaaReplicationTargetUnreachable alert (RHSTOR-8110)

### DIFF
--- a/ocs_ci/ocs/resources/bucketclass.py
+++ b/ocs_ci/ocs/resources/bucketclass.py
@@ -171,6 +171,8 @@ def bucket_class_factory(
                         ]
                         namespace_policy["write_resource"] = namespacestores[0].name
 
+            elif "backingstores" in bucket_class_dict:
+                backingstores = bucket_class_dict["backingstores"]
             elif "backingstore_dict" in bucket_class_dict:
                 try:
                     backingstores = [

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -201,12 +201,28 @@ class AWS(object):
 
     def delete_iam_user(self, username):
         """
-        Delete an IAM user. Keys and policies must be removed first.
+        Delete an IAM user after removing its inline policies and access keys.
 
         Args:
             username (str): IAM username to delete
 
         """
+        for policy_name in self.iam_client.list_user_policies(UserName=username).get(
+            "PolicyNames", []
+        ):
+            self.iam_client.delete_user_policy(
+                UserName=username, PolicyName=policy_name
+            )
+            logger.info(f"Deleted inline policy {policy_name} from user {username}")
+
+        for key in self.iam_client.list_access_keys(UserName=username).get(
+            "AccessKeyMetadata", []
+        ):
+            self.iam_client.delete_access_key(
+                UserName=username, AccessKeyId=key["AccessKeyId"]
+            )
+            logger.info(f"Deleted access key {key['AccessKeyId']} from user {username}")
+
         self.iam_client.delete_user(UserName=username)
         logger.info(f"Deleted IAM user {username}")
 

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -184,6 +184,106 @@ class AWS(object):
             )
         return self._sts_client
 
+    def create_iam_user(self, username):
+        """
+        Create a new IAM user.
+
+        Args:
+            username (str): IAM username to create
+
+        Returns:
+            dict: The CreateUser response
+
+        """
+        response = self.iam_client.create_user(UserName=username)
+        logger.info(f"Created IAM user {username}")
+        return response
+
+    def delete_iam_user(self, username):
+        """
+        Delete an IAM user. Keys and policies must be removed first.
+
+        Args:
+            username (str): IAM username to delete
+
+        """
+        self.iam_client.delete_user(UserName=username)
+        logger.info(f"Deleted IAM user {username}")
+
+    def put_user_policy(self, username, policy_name, policy_document):
+        """
+        Create or update an inline policy on an IAM user.
+
+        Args:
+            username (str): IAM username
+            policy_name (str): Name for the inline policy
+            policy_document (str): JSON policy document
+
+        """
+        self.iam_client.put_user_policy(
+            UserName=username,
+            PolicyName=policy_name,
+            PolicyDocument=policy_document,
+        )
+        logger.info(f"Put inline policy {policy_name} on user {username}")
+
+    def delete_user_policy(self, username, policy_name):
+        """
+        Delete an inline policy from an IAM user.
+
+        Args:
+            username (str): IAM username
+            policy_name (str): Name of the inline policy
+
+        """
+        self.iam_client.delete_user_policy(UserName=username, PolicyName=policy_name)
+        logger.info(f"Deleted inline policy {policy_name} from user {username}")
+
+    def create_access_key(self, username):
+        """
+        Create a new IAM access key for the given user.
+
+        Args:
+            username (str): IAM username
+
+        Returns:
+            dict: The CreateAccessKey response containing AccessKey details
+
+        """
+        response = self.iam_client.create_access_key(UserName=username)
+        logger.info(
+            f"Created IAM access key {response['AccessKey']['AccessKeyId']} "
+            f"for user {username}"
+        )
+        return response
+
+    def update_access_key_status(self, username, access_key_id, status):
+        """
+        Activate or deactivate an IAM access key.
+
+        Args:
+            username (str): IAM username
+            access_key_id (str): The access key ID to update
+            status (str): 'Active' or 'Inactive'
+
+        """
+        self.iam_client.update_access_key(
+            UserName=username, AccessKeyId=access_key_id, Status=status
+        )
+        logger.info(f"Set IAM access key {access_key_id} to {status}")
+
+    def delete_access_key(self, username, access_key_id):
+        """
+        Delete an IAM access key.
+
+        Args:
+            username (str): IAM username
+            access_key_id (str): The access key ID to delete
+
+        """
+        self.iam_client.delete_access_key(UserName=username, AccessKeyId=access_key_id)
+        logger.info(f"Deleted IAM access key {access_key_id}")
+
     @property
     def cloudfront_client(self):
         """

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -243,18 +243,6 @@ class AWS(object):
         )
         logger.info(f"Put inline policy {policy_name} on user {username}")
 
-    def delete_user_policy(self, username, policy_name):
-        """
-        Delete an inline policy from an IAM user.
-
-        Args:
-            username (str): IAM username
-            policy_name (str): Name of the inline policy
-
-        """
-        self.iam_client.delete_user_policy(UserName=username, PolicyName=policy_name)
-        logger.info(f"Deleted inline policy {policy_name} from user {username}")
-
     def create_access_key(self, username):
         """
         Create a new IAM access key for the given user.

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -273,16 +273,17 @@ class AWS(object):
         )
         return response
 
-    def update_access_key_status(self, username, access_key_id, status):
+    def update_access_key_status(self, username, access_key_id, active):
         """
         Activate or deactivate an IAM access key.
 
         Args:
             username (str): IAM username
             access_key_id (str): The access key ID to update
-            status (str): 'Active' or 'Inactive'
+            active (bool): True to activate, False to deactivate
 
         """
+        status = "Active" if active else "Inactive"
         self.iam_client.update_access_key(
             UserName=username, AccessKeyId=access_key_id, Status=status
         )

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -881,6 +881,31 @@ class PrometheusAPI(object):
                 timeout -= sleep
         return alerts
 
+    def get_alerts_for_bucket(self, alert_name, source_bucket):
+        """
+        Get firing alerts matching a specific alert name and source bucket label.
+
+        Args:
+            alert_name (str): Alert name to match.
+            source_bucket (str): Source bucket label value to filter by.
+
+        Returns:
+            list: Matching alert records, empty if none found.
+        """
+        with self._cluster_context():
+            response = self.get(
+                "alerts",
+                payload={"silenced": False, "inhibited": False},
+            )
+            if not response.ok:
+                raise AlertingError(f"Request {response.request.url} failed")
+            return [
+                alert
+                for alert in response.json()["data"]["alerts"]
+                if alert["labels"].get("alertname") == alert_name
+                and alert["labels"].get("source_bucket") == source_bucket
+            ]
+
     def check_alert_cleared(self, label, measure_end_time, time_min=120):
         """
         Check that all alerts with provided label are cleared.

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -881,13 +881,14 @@ class PrometheusAPI(object):
                 timeout -= sleep
         return alerts
 
-    def get_alerts_for_bucket(self, alert_name, source_bucket):
+    def get_alerts_by_labels(self, alert_name, labels_dict):
         """
-        Get firing alerts matching a specific alert name and source bucket label.
+        Get firing alerts matching a specific alert name and label values.
 
         Args:
             alert_name (str): Alert name to match.
-            source_bucket (str): Source bucket label value to filter by.
+            labels_dict (dict): Label key-value pairs to filter by
+                (e.g. {"source_bucket": "my-bucket"}).
 
         Returns:
             list: Matching alert records, empty if none found.
@@ -903,7 +904,7 @@ class PrometheusAPI(object):
                 alert
                 for alert in response.json()["data"]["alerts"]
                 if alert["labels"].get("alertname") == alert_name
-                and alert["labels"].get("source_bucket") == source_bucket
+                and all(alert["labels"].get(k) == v for k, v in labels_dict.items())
             ]
 
     def check_alert_cleared(self, label, measure_end_time, time_min=120):

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -881,7 +881,7 @@ class PrometheusAPI(object):
                 timeout -= sleep
         return alerts
 
-    def get_alerts_by_labels(self, alert_name, labels_dict):
+    def get_firing_alerts_by_labels(self, alert_name, labels_dict):
         """
         Get firing alerts matching a specific alert name and label values.
 
@@ -904,6 +904,7 @@ class PrometheusAPI(object):
                 alert
                 for alert in response.json()["data"]["alerts"]
                 if alert["labels"].get("alertname") == alert_name
+                and alert.get("state") == "firing"
                 and all(alert["labels"].get(k) == v for k, v in labels_dict.items())
             ]
 

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -881,9 +881,10 @@ class PrometheusAPI(object):
                 timeout -= sleep
         return alerts
 
-    def get_firing_alerts_by_labels(self, alert_name, labels_dict):
+    def get_alerts_by_labels(self, alert_name, labels_dict):
         """
-        Get firing alerts matching a specific alert name and label values.
+        Get alerts (pending or firing) matching a specific alert name and
+        label values.
 
         Args:
             alert_name (str): Alert name to match.
@@ -904,7 +905,6 @@ class PrometheusAPI(object):
                 alert
                 for alert in response.json()["data"]["alerts"]
                 if alert["labels"].get("alertname") == alert_name
-                and alert.get("state") == "firing"
                 and all(alert["labels"].get(k) == v for k, v in labels_dict.items())
             ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ from ocs_ci.ocs import utils
 from ocs_ci.ocs.resources.deployment import Deployment
 from ocs_ci.ocs.resources.job import get_job_obj
 from ocs_ci.ocs.resources.backingstore import (
+    BackingStore,
     backingstore_factory as backingstore_factory_implementation,
     clone_bs_dict_from_backingstore,
 )
@@ -179,6 +180,7 @@ from ocs_ci.utility.resource_check import (
 from ocs_ci.utility.flexy import load_cluster_info
 from ocs_ci.utility.kms import is_kms_enabled, get_ksctl_cli
 from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.utility.aws import AWS
 from ocs_ci.utility.reporting import update_live_must_gather_image
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.multicluster import (
@@ -11874,6 +11876,116 @@ def iam_users_factory_fixture(request, mcg_obj, awscli_pod_session):
 
     request.addfinalizer(finalizer)
     return factory
+
+
+@pytest.fixture()
+def aws_backingstore_with_toggleable_creds(
+    request, cld_mgr, mcg_obj, cloud_uls_factory
+):
+    """
+    Create an AWS S3 backingstore with dedicated IAM credentials
+    that can be toggled on and off at runtime.
+
+    Creates the full chain: S3 bucket (via cloud_uls_factory),
+    dedicated IAM user with a bucket-scoped policy, access key,
+    and backingstore (using --access-key/--secret-key, which
+    auto-creates a K8s secret with ownerReferences).
+
+    Returns:
+        dict: backingstore (BackingStore), disable (callable) to
+            revoke the IAM key, enable (callable) to restore it.
+
+    """
+    aws_obj = AWS()
+    region = cld_mgr.aws_client.region
+    created = {}
+
+    def _cleanup():
+        if "backingstore" in created:
+            try:
+                created["backingstore"].delete()
+            except Exception:
+                log.warning(
+                    f"Failed to delete backingstore " f"{created['backingstore'].name}"
+                )
+        if "username" in created:
+            try:
+                aws_obj.delete_iam_user(created["username"])
+            except Exception:
+                log.warning(f"Failed to delete IAM user {created['username']}")
+
+    request.addfinalizer(_cleanup)
+
+    # 1. Create the S3 bucket via cloud_uls_factory (handles cleanup)
+    uls_names = cloud_uls_factory({"aws": [(1, region)]})
+    bucket_name = list(uls_names["aws"])[0]
+
+    # 2. Create IAM user with a bucket-scoped inline policy
+    username = create_unique_resource_name("ocs-ci-s3", "iam")
+    aws_obj.create_iam_user(username)
+    created["username"] = username
+
+    # NooBaa requires s3:ListAllMyBuckets for CheckExternalConnection
+    policy_name = f"{username}-s3"
+    policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "s3:*",
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket_name}",
+                        f"arn:aws:s3:::{bucket_name}/*",
+                    ],
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": "s3:ListAllMyBuckets",
+                    "Resource": "arn:aws:s3:::*",
+                },
+            ],
+        }
+    )
+    aws_obj.put_user_policy(username, policy_name, policy_document)
+
+    # 3. Create access key
+    response = aws_obj.create_access_key(username)
+    key_data = response["AccessKey"]
+    access_key_id = key_data["AccessKeyId"]
+
+    log.info("Sleeping 60s for IAM credential propagation")
+    time.sleep(60)
+
+    # 4. Create backingstore (auto-creates a K8s secret via ownerReferences)
+    bs_name = create_unique_resource_name("repl-alert", "bs")
+    mcg_obj.exec_mcg_cmd(
+        f"backingstore create aws-s3 {bs_name} "
+        f"--access-key {access_key_id} "
+        f"--secret-key {key_data['SecretAccessKey']} "
+        f"--target-bucket {bucket_name} "
+        f"--region {region}",
+        use_yes=True,
+    )
+    bs_obj = BackingStore(
+        name=bs_name,
+        method="cli",
+        type="cloud",
+        uls_name=bucket_name,
+        mcg_obj=mcg_obj,
+    )
+    created["backingstore"] = bs_obj
+    log.info(f"Created backingstore {bs_name}")
+
+    return {
+        "backingstore": bs_obj,
+        "disable": lambda: aws_obj.update_access_key_status(
+            username, access_key_id, status="Inactive"
+        ),
+        "enable": lambda: aws_obj.update_access_key_status(
+            username, access_key_id, status="Active"
+        ),
+    }
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11980,10 +11980,10 @@ def aws_backingstore_with_toggleable_creds(
     return {
         "backingstore": bs_obj,
         "disable": lambda: aws_obj.update_access_key_status(
-            username, access_key_id, status="Inactive"
+            username, access_key_id, active=False
         ),
         "enable": lambda: aws_obj.update_access_key_status(
-            username, access_key_id, status="Active"
+            username, access_key_id, active=True
         ),
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11901,12 +11901,21 @@ def aws_backingstore_with_toggleable_creds(
     created = {}
 
     def _cleanup():
+        # If the test failed while creds were disabled, re-enable them so
+        # NooBaa can reach the target bucket during backingstore deletion
+        if "access_key_id" in created:
+            try:
+                aws_obj.update_access_key_status(
+                    created["username"], created["access_key_id"], active=True
+                )
+            except Exception:
+                log.warning("Failed to re-enable IAM access key before cleanup")
         if "backingstore" in created:
             try:
                 created["backingstore"].delete()
             except Exception:
                 log.warning(
-                    f"Failed to delete backingstore " f"{created['backingstore'].name}"
+                    f"Failed to delete backingstore {created['backingstore'].name}"
                 )
         if "username" in created:
             try:
@@ -11953,7 +11962,9 @@ def aws_backingstore_with_toggleable_creds(
     response = aws_obj.create_access_key(username)
     key_data = response["AccessKey"]
     access_key_id = key_data["AccessKeyId"]
+    created["access_key_id"] = access_key_id
 
+    # AWS IAM is eventually consistent; new credentials may not be usable immediately
     log.info("Sleeping 60s for IAM credential propagation")
     time.sleep(60)
 

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -140,65 +140,39 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
             len(cleared) == 0
         ), f"{constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE} alerts were not cleared"
 
-    @pytest.fixture()
-    def replication_target_with_aws_toggleable_creds(
-        self,
-        aws_backingstore_with_toggleable_creds,
-        bucket_class_factory,
-        bucket_factory,
-    ):
-        """
-        Create an MCG replication target OBC backed by an AWS S3
-        backingstore whose IAM credentials can be toggled on and off.
-
-        Returns:
-            dict: target_bucket (MCGOCBucket), disable (callable) to
-                revoke the IAM key, enable (callable) to restore it.
-
-        """
-        bs_obj = aws_backingstore_with_toggleable_creds["backingstore"]
-
-        bc_obj = bucket_class_factory({"interface": "CLI", "backingstores": [bs_obj]})
-        logger.info(f"Created bucketclass {bc_obj.name}")
-
-        target_bucket = bucket_factory(1, "OC", bucketclass=bc_obj)[0]
-        logger.info(f"Target OBC {target_bucket.name} is Bound and healthy")
-
-        return {
-            "target_bucket": target_bucket,
-            "disable": aws_backingstore_with_toggleable_creds["disable"],
-            "enable": aws_backingstore_with_toggleable_creds["enable"],
-        }
-
     @skipif_aws_creds_are_missing
     @skipif_disconnected_cluster
     @tier2
     @polarion_id("OCS-7918")
     def test_noobaa_replication_target_unreachable_iam_key_revocation(
         self,
+        aws_backingstore_with_toggleable_creds,
         bucket_factory,
+        bucket_class_factory,
         mcg_obj,
         awscli_pod_session,
         test_directory_setup,
         threading_lock,
-        replication_target_with_aws_toggleable_creds,
     ):
         """
-        1. Create a source OBC with a replication policy targeting
-           the AWS-backed target OBC
-        2. Write test objects and verify replication works
-        3. Disable the IAM access key
-        4. Upload new objects to trigger failing replication
-        5. Wait for the NooBaaReplicationTargetUnreachable alert to fire
-        6. Re-enable the IAM access key
-        7. Wait for the alert to clear
+        1. Create a target OBC backed by the toggleable-creds backingstore
+        2. Create a source OBC with a replication policy targeting it
+        3. Write test objects and verify replication works
+        4. Disable the IAM access key
+        5. Upload new objects to trigger failing replication
+        6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        7. Re-enable the IAM access key
+        8. Wait for the alert to clear
         """
 
-        target_obc_name = replication_target_with_aws_toggleable_creds[
-            "target_bucket"
-        ].name
+        # 1. Create a target OBC backed by the toggleable-creds backingstore
+        bs_obj = aws_backingstore_with_toggleable_creds["backingstore"]
+        bc_obj = bucket_class_factory({"interface": "CLI", "backingstores": [bs_obj]})
+        target_bucket = bucket_factory(1, "OC", bucketclass=bc_obj)[0]
+        target_obc_name = target_bucket.name
+        logger.info(f"Target OBC {target_obc_name} is Bound and healthy")
 
-        # 1. Create a source OBC with a replication policy
+        # 2. Create a source OBC with a replication policy
         replication_policy = ("repl-alert-rule", target_obc_name, None)
         source_bucket = bucket_factory(1, "OC", replication_policy=replication_policy)[
             0
@@ -207,7 +181,7 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
             f"Replication configured: {source_bucket.name} -> {target_obc_name}"
         )
 
-        # 2. Write test objects and verify replication works
+        # 3. Write test objects and verify replication works
         pre_disrupt_dir = f"{test_directory_setup.origin_dir}/pre"
         write_random_test_objects_to_bucket(
             awscli_pod_session,
@@ -222,10 +196,10 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         ), "Replication did not work before IAM key revocation"
         logger.info("Initial replication verified successfully")
 
-        # 3. Disable the IAM access key
-        replication_target_with_aws_toggleable_creds["disable"]()
+        # 4. Disable the IAM access key
+        aws_backingstore_with_toggleable_creds["disable"]()
 
-        # 4. Upload new objects to trigger failing replication
+        # 5. Upload new objects to trigger failing replication
         post_disrupt_dir = f"{test_directory_setup.origin_dir}/post"
         write_random_test_objects_to_bucket(
             awscli_pod_session,
@@ -236,7 +210,7 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
             mcg_obj=mcg_obj,
         )
 
-        # 5. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        # 6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
         alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
         api = PrometheusAPI(threading_lock=threading_lock)
         for alert_found in TimeoutSampler(
@@ -250,10 +224,10 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
                 logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
                 break
 
-        # 6. Re-enable the IAM access key
-        replication_target_with_aws_toggleable_creds["enable"]()
+        # 7. Re-enable the IAM access key
+        aws_backingstore_with_toggleable_creds["enable"]()
 
-        # 7. Wait for the alert to clear
+        # 8. Wait for the alert to clear
         for alert_cleared in TimeoutSampler(
             timeout=600,
             sleep=10,

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -1,16 +1,31 @@
+import base64
+import json
 import logging
+import time
 
 import pytest
 
-from ocs_ci.framework.testlib import MCGTest, tier2, polarion_id
-from ocs_ci.framework.pytest_customization.marks import mcg, red_squad
-from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    skipif_aws_creds_are_missing,
+    skipif_disconnected_cluster,
+)
+from ocs_ci.framework.testlib import MCGTest, polarion_id, tier2
+from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
-    write_random_test_objects_to_bucket,
     compare_bucket_object_list,
+    write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.utility import templating
+from ocs_ci.utility.aws import AWS
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.prometheus import PrometheusAPI
 
 logger = logging.getLogger(__name__)
 
@@ -133,3 +148,324 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         assert (
             len(cleared) == 0
         ), f"{constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE} alerts were not cleared"
+
+    @pytest.fixture()
+    def replication_target_with_aws_toggleable_creds(self, request, cld_mgr, mcg_obj):
+        """
+        Create an MCG replication target OBC backed by an AWS S3
+        backingstore whose IAM credentials can be toggled on and off.
+
+        Creates the full chain: S3 bucket, dedicated IAM user with
+        a bucket-scoped policy, access key, K8s secret, backingstore,
+        bucketclass, and target OBC.
+
+        Cleanup handles partial failures — any resource that was
+        successfully created will be torn down regardless of where
+        the fixture failed.
+
+        Returns:
+            dict: target_obc_name, disable (callable) to revoke
+                the IAM key, enable (callable) to restore it.
+
+        """
+        aws_obj = AWS()
+        namespace = config.ENV_DATA["cluster_namespace"]
+        region = cld_mgr.aws_client.region
+        created = {}
+
+        def _cleanup():
+            if "target_obc" in created:
+                try:
+                    OCP(kind="obc", namespace=namespace).delete(
+                        resource_name=created["target_obc"]
+                    )
+                except Exception:
+                    logger.warning(f"Failed to delete OBC {created['target_obc']}")
+            if "bucketclass" in created:
+                try:
+                    OCP(kind="bucketclass", namespace=namespace).delete(
+                        resource_name=created["bucketclass"]
+                    )
+                except Exception:
+                    logger.warning(
+                        f"Failed to delete bucketclass {created['bucketclass']}"
+                    )
+            if "backingstore" in created:
+                bs_ocp = OCP(kind="backingstore", namespace=namespace)
+                for attempt in range(6):
+                    try:
+                        bs_ocp.delete(resource_name=created["backingstore"])
+                        break
+                    except Exception:
+                        if attempt < 5:
+                            logger.info(
+                                f"Backingstore {created['backingstore']} not ready "
+                                f"for deletion, retrying in 10s ({attempt + 1}/6)"
+                            )
+                            time.sleep(10)
+                        else:
+                            logger.warning(
+                                f"Failed to delete backingstore "
+                                f"{created['backingstore']} after 6 attempts"
+                            )
+            if "secret" in created:
+                try:
+                    created["secret"].delete()
+                except Exception:
+                    logger.warning("Failed to delete K8s secret")
+            if "access_key_id" in created:
+                try:
+                    aws_obj.update_access_key_status(
+                        created["username"],
+                        created["access_key_id"],
+                        status="Active",
+                    )
+                except Exception:
+                    logger.warning("Failed to re-enable IAM key")
+                try:
+                    aws_obj.delete_access_key(
+                        created["username"], created["access_key_id"]
+                    )
+                except Exception:
+                    logger.warning("Failed to delete IAM key")
+            if "policy_name" in created:
+                try:
+                    aws_obj.delete_user_policy(
+                        created["username"], created["policy_name"]
+                    )
+                except Exception:
+                    logger.warning("Failed to delete IAM policy")
+            if "username" in created:
+                try:
+                    aws_obj.delete_iam_user(created["username"])
+                except Exception:
+                    logger.warning(f"Failed to delete IAM user {created['username']}")
+            if "bucket_name" in created:
+                try:
+                    cld_mgr.aws_client.internal_delete_uls(created["bucket_name"])
+                except Exception:
+                    logger.warning(
+                        f"Failed to delete S3 bucket {created['bucket_name']}"
+                    )
+
+        request.addfinalizer(_cleanup)
+
+        # 1. Create the S3 bucket
+        bucket_name = create_unique_resource_name("repl-alert", "aws")
+        cld_mgr.aws_client.internal_create_uls(bucket_name, region=region)
+        created["bucket_name"] = bucket_name
+        logger.info(f"Created S3 bucket {bucket_name}")
+
+        # 2. Create IAM user with a bucket-scoped inline policy
+        username = create_unique_resource_name("ocs-ci-s3", "iam")
+        aws_obj.create_iam_user(username)
+        created["username"] = username
+
+        # Scope the user to only this bucket — no access to any other S3 resource
+        # NooBaa also requires s3:ListAllMyBuckets for CheckExternalConnection
+        policy_name = f"{username}-s3"
+        policy_document = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "s3:*",
+                        "Resource": [
+                            f"arn:aws:s3:::{bucket_name}",
+                            f"arn:aws:s3:::{bucket_name}/*",
+                        ],
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "s3:ListAllMyBuckets",
+                        "Resource": "arn:aws:s3:::*",
+                    },
+                ],
+            }
+        )
+        aws_obj.put_user_policy(username, policy_name, policy_document)
+        created["policy_name"] = policy_name
+
+        # 3. Create access key
+        response = aws_obj.create_access_key(username)
+        key_data = response["AccessKey"]
+        access_key_id = key_data["AccessKeyId"]
+        created["access_key_id"] = access_key_id
+
+        # Wait for IAM credentials to propagate through AWS
+        logger.info("Sleeping 60s for IAM credential propagation")
+        time.sleep(60)
+
+        # 4. Create K8s secret with the IAM credentials
+        bs_secret_data = templating.load_yaml(constants.MCG_BACKINGSTORE_SECRET_YAML)
+        secret_name = create_unique_resource_name("repl-alert", "secret")
+        bs_secret_data["metadata"]["name"] = secret_name
+        bs_secret_data["metadata"]["namespace"] = namespace
+        bs_secret_data["data"]["AWS_ACCESS_KEY_ID"] = base64.urlsafe_b64encode(
+            access_key_id.encode()
+        ).decode()
+        bs_secret_data["data"]["AWS_SECRET_ACCESS_KEY"] = base64.urlsafe_b64encode(
+            key_data["SecretAccessKey"].encode()
+        ).decode()
+        secret_obj = OCS(**bs_secret_data)
+        secret_obj.create()
+        created["secret"] = secret_obj
+        logger.info(f"Created K8s secret {secret_name}")
+
+        # 5. Create backingstore
+        bs_name = create_unique_resource_name("repl-alert", "bs")
+        mcg_obj.exec_mcg_cmd(
+            f"backingstore create aws-s3 {bs_name} "
+            f"--secret-name {secret_name} "
+            f"--target-bucket {bucket_name} "
+            f"--region {region}",
+            use_yes=True,
+        )
+        created["backingstore"] = bs_name
+        logger.info(f"Created backingstore {bs_name}")
+
+        # 6. Create bucketclass
+        bc_name = create_unique_resource_name("repl-alert", "bc")
+        mcg_obj.exec_mcg_cmd(
+            f"bucketclass create placement-bucketclass {bc_name} "
+            f"--backingstores {bs_name}",
+            use_yes=True,
+        )
+        created["bucketclass"] = bc_name
+        logger.info(f"Created bucketclass {bc_name}")
+
+        # 7. Create target OBC
+        target_obc_name = create_unique_resource_name("repl-alert-tgt", "obc")
+        mcg_obj.exec_mcg_cmd(
+            f"obc create {target_obc_name} --bucketclass {bc_name} --exact",
+            use_yes=True,
+        )
+        created["target_obc"] = target_obc_name
+        OCP(kind="obc", namespace=namespace).wait_for_resource(
+            condition="Bound",
+            resource_name=target_obc_name,
+            column="PHASE",
+        )
+        for obc_healthy in TimeoutSampler(
+            timeout=300,
+            sleep=10,
+            func=lambda: all(
+                mark
+                in mcg_obj.exec_mcg_cmd(f"obc status {target_obc_name}").stdout.replace(
+                    " ", ""
+                )
+                for mark in [
+                    constants.HEALTHY_OBC_CLI_PHASE,
+                    constants.HEALTHY_OB_CLI_MODE,
+                ]
+            ),
+        ):
+            if obc_healthy:
+                break
+        logger.info(f"Target OBC {target_obc_name} is Bound and healthy")
+
+        return {
+            "target_obc_name": target_obc_name,
+            "disable": lambda: aws_obj.update_access_key_status(
+                username, access_key_id, status="Inactive"
+            ),
+            "enable": lambda: aws_obj.update_access_key_status(
+                username, access_key_id, status="Active"
+            ),
+        }
+
+    @skipif_aws_creds_are_missing
+    @skipif_disconnected_cluster
+    @tier2
+    @polarion_id("OCS-7918")
+    def test_noobaa_replication_target_unreachable_iam_key_revocation(
+        self,
+        bucket_factory,
+        mcg_obj,
+        awscli_pod_session,
+        test_directory_setup,
+        threading_lock,
+        replication_target_with_aws_toggleable_creds,
+    ):
+        """
+        1. Create a source OBC with a replication policy targeting
+           the AWS-backed target OBC
+        2. Write test objects and verify replication works
+        3. Disable the IAM access key
+        4. Upload new objects to trigger failing replication
+        5. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        6. Re-enable the IAM access key
+        7. Wait for the alert to clear
+        """
+
+        target_obc_name = replication_target_with_aws_toggleable_creds[
+            "target_obc_name"
+        ]
+
+        # 1. Create a source OBC with a replication policy
+        replication_policy = ("repl-alert-rule", target_obc_name, None)
+        source_bucket = bucket_factory(1, "OC", replication_policy=replication_policy)[
+            0
+        ]
+        logger.info(
+            f"Replication configured: {source_bucket.name} -> {target_obc_name}"
+        )
+
+        # 2. Write test objects and verify replication works
+        pre_disrupt_dir = f"{test_directory_setup.origin_dir}/pre"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            pre_disrupt_dir,
+            amount=3,
+            pattern="pre-disrupt-",
+            mcg_obj=mcg_obj,
+        )
+        assert compare_bucket_object_list(
+            mcg_obj, source_bucket.name, target_obc_name, timeout=600
+        ), "Replication did not work before IAM key revocation"
+        logger.info("Initial replication verified successfully")
+
+        # 3. Disable the IAM access key
+        replication_target_with_aws_toggleable_creds["disable"]()
+
+        # 4. Upload new objects to trigger failing replication
+        post_disrupt_dir = f"{test_directory_setup.origin_dir}/post"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            post_disrupt_dir,
+            amount=3,
+            pattern="post-disrupt-",
+            mcg_obj=mcg_obj,
+        )
+
+        # 5. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
+        api = PrometheusAPI(threading_lock=threading_lock)
+        for alert_found in TimeoutSampler(
+            timeout=600,
+            sleep=10,
+            func=api.get_alerts_for_bucket,
+            alert_name=alert_name,
+            source_bucket=source_bucket.name,
+        ):
+            if alert_found:
+                logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
+                break
+
+        # 6. Re-enable the IAM access key
+        replication_target_with_aws_toggleable_creds["enable"]()
+
+        # 7. Wait for the alert to clear
+        for alert_cleared in TimeoutSampler(
+            timeout=600,
+            sleep=10,
+            func=api.get_alerts_for_bucket,
+            alert_name=alert_name,
+            source_bucket=source_bucket.name,
+        ):
+            if not alert_cleared:
+                logger.info(f"Alert {alert_name} cleared for {source_bucket.name}")
+                break

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -1,11 +1,7 @@
-import base64
-import json
 import logging
-import time
 
 import pytest
 
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     red_squad,
@@ -13,19 +9,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
 )
 from ocs_ci.framework.testlib import MCGTest, polarion_id, tier2
-from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     compare_bucket_object_list,
     write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.resources.ocs import OCS
-from ocs_ci.utility import templating
-from ocs_ci.utility.aws import AWS
-from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility.prometheus import PrometheusAPI
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -150,229 +141,33 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         ), f"{constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE} alerts were not cleared"
 
     @pytest.fixture()
-    def replication_target_with_aws_toggleable_creds(self, request, cld_mgr, mcg_obj):
+    def replication_target_with_aws_toggleable_creds(
+        self,
+        aws_backingstore_with_toggleable_creds,
+        bucket_class_factory,
+        bucket_factory,
+    ):
         """
         Create an MCG replication target OBC backed by an AWS S3
         backingstore whose IAM credentials can be toggled on and off.
 
-        Creates the full chain: S3 bucket, dedicated IAM user with
-        a bucket-scoped policy, access key, K8s secret, backingstore,
-        bucketclass, and target OBC.
-
-        Cleanup handles partial failures — any resource that was
-        successfully created will be torn down regardless of where
-        the fixture failed.
-
         Returns:
-            dict: target_obc_name, disable (callable) to revoke
-                the IAM key, enable (callable) to restore it.
+            dict: target_bucket (MCGOCBucket), disable (callable) to
+                revoke the IAM key, enable (callable) to restore it.
 
         """
-        aws_obj = AWS()
-        namespace = config.ENV_DATA["cluster_namespace"]
-        region = cld_mgr.aws_client.region
-        created = {}
+        bs_obj = aws_backingstore_with_toggleable_creds["backingstore"]
 
-        def _cleanup():
-            if "target_obc" in created:
-                try:
-                    OCP(kind="obc", namespace=namespace).delete(
-                        resource_name=created["target_obc"]
-                    )
-                except Exception:
-                    logger.warning(f"Failed to delete OBC {created['target_obc']}")
-            if "bucketclass" in created:
-                try:
-                    OCP(kind="bucketclass", namespace=namespace).delete(
-                        resource_name=created["bucketclass"]
-                    )
-                except Exception:
-                    logger.warning(
-                        f"Failed to delete bucketclass {created['bucketclass']}"
-                    )
-            if "backingstore" in created:
-                bs_ocp = OCP(kind="backingstore", namespace=namespace)
-                for attempt in range(6):
-                    try:
-                        bs_ocp.delete(resource_name=created["backingstore"])
-                        break
-                    except Exception:
-                        if attempt < 5:
-                            logger.info(
-                                f"Backingstore {created['backingstore']} not ready "
-                                f"for deletion, retrying in 10s ({attempt + 1}/6)"
-                            )
-                            time.sleep(10)
-                        else:
-                            logger.warning(
-                                f"Failed to delete backingstore "
-                                f"{created['backingstore']} after 6 attempts"
-                            )
-            if "secret" in created:
-                try:
-                    created["secret"].delete()
-                except Exception:
-                    logger.warning("Failed to delete K8s secret")
-            if "access_key_id" in created:
-                try:
-                    aws_obj.update_access_key_status(
-                        created["username"],
-                        created["access_key_id"],
-                        status="Active",
-                    )
-                except Exception:
-                    logger.warning("Failed to re-enable IAM key")
-                try:
-                    aws_obj.delete_access_key(
-                        created["username"], created["access_key_id"]
-                    )
-                except Exception:
-                    logger.warning("Failed to delete IAM key")
-            if "policy_name" in created:
-                try:
-                    aws_obj.delete_user_policy(
-                        created["username"], created["policy_name"]
-                    )
-                except Exception:
-                    logger.warning("Failed to delete IAM policy")
-            if "username" in created:
-                try:
-                    aws_obj.delete_iam_user(created["username"])
-                except Exception:
-                    logger.warning(f"Failed to delete IAM user {created['username']}")
-            if "bucket_name" in created:
-                try:
-                    cld_mgr.aws_client.internal_delete_uls(created["bucket_name"])
-                except Exception:
-                    logger.warning(
-                        f"Failed to delete S3 bucket {created['bucket_name']}"
-                    )
+        bc_obj = bucket_class_factory({"interface": "CLI", "backingstores": [bs_obj]})
+        logger.info(f"Created bucketclass {bc_obj.name}")
 
-        request.addfinalizer(_cleanup)
-
-        # 1. Create the S3 bucket
-        bucket_name = create_unique_resource_name("repl-alert", "aws")
-        cld_mgr.aws_client.internal_create_uls(bucket_name, region=region)
-        created["bucket_name"] = bucket_name
-        logger.info(f"Created S3 bucket {bucket_name}")
-
-        # 2. Create IAM user with a bucket-scoped inline policy
-        username = create_unique_resource_name("ocs-ci-s3", "iam")
-        aws_obj.create_iam_user(username)
-        created["username"] = username
-
-        # Scope the user to only this bucket — no access to any other S3 resource
-        # NooBaa also requires s3:ListAllMyBuckets for CheckExternalConnection
-        policy_name = f"{username}-s3"
-        policy_document = json.dumps(
-            {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": "s3:*",
-                        "Resource": [
-                            f"arn:aws:s3:::{bucket_name}",
-                            f"arn:aws:s3:::{bucket_name}/*",
-                        ],
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": "s3:ListAllMyBuckets",
-                        "Resource": "arn:aws:s3:::*",
-                    },
-                ],
-            }
-        )
-        aws_obj.put_user_policy(username, policy_name, policy_document)
-        created["policy_name"] = policy_name
-
-        # 3. Create access key
-        response = aws_obj.create_access_key(username)
-        key_data = response["AccessKey"]
-        access_key_id = key_data["AccessKeyId"]
-        created["access_key_id"] = access_key_id
-
-        # Wait for IAM credentials to propagate through AWS
-        logger.info("Sleeping 60s for IAM credential propagation")
-        time.sleep(60)
-
-        # 4. Create K8s secret with the IAM credentials
-        bs_secret_data = templating.load_yaml(constants.MCG_BACKINGSTORE_SECRET_YAML)
-        secret_name = create_unique_resource_name("repl-alert", "secret")
-        bs_secret_data["metadata"]["name"] = secret_name
-        bs_secret_data["metadata"]["namespace"] = namespace
-        bs_secret_data["data"]["AWS_ACCESS_KEY_ID"] = base64.urlsafe_b64encode(
-            access_key_id.encode()
-        ).decode()
-        bs_secret_data["data"]["AWS_SECRET_ACCESS_KEY"] = base64.urlsafe_b64encode(
-            key_data["SecretAccessKey"].encode()
-        ).decode()
-        secret_obj = OCS(**bs_secret_data)
-        secret_obj.create()
-        created["secret"] = secret_obj
-        logger.info(f"Created K8s secret {secret_name}")
-
-        # 5. Create backingstore
-        bs_name = create_unique_resource_name("repl-alert", "bs")
-        mcg_obj.exec_mcg_cmd(
-            f"backingstore create aws-s3 {bs_name} "
-            f"--secret-name {secret_name} "
-            f"--target-bucket {bucket_name} "
-            f"--region {region}",
-            use_yes=True,
-        )
-        created["backingstore"] = bs_name
-        logger.info(f"Created backingstore {bs_name}")
-
-        # 6. Create bucketclass
-        bc_name = create_unique_resource_name("repl-alert", "bc")
-        mcg_obj.exec_mcg_cmd(
-            f"bucketclass create placement-bucketclass {bc_name} "
-            f"--backingstores {bs_name}",
-            use_yes=True,
-        )
-        created["bucketclass"] = bc_name
-        logger.info(f"Created bucketclass {bc_name}")
-
-        # 7. Create target OBC
-        target_obc_name = create_unique_resource_name("repl-alert-tgt", "obc")
-        mcg_obj.exec_mcg_cmd(
-            f"obc create {target_obc_name} --bucketclass {bc_name} --exact",
-            use_yes=True,
-        )
-        created["target_obc"] = target_obc_name
-        OCP(kind="obc", namespace=namespace).wait_for_resource(
-            condition="Bound",
-            resource_name=target_obc_name,
-            column="PHASE",
-        )
-        for obc_healthy in TimeoutSampler(
-            timeout=300,
-            sleep=10,
-            func=lambda: all(
-                mark
-                in mcg_obj.exec_mcg_cmd(f"obc status {target_obc_name}").stdout.replace(
-                    " ", ""
-                )
-                for mark in [
-                    constants.HEALTHY_OBC_CLI_PHASE,
-                    constants.HEALTHY_OB_CLI_MODE,
-                ]
-            ),
-        ):
-            if obc_healthy:
-                break
-        logger.info(f"Target OBC {target_obc_name} is Bound and healthy")
+        target_bucket = bucket_factory(1, "OC", bucketclass=bc_obj)[0]
+        logger.info(f"Target OBC {target_bucket.name} is Bound and healthy")
 
         return {
-            "target_obc_name": target_obc_name,
-            "disable": lambda: aws_obj.update_access_key_status(
-                username, access_key_id, status="Inactive"
-            ),
-            "enable": lambda: aws_obj.update_access_key_status(
-                username, access_key_id, status="Active"
-            ),
+            "target_bucket": target_bucket,
+            "disable": aws_backingstore_with_toggleable_creds["disable"],
+            "enable": aws_backingstore_with_toggleable_creds["enable"],
         }
 
     @skipif_aws_creds_are_missing
@@ -400,8 +195,8 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         """
 
         target_obc_name = replication_target_with_aws_toggleable_creds[
-            "target_obc_name"
-        ]
+            "target_bucket"
+        ].name
 
         # 1. Create a source OBC with a replication policy
         replication_policy = ("repl-alert-rule", target_obc_name, None)

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -56,7 +56,7 @@ def _wait_for_replication_alert(
     for alerts in TimeoutSampler(
         timeout=timeout,
         sleep=sleep,
-        func=api.get_firing_alerts_by_labels,
+        func=api.get_alerts_by_labels,
         alert_name=alert_name,
         labels_dict=labels,
     ):

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -21,6 +21,47 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
+def _wait_for_replication_alert(
+    threading_lock,
+    source_bucket_name,
+    target_bucket_name=None,
+    timeout=600,
+    sleep=30,
+    cleared=False,
+):
+    """
+    Wait for the NooBaaReplicationTargetUnreachable alert to fire or clear
+    for a specific source bucket and optionally a specific target bucket.
+
+    Args:
+        threading_lock: Lock for Prometheus API access
+        source_bucket_name (str): Source bucket name to filter by
+        target_bucket_name (str, optional): Target bucket name to filter by
+        timeout (int): Seconds to wait before timing out
+        sleep (int): Seconds between polls
+        cleared (bool): If True, wait for the alert to clear instead of appear
+
+    Returns:
+        list: The matching alerts (empty list when cleared=True).
+    """
+    alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
+    api = PrometheusAPI(threading_lock=threading_lock)
+    labels = {"source_bucket": source_bucket_name}
+    if target_bucket_name:
+        labels["target_bucket"] = target_bucket_name
+    for alerts in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=api.get_firing_alerts_by_labels,
+        alert_name=alert_name,
+        labels_dict=labels,
+    ):
+        if bool(alerts) != cleared:
+            state = "cleared" if cleared else "firing"
+            logger.info(f"Alert {alert_name} {state} for {source_bucket_name}")
+            return alerts
+
+
 @mcg
 @red_squad
 class TestMCGReplicationTargetUnreachableAlert(MCGTest):
@@ -88,18 +129,9 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         target_bucket.delete()
         logger.info(f"Target bucket deleted: {target_bucket.name}")
 
-        alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
-        api = PrometheusAPI(threading_lock=threading_lock)
-        for alerts in TimeoutSampler(
-            timeout=60 * 8,
-            sleep=30,
-            func=api.get_alerts_by_labels,
-            alert_name=alert_name,
-            labels_dict={"source_bucket": source_bucket.name},
-        ):
-            if alerts:
-                logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
-                break
+        alerts = _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=60 * 8
+        )
 
         # 4. Verify alert properties and bucket names (not hash IDs - DFBUGS-6380)
         alert = alerts[0]
@@ -126,16 +158,9 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         if jira_issue("DFBUGS-6398"):
             pytest.skip("DFBUGS-6398: alert persists after source bucket deletion")
 
-        for alerts in TimeoutSampler(
-            timeout=60 * 5,
-            sleep=30,
-            func=api.get_alerts_by_labels,
-            alert_name=alert_name,
-            labels_dict={"source_bucket": source_bucket.name},
-        ):
-            if not alerts:
-                logger.info(f"Alert {alert_name} cleared for {source_bucket.name}")
-                break
+        _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=60 * 5, cleared=True
+        )
 
     @skipif_aws_creds_are_missing
     @skipif_disconnected_cluster
@@ -167,7 +192,6 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         bc_obj = bucket_class_factory({"interface": "CLI", "backingstores": [bs_obj]})
         target_bucket = bucket_factory(1, "OC", bucketclass=bc_obj)[0]
         target_obc_name = target_bucket.name
-        logger.info(f"Target OBC {target_obc_name} is Bound and healthy")
 
         # 2. Create a source OBC with a replication policy
         replication_policy = ("repl-alert-rule", target_obc_name, None)
@@ -208,30 +232,14 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         )
 
         # 6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
-        alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
-        api = PrometheusAPI(threading_lock=threading_lock)
-        for alert_found in TimeoutSampler(
-            timeout=600,
-            sleep=10,
-            func=api.get_alerts_by_labels,
-            alert_name=alert_name,
-            labels_dict={"source_bucket": source_bucket.name},
-        ):
-            if alert_found:
-                logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
-                break
+        _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=600, sleep=10
+        )
 
         # 7. Re-enable the IAM access key
         aws_backingstore_with_toggleable_creds["enable"]()
 
         # 8. Wait for the alert to clear
-        for alert_cleared in TimeoutSampler(
-            timeout=600,
-            sleep=10,
-            func=api.get_alerts_by_labels,
-            alert_name=alert_name,
-            labels_dict={"source_bucket": source_bucket.name},
-        ):
-            if not alert_cleared:
-                logger.info(f"Alert {alert_name} cleared for {source_bucket.name}")
-                break
+        _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=600, sleep=10, cleared=True
+        )

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -60,7 +60,8 @@ def _wait_for_replication_alert(
         alert_name=alert_name,
         labels_dict=labels,
     ):
-        if bool(alerts) != cleared:
+        found = bool(alerts)
+        if (cleared and not found) or (not cleared and found):
             state = "cleared" if cleared else "firing"
             logger.info(f"Alert {alert_name} {state} for {source_bucket_name}")
             return alerts

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -189,7 +189,8 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         5. Upload new objects to trigger failing replication
         6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
         7. Re-enable the IAM access key
-        8. Wait for the alert to clear
+        8. Write test objects and verify replication works again
+        9. Wait for the alert to clear
         """
 
         # 1. Create a target OBC backed by the toggleable-creds backingstore
@@ -226,7 +227,7 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         aws_backingstore_with_toggleable_creds["disable"]()
 
         # 5. Upload new objects to trigger failing replication
-        post_disrupt_dir = f"{test_directory_setup.origin_dir}/post"
+        post_disrupt_dir = f"{test_directory_setup.origin_dir}/post_disrupt"
         write_random_test_objects_to_bucket(
             awscli_pod_session,
             source_bucket.name,
@@ -244,7 +245,22 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         # 7. Re-enable the IAM access key
         aws_backingstore_with_toggleable_creds["enable"]()
 
-        # 8. Wait for the alert to clear
+        # 8. Write test objects and verify replication works again
+        post_recovery_dir = f"{test_directory_setup.origin_dir}/post_recovery"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            post_recovery_dir,
+            amount=3,
+            pattern="post-recovery-",
+            mcg_obj=mcg_obj,
+        )
+        assert compare_bucket_object_list(
+            mcg_obj, source_bucket.name, target_obc_name, timeout=600
+        ), "Replication did not work after IAM key recovery"
+        logger.info("Post-recovery replication verified successfully")
+
+        # 9. Wait for the alert to clear
         _wait_for_replication_alert(
             threading_lock, source_bucket.name, timeout=600, sleep=10, cleared=True
         )

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -43,6 +43,10 @@ def _wait_for_replication_alert(
 
     Returns:
         list: The matching alerts (empty list when cleared=True).
+
+    Raises:
+        TimeoutExpiredError: If the alert does not reach the expected
+            state within the timeout.
     """
     alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
     api = PrometheusAPI(threading_lock=threading_lock)

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -88,25 +88,21 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         target_bucket.delete()
         logger.info(f"Target bucket deleted: {target_bucket.name}")
 
+        alert_name = constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE
         api = PrometheusAPI(threading_lock=threading_lock)
-        alerts = api.wait_for_alert(
-            name=constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE,
-            state="firing",
+        for alerts in TimeoutSampler(
             timeout=60 * 8,
             sleep=30,
-        )
+            func=api.get_alerts_by_labels,
+            alert_name=alert_name,
+            labels_dict={"source_bucket": source_bucket.name},
+        ):
+            if alerts:
+                logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
+                break
+
         # 4. Verify alert properties and bucket names (not hash IDs - DFBUGS-6380)
-        alert = next(
-            (
-                a
-                for a in alerts
-                if a.get("labels", {}).get("source_bucket") == source_bucket.name
-            ),
-            None,
-        )
-        assert (
-            alert is not None
-        ), "NooBaaReplicationTargetUnreachable alert not found for source bucket"
+        alert = alerts[0]
         assert (
             alert["annotations"]["message"]
             == "A NooBaa Replication Target Is Unreachable"
@@ -130,15 +126,16 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         if jira_issue("DFBUGS-6398"):
             pytest.skip("DFBUGS-6398: alert persists after source bucket deletion")
 
-        cleared = api.wait_for_alert(
-            name=constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE,
-            state=None,
+        for alerts in TimeoutSampler(
             timeout=60 * 5,
             sleep=30,
-        )
-        assert (
-            len(cleared) == 0
-        ), f"{constants.ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE} alerts were not cleared"
+            func=api.get_alerts_by_labels,
+            alert_name=alert_name,
+            labels_dict={"source_bucket": source_bucket.name},
+        ):
+            if not alerts:
+                logger.info(f"Alert {alert_name} cleared for {source_bucket.name}")
+                break
 
     @skipif_aws_creds_are_missing
     @skipif_disconnected_cluster
@@ -216,9 +213,9 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         for alert_found in TimeoutSampler(
             timeout=600,
             sleep=10,
-            func=api.get_alerts_for_bucket,
+            func=api.get_alerts_by_labels,
             alert_name=alert_name,
-            source_bucket=source_bucket.name,
+            labels_dict={"source_bucket": source_bucket.name},
         ):
             if alert_found:
                 logger.info(f"Alert {alert_name} is firing for {source_bucket.name}")
@@ -231,9 +228,9 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         for alert_cleared in TimeoutSampler(
             timeout=600,
             sleep=10,
-            func=api.get_alerts_for_bucket,
+            func=api.get_alerts_by_labels,
             alert_name=alert_name,
-            source_bucket=source_bucket.name,
+            labels_dict={"source_bucket": source_bucket.name},
         ):
             if not alert_cleared:
                 logger.info(f"Alert {alert_name} cleared for {source_bucket.name}")


### PR DESCRIPTION
## Summary
- Add a second test case for the NooBaaReplicationTargetUnreachable alert that
  validates the full alert lifecycle by revoking and restoring IAM credentials
  on an AWS-backed replication target
- Add reusable `aws_backingstore_with_toggleable_creds` fixture in conftest.py
  for creating AWS backingstores with IAM keys that can be disabled/enabled
- Add AWS IAM utility methods (`create_iam_user`, `delete_iam_user`,
  `put_user_policy`, `create_access_key`, `update_access_key_status`)
- Add `get_alerts_by_labels` to PrometheusAPI for filtering alerts by
  arbitrary label key-value pairs
- Update the first test to use `get_alerts_by_labels` instead of
  `wait_for_alert` for alert polling. `wait_for_alert` matches only by alert
  name, so it can return early if an unrelated alert with the same name is
  firing for a different bucket (e.g. a stale alert from a previous test).
  `get_alerts_by_labels` filters by `source_bucket` label, ensuring each test
  only sees alerts for its own replication pair.

## Changes
- `tests/.../test_mcg_replication_target_unreachable.py` — new test
  `test_noobaa_replication_target_unreachable_iam_key_revocation` (OCS-7918);
  update first test to use `get_alerts_by_labels` for bucket-scoped alert
  polling
- `tests/conftest.py` — new fixture `aws_backingstore_with_toggleable_creds`
- `ocs_ci/utility/aws.py` — IAM lifecycle methods on the `AWS` class
- `ocs_ci/utility/prometheus.py` — `get_alerts_by_labels` helper for
  label-filtered alert queries
- `ocs_ci/ocs/resources/bucketclass.py` — support `"backingstores"` key in
  `bucket_class_factory` to accept pre-created BackingStore objects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS IAM user management: create/delete users, manage inline policies and access keys.
  * Prometheus alert querying: fetch alerts filtered by alert name and labels.
  * Bucket-class creation: accept explicit backingstore lists when specified.

* **Tests**
  * New fixture to provision AWS-backed backingstore with toggleable IAM credentials.
  * Replication alert tests updated to use a shared alert-wait helper for firing/cleared checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->