### PR TITLE
NooBaa bucket tagging testcase

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3687,22 +3687,25 @@ def verify_bucket_tagging_matches_labels(
     )
 
 
-def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
+def get_noobaa_bucket_tagging_metric_results(
+    metric_name, bucket_name, threading_lock, timeout=30
+):
     """
-    Query Prometheus for a NooBaa bucket metric filtered by bucket_name.
+    Query Prometheus for NooBaa bucket tagging metric series filtered by bucket_name.
 
     Args:
-        metric_name (str): Prometheus metric name
+        metric_name (str): Prometheus metric name (e.g. NooBaa_bucket_tagging)
         bucket_name (str): Bucket name label value
         threading_lock: Threading lock for PrometheusAPI
+        timeout (int): Prometheus query timeout in seconds
 
     Returns:
-        int or None: Metric value if present, None if the metric is not found
+        list: Prometheus query result entries for the bucket
     """
     query = f'{metric_name}{{bucket_name="{bucket_name}"}}'
     api = PrometheusAPI(threading_lock=threading_lock)
     logger.info(f"Prometheus query: {query}")
-    resp = api.get("query", payload={"query": query}, timeout=120)
+    resp = api.get("query", payload={"query": query}, timeout=timeout)
     if not resp.ok:
         raise Exception(
             f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
@@ -3711,7 +3714,71 @@ def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
     results = metrics_output.get("data", {}).get("result", [])
     if not results:
         logger.info(f"No results for metric {metric_name} on bucket {bucket_name}")
-        return None
-    value = int(float(results[0]["value"][1]))
-    logger.info(f"Metric {metric_name} for bucket {bucket_name}: {value}")
-    return value
+    return results
+
+
+def _noobaa_tagging_label_contains_labels(tagging_label, expected_labels):
+    """
+    Check whether a NooBaa_bucket_tagging ``tagging`` label contains expected tags.
+
+    NooBaa formats each tag as ``{ key : value }`` in the label value.
+    """
+    return all(
+        f"{{ {key} : {value} }}" in tagging_label
+        for key, value in expected_labels.items()
+    )
+
+
+def verify_noobaa_bucket_tagging_metric(
+    metric_name,
+    bucket_name,
+    expected_labels,
+    threading_lock,
+    timeout=360,
+    sleep=15,
+):
+    """
+    Wait until NooBaa bucket tagging metrics reflect the expected labels.
+
+    The metric is a gauge updated by the stats aggregator (roughly every 5
+    minutes), so callers should use a timeout that covers at least one cycle.
+
+    Args:
+        metric_name (str): Prometheus metric name
+        bucket_name (str): Bucket name label value
+        expected_labels (dict): Labels that should appear in the tagging label
+        threading_lock: Threading lock for PrometheusAPI
+        timeout (int): Timeout in seconds
+        sleep (int): Sleep interval between checks
+
+    Returns:
+        list: Matching Prometheus query result entries
+
+    Raises:
+        TimeoutExpiredError: If the metric does not match within the timeout
+    """
+    for results in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_noobaa_bucket_tagging_metric_results,
+        metric_name=metric_name,
+        bucket_name=bucket_name,
+        threading_lock=threading_lock,
+    ):
+        matching_results = [
+            result
+            for result in results
+            if _noobaa_tagging_label_contains_labels(
+                result.get("metric", {}).get("tagging", ""), expected_labels
+            )
+        ]
+        if matching_results:
+            logger.info(
+                f"Metric {metric_name} for bucket {bucket_name} reflects "
+                f"expected labels {expected_labels}: {matching_results}"
+            )
+            return matching_results
+    raise TimeoutExpiredError(
+        f"Metric {metric_name} for bucket {bucket_name} did not reflect "
+        f"expected labels {expected_labels} within {timeout}s"
+    )

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3681,10 +3681,6 @@ def verify_bucket_tagging_matches_labels(
                 f"{expected_labels}"
             )
             return bucket_tags
