### PR TITLE
Fixing critical test case in HealthOverview

### DIFF
--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -33,7 +33,7 @@ DATETIME_RE = re.compile(
     r"((?:\d{1,2}\s+\w+|\w+\s+\d{1,2}),?\s+\d{4},\s+\d{1,2}:\d{2}(?:\s*(?:AM|PM))?)",
     re.IGNORECASE,
 )
-CHECK_RE = re.compile(r"\b(ODF[A-Za-z0-9]+)\b")
+CHECK_RE = re.compile(r"\b((?:ODF|Ceph)[A-Za-z0-9]+)\b")
 
 
 @dataclass

--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -17,6 +17,8 @@ SEVERITY_BY_CHECK = {
     constants.ALERT_ODF_DISK_UTILIZATION_HIGH: "Medium",
     constants.ALERT_ODF_CORE_POD_RESTART: "Medium",
     constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION: "Medium",
+    constants.ALERT_CLUSTERERRORSTATE: "Critical",
+    constants.ALERT_CLUSTERWARNINGSTATE: "Medium",
 }
 
 logger = logging.getLogger(__name__)

--- a/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-error.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-error.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-state-alert.rules
+  namespace: openshift-storage
+  labels:
+    app: rook-ceph
+spec:
+  groups:
+    - name: cluster-state-alert.rules
+      rules:
+        - alert: CephClusterErrorState
+          expr: ceph_health_status{job="rook-ceph-mgr"} >= 1
+          for: 1m
+          labels:
+            severity: critical
+            severity_level: error
+            storage_type: ceph
+          annotations:
+            description: Storage cluster is in error state for more than 1m.
+            message: Storage cluster is in error state
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephClusterErrorState.md

--- a/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-state-alert.rules
+  namespace: openshift-storage
+  labels:
+    app: rook-ceph
+spec:
+  groups:
+    - name: cluster-state-alert.rules
+      rules:
+        - alert: CephClusterWarningState
+          expr: ceph_health_status{job="rook-ceph-mgr"} == 1
+          for: 1m
+          labels:
+            severity: warning
+            severity_level: warning
+            storage_type: ceph
+          annotations:
+            description: Storage cluster is in warning state for more than 15m.
+            message: Storage cluster is in degraded state
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephClusterWarningState.md

--- a/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
@@ -17,6 +17,6 @@ spec:
             severity_level: warning
             storage_type: ceph
           annotations:
-            description: Storage cluster is in warning state for more than 15m.
+            description: Storage cluster is in warning state for more than 1m.
             message: Storage cluster is in degraded state
             runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/CephClusterWarningState.md

--- a/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-ceph-cluster-warn.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: cluster-state-alert.rules
+  name: cluster-state-alert-warn.rules
   namespace: openshift-storage
   labels:
     app: rook-ceph

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
@@ -21,7 +21,7 @@ spec:
           phase="rtt",
           job="odf-blackbox-exporter",
           daemon_type="osd"}[24h: ]
-        ) > 0.010
+        ) > 0.005
       for: 1m
       labels:
         component: odf

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
@@ -17,22 +17,11 @@ spec:
         summary: High ICMP latency (>1ms) detected on ODF OSD node(s)
       expr: |
         max_over_time(
-          (
-            probe_icmp_duration_seconds{phase="rtt", job="odf-blackbox-exporter"}
-            and on(instance)
-            (
-              count by (hostname) (ceph_osd_metadata)
-              * on(hostname) group_left(instance)
-              label_replace(
-                label_replace(
-                  max by (node, internal_ip) (kube_node_info),
-                  "hostname", "$1", "node", "(.+)"
-                ),
-                "instance", "$1", "internal_ip", "(.+)"
-              )
-            )
-          )[2m:]
-        ) > .005
+        probe_icmp_duration_seconds{
+          phase="rtt",
+          job="odf-blackbox-exporter",
+          daemon_type="osd"}[24h: ]
+        ) > 0.010
       for: 1m
       labels:
         component: odf

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: odf-node-latency-high-non-osd
+  namespace: openshift-storage
+spec:
+  groups:
+    - name: odf-node-latency.rules
+      rules:
+        - alert: ODFNodeLatencyHighOnNonOSDNodes
+          expr: |
+            max_over_time(
+              probe_icmp_duration_seconds{
+                phase="rtt",
+                job="odf-blackbox-exporter",
+                daemon_type="mon"
+              }[24h:]
+            ) > 0.01
+          for: 1m
+          labels:
+            Component: odf
+            Severity: warning
+          annotations:
+            Description: >
+              Node {{ $labels.instance }} has max ICMP RTT latency > 100ms
+              over the last 24h. Investigate network health.
+            Summary: >
+              High ICMP latency (>100ms) detected on ODF non-OSD node(s)
+            runbook_url: >
+              https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnNONOSDNodes.md

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -18,13 +18,13 @@ spec:
             ) > 0.01
           for: 1m
           labels:
