### PR TITLE
Add happy path test for NooBaa denyHTTP feature ( RHSTOR-8118) 

### DIFF
--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -186,8 +186,11 @@ class TestDenyHTTP:
                     "",
                 ), f"Expected successful connection to {url}, got status {status_code}"
                 return True
-            else:
-                return True
+            assert status_code in (
+                "000",
+                "",
+            ), f"Expected connection to {url} to be refused, but got status {status_code}"
+            return True
         except Exception as e:
             if should_succeed:
                 raise AssertionError(
@@ -199,7 +202,6 @@ class TestDenyHTTP:
     @tier2
     @skipif_external_mode
     @skipif_ocs_version("<4.22")
-    @pytest.mark.polarion_id("OCS-XXXX")
     def test_deny_http_noobaa(self, mcg_obj, bucket_factory, revert_deny_http):
         """
         Test the denyHTTP feature on the NooBaa CR.
@@ -309,7 +311,6 @@ class TestDenyHTTP:
                 "HTTP access succeeded unexpectedly after denyHTTP was enabled"
             )
         except (
-            botocore.exceptions.ClientError,
             botocore.exceptions.EndpointConnectionError,
             botocore.exceptions.ConnectionClosedError,
             ConnectionError,

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -7,6 +7,7 @@ encrypted-only transport requirements.
 """
 
 import logging
+import time
 
 import boto3
 import botocore.exceptions
@@ -61,7 +62,7 @@ class TestDenyHTTP:
                     )
                     logger.info("Reverting denyHTTP to false on NooBaa CR")
                     noobaa_obj.patch(params=patch_param, format_type="json")
-            except Exception:
+            except KeyError:
                 logger.warning(
                     "denyHTTP field not found on NooBaa CR, no revert needed"
                 )
@@ -292,9 +293,9 @@ class TestDenyHTTP:
                 logger.info("S3 route insecureEdgeTerminationPolicy changed to 'None'")
                 break
 
-        updated_policy = nb_s3_route.data["spec"]["tls"][
-            "insecureEdgeTerminationPolicy"
-        ]
+        # Allow the route to settle to catch reconciliation flaps
+        time.sleep(RECONCILE_INTERVAL)
+        updated_policy = self._get_insecure_policy(nb_s3_route)
         assert (
             updated_policy == "None"
         ), f"Expected insecureEdgeTerminationPolicy to be 'None', got '{updated_policy}'"

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -222,6 +222,12 @@ class TestDenyHTTP:
            - Verify S3 route insecureEdgeTerminationPolicy changes to 'None'
            - Verify HTTP access to the bucket fails
            - Verify HTTPS access to the bucket still succeeds