-    raise TimeoutExpiredError(
-        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
-        f"within {timeout}s"
-    )
 
 
 def get_noobaa_bucket_tagging_metric_results(

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3618,3 +3618,100 @@ def get_bucket_status_value(mcg_obj, bucket_name, key):
     op = bucket_status.split("\n")
     value = next(item.split(":")[1].strip() for item in op if key in item)
     return value
+
+
+def get_bucket_tagging(s3_client, bucket_name):
+    """
+    Get S3 bucket tagging via the S3 API.
+
+    Args:
+        s3_client: boto3 S3 client with credentials for the bucket
+        bucket_name (str): Name of the S3 bucket
+
+    Returns:
+        list: TagSet from get_bucket_tagging response
+
+    Raises:
+        botocore.exceptions.ClientError: When tagging is not set (NoSuchTagSet)
+    """
+    response = s3_client.get_bucket_tagging(Bucket=bucket_name)
+    return response.get("TagSet", [])
+
+
+def tag_set_to_dict(tag_set):
+    """
+    Convert S3 TagSet to a key-value dictionary.
+
+    Args:
+        tag_set (list): List of dicts with Key and Value keys
+
+    Returns:
+        dict: Mapping of tag keys to values
+    """
+    return {tag["Key"]: tag["Value"] for tag in tag_set}
+
+
+def verify_bucket_tagging_matches_labels(
+    s3_client, bucket_name, expected_labels, timeout=180, sleep=10
+):
+    """
+    Wait until bucket S3 tags include the expected label key-value pairs.
+
+    Args:
+        s3_client: boto3 S3 client with credentials for the bucket
+        bucket_name (str): Name of the S3 bucket
+        expected_labels (dict): Labels that should appear as bucket tags
+        timeout (int): Timeout in seconds
+        sleep (int): Sleep interval between checks
+
+    Raises:
+        TimeoutExpiredError: If tags do not match within the timeout
+    """
+    for tag_set in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_bucket_tagging,
+        s3_client=s3_client,
+        bucket_name=bucket_name,
+    ):
+        bucket_tags = tag_set_to_dict(tag_set)
+        if all(bucket_tags.get(key) == value for key, value in expected_labels.items()):
+            logger.info(
+                f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
+                f"{expected_labels}"
+            )
+            return bucket_tags
+    raise TimeoutExpiredError(
+        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
+        f"within {timeout}s"
+    )
+
+
+def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
+    """
+    Query Prometheus for a NooBaa bucket metric filtered by bucket_name.
+
+    Args:
+        metric_name (str): Prometheus metric name
+        bucket_name (str): Bucket name label value
+        threading_lock: Threading lock for PrometheusAPI
+
+    Returns:
+        int or None: Metric value if present, None if the metric is not found
+    """
+    query = f'{metric_name}{{bucket_name="{bucket_name}"}}'
+    api = PrometheusAPI(threading_lock=threading_lock)
+    logger.info(f"Prometheus query: {query}")
+    resp = api.get("query", payload={"query": query}, timeout=120)
+    if not resp.ok:
+        raise Exception(
+            f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
+        )
+    metrics_output = json.loads(resp.text)
+    results = metrics_output.get("data", {}).get("result", [])
+    if not results:
+        logger.info(f"No results for metric {metric_name} on bucket {bucket_name}")
+        return None
+    value = int(float(results[0]["value"][1]))
+    logger.info(f"Metric {metric_name} for bucket {bucket_name}: {value}")
+    return value

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3948,22 +3948,22 @@ def assert_store_phase_and_mode(
         raise
 
 
-def get_bucket_tagging(s3_client, bucket_name):
+def get_bucket_tagging(s3_obj, bucket_name):
     """
     Get S3 bucket tagging via the S3 API.
 
     Args:
-        s3_client: boto3 S3 client with credentials for the bucket
+        s3_obj (obj): MCG or OBC object
         bucket_name (str): Name of the S3 bucket
 
     Returns:
-        list: TagSet from get_bucket_tagging response
+        dict: Full get_bucket_tagging response
 
     Raises:
         botocore.exceptions.ClientError: When tagging is not set (NoSuchTagSet)
     """
-    response = s3_client.get_bucket_tagging(Bucket=bucket_name)
-    return response.get("TagSet", [])
+    response = s3_obj.s3_client.get_bucket_tagging(Bucket=bucket_name)
+    return response
 
 
 def tag_set_to_dict(tag_set):
@@ -3980,35 +3980,42 @@ def tag_set_to_dict(tag_set):
 
 
 def verify_bucket_tagging_matches_labels(
-    s3_client, bucket_name, expected_labels, timeout=180, sleep=10
+    s3_obj, bucket_name, expected_labels, timeout=180, sleep=10
 ):
     """
     Wait until bucket S3 tags include the expected label key-value pairs.
 
     Args:
-        s3_client: boto3 S3 client with credentials for the bucket
+        s3_obj (obj): MCG or OBC object
         bucket_name (str): Name of the S3 bucket
         expected_labels (dict): Labels that should appear as bucket tags
         timeout (int): Timeout in seconds
         sleep (int): Sleep interval between checks
 
+    Returns:
+        dict: Full get_bucket_tagging response once expected labels are present
+
     Raises:
         TimeoutExpiredError: If tags do not match within the timeout
     """
-    for tag_set in TimeoutSampler(
+    for response in TimeoutSampler(
         timeout=timeout,
         sleep=sleep,
         func=get_bucket_tagging,
-        s3_client=s3_client,
+        s3_obj=s3_obj,
         bucket_name=bucket_name,
     ):
-        bucket_tags = tag_set_to_dict(tag_set)
+        bucket_tags = tag_set_to_dict(response.get("TagSet", []))
         if all(bucket_tags.get(key) == value for key, value in expected_labels.items()):
             logger.info(
                 f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
                 f"{expected_labels}"
             )
-            return bucket_tags
+            return response
+    raise TimeoutExpiredError(
+        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
+        f"within {timeout}s"
+    )
 
 
 def get_noobaa_bucket_tagging_metric_results(

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3620,22 +3620,22 @@ def get_bucket_status_value(mcg_obj, bucket_name, key):
     return value
 
 
-def get_bucket_tagging(s3_client, bucket_name):
+def get_bucket_tagging(s3_obj, bucket_name):
     """
     Get S3 bucket tagging via the S3 API.
 
     Args:
-        s3_client: boto3 S3 client with credentials for the bucket
+        s3_obj (obj): MCG or OBC object
         bucket_name (str): Name of the S3 bucket
 
     Returns:
-        list: TagSet from get_bucket_tagging response
+        dict: Full get_bucket_tagging response
 
     Raises:
         botocore.exceptions.ClientError: When tagging is not set (NoSuchTagSet)
     """
-    response = s3_client.get_bucket_tagging(Bucket=bucket_name)
-    return response.get("TagSet", [])
+    response = s3_obj.s3_client.get_bucket_tagging(Bucket=bucket_name)
+    return response
 
 
 def tag_set_to_dict(tag_set):
@@ -3652,35 +3652,42 @@ def tag_set_to_dict(tag_set):
 
 
 def verify_bucket_tagging_matches_labels(
-    s3_client, bucket_name, expected_labels, timeout=180, sleep=10
+    s3_obj, bucket_name, expected_labels, timeout=180, sleep=10
 ):
     """
     Wait until bucket S3 tags include the expected label key-value pairs.
 
     Args:
-        s3_client: boto3 S3 client with credentials for the bucket
+        s3_obj (obj): MCG or OBC object
         bucket_name (str): Name of the S3 bucket
         expected_labels (dict): Labels that should appear as bucket tags
         timeout (int): Timeout in seconds
         sleep (int): Sleep interval between checks
 
+    Returns:
+        dict: Full get_bucket_tagging response once expected labels are present
+
     Raises:
         TimeoutExpiredError: If tags do not match within the timeout
     """
-    for tag_set in TimeoutSampler(
+    for response in TimeoutSampler(
         timeout=timeout,
         sleep=sleep,
         func=get_bucket_tagging,
-        s3_client=s3_client,
+        s3_obj=s3_obj,
         bucket_name=bucket_name,
     ):
-        bucket_tags = tag_set_to_dict(tag_set)
+        bucket_tags = tag_set_to_dict(response.get("TagSet", []))
         if all(bucket_tags.get(key) == value for key, value in expected_labels.items()):
             logger.info(
                 f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
                 f"{expected_labels}"
             )
-            return bucket_tags
+            return response
+    raise TimeoutExpiredError(
+        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
+        f"within {timeout}s"
+    )
 
 
 def get_noobaa_bucket_tagging_metric_results(

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3785,7 +3785,7 @@ def get_noobaa_bucket_replication_metrics_in_prometheus(
         logger.info(f"Metrics {metric_name} : {got_metrics_value}")
         return got_metrics_value
     else:
-        raise Exception(
+        raise UnexpectedBehaviour(
             f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
         )
 
@@ -4047,7 +4047,7 @@ def get_noobaa_bucket_tagging_metric_results(
     logger.info(f"Prometheus query: {query}")
     resp = api.get("query", payload={"query": query}, timeout=timeout)
     if not resp.ok:
-        raise Exception(
+        raise UnexpectedBehaviour(
             f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
         )
     metrics_output = json.loads(resp.text)

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -4009,10 +4009,6 @@ def verify_bucket_tagging_matches_labels(
                 f"{expected_labels}"
             )
             return bucket_tags
-    raise TimeoutExpiredError(
-        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
-        f"within {timeout}s"
-    )
 
 
 def get_noobaa_bucket_tagging_metric_results(

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -4015,22 +4015,25 @@ def verify_bucket_tagging_matches_labels(
     )
 
 
-def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
+def get_noobaa_bucket_tagging_metric_results(
+    metric_name, bucket_name, threading_lock, timeout=30
+):
     """
-    Query Prometheus for a NooBaa bucket metric filtered by bucket_name.
+    Query Prometheus for NooBaa bucket tagging metric series filtered by bucket_name.
 
     Args:
-        metric_name (str): Prometheus metric name
+        metric_name (str): Prometheus metric name (e.g. NooBaa_bucket_tagging)
         bucket_name (str): Bucket name label value
         threading_lock: Threading lock for PrometheusAPI
+        timeout (int): Prometheus query timeout in seconds
 
     Returns:
-        int or None: Metric value if present, None if the metric is not found
+        list: Prometheus query result entries for the bucket
     """
     query = f'{metric_name}{{bucket_name="{bucket_name}"}}'
     api = PrometheusAPI(threading_lock=threading_lock)
     logger.info(f"Prometheus query: {query}")
-    resp = api.get("query", payload={"query": query}, timeout=120)
+    resp = api.get("query", payload={"query": query}, timeout=timeout)
     if not resp.ok:
         raise Exception(
             f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
@@ -4039,7 +4042,71 @@ def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
     results = metrics_output.get("data", {}).get("result", [])
     if not results:
         logger.info(f"No results for metric {metric_name} on bucket {bucket_name}")
-        return None
-    value = int(float(results[0]["value"][1]))
-    logger.info(f"Metric {metric_name} for bucket {bucket_name}: {value}")
-    return value
+    return results
+
+
+def _noobaa_tagging_label_contains_labels(tagging_label, expected_labels):
+    """
+    Check whether a NooBaa_bucket_tagging ``tagging`` label contains expected tags.
+
+    NooBaa formats each tag as ``{ key : value }`` in the label value.
+    """
+    return all(
+        f"{{ {key} : {value} }}" in tagging_label
+        for key, value in expected_labels.items()
+    )
+
+
+def verify_noobaa_bucket_tagging_metric(
+    metric_name,
+    bucket_name,
+    expected_labels,
+    threading_lock,
+    timeout=360,
+    sleep=15,
+):
+    """
+    Wait until NooBaa bucket tagging metrics reflect the expected labels.
+
+    The metric is a gauge updated by the stats aggregator (roughly every 5
+    minutes), so callers should use a timeout that covers at least one cycle.
+
+    Args:
+        metric_name (str): Prometheus metric name
+        bucket_name (str): Bucket name label value
+        expected_labels (dict): Labels that should appear in the tagging label
+        threading_lock: Threading lock for PrometheusAPI
+        timeout (int): Timeout in seconds
+        sleep (int): Sleep interval between checks
+
+    Returns:
+        list: Matching Prometheus query result entries
+
+    Raises:
+        TimeoutExpiredError: If the metric does not match within the timeout
+    """
+    for results in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_noobaa_bucket_tagging_metric_results,
+        metric_name=metric_name,
+        bucket_name=bucket_name,
+        threading_lock=threading_lock,
+    ):
+        matching_results = [
+            result
+            for result in results
+            if _noobaa_tagging_label_contains_labels(
+                result.get("metric", {}).get("tagging", ""), expected_labels
+            )
+        ]
+        if matching_results:
+            logger.info(
+                f"Metric {metric_name} for bucket {bucket_name} reflects "
+                f"expected labels {expected_labels}: {matching_results}"
+            )
+            return matching_results
+    raise TimeoutExpiredError(
+        f"Metric {metric_name} for bucket {bucket_name} did not reflect "
+        f"expected labels {expected_labels} within {timeout}s"
+    )

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3998,24 +3998,33 @@ def verify_bucket_tagging_matches_labels(
     Raises:
         TimeoutExpiredError: If tags do not match within the timeout
     """
-    for response in TimeoutSampler(
-        timeout=timeout,
-        sleep=sleep,
-        func=get_bucket_tagging,
-        s3_obj=s3_obj,
-        bucket_name=bucket_name,
-    ):
-        bucket_tags = tag_set_to_dict(response.get("TagSet", []))
-        if all(bucket_tags.get(key) == value for key, value in expected_labels.items()):
-            logger.info(
-                f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
-                f"{expected_labels}"
-            )
-            return response
-    raise TimeoutExpiredError(
-        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
-        f"within {timeout}s"
-    )
+    last_bucket_tags = {}
+    try:
+        for response in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_bucket_tagging,
+            s3_obj=s3_obj,
+            bucket_name=bucket_name,
+        ):
+            bucket_tags = tag_set_to_dict(response.get("TagSet", []))
+            last_bucket_tags = bucket_tags
+            if all(
+                bucket_tags.get(key) == value for key, value in expected_labels.items()
+            ):
+                logger.info(
+                    f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
+                    f"{expected_labels}"
+                )
+                return response
+    except TimeoutExpiredError as e:
+        err_msg = (
+            f"Bucket {bucket_name} tags did not match expected labels "
+            f"{expected_labels} within {timeout}s. "
+            f"Last observed tags: {last_bucket_tags}"
+        )
+        logger.error(err_msg)
+        raise TimeoutExpiredError(f"{str(e)}\n\n{err_msg}") from e
 
 
 def get_noobaa_bucket_tagging_metric_results(
@@ -4088,28 +4097,35 @@ def verify_noobaa_bucket_tagging_metric(
     Raises:
         TimeoutExpiredError: If the metric does not match within the timeout
     """
-    for results in TimeoutSampler(
-        timeout=timeout,
-        sleep=sleep,
-        func=get_noobaa_bucket_tagging_metric_results,
-        metric_name=metric_name,
-        bucket_name=bucket_name,
-        threading_lock=threading_lock,
-    ):
-        matching_results = [
-            result
-            for result in results
-            if _noobaa_tagging_label_contains_labels(
-                result.get("metric", {}).get("tagging", ""), expected_labels
-            )
-        ]
-        if matching_results:
-            logger.info(
-                f"Metric {metric_name} for bucket {bucket_name} reflects "
-                f"expected labels {expected_labels}: {matching_results}"
-            )
-            return matching_results
-    raise TimeoutExpiredError(
-        f"Metric {metric_name} for bucket {bucket_name} did not reflect "
-        f"expected labels {expected_labels} within {timeout}s"
-    )
+    last_results = []
+    try:
+        for results in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_noobaa_bucket_tagging_metric_results,
+            metric_name=metric_name,
+            bucket_name=bucket_name,
+            threading_lock=threading_lock,
+        ):
+            last_results = results
+            matching_results = [
+                result
+                for result in results
+                if _noobaa_tagging_label_contains_labels(
+                    result.get("metric", {}).get("tagging", ""), expected_labels
+                )
+            ]
+            if matching_results:
+                logger.info(
+                    f"Metric {metric_name} for bucket {bucket_name} reflects "
+                    f"expected labels {expected_labels}: {matching_results}"
+                )
+                return matching_results
+    except TimeoutExpiredError as e:
+        err_msg = (
+            f"Metric {metric_name} for bucket {bucket_name} did not reflect "
+            f"expected labels {expected_labels} within {timeout}s. "
+            f"Last observed results: {last_results}"
+        )
+        logger.error(err_msg)
+        raise TimeoutExpiredError(f"{str(e)}\n\n{err_msg}") from e

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3946,3 +3946,100 @@ def assert_store_phase_and_mode(
             f"{expected_mode} within {timeout}s"
         )
         raise
+
+
+def get_bucket_tagging(s3_client, bucket_name):
+    """
+    Get S3 bucket tagging via the S3 API.
+
+    Args:
+        s3_client: boto3 S3 client with credentials for the bucket
+        bucket_name (str): Name of the S3 bucket
+
+    Returns:
+        list: TagSet from get_bucket_tagging response
+
+    Raises:
+        botocore.exceptions.ClientError: When tagging is not set (NoSuchTagSet)
+    """
+    response = s3_client.get_bucket_tagging(Bucket=bucket_name)
+    return response.get("TagSet", [])
+
+
+def tag_set_to_dict(tag_set):
+    """
+    Convert S3 TagSet to a key-value dictionary.
+
+    Args:
+        tag_set (list): List of dicts with Key and Value keys
+
+    Returns:
+        dict: Mapping of tag keys to values
+    """
+    return {tag["Key"]: tag["Value"] for tag in tag_set}
+
+
+def verify_bucket_tagging_matches_labels(
+    s3_client, bucket_name, expected_labels, timeout=180, sleep=10
+):
+    """
+    Wait until bucket S3 tags include the expected label key-value pairs.
+
+    Args:
+        s3_client: boto3 S3 client with credentials for the bucket
+        bucket_name (str): Name of the S3 bucket
+        expected_labels (dict): Labels that should appear as bucket tags
+        timeout (int): Timeout in seconds
+        sleep (int): Sleep interval between checks
+
+    Raises:
+        TimeoutExpiredError: If tags do not match within the timeout
+    """
+    for tag_set in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_bucket_tagging,
+        s3_client=s3_client,
+        bucket_name=bucket_name,
+    ):
+        bucket_tags = tag_set_to_dict(tag_set)
+        if all(bucket_tags.get(key) == value for key, value in expected_labels.items()):
+            logger.info(
+                f"Bucket {bucket_name} tags {bucket_tags} match expected labels "
+                f"{expected_labels}"
+            )
+            return bucket_tags
+    raise TimeoutExpiredError(
+        f"Bucket {bucket_name} tags did not match expected labels {expected_labels} "
+        f"within {timeout}s"
+    )
+
+
+def get_noobaa_bucket_metric_value(metric_name, bucket_name, threading_lock):
+    """
+    Query Prometheus for a NooBaa bucket metric filtered by bucket_name.
+
+    Args:
+        metric_name (str): Prometheus metric name
+        bucket_name (str): Bucket name label value
+        threading_lock: Threading lock for PrometheusAPI
+
+    Returns:
+        int or None: Metric value if present, None if the metric is not found
+    """
+    query = f'{metric_name}{{bucket_name="{bucket_name}"}}'
+    api = PrometheusAPI(threading_lock=threading_lock)
+    logger.info(f"Prometheus query: {query}")
+    resp = api.get("query", payload={"query": query}, timeout=120)
+    if not resp.ok:
+        raise Exception(
+            f"Failed to query Prometheus for metric {metric_name}: {resp.text}"
+        )
+    metrics_output = json.loads(resp.text)
+    results = metrics_output.get("data", {}).get("result", [])
+    if not results:
+        logger.info(f"No results for metric {metric_name} on bucket {bucket_name}")
+        return None
+    value = int(float(results[0]["value"][1]))
+    logger.info(f"Metric {metric_name} for bucket {bucket_name}: {value}")
+    return value

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -993,6 +993,7 @@ NOOBAA_S3_SERVING_CERT = "noobaa-s3-serving-cert"
 
 # Noobaa metrics secret
 NOOBAA_METRICS_AUTH_SECRET = "noobaa-metrics-auth-secret"
+NOOBAA_BUCKET_TAGGING_METRIC = "NooBaa_bucket_tagging"
 
 # NooBaa DB CNPG
 NB_DB_PRIMARY_POD_LABEL = "cnpg.io/instanceRole=primary"

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -50,63 +50,88 @@ class TestOBCLabelBucketTagging:
         6. Verify the bucket has matching S3 tags
         7. Verify NooBaa_bucket_tagging metric reflects the labels
         """
+        logger.test_step("Create OBC and verify initial state")
         obc_name = bucket_factory(amount=1, interface="OC")[0].name
         obc_obj = OBC(obc_name)
         bucket_name = obc_obj.bucket_name
         expected_labels = {OBC_LABEL_KEY: OBC_LABEL_VALUE}
-        logger.info(f"Created OBC {obc_name} with S3 bucket {bucket_name}")
+        logger.info(f"Created OBC '{obc_name}' with S3 bucket '{bucket_name}'")
 
-        # Bucket should have no tags before OBC labels are applied
+        logger.test_step("Verify bucket has no tags before labeling OBC")
         with pytest.raises(boto3exception.ClientError) as exc:
             get_bucket_tagging(obc_obj.s3_client, bucket_name)
+        logger.assertion(
+            f"Bucket tagging error: expected='NoSuchTagSet', "
+            f"actual='{exc.value.response['Error']['Code']}'"
+        )
         assert (
             exc.value.response["Error"]["Code"] == "NoSuchTagSet"
         ), f"Expected NoSuchTagSet before labeling, got {exc.value.response}"
 
+        logger.test_step(
+            "Verify NooBaa_bucket_tagging metric is absent before label update"
+        )
         metric_before = get_noobaa_bucket_tagging_metric_results(
             NOOBAA_BUCKET_TAGGING_METRIC,
             bucket_name,
             threading_lock,
+        )
+        logger.assertion(
+            f"NooBaa_bucket_tagging metric before labeling: "
+            f"results_count={len(metric_before)}, expected=0"
         )
         assert not metric_before, (
             f"Expected no {NOOBAA_BUCKET_TAGGING_METRIC} results before labeling, "
             f"got {metric_before}"
         )
         logger.info(
-            f"No {NOOBAA_BUCKET_TAGGING_METRIC} results for bucket {bucket_name} "
-            "before label update"
+            f"Confirmed no {NOOBAA_BUCKET_TAGGING_METRIC} results for bucket '{bucket_name}'"
         )
 
-        # Add labels to the OBC
+        logger.test_step("Add labels to OBC")
         obc_ocp = OCP(
             kind="obc",
             namespace=config.ENV_DATA["cluster_namespace"],
             resource_name=obc_name,
         )
         label = f"{OBC_LABEL_KEY}={OBC_LABEL_VALUE}"
-        assert obc_ocp.add_label(
-            resource_name=obc_name, label=label
-        ), f"Failed to add label {label} to OBC {obc_name}"
+        label_added = obc_ocp.add_label(resource_name=obc_name, label=label)
+        logger.info(f"Added label '{label}' to OBC '{obc_name}'")
+        logger.assertion(f"Label addition: success={label_added}")
+        assert label_added, f"Failed to add label {label} to OBC {obc_name}"
 
-        # Verify OBC metadata contains the label
+        logger.test_step("Verify OBC metadata contains the labels")
         obc_labels = (
             obc_ocp.get(resource_name=obc_name).get("metadata", {}).get("labels", {})
+        )
+        logger.assertion(
+            f"OBC labels check: expected={expected_labels}, "
+            f"actual={obc_labels}, "
+            f"match={obc_labels.get(OBC_LABEL_KEY) == OBC_LABEL_VALUE}"
         )
         assert (
             obc_labels.get(OBC_LABEL_KEY) == OBC_LABEL_VALUE
         ), f"OBC {obc_name} labels {obc_labels} missing {expected_labels}"
 
-        # Step 6: verify bucket S3 tags match OBC labels
+        logger.test_step("Verify bucket S3 tags match OBC labels")
         bucket_tags = verify_bucket_tagging_matches_labels(
             obc_obj.s3_client,
             bucket_name,
             expected_labels,
         )
         tag_set = get_bucket_tagging(obc_obj.s3_client, bucket_name)
-        assert tag_set_to_dict(tag_set) == bucket_tags
+        tag_set_dict = tag_set_to_dict(tag_set)
+        logger.assertion(
+            f"S3 tags verification: expected={bucket_tags}, "
+            f"actual={tag_set_dict}, "
+            f"match={tag_set_dict == bucket_tags}"
+        )
+        assert tag_set_dict == bucket_tags
 
-        # Verify NooBaa_bucket_tagging metric reflects OBC labels (gauge updated
-        # by the stats aggregator, which runs on a ~5 minute cycle).
+        logger.test_step(
+            "Verify NooBaa_bucket_tagging metric reflects OBC labels "
+            f"(timeout: {NOOBAA_BUCKET_TAGGING_METRIC_TIMEOUT}s)"
+        )
         metric_after = verify_noobaa_bucket_tagging_metric(
             NOOBAA_BUCKET_TAGGING_METRIC,
             bucket_name,

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -1,0 +1,122 @@
+import logging
+
+import botocore.exceptions as boto3exception
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    runs_on_provider,
+    tier2,
+)
+from ocs_ci.ocs.bucket_utils import (
+    get_bucket_tagging,
+    get_noobaa_bucket_metric_value,
+    tag_set_to_dict,
+    verify_bucket_tagging_matches_labels,
+)
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.objectbucket import OBC
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+NOOBAA_BUCKET_TAGGING_METRIC = "NooBaa_bucket_tagging"
+OBC_LABEL_KEY = "test-label"
+OBC_LABEL_VALUE = "verified"
+
+
+@tier2
+@mcg
+@red_squad
+@runs_on_provider
+class TestOBCLabelBucketTagging:
+    """
+    Verify OBC labels are propagated as S3 bucket tags and reflected in
+    NooBaa bucket tagging metrics.
+    """
+
+    def test_obc_labels_sync_to_bucket_tags(self, bucket_factory, threading_lock):
+        """
+        1. Create a new OBC
+        2. Verify the bucket has no tags before labeling the OBC
+        3. Record NooBaa_bucket_tagging metric before label update
+        4. Add labels to the OBC
+        5. Verify OBC metadata contains the labels
+        6. Verify the bucket has matching S3 tags
+        7. Verify NooBaa_bucket_tagging metric increased after label update
+        """
+        obc_name = bucket_factory(amount=1, interface="OC")[0].name
+        obc_obj = OBC(obc_name)
+        bucket_name = obc_obj.bucket_name
+        expected_labels = {OBC_LABEL_KEY: OBC_LABEL_VALUE}
+        logger.info(f"Created OBC {obc_name} with S3 bucket {bucket_name}")
+
+        # Bucket should have no tags before OBC labels are applied
+        with pytest.raises(boto3exception.ClientError) as exc:
+            get_bucket_tagging(obc_obj.s3_client, bucket_name)
+        assert (
+            exc.value.response["Error"]["Code"] == "NoSuchTagSet"
+        ), f"Expected NoSuchTagSet before labeling, got {exc.value.response}"
+
+        metric_before = get_noobaa_bucket_metric_value(
+            NOOBAA_BUCKET_TAGGING_METRIC,
+            bucket_name,
+            threading_lock,
+        )
+        logger.info(
+            f"{NOOBAA_BUCKET_TAGGING_METRIC} before label update: {metric_before}"
+        )
+
+        # Add labels to the OBC
+        obc_ocp = OCP(
+            kind="obc",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=obc_name,
+        )
+        label = f"{OBC_LABEL_KEY}={OBC_LABEL_VALUE}"
+        assert obc_ocp.add_label(
+            resource_name=obc_name, label=label
+        ), f"Failed to add label {label} to OBC {obc_name}"
+
+        # Verify OBC metadata contains the label
+        obc_labels = (
+            obc_ocp.get(resource_name=obc_name).get("metadata", {}).get("labels", {})
+        )
+        assert (
+            obc_labels.get(OBC_LABEL_KEY) == OBC_LABEL_VALUE
+        ), f"OBC {obc_name} labels {obc_labels} missing {expected_labels}"
+
+        # Step 6: verify bucket S3 tags match OBC labels
+        bucket_tags = verify_bucket_tagging_matches_labels(
+            obc_obj.s3_client,
+            bucket_name,
+            expected_labels,
+        )
+        tag_set = get_bucket_tagging(obc_obj.s3_client, bucket_name)
+        assert tag_set_to_dict(tag_set) == bucket_tags
+
+        # Verify NooBaa_bucket_tagging metric increased
+        metric_after = None
+        for sample in TimeoutSampler(
+            timeout=180,
+            sleep=10,
+            func=get_noobaa_bucket_metric_value,
+            metric_name=NOOBAA_BUCKET_TAGGING_METRIC,
+            bucket_name=bucket_name,
+            threading_lock=threading_lock,
+        ):
+            if sample is not None and (metric_before is None or sample > metric_before):
+                metric_after = sample
+                break
+        if metric_after is None:
+            raise TimeoutExpiredError(
+                f"{NOOBAA_BUCKET_TAGGING_METRIC} did not increase after labeling. "
+                f"before={metric_before}, after={metric_after}"
+            )
+        logger.info(
+            f"{NOOBAA_BUCKET_TAGGING_METRIC} after label update: {metric_after} "
+            f"(before: {metric_before})"
+        )

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -12,20 +12,22 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.ocs.bucket_utils import (
     get_bucket_tagging,
-    get_noobaa_bucket_metric_value,
+    get_noobaa_bucket_tagging_metric_results,
     tag_set_to_dict,
     verify_bucket_tagging_matches_labels,
+    verify_noobaa_bucket_tagging_metric,
 )
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import OBC
-from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
 NOOBAA_BUCKET_TAGGING_METRIC = "NooBaa_bucket_tagging"
 OBC_LABEL_KEY = "test-label"
 OBC_LABEL_VALUE = "verified"
+# NooBaa stats aggregator refreshes bucket metrics about every 5 minutes.
+NOOBAA_BUCKET_TAGGING_METRIC_TIMEOUT = 360
+NOOBAA_BUCKET_TAGGING_METRIC_SLEEP = 15
 
 
 @tier2
@@ -42,11 +44,11 @@ class TestOBCLabelBucketTagging:
         """
         1. Create a new OBC
         2. Verify the bucket has no tags before labeling the OBC
-        3. Record NooBaa_bucket_tagging metric before label update
+        3. Verify NooBaa_bucket_tagging metric is absent before label update
         4. Add labels to the OBC
         5. Verify OBC metadata contains the labels
         6. Verify the bucket has matching S3 tags
-        7. Verify NooBaa_bucket_tagging metric increased after label update
+        7. Verify NooBaa_bucket_tagging metric reflects the labels
         """
         obc_name = bucket_factory(amount=1, interface="OC")[0].name
         obc_obj = OBC(obc_name)
@@ -61,13 +63,18 @@ class TestOBCLabelBucketTagging:
             exc.value.response["Error"]["Code"] == "NoSuchTagSet"
         ), f"Expected NoSuchTagSet before labeling, got {exc.value.response}"
 
-        metric_before = get_noobaa_bucket_metric_value(
+        metric_before = get_noobaa_bucket_tagging_metric_results(
             NOOBAA_BUCKET_TAGGING_METRIC,
             bucket_name,
             threading_lock,
         )
+        assert not metric_before, (
+            f"Expected no {NOOBAA_BUCKET_TAGGING_METRIC} results before labeling, "
+            f"got {metric_before}"
+        )
         logger.info(
-            f"{NOOBAA_BUCKET_TAGGING_METRIC} before label update: {metric_before}"
+            f"No {NOOBAA_BUCKET_TAGGING_METRIC} results for bucket {bucket_name} "
+            "before label update"
         )
 
         # Add labels to the OBC
@@ -98,24 +105,16 @@ class TestOBCLabelBucketTagging:
         tag_set = get_bucket_tagging(obc_obj.s3_client, bucket_name)
         assert tag_set_to_dict(tag_set) == bucket_tags
 
-        # Verify NooBaa_bucket_tagging metric increased
-        metric_after = None
-        for sample in TimeoutSampler(
-            timeout=180,
-            sleep=10,
-            func=get_noobaa_bucket_metric_value,
-            metric_name=NOOBAA_BUCKET_TAGGING_METRIC,
-            bucket_name=bucket_name,
-            threading_lock=threading_lock,
-        ):
-            if sample is not None and (metric_before is None or sample > metric_before):
-                metric_after = sample
-                break
-        if metric_after is None:
-            raise TimeoutExpiredError(
-                f"{NOOBAA_BUCKET_TAGGING_METRIC} did not increase after labeling. "
-                f"before={metric_before}, after={metric_after}"
-            )
+        # Verify NooBaa_bucket_tagging metric reflects OBC labels (gauge updated
+        # by the stats aggregator, which runs on a ~5 minute cycle).
+        metric_after = verify_noobaa_bucket_tagging_metric(
+            NOOBAA_BUCKET_TAGGING_METRIC,
+            bucket_name,
+            expected_labels,
+            threading_lock,
+            timeout=NOOBAA_BUCKET_TAGGING_METRIC_TIMEOUT,
+            sleep=NOOBAA_BUCKET_TAGGING_METRIC_SLEEP,
+        )
         logger.info(
             f"{NOOBAA_BUCKET_TAGGING_METRIC} after label update: {metric_after} "
             f"(before: {metric_before})"

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -13,7 +13,6 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.ocs.bucket_utils import (
     get_bucket_tagging,
     get_noobaa_bucket_tagging_metric_results,
-    tag_set_to_dict,
     verify_bucket_tagging_matches_labels,
     verify_noobaa_bucket_tagging_metric,
 )
@@ -119,14 +118,12 @@ class TestOBCLabelBucketTagging:
             bucket_name,
             expected_labels,
         )
-        tag_set = get_bucket_tagging(obc_obj.s3_client, bucket_name)
-        tag_set_dict = tag_set_to_dict(tag_set)
         logger.assertion(
-            f"S3 tags verification: expected={bucket_tags}, "
-            f"actual={tag_set_dict}, "
-            f"match={tag_set_dict == bucket_tags}"
+            f"S3 tags verification: expected_subset={expected_labels}, actual={bucket_tags} "
         )
-        assert tag_set_dict == bucket_tags
+        assert all(
+            bucket_tags.get(key) == value for key, value in expected_labels.items()
+        ), f"Bucket tags {bucket_tags} missing expected labels {expected_labels}"
 
         logger.test_step(
             "Verify NooBaa_bucket_tagging metric reflects OBC labels "

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.ocs.bucket_utils import (
     get_bucket_tagging,
     get_noobaa_bucket_tagging_metric_results,
+    tag_set_to_dict,
     verify_bucket_tagging_matches_labels,
     verify_noobaa_bucket_tagging_metric,
 )
@@ -39,7 +40,9 @@ class TestOBCLabelBucketTagging:
     NooBaa bucket tagging metrics.
     """
 
-    def test_obc_labels_sync_to_bucket_tags(self, bucket_factory, threading_lock):
+    def test_obc_labels_sync_to_bucket_tags(
+        self, bucket_factory, mcg_obj, threading_lock
+    ):
         """
         1. Create a new OBC
         2. Verify the bucket has no tags before labeling the OBC
@@ -58,7 +61,7 @@ class TestOBCLabelBucketTagging:
 
         logger.test_step("Verify bucket has no tags before labeling OBC")
         with pytest.raises(boto3exception.ClientError) as exc:
-            get_bucket_tagging(obc_obj.s3_client, bucket_name)
+            get_bucket_tagging(mcg_obj, bucket_name)
         logger.assertion(
             f"Bucket tagging error: expected='NoSuchTagSet', "
             f"actual='{exc.value.response['Error']['Code']}'"
@@ -113,11 +116,12 @@ class TestOBCLabelBucketTagging:
         ), f"OBC {obc_name} labels {obc_labels} missing {expected_labels}"
 
         logger.test_step("Verify bucket S3 tags match OBC labels")
-        bucket_tags = verify_bucket_tagging_matches_labels(
-            obc_obj.s3_client,
+        response = verify_bucket_tagging_matches_labels(
+            mcg_obj,
             bucket_name,
             expected_labels,
         )
+        bucket_tags = tag_set_to_dict(response.get("TagSet", []))
         logger.assertion(
             f"S3 tags verification: expected_subset={expected_labels}, actual={bucket_tags} "
         )

--- a/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
+++ b/tests/functional/object/mcg/test_obc_label_bucket_tagging.py
@@ -5,11 +5,14 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    jira,
     mcg,
     red_squad,
     runs_on_provider,
     tier2,
 )
+from ocs_ci.framework.testlib import MCGTest
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     get_bucket_tagging,
     get_noobaa_bucket_tagging_metric_results,
@@ -22,7 +25,6 @@ from ocs_ci.ocs.resources.objectbucket import OBC
 
 logger = logging.getLogger(__name__)
 
-NOOBAA_BUCKET_TAGGING_METRIC = "NooBaa_bucket_tagging"
 OBC_LABEL_KEY = "test-label"
 OBC_LABEL_VALUE = "verified"
 # NooBaa stats aggregator refreshes bucket metrics about every 5 minutes.
@@ -33,8 +35,10 @@ NOOBAA_BUCKET_TAGGING_METRIC_SLEEP = 15
 @tier2
 @mcg
 @red_squad
+@jira("DFBUGS-1615")
 @runs_on_provider
-class TestOBCLabelBucketTagging:
+@pytest.mark.polarion_id("OCS-8254")
+class TestOBCLabelBucketTagging(MCGTest):
     """
     Verify OBC labels are propagated as S3 bucket tags and reflected in
     NooBaa bucket tagging metrics.
@@ -74,7 +78,7 @@ class TestOBCLabelBucketTagging:
             "Verify NooBaa_bucket_tagging metric is absent before label update"
         )
         metric_before = get_noobaa_bucket_tagging_metric_results(
-            NOOBAA_BUCKET_TAGGING_METRIC,
+            constants.NOOBAA_BUCKET_TAGGING_METRIC,
             bucket_name,
             threading_lock,
         )
@@ -83,11 +87,11 @@ class TestOBCLabelBucketTagging:
             f"results_count={len(metric_before)}, expected=0"
         )
         assert not metric_before, (
-            f"Expected no {NOOBAA_BUCKET_TAGGING_METRIC} results before labeling, "
+            f"Expected no {constants.NOOBAA_BUCKET_TAGGING_METRIC} results before labeling, "
             f"got {metric_before}"
         )
         logger.info(
-            f"Confirmed no {NOOBAA_BUCKET_TAGGING_METRIC} results for bucket '{bucket_name}'"
+            f"Confirmed no {constants.NOOBAA_BUCKET_TAGGING_METRIC} results for bucket '{bucket_name}'"
         )
 
         logger.test_step("Add labels to OBC")
@@ -134,7 +138,7 @@ class TestOBCLabelBucketTagging:
             f"(timeout: {NOOBAA_BUCKET_TAGGING_METRIC_TIMEOUT}s)"
         )
         metric_after = verify_noobaa_bucket_tagging_metric(
-            NOOBAA_BUCKET_TAGGING_METRIC,
+            constants.NOOBAA_BUCKET_TAGGING_METRIC,
             bucket_name,
             expected_labels,
             threading_lock,
@@ -142,6 +146,6 @@ class TestOBCLabelBucketTagging:
             sleep=NOOBAA_BUCKET_TAGGING_METRIC_SLEEP,
         )
         logger.info(
-            f"{NOOBAA_BUCKET_TAGGING_METRIC} after label update: {metric_after} "
+            f"{constants.NOOBAA_BUCKET_TAGGING_METRIC} after label update: {metric_after} "
             f"(before: {metric_before})"
         )


### PR DESCRIPTION
Test coverage for https://redhat.atlassian.net/browse/DFBUGS-1615?focusedCommentId=8527459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added S3 bucket-tagging helpers to retrieve and convert bucket tag sets, along with polling-based verification to confirm expected key/value labels are present.
  * Added Prometheus-based helpers to query and poll `NooBaa_bucket_tagging` metric results for a bucket until expected label changes are reflected.

* **Tests**
  * Added an end-to-end functional test verifying OBC label updates propagate to S3 bucket tags and appear in the `NooBaa_bucket_tagging` metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->