### PR TITLE
Add vSphere LSO UI conf files for pre-used disks and forceful deployment 

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_encrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_encrypted.yaml
@@ -25,3 +25,6 @@ ENV_DATA:
   skip_disks_cleanup: true
   simulate_bluestore_label: true
   encryption_at_rest: true
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-7992'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_encrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_encrypted.yaml
@@ -1,0 +1,27 @@
+---
+# Deploys an LSO-backed ODF cluster via the UI on vSphere UPI (VMDK, 3m/3w).
+# Simulates pre-existing unencrypted bluestore OSDs on the worker disks before
+# deployment (simulate_bluestore_label), skips disk cleanup so the simulation
+# data is preserved, then deploys with forceful deployment enabled and
+# encryption at rest — verifying that rook-ceph correctly detects, wipes the
+# foreign bluestore data, and provisions new encrypted OSDs.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: true
+  odf_forceful_deployment: true
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  skip_disks_cleanup: true
+  simulate_bluestore_label: true
+  encryption_at_rest: true

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_unencrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_unencrypted.yaml
@@ -1,0 +1,27 @@
+---
+# Deploys an LSO-backed ODF cluster via the UI on vSphere UPI (VMDK, 3m/3w).
+# Simulates pre-existing unencrypted bluestore OSDs on the worker disks before
+# deployment (simulate_bluestore_label), skips disk cleanup so the simulation
+# data is preserved, then deploys with forceful deployment enabled and no
+# encryption — verifying that rook-ceph correctly detects, wipes the foreign
+# bluestore data, and provisions new unencrypted OSDs.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: true
+  odf_forceful_deployment: true
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  skip_disks_cleanup: true
+  simulate_bluestore_label: true
+  encryption_at_rest: false

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_unencrypted.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_unencrypted_to_unencrypted.yaml
@@ -25,3 +25,6 @@ ENV_DATA:
   skip_disks_cleanup: true
   simulate_bluestore_label: true
   encryption_at_rest: false
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-7991'

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1351,6 +1351,22 @@ class Deployment(object):
             and platform in constants.AWS_STS_PLATFORMS
         )
 
+        add_new_disks_for_lso = True
+        # Simulate bluestore label on worker nodes before deploying OCS.
+        # Must run before ui_deployment early-return so it applies to both
+        # UI and non-UI paths.
+        simulate_bluestore_label = config.ENV_DATA.get(
+            "simulate_bluestore_label", False
+        )
+        if simulate_bluestore_label:
+            from ocs_ci.deployment.helpers.ceph_cluster import (
+                simulate_full_ceph_bluestore_process_on_wnodes,
+            )
+
+            log_step("Simulate Ceph OSD bluestore on worker nodes")
+            simulate_full_ceph_bluestore_process_on_wnodes()
+            add_new_disks_for_lso = False
+
         if ui_deployment and ui_deployment_conditions():
             log_step("Start ODF deployment with UI")
             self.deployment_with_ui()
@@ -1412,19 +1428,6 @@ class Deployment(object):
                     "oc wait --for=condition=Updated --timeout=30m mcp/worker",
                     timeout=2100,
                 )
-
-        add_new_disks_for_lso = True
-        # Simulate bluestore label on Baremetal or vSphere LSO worker nodes before deploying OCS
-        simulate_bluestore_label = config.ENV_DATA.get(
-            "simulate_bluestore_label", False
-        )
-        if simulate_bluestore_label:
-            from ocs_ci.deployment.helpers.ceph_cluster import (
-                simulate_full_ceph_bluestore_process_on_wnodes,
-            )
-
-            simulate_full_ceph_bluestore_process_on_wnodes()
-            add_new_disks_for_lso = False
 
         # with Hub/Spoke deployments LSO on IBM BareMetal is a mandatory requirement, it is installed on Dependency
         # stage when config["DEPLOYMENT"]["lso_standalone_deployment"] is set to True
@@ -2253,6 +2256,16 @@ class Deployment(object):
                 resource_count=1,
                 timeout=600,
             )