+
+        3. Revert denyHTTP to restore HTTP access:
+           - Patch spec.multiCloudGateway.denyHTTP = false on the StorageCluster CR
+           - Verify S3 route insecureEdgeTerminationPolicy reverts to 'Allow'
+           - Verify HTTP access to the bucket succeeds again
+           - Verify HTTPS access to the bucket still succeeds
         """
 
         # --- Part 1: Verify default state (HTTP allowed) ---
@@ -348,6 +354,61 @@ class TestDenyHTTP:
         logger.info("Verifying access via curl after denyHTTP is enabled")
         self._verify_curl_access(
             mcg_obj.core_pod, f"http://{route_host}:80", should_succeed=False
+        )
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"https://{route_host}:443", should_succeed=True
+        )
+
+        # --- Part 3: Revert denyHTTP and verify HTTP is allowed again ---
+
+        logger.info("Part 3: Reverting denyHTTP to restore HTTP access")
+
+        revert_param = '[{"op": "replace", "path": "/spec/multiCloudGateway/denyHTTP", "value": false}]'
+        storagecluster_obj.patch(params=revert_param, format_type="json")
+        logger.info(
+            "Patched StorageCluster CR with spec.multiCloudGateway.denyHTTP=false"
+        )
+
+        logger.info("Waiting for S3 route to reconcile back to Allow")
+        for sample in TimeoutSampler(
+            timeout=RECONCILE_TIMEOUT,
+            sleep=RECONCILE_INTERVAL,
+            func=self._get_insecure_policy,
+            route_obj=nb_s3_route,
+        ):
+            if sample == "Allow":
+                logger.info(
+                    "S3 route insecureEdgeTerminationPolicy changed back to 'Allow'"
+                )
+                break
+
+        time.sleep(RECONCILE_INTERVAL)
+        reverted_policy = self._get_insecure_policy(nb_s3_route)
+        assert (
+            reverted_policy == "Allow"
+        ), f"Expected insecureEdgeTerminationPolicy to be 'Allow', got '{reverted_policy}'"
+
+        logger.info("Verifying HTTP access works again after reverting denyHTTP")
+        http_client_reverted = self._create_s3_client(
+            http_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        self._verify_s3_put_get(
+            http_client_reverted, bucket_name, object_key="http-reverted-obj"
+        )
+        logger.info("HTTP access succeeded as expected after reverting denyHTTP")
+
+        logger.info("Verifying HTTPS access still works after reverting denyHTTP")
+        https_client_reverted = self._create_s3_client(
+            https_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        self._verify_s3_put_get(
+            https_client_reverted, bucket_name, object_key="https-reverted-obj"
+        )
+        logger.info("HTTPS access succeeded as expected after reverting denyHTTP")
+
+        logger.info("Verifying access via curl after reverting denyHTTP")
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"http://{route_host}:80", should_succeed=True
         )
         self._verify_curl_access(
             mcg_obj.core_pod, f"https://{route_host}:443", should_succeed=True

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -318,12 +318,23 @@ class TestDenyHTTP:
             raise AssertionError(
                 "HTTP access succeeded unexpectedly after denyHTTP was enabled"
             )
+        except botocore.exceptions.ClientError as e:
+            error_code = int(e.response["Error"]["Code"])
+            assert error_code == 503, (
+                f"Expected HTTP 503 Service Unavailable, got {error_code}. "
+                "HTTP transport may still be functional."
+            )
+            logger.info(
+                "HTTP access returned 503 as expected after denyHTTP was enabled"
+            )
         except (
             botocore.exceptions.EndpointConnectionError,
             botocore.exceptions.ConnectionClosedError,
             ConnectionError,
         ):
-            logger.info("HTTP access failed as expected after denyHTTP was enabled")
+            logger.info(
+                "HTTP connection refused as expected after denyHTTP was enabled"
+            )
 
         logger.info("Verifying HTTPS access still works after denyHTTP is enabled")
         https_client_after = self._create_s3_client(

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -1,9 +1,9 @@
 """
 Tests for NooBaa denyHTTP feature (RHSTOR-8118).
 
-Validates that setting spec.denyHTTP on the NooBaa CR disables HTTP access
-to the S3 route while keeping HTTPS functional, ensuring compliance with
-encrypted-only transport requirements.
+Validates that setting spec.multiCloudGateway.denyHTTP on the StorageCluster CR
+disables HTTP access to the S3 route while keeping HTTPS functional, ensuring
+compliance with encrypted-only transport requirements.
 """
 
 import logging
@@ -44,9 +44,10 @@ class TestDenyHTTP:
     @pytest.fixture()
     def revert_deny_http(self, request):
         """
-        Teardown fixture that reverts spec.denyHTTP on the NooBaa CR
-        back to false and verifies the S3 route is restored to its
-        default insecureEdgeTerminationPolicy of Allow.
+        Teardown fixture that reverts spec.multiCloudGateway.denyHTTP
+        on the StorageCluster CR back to false and verifies the S3
+        route is restored to its default insecureEdgeTerminationPolicy
+        of Allow.
         """
 
         def finalizer():
@@ -207,7 +208,7 @@ class TestDenyHTTP:
     @skipif_ocs_version("<4.22")
     def test_deny_http_noobaa(self, mcg_obj, bucket_factory, revert_deny_http):
         """
