### PR TITLE
Wait for CatalogSource READY before proceeding to subscription

### DIFF
--- a/ocs_ci/utility/operators.py
+++ b/ocs_ci/utility/operators.py
@@ -11,6 +11,7 @@ from ocs_ci.framework import config
 from ocs_ci.ocs import node
 from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
 from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.packagemanifest import PackageManifest
 from ocs_ci.ocs.exceptions import (
     ResourceNotFoundError,
@@ -204,6 +205,10 @@ class Operator:
         )
         if not is_hosted:
             wait_for_machineconfigpool_status("all", force_delete_pods=False)
+        CatalogSource(
+            resource_name=self.unreleased_catalog_name,
+            namespace=constants.MARKETPLACE_NAMESPACE,
+        ).wait_for_state("READY")
 
     def create_disconnected_catalog(self):
         # in case of disconnected environment, we have to mirror all the
@@ -225,6 +230,10 @@ class Operator:
 
         if not is_hosted_cluster(config.ENV_DATA.get("cluster_name")):
             wait_for_machineconfigpool_status("all", force_delete_pods=False)
+        CatalogSource(
+            resource_name=self.unreleased_catalog_name,
+            namespace=constants.MARKETPLACE_NAMESPACE,
+        ).wait_for_state("READY")
 
     @retry(CommandFailed, tries=5, delay=30, backoff=1)
     def is_available(self):

--- a/ocs_ci/utility/operators.py
+++ b/ocs_ci/utility/operators.py
@@ -205,10 +205,11 @@ class Operator:
         )
         if not is_hosted:
             wait_for_machineconfigpool_status("all", force_delete_pods=False)
-        CatalogSource(
+        catalog_source = CatalogSource(
             resource_name=self.unreleased_catalog_name,
             namespace=constants.MARKETPLACE_NAMESPACE,
-        ).wait_for_state("READY")
+        )
+        catalog_source.wait_for_state("READY")
 
     def create_disconnected_catalog(self):
         # in case of disconnected environment, we have to mirror all the
@@ -230,10 +231,11 @@ class Operator:
 
         if not is_hosted_cluster(config.ENV_DATA.get("cluster_name")):
             wait_for_machineconfigpool_status("all", force_delete_pods=False)
-        CatalogSource(
+        catalog_source = CatalogSource(
             resource_name=self.unreleased_catalog_name,
             namespace=constants.MARKETPLACE_NAMESPACE,
-        ).wait_for_state("READY")
+        )
+        catalog_source.wait_for_state("READY")
 
     @retry(CommandFailed, tries=5, delay=30, backoff=1)
     def is_available(self):


### PR DESCRIPTION
See the more details in the failed job here: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster-multi/1024/console.

After creating a catalog source with oc apply, the catalog pod needs time to pull its image and start serving packages over gRPC. If you do not wait, `get_channel()` may run out of its 100-second PackageManifest retry window while the pod is still in `ImagePullBackOff`, causing the deployment to fail. To prevent this, `add wait_for_state("READY")` in both `create_unreleased_catalog()` and `create_disconnected_catalog()`, after `wait_for_machineconfigpool_status()`. 
This ensures that node-reboot churn from the IDMS application has settled before the catalog pod is expected to be stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creation of operator catalogs now waits for marketplace catalog sources to reach a ready state before continuing, reducing race conditions and ensuring operator resources are available during both standard and disconnected installation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->