+
+            if config.ENV_DATA.get("simulate_bluestore_label", False):
+                from ocs_ci.deployment.helpers.ceph_cluster import (
+                    verify_osd_prepare_logs_bluestore_wipe,
+                )
+
+                logger.info("Verify rook-ceph-osd-prepare logs confirm bluestore wipe")
+                assert (
+                    verify_osd_prepare_logs_bluestore_wipe()
+                ), "Bluestore wipe verification failed in rook-ceph-osd-prepare logs"
 
             if not config.COMPONENTS["disable_cephfs"]:
                 # Check for CephFilesystem creation in ocp

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2257,15 +2257,24 @@ class Deployment(object):
                 timeout=600,
             )
 
-            if config.ENV_DATA.get("simulate_bluestore_label", False):
+            wipe_devices_from_other_clusters = config.ENV_DATA.get(
+                "wipe_devices_from_other_clusters", False
+            )
+            odf_forceful_deployment = config.DEPLOYMENT.get(
+                "odf_forceful_deployment", False
+            )
+            if wipe_devices_from_other_clusters or odf_forceful_deployment:
                 from ocs_ci.deployment.helpers.ceph_cluster import (
-                    verify_osd_prepare_logs_bluestore_wipe,
+                    verify_wipe_devices_from_other_clusters,
                 )
 
-                logger.info("Verify rook-ceph-osd-prepare logs confirm bluestore wipe")
+                logger.info(
+                    "Verify wipe devices from other clusters "
+                    "(StorageCluster CR flag and OSD prepare logs)"
+                )
                 assert (
-                    verify_osd_prepare_logs_bluestore_wipe()
-                ), "Bluestore wipe verification failed in rook-ceph-osd-prepare logs"
+                    verify_wipe_devices_from_other_clusters()
+                ), "Wipe devices from other clusters verification failed"
 
             if not config.COMPONENTS["disable_cephfs"]:
                 # Check for CephFilesystem creation in ocp

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -485,27 +485,55 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
     return True
 
 
-def verify_osd_prepare_logs_bluestore_wipe():
+def verify_wipe_devices_from_other_clusters():
     """
-    Check that each rook-ceph-osd-prepare pod successfully detected and wiped
-    a pre-existing bluestore OSD from a different cluster before provisioning
-    a new OSD.
+    Verify that the cluster correctly wiped pre-existing bluestore OSDs from
+    another cluster before provisioning new OSDs.
 
-    These patterns are present in both encrypted and unencrypted OSD prepare
-    logs whenever the disk carried bluestore data from a prior cluster.
+    Performs two checks:
 
-    Checks for the following regex patterns in each pod's logs:
-    - completed wiping OSD <id> device "<dev>" belonging to a different ceph
-      cluster — foreign bluestore data was detected and zapped
-    - successfully zapped osd.<id> path "<dev>" — low-level wipe succeeded
-    - ceph-volume raw dmcrypt prepare successful — new OSD prepared
-      (rook-ceph emits this message for both encrypted and unencrypted OSDs)
+    1. **StorageCluster CR** — asserts that
+       ``spec.managedResources.cephCluster.cleanupPolicy.wipeDevicesFromOtherClusters``
+       is exactly ``true``.
+
+    2. **OSD prepare logs** — checks each ``rook-ceph-osd-prepare`` pod for
+       the following regex patterns, which confirm that foreign bluestore data
+       was detected and zapped:
+
+       - ``completed wiping OSD <id> device "<dev>" belonging to a different
+         ceph cluster`` — foreign bluestore data detected and zapped
+       - ``successfully zapped osd.<id> path "<dev>"`` — low-level wipe
+         succeeded
+       - ``ceph-volume raw dmcrypt prepare successful`` — new OSD prepared
+         (emitted for both encrypted and unencrypted OSDs)
 
     Returns:
-        bool: True if all patterns are found in all pods, False otherwise.
+        bool: True if both checks pass, False otherwise.
+
     """
     from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
