### PR TITLE
Add ApplicationCleanupPending alert verification for discovered apps

### DIFF
--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -19,7 +19,11 @@ from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
-from ocs_ci.ocs.exceptions import ResourceWrongStatusException, TimeoutException
+from ocs_ci.ocs.exceptions import (
+    ResourceWrongStatusException,
+    TimeoutException,
+    UnexpectedBehaviour,
+)
 from ocs_ci.ocs.ui.base_ui import (
     wait_for_element_to_be_clickable,
     wait_for_element_to_be_visible,
@@ -862,6 +866,203 @@ def verify_drpolicy_ui(acm_obj, scheduling_interval):
     acm_obj.do_click(
         acm_loc["disaster-recovery-overview"], avoid_stale=True, enable_screenshot=True
     )
+
+
+def verify_pending_cleanup_alert_firing(
+    acm_obj, operation="Failover", drpc_name=None, namespace=None
+):
+    """
+    Verify that ApplicationCleanupPending alert is firing on DR Dashboard.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        operation (str): DR operation name for logging (Failover/Relocate)
+        drpc_name (str): DRPC name to verify specific alert (optional)
+        namespace (str): Namespace of DRPC (optional, defaults to DR_OPS_NAMESPACE)
+
+    Raises:
+        UnexpectedBehaviour: If alert is not found on DR Dashboard
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    namespace = namespace or constants.DR_OPS_NAMESPACE
+
+    log.info(
+        f"Verifying {constants.ALERT_APPLICATION_CLEANUP_PENDING} "
+        f"alert is firing on DR Dashboard after {operation}"
+        + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+    )
+    acm_obj.refresh_page()
+    acm_obj.navigate_data_services()
+
+    # Navigate to Disaster Recovery Overview page where alerts are shown
+    acm_obj.do_click(
+        acm_loc["disaster-recovery-overview"],
+        avoid_stale=True,
+        enable_screenshot=True,
+        timeout=60,
+    )
+    acm_obj.take_screenshot()
+
+    # Expand Critical alerts section (best-effort)
+    try:
+        critical_alert = acm_obj.find_an_element_by_xpath(
+            acm_loc["critical-alert"][0]
+        ).get_attribute("aria-expanded")
+
+        if critical_alert == "false":
+            critical_alert_elem = wait_for_element_to_be_clickable(
+                acm_loc["critical-alert"]
+            )
+            acm_obj.driver.execute_script("arguments[0].click();", critical_alert_elem)
+            acm_obj.take_screenshot()
+    except (NoSuchElementException, StaleElementReferenceException) as e:
+        log.warning(
+            f"Could not expand Critical alerts section: {e}. "
+            "Proceeding to verify alert presence directly."
+        )
+        acm_obj.take_screenshot()
+
+    # Verify alert is visible - use DRPC-specific locator if drpc_name provided
+    if drpc_name:
+        alert_locator = (
+            acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                drpc_name, namespace
+            ),
+            acm_loc["pending-cleanup-alert-drpc-message"][1],
+        )
+        expected_text = f"DRPC '{drpc_name}'"
+    else:
+        alert_locator = acm_loc["pending-cleanup-alert"]
+        expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+
+    alert_found = acm_obj.wait_until_expected_text_is_found(
+        locator=alert_locator,
+        expected_text=expected_text,
+        timeout=120,
+    )
+
+    if alert_found:
+        log.info(
+            f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"found on DR Dashboard after {operation}"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+        acm_obj.take_screenshot()
+    else:
+        log.error(
+            f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"NOT found on DR Dashboard after {operation}"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+        acm_obj.take_screenshot()
+        raise UnexpectedBehaviour(
+            f"{constants.ALERT_APPLICATION_CLEANUP_PENDING} alert "
+            f"did not appear on DR Dashboard after {operation}"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+
+
+def verify_pending_cleanup_alert_resolved(
+    acm_obj, operation="Failover", drpc_name=None, namespace=None
+):
+    """
+    Verify that ApplicationCleanupPending alert is resolved/cleared from DR Dashboard.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        operation (str): DR operation name for logging (Failover/Relocate)
+        drpc_name (str): DRPC name to verify specific alert resolved (optional)
+        namespace (str): Namespace of DRPC (optional, defaults to DR_OPS_NAMESPACE)
+
+    Raises:
+        UnexpectedBehaviour: If alert is still present on DR Dashboard
+
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    namespace = namespace or constants.DR_OPS_NAMESPACE
+
+    log.info(
+        f"Verifying {constants.ALERT_APPLICATION_CLEANUP_PENDING} "
+        f"alert is cleared from DR Dashboard after {operation} cleanup"
+        + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+    )
+
+    # Navigate to DR Dashboard Overview page
+    acm_obj.refresh_page()
+    acm_obj.navigate_data_services()
+    acm_obj.do_click(
+        acm_loc["disaster-recovery-overview"],
+        avoid_stale=True,
+        enable_screenshot=True,
+        timeout=60,
+    )
+    acm_obj.take_screenshot()
+
+    # Try to expand Critical alerts section if it exists
+    try:
+        critical_alert = acm_obj.find_an_element_by_xpath(
+            acm_loc["critical-alert"][0]
+        ).get_attribute("aria-expanded")
+
+        if critical_alert == "false":
+            critical_alert_elem = wait_for_element_to_be_clickable(
+                acm_loc["critical-alert"]
+            )
+            acm_obj.driver.execute_script("arguments[0].click();", critical_alert_elem)
+            acm_obj.take_screenshot()
+    except (NoSuchElementException, StaleElementReferenceException) as e:
+        log.info(
+            f"Critical alerts section not found or not expandable: {e}. "
+            "This may indicate no critical alerts exist (expected)."
+        )
+        acm_obj.take_screenshot()
+    except Exception as e:
+        acm_obj.take_screenshot()
+        raise UnexpectedBehaviour(
+            f"Unable to verify DR Dashboard critical-alert section after {operation} cleanup."
+        ) from e
+
+    # Verify alert is NOT visible - use DRPC-specific locator if drpc_name provided
+    if drpc_name:
+        alert_locator = (
+            acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                drpc_name, namespace
+            ),
+            acm_loc["pending-cleanup-alert-drpc-message"][1],
+        )
+        expected_text = f"DRPC '{drpc_name}'"
+    else:
+        alert_locator = acm_loc["pending-cleanup-alert"]
+        expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+
+    # use_fallback=False as this is intentional negative check (alert should NOT exist)
+    alert_still_present = acm_obj.wait_until_expected_text_is_found(
+        locator=alert_locator,
+        expected_text=expected_text,
+        timeout=60,
+        use_fallback=False,
+    )
+
+    if alert_still_present:
+        log.error(
+            f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"still present on DR Dashboard after {operation} cleanup"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+        acm_obj.take_screenshot()
+        raise UnexpectedBehaviour(
+            f"{constants.ALERT_APPLICATION_CLEANUP_PENDING} alert "
+            f"did not clear after {operation} cleanup"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+    else:
+        log.info(
+            f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"successfully cleared from DR Dashboard after {operation}"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+        acm_obj.take_screenshot()
 
 
 def failover_relocate_ui(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1693,6 +1693,10 @@ CEPHFS_SNAPSHOT_STATE_ORPHANED = "orphaned"
 CEPHFS_SNAPSHOT_STATE_BOUND = "bound"
 ALERT_MDSXATTR = "CephXattrSetLatency"
 
+# DR Pending Cleanup Alert (OCS 4.22+)
+ALERT_APPLICATION_CLEANUP_PENDING = "ApplicationCleanupPending"
+ALERT_APPLICATION_CLEANUP_PENDING_THRESHOLD = 15 * 60  # 15 minutes in seconds
+
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"
 INFRA_NODE_LABEL = "node-role.kubernetes.io/infra=''"

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1741,6 +1741,15 @@ acm_configuration_4_18 = {
         By.XPATH,
     ),
     "disconnected-checkbox": ("//input[@id='isAirGappedDeployment']", By.XPATH),
+    "pending-cleanup-alert": (
+        f"//span[@class='mco-status-card__alert-item-header']"
+        f"[normalize-space()='{constants.ALERT_APPLICATION_CLEANUP_PENDING}']",
+        By.XPATH,
+    ),
+    "pending-cleanup-alert-drpc-message": (
+        "//span[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
+        By.XPATH,
+    ),
 }
 
 acm_configuration_4_19 = {

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -17,6 +17,13 @@ from ocs_ci.ocs.resources.drpc import DRPC
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.utility.version import get_semantic_ocs_version_from_config
+from semantic_version import Version
+from ocs_ci.helpers.dr_helpers_ui import (
+    verify_pending_cleanup_alert_firing,
+    verify_pending_cleanup_alert_resolved,
+)
+from ocs_ci.ocs.acm.acm import AcmAddClusters
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +73,7 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         discovered_apps_dr_workload,
         nodes_multicluster,
         node_restart_teardown,
+        setup_acm_ui,
     ):
         """
         Tests to verify application failover and relocate with discovered applications
@@ -177,6 +185,25 @@ class TestFailoverAndRelocateWithDiscoveredApps:
             logger.info("Checking for Ceph Health OK")
             ceph_health_check()
 
+        # Verify ApplicationCleanupPending alert firing before cleanup (OCS 4.22+)
+        if get_semantic_ocs_version_from_config() >= Version("4.22", partial=True):
+            wait_time_for_alert = (
+                constants.ALERT_APPLICATION_CLEANUP_PENDING_THRESHOLD + 180
+            )
+            logger.info(
+                f"Waiting for {wait_time_for_alert} seconds for ApplicationCleanupPending alert to fire"
+            )
+            sleep(wait_time_for_alert)
+            acm_obj = AcmAddClusters()
+
+            # Verify alert firing for each workload
+            for rdr_workload in rdr_workloads:
+                verify_pending_cleanup_alert_firing(
+                    acm_obj,
+                    "Failover",
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                )
+
         for rdr_workload in rdr_workloads:
             logger.info("Doing Cleanup Operations")
             dr_helpers.do_discovered_apps_cleanup(
@@ -186,6 +213,16 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 workload_dir=rdr_workload.workload_dir,
                 vrg_name=rdr_workload.discovered_apps_placement_name,
             )
+
+        # Verify ApplicationCleanupPending alert resolved after cleanup (OCS 4.22+)
+        if get_semantic_ocs_version_from_config() >= Version("4.22", partial=True):
+            # Verify alert resolved for each workload
+            for rdr_workload in rdr_workloads:
+                verify_pending_cleanup_alert_resolved(
+                    acm_obj,
+                    "Failover",
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                )
 
         # Verify resources creation on secondary cluster (failoverCluster)
         config.switch_to_cluster_by_name(secondary_cluster_name)
@@ -257,7 +294,50 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                 discovered_apps=True,
                 old_primary=secondary_cluster_name,
                 workload_instance=rdr_workload,
+                vm_auto_cleanup=(
+                    get_semantic_ocs_version_from_config()
+                    >= Version("4.22", partial=True)
+                ),
             )
+
+        # Verify ApplicationCleanupPending alert firing after relocate (OCS 4.22+)
+        if get_semantic_ocs_version_from_config() >= Version("4.22", partial=True):
+            wait_time_for_alert = (
+                constants.ALERT_APPLICATION_CLEANUP_PENDING_THRESHOLD + 180
+            )
+            logger.info(
+                f"Waiting for {wait_time_for_alert} seconds for ApplicationCleanupPending alert to fire after Relocate"
+            )
+            sleep(wait_time_for_alert)
+            # Create fresh ACM UI session as previous session may have expired
+            acm_obj = AcmAddClusters()
+
+            # Verify alert firing for each workload
+            for rdr_workload in rdr_workloads:
+                verify_pending_cleanup_alert_firing(
+                    acm_obj,
+                    "Relocate",
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                )
+
+            # Manual cleanup after relocate
+            for rdr_workload in rdr_workloads:
+                logger.info("Doing Cleanup Operations after Relocate")
+                dr_helpers.do_discovered_apps_cleanup(
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                    old_primary=secondary_cluster_name,
+                    workload_namespace=rdr_workload.workload_namespace,
+                    workload_dir=rdr_workload.workload_dir,
+                    vrg_name=rdr_workload.discovered_apps_placement_name,
+                )
+
+            # Verify alert resolved for each workload
+            for rdr_workload in rdr_workloads:
+                verify_pending_cleanup_alert_resolved(
+                    acm_obj,
+                    "Relocate",
+                    drpc_name=rdr_workload.discovered_apps_placement_name,
+                )
 
         # Verify resources creation on primary cluster (preferredCluster)
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)


### PR DESCRIPTION
Added test coverage for the new ApplicationCleanupPending alert feature:
- Verify alert fires after DRPC enters WaitOnUserToCleanUp state for 15+ min
- Verify alert resolves after manual cleanup is performed
- Covers both Failover and Relocate operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced disaster-recovery verification by adding DR Dashboard UI checks for the **ApplicationCleanupPending** alert, covering both **when it starts firing** and **when it resolves** (with DRPC-scoped messaging when applicable).

* **Tests**
  * Updated failover and relocate scenarios for **OCS 4.22+** to validate the alert lifecycle per discovered-application workload, including threshold-aligned waits and confirmation before and after cleanup actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->