-        Test the denyHTTP feature on the NooBaa CR.
+        Test the denyHTTP feature via the StorageCluster CR.
 
         This test validates the happy path for RHSTOR-8118:
 

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -1,0 +1,336 @@
+"""
+Tests for NooBaa denyHTTP feature (RHSTOR-8118).
+
+Validates that setting spec.denyHTTP on the NooBaa CR disables HTTP access
+to the S3 route while keeping HTTPS functional, ensuring compliance with
+encrypted-only transport requirements.
+"""
+
+import logging
+
+import boto3
+import botocore.exceptions
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    runs_on_provider,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier2,
+)
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.bucket_utils import retrieve_verification_mode
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+RECONCILE_TIMEOUT = 180
+RECONCILE_INTERVAL = 10
+
+
+@mcg
+@red_squad
+@runs_on_provider
+class TestDenyHTTP:
+    """
+    Test suite for the NooBaa denyHTTP feature that allows customers
+    to disable HTTP access on the S3 route, forcing HTTPS-only usage.
+    """
+
+    @pytest.fixture()
+    def revert_deny_http(self, request):
+        """
+        Teardown fixture that reverts spec.denyHTTP on the NooBaa CR
+        back to false and verifies the S3 route is restored to its
+        default insecureEdgeTerminationPolicy of Allow.
+        """
+
+        def finalizer():
+            noobaa_obj = ocp.OCP(
+                kind="noobaa",
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=constants.NOOBAA_RESOURCE_NAME,
+            )
+            try:
+                if noobaa_obj.data.get("spec", {}).get("denyHTTP"):
+                    patch_param = (
+                        '[{"op": "replace", "path": "/spec/denyHTTP", "value": false}]'
+                    )
+                    logger.info("Reverting denyHTTP to false on NooBaa CR")
+                    noobaa_obj.patch(params=patch_param, format_type="json")
+            except Exception:
+                logger.warning(
+                    "denyHTTP field not found on NooBaa CR, no revert needed"
+                )
+
+            nb_s3_route = ocp.OCP(
+                kind=constants.ROUTE,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name="s3",
+            )
+            for sample in TimeoutSampler(
+                timeout=RECONCILE_TIMEOUT,
+                sleep=RECONCILE_INTERVAL,
+                func=self._get_insecure_policy,
+                route_obj=nb_s3_route,
+            ):
+                if sample == "Allow":
+                    logger.info(
+                        "S3 route insecureEdgeTerminationPolicy reverted to Allow"
+                    )
+                    break
+
+        request.addfinalizer(finalizer)
+
+    @staticmethod
+    def _get_insecure_policy(route_obj):
+        """
+        Reload route data and return the current insecureEdgeTerminationPolicy.
+
+        Args:
+            route_obj (OCP): OCP object for the S3 route.
+
+        Returns:
+            str: The current insecureEdgeTerminationPolicy value.
+        """
+        route_obj.reload_data()
+        return route_obj.data["spec"]["tls"]["insecureEdgeTerminationPolicy"]
+
+    @staticmethod
+    def _get_s3_route_host():
+        """
+        Retrieve the hostname of the S3 route.
+
+        Returns:
+            str: The S3 route hostname.
+        """
+        nb_s3_route = ocp.OCP(
+            kind=constants.ROUTE,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name="s3",
+        )
+        return nb_s3_route.data["spec"]["host"]
+
+    @staticmethod
+    def _create_s3_client(endpoint_url, access_key_id, access_key):
+        """
+        Create a boto3 S3 client with the given endpoint URL and credentials.
+
+        Args:
+            endpoint_url (str): The S3 endpoint URL (http:// or https://).
+            access_key_id (str): AWS access key ID.
+            access_key (str): AWS secret access key.
+
+        Returns:
+            boto3.client: A boto3 S3 client.
+        """
+        s3_resource = boto3.resource(
+            "s3",
+            verify=retrieve_verification_mode(),
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=access_key,
+        )
+        return s3_resource.meta.client
+
+    @staticmethod
+    def _verify_s3_put_get(s3_client, bucket_name, object_key="test-deny-http-obj"):
+        """
+        Perform a put and get operation on a bucket to verify S3 access.
+
+        Args:
+            s3_client (boto3.client): A boto3 S3 client.
+            bucket_name (str): Name of the bucket to access.
+            object_key (str): Key for the test object.
+
+        Returns:
+            bool: True if put and get succeed.
+        """
+        test_data = "deny-http-test-data"
+        s3_client.put_object(Bucket=bucket_name, Key=object_key, Body=test_data)
+        response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+        retrieved_data = response["Body"].read().decode()
+        assert (
+            retrieved_data == test_data
+        ), f"Data mismatch: expected '{test_data}', got '{retrieved_data}'"
+        return True
+
+    @staticmethod
+    def _verify_curl_access(pod, url, should_succeed=True):
+        """
+        Verify HTTP/HTTPS access via curl from an in-cluster pod.
+
+        Args:
+            pod (Pod): Pod object to execute curl from.
+            url (str): URL to curl.
+            should_succeed (bool): Whether the request is expected to succeed.
+
+        Returns:
+            bool: True if the result matches the expectation.
+        """
+        cmd = f"curl -sk -o /dev/null -w '%{{http_code}}' --max-time 15 {url}"
+        try:
+            result = pod.exec_cmd_on_pod(
+                command=cmd,
+                out_yaml_format=False,
+                timeout=30,
+            )
+            status_code = str(result).strip().strip("'")
+            logger.info(f"Curl to {url} returned status code: {status_code}")
+            if should_succeed:
+                assert status_code not in (
+                    "000",
+                    "",
+                ), f"Expected successful connection to {url}, got status {status_code}"
+                return True
+            else:
+                return True
+        except Exception as e:
+            if should_succeed:
+                raise AssertionError(
+                    f"Expected successful curl to {url}, but got error: {e}"
+                )
+            logger.info(f"Curl to {url} failed as expected: {e}")
+            return True
+
+    @tier2
+    @skipif_external_mode
+    @skipif_ocs_version("<4.22")
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_deny_http_noobaa(self, mcg_obj, bucket_factory, revert_deny_http):
+        """
+        Test the denyHTTP feature on the NooBaa CR.
+
+        This test validates the happy path for RHSTOR-8118:
+
+        1. Verify default state:
+           - S3 route insecureEdgeTerminationPolicy is 'Allow'
+           - HTTP access to a bucket succeeds
+           - HTTPS access to a bucket succeeds
+
+        2. Enable denyHTTP on NooBaa CR:
+           - Patch spec.denyHTTP = true on the NooBaa CR
+           - Verify S3 route insecureEdgeTerminationPolicy changes to 'None'
+           - Verify HTTP access to the bucket fails
+           - Verify HTTPS access to the bucket still succeeds
+        """
+
+        # --- Part 1: Verify default state (HTTP allowed) ---
+
+        logger.info("Part 1: Verifying default state with HTTP allowed")
+
+        nb_s3_route = ocp.OCP(
+            kind=constants.ROUTE,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name="s3",
+        )
+        current_policy = nb_s3_route.data["spec"]["tls"][
+            "insecureEdgeTerminationPolicy"
+        ]
+        assert (
+            current_policy == "Allow"
+        ), f"Expected insecureEdgeTerminationPolicy to be 'Allow', got '{current_policy}'"
+        logger.info(
+            f"S3 route insecureEdgeTerminationPolicy is '{current_policy}' as expected"
+        )
+
+        bucket_name = bucket_factory()[0].name
+        logger.info(f"Created test bucket: {bucket_name}")
+
+        route_host = self._get_s3_route_host()
+        http_endpoint = f"http://{route_host}:80"
+        https_endpoint = mcg_obj.s3_endpoint
+
+        logger.info(f"Testing HTTP access via {http_endpoint}")
+        http_client = self._create_s3_client(
+            http_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        self._verify_s3_put_get(http_client, bucket_name, object_key="http-test-obj")
+        logger.info("HTTP access succeeded as expected")
+
+        logger.info(f"Testing HTTPS access via {https_endpoint}")
+        https_client = self._create_s3_client(
+            https_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        self._verify_s3_put_get(https_client, bucket_name, object_key="https-test-obj")
+        logger.info("HTTPS access succeeded as expected")
+
+        logger.info("Verifying access via curl from NooBaa core pod")
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"http://{route_host}:80", should_succeed=True
+        )
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"https://{route_host}:443", should_succeed=True
+        )
+
+        # --- Part 2: Enable denyHTTP and verify ---
+
+        logger.info("Part 2: Enabling denyHTTP on the NooBaa CR")
+
+        noobaa_obj = ocp.OCP(
+            kind="noobaa",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=constants.NOOBAA_RESOURCE_NAME,
+        )
+        patch_param = '[{"op": "add", "path": "/spec/denyHTTP", "value": true}]'
+        noobaa_obj.patch(params=patch_param, format_type="json")
+        logger.info("Patched NooBaa CR with spec.denyHTTP=true")
+
+        logger.info("Waiting for S3 route to reconcile")
+        for sample in TimeoutSampler(
+            timeout=RECONCILE_TIMEOUT,
+            sleep=RECONCILE_INTERVAL,
+            func=self._get_insecure_policy,
+            route_obj=nb_s3_route,
+        ):
+            if sample == "None":
+                logger.info("S3 route insecureEdgeTerminationPolicy changed to 'None'")
+                break
+
+        updated_policy = nb_s3_route.data["spec"]["tls"][
+            "insecureEdgeTerminationPolicy"
+        ]
+        assert (
+            updated_policy == "None"
+        ), f"Expected insecureEdgeTerminationPolicy to be 'None', got '{updated_policy}'"
+
+        logger.info("Verifying HTTP access fails after denyHTTP is enabled")
+        http_client_after = self._create_s3_client(
+            http_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        try:
+            self._verify_s3_put_get(
+                http_client_after, bucket_name, object_key="http-denied-obj"
+            )
+            raise AssertionError(
+                "HTTP access succeeded unexpectedly after denyHTTP was enabled"
+            )
+        except (
+            botocore.exceptions.ClientError,
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ConnectionClosedError,
+            ConnectionError,
+        ):
+            logger.info("HTTP access failed as expected after denyHTTP was enabled")
+
+        logger.info("Verifying HTTPS access still works after denyHTTP is enabled")
+        https_client_after = self._create_s3_client(
+            https_endpoint, mcg_obj.access_key_id, mcg_obj.access_key
+        )
+        self._verify_s3_put_get(
+            https_client_after, bucket_name, object_key="https-after-deny-obj"
+        )
+        logger.info("HTTPS access succeeded as expected after denyHTTP was enabled")
+
+        logger.info("Verifying access via curl after denyHTTP is enabled")
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"http://{route_host}:80", should_succeed=False
+        )
+        self._verify_curl_access(
+            mcg_obj.core_pod, f"https://{route_host}:443", should_succeed=True
+        )
+
+        logger.info("denyHTTP happy path test completed successfully")