-            Component: odf
-            Severity: warning
+            component: odf
+            severity: warning
           annotations:
-            Description: >
+            description: >
               Node {{ $labels.instance }} has max ICMP RTT latency > 100ms
               over the last 24h. Investigate network health.
-            Summary: >
+            summary: >
               High ICMP latency (>100ms) detected on ODF non-OSD node(s)
             runbook_url: >
               https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnNONOSDNodes.md

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -15,14 +15,14 @@ spec:
                 job="odf-blackbox-exporter",
                 daemon_type="mon"
               }[24h:]
-            ) > 0.01
+            ) > 0.005
           for: 1m
           labels:
             component: odf
             severity: warning
           annotations:
             description: >
-              Node {{ $labels.instance }} has max ICMP RTT latency > 10ms
+              Node {{ $labels.instance }} has max ICMP RTT latency > 5ms
               over the last 24h. Investigate network health.
             summary: >
               High ICMP latency (>10ms) detected on ODF non-OSD node(s)

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -25,6 +25,6 @@ spec:
               Node {{ $labels.instance }} has max ICMP RTT latency > 5ms
               over the last 24h. Investigate network health.
             summary: >
-              High ICMP latency (>10ms) detected on ODF non-OSD node(s)
+              High ICMP latency (>5ms) detected on ODF non-OSD node(s)
             runbook_url: >
               https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnNONOSDNodes.md

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -22,9 +22,9 @@ spec:
             severity: warning
           annotations:
             description: >
-              Node {{ $labels.instance }} has max ICMP RTT latency > 100ms
+              Node {{ $labels.instance }} has max ICMP RTT latency > 10ms
               over the last 24h. Investigate network health.
             summary: >
-              High ICMP latency (>100ms) detected on ODF non-OSD node(s)
+              High ICMP latency (>10ms) detected on ODF non-OSD node(s)
             runbook_url: >
               https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnNONOSDNodes.md

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -61,9 +61,10 @@ def get_alert_params():
     Returns:
         list: List of tuples (alert_name, alert_yaml)
     """
-    # Base parameters for all versions
     try:
         ocs_version = get_ocs_version_from_csv(only_major_minor=True)
+        if ocs_version is None:
+            raise ValueError("get_ocs_version_from_csv returned None")
     except Exception as e:
         # Fallback if cluster not ready (e.g., during deployment)
         logger.warning(

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -93,6 +93,10 @@ def get_alert_params():
             constants.ALERT_ODF_CORE_POD_RESTART,
             "custom-odf-core-pod-restarted.yaml",
         ),
+        (
+            constants.ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES,
+            "custom-odf-node-latency-high-non-osd.yaml",
+        ),
     ]
     if ocs_version >= VERSION_4_22:
         params.extend(

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -571,6 +571,7 @@ class TestHealthOverview(ManageTest):
         """
         self.rule = None
         ocp = OCP(namespace=config.ENV_DATA.get("cluster_namespace"))