+    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 
+    # Check 1: StorageCluster CR flag
+    sc_obj = get_storage_cluster()
+    sc_data = sc_obj.get(resource_name=constants.DEFAULT_STORAGE_CLUSTER)
+    flag = (
+        sc_data.get("spec", {})
+        .get("managedResources", {})
+        .get("cephCluster", {})
+        .get("cleanupPolicy", {})
+        .get("wipeDevicesFromOtherClusters")
+    )
+    if flag is True:
+        logger.info("StorageCluster has wipeDevicesFromOtherClusters set to true")
+    else:
+        logger.error(
+            "StorageCluster wipeDevicesFromOtherClusters is %r, expected true",
+            flag,
+        )
+        return False
+
+    # Check 2: OSD prepare pod logs
     expected_patterns = [
         re.compile(
             r'completed wiping OSD \d+ device ".+" belonging to a different'

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import re
 from pathlib import Path
 
 from ocs_ci.deployment.baremetal import (
@@ -481,4 +482,54 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
         return False
 
     logger.info("Full Ceph BlueStore simulation process completed successfully.")
+    return True
+
+
+def verify_osd_prepare_logs_bluestore_wipe():
+    """
+    Check that each rook-ceph-osd-prepare pod successfully detected and wiped
+    a pre-existing bluestore OSD from a different cluster before provisioning
+    a new OSD.
+
+    These patterns are present in both encrypted and unencrypted OSD prepare
+    logs whenever the disk carried bluestore data from a prior cluster.
+
+    Checks for the following regex patterns in each pod's logs:
+    - completed wiping OSD <id> device "<dev>" belonging to a different ceph
+      cluster — foreign bluestore data was detected and zapped
+    - successfully zapped osd.<id> path "<dev>" — low-level wipe succeeded
+    - ceph-volume raw dmcrypt prepare successful — new OSD prepared
+      (rook-ceph emits this message for both encrypted and unencrypted OSDs)
+
+    Returns:
+        bool: True if all patterns are found in all pods, False otherwise.
+    """
+    from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
+
+    expected_patterns = [
+        re.compile(
+            r'completed wiping OSD \d+ device ".+" belonging to a different'
+            r" ceph cluster"
+        ),
+        re.compile(r'successfully zapped osd\.\d+ path ".+"'),
+        re.compile(r"ceph-volume raw dmcrypt prepare successful"),
+    ]
+
+    osd_prepare_pods = get_osd_prepare_pods()
+    if not osd_prepare_pods:
+        logger.error("No rook-ceph-osd-prepare pods found")
+        return False
+
+    for pod in osd_prepare_pods:
+        logs = get_pod_logs(pod.name)
+        logger.info("Verifying bluestore wipe log entries in pod %s", pod.name)
+        for pattern in expected_patterns:
+            if not pattern.search(logs):
+                logger.error(
+                    "Expected log pattern not found in pod %r: %r",
+                    pod.name,
+                    pattern.pattern,
+                )
+                return False
+
     return True


### PR DESCRIPTION
See more details in the feature: https://redhat.atlassian.net/browse/RHSTOR-8102.
This PR depends on the PR https://github.com/red-hat-storage/ocs-ci/pull/15259.

**Description:**
  Ensures that when deploying ODF on worker nodes with pre-existing bluestore
  data (simulated via `simulate_bluestore_label`), the simulation runs correctly
  for both UI and non-UI deployment paths, and verifies that, after deployment,
  rook-ceph detects and wipes the foreign bluestore OSDs.

  **Changes:**
  - Add two vSphere UPI LSO VMDK conf files covering the UI deployment flow with the two scenarios:
    - pre-used unencrypted disks --> LSO ODF deployment with forceful deployment and unencrypted disks. 
    - pre-used unencrypted disks --> LSO ODF deployment with forceful deployment and encrypted disks.  
  - Move the `simulate_bluestore_label` block before the `ui_deployment` early-return
    in `deploy_ocs_via_operator` so the simulation is not skipped for UI deployments.
  - Add `verify_osd_prepare_logs_bluestore_wipe()` to `ceph_cluster.py` to read
    each `rook-ceph-osd-prepare` pod's logs and verify that the bluestore wipe and new
    OSD provisioning completed successfully.

**To do:**
- Add another two similar conf files covering the two remaining scenarios: 
  - pre-used encrypted disks --> LSO ODF deployment with forceful deployment and unencrypted disks. 
  - pre-used encrypted disks --> LSO ODF deployment with forceful deployment and encrypted disks. 

- Add another conf file for negative test case: 
  - pre-used unencrypted disks --> LSO ODF deployment with forceful deployment **not enabled** and encrypted disks.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vSphere UPI deployment configurations for LSO-backed ODF clusters with UI-based deployment and support for both encrypted and unencrypted storage scenarios.

* **Bug Fixes**
  * Enhanced OCS deployment to validate proper cleanup of storage devices from foreign clusters when using forceful deployment mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->