### PR TITLE
Fix vsphere-cleanup to prevent destroying wrong cluster resources

### DIFF
--- a/ocs_ci/cleanup/vsphere/cleanup.py
+++ b/ocs_ci/cleanup/vsphere/cleanup.py
@@ -87,7 +87,10 @@ def delete_ipi_nodes(vsphere, cluster_name):
     vms_ipi = []
     for vm in vms_dc:
         try:
-            if cluster_name in vm.name and "generated-zone" not in vm.name:
+            if (
+                vm.name.startswith(f"{cluster_name}-")
+                and "generated-zone" not in vm.name
+            ):
                 vms_ipi.append(vm)
                 logger.info(vm.name)
         except vmodl.fault.ManagedObjectNotFound as e:


### PR DESCRIPTION
The vsphere-cleanup script had a critical bug where substring matching caused it to destroy resources from unintended clusters. For example, cleaning up cluster "asagare-dev" would also match and destroy VMs from "asagare-devnew" because it used 'cluster_name in vm.name' instead of proper prefix matching.

Changed the VM name matching from substring check to startswith() with a hyphen boundary to ensure only VMs belonging to the exact cluster name are deleted.

Example impact:
- Before: "asagare-dev" matches both "asagare-dev-xxx" and "asagare-devnew-xxx"
- After: "asagare-dev" only matches "asagare-dev-xxx"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vSphere VM cleanup logic to more accurately identify and select virtual machines during infrastructure teardown, reducing the risk of unintended VM deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->