+        self.mon_scaling = False
         if alert_name == constants.ALERT_ODF_CORE_POD_RESTART:
             self.restart_pod()
             logger.info("Waiting for 120 sec for pod to restart")

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -30,6 +30,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility.version import (
     get_semantic_running_odf_version,
     get_semantic_version,
+    get_ocs_version_from_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,14 @@ ALERT_MAP = {
     constants.ALERT_ODF_DISK_UTILIZATION_HIGH: 0,
     constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION: 0,
 }
+ocs_version = get_ocs_version_from_csv(only_major_minor=True)
+if ocs_version >= get_semantic_version("4.22"):
+    ALERT_MAP.update(
+        {
+            constants.ALERT_CLUSTERWARNINGSTATE: 0,
+            constants.ALERT_CLUSTERERRORSTATE: 0,
+        }
+    )
 
 SEVERITY_DROP_MAP = {
     "Minor": 2,
@@ -344,6 +353,69 @@ class TestHealthOverview(ManageTest):
 
         request.addfinalizer(finalizer)
 
+    @pytest.fixture
+    def scale_mon_teardown(self, request):
+        """
+        Teardown fixture to scale up mon after mock critical alert test completes.
+        """
+
+        def finalizer():
+            if self.mon_scaling:
+                logger.info("[CLEANUP] Ensuring mon scaling is done")
+                try:
+                    ocp = OCP(namespace=config.ENV_DATA.get("cluster_namespace"))
+                    scale_cmd = "scale deployment rook-ceph-mon-a --replicas=1"
+                    ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+                except Exception as ex:
+                    logger.warning(f"Failed to scale mon during cleanup: {ex}")
+
+        request.addfinalizer(finalizer)
+
+    def get_alert_params(self):
+        """
+        Get alert parameters based on OCS version
+
+        Returns:
+            list: List of tuples (alert_name, alert_yaml)
+        """
+        # Base parameters for all versions
+        params = [
+            (
+                constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
+                "custom-odf-mtu-less-than-9000.yaml",
+            ),
+            (
+                constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
+                "custom-odf-nic-bandwidth-saturation.yaml",
+            ),
+            (
+                constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
+                "custom-odf-disk-utilization-high.yaml",
+            ),
+            (
+                constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
+                "custom-odf-latency-rule.yaml",
+            ),
+            (
+                constants.ALERT_ODF_CORE_POD_RESTART,
+                "custom-odf-core-pod-restarted.yaml",
+            ),
+        ]
+        if ocs_version >= get_semantic_version("4.22"):
+            params.extend(
+                [
+                    (
+                        constants.ALERT_CLUSTERERRORSTATE,
+                        "custom-ceph-cluster-error.yaml",
+                    ),
+                    (
+                        constants.ALERT_CLUSTERWARNINGSTATE,
+                        "custom-ceph-cluster-warn.yaml",
+                    ),
+                ]
+            )
+        return params
+
     @tier1
     @polarion_id("OCS-7475")
     def test_health_overview_modal(
@@ -422,28 +494,7 @@ class TestHealthOverview(ManageTest):
     @polarion_id("OCS-7509")
     @pytest.mark.parametrize(
         "alert_name, alert_yaml",
-        [
-            (
-                constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
-                "custom-odf-mtu-less-than-9000.yaml",
-            ),
-            (
-                constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
-                "custom-odf-nic-bandwidth-saturation.yaml",
-            ),
-            (
-                constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
-                "custom-odf-disk-utilization-high.yaml",
-            ),
-            (
-                constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
-                "custom-odf-latency-rule.yaml",
-            ),
-            (
-                constants.ALERT_ODF_CORE_POD_RESTART,
-                "custom-odf-core-pod-restarted.yaml",
-            ),
-        ],
+        get_alert_params(),
     )
     def test_health_score_changes_based_on_alert_severity(
         self,
@@ -453,6 +504,7 @@ class TestHealthOverview(ManageTest):
         threading_lock,
         unsilence_alerts_teardown,
         alert_rule_teardown,
+        scale_mon_teardown,
     ):
         """
         Test to decrease health score based on alert severity and recover after alert is reversed.
@@ -465,6 +517,7 @@ class TestHealthOverview(ManageTest):
         7. Verify health score is recovered
         """
         self.rule = None
+        ocp = OCP(namespace=config.ENV_DATA.get("cluster_namespace"))
         if alert_name == constants.ALERT_ODF_CORE_POD_RESTART:
             self.restart_pod()
             logger.info("Waiting for 120 sec for pod to restart")
@@ -482,7 +535,16 @@ class TestHealthOverview(ManageTest):
         assert (
             baseline_score == self.get_health_score_ui()
         ), "Full health score not recovered"
-
+        if (
+            alert_name == constants.ALERT_CLUSTERWARNINGSTATE
+            or alert_name == constants.ALERT_CLUSTERERRORSTATE
+        ):
+            logger.info(
+                "Scaling down rook-ceph-mon-a deployment to 0 replicas to mock up alert"
+            )
+            scale_cmd = "scale deployment rook-ceph-mon-a --replicas=0 "
+            ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+            self.mon_scaling = True
         severity = SEVERITY_BY_CHECK.get(alert_name)
         PageNavigator().take_screenshot(f"severity_of_alert_{alert_name}")
         assert severity, f"Severity not defined for alert {alert_name}"
@@ -508,13 +570,15 @@ class TestHealthOverview(ManageTest):
                 "Waiting for 120 sec to update health score after alert is triggered"
             )
             time.sleep(120)
-            self.wait_for_health_score_change(
-                len(alerts) * expected_drop, baseline_score
-            )
+            self.wait_for_health_score_change(expected_drop, baseline_score)
 
             logger.info("Deleting alert rule to resolve alert")
             self.rule.delete()
             self.rule = None
+            if self.mon_scaling:
+                scale_cmd = "scale deployment rook-ceph-mon-a --replicas=1 "
+                ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+                self.mon_scaling = False
             logger.info("Waiting for alert to be resolved...")
             api.refresh_connection()
             alerts = api.wait_for_alert(name=alert_name, timeout=180, sleep=60)
@@ -529,9 +593,7 @@ class TestHealthOverview(ManageTest):
             logger.info("Alert already present no need to trigger again")
             infra_health_overview = df_overview.nav_health_view_checks()
             infra_health_overview.unsilence_alert_by_name(alert_name)
-            self.wait_for_health_score_change(
-                ALERT_MAP[alert_name] * expected_drop, baseline_score
-            )
+            self.wait_for_health_score_change(expected_drop, baseline_score)
 
     @tier2
     @polarion_id("OCS-7731")

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 import time
 import pytest
 import requests
@@ -37,7 +36,6 @@ from ocs_ci.utility.version import (
 
 logger = logging.getLogger(__name__)
 
-is_collect_only = "--collect-only" in sys.argv or "--co" in sys.argv
 ALERT_MAP = {
     constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES: 0,
     constants.ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES: 0,
@@ -45,20 +43,9 @@ ALERT_MAP = {
     constants.ALERT_ODF_CORE_POD_RESTART: 0,
     constants.ALERT_ODF_DISK_UTILIZATION_HIGH: 0,
     constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION: 0,
+    constants.ALERT_CLUSTERWARNINGSTATE: 0,
+    constants.ALERT_CLUSTERERRORSTATE: 0,
 }
-
-if is_collect_only:
-    ocs_version = VERSION_4_22  # Default to latest for collection
-else:
-    ocs_version = get_ocs_version_from_csv(only_major_minor=True)
-
-if ocs_version >= VERSION_4_22:
-    ALERT_MAP.update(
-        {
-            constants.ALERT_CLUSTERWARNINGSTATE: 0,
-            constants.ALERT_CLUSTERERRORSTATE: 0,
-        }
-    )
 
 SEVERITY_DROP_MAP = {
     "Minor": 2,
@@ -75,6 +62,15 @@ def get_alert_params():
         list: List of tuples (alert_name, alert_yaml)
     """
     # Base parameters for all versions
+    try:
+        ocs_version = get_ocs_version_from_csv(only_major_minor=True)
+    except Exception as e:
+        # Fallback if cluster not ready (e.g., during deployment)
+        logger.warning(
+            f"Could not detect OCS version (cluster may not be ready): {e}. "
+            f"Using default version {VERSION_4_22}"
+        )
+        ocs_version = VERSION_4_22
     params = [
         (
             constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -30,8 +30,6 @@ from ocs_ci.framework import config
 from ocs_ci.utility.version import (
     get_semantic_running_odf_version,
     get_semantic_version,
-    VERSION_4_22,
-    get_ocs_version_from_csv,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,66 +50,6 @@ SEVERITY_DROP_MAP = {
     "Medium": 10,
     "Critical": 20,
 }
-
-
-def get_alert_params():
-    """
-    Get alert parameters based on OCS version
-
-    Returns:
-        list: List of tuples (alert_name, alert_yaml)
-    """
-    try:
-        ocs_version = get_ocs_version_from_csv(only_major_minor=True)
-        if ocs_version is None:
-            raise ValueError("get_ocs_version_from_csv returned None")
-    except Exception as e:
-        # Fallback if cluster not ready (e.g., during deployment)
-        logger.warning(
-            f"Could not detect OCS version (cluster may not be ready): {e}. "
-            f"Using default version {VERSION_4_22}"
-        )
-        ocs_version = VERSION_4_22
-    params = [
-        (
-            constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
-            "custom-odf-mtu-less-than-9000.yaml",
-        ),
-        (
-            constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
-            "custom-odf-nic-bandwidth-saturation.yaml",
-        ),
-        (
-            constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
-            "custom-odf-disk-utilization-high.yaml",
-        ),
-        (
-            constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
-            "custom-odf-latency-rule.yaml",
-        ),
-        (
-            constants.ALERT_ODF_CORE_POD_RESTART,
-            "custom-odf-core-pod-restarted.yaml",
-        ),
-        (
-            constants.ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES,
-            "custom-odf-node-latency-high-non-osd.yaml",
-        ),
-    ]
-    if ocs_version >= VERSION_4_22:
-        params.extend(
-            [
-                (
-                    constants.ALERT_CLUSTERERRORSTATE,
-                    "custom-ceph-cluster-error.yaml",
-                ),
-                (
-                    constants.ALERT_CLUSTERWARNINGSTATE,
-                    "custom-ceph-cluster-warn.yaml",
-                ),
-            ]
-        )
-    return params
 
 
 @ui
@@ -510,7 +448,42 @@ class TestHealthOverview(ManageTest):
     @polarion_id("OCS-7509")
     @pytest.mark.parametrize(
         "alert_name, alert_yaml",
-        get_alert_params(),
+        [
+            (
+                constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
+                "custom-odf-mtu-less-than-9000.yaml",
+            ),
+            (
+                constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
+                "custom-odf-nic-bandwidth-saturation.yaml",
+            ),
+            (
+                constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
+                "custom-odf-disk-utilization-high.yaml",
+            ),
+            (
+                constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
+                "custom-odf-latency-rule.yaml",
+            ),
+            (
+                constants.ALERT_ODF_CORE_POD_RESTART,
+                "custom-odf-core-pod-restarted.yaml",
+            ),
+            (
+                constants.ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES,
+                "custom-odf-node-latency-high-non-osd.yaml",
+            ),
+            pytest.param(
+                constants.ALERT_CLUSTERERRORSTATE,
+                "custom-ceph-cluster-error.yaml",
+                marks=skipif_ocs_version("<4.22"),
+            ),
+            pytest.param(
+                constants.ALERT_CLUSTERWARNINGSTATE,
+                "custom-ceph-cluster-warn.yaml",
+                marks=skipif_ocs_version("<4.22"),
+            ),
+        ],
     )
     def test_health_score_changes_based_on_alert_severity(
         self,

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -424,6 +424,9 @@ class TestHealthOverview(ManageTest):
                     ocp = OCP(namespace=config.ENV_DATA.get("cluster_namespace"))
                     scale_cmd = "scale deployment rook-ceph-mon-a --replicas=1"
                     ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+                    self.wait_for_deployment_ready_replicas(
+                        "rook-ceph-mon-a", expected_replicas=1
+                    )
                 except Exception as ex:
                     logger.warning(f"Failed to scale mon during cleanup: {ex}")
 

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 import pytest
 import requests
@@ -35,6 +36,7 @@ from ocs_ci.utility.version import (
 
 logger = logging.getLogger(__name__)
 
+is_collect_only = "--collect-only" in sys.argv or "--co" in sys.argv
 ALERT_MAP = {
     constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES: 0,
     constants.ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES: 0,
@@ -43,7 +45,12 @@ ALERT_MAP = {
     constants.ALERT_ODF_DISK_UTILIZATION_HIGH: 0,
     constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION: 0,
 }
-ocs_version = get_ocs_version_from_csv(only_major_minor=True)
+
+if is_collect_only:
+    ocs_version = get_semantic_version("4.22")  # Default to latest for collection
+else:
+    ocs_version = get_ocs_version_from_csv(only_major_minor=True)
+
 if ocs_version >= get_semantic_version("4.22"):
     ALERT_MAP.update(
         {
@@ -89,7 +96,7 @@ def get_alert_params():
             "custom-odf-core-pod-restarted.yaml",
         ),
     ]
-    if ocs_version >= version.VERSION_4_22:
+    if ocs_version >= get_semantic_version("4.22"):
         params.extend(
             [
                 (

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -31,6 +31,7 @@ from ocs_ci.framework import config
 from ocs_ci.utility.version import (
     get_semantic_running_odf_version,
     get_semantic_version,
+    VERSION_4_22,
     get_ocs_version_from_csv,
 )
 
@@ -47,11 +48,11 @@ ALERT_MAP = {
 }
 
 if is_collect_only:
-    ocs_version = get_semantic_version("4.22")  # Default to latest for collection
+    ocs_version = VERSION_4_22  # Default to latest for collection
 else:
     ocs_version = get_ocs_version_from_csv(only_major_minor=True)
 
-if ocs_version >= get_semantic_version("4.22"):
+if ocs_version >= VERSION_4_22:
     ALERT_MAP.update(
         {
             constants.ALERT_CLUSTERWARNINGSTATE: 0,
@@ -96,7 +97,7 @@ def get_alert_params():
             "custom-odf-core-pod-restarted.yaml",
         ),
     ]
-    if ocs_version >= get_semantic_version("4.22"):
+    if ocs_version >= VERSION_4_22:
         params.extend(
             [
                 (
@@ -413,7 +414,7 @@ class TestHealthOverview(ManageTest):
         """
 
         def finalizer():
-            if self.mon_scaling:
+            if getattr(self, "mon_scaling", False):
                 logger.info("[CLEANUP] Ensuring mon scaling is done")
                 try:
                     ocp = OCP(namespace=config.ENV_DATA.get("cluster_namespace"))
@@ -423,51 +424,6 @@ class TestHealthOverview(ManageTest):
                     logger.warning(f"Failed to scale mon during cleanup: {ex}")
 
         request.addfinalizer(finalizer)
-
-    def get_alert_params(self):
-        """
-        Get alert parameters based on OCS version
-
-        Returns:
-            list: List of tuples (alert_name, alert_yaml)
-        """
-        # Base parameters for all versions
-        params = [
-            (
-                constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
-                "custom-odf-mtu-less-than-9000.yaml",
-            ),
-            (
-                constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
-                "custom-odf-nic-bandwidth-saturation.yaml",
-            ),
-            (
-                constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
-                "custom-odf-disk-utilization-high.yaml",
-            ),
-            (
-                constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
-                "custom-odf-latency-rule.yaml",
-            ),
-            (
-                constants.ALERT_ODF_CORE_POD_RESTART,
-                "custom-odf-core-pod-restarted.yaml",
-            ),
-        ]
-        if ocs_version >= get_semantic_version("4.22"):
-            params.extend(
-                [
-                    (
-                        constants.ALERT_CLUSTERERRORSTATE,
-                        "custom-ceph-cluster-error.yaml",
-                    ),
-                    (
-                        constants.ALERT_CLUSTERWARNINGSTATE,
-                        "custom-ceph-cluster-warn.yaml",
-                    ),
-                ]
-            )
-        return params
 
     @tier1
     @polarion_id("OCS-7475")
@@ -589,16 +545,6 @@ class TestHealthOverview(ManageTest):
         assert (
             baseline_score == self.get_health_score_ui()
         ), "Full health score not recovered"
-        if (
-            alert_name == constants.ALERT_CLUSTERWARNINGSTATE
-            or alert_name == constants.ALERT_CLUSTERERRORSTATE
-        ):
-            logger.info(
-                "Scaling down rook-ceph-mon-a deployment to 0 replicas to mock up alert"
-            )
-            scale_cmd = "scale deployment rook-ceph-mon-a --replicas=0 "
-            ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
-            self.mon_scaling = True
         severity = SEVERITY_BY_CHECK.get(alert_name)
         PageNavigator().take_screenshot(f"severity_of_alert_{alert_name}")
         assert severity, f"Severity not defined for alert {alert_name}"
@@ -608,6 +554,19 @@ class TestHealthOverview(ManageTest):
             f"expected drop={expected_drop}%"
         )
         if ALERT_MAP[alert_name] == 0 and alert_name != "ODFCorePodRestarted":
+            if alert_name in {
+                constants.ALERT_CLUSTERWARNINGSTATE,
+                constants.ALERT_CLUSTERERRORSTATE,
+            }:
+                logger.info(
+                    "Scaling down rook-ceph-mon-a deployment to 0 replicas to mock up alert"
+                )
+                scale_cmd = "scale deployment rook-ceph-mon-a --replicas=0 "
+                ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+                self.wait_for_deployment_ready_replicas(
+                    "rook-ceph-mon-a", expected_replicas=0
+                )
+                self.mon_scaling = True
             logger.info(f"Applying alert rule YAML: {alert_yaml}")
             alert_yaml_load = load_yaml(
                 os.path.join(constants.HEALTHALERTS_DIR, alert_yaml)
@@ -632,6 +591,9 @@ class TestHealthOverview(ManageTest):
             if self.mon_scaling:
                 scale_cmd = "scale deployment rook-ceph-mon-a --replicas=1 "
                 ocp.exec_oc_cmd(command=scale_cmd, out_yaml_format=False)
+                self.wait_for_deployment_ready_replicas(
+                    "rook-ceph-mon-a", expected_replicas=1
+                )
                 self.mon_scaling = False
             logger.info("Waiting for alert to be resolved...")
             api.refresh_connection()

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -59,6 +59,52 @@ SEVERITY_DROP_MAP = {
 }
 
 
+def get_alert_params():
+    """
+    Get alert parameters based on OCS version
+
+    Returns:
+        list: List of tuples (alert_name, alert_yaml)
+    """
+    # Base parameters for all versions
+    params = [
+        (
+            constants.ALERT_ODF_NODE_MTU_LESS_THAN_9000,
+            "custom-odf-mtu-less-than-9000.yaml",
+        ),
+        (
+            constants.ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION,
+            "custom-odf-nic-bandwidth-saturation.yaml",
+        ),
+        (
+            constants.ALERT_ODF_DISK_UTILIZATION_HIGH,
+            "custom-odf-disk-utilization-high.yaml",
+        ),
+        (
+            constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
+            "custom-odf-latency-rule.yaml",
+        ),
+        (
+            constants.ALERT_ODF_CORE_POD_RESTART,
+            "custom-odf-core-pod-restarted.yaml",
+        ),
+    ]
+    if ocs_version >= version.VERSION_4_22:
+        params.extend(
+            [
+                (
+                    constants.ALERT_CLUSTERERRORSTATE,
+                    "custom-ceph-cluster-error.yaml",
+                ),
+                (
+                    constants.ALERT_CLUSTERWARNINGSTATE,
+                    "custom-ceph-cluster-warn.yaml",
+                ),
+            ]
+        )
+    return params
+
+
 @ui
 @black_squad
 @runs_on_provider

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -364,6 +364,9 @@ class TestHealthOverview(ManageTest):
                 f"Deployment '{deployment}' ready replicas: {ready}, "
                 f"waiting for {expected_replicas}"
             )
+        raise TimeoutError(
+            f"Deployment '{deployment}' did not reach {expected_replicas} ready replica(s) within {timeout}s"
+        )
 
     @pytest.fixture
     def scale_exporters_teardown(self, request):


### PR DESCRIPTION
Add fix for deployment failure in extend critical test case in healthoverview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ceph cluster error and warning alerts, plus a non‑OSD node latency alert and an updated OSD‑node latency rule.

* **Bug Fixes**
  * Improved alert-name recognition to handle both ODF and Ceph variants.

* **Tests**
  * Enhanced health-overview tests with alert parameterization, simulated monitor scaling/teardown, and clearer deployment timeout reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->