### PR TITLE
Add GetBucketVersioning check before replication with versioning suspension test

### DIFF
--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     get_obj_versions,
     put_bucket_versioning_via_awscli,
+    s3_get_bucket_versioning,
     update_replication_policy,
     upload_obj_versions,
     wait_for_object_versions_match,
@@ -290,6 +291,12 @@ class TestReplicationWithVersioning(MCGTest):
         put_bucket_versioning_via_awscli(
             mcg_obj, awscli_pod, target_bucket.name, status="Suspended"
         )
+
+        # Verify target versioning is actually Suspended before proceeding
+        target_versioning = s3_get_bucket_versioning(mcg_obj, target_bucket.name)
+        assert (
+            target_versioning.get("Status") == "Suspended"
+        ), f"Expected target bucket versioning to be Suspended, got: {target_versioning}"
 
         # 7. Write versions to the source bucket under a different object key
         obj_key = "test_obj_" + str(uuid4())[:4]

--- a/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
+++ b/tests/functional/object/mcg/test_bucket_replication_with_versioning.py
@@ -293,10 +293,16 @@ class TestReplicationWithVersioning(MCGTest):
         )
 
         # Verify target versioning is actually Suspended before proceeding
-        target_versioning = s3_get_bucket_versioning(mcg_obj, target_bucket.name)
-        assert (
-            target_versioning.get("Status") == "Suspended"
-        ), f"Expected target bucket versioning to be Suspended, got: {target_versioning}"
+        for target_versioning in TimeoutSampler(
+            timeout=60,
+            sleep=5,
+            func=s3_get_bucket_versioning,
+            s3_obj=mcg_obj,
+            bucketname=target_bucket.name,
+        ):
+            if target_versioning.get("Status") == "Suspended":
+                logger.info("Target bucket versioning is confirmed Suspended")
+                break
 
         # 7. Write versions to the source bucket under a different object key
         obj_key = "test_obj_" + str(uuid4())[:4]


### PR DESCRIPTION
Summary

  - Add explicit GetBucketVersioning verification in test_bucket_replication_with_versioning_suspension to confirm the target bucket's versioning is actually Suspended before proceeding with
  uploads and replication checks

Context: 

  Per investigation in [DFBUGS-7054](https://redhat.atlassian.net/browse/DFBUGS-7054), the test intermittently fails at step 8 with multiple versioned entries appearing on a target bucket that should have versioning Suspended. The NooBaa team
  asked whether we are verifying that the destination bucket is version-suspended before we write, to help isolate whether this is a versioning state propagation issue or a copyObject behavior
  issue.

This change adds a s3_get_bucket_versioning assertion after suspending versioning on the target bucket (step 6), so that if the suspension didn't take effect, the test fails early with a
  clear message rather than producing a confusing replication mismatch later.

In order to verify this PR - Run test_bucket_replication_with_versioning_suspension on ODF 4.19

Link to the bug: https://redhat.atlassian.net/browse/DFBUGS-7054 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of bucket replication tests by adding active checks for bucket versioning state before continuing, reducing intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->