### PR TITLE
Fix flaky test_bucket_delete_with_objects by adding retry to sync_object_directory

### DIFF
--- a/tests/functional/object/mcg/test_bucket_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_deletion.py
@@ -27,6 +27,7 @@ from ocs_ci.ocs.constants import AWSCLI_TEST_OBJ_DIR
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGS3Bucket
+from ocs_ci.utility.retry import retry
 
 logger = logging.getLogger(__name__)
 ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
@@ -123,11 +124,29 @@ class TestBucketDeletion(MCGTest):
         Negative test with deletion of bucket has objects stored in.
 
         """
-        bucketname = bucket_factory(bucketclass=bucketclass_dict)[0].name
+        logger.info(
+            f"Creating bucket with interface={interface}, "
+            f"bucketclass_dict={bucketclass_dict}"
+        )
+        bucket = bucket_factory(bucketclass=bucketclass_dict)[0]
+        bucketname = bucket.name
+        logger.info(f"Bucket {bucketname} created successfully")
 
         data_dir = AWSCLI_TEST_OBJ_DIR
         full_object_path = f"s3://{bucketname}"
-        sync_object_directory(awscli_pod_session, data_dir, full_object_path, mcg_obj)
+        logger.info(
+            f"Syncing objects from {data_dir} to {full_object_path} "
+            f"(endpoint: {mcg_obj.s3_internal_endpoint})"
+        )
+        retry(
+            (CommandFailed, botocore.exceptions.ClientError),
+            tries=3,
+            delay=30,
+            backoff=2,
+        )(sync_object_directory)(
+            awscli_pod_session, data_dir, full_object_path, mcg_obj
+        )
+        logger.info(f"Objects synced successfully to {bucketname}")
 
         logger.info(f"Deleting bucket: {bucketname}")
         if interface == "S3":


### PR DESCRIPTION
Summary

  - Add retry logic around sync_object_directory in test_bucket_delete_with_objects to handle transient NooBaa S3 errors (504 Gateway Timeout on bucket operations, InvalidBucketState during
  multipart uploads)
  - Add logging for bucket creation, sync operation details (endpoint, paths), and sync completion to improve debuggability of future failures

  Details

  The test fails in ~50% of runs on 4.21 due to two transient S3 errors:
  1. 504 Gateway Timeout — NooBaa S3 service is temporarily slow/unavailable
  2. InvalidBucketState on UploadPart — bucket passes health checks but backing store isn't fully ready for multipart uploads

  The sync_object_directory call now retries up to 3 times (30s, 60s delays) on CommandFailed and botocore.exceptions.ClientError.

  Resolves: https://github.com/red-hat-storage/ocs-ci/issues/14693


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience for object synchronization operations with automatic retry logic and enhanced error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->