--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -50,21 +50,23 @@ class TestDenyHTTP:
         """
 
         def finalizer():
-            noobaa_obj = ocp.OCP(
-                kind="noobaa",
+            storagecluster_obj = ocp.OCP(
+                kind=constants.STORAGECLUSTER,
                 namespace=config.ENV_DATA["cluster_namespace"],
-                resource_name=constants.NOOBAA_RESOURCE_NAME,
+                resource_name=constants.DEFAULT_CLUSTERNAME,
             )
             try:
-                if noobaa_obj.data.get("spec", {}).get("denyHTTP"):
-                    patch_param = (
-                        '[{"op": "replace", "path": "/spec/denyHTTP", "value": false}]'
-                    )
-                    logger.info("Reverting denyHTTP to false on NooBaa CR")
-                    noobaa_obj.patch(params=patch_param, format_type="json")
+                if (
+                    storagecluster_obj.data.get("spec", {})
+                    .get("multiCloudGateway", {})
+                    .get("denyHTTP")
+                ):
+                    patch_param = '[{"op": "replace", "path": "/spec/multiCloudGateway/denyHTTP", "value": false}]'
+                    logger.info("Reverting denyHTTP to false on StorageCluster CR")
+                    storagecluster_obj.patch(params=patch_param, format_type="json")
             except KeyError:
                 logger.warning(
-                    "denyHTTP field not found on NooBaa CR, no revert needed"
+                    "denyHTTP field not found on StorageCluster CR, no revert needed"
                 )
 
             nb_s3_route = ocp.OCP(
@@ -214,8 +216,8 @@ class TestDenyHTTP:
            - HTTP access to a bucket succeeds
            - HTTPS access to a bucket succeeds
 
-        2. Enable denyHTTP on NooBaa CR:
-           - Patch spec.denyHTTP = true on the NooBaa CR
+        2. Enable denyHTTP via StorageCluster CR:
+           - Patch spec.multiCloudGateway.denyHTTP = true on the StorageCluster CR
            - Verify S3 route insecureEdgeTerminationPolicy changes to 'None'
            - Verify HTTP access to the bucket fails
            - Verify HTTPS access to the bucket still succeeds
@@ -271,16 +273,20 @@ class TestDenyHTTP:
 
         # --- Part 2: Enable denyHTTP and verify ---
 
-        logger.info("Part 2: Enabling denyHTTP on the NooBaa CR")
+        logger.info("Part 2: Enabling denyHTTP via the StorageCluster CR")
 
-        noobaa_obj = ocp.OCP(
-            kind="noobaa",
+        storagecluster_obj = ocp.OCP(
+            kind=constants.STORAGECLUSTER,
             namespace=config.ENV_DATA["cluster_namespace"],
-            resource_name=constants.NOOBAA_RESOURCE_NAME,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
         )
-        patch_param = '[{"op": "add", "path": "/spec/denyHTTP", "value": true}]'
-        noobaa_obj.patch(params=patch_param, format_type="json")
-        logger.info("Patched NooBaa CR with spec.denyHTTP=true")
+        patch_param = (
+            '[{"op": "add", "path": "/spec/multiCloudGateway/denyHTTP", "value": true}]'
+        )
+        storagecluster_obj.patch(params=patch_param, format_type="json")
+        logger.info(
+            "Patched StorageCluster CR with spec.multiCloudGateway.denyHTTP=true"
+        )
 
         logger.info("Waiting for S3 route to reconcile")
         for sample in TimeoutSampler(


### PR DESCRIPTION
The test (test_deny_http_noobaa) validates the denyHTTP feature ([RHSTOR-8118](https://redhat.atlassian.net/browse/RHSTOR-8118)) in three phases:

  Part 1 — Verify default state (HTTP allowed)

  1. Get the S3 route and confirm insecureEdgeTerminationPolicy is Allow
  2. Create a test bucket via bucket_factory
  3. Access the bucket over HTTP using a boto3 S3 client — verify put/get succeeds
  4. Access the bucket over HTTPS using a boto3 S3 client — verify put/get succeeds
  5. Verify HTTP and HTTPS access via curl from the NooBaa core pod

  Part 2 — Enable denyHTTP via the StorageCluster CR

  1. Patch the StorageCluster CR with spec.multiCloudGateway.denyHTTP: true
  2. Wait for the S3 route to reconcile (poll until insecureEdgeTerminationPolicy changes to None)
  3. Sleep to catch reconciliation flaps, then re-verify insecureEdgeTerminationPolicy is None
  4. Access the bucket over HTTP — verify it fails (expects HTTP 503 or connection refused)
  5. Access the bucket over HTTPS — verify it still succeeds
  6. Verify HTTP failure and HTTPS success via curl from the NooBaa core pod

  Part 3 — Revert denyHTTP and verify HTTP is allowed again

  1. Patch the StorageCluster CR with spec.multiCloudGateway.denyHTTP: false
  2. Wait for the S3 route to reconcile back (insecureEdgeTerminationPolicy returns to Allow)
  3. Sleep to catch reconciliation flaps, then re-verify insecureEdgeTerminationPolicy is Allow
  4. Access the bucket over HTTP — verify it succeeds again
  5. Access the bucket over HTTPS — verify it still succeeds
  6. Verify HTTP and HTTPS access via curl from the NooBaa core pod

  Teardown

  - Reverts spec.multiCloudGateway.denyHTTP to false on the StorageCluster CR
  - Waits for the S3 route to revert insecureEdgeTerminationPolicy back to Allow

  Markers

  - @tier2, @mcg, @red_squad, @runs_on_provider
  - @skipif_external_mode, @skipif_ocs_version("<4.22")



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end functional test for denyHTTP: verifies default HTTP is allowed, creates a bucket and confirms S3 operations over both HTTP and HTTPS, enables denyHTTP and confirms HTTP-based S3 access is blocked while HTTPS remains available, validates pod-level HTTP/HTTPS reachability, and includes teardown to revert the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->